### PR TITLE
Move bench and report commands into deplodock package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,16 +27,25 @@ Or for a specific test file:
 pytest tests/test_recipe.py -v
 ```
 
+## CLI Commands
+
+- `deplodock deploy local ...` — deploy locally via docker compose
+- `deplodock deploy ssh ...` — deploy to remote server via SSH
+- `deplodock bench ...` — run benchmarks on remote servers
+- `deplodock report ...` — generate Excel reports from benchmark results
+
 ## Key Make Targets
 
 - `make setup` — create venv and install dependencies
-- `make bench` — run benchmarks in parallel across configured servers
-- `make report` — generate Excel report from benchmark results
+- `make bench` — run benchmarks in parallel (`deplodock bench --parallel`)
+- `make report` — generate Excel report (`deplodock report`)
 - `make clean` — remove venv and generated files
 
-## PR Procedure
+## Contribution Instructions
 
-1. Write code following `STYLE.md`
-2. Add tests if reasonable (in `tests/`)
-3. Run tests: `pytest tests/ -v`
-4. Push and open a PR
+1. Create a feature branch from `main` (e.g. `feature/my-new-feature`)
+2. Write code following guidelines here, in `STYLE.md` and in `README.md`
+3. Add tests if reasonable (in `tests/`)
+4. Update `STYLE.md`, `README.md` and `CLAUDE.md` if necessary
+5. Run tests: `pytest tests/ -v`
+6. Push and open a PR

--- a/Makefile
+++ b/Makefile
@@ -25,32 +25,32 @@ setup:
 
 bench: setup
 	@echo "Running benchmarks in parallel..."
-	./run_remote_benchmark.py --parallel
+	deplodock bench --parallel
 
 bench-force: setup
 	@echo "Running benchmarks in parallel (force mode)..."
-	./run_remote_benchmark.py --parallel --force
+	deplodock bench --parallel --force
 
 report: setup
 	@echo "Generating Excel report from benchmark results..."
-	./venv/bin/python generate_benchmark_report.py
-	@echo "✅ Report generated: benchmark_report.xlsx"
+	deplodock report
+	@echo "Report generated: benchmark_report.xlsx"
 
 report-nov2025: setup
 	@echo "Generating Excel report from Nov 2025 benchmark results..."
-	./venv/bin/python generate_benchmark_report.py \
+	deplodock report \
 		--results-dir results/pro6000_l40s_h100_h200_11_2025 \
 		--output results/pro6000_l40s_h100_h200_11_2025/benchmark_report.xlsx
-	./venv/bin/python generate_benchmark_report.py \
+	deplodock report \
 		--results-dir results/pro6000_l40s_h100_h200_11_2025/single-query \
 		--output results/pro6000_l40s_h100_h200_11_2025/single-query/benchmark_report.xlsx
-	./venv/bin/python generate_benchmark_report.py \
+	deplodock report \
 		--results-dir results/pro6000_l40s_h100_h200_11_2025/single-gpu \
 		--output results/pro6000_l40s_h100_h200_11_2025/single-gpu/benchmark_report.xlsx
 
 report-jan2026: setup
 	@echo "Generating Excel report from Jan 2026 benchmark results..."
-	./venv/bin/python generate_benchmark_report.py \
+	deplodock report \
 		--results-dir results/pro6000_h100_h200_b200_01_2026/summary \
 		--output results/pro6000_h100_h200_b200_01_2026/benchmark_report.xlsx
 

--- a/Makefile
+++ b/Makefile
@@ -25,32 +25,32 @@ setup:
 
 bench: setup
 	@echo "Running benchmarks in parallel..."
-	deplodock bench --parallel
+	./venv/bin/deplodock bench --parallel
 
 bench-force: setup
 	@echo "Running benchmarks in parallel (force mode)..."
-	deplodock bench --parallel --force
+	./venv/bin/deplodock bench --parallel --force
 
 report: setup
 	@echo "Generating Excel report from benchmark results..."
-	deplodock report
+	./venv/bin/deplodock report
 	@echo "Report generated: benchmark_report.xlsx"
 
 report-nov2025: setup
 	@echo "Generating Excel report from Nov 2025 benchmark results..."
-	deplodock report \
+	./venv/bin/deplodock report \
 		--results-dir results/pro6000_l40s_h100_h200_11_2025 \
 		--output results/pro6000_l40s_h100_h200_11_2025/benchmark_report.xlsx
-	deplodock report \
+	./venv/bin/deplodock report \
 		--results-dir results/pro6000_l40s_h100_h200_11_2025/single-query \
 		--output results/pro6000_l40s_h100_h200_11_2025/single-query/benchmark_report.xlsx
-	deplodock report \
+	./venv/bin/deplodock report \
 		--results-dir results/pro6000_l40s_h100_h200_11_2025/single-gpu \
 		--output results/pro6000_l40s_h100_h200_11_2025/single-gpu/benchmark_report.xlsx
 
 report-jan2026: setup
 	@echo "Generating Excel report from Jan 2026 benchmark results..."
-	deplodock report \
+	./venv/bin/deplodock report \
 		--results-dir results/pro6000_h100_h200_b200_01_2026/summary \
 		--output results/pro6000_h100_h200_b200_01_2026/benchmark_report.xlsx
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,41 @@ pytest tests/ -v
 
 ## Benchmarking
 
-For automated benchmarking across multiple servers:
+### Run Benchmarks
 
 ```bash
-make bench        # Run benchmarks
+deplodock bench --parallel            # Run benchmarks in parallel
+deplodock bench --server my_server    # Run for specific server
+deplodock bench --model org/model     # Run for specific model
+deplodock bench --parallel --force    # Force re-run, skip cached results
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config` | `config.yaml` | Path to configuration file |
+| `--force` | false | Force re-run even if results exist |
+| `--server` | - | Run only for a specific server |
+| `--model` | - | Run only for a specific model |
+| `--parallel` | false | Run servers in parallel |
+| `--max-workers` | num servers | Max parallel server benchmarks |
+
+### Generate Reports
+
+```bash
+deplodock report                                      # Default: results/ -> results/benchmark_report.xlsx
+deplodock report --results-dir results/custom --output results/custom/report.xlsx
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config` | `config.yaml` | Path to configuration file |
+| `--results-dir` | `results` | Directory containing benchmark results |
+| `--output` | `results/benchmark_report.xlsx` | Output Excel file path |
+
+### Make Targets
+
+```bash
+make bench        # Run benchmarks in parallel
 make report       # Generate Excel report
 make bench-force  # Force re-run
 ```
@@ -154,13 +185,18 @@ See `config.yaml` for server and model configuration. Benchmark scripts in `benc
 ## Project Structure
 
 ```
-server-benchmark/
-├── main.py                          # CLI entrypoint
-├── commands/
-│   └── deploy/
-│       ├── __init__.py              # Shared: recipe, compose, orchestration
-│       ├── local.py                 # Local target
-│       └── ssh.py                   # SSH target
+deplodock/
+├── deplodock/
+│   ├── deplodock.py                 # CLI entrypoint
+│   └── commands/
+│       ├── deploy/
+│       │   ├── __init__.py          # Shared: recipe, compose, orchestration
+│       │   ├── local.py             # Local target
+│       │   └── ssh.py               # SSH target
+│       ├── bench/
+│       │   └── __init__.py          # Benchmark runner
+│       └── report/
+│           └── __init__.py          # Report generator
 ├── recipes/                         # Model deploy recipes
 │   ├── GLM-4.6-FP8/
 │   ├── GLM-4.6/
@@ -172,6 +208,5 @@ server-benchmark/
 ├── benchmarks/                      # Benchmark scripts
 ├── utils/                           # Utilities
 ├── config.yaml                      # Benchmark configuration
-├── Makefile                         # Build automation
-└── run_remote_benchmark.py          # Benchmark orchestration
+└── Makefile                         # Build automation
 ```

--- a/README.md
+++ b/README.md
@@ -172,16 +172,6 @@ deplodock report --results-dir results/custom --output results/custom/report.xls
 | `--results-dir` | `results` | Directory containing benchmark results |
 | `--output` | `results/benchmark_report.xlsx` | Output Excel file path |
 
-### Make Targets
-
-```bash
-make bench        # Run benchmarks in parallel
-make report       # Generate Excel report
-make bench-force  # Force re-run
-```
-
-See `config.yaml` for server and model configuration. Benchmark scripts in `benchmarks/` are auto-discovered by naming convention (`<step>_<name>.sh`).
-
 ## Project Structure
 
 ```

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -1,26 +1,15 @@
-#!/usr/bin/env python3
-"""
-Automated LLM Benchmark Runner
+"""Bench command: run LLM benchmarks on remote servers via SSH."""
 
-This script reads configuration from config.yaml and runs benchmarks on remote servers via SSH.
-It supports multiple servers and models, running all combinations.
-It will skip benchmarks if the results file already exists locally.
-
-Benchmark scripts follow the naming convention: <step_index>_<benchmark_name>.sh
-Result files follow the naming convention: <benchmark_name>.txt
-"""
-
-import argparse
-import os
-import sys
-import subprocess
-import time
-import re
 import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, List
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Optional
 
 import yaml
 
@@ -80,17 +69,8 @@ def setup_logging() -> str:
 
 
 def get_server_logger(server_name: str, model_name: Optional[str] = None) -> logging.Logger:
-    """Get or create a logger for a specific server and model.
-
-    Args:
-        server_name: Name of the server (e.g., 'rtx5090_x_1')
-        model_name: Name of the model (e.g., 'kosbu/Llama-3.3-70B-Instruct-AWQ')
-
-    Returns:
-        Logger instance for this server/model combination
-    """
+    """Get or create a logger for a specific server and model."""
     if model_name:
-        # Extract just the model name without organization prefix for brevity
         short_model = model_name.split('/')[-1] if '/' in model_name else model_name
         logger_name = f"{server_name}.{short_model}"
     else:
@@ -103,16 +83,7 @@ def run_ssh_command_with_logging(
     ssh_cmd: List[str],
     logger: logging.Logger
 ) -> int:
-    """Run SSH command and log output line-by-line with server prefix.
-
-    Args:
-        server_name: Name of the server
-        ssh_cmd: SSH command as list of arguments
-        logger: Logger instance for this server
-
-    Returns:
-        Return code from the SSH command
-    """
+    """Run SSH command and log output line-by-line with server prefix."""
     process = subprocess.Popen(
         ssh_cmd,
         stdout=subprocess.PIPE,
@@ -122,10 +93,8 @@ def run_ssh_command_with_logging(
         universal_newlines=True
     )
 
-    # Stream output line by line
     for line in iter(process.stdout.readline, ''):
         if line:
-            # Log to file with full context, print to console with server prefix
             logger.info(line.rstrip())
 
     returncode = process.wait()
@@ -139,42 +108,38 @@ def load_config(config_path: str = "config.yaml") -> dict:
             config = yaml.safe_load(f)
         return config
     except FileNotFoundError:
-        print(f"❌ Error: Config file '{config_path}' not found.")
+        print(f"Error: Config file '{config_path}' not found.")
         sys.exit(1)
     except yaml.YAMLError as e:
-        print(f"❌ Error parsing YAML config: {e}")
+        print(f"Error parsing YAML config: {e}")
         sys.exit(1)
 
 
 def validate_config(config: dict) -> None:
     """Validate that required configuration fields are present."""
-    # Check for required sections
     if 'benchmark' not in config:
-        print("❌ Error: Missing 'benchmark' section in config.")
+        print("Error: Missing 'benchmark' section in config.")
         sys.exit(1)
 
     if 'servers' not in config or not config['servers']:
-        print("❌ Error: Missing 'servers' section or empty servers list in config.")
+        print("Error: Missing 'servers' section or empty servers list in config.")
         sys.exit(1)
 
-    # Check benchmark fields
     required_benchmark_fields = ['local_results_dir']
     for field in required_benchmark_fields:
         if field not in config['benchmark']:
-            print(f"❌ Error: Missing '{field}' in 'benchmark' section.")
+            print(f"Error: Missing '{field}' in 'benchmark' section.")
             sys.exit(1)
 
-    # Validate server entries
     required_server_fields = ['name', 'address', 'ssh_key', 'models']
     for idx, server in enumerate(config['servers']):
         for field in required_server_fields:
             if field not in server:
-                print(f"❌ Error: Missing '{field}' in server entry {idx} ({server.get('name', 'unnamed')}).")
+                print(f"Error: Missing '{field}' in server entry {idx} ({server.get('name', 'unnamed')}).")
                 sys.exit(1)
 
-        # Validate models list
         if not server['models'] or not isinstance(server['models'], list):
-            print(f"❌ Error: Server '{server['name']}' must have a non-empty 'models' list.")
+            print(f"Error: Server '{server['name']}' must have a non-empty 'models' list.")
             sys.exit(1)
 
 
@@ -218,22 +183,21 @@ def run_ssh_command(server: dict, command: str, capture_output: bool = False) ->
             subprocess.run(ssh_cmd, check=True)
             return None
     except subprocess.CalledProcessError as e:
-        print(f"❌ SSH command failed: {e}")
+        print(f"SSH command failed: {e}")
         if capture_output and e.stderr:
             print(f"Error output: {e.stderr}")
         return None
 
 
 def setup_remote_repo(server: dict, logger: logging.Logger) -> bool:
-    """Clone or update the server-benchmark repository on remote server. Returns True if successful."""
+    """Clone or update the server-benchmark repository on remote server."""
     server_name = server['name']
-    logger.info("📦 Setting up repository on remote server...")
+    logger.info("Setting up repository on remote server...")
 
     ssh_key = expand_path(server['ssh_key'])
     address = server['address']
     port = server.get('port', 22)
 
-    # Clean checkout: remove old repo and clone fresh to ensure latest code
     setup_cmd = (
         'rm -rf server-benchmark && '
         'git clone https://github.com/cloudrift-ai/server-benchmark.git'
@@ -250,15 +214,14 @@ def setup_remote_repo(server: dict, logger: logging.Logger) -> bool:
         ]
         returncode = run_ssh_command_with_logging(server_name, ssh_cmd, logger)
         if returncode != 0:
-            logger.error(f"❌ Failed to setup repository (exit code: {returncode})")
+            logger.error(f"Failed to setup repository (exit code: {returncode})")
             return False
-        logger.info("✅ Repository ready on remote server")
+        logger.info("Repository ready on remote server")
     except Exception as e:
-        logger.error(f"❌ Failed to setup repository: {e}")
+        logger.error(f"Failed to setup repository: {e}")
         return False
 
-    # Run setup to install dependencies
-    logger.info("🔧 Installing dependencies on remote server...")
+    logger.info("Installing dependencies on remote server...")
     setup_script_cmd = 'cd server-benchmark && make setup'
 
     try:
@@ -272,52 +235,34 @@ def setup_remote_repo(server: dict, logger: logging.Logger) -> bool:
         ]
         returncode = run_ssh_command_with_logging(server_name, ssh_cmd, logger)
         if returncode != 0:
-            logger.error(f"❌ Failed to install dependencies (exit code: {returncode})")
+            logger.error(f"Failed to install dependencies (exit code: {returncode})")
             return False
-        logger.info("✅ Dependencies installed successfully")
+        logger.info("Dependencies installed successfully")
         return True
     except Exception as e:
-        logger.error(f"❌ Failed to install dependencies: {e}")
+        logger.error(f"Failed to install dependencies: {e}")
         return False
 
 
 def run_benchmark_step(server: dict, model_config: dict, config: dict, step_name: str, script_name: str,
                        result_file: str, force: bool = False, logger: logging.Logger = None) -> bool:
-    """Run a single benchmark step if result doesn't exist, then download the result.
-
-    Args:
-        server: Server configuration dict
-        model_config: Model configuration dict with 'name' and optional 'tensor_parallel_size'
-        config: Full config dict
-        step_name: Display name (e.g., "System Info", "HF Download")
-        script_name: Shell script to run (e.g., "run_system_info.sh")
-        result_file: Result file to download (e.g., "system_info.txt")
-        force: Force re-run even if result exists
-        logger: Logger instance for this server
-
-    Returns:
-        True if successful (either skipped or downloaded), False on failure
-    """
+    """Run a single benchmark step if result doesn't exist, then download the result."""
     server_name = server['name']
     model_name = model_config['name']
 
-    # Use provided logger or get one for this server
     if logger is None:
         logger = get_server_logger(server_name, model_name)
 
-    # Check if result already exists
     if not force and check_result_file_exists(server, model_name, config, result_file):
-        logger.info(f"⏭️  {step_name} result already exists, skipping...")
+        logger.info(f"{step_name} result already exists, skipping...")
         return True
 
-    # Run the benchmark step
-    logger.info(f"🚀 Running {step_name}...")
+    logger.info(f"Running {step_name}...")
 
     ssh_key = expand_path(server['ssh_key'])
     address = server['address']
     port = server.get('port', 22)
 
-    # Get benchmark parameters from config (required)
     if 'benchmark_params' not in config:
         raise ValueError("benchmark_params must be defined in config.yaml")
 
@@ -332,13 +277,11 @@ def run_benchmark_step(server: dict, model_config: dict, config: dict, step_name
     random_input_len = benchmark_params['random_input_len']
     random_output_len = benchmark_params['random_output_len']
 
-    # Get parallelism parameters from model config (default to 1 if not specified)
     tensor_parallel_size = model_config.get('tensor_parallel_size', 1)
     pipeline_parallel_size = model_config.get('pipeline_parallel_size', 1)
     num_instances = model_config.get('num_instances', 1)
     extra_args = model_config.get('extra_args', '')
 
-    # Get HuggingFace cache directory from config (default to /hf_models for backwards compatibility)
     hf_cache_dir = config['benchmark'].get('huggingface_cache_dir', '/hf_models')
 
     env_vars = (
@@ -369,20 +312,19 @@ def run_benchmark_step(server: dict, model_config: dict, config: dict, step_name
     try:
         returncode = run_ssh_command_with_logging(server_name, ssh_cmd, logger)
         if returncode != 0:
-            logger.error(f"❌ Failed to run {step_name} (exit code: {returncode})")
+            logger.error(f"Failed to run {step_name} (exit code: {returncode})")
             return False
     except Exception as e:
-        logger.error(f"❌ Failed to run {step_name}: {e}")
+        logger.error(f"Failed to run {step_name}: {e}")
         return False
 
-    # Download the result file
-    logger.info(f"📥 Downloading {step_name} results...")
+    logger.info(f"Downloading {step_name} results...")
     success = download_single_file(server, model_name, config, result_file, result_file)
 
     if success:
-        logger.info(f"✅ {step_name} completed")
+        logger.info(f"{step_name} completed")
     else:
-        logger.warning(f"⚠️  {step_name} completed but download failed")
+        logger.warning(f"{step_name} completed but download failed")
 
     return success
 
@@ -415,21 +357,15 @@ def get_benchmark_result_file(benchmark_name: str) -> str:
 
 
 def discover_benchmarks(server: dict, logger: logging.Logger = None) -> List[str]:
-    """Discover benchmark scripts from the remote server's benchmarks directory.
-
-    Returns a list of script names (e.g., ['1_system_info.sh', '2_hf_download.sh']).
-    Scripts must follow naming convention: <step_index>_<benchmark_name>.sh
-    Result files follow convention: <benchmark_name>.txt
-    """
+    """Discover benchmark scripts from the remote server's benchmarks directory."""
     server_name = server['name']
     if logger is None:
-        logger = get_server_logger(server_name)  # No model context for discovery
+        logger = get_server_logger(server_name)
 
     ssh_key = expand_path(server['ssh_key'])
     address = server['address']
     port = server.get('port', 22)
 
-    # List benchmark scripts matching pattern: <digit>_*.sh
     ssh_cmd = [
         'ssh',
         '-i', ssh_key,
@@ -444,49 +380,44 @@ def discover_benchmarks(server: dict, logger: logging.Logger = None) -> List[str
         script_paths = result.stdout.strip().split('\n')
 
         if not script_paths or script_paths == ['']:
-            logger.warning("⚠️  Warning: No benchmark scripts found matching pattern [0-9]*_*.sh")
+            logger.warning("No benchmark scripts found matching pattern [0-9]*_*.sh")
             return []
 
         script_names = []
         for script_path in script_paths:
-            # Extract filename from path
             script_name = script_path.split('/')[-1]
-
-            # Validate: <step_index>_<benchmark_name>.sh
             if re.match(r'\d+_.+\.sh$', script_name):
                 script_names.append(script_name)
 
         return script_names
     except subprocess.CalledProcessError as e:
-        logger.warning(f"⚠️  Warning: Failed to discover benchmarks: {e}")
+        logger.warning(f"Failed to discover benchmarks: {e}")
         return []
 
 
 def run_benchmark(server: dict, model_config: dict, config: dict, force: bool = False, logger: logging.Logger = None) -> bool:
-    """Run all benchmark steps sequentially. Returns True if successful, False otherwise."""
+    """Run all benchmark steps sequentially."""
     model_name = model_config['name']
     server_name = server['name']
 
-    # Use provided logger or get one for this server
     if logger is None:
         logger = get_server_logger(server_name, model_name)
 
-    logger.info(f"🚀 Starting benchmarks for model: {model_name}")
-    logger.info(f"📡 Connecting to: {server['address']} ({server_name})")
+    logger.info(f"Starting benchmarks for model: {model_name}")
+    logger.info(f"Connecting to: {server['address']} ({server_name})")
 
-    # Discover benchmark scripts from remote server
     script_names = discover_benchmarks(server, logger)
 
     if not script_names:
-        logger.error("❌ No benchmark steps found. Ensure scripts follow naming convention: <step_index>_<benchmark_name>.sh")
+        logger.error("No benchmark steps found. Ensure scripts follow naming convention: <step_index>_<benchmark_name>.sh")
         return False
 
-    logger.info(f"📋 Found {len(script_names)} benchmark step(s):")
+    logger.info(f"Found {len(script_names)} benchmark step(s):")
     for script_name in script_names:
         benchmark_name = extract_benchmark_name(script_name)
         display_name = get_benchmark_display_name(benchmark_name)
         result_file = get_benchmark_result_file(benchmark_name)
-        logger.info(f"   • {display_name} → {result_file}")
+        logger.info(f"   - {display_name} -> {result_file}")
 
     all_success = True
     for script_name in script_names:
@@ -496,13 +427,13 @@ def run_benchmark(server: dict, model_config: dict, config: dict, force: bool = 
 
         success = run_benchmark_step(server, model_config, config, display_name, script_name, result_file, force, logger)
         if not success:
-            logger.warning(f"⚠️  Warning: {display_name} failed")
+            logger.warning(f"{display_name} failed")
             all_success = False
 
     if all_success:
-        logger.info("🎉 All benchmark steps completed successfully!")
+        logger.info("All benchmark steps completed successfully!")
     else:
-        logger.warning("⚠️  Some benchmark steps failed")
+        logger.warning("Some benchmark steps failed")
 
     return all_success
 
@@ -515,16 +446,14 @@ def download_single_file(server: dict, model_name: str, config: dict, remote_fil
     model_name_safe = model_name.replace('/', '_')
     server_name = server['name']
 
-    # Create local results directory
     local_results_dir = Path(expand_path(config['benchmark']['local_results_dir']))
     local_results_dir.mkdir(parents=True, exist_ok=True)
 
-    # Build local and remote paths
     local_file = f"{server_name}_{model_name_safe}_{local_prefix}"
     local_path = local_results_dir / local_file
     remote_path = f"server-benchmark/{remote_file}"
 
-    print(f"📥 Downloading {local_prefix} to: {local_path}")
+    print(f"Downloading {local_prefix} to: {local_path}")
 
     scp_cmd = [
         'scp',
@@ -538,35 +467,25 @@ def download_single_file(server: dict, model_name: str, config: dict, remote_fil
     try:
         subprocess.run(scp_cmd, check=True)
 
-        # Check if downloaded file is empty
         if local_path.stat().st_size == 0:
-            print(f"❌ Error: Downloaded {local_prefix} is empty (benchmark likely failed)")
-            # Remove the empty file
+            print(f"Error: Downloaded {local_prefix} is empty (benchmark likely failed)")
             local_path.unlink()
             return False
 
-        print(f"✅ {local_prefix} saved")
+        print(f"{local_prefix} saved")
         return True
     except subprocess.CalledProcessError as e:
-        print(f"⚠️  Warning: Failed to download {local_prefix}: {e}")
+        print(f"Warning: Failed to download {local_prefix}: {e}")
         return False
 
 
 def normalize_model_config(model) -> dict:
-    """Normalize model configuration to dict format.
-
-    Args:
-        model: Either a string (model name) or dict (model config)
-
-    Returns:
-        Dict with 'name' and optional 'tensor_parallel_size'
-    """
+    """Normalize model configuration to dict format."""
     if isinstance(model, str):
         return {'name': model, 'tensor_parallel_size': 1}
     elif isinstance(model, dict):
         if 'name' not in model:
             raise ValueError(f"Model config must have 'name' field: {model}")
-        # Set default tensor_parallel_size if not specified
         if 'tensor_parallel_size' not in model:
             model['tensor_parallel_size'] = 1
         return model
@@ -575,31 +494,25 @@ def normalize_model_config(model) -> dict:
 
 
 def run_benchmark_combination(server: dict, model_config: dict, config: dict, force: bool = False, logger: logging.Logger = None) -> tuple:
-    """Run a single server-model combination benchmark. Returns (server_name, model_name, success)."""
+    """Run a single server-model combination benchmark."""
     server_name = server['name']
     model_name = model_config['name']
 
-    # Use provided logger or get one for this server
     if logger is None:
         logger = get_server_logger(server_name, model_name)
 
-    # Run benchmark (with per-step skip logic)
     success = run_benchmark(server, model_config, config, force, logger)
-
     return (server_name, model_name, success)
 
 
 def run_server_benchmarks(server: dict, models: List, config: dict, force: bool = False) -> List[tuple]:
-    """Run all benchmarks for a single server sequentially. Returns list of (server_name, model_name, success)."""
+    """Run all benchmarks for a single server sequentially."""
     results = []
     server_name = server['name']
 
-    # Create logger for this server (no model context yet)
     logger = get_server_logger(server_name)
-
     logger.info(f"Starting benchmarks for server: {server_name}")
 
-    # Setup repository with logging
     if not setup_remote_repo(server, logger):
         logger.error(f"Failed to setup repository on {server_name}, skipping all benchmarks for this server")
         for model in models:
@@ -612,56 +525,19 @@ def run_server_benchmarks(server: dict, models: List, config: dict, force: bool 
         model_name = model_config['name']
 
         logger.info(f"Server: {server_name} | Model: {model_name}")
-
-        # Don't pass logger - let run_benchmark_combination create model-specific logger
         result = run_benchmark_combination(server, model_config, config, force)
         results.append(result)
 
     logger.info(f"Completed benchmarks for server: {server_name}")
-
     return results
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description='Run LLM benchmarks on remote servers via SSH for multiple server-model combinations'
-    )
-    parser.add_argument(
-        '--config',
-        default='config.yaml',
-        help='Path to configuration file (default: config.yaml)'
-    )
-    parser.add_argument(
-        '--force',
-        action='store_true',
-        help='Force benchmark even if results already exist'
-    )
-    parser.add_argument(
-        '--server',
-        help='Run benchmarks only for a specific server (by name)'
-    )
-    parser.add_argument(
-        '--model',
-        help='Run benchmarks only for a specific model'
-    )
-    parser.add_argument(
-        '--parallel',
-        action='store_true',
-        help='Run benchmarks on different servers in parallel (models on same server run sequentially)'
-    )
-    parser.add_argument(
-        '--max-workers',
-        type=int,
-        default=None,
-        help='Maximum number of parallel server benchmarks (default: number of servers)'
-    )
-
-    args = parser.parse_args()
-
+def handle_bench(args):
+    """Handle the bench command."""
     # Setup logging
     log_file_path = setup_logging()
     root_logger = logging.getLogger()
-    root_logger.info(f"📝 Logging to: {log_file_path}")
+    root_logger.info(f"Logging to: {log_file_path}")
     root_logger.info("")
 
     # Load and validate configuration
@@ -674,7 +550,7 @@ def main():
     if args.server:
         servers = [s for s in servers if s['name'] == args.server]
         if not servers:
-            root_logger.error(f"❌ Error: Server '{args.server}' not found in config.")
+            root_logger.error(f"Error: Server '{args.server}' not found in config.")
             sys.exit(1)
 
     # Build list of (server, models) tuples for parallel execution
@@ -684,9 +560,7 @@ def main():
     for server in servers:
         models = server['models']
 
-        # Filter models if specified
         if args.model:
-            # Handle both string and dict model formats
             filtered_models = []
             for m in models:
                 model_name = m if isinstance(m, str) else m.get('name')
@@ -694,7 +568,7 @@ def main():
                     filtered_models.append(m)
 
             if not filtered_models:
-                root_logger.warning(f"⚠️  Warning: Model '{args.model}' not found in server '{server['name']}'. Skipping this server.")
+                root_logger.warning(f"Warning: Model '{args.model}' not found in server '{server['name']}'. Skipping this server.")
                 continue
 
             models = filtered_models
@@ -703,70 +577,97 @@ def main():
         total_combinations += len(models)
 
     if not server_tasks:
-        root_logger.error("❌ Error: No server-model combinations to benchmark.")
+        root_logger.error("Error: No server-model combinations to benchmark.")
         sys.exit(1)
 
-    root_logger.info(f"📊 Running benchmarks for {total_combinations} server-model combination(s) across {len(server_tasks)} server(s)")
+    root_logger.info(f"Running benchmarks for {total_combinations} server-model combination(s) across {len(server_tasks)} server(s)")
     if args.parallel:
-        root_logger.info(f"🚀 Parallel mode: Servers will run in parallel (max workers: {args.max_workers or len(server_tasks)})")
+        root_logger.info(f"Parallel mode: Servers will run in parallel (max workers: {args.max_workers or len(server_tasks)})")
     else:
-        root_logger.info("⏳ Sequential mode: Servers will run one at a time")
+        root_logger.info("Sequential mode: Servers will run one at a time")
     root_logger.info("")
 
-    # Track results
     results = []
 
-    # Run benchmarks - either in parallel or sequentially
     if args.parallel:
-        # Parallel execution: each server runs in its own thread
         max_workers = args.max_workers or len(server_tasks)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all server benchmark tasks
             future_to_server = {
                 executor.submit(run_server_benchmarks, server, models, config, args.force): server['name']
                 for server, models in server_tasks
             }
 
-            # Collect results as they complete
             for future in as_completed(future_to_server):
                 server_name = future_to_server[future]
                 try:
                     server_results = future.result()
                     results.extend(server_results)
                 except Exception as exc:
-                    root_logger.error(f"❌ Server {server_name} generated an exception: {exc}")
-                    # Add failed results for all models on this server
+                    root_logger.error(f"Server {server_name} generated an exception: {exc}")
                     for server, models in server_tasks:
                         if server['name'] == server_name:
                             for model in models:
                                 results.append((server_name, model, False))
     else:
-        # Sequential execution
         for server, models in server_tasks:
             server_results = run_server_benchmarks(server, models, config, args.force)
             results.extend(server_results)
 
     # Print summary
-    root_logger.info("📋 SUMMARY")
+    root_logger.info("SUMMARY")
 
     successful = [r for r in results if r[2]]
     failed = [r for r in results if not r[2]]
 
-    root_logger.info(f"✅ Successful: {len(successful)}/{len(results)}")
+    root_logger.info(f"Successful: {len(successful)}/{len(results)}")
     if successful:
         for server_name, model, _ in successful:
-            root_logger.info(f"   - {server_name} × {model}")
+            root_logger.info(f"   - {server_name} x {model}")
 
     if failed:
         root_logger.info("")
-        root_logger.info(f"❌ Failed: {len(failed)}/{len(results)}")
+        root_logger.info(f"Failed: {len(failed)}/{len(results)}")
         for server_name, model, _ in failed:
-            root_logger.info(f"   - {server_name} × {model}")
+            root_logger.info(f"   - {server_name} x {model}")
 
     root_logger.info("")
-    root_logger.info("🎉 All done!")
-    root_logger.info(f"📝 Full logs saved to: {log_file_path}")
+    root_logger.info("All done!")
+    root_logger.info(f"Full logs saved to: {log_file_path}")
 
 
-if __name__ == '__main__':
-    main()
+def register_bench_command(subparsers):
+    """Register the bench subcommand."""
+    parser = subparsers.add_parser(
+        "bench",
+        help="Run LLM benchmarks on remote servers via SSH",
+    )
+    parser.add_argument(
+        '--config',
+        default='config.yaml',
+        help='Path to configuration file (default: config.yaml)',
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Force benchmark even if results already exist',
+    )
+    parser.add_argument(
+        '--server',
+        help='Run benchmarks only for a specific server (by name)',
+    )
+    parser.add_argument(
+        '--model',
+        help='Run benchmarks only for a specific model',
+    )
+    parser.add_argument(
+        '--parallel',
+        action='store_true',
+        help='Run benchmarks on different servers in parallel (models on same server run sequentially)',
+    )
+    parser.add_argument(
+        '--max-workers',
+        type=int,
+        default=None,
+        help='Maximum number of parallel server benchmarks (default: number of servers)',
+    )
+    parser.set_defaults(func=handle_bench)

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -4,8 +4,10 @@
 import argparse
 import sys
 
+from deplodock.commands.bench import register_bench_command
 from deplodock.commands.deploy.local import register_local_target
 from deplodock.commands.deploy.ssh import register_ssh_target
+from deplodock.commands.report import register_report_command
 
 
 def main():
@@ -18,6 +20,10 @@ def main():
 
     register_local_target(deploy_subparsers)
     register_ssh_target(deploy_subparsers)
+
+    # bench and report subcommands
+    register_bench_command(subparsers)
+    register_report_command(subparsers)
 
     args = parser.parse_args()
     args.func(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ description = "Deploy and benchmark LLM inference on GPU servers using vLLM"
 requires-python = ">=3.13"
 dependencies = [
     "huggingface_hub[cli,hf_transfer]",
+    "openpyxl",
+    "pandas",
     "pyyaml",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "deplodock"
 version = "0.1.0"
 description = "Deploy and benchmark LLM inference on GPU servers using vLLM"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
     "huggingface_hub[cli,hf_transfer]",
     "openpyxl",

--- a/tests/test_deploy_dryrun.py
+++ b/tests/test_deploy_dryrun.py
@@ -184,3 +184,27 @@ class TestCLIHelp:
         assert "--server" in stdout
         assert "--ssh-key" in stdout
         assert "--ssh-port" in stdout
+
+    def test_bench_help(self):
+        rc, stdout, _ = run_cli("bench", "--help")
+        assert rc == 0
+        assert "--config" in stdout
+        assert "--force" in stdout
+        assert "--server" in stdout
+        assert "--model" in stdout
+        assert "--parallel" in stdout
+        assert "--max-workers" in stdout
+
+    def test_report_help(self):
+        rc, stdout, _ = run_cli("report", "--help")
+        assert rc == 0
+        assert "--config" in stdout
+        assert "--results-dir" in stdout
+        assert "--output" in stdout
+
+    def test_top_level_help(self):
+        rc, stdout, _ = run_cli("--help")
+        assert rc == 0
+        assert "deploy" in stdout
+        assert "bench" in stdout
+        assert "report" in stdout


### PR DESCRIPTION
## Summary

- Migrate `run_remote_benchmark.py` → `deplodock/commands/bench/__init__.py` (accessible via `deplodock bench`)
- Migrate `generate_benchmark_report.py` → `deplodock/commands/report/__init__.py` (accessible via `deplodock report`)
- Add `pandas` and `openpyxl` to `pyproject.toml` dependencies
- Update `Makefile` targets to use new CLI entry points
- Add CLI help tests for `bench`, `report`, and top-level `--help`
- Update `README.md` and `CLAUDE.md` with new CLI usage

## Test plan

- [x] `pytest tests/ -v` — all 34 tests pass (including 3 new help tests)
- [x] `deplodock --help` shows `deploy`, `bench`, `report`
- [x] `deplodock bench --help` shows all benchmark options
- [x] `deplodock report --help` shows all report options

🤖 Generated with [Claude Code](https://claude.com/claude-code)