### PR TITLE
Consolidate SSH transport into provisioning module

### DIFF
--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -13,7 +13,7 @@ from deplodock.deploy import (
     deploy as deploy_entry,
     teardown as teardown_entry,
 )
-from deplodock.deploy.ssh import make_run_cmd
+from deplodock.provisioning.ssh_transport import make_run_cmd
 from deplodock.hardware import gpu_short_name
 from deplodock.planner import ExecutionGroup
 from deplodock.provisioning.cloud import (

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -68,5 +68,5 @@ def run_benchmark_workload(run_cmd, recipe_config, dry_run=False):
         f"'"
     )
 
-    rc, output = run_cmd(bench_cmd, stream=False)
+    rc, output, _ = run_cmd(bench_cmd, stream=False)
     return rc == 0, output

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -9,7 +9,6 @@ from deplodock.deploy import (
     load_recipe,
 )
 from deplodock.provisioning.cloud import (
-    resolve_vm_spec,
     provision_cloud_vm,
     delete_cloud_vm,
 )

--- a/deplodock/commands/deploy/ssh.py
+++ b/deplodock/commands/deploy/ssh.py
@@ -9,7 +9,7 @@ from deplodock.deploy import (
     load_recipe,
     teardown as teardown_entry,
 )
-from deplodock.deploy.ssh import make_run_cmd, make_write_file, scp_file, ssh_base_args, REMOTE_DEPLOY_DIR
+from deplodock.provisioning.ssh_transport import make_run_cmd, make_write_file, scp_file, ssh_base_args, REMOTE_DEPLOY_DIR
 from deplodock.provisioning.remote import provision_remote
 
 

--- a/deplodock/deploy/local.py
+++ b/deplodock/deploy/local.py
@@ -11,7 +11,7 @@ def make_run_cmd(deploy_dir, dry_run=False):
     def run_cmd(command, stream=True):
         if dry_run:
             print(f"[dry-run] {command}")
-            return 0, ""
+            return 0, "", ""
 
         try:
             result = subprocess.run(
@@ -24,10 +24,11 @@ def make_run_cmd(deploy_dir, dry_run=False):
                 stderr=None if stream else subprocess.PIPE,
             )
             stdout = "" if stream else (result.stdout or "")
-            return result.returncode, stdout
+            stderr = "" if stream else (result.stderr or "")
+            return result.returncode, stdout, stderr
         except Exception as e:
             print(f"Error running command: {e}", file=sys.stderr)
-            return 1, ""
+            return 1, "", ""
 
     return run_cmd
 

--- a/deplodock/provisioning/__init__.py
+++ b/deplodock/provisioning/__init__.py
@@ -4,6 +4,13 @@ from deplodock.provisioning.types import VMConnectionInfo
 from deplodock.provisioning.ssh import wait_for_ssh
 from deplodock.provisioning.shell import run_shell_cmd
 from deplodock.provisioning.remote import provision_remote
+from deplodock.provisioning.ssh_transport import (
+    ssh_base_args,
+    make_run_cmd,
+    make_write_file,
+    scp_file,
+    REMOTE_DEPLOY_DIR,
+)
 from deplodock.provisioning.cloud import (
     resolve_vm_spec,
     provision_cloud_vm,
@@ -15,6 +22,11 @@ __all__ = [
     "wait_for_ssh",
     "run_shell_cmd",
     "provision_remote",
+    "ssh_base_args",
+    "make_run_cmd",
+    "make_write_file",
+    "scp_file",
+    "REMOTE_DEPLOY_DIR",
     "resolve_vm_spec",
     "provision_cloud_vm",
     "delete_cloud_vm",

--- a/deplodock/provisioning/remote.py
+++ b/deplodock/provisioning/remote.py
@@ -2,16 +2,7 @@
 
 import subprocess
 
-
-def ssh_base_args(server, ssh_key, ssh_port):
-    """Build base SSH arguments."""
-    args = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "BatchMode=yes"]
-    if ssh_key:
-        args += ["-i", ssh_key]
-    if ssh_port and ssh_port != 22:
-        args += ["-p", str(ssh_port)]
-    args.append(server)
-    return args
+from deplodock.provisioning.ssh_transport import ssh_base_args
 
 
 def provision_remote(server, ssh_key, ssh_port, dry_run=False):

--- a/deplodock/provisioning/ssh_transport.py
+++ b/deplodock/provisioning/ssh_transport.py
@@ -32,7 +32,7 @@ def make_run_cmd(server, ssh_key, ssh_port, dry_run=False):
             full_cmd = f"cd {REMOTE_DEPLOY_DIR} && {command}"
         if dry_run:
             print(f"[dry-run] ssh {server}: {full_cmd}")
-            return 0, ""
+            return 0, "", ""
 
         ssh_args = ssh_base_args(server, ssh_key, ssh_port)
         ssh_args.append(full_cmd)
@@ -45,10 +45,11 @@ def make_run_cmd(server, ssh_key, ssh_port, dry_run=False):
                 stderr=None if stream else subprocess.PIPE,
             )
             stdout = "" if stream else (result.stdout or "")
-            return result.returncode, stdout
+            stderr = "" if stream else (result.stderr or "")
+            return result.returncode, stdout, stderr
         except Exception as e:
             print(f"Error running SSH command: {e}", file=sys.stderr)
-            return 1, ""
+            return 1, "", ""
 
     return run_cmd
 


### PR DESCRIPTION
## Summary

- Move SSH transport (`ssh_base_args`, `make_run_cmd`, `make_write_file`, `scp_file`) from `deploy/ssh.py` → `provisioning/ssh_transport.py`, eliminating the duplicate `ssh_base_args` definition in `provisioning/remote.py`
- Standardize `run_cmd` return signature to `(rc, stdout, stderr)` across both SSH and local transports, matching the convention in `provisioning/shell.py`
- Refactor `resolve_vm_spec` to accept pre-loaded `(entry, config)` tuples, removing the backward dependency from `provisioning/cloud.py` → `deploy/recipe.py`

## Test plan

- [x] All 131 existing tests pass (`pytest tests/ -v`)
- [ ] Verify dry-run SSH deploy still works: `deplodock deploy ssh --dry-run ...`
- [ ] Verify dry-run bench pipeline still works: `deplodock bench recipes/* --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)