### PR TITLE
Replace servers config with recipe-first bench CLI + Planner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ pytest tests/test_recipe.py -v
 - `deplodock deploy local ...` — deploy locally via docker compose
 - `deplodock deploy ssh ...` — deploy to remote server via SSH
 - `deplodock deploy cloud ...` — provision a cloud VM and deploy via SSH
-- `deplodock bench ...` — deploy + benchmark + teardown on remote servers (uses deploy infrastructure)
+- `deplodock bench recipes/* ...` — deploy + benchmark + teardown on cloud VMs (recipe dirs as positional args)
 - `deplodock report ...` — generate Excel reports from benchmark results
 - `deplodock vm create gcp-flex-start ...` — create a GCP flex-start GPU VM
 - `deplodock vm create cloudrift ...` — create a CloudRift GPU VM
@@ -42,7 +42,7 @@ pytest tests/test_recipe.py -v
 ## Key Make Targets
 
 - `make setup` — create venv and install dependencies
-- `make bench` — run benchmarks in parallel (`deplodock bench --parallel`)
+- `make bench` — run benchmarks (`deplodock bench recipes/*`)
 - `make report` — generate Excel report (`deplodock report`)
 - `make clean` — remove venv and generated files
 

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ setup:
 	fi
 
 bench: setup
-	@echo "Running benchmarks in parallel..."
-	./venv/bin/deplodock bench --parallel
+	@echo "Running benchmarks..."
+	./venv/bin/deplodock bench recipes/*
 
 bench-force: setup
-	@echo "Running benchmarks in parallel (force mode)..."
-	./venv/bin/deplodock bench --parallel --force
+	@echo "Running benchmarks (force mode)..."
+	./venv/bin/deplodock bench recipes/* --force
 
 report: setup
 	@echo "Generating Excel report from benchmark results..."

--- a/STYLE.md
+++ b/STYLE.md
@@ -61,6 +61,21 @@ tests can use dry-run or mock versions:
 def run_deploy(run_cmd, write_file, config, model_dir, ...):
 ```
 
+### Concurrency
+
+Use `asyncio` for concurrent execution. Wrap blocking (subprocess/IO)
+calls with `asyncio.to_thread()`. Use `asyncio.Semaphore` to limit
+concurrency. Entry point uses `asyncio.run()`:
+
+```python
+async def _run_groups(groups):
+    sem = asyncio.Semaphore(max_workers)
+    async def _run(group):
+        async with sem:
+            return await asyncio.to_thread(blocking_fn, group)
+    await asyncio.gather(*(_run(g) for g in groups))
+```
+
 ## Commit Messages
 
 - Keep the subject line short (under ~72 characters).

--- a/config.yaml
+++ b/config.yaml
@@ -23,17 +23,3 @@ providers:
     tags: "ssh"
     # service_account: defaults to $GCP_SERVICE_ACCOUNT env var
   # cloudrift: uses CLOUDRIFT_API_KEY env var
-
-# Define servers with their recipes to benchmark
-# VMs are auto-provisioned based on GPU requirements in recipes
-servers:
-  - name: "rtx5090_x_1"
-    ssh_key: "~/.ssh/id_ed25519"
-    recipes:
-      - recipe: "recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ"
-        variant: "RTX5090"
-  - name: "pro6000_x_1"
-    ssh_key: "~/.ssh/id_ed25519"
-    recipes:
-      - recipe: "recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ"
-        variant: "Pro6000"

--- a/deplodock/commands/deploy/__init__.py
+++ b/deplodock/commands/deploy/__init__.py
@@ -88,9 +88,16 @@ def generate_compose(config, model_dir, hf_token):
 
     services = "services:\n"
 
+    # Optional: restrict GPU visibility to specific device IDs
+    device_ids_override = config.get("_gpu_device_ids")
+
     for i in range(num_instances):
         if num_instances == 1:
-            gpu_config = "count: all"
+            if device_ids_override is not None:
+                gpu_ids_yaml = ", ".join(f"'{g}'" for g in device_ids_override)
+                gpu_config = f"device_ids: [{gpu_ids_yaml}]"
+            else:
+                gpu_config = "count: all"
             port = 8000
         else:
             start = i * gpus_per_instance

--- a/deplodock/hardware.py
+++ b/deplodock/hardware.py
@@ -51,6 +51,33 @@ GPU_INSTANCE_TYPES = {
 }
 
 
+# Full GPU name -> short name for result filenames.
+GPU_SHORT_NAMES = {
+    "NVIDIA GeForce RTX 4090": "rtx4090",
+    "NVIDIA GeForce RTX 5090": "rtx5090",
+    "NVIDIA RTX PRO 6000 Workstation Edition": "pro6000",
+    "NVIDIA RTX PRO 6000 Server Edition": "pro6000",
+    "NVIDIA L40S": "l40s",
+    "NVIDIA H100 80GB": "h100",
+    "NVIDIA H200 141GB": "h200",
+    "NVIDIA B200": "b200",
+    "NVIDIA A100 40GB": "a100",
+    "NVIDIA A100 80GB": "a100",
+    "AMD Instinct MI350X": "mi350x",
+}
+
+
+def gpu_short_name(full_name):
+    """Map a full GPU name to a short name for filenames.
+
+    Falls back to lowercased alphanumeric if not in the lookup table.
+    """
+    if full_name in GPU_SHORT_NAMES:
+        return GPU_SHORT_NAMES[full_name]
+    import re
+    return re.sub(r"[^a-z0-9]", "", full_name.lower())
+
+
 def resolve_instance_type(provider, base, gpu_count):
     """Derive full instance type name from base name and GPU count."""
     if provider == "cloudrift":

--- a/deplodock/planner/__init__.py
+++ b/deplodock/planner/__init__.py
@@ -1,0 +1,47 @@
+"""Planner: group benchmark tasks into execution groups for VM allocation."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List
+
+from deplodock.hardware import gpu_short_name
+
+
+@dataclass
+class BenchmarkTask:
+    """One recipe+variant combination to benchmark."""
+
+    recipe_dir: str
+    variant: str
+    recipe_config: dict
+    gpu_name: str
+    gpu_count: int
+
+    @property
+    def model_name(self) -> str:
+        return self.recipe_config["model"]["name"]
+
+    @property
+    def result_filename(self) -> str:
+        """Result filename: {gpu_short}_{gpu_count}x_{model_safe}_vllm_benchmark.txt"""
+        short = gpu_short_name(self.gpu_name)
+        model_safe = self.model_name.replace("/", "_")
+        return f"{short}_{self.gpu_count}x_{model_safe}_vllm_benchmark.txt"
+
+
+@dataclass
+class ExecutionGroup:
+    """Group of tasks sharing one VM."""
+
+    gpu_name: str
+    gpu_count: int
+    tasks: List[BenchmarkTask] = field(default_factory=list)
+
+
+class BenchmarkPlanner(ABC):
+    """Abstract base for grouping benchmark tasks into execution groups."""
+
+    @abstractmethod
+    def plan(self, tasks: List[BenchmarkTask]) -> List[ExecutionGroup]:
+        """Group benchmark tasks into execution groups."""
+        ...

--- a/deplodock/planner/group_by_model_and_gpu.py
+++ b/deplodock/planner/group_by_model_and_gpu.py
@@ -1,0 +1,27 @@
+"""GroupByModelAndGpuPlanner: group tasks by (model_name, gpu_name).
+
+Same LLM model on same GPU type shares a VM so model weights are cached
+across different GPU-count benchmarks. Different models on the same GPU
+type get separate VMs.
+"""
+
+from deplodock.planner import BenchmarkPlanner, BenchmarkTask, ExecutionGroup
+
+
+class GroupByModelAndGpuPlanner(BenchmarkPlanner):
+    """Group tasks by (model_name, gpu_name) tuple."""
+
+    def plan(self, tasks):
+        groups = {}
+        for task in tasks:
+            key = (task.model_name, task.gpu_name)
+            groups.setdefault(key, []).append(task)
+
+        result = []
+        for (model, gpu), group_tasks in groups.items():
+            group_tasks.sort(key=lambda t: t.gpu_count, reverse=True)
+            max_count = max(t.gpu_count for t in group_tasks)
+            result.append(ExecutionGroup(
+                gpu_name=gpu, gpu_count=max_count, tasks=group_tasks,
+            ))
+        return result

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -13,8 +13,10 @@ Test individual functions in isolation with synthetic inputs.
 | File | Covers |
 |------|--------|
 | `test_recipe.py` | `load_recipe()`, `deep_merge()` — recipe loading, variant resolution, YAML parsing |
-| `test_compose.py` | `generate_compose()`, `generate_nginx_conf()` — Docker Compose and nginx config generation |
+| `test_compose.py` | `generate_compose()`, `generate_nginx_conf()` — Docker Compose and nginx config generation, `_gpu_device_ids` support |
 | `test_deploy_cloud.py` | `resolve_vm_spec()`, `delete_cloud_vm()`, `VMConnectionInfo` — cloud deploy bridge unit tests |
+| `test_planner.py` | `BenchmarkTask`, `GroupByModelAndGpuPlanner` — task properties, grouping logic, sorting |
+| `test_hardware.py` | `resolve_instance_type()`, `gpu_short_name()`, `GPU_INSTANCE_TYPES` — hardware lookup tables |
 
 Unit tests use **fixtures from `conftest.py`** (`tmp_recipe_dir`, `sample_config`, `sample_config_multi`) to supply pre-built recipe directories and config dicts.
 
@@ -26,7 +28,7 @@ Test the full CLI pipeline end-to-end by invoking `deplodock` as a subprocess wi
 |------|--------|
 | `test_deploy_dryrun.py` | `deploy ssh`, `deploy local` — dry-run output, command sequence, variant resolution, teardown, CLI help |
 | `test_deploy_cloud_dryrun.py` | `deploy cloud` — dry-run output, deploy steps, error handling, CLI help |
-| `test_bench_dryrun.py` | `bench` — dry-run output, deploy→benchmark→teardown sequence, server/recipe filtering, CLI help |
+| `test_bench_dryrun.py` | `bench` — dry-run output, deploy→benchmark→teardown sequence, variant filtering, CLI help |
 | `test_vm_gcp_flex_start.py` | `_gcloud_*_cmd()` — GCP flex-start command builder functions (create, delete, status, IP, SSH) |
 | `test_vm_dryrun.py` | `vm create/delete gcp-flex-start`, `vm create/delete cloudrift` — dry-run output, argparse validation, CLI help |
 
@@ -39,7 +41,7 @@ CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench
 | `project_root` | session | Absolute path to repo root |
 | `recipes_dir` | session | Absolute path to `recipes/` |
 | `run_cli` | session | Callable that invokes `python -m deplodock.deplodock` as a subprocess |
-| `make_bench_config` | function | Factory that writes a temp `config.yaml` for bench tests |
+| `make_bench_config` | function | Factory that writes a temp `config.yaml` for bench tests (benchmark section only) |
 | `tmp_recipe_dir` | function | Temp directory with a sample `recipe.yaml` for unit tests |
 | `sample_config` | function | Single-instance config dict for compose tests |
 | `sample_config_multi` | function | Multi-instance config dict for compose tests |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,30 +44,12 @@ def run_cli(project_root):
 def make_bench_config(recipes_dir):
     """Return a factory that writes a temporary bench config.yaml."""
 
-    def _make(tmp_dir, servers=None):
-        if servers is None:
-            servers = [
-                {
-                    "name": "test_server",
-                    "ssh_key": "~/.ssh/id_ed25519",
-                    "recipes": [
-                        {
-                            "recipe": os.path.join(
-                                recipes_dir,
-                                "Qwen3-Coder-30B-A3B-Instruct-AWQ",
-                            ),
-                            "variant": "RTX5090",
-                        }
-                    ],
-                }
-            ]
-
+    def _make(tmp_dir):
         config = {
             "benchmark": {
                 "local_results_dir": os.path.join(str(tmp_dir), "results"),
                 "model_dir": "/hf_models",
             },
-            "servers": servers,
         }
         config_path = os.path.join(str(tmp_dir), "config.yaml")
         with open(config_path, "w") as f:

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -79,6 +79,25 @@ def test_compose_image_from_config(sample_config):
     assert "custom/image:v2" in result
 
 
+def test_compose_gpu_device_ids_override(sample_config):
+    """_gpu_device_ids restricts GPU visibility in single-instance mode."""
+    sample_config["_num_instances"] = 1
+    sample_config["_gpu_device_ids"] = [0, 1]
+    result = generate_compose(sample_config, "/mnt/models", "token")
+    assert "device_ids:" in result
+    assert "'0'" in result
+    assert "'1'" in result
+    assert "count: all" not in result
+
+
+def test_compose_no_gpu_device_ids_uses_count_all(sample_config):
+    """Without _gpu_device_ids, single-instance uses count: all."""
+    sample_config["_num_instances"] = 1
+    result = generate_compose(sample_config, "/mnt/models", "token")
+    assert "count: all" in result
+    assert "device_ids:" not in result
+
+
 # ── generate_nginx_conf ─────────────────────────────────────────────
 
 

--- a/tests/test_deploy_dryrun.py
+++ b/tests/test_deploy_dryrun.py
@@ -192,11 +192,11 @@ def test_bench_help(run_cli):
     assert rc == 0
     assert "--config" in stdout
     assert "--force" in stdout
-    assert "--server" in stdout
-    assert "--recipe" in stdout
+    assert "--variants" in stdout
+    assert "--ssh-key" in stdout
     assert "--dry-run" in stdout
-    assert "--parallel" in stdout
     assert "--max-workers" in stdout
+    assert "recipes" in stdout
 
 
 def test_report_help(run_cli):

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,6 +1,6 @@
 """Unit tests for hardware lookup tables."""
 
-from deplodock.hardware import GPU_INSTANCE_TYPES, resolve_instance_type
+from deplodock.hardware import GPU_INSTANCE_TYPES, GPU_SHORT_NAMES, gpu_short_name, resolve_instance_type
 
 
 # ── resolve_instance_type ────────────────────────────────────────
@@ -43,3 +43,23 @@ def test_known_gpu_lookup():
 def test_gcp_gpu_lookup():
     entries = GPU_INSTANCE_TYPES["NVIDIA H100 80GB"]
     assert entries[0] == ("gcp", "a3-highgpu")
+
+
+# ── gpu_short_name ────────────────────────────────────────────────
+
+
+def test_gpu_short_name_known():
+    assert gpu_short_name("NVIDIA GeForce RTX 5090") == "rtx5090"
+    assert gpu_short_name("NVIDIA H200 141GB") == "h200"
+    assert gpu_short_name("NVIDIA RTX PRO 6000 Server Edition") == "pro6000"
+
+
+def test_gpu_short_name_unknown_fallback():
+    result = gpu_short_name("Some Unknown GPU 9000")
+    assert result == "someunknowngpu9000"
+
+
+def test_gpu_short_names_covers_all_instance_types():
+    """Every GPU in GPU_INSTANCE_TYPES has a short name."""
+    for gpu_name in GPU_INSTANCE_TYPES:
+        assert gpu_name in GPU_SHORT_NAMES, f"GPU '{gpu_name}' missing from GPU_SHORT_NAMES"

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,103 @@
+"""Unit tests for the planner module."""
+
+from deplodock.planner import BenchmarkTask, ExecutionGroup
+from deplodock.planner.group_by_model_and_gpu import GroupByModelAndGpuPlanner
+
+
+def _make_task(model="org/model-a", gpu="NVIDIA GeForce RTX 5090", gpu_count=1, recipe_dir="/r"):
+    """Helper to build a BenchmarkTask with minimal config."""
+    return BenchmarkTask(
+        recipe_dir=recipe_dir,
+        variant="V1",
+        recipe_config={"model": {"name": model}},
+        gpu_name=gpu,
+        gpu_count=gpu_count,
+    )
+
+
+# ── BenchmarkTask ─────────────────────────────────────────────────
+
+
+def test_task_model_name():
+    task = _make_task(model="org/my-model")
+    assert task.model_name == "org/my-model"
+
+
+def test_task_result_filename():
+    task = _make_task(model="org/my-model", gpu="NVIDIA GeForce RTX 5090", gpu_count=1)
+    assert task.result_filename == "rtx5090_1x_org_my-model_vllm_benchmark.txt"
+
+
+def test_task_result_filename_multi_gpu():
+    task = _make_task(model="org/my-model", gpu="NVIDIA H200 141GB", gpu_count=8)
+    assert task.result_filename == "h200_8x_org_my-model_vllm_benchmark.txt"
+
+
+# ── GroupByModelAndGpuPlanner ─────────────────────────────────────
+
+
+def test_same_model_same_gpu_one_group():
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=1),
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=4),
+    ]
+    groups = planner.plan(tasks)
+    assert len(groups) == 1
+    assert len(groups[0].tasks) == 2
+
+
+def test_different_models_same_gpu_separate_groups():
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_task(model="org/model-a", gpu="GPU_A", gpu_count=1),
+        _make_task(model="org/model-b", gpu="GPU_A", gpu_count=1),
+    ]
+    groups = planner.plan(tasks)
+    assert len(groups) == 2
+
+
+def test_same_model_different_gpu_separate_groups():
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=1),
+        _make_task(model="org/m", gpu="GPU_B", gpu_count=1),
+    ]
+    groups = planner.plan(tasks)
+    assert len(groups) == 2
+
+
+def test_max_gpu_count_per_group():
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=1),
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=4),
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=2),
+    ]
+    groups = planner.plan(tasks)
+    assert len(groups) == 1
+    assert groups[0].gpu_count == 4
+
+
+def test_tasks_sorted_descending_by_gpu_count():
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=1),
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=4),
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=2),
+    ]
+    groups = planner.plan(tasks)
+    counts = [t.gpu_count for t in groups[0].tasks]
+    assert counts == [4, 2, 1]
+
+
+def test_cross_recipe_grouping():
+    """Tasks from different recipe dirs but same model+GPU are grouped."""
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=1, recipe_dir="/recipe1"),
+        _make_task(model="org/m", gpu="GPU_A", gpu_count=2, recipe_dir="/recipe2"),
+    ]
+    groups = planner.plan(tasks)
+    assert len(groups) == 1
+    assert len(groups[0].tasks) == 2


### PR DESCRIPTION
## Summary

- Remove `servers` section from `config.yaml` — bench CLI now takes recipe directories as positional args with `--variants` filter
- Add `planner/` module with `GroupByModelAndGpuPlanner` that groups tasks by (model_name, gpu_name) so same-model tasks share a VM and reuse cached weights
- Execution groups run in parallel via `asyncio` + `asyncio.to_thread()` with `--max-workers` semaphore
- Add `_gpu_device_ids` support in `generate_compose()` for GPU visibility when a task needs fewer GPUs than the VM
- Add `GPU_SHORT_NAMES` + `gpu_short_name()` to `hardware.py` for result filenames
- Update report filename parsing to support new format while keeping backwards compat

## New CLI

```bash
deplodock bench recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ --variants RTX5090 --dry-run
deplodock bench recipes/* --variants RTX5090 Pro6000
deplodock bench recipes/* --force
```

## Test plan

- [x] All 119 tests pass (`pytest tests/ -v`)
- [ ] `deplodock bench recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ --variants RTX5090 --dry-run`
- [ ] `deplodock bench recipes/* --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)