### PR TITLE
Move benchmark params from config.yaml into recipe files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,20 @@ backend:
     gpu_memory_utilization: 0.9
     extra_args: "--max-num-seqs 512 --max-model-len 16384"
 
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 8000
+  random_output_len: 8000
+
 variants:
   8xH200: {}                    # Uses defaults
   8xH100:
     backend:
       vllm:
         extra_args: "--max-model-len 8192"  # Override for this hardware
+    benchmark:                              # Per-variant benchmark override
+      max_concurrency: 64
 ```
 
 ### Variant Naming
@@ -207,21 +215,15 @@ benchmark:
   local_results_dir: "results"
   model_dir: "/hf_models"
 
-benchmark_params:
-  max_concurrency: 128
-  num_prompts: 256
-  random_input_len: 8000
-  random_output_len: 8000
-
 servers:
   - name: "rtx4090_x_1"
-    address: "riftuser@142.214.185.165"
     ssh_key: "~/.ssh/id_ed25519"
-    port: 22
     recipes:
       - recipe: "recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ"
         variant: "RTX4090"
 ```
+
+Benchmark parameters (`max_concurrency`, `num_prompts`, `random_input_len`, `random_output_len`) are defined per-recipe in the recipe's `benchmark` section, not in `config.yaml`.
 
 ### Run Benchmarks
 

--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,8 @@ servers:
     recipes:
       - recipe: "recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ"
         variant: "RTX5090"
+  - name: "pro6000_x_1"
+    ssh_key: "~/.ssh/id_ed25519"
+    recipes:
+      - recipe: "recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ"
+        variant: "Pro6000"

--- a/config.yaml
+++ b/config.yaml
@@ -5,13 +5,6 @@ benchmark:
   local_results_dir: "results"
   model_dir: "/hf_models"
 
-# Benchmark parameters (required)
-benchmark_params:
-  max_concurrency: 128
-  num_prompts: 256
-  random_input_len: 8000
-  random_output_len: 8000
-
 # GPU Pricing ($ per hour per GPU)
 pricing:
   pro6000: 0.93

--- a/recipes/GLM-4.5-Air-AWQ-4bit/recipe.yaml
+++ b/recipes/GLM-4.5-Air-AWQ-4bit/recipe.yaml
@@ -19,9 +19,15 @@ variants:
   B200:
     gpu: "NVIDIA B200"
     gpu_count: 1
+    benchmark:
+      max_concurrency: 256
+      num_prompts: 512
   H200:
     gpu: "NVIDIA H200 141GB"
     gpu_count: 1
+    benchmark:
+      max_concurrency: 256
+      num_prompts: 512
   H100:
     gpu: "NVIDIA H100 80GB"
     gpu_count: 1

--- a/recipes/GLM-4.5-Air-AWQ-4bit/recipe.yaml
+++ b/recipes/GLM-4.5-Air-AWQ-4bit/recipe.yaml
@@ -9,6 +9,12 @@ backend:
     gpu_memory_utilization: 0.9
     extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 16384 --max-num-seqs 256 --kv-cache-dtype fp8"
 
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 8000
+  random_output_len: 8000
+
 variants:
   B200:
     gpu: "NVIDIA B200"
@@ -21,31 +27,31 @@ variants:
     gpu_count: 1
     backend:
       vllm:
-        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 8192 --max-num-seqs 256 --enable-expert-parallel --kv-cache-dtype fp8"
+        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 16384 --max-num-seqs 256 --enable-expert-parallel --kv-cache-dtype fp8"
   Pro6000:
     gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
     gpu_count: 1
     backend:
       vllm:
-        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 8192 --max-num-seqs 256 --enable-expert-parallel --kv-cache-dtype fp8"
+        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 16384 --max-num-seqs 256 --enable-expert-parallel --kv-cache-dtype fp8"
   4xRTX5090:
     gpu: "NVIDIA GeForce RTX 5090"
     gpu_count: 4
     backend:
       vllm:
         pipeline_parallel_size: 4
-        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 8192 --enable-expert-parallel --kv-cache-dtype fp8"
+        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 16384 --enable-expert-parallel --kv-cache-dtype fp8"
   4xRTX4090:
     gpu: "NVIDIA GeForce RTX 4090"
     gpu_count: 4
     backend:
       vllm:
         pipeline_parallel_size: 4
-        extra_args: "--dtype float16 --tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 8192 --enable-expert-parallel"
+        extra_args: "--dtype float16 --tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 16384 --enable-expert-parallel"
   2xL40S:
     gpu: "NVIDIA L40S"
     gpu_count: 2
     backend:
       vllm:
         pipeline_parallel_size: 2
-        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 8192 --enable-expert-parallel --kv-cache-dtype fp8"
+        extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --max-model-len 16384 --enable-expert-parallel --kv-cache-dtype fp8"

--- a/recipes/GLM-4.6-FP8/recipe.yaml
+++ b/recipes/GLM-4.6-FP8/recipe.yaml
@@ -9,6 +9,12 @@ backend:
     gpu_memory_utilization: 0.9
     extra_args: "--max-num-seqs 512 --max-model-len 16384 --kv-cache-dtype fp8"
 
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 8000
+  random_output_len: 8000
+
 variants:
   8xH200:
     gpu: "NVIDIA H200 141GB"
@@ -24,10 +30,10 @@ variants:
     gpu_count: 8
     backend:
       vllm:
-        extra_args: "--max-num-seqs 256 --max-model-len 8192 --kv-cache-dtype fp8"
+        extra_args: "--max-num-seqs 256 --max-model-len 16384 --kv-cache-dtype fp8"
   8xPro6000:
     gpu: "NVIDIA RTX PRO 6000 Server Edition"
     gpu_count: 8
     backend:
       vllm:
-        extra_args: "--max-num-seqs 256 --max-model-len 8192 --kv-cache-dtype fp8"
+        extra_args: "--max-num-seqs 256 --max-model-len 16384 --kv-cache-dtype fp8"

--- a/recipes/GLM-4.6-FP8/recipe.yaml
+++ b/recipes/GLM-4.6-FP8/recipe.yaml
@@ -19,12 +19,18 @@ variants:
   8xH200:
     gpu: "NVIDIA H200 141GB"
     gpu_count: 8
+    benchmark:
+      max_concurrency: 256
+      num_prompts: 512
   8xB200:
     gpu: "NVIDIA B200"
     gpu_count: 8
     backend:
       vllm:
         extra_args: "--max-num-seqs 512 --max-model-len 16384 --kv-cache-dtype fp8 --enable-expert-parallel"
+    benchmark:
+      max_concurrency: 256
+      num_prompts: 512
   8xH100:
     gpu: "NVIDIA H100 80GB"
     gpu_count: 8
@@ -37,3 +43,6 @@ variants:
     backend:
       vllm:
         extra_args: "--max-num-seqs 256 --max-model-len 16384 --kv-cache-dtype fp8"
+    benchmark:
+      max_concurrency: 64
+      num_prompts: 128

--- a/recipes/Meta-Llama-3.3-70B-Instruct-AWQ-INT4/recipe.yaml
+++ b/recipes/Meta-Llama-3.3-70B-Instruct-AWQ-INT4/recipe.yaml
@@ -9,6 +9,12 @@ backend:
     gpu_memory_utilization: 0.9
     extra_args: "--max-model-len 8192 --kv-cache-dtype fp8"
 
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 4000
+  random_output_len: 4000
+
 variants:
   2xRTX4090:
     gpu: "NVIDIA GeForce RTX 4090"
@@ -28,4 +34,3 @@ variants:
     backend:
       vllm:
         pipeline_parallel_size: 1
-        extra_args: "--max-model-len 2048"

--- a/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -9,6 +9,12 @@ backend:
     gpu_memory_utilization: 0.9
     extra_args: "--max-model-len 8192"
 
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 4000
+  random_output_len: 4000
+
 variants:
 #  RTX4090:
 #    gpu: "NVIDIA GeForce RTX 4090"
@@ -16,9 +22,9 @@ variants:
   RTX5090:
     gpu: "NVIDIA GeForce RTX 5090"
     gpu_count: 1
-#  Pro6000:
-#    gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
-#    gpu_count: 1
+  Pro6000:
+    gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
+    gpu_count: 1
 #  L40S:
 #    gpu: "NVIDIA L40S"
 #    gpu_count: 1

--- a/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -16,15 +16,15 @@ benchmark:
   random_output_len: 4000
 
 variants:
-#  RTX4090:
-#    gpu: "NVIDIA GeForce RTX 4090"
-#    gpu_count: 1
+  RTX4090:
+    gpu: "NVIDIA GeForce RTX 4090"
+    gpu_count: 1
   RTX5090:
     gpu: "NVIDIA GeForce RTX 5090"
     gpu_count: 1
   Pro6000:
-    gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
+    gpu: "NVIDIA RTX PRO 6000 Server Edition"
     gpu_count: 1
-#  L40S:
-#    gpu: "NVIDIA L40S"
-#    gpu_count: 1
+  L40S:
+    gpu: "NVIDIA L40S"
+    gpu_count: 1

--- a/recipes/Qwen3-Coder-480B-A35B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-480B-A35B-Instruct-AWQ/recipe.yaml
@@ -9,6 +9,12 @@ backend:
     gpu_memory_utilization: 0.9
     extra_args: "--max-num-seqs 512 --max-model-len 16384 --enable-expert-parallel"
 
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 8000
+  random_output_len: 8000
+
 variants:
   4xH200:
     gpu: "NVIDIA H200 141GB"
@@ -22,12 +28,9 @@ variants:
   4xH100:
     gpu: "NVIDIA H100 80GB"
     gpu_count: 4
-    backend:
-      vllm:
-        extra_args: "--max-num-seqs 512 --max-model-len 8192 --enable-expert-parallel"
   4xPro6000:
     gpu: "NVIDIA RTX PRO 6000 Server Edition"
     gpu_count: 4
     backend:
       vllm:
-        extra_args: "--max-num-seqs 256 --max-model-len 8192 --enable-expert-parallel"
+        extra_args: "--max-num-seqs 256 --max-model-len 16384 --enable-expert-parallel"

--- a/recipes/Qwen3-Coder-480B-A35B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-480B-A35B-Instruct-AWQ/recipe.yaml
@@ -19,6 +19,9 @@ variants:
   4xH200:
     gpu: "NVIDIA H200 141GB"
     gpu_count: 4
+    benchmark:
+      max_concurrency: 256
+      num_prompts: 512
   4xB200:
     gpu: "NVIDIA B200"
     gpu_count: 4
@@ -34,3 +37,6 @@ variants:
     backend:
       vllm:
         extra_args: "--max-num-seqs 256 --max-model-len 16384 --enable-expert-parallel"
+    benchmark:
+      max_concurrency: 64
+      num_prompts: 128

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,12 +67,6 @@ def make_bench_config(recipes_dir):
                 "local_results_dir": os.path.join(str(tmp_dir), "results"),
                 "model_dir": "/hf_models",
             },
-            "benchmark_params": {
-                "max_concurrency": 128,
-                "num_prompts": 256,
-                "random_input_len": 8000,
-                "random_output_len": 8000,
-            },
             "servers": servers,
         }
         config_path = os.path.join(str(tmp_dir), "config.yaml")
@@ -100,6 +94,12 @@ def tmp_recipe_dir(tmp_path):
                 "extra_args": "--max-model-len 8192",
             }
         },
+        "benchmark": {
+            "max_concurrency": 128,
+            "num_prompts": 256,
+            "random_input_len": 4000,
+            "random_output_len": 4000,
+        },
         "variants": {
             "RTX5090": {
                 "gpu": "NVIDIA GeForce RTX 5090",
@@ -113,6 +113,10 @@ def tmp_recipe_dir(tmp_path):
                         "tensor_parallel_size": 8,
                         "extra_args": "--max-model-len 16384 --kv-cache-dtype fp8",
                     }
+                },
+                "benchmark": {
+                    "random_input_len": 8000,
+                    "random_output_len": 8000,
                 },
             },
             "4xH100": {
@@ -148,6 +152,12 @@ def sample_config():
                 "gpu_memory_utilization": 0.9,
                 "extra_args": "--max-model-len 8192",
             }
+        },
+        "benchmark": {
+            "max_concurrency": 128,
+            "num_prompts": 256,
+            "random_input_len": 4000,
+            "random_output_len": 4000,
         },
     }
 

--- a/tests/test_bench_dryrun.py
+++ b/tests/test_bench_dryrun.py
@@ -19,8 +19,10 @@ def test_bench_dry_run_deploy_then_benchmark(run_cli, make_bench_config, tmp_pat
     assert "docker compose pull" in stdout
     assert "docker compose up" in stdout
 
-    # Verify benchmark step appears
+    # Verify benchmark step appears with recipe params
     assert "vllm bench serve" in stdout
+    assert "--random-input-len 4000" in stdout
+    assert "--random-output-len 4000" in stdout
 
     # Verify teardown appears
     assert "docker compose down" in stdout

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -80,3 +80,34 @@ def test_load_recipe_variants_stripped(tmp_recipe_dir):
 def test_load_recipe_variants_stripped_no_variant(tmp_recipe_dir):
     config = load_recipe(tmp_recipe_dir)
     assert "variants" not in config
+
+
+# ── benchmark section ──────────────────────────────────────────────
+
+
+def test_load_recipe_benchmark_defaults(tmp_recipe_dir):
+    config = load_recipe(tmp_recipe_dir)
+    assert config["benchmark"]["max_concurrency"] == 128
+    assert config["benchmark"]["num_prompts"] == 256
+    assert config["benchmark"]["random_input_len"] == 4000
+    assert config["benchmark"]["random_output_len"] == 4000
+
+
+def test_load_recipe_benchmark_preserved_with_variant(tmp_recipe_dir):
+    config = load_recipe(tmp_recipe_dir, variant="RTX5090")
+    assert config["benchmark"]["max_concurrency"] == 128
+    assert config["benchmark"]["random_input_len"] == 4000
+
+
+def test_load_recipe_benchmark_variant_override(tmp_recipe_dir):
+    config = load_recipe(tmp_recipe_dir, variant="8xH200")
+    assert config["benchmark"]["max_concurrency"] == 128  # from base
+    assert config["benchmark"]["random_input_len"] == 8000  # overridden
+    assert config["benchmark"]["random_output_len"] == 8000  # overridden
+    assert config["benchmark"]["num_prompts"] == 256  # from base
+
+
+def test_load_recipe_benchmark_no_override_variant(tmp_recipe_dir):
+    config = load_recipe(tmp_recipe_dir, variant="4xH100")
+    assert config["benchmark"]["random_input_len"] == 4000  # base preserved
+    assert config["benchmark"]["random_output_len"] == 4000  # base preserved


### PR DESCRIPTION
## Summary

- Moved benchmark parameters (`max_concurrency`, `num_prompts`, `random_input_len`, `random_output_len`) from global `benchmark_params` in `config.yaml` into each recipe's `benchmark` section
- Sized `random_input_len` and `random_output_len` to half of each recipe's `max-model-len` (4000 for 8192-context models, 8000 for 16384-context models)
- Unified `--max-model-len` across all variants within each recipe so benchmark params are consistent
- Added validation warning when `input + output >= max_model_len`
- Variant-level `benchmark` overrides supported via `deep_merge`

## Test plan

- [x] `pytest tests/ -v` — 105 tests pass (4 new benchmark section tests)
- [ ] `deplodock bench --config config.yaml --dry-run` — verify benchmark params come from recipe
- [ ] Verify for each recipe: `random_input_len + random_output_len < max_model_len`

🤖 Generated with [Claude Code](https://claude.com/claude-code)