### PR TITLE
Add vm start/stop command for GCP flex-start VMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ pytest tests/test_recipe.py -v
 - `deplodock deploy ssh ...` — deploy to remote server via SSH
 - `deplodock bench ...` — deploy + benchmark + teardown on remote servers (uses deploy infrastructure)
 - `deplodock report ...` — generate Excel reports from benchmark results
+- `deplodock vm start gcp-flex-start ...` — start a GCP flex-start GPU VM
+- `deplodock vm stop gcp-flex-start ...` — stop a GCP flex-start GPU VM
 
 ## Key Make Targets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ pytest tests/test_recipe.py -v
 - `deplodock deploy ssh ...` — deploy to remote server via SSH
 - `deplodock bench ...` — deploy + benchmark + teardown on remote servers (uses deploy infrastructure)
 - `deplodock report ...` — generate Excel reports from benchmark results
-- `deplodock vm start gcp-flex-start ...` — start a GCP flex-start GPU VM
-- `deplodock vm stop gcp-flex-start ...` — stop a GCP flex-start GPU VM
+- `deplodock vm create gcp-flex-start ...` — create a GCP flex-start GPU VM
+- `deplodock vm delete gcp-flex-start ...` — delete a GCP flex-start GPU VM
 
 ## Key Make Targets
 

--- a/README.md
+++ b/README.md
@@ -135,33 +135,48 @@ python main.py deploy ssh --recipe <path> --server user@host [--variant <name>] 
 
 ## VM Management
 
-The `vm` command manages cloud GPU VM lifecycles. Currently supports GCP flex-start (which can take hours to provision capacity).
+The `vm` command manages cloud GPU VM lifecycles. Currently supports GCP flex-start, which provisions new GPU capacity using `--provisioning-model=FLEX_START` (can take hours). Instances are ephemeral — `delete` removes them entirely.
 
-### Start a VM
-
-```bash
-deplodock vm start gcp-flex-start --instance my-gpu-vm --zone us-central1-a
-deplodock vm start gcp-flex-start --instance my-gpu-vm --zone us-central1-a --wait-ssh
-deplodock vm start gcp-flex-start --instance my-gpu-vm --zone us-central1-a --timeout 7200 --dry-run
-```
-
-### Stop a VM
+### Create a VM
 
 ```bash
-deplodock vm stop gcp-flex-start --instance my-gpu-vm --zone us-central1-a
-deplodock vm stop gcp-flex-start --instance my-gpu-vm --zone us-central1-a --dry-run
+deplodock vm create gcp-flex-start --instance my-gpu-vm --zone us-central1-a --machine-type a2-highgpu-1g
+deplodock vm create gcp-flex-start --instance my-gpu-vm --zone us-central1-a --machine-type e2-micro --wait-ssh
+deplodock vm create gcp-flex-start --instance my-gpu-vm --zone us-central1-a --machine-type e2-micro --gcloud-args "--no-service-account --no-scopes" --dry-run
 ```
 
-### VM Flags
+### Delete a VM
+
+```bash
+deplodock vm delete gcp-flex-start --instance my-gpu-vm --zone us-central1-a
+deplodock vm delete gcp-flex-start --instance my-gpu-vm --zone us-central1-a --dry-run
+```
+
+### Create Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--instance` | (required) | GCP instance name |
 | `--zone` | (required) | GCP zone (e.g. us-central1-a) |
-| `--timeout` | 14400 (start) / 300 (stop) | Timeout in seconds |
+| `--machine-type` | (required) | Machine type (e.g. a2-highgpu-1g) |
+| `--max-run-duration` | `7d` | Max VM run time (10m–7d) |
+| `--request-valid-for-duration` | `2h` | How long to wait for capacity |
+| `--termination-action` | `DELETE` | Action when max-run-duration expires (`STOP` or `DELETE`) |
+| `--image-family` | `debian-12` | Boot disk image family |
+| `--image-project` | `debian-cloud` | Boot disk image project |
+| `--gcloud-args` | - | Extra args passed to `gcloud compute instances create` |
+| `--timeout` | `14400` | How long to poll for RUNNING status (seconds) |
+| `--wait-ssh` | false | Wait for SSH after VM is RUNNING |
+| `--wait-ssh-timeout` | `300` | SSH wait timeout in seconds |
 | `--dry-run` | false | Print commands without executing |
-| `--wait-ssh` | false | Wait for SSH connectivity after start |
-| `--wait-ssh-timeout` | 300 | SSH wait timeout in seconds |
+
+### Delete Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--instance` | (required) | GCP instance name |
+| `--zone` | (required) | GCP zone (e.g. us-central1-a) |
+| `--dry-run` | false | Print commands without executing |
 
 GCP project is inferred from `gcloud` config (no `--project` flag needed).
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,38 @@ python main.py deploy ssh --recipe <path> --server user@host [--variant <name>] 
 | `--ssh-key` | No | `~/.ssh/id_ed25519` | SSH key path |
 | `--ssh-port` | No | 22 | SSH port |
 
+## VM Management
+
+The `vm` command manages cloud GPU VM lifecycles. Currently supports GCP flex-start (which can take hours to provision capacity).
+
+### Start a VM
+
+```bash
+deplodock vm start gcp-flex-start --instance my-gpu-vm --zone us-central1-a
+deplodock vm start gcp-flex-start --instance my-gpu-vm --zone us-central1-a --wait-ssh
+deplodock vm start gcp-flex-start --instance my-gpu-vm --zone us-central1-a --timeout 7200 --dry-run
+```
+
+### Stop a VM
+
+```bash
+deplodock vm stop gcp-flex-start --instance my-gpu-vm --zone us-central1-a
+deplodock vm stop gcp-flex-start --instance my-gpu-vm --zone us-central1-a --dry-run
+```
+
+### VM Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--instance` | (required) | GCP instance name |
+| `--zone` | (required) | GCP zone (e.g. us-central1-a) |
+| `--timeout` | 14400 (start) / 300 (stop) | Timeout in seconds |
+| `--dry-run` | false | Print commands without executing |
+| `--wait-ssh` | false | Wait for SSH connectivity after start |
+| `--wait-ssh-timeout` | 300 | SSH wait timeout in seconds |
+
+GCP project is inferred from `gcloud` config (no `--project` flag needed).
+
 ## Running Tests
 
 ```bash
@@ -214,8 +246,11 @@ deplodock/
 │       │   └── ssh.py               # SSH target
 │       ├── bench/
 │       │   └── __init__.py          # Benchmark runner
-│       └── report/
-│           └── __init__.py          # Report generator
+│       ├── report/
+│       │   └── __init__.py          # Report generator
+│       └── vm/
+│           ├── __init__.py          # VM command registration
+│           └── gcp_flex_start.py    # GCP flex-start provider
 ├── recipes/                         # Model deploy recipes
 │   ├── GLM-4.6-FP8/
 │   ├── GLM-4.6/

--- a/deplodock/commands/vm/__init__.py
+++ b/deplodock/commands/vm/__init__.py
@@ -1,0 +1,45 @@
+"""VM lifecycle management: start/stop cloud GPU instances."""
+
+import subprocess
+import sys
+
+
+def run_shell_cmd(command, dry_run=False):
+    """Run a shell command and return (returncode, stdout, stderr).
+
+    Args:
+        command: list of command arguments
+        dry_run: if True, print the command instead of executing
+
+    Returns:
+        (returncode, stdout, stderr) tuple
+    """
+    if dry_run:
+        print(f"[dry-run] {' '.join(command)}")
+        return 0, "", ""
+
+    try:
+        result = subprocess.run(command, capture_output=True, text=True)
+        return result.returncode, result.stdout, result.stderr
+    except FileNotFoundError:
+        print(f"Error: '{command[0]}' not found. Is it installed and on PATH?", file=sys.stderr)
+        return 1, "", f"'{command[0]}' not found"
+
+
+def register_vm_command(subparsers):
+    """Register the 'vm' command with start/stop action subparsers."""
+    from deplodock.commands.vm.gcp_flex_start import register_start_target, register_stop_target
+
+    vm_parser = subparsers.add_parser("vm", help="Manage cloud VM instances")
+
+    action_subparsers = vm_parser.add_subparsers(dest="action", required=True)
+
+    # start action
+    start_parser = action_subparsers.add_parser("start", help="Start a VM instance")
+    start_subparsers = start_parser.add_subparsers(dest="provider", required=True)
+    register_start_target(start_subparsers)
+
+    # stop action
+    stop_parser = action_subparsers.add_parser("stop", help="Stop a VM instance")
+    stop_subparsers = stop_parser.add_subparsers(dest="provider", required=True)
+    register_stop_target(stop_subparsers)

--- a/deplodock/commands/vm/__init__.py
+++ b/deplodock/commands/vm/__init__.py
@@ -1,4 +1,4 @@
-"""VM lifecycle management: start/stop cloud GPU instances."""
+"""VM lifecycle management: create/delete cloud GPU instances."""
 
 import subprocess
 import sys
@@ -27,19 +27,19 @@ def run_shell_cmd(command, dry_run=False):
 
 
 def register_vm_command(subparsers):
-    """Register the 'vm' command with start/stop action subparsers."""
-    from deplodock.commands.vm.gcp_flex_start import register_start_target, register_stop_target
+    """Register the 'vm' command with create/delete action subparsers."""
+    from deplodock.commands.vm.gcp_flex_start import register_create_target, register_delete_target
 
     vm_parser = subparsers.add_parser("vm", help="Manage cloud VM instances")
 
     action_subparsers = vm_parser.add_subparsers(dest="action", required=True)
 
-    # start action
-    start_parser = action_subparsers.add_parser("start", help="Start a VM instance")
-    start_subparsers = start_parser.add_subparsers(dest="provider", required=True)
-    register_start_target(start_subparsers)
+    # create action
+    create_parser = action_subparsers.add_parser("create", help="Create a VM instance")
+    create_subparsers = create_parser.add_subparsers(dest="provider", required=True)
+    register_create_target(create_subparsers)
 
-    # stop action
-    stop_parser = action_subparsers.add_parser("stop", help="Stop a VM instance")
-    stop_subparsers = stop_parser.add_subparsers(dest="provider", required=True)
-    register_stop_target(stop_subparsers)
+    # delete action
+    delete_parser = action_subparsers.add_parser("delete", help="Delete a VM instance")
+    delete_subparsers = delete_parser.add_subparsers(dest="provider", required=True)
+    register_delete_target(delete_subparsers)

--- a/deplodock/commands/vm/gcp_flex_start.py
+++ b/deplodock/commands/vm/gcp_flex_start.py
@@ -1,0 +1,214 @@
+"""GCP flex-start provider: start/stop GPU VMs using gcloud compute."""
+
+import sys
+import time
+
+from deplodock.commands.vm import run_shell_cmd
+
+
+# ── Command builders ───────────────────────────────────────────────
+
+
+def _gcloud_start_cmd(instance, zone):
+    """Build gcloud command to start an instance."""
+    return ["gcloud", "compute", "instances", "start", instance, "--zone", zone]
+
+
+def _gcloud_stop_cmd(instance, zone):
+    """Build gcloud command to stop an instance."""
+    return ["gcloud", "compute", "instances", "stop", instance, "--zone", zone]
+
+
+def _gcloud_status_cmd(instance, zone):
+    """Build gcloud command to get instance status."""
+    return [
+        "gcloud", "compute", "instances", "describe", instance,
+        "--zone", zone, "--format", "value(status)",
+    ]
+
+
+def _gcloud_external_ip_cmd(instance, zone):
+    """Build gcloud command to get external IP."""
+    return [
+        "gcloud", "compute", "instances", "describe", instance,
+        "--zone", zone, "--format", "value(networkInterfaces[0].accessConfigs[0].natIP)",
+    ]
+
+
+def _gcloud_ssh_check_cmd(instance, zone):
+    """Build gcloud command to check SSH connectivity."""
+    return [
+        "gcloud", "compute", "ssh", instance,
+        "--zone", zone, "--command", "true",
+        "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
+        "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
+    ]
+
+
+# ── Core logic ─────────────────────────────────────────────────────
+
+
+def wait_for_status(instance, zone, target_status, timeout, interval=10, dry_run=False):
+    """Poll instance status until it matches target_status or timeout.
+
+    Returns:
+        True if target status reached, False on timeout.
+    """
+    if dry_run:
+        cmd = _gcloud_status_cmd(instance, zone)
+        print(f"[dry-run] Poll every {interval}s (up to {timeout}s): {' '.join(cmd)} -> {target_status}")
+        return True
+
+    elapsed = 0
+    while elapsed < timeout:
+        rc, stdout, _ = run_shell_cmd(_gcloud_status_cmd(instance, zone))
+        status = stdout.strip()
+        if rc == 0 and status == target_status:
+            return True
+        time.sleep(interval)
+        elapsed += interval
+
+    print(f"Timeout after {timeout}s waiting for status '{target_status}' (last: '{status}')", file=sys.stderr)
+    return False
+
+
+def wait_for_ssh(instance, zone, timeout=300, interval=10, dry_run=False):
+    """Poll SSH connectivity until success or timeout.
+
+    Returns:
+        True if SSH connected, False on timeout.
+    """
+    if dry_run:
+        cmd = _gcloud_ssh_check_cmd(instance, zone)
+        print(f"[dry-run] Poll SSH every {interval}s (up to {timeout}s): {' '.join(cmd)}")
+        return True
+
+    elapsed = 0
+    while elapsed < timeout:
+        rc, _, _ = run_shell_cmd(_gcloud_ssh_check_cmd(instance, zone))
+        if rc == 0:
+            return True
+        time.sleep(interval)
+        elapsed += interval
+
+    print(f"Timeout after {timeout}s waiting for SSH connectivity", file=sys.stderr)
+    return False
+
+
+def start_instance(instance, zone, timeout=14400, wait_ssh=False, wait_ssh_timeout=300, dry_run=False):
+    """Start a GCP instance and optionally wait for SSH.
+
+    Steps:
+        1. Issue gcloud compute instances start
+        2. Wait for RUNNING status (up to timeout)
+        3. Print external IP
+        4. Optionally wait for SSH connectivity
+    """
+    print(f"Starting instance '{instance}' in zone '{zone}'...")
+
+    rc, stdout, stderr = run_shell_cmd(_gcloud_start_cmd(instance, zone), dry_run=dry_run)
+    if rc != 0:
+        print(f"Failed to start instance: {stderr.strip()}", file=sys.stderr)
+        return False
+
+    print(f"Waiting for instance to reach RUNNING status (timeout: {timeout}s)...")
+    if not wait_for_status(instance, zone, "RUNNING", timeout, dry_run=dry_run):
+        return False
+    print("Instance is RUNNING.")
+
+    # Get and print external IP
+    rc, stdout, _ = run_shell_cmd(_gcloud_external_ip_cmd(instance, zone), dry_run=dry_run)
+    if rc == 0:
+        ip = stdout.strip()
+        if ip:
+            print(f"External IP: {ip}")
+        elif not dry_run:
+            print("Warning: No external IP found.")
+
+    if wait_ssh:
+        print(f"Waiting for SSH connectivity (timeout: {wait_ssh_timeout}s)...")
+        if not wait_for_ssh(instance, zone, timeout=wait_ssh_timeout, dry_run=dry_run):
+            return False
+        print("SSH is ready.")
+
+    return True
+
+
+def stop_instance(instance, zone, timeout=300, dry_run=False):
+    """Stop a GCP instance and wait for TERMINATED status.
+
+    Steps:
+        1. Issue gcloud compute instances stop
+        2. Wait for TERMINATED status (up to timeout)
+    """
+    print(f"Stopping instance '{instance}' in zone '{zone}'...")
+
+    rc, stdout, stderr = run_shell_cmd(_gcloud_stop_cmd(instance, zone), dry_run=dry_run)
+    if rc != 0:
+        print(f"Failed to stop instance: {stderr.strip()}", file=sys.stderr)
+        return False
+
+    print(f"Waiting for instance to reach TERMINATED status (timeout: {timeout}s)...")
+    if not wait_for_status(instance, zone, "TERMINATED", timeout, dry_run=dry_run):
+        return False
+    print("Instance is TERMINATED.")
+
+    return True
+
+
+# ── CLI handlers ───────────────────────────────────────────────────
+
+
+def handle_start(args):
+    """CLI handler for 'vm start gcp-flex-start'."""
+    success = start_instance(
+        instance=args.instance,
+        zone=args.zone,
+        timeout=args.timeout,
+        wait_ssh=args.wait_ssh,
+        wait_ssh_timeout=args.wait_ssh_timeout,
+        dry_run=args.dry_run,
+    )
+    if not success:
+        sys.exit(1)
+
+
+def handle_stop(args):
+    """CLI handler for 'vm stop gcp-flex-start'."""
+    success = stop_instance(
+        instance=args.instance,
+        zone=args.zone,
+        timeout=args.timeout,
+        dry_run=args.dry_run,
+    )
+    if not success:
+        sys.exit(1)
+
+
+# ── Registration ───────────────────────────────────────────────────
+
+
+def _add_common_args(parser):
+    """Add arguments shared by start and stop."""
+    parser.add_argument("--instance", required=True, help="GCP instance name")
+    parser.add_argument("--zone", required=True, help="GCP zone (e.g. us-central1-a)")
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
+    parser.add_argument("--timeout", type=int, help="Timeout in seconds")
+
+
+def register_start_target(subparsers):
+    """Register the gcp-flex-start provider under 'vm start'."""
+    parser = subparsers.add_parser("gcp-flex-start", help="Start a GCP flex-start GPU VM")
+    _add_common_args(parser)
+    parser.set_defaults(timeout=14400)
+    parser.add_argument("--wait-ssh", action="store_true", help="Wait for SSH connectivity after start")
+    parser.add_argument("--wait-ssh-timeout", type=int, default=300, help="SSH wait timeout in seconds (default: 300)")
+    parser.set_defaults(func=handle_start)
+
+
+def register_stop_target(subparsers):
+    """Register the gcp-flex-start provider under 'vm stop'."""
+    parser = subparsers.add_parser("gcp-flex-start", help="Stop a GCP flex-start GPU VM")
+    _add_common_args(parser)
+    parser.set_defaults(timeout=300)
+    parser.set_defaults(func=handle_stop)

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -8,6 +8,7 @@ from deplodock.commands.bench import register_bench_command
 from deplodock.commands.deploy.local import register_local_target
 from deplodock.commands.deploy.ssh import register_ssh_target
 from deplodock.commands.report import register_report_command
+from deplodock.commands.vm import register_vm_command
 
 
 def main():
@@ -24,6 +25,7 @@ def main():
     # bench and report subcommands
     register_bench_command(subparsers)
     register_report_command(subparsers)
+    register_vm_command(subparsers)
 
     args = parser.parse_args()
     args.func(args)

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -25,8 +25,8 @@ Test the full CLI pipeline end-to-end by invoking `deplodock` as a subprocess wi
 |------|--------|
 | `test_deploy_dryrun.py` | `deploy ssh`, `deploy local` — dry-run output, command sequence, variant resolution, teardown, CLI help |
 | `test_bench_dryrun.py` | `bench` — dry-run output, deploy→benchmark→teardown sequence, server/recipe filtering, CLI help |
-| `test_vm_gcp_flex_start.py` | `_gcloud_*_cmd()` — GCP flex-start command builder functions |
-| `test_vm_dryrun.py` | `vm start/stop gcp-flex-start` — dry-run output, argparse validation, CLI help |
+| `test_vm_gcp_flex_start.py` | `_gcloud_*_cmd()` — GCP flex-start command builder functions (create, delete, status, IP, SSH) |
+| `test_vm_dryrun.py` | `vm create/delete gcp-flex-start` — dry-run output, argparse validation, CLI help |
 
 CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench_config`** (a factory for temporary `config.yaml` files). Both are defined in `conftest.py`.
 

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -25,6 +25,8 @@ Test the full CLI pipeline end-to-end by invoking `deplodock` as a subprocess wi
 |------|--------|
 | `test_deploy_dryrun.py` | `deploy ssh`, `deploy local` — dry-run output, command sequence, variant resolution, teardown, CLI help |
 | `test_bench_dryrun.py` | `bench` — dry-run output, deploy→benchmark→teardown sequence, server/recipe filtering, CLI help |
+| `test_vm_gcp_flex_start.py` | `_gcloud_*_cmd()` — GCP flex-start command builder functions |
+| `test_vm_dryrun.py` | `vm start/stop gcp-flex-start` — dry-run output, argparse validation, CLI help |
 
 CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench_config`** (a factory for temporary `config.yaml` files). Both are defined in `conftest.py`.
 

--- a/tests/test_vm_dryrun.py
+++ b/tests/test_vm_dryrun.py
@@ -1,70 +1,101 @@
 """Dry-run end-to-end tests for the vm command."""
 
 
-# ── Dry-run start/stop ─────────────────────────────────────────────
+# ── Dry-run create/delete ─────────────────────────────────────────
 
 
-def test_vm_start_dry_run(run_cli):
+def test_vm_create_dry_run(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "start", "gcp-flex-start",
+        "vm", "create", "gcp-flex-start",
         "--instance", "my-gpu-vm",
         "--zone", "us-central1-a",
+        "--machine-type", "a2-highgpu-1g",
         "--dry-run",
     )
     assert rc == 0
     assert "[dry-run]" in stdout
-    assert "gcloud compute instances start" in stdout
+    assert "gcloud compute instances create" in stdout
     assert "my-gpu-vm" in stdout
     assert "us-central1-a" in stdout
+    assert "--provisioning-model=FLEX_START" in stdout
+    assert "--machine-type" in stdout
 
 
-def test_vm_start_dry_run_with_wait_ssh(run_cli):
+def test_vm_create_dry_run_with_wait_ssh(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "start", "gcp-flex-start",
+        "vm", "create", "gcp-flex-start",
         "--instance", "my-gpu-vm",
         "--zone", "us-central1-a",
+        "--machine-type", "e2-micro",
         "--wait-ssh",
         "--dry-run",
     )
     assert rc == 0
     assert "[dry-run]" in stdout
-    assert "gcloud compute instances start" in stdout
+    assert "gcloud compute instances create" in stdout
     assert "gcloud compute ssh" in stdout
     assert "Waiting for SSH connectivity" in stdout
 
 
-def test_vm_stop_dry_run(run_cli):
+def test_vm_create_dry_run_with_gcloud_args(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "stop", "gcp-flex-start",
+        "vm", "create", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+        "--zone", "us-central1-a",
+        "--machine-type", "e2-micro",
+        "--gcloud-args", "--no-service-account --no-scopes",
+        "--dry-run",
+    )
+    assert rc == 0
+    assert "--no-service-account" in stdout
+    assert "--no-scopes" in stdout
+
+
+def test_vm_delete_dry_run(run_cli):
+    rc, stdout, _ = run_cli(
+        "vm", "delete", "gcp-flex-start",
         "--instance", "my-gpu-vm",
         "--zone", "us-central1-a",
         "--dry-run",
     )
     assert rc == 0
     assert "[dry-run]" in stdout
-    assert "gcloud compute instances stop" in stdout
+    assert "gcloud compute instances delete" in stdout
+    assert "--quiet" in stdout
     assert "my-gpu-vm" in stdout
 
 
 # ── Argparse validation ────────────────────────────────────────────
 
 
-def test_vm_start_missing_instance(run_cli):
+def test_vm_create_missing_instance(run_cli):
     rc, _, stderr = run_cli(
-        "vm", "start", "gcp-flex-start",
+        "vm", "create", "gcp-flex-start",
         "--zone", "us-central1-a",
+        "--machine-type", "e2-micro",
     )
     assert rc != 0
     assert "--instance" in stderr
 
 
-def test_vm_start_missing_zone(run_cli):
+def test_vm_create_missing_zone(run_cli):
     rc, _, stderr = run_cli(
-        "vm", "start", "gcp-flex-start",
+        "vm", "create", "gcp-flex-start",
         "--instance", "my-gpu-vm",
+        "--machine-type", "e2-micro",
     )
     assert rc != 0
     assert "--zone" in stderr
+
+
+def test_vm_create_missing_machine_type(run_cli):
+    rc, _, stderr = run_cli(
+        "vm", "create", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+        "--zone", "us-central1-a",
+    )
+    assert rc != 0
+    assert "--machine-type" in stderr
 
 
 # ── CLI help ───────────────────────────────────────────────────────
@@ -73,33 +104,35 @@ def test_vm_start_missing_zone(run_cli):
 def test_vm_help(run_cli):
     rc, stdout, _ = run_cli("vm", "--help")
     assert rc == 0
-    assert "start" in stdout
-    assert "stop" in stdout
+    assert "create" in stdout
+    assert "delete" in stdout
 
 
-def test_vm_start_help(run_cli):
-    rc, stdout, _ = run_cli("vm", "start", "--help")
+def test_vm_create_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "create", "--help")
     assert rc == 0
     assert "gcp-flex-start" in stdout
 
 
-def test_vm_start_gcp_flex_start_help(run_cli):
-    rc, stdout, _ = run_cli("vm", "start", "gcp-flex-start", "--help")
+def test_vm_create_gcp_flex_start_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "create", "gcp-flex-start", "--help")
     assert rc == 0
     assert "--instance" in stdout
     assert "--zone" in stdout
+    assert "--machine-type" in stdout
     assert "--timeout" in stdout
     assert "--dry-run" in stdout
     assert "--wait-ssh" in stdout
     assert "--wait-ssh-timeout" in stdout
+    assert "--max-run-duration" in stdout
+    assert "--gcloud-args" in stdout
 
 
-def test_vm_stop_gcp_flex_start_help(run_cli):
-    rc, stdout, _ = run_cli("vm", "stop", "gcp-flex-start", "--help")
+def test_vm_delete_gcp_flex_start_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "delete", "gcp-flex-start", "--help")
     assert rc == 0
     assert "--instance" in stdout
     assert "--zone" in stdout
-    assert "--timeout" in stdout
     assert "--dry-run" in stdout
 
 

--- a/tests/test_vm_dryrun.py
+++ b/tests/test_vm_dryrun.py
@@ -51,6 +51,20 @@ def test_vm_create_dry_run_with_gcloud_args(run_cli):
     assert "--no-scopes" in stdout
 
 
+def test_vm_create_dry_run_with_ssh_gateway(run_cli):
+    rc, stdout, _ = run_cli(
+        "vm", "create", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+        "--zone", "us-central1-a",
+        "--machine-type", "e2-micro",
+        "--wait-ssh",
+        "--ssh-gateway", "gcp-ssh-gateway",
+        "--dry-run",
+    )
+    assert rc == 0
+    assert "ProxyJump=gcp-ssh-gateway" in stdout
+
+
 def test_vm_delete_dry_run(run_cli):
     rc, stdout, _ = run_cli(
         "vm", "delete", "gcp-flex-start",
@@ -126,6 +140,7 @@ def test_vm_create_gcp_flex_start_help(run_cli):
     assert "--wait-ssh-timeout" in stdout
     assert "--max-run-duration" in stdout
     assert "--gcloud-args" in stdout
+    assert "--ssh-gateway" in stdout
 
 
 def test_vm_delete_gcp_flex_start_help(run_cli):

--- a/tests/test_vm_dryrun.py
+++ b/tests/test_vm_dryrun.py
@@ -1,0 +1,109 @@
+"""Dry-run end-to-end tests for the vm command."""
+
+
+# ── Dry-run start/stop ─────────────────────────────────────────────
+
+
+def test_vm_start_dry_run(run_cli):
+    rc, stdout, _ = run_cli(
+        "vm", "start", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+        "--zone", "us-central1-a",
+        "--dry-run",
+    )
+    assert rc == 0
+    assert "[dry-run]" in stdout
+    assert "gcloud compute instances start" in stdout
+    assert "my-gpu-vm" in stdout
+    assert "us-central1-a" in stdout
+
+
+def test_vm_start_dry_run_with_wait_ssh(run_cli):
+    rc, stdout, _ = run_cli(
+        "vm", "start", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+        "--zone", "us-central1-a",
+        "--wait-ssh",
+        "--dry-run",
+    )
+    assert rc == 0
+    assert "[dry-run]" in stdout
+    assert "gcloud compute instances start" in stdout
+    assert "gcloud compute ssh" in stdout
+    assert "Waiting for SSH connectivity" in stdout
+
+
+def test_vm_stop_dry_run(run_cli):
+    rc, stdout, _ = run_cli(
+        "vm", "stop", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+        "--zone", "us-central1-a",
+        "--dry-run",
+    )
+    assert rc == 0
+    assert "[dry-run]" in stdout
+    assert "gcloud compute instances stop" in stdout
+    assert "my-gpu-vm" in stdout
+
+
+# ── Argparse validation ────────────────────────────────────────────
+
+
+def test_vm_start_missing_instance(run_cli):
+    rc, _, stderr = run_cli(
+        "vm", "start", "gcp-flex-start",
+        "--zone", "us-central1-a",
+    )
+    assert rc != 0
+    assert "--instance" in stderr
+
+
+def test_vm_start_missing_zone(run_cli):
+    rc, _, stderr = run_cli(
+        "vm", "start", "gcp-flex-start",
+        "--instance", "my-gpu-vm",
+    )
+    assert rc != 0
+    assert "--zone" in stderr
+
+
+# ── CLI help ───────────────────────────────────────────────────────
+
+
+def test_vm_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "--help")
+    assert rc == 0
+    assert "start" in stdout
+    assert "stop" in stdout
+
+
+def test_vm_start_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "start", "--help")
+    assert rc == 0
+    assert "gcp-flex-start" in stdout
+
+
+def test_vm_start_gcp_flex_start_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "start", "gcp-flex-start", "--help")
+    assert rc == 0
+    assert "--instance" in stdout
+    assert "--zone" in stdout
+    assert "--timeout" in stdout
+    assert "--dry-run" in stdout
+    assert "--wait-ssh" in stdout
+    assert "--wait-ssh-timeout" in stdout
+
+
+def test_vm_stop_gcp_flex_start_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "stop", "gcp-flex-start", "--help")
+    assert rc == 0
+    assert "--instance" in stdout
+    assert "--zone" in stdout
+    assert "--timeout" in stdout
+    assert "--dry-run" in stdout
+
+
+def test_top_level_help_includes_vm(run_cli):
+    rc, stdout, _ = run_cli("--help")
+    assert rc == 0
+    assert "vm" in stdout

--- a/tests/test_vm_gcp_flex_start.py
+++ b/tests/test_vm_gcp_flex_start.py
@@ -85,3 +85,14 @@ def test_gcloud_ssh_check_cmd():
         "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
         "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
     ]
+
+
+def test_gcloud_ssh_check_cmd_with_gateway():
+    cmd = _gcloud_ssh_check_cmd("my-vm", "us-central1-a", ssh_gateway="gcp-ssh-gateway")
+    assert cmd == [
+        "gcloud", "compute", "ssh", "my-vm",
+        "--zone", "us-central1-a", "--command", "true",
+        "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
+        "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
+        "--ssh-flag=-o", "--ssh-flag=ProxyJump=gcp-ssh-gateway",
+    ]

--- a/tests/test_vm_gcp_flex_start.py
+++ b/tests/test_vm_gcp_flex_start.py
@@ -1,8 +1,8 @@
 """Unit tests for GCP flex-start command builders."""
 
 from deplodock.commands.vm.gcp_flex_start import (
-    _gcloud_start_cmd,
-    _gcloud_stop_cmd,
+    _gcloud_create_cmd,
+    _gcloud_delete_cmd,
     _gcloud_status_cmd,
     _gcloud_external_ip_cmd,
     _gcloud_ssh_check_cmd,
@@ -12,14 +12,52 @@ from deplodock.commands.vm.gcp_flex_start import (
 # ── Command builder tests ─────────────────────────────────────────
 
 
-def test_gcloud_start_cmd():
-    cmd = _gcloud_start_cmd("my-vm", "us-central1-a")
-    assert cmd == ["gcloud", "compute", "instances", "start", "my-vm", "--zone", "us-central1-a"]
+def test_gcloud_create_cmd():
+    cmd = _gcloud_create_cmd("my-vm", "us-central1-a", "a2-highgpu-1g")
+    assert cmd == [
+        "gcloud", "compute", "instances", "create", "my-vm",
+        "--zone", "us-central1-a",
+        "--machine-type", "a2-highgpu-1g",
+        "--provisioning-model=FLEX_START",
+        "--maintenance-policy=TERMINATE",
+        "--reservation-affinity=none",
+        "--max-run-duration", "7d",
+        "--instance-termination-action=DELETE",
+        "--image-family", "debian-12",
+        "--image-project", "debian-cloud",
+        "--request-valid-for-duration", "2h",
+    ]
 
 
-def test_gcloud_stop_cmd():
-    cmd = _gcloud_stop_cmd("my-vm", "us-central1-a")
-    assert cmd == ["gcloud", "compute", "instances", "stop", "my-vm", "--zone", "us-central1-a"]
+def test_gcloud_create_cmd_with_gcloud_args():
+    cmd = _gcloud_create_cmd(
+        "my-vm", "us-central1-a", "e2-micro",
+        extra_gcloud_args="--no-service-account --no-scopes",
+    )
+    assert cmd[-2:] == ["--no-service-account", "--no-scopes"]
+
+
+def test_gcloud_create_cmd_custom_options():
+    cmd = _gcloud_create_cmd(
+        "my-vm", "us-central1-a", "e2-micro",
+        max_run_duration="1h",
+        termination_action="STOP",
+        image_family="ubuntu-2204-lts",
+        image_project="ubuntu-os-cloud",
+    )
+    assert "--max-run-duration" in cmd
+    idx = cmd.index("--max-run-duration")
+    assert cmd[idx + 1] == "1h"
+    assert "--instance-termination-action=STOP" in cmd
+    idx = cmd.index("--image-family")
+    assert cmd[idx + 1] == "ubuntu-2204-lts"
+    idx = cmd.index("--image-project")
+    assert cmd[idx + 1] == "ubuntu-os-cloud"
+
+
+def test_gcloud_delete_cmd():
+    cmd = _gcloud_delete_cmd("my-vm", "us-central1-a")
+    assert cmd == ["gcloud", "compute", "instances", "delete", "my-vm", "--zone", "us-central1-a", "--quiet"]
 
 
 def test_gcloud_status_cmd():

--- a/tests/test_vm_gcp_flex_start.py
+++ b/tests/test_vm_gcp_flex_start.py
@@ -1,0 +1,49 @@
+"""Unit tests for GCP flex-start command builders."""
+
+from deplodock.commands.vm.gcp_flex_start import (
+    _gcloud_start_cmd,
+    _gcloud_stop_cmd,
+    _gcloud_status_cmd,
+    _gcloud_external_ip_cmd,
+    _gcloud_ssh_check_cmd,
+)
+
+
+# ── Command builder tests ─────────────────────────────────────────
+
+
+def test_gcloud_start_cmd():
+    cmd = _gcloud_start_cmd("my-vm", "us-central1-a")
+    assert cmd == ["gcloud", "compute", "instances", "start", "my-vm", "--zone", "us-central1-a"]
+
+
+def test_gcloud_stop_cmd():
+    cmd = _gcloud_stop_cmd("my-vm", "us-central1-a")
+    assert cmd == ["gcloud", "compute", "instances", "stop", "my-vm", "--zone", "us-central1-a"]
+
+
+def test_gcloud_status_cmd():
+    cmd = _gcloud_status_cmd("my-vm", "us-central1-a")
+    assert cmd == [
+        "gcloud", "compute", "instances", "describe", "my-vm",
+        "--zone", "us-central1-a", "--format", "value(status)",
+    ]
+
+
+def test_gcloud_external_ip_cmd():
+    cmd = _gcloud_external_ip_cmd("my-vm", "us-central1-a")
+    assert cmd == [
+        "gcloud", "compute", "instances", "describe", "my-vm",
+        "--zone", "us-central1-a",
+        "--format", "value(networkInterfaces[0].accessConfigs[0].natIP)",
+    ]
+
+
+def test_gcloud_ssh_check_cmd():
+    cmd = _gcloud_ssh_check_cmd("my-vm", "us-central1-a")
+    assert cmd == [
+        "gcloud", "compute", "ssh", "my-vm",
+        "--zone", "us-central1-a", "--command", "true",
+        "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
+        "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
+    ]


### PR DESCRIPTION
## Summary
- Adds `deplodock vm start/stop gcp-flex-start` commands to manage GCP GPU VM lifecycles via `gcloud`
- Supports dry-run mode, configurable timeouts (4h default for start, 5min for stop), and optional `--wait-ssh` polling
- Architecture follows existing deploy pattern (`vm` → `start`/`stop` action → `gcp-flex-start` provider) for future provider extensibility

## Test plan
- [x] 5 unit tests for gcloud command builders (`test_vm_gcp_flex_start.py`)
- [x] 10 CLI dry-run tests covering start, stop, wait-ssh, argparse validation, and help at every level (`test_vm_dryrun.py`)
- [x] All 54 tests pass (`pytest tests/ -v`)
- [ ] Manual dry-run verification: `deplodock vm start gcp-flex-start --instance my-vm --zone us-central1-a --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)