### PR TITLE
Consolidate SSH transport and add ruff linter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,24 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: make setup
+
+      - name: Ruff check
+        run: ./venv/bin/ruff check
+
+      - name: Ruff format check
+        run: ./venv/bin/ruff format --check
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,9 @@ pytest tests/test_recipe.py -v
 
 ## Key Make Targets
 
-- `make setup` — create venv and install dependencies
+- `make setup` — create venv and install dependencies (includes ruff)
+- `make lint` — run `ruff check` and `ruff format --check`
+- `make format` — auto-format code and fix lint violations
 - `make bench` — run benchmarks (`deplodock bench recipes/*`)
 - `make report` — generate Excel report (`deplodock report`)
 - `make clean` — remove venv and generated files
@@ -51,6 +53,11 @@ pytest tests/test_recipe.py -v
 1. Create a feature branch from `main` (e.g. `feature/my-new-feature`)
 2. Write code following guidelines here, in `STYLE.md`, `README.md` and `ARCHITECTURE.md` files in respective folders
 3. Add tests if reasonable (in `tests/` following `tests/ARCHITECTURE.md` guidelines)
-4. Update `STYLE.md`, `README.md`, `CLAUDE.md` and respective `ARCHITECTURE.md` files if necessary
-5. Run tests: `pytest tests/ -v`
-6. Push and open a PR
+4. Check if style changes were introduced and update `STYLE.md` if necessary
+5. Check if project setup, structure or usage patterns have changes and update `README.md` if necessary
+6. Check if general instructions in `CLAUDE.md` are still accurate and update if necessary
+7. Check for `ARCHITECTURE.md` files in directories that were updated and update them if necessary
+8. Run tests: `pytest tests/ -v`
+9. Run linter and format check: `make lint`
+10. Auto-fix formatting: `make format`
+11. Push and open a PR

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-.PHONY: help setup clean bench bench-force logs clean-logs test-compose report report-nov2025
+.PHONY: help setup clean bench bench-force logs clean-logs test-compose report report-nov2025 lint format
 
 help:
 	@echo "Server Benchmark Makefile"
 	@echo ""
 	@echo "Available targets:"
 	@echo "  setup          - Install system dependencies, create venv, and install Python packages"
+	@echo "  lint           - Run linter and format checks"
+	@echo "  format         - Auto-format code and fix lint violations"
 	@echo "  bench          - Run benchmarks in parallel"
 	@echo "  bench-force    - Run benchmarks in parallel (force re-run, skip cached results)"
 	@echo "  report         - Generate Excel report from benchmark results"
@@ -19,9 +21,17 @@ setup:
 		echo "Creating virtual environment..."; \
 		python3 -m venv venv; \
 		echo "Installing Python dependencies..."; \
-		./venv/bin/pip install -e ".[test]"; \
+		./venv/bin/pip install -e ".[dev]"; \
 		echo "✅ Setup complete!"; \
 	fi
+
+lint: setup
+	./venv/bin/ruff check
+	./venv/bin/ruff format --check
+
+format: setup
+	./venv/bin/ruff format
+	./venv/bin/ruff check --fix
 
 bench: setup
 	@echo "Running benchmarks..."

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ GCP project is inferred from `gcloud` config (no `--project` flag needed).
 pytest tests/ -v
 ```
 
+## Linting & Formatting
+
+The project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting. Configuration is in `pyproject.toml`.
+
+```bash
+make lint      # check for lint errors and formatting issues
+make format    # auto-fix formatting and lint violations
+```
+
 ## Benchmarking
 
 The `bench` command reuses the deploy infrastructure — it loads a recipe, deploys the model via SSH, runs `vllm bench serve`, captures results, and tears down. No repo cloning needed.

--- a/STYLE.md
+++ b/STYLE.md
@@ -54,8 +54,12 @@ Group imports in this order, separated by blank lines:
 ### Formatting
 
 - 4 spaces for indentation.
-- Keep lines under ~100 characters where practical.
+- Keep lines under ~140 characters (enforced by Ruff).
 - Double quotes for strings.
+
+### Tooling
+
+Style rules are enforced by [Ruff](https://docs.astral.sh/ruff/), configured in `pyproject.toml`. Run `make lint` to check and `make format` to auto-fix. Enabled rule sets: `E` (pycodestyle), `F` (pyflakes), `W` (warnings), `I` (isort), `UP` (pyupgrade), `B` (bugbear).
 
 ### Dependency Injection for Testability
 

--- a/deplodock/benchmark/__init__.py
+++ b/deplodock/benchmark/__init__.py
@@ -1,20 +1,20 @@
 """Benchmark library: tracking, config, logging, workload, tasks, execution."""
 
+from deplodock.benchmark.bench_logging import _get_group_logger, setup_logging
+from deplodock.benchmark.config import _expand_path, load_config, validate_config
+from deplodock.benchmark.execution import _run_groups, run_execution_group
+from deplodock.benchmark.tasks import _task_meta, enumerate_tasks
 from deplodock.benchmark.tracking import (
     compute_code_hash,
     create_run_dir,
-    write_manifest,
     read_manifest,
+    write_manifest,
 )
-from deplodock.benchmark.config import load_config, validate_config, _expand_path
-from deplodock.benchmark.bench_logging import setup_logging, _get_group_logger
 from deplodock.benchmark.workload import (
-    extract_benchmark_results,
     _parse_max_model_len,
+    extract_benchmark_results,
     run_benchmark_workload,
 )
-from deplodock.benchmark.tasks import enumerate_tasks, _task_meta
-from deplodock.benchmark.execution import run_execution_group, _run_groups
 
 __all__ = [
     "compute_code_hash",

--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -4,11 +4,9 @@ import logging
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from deplodock.hardware import gpu_short_name
 from deplodock.planner import ExecutionGroup
-
 
 # Global log file path
 LOG_FILE = None
@@ -56,7 +54,7 @@ def setup_logging() -> str:
     return str(LOG_FILE)
 
 
-def _get_group_logger(group: ExecutionGroup, model_name: Optional[str] = None) -> logging.Logger:
+def _get_group_logger(group: ExecutionGroup, model_name: str | None = None) -> logging.Logger:
     """Get a logger for an execution group."""
     short = gpu_short_name(group.gpu_name)
     group_label = f"{short}_x_{group.gpu_count}"

--- a/deplodock/benchmark/config.py
+++ b/deplodock/benchmark/config.py
@@ -9,7 +9,7 @@ import yaml
 def load_config(config_path: str = "config.yaml") -> dict:
     """Load configuration from YAML file."""
     try:
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             config = yaml.safe_load(f)
         return config
     except FileNotFoundError:

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -3,17 +3,19 @@
 import asyncio
 import os
 from pathlib import Path
-from typing import List
 
 from deplodock.benchmark.bench_logging import _get_group_logger
 from deplodock.benchmark.tasks import _task_meta
 from deplodock.benchmark.workload import extract_benchmark_results, run_benchmark_workload
 from deplodock.deploy import (
     DeployParams,
+)
+from deplodock.deploy import (
     deploy as deploy_entry,
+)
+from deplodock.deploy import (
     teardown as teardown_entry,
 )
-from deplodock.provisioning.ssh_transport import make_run_cmd
 from deplodock.hardware import gpu_short_name
 from deplodock.planner import ExecutionGroup
 from deplodock.provisioning.cloud import (
@@ -21,10 +23,10 @@ from deplodock.provisioning.cloud import (
     provision_cloud_vm,
 )
 from deplodock.provisioning.remote import provision_remote
+from deplodock.provisioning.ssh_transport import make_run_cmd
 
 
-def run_execution_group(group: ExecutionGroup, config: dict, ssh_key: str,
-                        run_dir: Path, dry_run: bool = False) -> List[dict]:
+def run_execution_group(group: ExecutionGroup, config: dict, ssh_key: str, run_dir: Path, dry_run: bool = False) -> list[dict]:
     """Run all benchmark tasks for one execution group.
 
     Provisions a VM with group.gpu_count GPUs, then runs each task.
@@ -45,8 +47,13 @@ def run_execution_group(group: ExecutionGroup, config: dict, ssh_key: str,
     conn = None
     try:
         conn = provision_cloud_vm(
-            group.gpu_name, group.gpu_count, ssh_key, providers_config,
-            server_name=group_label, dry_run=dry_run, logger=logger,
+            group.gpu_name,
+            group.gpu_count,
+            ssh_key,
+            providers_config,
+            server_name=group_label,
+            dry_run=dry_run,
+            logger=logger,
         )
         if conn is None:
             logger.error("VM provisioning failed")
@@ -93,7 +100,9 @@ def run_execution_group(group: ExecutionGroup, config: dict, ssh_key: str,
             task_logger.info("Running benchmark...")
             run_cmd = make_run_cmd(conn.address, ssh_key, conn.ssh_port, dry_run=dry_run)
             bench_success, output = run_benchmark_workload(
-                run_cmd, recipe_config, dry_run=dry_run,
+                run_cmd,
+                recipe_config,
+                dry_run=dry_run,
             )
 
             if bench_success or dry_run:
@@ -131,7 +140,12 @@ async def _run_groups(groups, config, ssh_key, run_dir, dry_run, max_workers):
     async def _run_with_semaphore(group):
         async with sem:
             return await asyncio.to_thread(
-                run_execution_group, group, config, ssh_key, run_dir, dry_run,
+                run_execution_group,
+                group,
+                config,
+                ssh_key,
+                run_dir,
+                dry_run,
             )
 
     results = await asyncio.gather(

--- a/deplodock/benchmark/tasks.py
+++ b/deplodock/benchmark/tasks.py
@@ -40,8 +40,7 @@ def enumerate_tasks(recipe_dirs, variants_filter=None):
                     selected.append(v)
                 else:
                     print(
-                        f"Warning: variant '{v}' not in {recipe_dir} "
-                        f"(available: {', '.join(available_variants)}), skipping.",
+                        f"Warning: variant '{v}' not in {recipe_dir} (available: {', '.join(available_variants)}), skipping.",
                         file=sys.stderr,
                     )
             variants_to_run = selected
@@ -59,13 +58,15 @@ def enumerate_tasks(recipe_dirs, variants_filter=None):
                 )
                 continue
 
-            tasks.append(BenchmarkTask(
-                recipe_dir=recipe_dir,
-                variant=variant,
-                recipe_config=config,
-                gpu_name=gpu_name,
-                gpu_count=gpu_count,
-            ))
+            tasks.append(
+                BenchmarkTask(
+                    recipe_dir=recipe_dir,
+                    variant=variant,
+                    recipe_config=config,
+                    gpu_name=gpu_name,
+                    gpu_count=gpu_count,
+                )
+            )
 
     return tasks
 

--- a/deplodock/benchmark/tracking.py
+++ b/deplodock/benchmark/tracking.py
@@ -17,7 +17,7 @@ def compute_code_hash() -> str:
     for py_file in sorted(pkg_dir.rglob("*.py")):
         rel = py_file.relative_to(pkg_dir)
         content = py_file.read_text(encoding="utf-8")
-        hasher.update(f"{rel}\n{content}\n".encode("utf-8"))
+        hasher.update(f"{rel}\n{content}\n".encode())
     return hasher.hexdigest()
 
 

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -1,7 +1,6 @@
 """Benchmark workload execution."""
 
 import logging
-from typing import Optional
 
 from deplodock.deploy.compose import calculate_num_instances
 
@@ -15,7 +14,7 @@ def extract_benchmark_results(output: str) -> str:
     return output[idx:]
 
 
-def _parse_max_model_len(extra_args: str) -> Optional[int]:
+def _parse_max_model_len(extra_args: str) -> int | None:
     """Extract --max-model-len value from extra_args string."""
     parts = extra_args.split()
     for i, part in enumerate(parts):

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -12,16 +12,16 @@ from datetime import datetime
 from pathlib import Path
 
 from deplodock.benchmark import (
+    _expand_path,
+    _run_groups,
+    _task_meta,
     compute_code_hash,
     create_run_dir,
-    write_manifest,
-    setup_logging,
-    load_config,
-    validate_config,
-    _expand_path,
     enumerate_tasks,
-    _task_meta,
-    _run_groups,
+    load_config,
+    setup_logging,
+    validate_config,
+    write_manifest,
 )
 from deplodock.planner.group_by_model_and_gpu import GroupByModelAndGpuPlanner
 
@@ -66,18 +66,12 @@ def handle_bench(args):
     planner = GroupByModelAndGpuPlanner()
     groups = planner.plan(tasks)
 
-    root_logger.info(
-        f"Running {len(tasks)} benchmark task(s) in {len(groups)} execution group(s)"
-    )
-    root_logger.info(
-        f"Parallel mode (max workers: {args.max_workers or len(groups)})"
-    )
+    root_logger.info(f"Running {len(tasks)} benchmark task(s) in {len(groups)} execution group(s)")
+    root_logger.info(f"Parallel mode (max workers: {args.max_workers or len(groups)})")
     root_logger.info("")
 
     # Run groups
-    raw_results = asyncio.run(
-        _run_groups(groups, config, ssh_key, run_dir, dry_run, args.max_workers)
-    )
+    raw_results = asyncio.run(_run_groups(groups, config, ssh_key, run_dir, dry_run, args.max_workers))
 
     # Flatten results, handling exceptions
     all_task_meta = []

--- a/deplodock/commands/deploy/__init__.py
+++ b/deplodock/commands/deploy/__init__.py
@@ -1,18 +1,18 @@
 """Deploy command layer — re-exports from deplodock.deploy for backward compatibility."""
 
-from deplodock.deploy.params import DeployParams
-from deplodock.deploy.recipe import deep_merge, load_recipe
 from deplodock.deploy.compose import (
     calculate_num_instances,
     generate_compose,
     generate_nginx_conf,
 )
 from deplodock.deploy.orchestrate import (
+    deploy,
     run_deploy,
     run_teardown,
-    deploy,
     teardown,
 )
+from deplodock.deploy.params import DeployParams
+from deplodock.deploy.recipe import deep_merge, load_recipe
 
 __all__ = [
     "DeployParams",

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -5,15 +5,15 @@ import sys
 
 from deplodock.deploy import (
     DeployParams,
-    deploy as deploy_entry,
     load_recipe,
+)
+from deplodock.deploy import (
+    deploy as deploy_entry,
 )
 from deplodock.provisioning.cloud import (
     provision_cloud_vm,
-    delete_cloud_vm,
 )
 from deplodock.provisioning.remote import provision_remote
-
 
 # ── CLI handler ────────────────────────────────────────────────────
 
@@ -22,8 +22,8 @@ def handle_cloud(args):
     """CLI handler for 'deploy cloud'."""
     config = load_recipe(args.recipe, variant=args.variant)
 
-    gpu_name = config.get('gpu')
-    gpu_count = config.get('gpu_count', 1)
+    gpu_name = config.get("gpu")
+    gpu_count = config.get("gpu_count", 1)
     if not gpu_name:
         print("Error: recipe must have a 'gpu' field (use a variant with GPU info).", file=sys.stderr)
         sys.exit(1)

--- a/deplodock/commands/deploy/ssh.py
+++ b/deplodock/commands/deploy/ssh.py
@@ -5,11 +5,14 @@ import sys
 
 from deplodock.deploy import (
     DeployParams,
-    deploy as deploy_entry,
     load_recipe,
+)
+from deplodock.deploy import (
+    deploy as deploy_entry,
+)
+from deplodock.deploy import (
     teardown as teardown_entry,
 )
-from deplodock.provisioning.ssh_transport import make_run_cmd, make_write_file, scp_file, ssh_base_args, REMOTE_DEPLOY_DIR
 from deplodock.provisioning.remote import provision_remote
 
 

--- a/deplodock/commands/report/__init__.py
+++ b/deplodock/commands/report/__init__.py
@@ -1,12 +1,6 @@
 """Report command CLI handler."""
 
-from deplodock.report import (
-    # Re-export for backward compatibility
-    parse_benchmark_result,
-    get_gpu_price,
-    generate_report,
-    collect_tasks_from_manifests as _collect_tasks_from_manifests,
-)
+from deplodock.report import generate_report
 from deplodock.report.collector import load_config
 
 
@@ -23,18 +17,18 @@ def register_report_command(subparsers):
         help="Generate Excel report from benchmark results",
     )
     parser.add_argument(
-        '--config',
-        default='config.yaml',
-        help='Path to configuration file (default: config.yaml)',
+        "--config",
+        default="config.yaml",
+        help="Path to configuration file (default: config.yaml)",
     )
     parser.add_argument(
-        '--results-dir',
-        default='results',
-        help='Directory containing benchmark results (default: results)',
+        "--results-dir",
+        default="results",
+        help="Directory containing benchmark results (default: results)",
     )
     parser.add_argument(
-        '--output',
-        default='results/benchmark_report.xlsx',
-        help='Output Excel file path (default: results/benchmark_report.xlsx)',
+        "--output",
+        default="results/benchmark_report.xlsx",
+        help="Output Excel file path (default: results/benchmark_report.xlsx)",
     )
     parser.set_defaults(func=handle_report)

--- a/deplodock/commands/vm/__init__.py
+++ b/deplodock/commands/vm/__init__.py
@@ -1,16 +1,15 @@
 """VM lifecycle management: create/delete cloud GPU instances."""
 
-from deplodock.provisioning.ssh import wait_for_ssh
-from deplodock.provisioning.shell import run_shell_cmd
-
 
 def register_vm_command(subparsers):
     """Register the 'vm' command with create/delete action subparsers."""
-    from deplodock.commands.vm.gcp_flex_start import register_create_target, register_delete_target
     from deplodock.commands.vm.cloudrift import (
         register_create_target as register_cloudrift_create,
+    )
+    from deplodock.commands.vm.cloudrift import (
         register_delete_target as register_cloudrift_delete,
     )
+    from deplodock.commands.vm.gcp_flex_start import register_create_target, register_delete_target
 
     vm_parser = subparsers.add_parser("vm", help="Manage cloud VM instances")
 

--- a/deplodock/commands/vm/cloudrift.py
+++ b/deplodock/commands/vm/cloudrift.py
@@ -6,21 +6,8 @@ import sys
 from deplodock.provisioning.cloudrift import (
     DEFAULT_API_URL,
     DEFAULT_IMAGE_URL,
-    # Re-export business logic for backward compatibility
-    _api_request,
-    _rent_instance,
-    _terminate_instance,
-    _get_instance_info,
-    _list_ssh_keys,
-    _add_ssh_key,
-    _ensure_ssh_key,
-    _extract_connection_info,
-    _print_connection_info,
-    wait_for_status,
     create_instance,
     delete_instance,
-    API_VERSION,
-    DEFAULT_CLOUDINIT_URL,
 )
 
 

--- a/deplodock/commands/vm/gcp_flex_start.py
+++ b/deplodock/commands/vm/gcp_flex_start.py
@@ -4,17 +4,9 @@ import sys
 
 from deplodock.provisioning.gcp_flex_start import (
     # Re-export business logic for backward compatibility
-    _gcloud_create_cmd,
-    _gcloud_delete_cmd,
-    _gcloud_status_cmd,
-    _gcloud_external_ip_cmd,
-    _gcloud_ssh_check_cmd,
-    wait_for_status,
-    wait_for_ssh,
     create_instance,
     delete_instance,
 )
-
 
 # ── CLI handlers ───────────────────────────────────────────────────
 
@@ -62,10 +54,20 @@ def register_create_target(subparsers):
     parser.add_argument("--instance", required=True, help="GCP instance name")
     parser.add_argument("--zone", required=True, help="GCP zone (e.g. us-central1-a)")
     parser.add_argument("--machine-type", required=True, help="Machine type (e.g. a2-highgpu-1g)")
-    parser.add_argument("--provisioning-model", default="FLEX_START", choices=["FLEX_START", "SPOT", "STANDARD"], help="Provisioning model (default: FLEX_START)")
+    parser.add_argument(
+        "--provisioning-model",
+        default="FLEX_START",
+        choices=["FLEX_START", "SPOT", "STANDARD"],
+        help="Provisioning model (default: FLEX_START)",
+    )
     parser.add_argument("--max-run-duration", default="7d", help="Max VM run time (default: 7d)")
     parser.add_argument("--request-valid-for-duration", default="2h", help="How long to wait for capacity (default: 2h)")
-    parser.add_argument("--termination-action", default="DELETE", choices=["STOP", "DELETE"], help="Action when max-run-duration expires (default: DELETE)")
+    parser.add_argument(
+        "--termination-action",
+        default="DELETE",
+        choices=["STOP", "DELETE"],
+        help="Action when max-run-duration expires (default: DELETE)",
+    )
     parser.add_argument("--image-family", default="debian-12", help="Boot disk image family (default: debian-12)")
     parser.add_argument("--image-project", default="debian-cloud", help="Boot disk image project (default: debian-cloud)")
     parser.add_argument("--gcloud-args", default=None, help="Extra args passed to gcloud compute instances create")

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -2,7 +2,6 @@
 """Server benchmark tools — CLI entrypoint."""
 
 import argparse
-import sys
 
 from deplodock.commands.bench import register_bench_command
 from deplodock.commands.deploy.cloud import register_cloud_target

--- a/deplodock/deploy/__init__.py
+++ b/deplodock/deploy/__init__.py
@@ -1,18 +1,18 @@
 """Deploy library: recipe loading, compose generation, deploy orchestration."""
 
-from deplodock.deploy.params import DeployParams
-from deplodock.deploy.recipe import deep_merge, load_recipe
 from deplodock.deploy.compose import (
     calculate_num_instances,
     generate_compose,
     generate_nginx_conf,
 )
 from deplodock.deploy.orchestrate import (
+    deploy,
     run_deploy,
     run_teardown,
-    deploy,
     teardown,
 )
+from deplodock.deploy.params import DeployParams
+from deplodock.deploy.recipe import deep_merge, load_recipe
 
 __all__ = [
     "DeployParams",

--- a/deplodock/deploy/compose.py
+++ b/deplodock/deploy/compose.py
@@ -111,9 +111,7 @@ def generate_compose(config, model_dir, hf_token):
 
 def generate_nginx_conf(num_instances):
     """Generate nginx config with least_conn upstream."""
-    upstream_servers = "\n".join(
-        f"        server vllm_{i}:8000;" for i in range(num_instances)
-    )
+    upstream_servers = "\n".join(f"        server vllm_{i}:8000;" for i in range(num_instances))
 
     return f"""worker_processes auto;
 

--- a/deplodock/deploy/orchestrate.py
+++ b/deplodock/deploy/orchestrate.py
@@ -115,7 +115,7 @@ def run_deploy(run_cmd, write_file, config, model_dir, hf_token, host, dry_run=F
             print("WARNING: Smoke test failed. The endpoint may not be ready yet.", file=sys.stderr)
 
     # Print curl example
-    print(f"\nExample curl:")
+    print("\nExample curl:")
     print(
         f"  curl http://{host}:{port}/v1/chat/completions \\\n"
         f"    -H 'Content-Type: application/json' \\\n"
@@ -145,8 +145,7 @@ def deploy(params: DeployParams) -> bool:
     run_cmd = make_run_cmd(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
     write_file = make_write_file(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
     host = params.server.split("@")[-1] if "@" in params.server else params.server
-    return run_deploy(run_cmd, write_file, params.recipe_config,
-                      params.model_dir, params.hf_token, host, params.dry_run)
+    return run_deploy(run_cmd, write_file, params.recipe_config, params.model_dir, params.hf_token, host, params.dry_run)
 
 
 def teardown(params: DeployParams) -> bool:

--- a/deplodock/deploy/params.py
+++ b/deplodock/deploy/params.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass, field
 class DeployParams:
     """All parameters needed for a single deployment. Serializable for future API use."""
 
-    server: str                             # user@host or IP
-    ssh_key: str                            # path to SSH private key
+    server: str  # user@host or IP
+    ssh_key: str  # path to SSH private key
     ssh_port: int = 22
     recipe_config: dict = field(default_factory=dict)  # pre-loaded recipe
     model_dir: str = "/hf_models"

--- a/deplodock/deploy/recipe.py
+++ b/deplodock/deploy/recipe.py
@@ -30,9 +30,7 @@ def load_recipe(recipe_dir, variant=None):
     if variant is not None:
         if variant not in variants:
             available = ", ".join(sorted(variants.keys())) if variants else "none"
-            raise ValueError(
-                f"Unknown variant '{variant}'. Available variants: {available}"
-            )
+            raise ValueError(f"Unknown variant '{variant}'. Available variants: {available}")
         config = deep_merge(config, variants[variant])
 
     return config

--- a/deplodock/hardware.py
+++ b/deplodock/hardware.py
@@ -75,6 +75,7 @@ def gpu_short_name(full_name):
     if full_name in GPU_SHORT_NAMES:
         return GPU_SHORT_NAMES[full_name]
     import re
+
     return re.sub(r"[^a-z0-9]", "", full_name.lower())
 
 

--- a/deplodock/planner/__init__.py
+++ b/deplodock/planner/__init__.py
@@ -4,7 +4,6 @@ import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
 
 
 @dataclass
@@ -37,13 +36,13 @@ class ExecutionGroup:
 
     gpu_name: str
     gpu_count: int
-    tasks: List[BenchmarkTask] = field(default_factory=list)
+    tasks: list[BenchmarkTask] = field(default_factory=list)
 
 
 class BenchmarkPlanner(ABC):
     """Abstract base for grouping benchmark tasks into execution groups."""
 
     @abstractmethod
-    def plan(self, tasks: List[BenchmarkTask]) -> List[ExecutionGroup]:
+    def plan(self, tasks: list[BenchmarkTask]) -> list[ExecutionGroup]:
         """Group benchmark tasks into execution groups."""
         ...

--- a/deplodock/planner/group_by_model_and_gpu.py
+++ b/deplodock/planner/group_by_model_and_gpu.py
@@ -5,7 +5,7 @@ across different GPU-count benchmarks. Different models on the same GPU
 type get separate VMs.
 """
 
-from deplodock.planner import BenchmarkPlanner, BenchmarkTask, ExecutionGroup
+from deplodock.planner import BenchmarkPlanner, ExecutionGroup
 
 
 class GroupByModelAndGpuPlanner(BenchmarkPlanner):
@@ -18,10 +18,14 @@ class GroupByModelAndGpuPlanner(BenchmarkPlanner):
             groups.setdefault(key, []).append(task)
 
         result = []
-        for (model, gpu), group_tasks in groups.items():
+        for (_model, gpu), group_tasks in groups.items():
             group_tasks.sort(key=lambda t: t.gpu_count, reverse=True)
             max_count = max(t.gpu_count for t in group_tasks)
-            result.append(ExecutionGroup(
-                gpu_name=gpu, gpu_count=max_count, tasks=group_tasks,
-            ))
+            result.append(
+                ExecutionGroup(
+                    gpu_name=gpu,
+                    gpu_count=max_count,
+                    tasks=group_tasks,
+                )
+            )
         return result

--- a/deplodock/provisioning/__init__.py
+++ b/deplodock/provisioning/__init__.py
@@ -1,21 +1,21 @@
 """VM and cloud provisioning: types, SSH polling, shell helpers, providers."""
 
-from deplodock.provisioning.types import VMConnectionInfo
-from deplodock.provisioning.ssh import wait_for_ssh
-from deplodock.provisioning.shell import run_shell_cmd
+from deplodock.provisioning.cloud import (
+    delete_cloud_vm,
+    provision_cloud_vm,
+    resolve_vm_spec,
+)
 from deplodock.provisioning.remote import provision_remote
+from deplodock.provisioning.shell import run_shell_cmd
+from deplodock.provisioning.ssh import wait_for_ssh
 from deplodock.provisioning.ssh_transport import (
-    ssh_base_args,
+    REMOTE_DEPLOY_DIR,
     make_run_cmd,
     make_write_file,
     scp_file,
-    REMOTE_DEPLOY_DIR,
+    ssh_base_args,
 )
-from deplodock.provisioning.cloud import (
-    resolve_vm_spec,
-    provision_cloud_vm,
-    delete_cloud_vm,
-)
+from deplodock.provisioning.types import VMConnectionInfo
 
 __all__ = [
     "VMConnectionInfo",

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -8,9 +8,9 @@ import logging
 import os
 import shlex
 
+from deplodock.hardware import GPU_INSTANCE_TYPES, resolve_instance_type
 from deplodock.provisioning import cloudrift as cr_provider
 from deplodock.provisioning import gcp_flex_start as gcp_provider
-from deplodock.hardware import GPU_INSTANCE_TYPES, resolve_instance_type
 
 
 def resolve_vm_spec(loaded_configs, server_name=None):
@@ -32,23 +32,20 @@ def resolve_vm_spec(loaded_configs, server_name=None):
     max_gpu_count = 0
 
     for entry, recipe_config in loaded_configs:
-        recipe_path = entry['recipe']
-        variant = entry.get('variant')
+        recipe_path = entry["recipe"]
+        variant = entry.get("variant")
 
-        entry_gpu = recipe_config.get('gpu')
-        entry_gpu_count = recipe_config.get('gpu_count', 1)
+        entry_gpu = recipe_config.get("gpu")
+        entry_gpu_count = recipe_config.get("gpu_count", 1)
 
         if entry_gpu is None:
-            raise ValueError(
-                f"Recipe '{recipe_path}' variant '{variant}' is missing 'gpu' field"
-            )
+            raise ValueError(f"Recipe '{recipe_path}' variant '{variant}' is missing 'gpu' field")
 
         if gpu_name is None:
             gpu_name = entry_gpu
         elif entry_gpu != gpu_name:
             raise ValueError(
-                f"Server '{server_name}': mixed GPUs ({gpu_name} vs {entry_gpu}). "
-                "All recipes in a server entry must target the same GPU."
+                f"Server '{server_name}': mixed GPUs ({gpu_name} vs {entry_gpu}). All recipes in a server entry must target the same GPU."
             )
 
         max_gpu_count = max(max_gpu_count, entry_gpu_count)
@@ -56,8 +53,7 @@ def resolve_vm_spec(loaded_configs, server_name=None):
     return gpu_name, max_gpu_count
 
 
-def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None,
-                       server_name=None, dry_run=False, logger=None):
+def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None, server_name=None, dry_run=False, logger=None):
     """Provision a cloud VM for the given GPU requirements.
 
     Looks up the provider from the hardware table and dispatches to the
@@ -118,7 +114,8 @@ def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None,
         extra_parts = []
 
         service_account = gcp_config.get(
-            "service_account", os.environ.get("GCP_SERVICE_ACCOUNT", ""),
+            "service_account",
+            os.environ.get("GCP_SERVICE_ACCOUNT", ""),
         )
         if service_account:
             extra_parts.append(f"--service-account={service_account}")
@@ -137,7 +134,7 @@ def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None,
         if os.path.exists(pub_key_path) and not dry_run:
             with open(pub_key_path) as f:
                 pub_key = f.read().strip()
-            metadata_arg = f'--metadata=ssh-keys={ssh_user}:{pub_key}'
+            metadata_arg = f"--metadata=ssh-keys={ssh_user}:{pub_key}"
             extra_parts.append(shlex.quote(metadata_arg))
 
         # Append any raw extra_gcloud_args from config

--- a/deplodock/provisioning/cloudrift.py
+++ b/deplodock/provisioning/cloudrift.py
@@ -6,9 +6,8 @@ import time
 
 import requests
 
-from deplodock.provisioning.types import VMConnectionInfo
 from deplodock.provisioning.ssh import wait_for_ssh
-
+from deplodock.provisioning.types import VMConnectionInfo
 
 DEFAULT_API_URL = "https://api.cloudrift.ai"
 DEFAULT_IMAGE_URL = "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-gpu-580-129-20251015-183936.img"
@@ -41,9 +40,16 @@ def _api_request(method, path, data, api_key, api_url=DEFAULT_API_URL, dry_run=F
     return resp.json().get("data", resp.json())
 
 
-def _rent_instance(api_key, instance_type, ssh_public_keys,
-                   image_url=DEFAULT_IMAGE_URL, cloudinit_url=DEFAULT_CLOUDINIT_URL,
-                   ports=None, api_url=DEFAULT_API_URL, dry_run=False):
+def _rent_instance(
+    api_key,
+    instance_type,
+    ssh_public_keys,
+    image_url=DEFAULT_IMAGE_URL,
+    cloudinit_url=DEFAULT_CLOUDINIT_URL,
+    ports=None,
+    api_url=DEFAULT_API_URL,
+    dry_run=False,
+):
     """Rent a new CloudRift VM instance.
 
     POST /api/v1/instances/rent
@@ -147,9 +153,7 @@ def _ensure_ssh_key(api_key, ssh_key_path, api_url=DEFAULT_API_URL, dry_run=Fals
     return key_id
 
 
-def wait_for_status(api_key, instance_id, target_status, timeout,
-                    api_url=DEFAULT_API_URL, interval=10, dry_run=False,
-                    fail_statuses=None):
+def wait_for_status(api_key, instance_id, target_status, timeout, api_url=DEFAULT_API_URL, interval=10, dry_run=False, fail_statuses=None):
     """Poll instance status until it matches *target_status* or timeout.
 
     Args:
@@ -262,9 +266,19 @@ def _print_connection_info(instance):
         print("Warning: no host address found in instance info.")
 
 
-def create_instance(api_key, instance_type, ssh_key_path, image_url=DEFAULT_IMAGE_URL,
-                    ports=None, timeout=600, api_url=DEFAULT_API_URL, dry_run=False,
-                    fail_statuses=None, wait_ssh=False, ssh_private_key_path=None):
+def create_instance(
+    api_key,
+    instance_type,
+    ssh_key_path,
+    image_url=DEFAULT_IMAGE_URL,
+    ports=None,
+    timeout=600,
+    api_url=DEFAULT_API_URL,
+    dry_run=False,
+    fail_statuses=None,
+    wait_ssh=False,
+    ssh_private_key_path=None,
+):
     """Create a CloudRift VM instance.
 
     Args:
@@ -287,12 +301,13 @@ def create_instance(api_key, instance_type, ssh_key_path, image_url=DEFAULT_IMAG
         with open(ssh_key_path) as f:
             public_key = f.read().strip()
 
-    result = _rent_instance(api_key, instance_type, [public_key], image_url=image_url,
-                            ports=ports, api_url=api_url, dry_run=dry_run)
+    result = _rent_instance(api_key, instance_type, [public_key], image_url=image_url, ports=ports, api_url=api_url, dry_run=dry_run)
     if dry_run:
         print("[dry-run] Would wait for Active status, then print connection info.")
         return VMConnectionInfo(
-            host="dry-run-host", username="riftuser", ssh_port=22222,
+            host="dry-run-host",
+            username="riftuser",
+            ssh_port=22222,
             delete_info=("cloudrift", "dry-run-id"),
         )
 
@@ -303,8 +318,7 @@ def create_instance(api_key, instance_type, ssh_key_path, image_url=DEFAULT_IMAG
     instance_id = instance_ids[0]
     print(f"Instance rented (id={instance_id}). Waiting for Active status (timeout: {timeout}s)...")
 
-    info = wait_for_status(api_key, instance_id, "Active", timeout, api_url,
-                           fail_statuses=fail_statuses)
+    info = wait_for_status(api_key, instance_id, "Active", timeout, api_url, fail_statuses=fail_statuses)
     if info is None:
         return None
 
@@ -313,7 +327,7 @@ def create_instance(api_key, instance_type, ssh_key_path, image_url=DEFAULT_IMAG
     _print_connection_info(info)
 
     if wait_ssh and ssh_private_key_path:
-        print(f"Waiting for SSH connectivity...")
+        print("Waiting for SSH connectivity...")
         wait_for_ssh(conn.host, conn.username, conn.ssh_port, ssh_private_key_path)
 
     return conn

--- a/deplodock/provisioning/gcp_flex_start.py
+++ b/deplodock/provisioning/gcp_flex_start.py
@@ -7,7 +7,6 @@ import time
 from deplodock.provisioning.shell import run_shell_cmd
 from deplodock.provisioning.types import VMConnectionInfo
 
-
 # ── Command builders ───────────────────────────────────────────────
 
 
@@ -29,14 +28,22 @@ def _gcloud_create_cmd(
         provisioning_model: FLEX_START, SPOT, or STANDARD.
     """
     cmd = [
-        "gcloud", "compute", "instances", "create", instance,
-        "--zone", zone,
-        "--machine-type", machine_type,
+        "gcloud",
+        "compute",
+        "instances",
+        "create",
+        instance,
+        "--zone",
+        zone,
+        "--machine-type",
+        machine_type,
         f"--provisioning-model={provisioning_model}",
         "--maintenance-policy=TERMINATE",
         "--reservation-affinity=none",
-        "--image-family", image_family,
-        "--image-project", image_project,
+        "--image-family",
+        image_family,
+        "--image-project",
+        image_project,
     ]
     # Duration and termination flags are only valid for FLEX_START
     if provisioning_model == "FLEX_START":
@@ -57,26 +64,48 @@ def _gcloud_delete_cmd(instance, zone):
 def _gcloud_status_cmd(instance, zone):
     """Build gcloud command to get instance status."""
     return [
-        "gcloud", "compute", "instances", "describe", instance,
-        "--zone", zone, "--format", "value(status)",
+        "gcloud",
+        "compute",
+        "instances",
+        "describe",
+        instance,
+        "--zone",
+        zone,
+        "--format",
+        "value(status)",
     ]
 
 
 def _gcloud_external_ip_cmd(instance, zone):
     """Build gcloud command to get external IP."""
     return [
-        "gcloud", "compute", "instances", "describe", instance,
-        "--zone", zone, "--format", "value(networkInterfaces[0].accessConfigs[0].natIP)",
+        "gcloud",
+        "compute",
+        "instances",
+        "describe",
+        instance,
+        "--zone",
+        zone,
+        "--format",
+        "value(networkInterfaces[0].accessConfigs[0].natIP)",
     ]
 
 
 def _gcloud_ssh_check_cmd(instance, zone, ssh_gateway=None):
     """Build gcloud command to check SSH connectivity."""
     cmd = [
-        "gcloud", "compute", "ssh", instance,
-        "--zone", zone, "--command", "true",
-        "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
-        "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
+        "gcloud",
+        "compute",
+        "ssh",
+        instance,
+        "--zone",
+        zone,
+        "--command",
+        "true",
+        "--ssh-flag=-o",
+        "--ssh-flag=ConnectTimeout=5",
+        "--ssh-flag=-o",
+        "--ssh-flag=StrictHostKeyChecking=no",
     ]
     if ssh_gateway:
         cmd.extend(["--ssh-flag=-o", f"--ssh-flag=ProxyJump={ssh_gateway}"])
@@ -168,7 +197,9 @@ def create_instance(
     print(f"Creating instance '{instance}' in zone '{zone}' (provisioning: {provisioning_model})...")
 
     cmd = _gcloud_create_cmd(
-        instance, zone, machine_type,
+        instance,
+        zone,
+        machine_type,
         provisioning_model=provisioning_model,
         max_run_duration=max_run_duration,
         request_valid_for_duration=request_valid_for_duration,

--- a/deplodock/provisioning/ssh_transport.py
+++ b/deplodock/provisioning/ssh_transport.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import tempfile
 
-
 REMOTE_DEPLOY_DIR = "~/deploy"
 
 

--- a/deplodock/provisioning/types.py
+++ b/deplodock/provisioning/types.py
@@ -1,7 +1,6 @@
 """Shared data types for VM providers."""
 
 from dataclasses import dataclass, field
-from typing import List, Tuple
 
 
 @dataclass
@@ -11,7 +10,7 @@ class VMConnectionInfo:
     host: str
     username: str
     ssh_port: int = 22
-    port_mappings: List[Tuple[int, int]] = field(default_factory=list)
+    port_mappings: list[tuple[int, int]] = field(default_factory=list)
     delete_info: tuple = ()
 
     @property

--- a/deplodock/report/__init__.py
+++ b/deplodock/report/__init__.py
@@ -1,9 +1,9 @@
 """Report library: parse results, collect tasks, generate Excel reports."""
 
+from deplodock.report.collector import collect_tasks_from_manifests, load_config
+from deplodock.report.generator import generate_report
 from deplodock.report.parser import parse_benchmark_result
 from deplodock.report.pricing import get_gpu_price
-from deplodock.report.collector import load_config, collect_tasks_from_manifests
-from deplodock.report.generator import generate_report
 
 __all__ = [
     "parse_benchmark_result",

--- a/deplodock/report/collector.py
+++ b/deplodock/report/collector.py
@@ -8,7 +8,7 @@ import yaml
 
 def load_config(config_file: str) -> dict:
     """Load configuration from YAML file."""
-    with open(config_file, 'r') as f:
+    with open(config_file) as f:
         return yaml.safe_load(f)
 
 

--- a/deplodock/report/generator.py
+++ b/deplodock/report/generator.py
@@ -33,16 +33,16 @@ def generate_report(config: dict, results_dir: str, output_file: str):
 
         price = get_gpu_price(config, gpu_type, gpu_count)
 
-        gpu_display = gpu_type.upper().replace('RTX', '').replace('PRO', '')
+        gpu_display = gpu_type.upper().replace("RTX", "").replace("PRO", "")
         machine_name = f"{gpu_count}x{gpu_display}"
 
         price_per_mtok = (price / (total_throughput * 3600)) * 1_000_000 if total_throughput > 0 else 0
 
         row_data = {
-            'Machine': machine_name,
-            'Throughput (tok/s)': total_throughput,
-            'GPU Price ($/hour)': price,
-            'Token Price ($/mtok)': price_per_mtok,
+            "Machine": machine_name,
+            "Throughput (tok/s)": total_throughput,
+            "GPU Price ($/hour)": price,
+            "Token Price ($/mtok)": price_per_mtok,
         }
 
         all_data.append(row_data)
@@ -58,14 +58,14 @@ def generate_report(config: dict, results_dir: str, output_file: str):
     print(f"Found {len(all_data)} benchmark results across run directories")
 
     df = pd.DataFrame(all_data)
-    df = df.sort_values('Machine')
+    df = df.sort_values("Machine")
 
     output_path = Path(output_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with pd.ExcelWriter(output_path, engine='openpyxl') as writer:
-        df.to_excel(writer, sheet_name='Benchmark Results', index=False)
-        worksheet = writer.sheets['Benchmark Results']
+    with pd.ExcelWriter(output_path, engine="openpyxl") as writer:
+        df.to_excel(writer, sheet_name="Benchmark Results", index=False)
+        worksheet = writer.sheets["Benchmark Results"]
 
         for column in worksheet.columns:
             max_length = 0
@@ -74,7 +74,7 @@ def generate_report(config: dict, results_dir: str, output_file: str):
                 try:
                     if len(str(cell.value)) > max_length:
                         max_length = len(str(cell.value))
-                except:
+                except Exception:
                     pass
             adjusted_width = min(max_length + 2, 50)
             worksheet.column_dimensions[column_letter].width = adjusted_width
@@ -84,15 +84,15 @@ def generate_report(config: dict, results_dir: str, output_file: str):
 
     output_dir = output_path.parent
     for model_name, model_data in data_by_model.items():
-        safe_model_name = model_name.replace('/', '_').replace(' ', '_')
+        safe_model_name = model_name.replace("/", "_").replace(" ", "_")
         model_output_path = output_dir / f"benchmark_report_{safe_model_name}.xlsx"
 
         df_model = pd.DataFrame(model_data)
-        df_model = df_model.sort_values('Machine')
+        df_model = df_model.sort_values("Machine")
 
-        with pd.ExcelWriter(model_output_path, engine='openpyxl') as writer:
-            df_model.to_excel(writer, sheet_name='Benchmark Results', index=False)
-            worksheet = writer.sheets['Benchmark Results']
+        with pd.ExcelWriter(model_output_path, engine="openpyxl") as writer:
+            df_model.to_excel(writer, sheet_name="Benchmark Results", index=False)
+            worksheet = writer.sheets["Benchmark Results"]
 
             for column in worksheet.columns:
                 max_length = 0
@@ -101,7 +101,7 @@ def generate_report(config: dict, results_dir: str, output_file: str):
                     try:
                         if len(str(cell.value)) > max_length:
                             max_length = len(str(cell.value))
-                    except:
+                    except Exception:
                         pass
                 adjusted_width = min(max_length + 2, 50)
                 worksheet.column_dimensions[column_letter].width = adjusted_width

--- a/deplodock/report/parser.py
+++ b/deplodock/report/parser.py
@@ -2,15 +2,14 @@
 
 import re
 from pathlib import Path
-from typing import Dict, Tuple
 
 
-def parse_benchmark_result(result_file: Path) -> Tuple[float, Dict]:
+def parse_benchmark_result(result_file: Path) -> tuple[float, dict]:
     """Parse vLLM benchmark result file and extract total token throughput."""
-    with open(result_file, 'r') as f:
+    with open(result_file) as f:
         content = f.read()
 
-    total_match = re.search(r'Total [Tt]oken throughput \(tok/s\):\s+([\d.]+)', content)
+    total_match = re.search(r"Total [Tt]oken throughput \(tok/s\):\s+([\d.]+)", content)
     if not total_match:
         return None, {}
 
@@ -18,20 +17,20 @@ def parse_benchmark_result(result_file: Path) -> Tuple[float, Dict]:
 
     metrics = {}
 
-    req_match = re.search(r'Request throughput \(req/s\):\s+([\d.]+)', content)
+    req_match = re.search(r"Request throughput \(req/s\):\s+([\d.]+)", content)
     if req_match:
-        metrics['request_throughput'] = float(req_match.group(1))
+        metrics["request_throughput"] = float(req_match.group(1))
 
-    output_match = re.search(r'Output token throughput \(tok/s\):\s+([\d.]+)', content)
+    output_match = re.search(r"Output token throughput \(tok/s\):\s+([\d.]+)", content)
     if output_match:
-        metrics['output_throughput'] = float(output_match.group(1))
+        metrics["output_throughput"] = float(output_match.group(1))
 
-    ttft_match = re.search(r'Mean TTFT \(ms\):\s+([\d.]+)', content)
+    ttft_match = re.search(r"Mean TTFT \(ms\):\s+([\d.]+)", content)
     if ttft_match:
-        metrics['mean_ttft_ms'] = float(ttft_match.group(1))
+        metrics["mean_ttft_ms"] = float(ttft_match.group(1))
 
-    tpot_match = re.search(r'Mean TPOT \(ms\):\s+([\d.]+)', content)
+    tpot_match = re.search(r"Mean TPOT \(ms\):\s+([\d.]+)", content)
     if tpot_match:
-        metrics['mean_tpot_ms'] = float(tpot_match.group(1))
+        metrics["mean_tpot_ms"] = float(tpot_match.group(1))
 
     return total_throughput, metrics

--- a/deplodock/report/pricing.py
+++ b/deplodock/report/pricing.py
@@ -3,10 +3,10 @@
 
 def get_gpu_price(config: dict, gpu_type: str, gpu_count: int) -> float:
     """Get GPU price from config."""
-    if 'pricing' not in config:
+    if "pricing" not in config:
         return 0.0
 
-    pricing = config['pricing']
+    pricing = config["pricing"]
     gpu_type_normalized = gpu_type.lower()
 
     if gpu_type_normalized in pricing:
@@ -14,9 +14,9 @@ def get_gpu_price(config: dict, gpu_type: str, gpu_count: int) -> float:
         return price_per_gpu * gpu_count
 
     variations = {
-        'rtx4090': ['4090', 'rtx_4090'],
-        'rtx5090': ['5090', 'rtx_5090'],
-        'pro6000': ['6000', 'rtx_6000', 'rtx6000', 'quadro_rtx_6000']
+        "rtx4090": ["4090", "rtx_4090"],
+        "rtx5090": ["5090", "rtx_5090"],
+        "pro6000": ["6000", "rtx_6000", "rtx6000", "quadro_rtx_6000"],
     }
 
     for base_name, alternatives in variations.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,21 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest"]
+dev = ["pytest", "ruff"]
 
 [tool.setuptools.packages.find]
 include = ["deplodock*"]
 
 [project.scripts]
 deplodock = "deplodock.deplodock:main"
+
+[tool.ruff]
+line-length = 140
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/tests/benchmark/test_manifest.py
+++ b/tests/benchmark/test_manifest.py
@@ -29,12 +29,26 @@ def test_manifest_round_trip(tmp_path):
 
 def test_manifest_multiple_tasks(tmp_path):
     tasks = [
-        {"recipe": "A", "variant": "V1", "status": "completed",
-         "gpu_name": "G", "gpu_short": "g", "gpu_count": 1,
-         "model_name": "m", "result_file": "A/V1_vllm_benchmark.txt"},
-        {"recipe": "B", "variant": "V2", "status": "failed",
-         "gpu_name": "G", "gpu_short": "g", "gpu_count": 2,
-         "model_name": "m", "result_file": "B/V2_vllm_benchmark.txt"},
+        {
+            "recipe": "A",
+            "variant": "V1",
+            "status": "completed",
+            "gpu_name": "G",
+            "gpu_short": "g",
+            "gpu_count": 1,
+            "model_name": "m",
+            "result_file": "A/V1_vllm_benchmark.txt",
+        },
+        {
+            "recipe": "B",
+            "variant": "V2",
+            "status": "failed",
+            "gpu_name": "G",
+            "gpu_short": "g",
+            "gpu_count": 2,
+            "model_name": "m",
+            "result_file": "B/V2_vllm_benchmark.txt",
+        },
     ]
     write_manifest(tmp_path, "2026-01-01T00:00:00", "def456", ["A", "B"], tasks)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import sys
 import pytest
 import yaml
 
-
 PROJECT_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
 RECIPES_DIR = os.path.join(PROJECT_ROOT, "recipes")
 

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -4,7 +4,6 @@ import json
 
 from deplodock.report import collect_tasks_from_manifests, parse_benchmark_result
 
-
 SAMPLE_BENCHMARK = """\
 ============ Serving Benchmark Result ============
 Request throughput (req/s):                     12.50
@@ -80,17 +79,25 @@ def test_collect_skips_failed_tasks(tmp_path):
 def test_collect_multiple_runs(tmp_path):
     tasks1 = [
         {
-            "recipe": "A", "variant": "V1",
-            "gpu_name": "G", "gpu_short": "g", "gpu_count": 1,
-            "model_name": "m/A", "result_file": "A/V1_vllm_benchmark.txt",
+            "recipe": "A",
+            "variant": "V1",
+            "gpu_name": "G",
+            "gpu_short": "g",
+            "gpu_count": 1,
+            "model_name": "m/A",
+            "result_file": "A/V1_vllm_benchmark.txt",
             "status": "completed",
         },
     ]
     tasks2 = [
         {
-            "recipe": "B", "variant": "V2",
-            "gpu_name": "G", "gpu_short": "g", "gpu_count": 2,
-            "model_name": "m/B", "result_file": "B/V2_vllm_benchmark.txt",
+            "recipe": "B",
+            "variant": "V2",
+            "gpu_name": "G",
+            "gpu_short": "g",
+            "gpu_count": 2,
+            "model_name": "m/B",
+            "result_file": "B/V2_vllm_benchmark.txt",
             "status": "completed",
         },
     ]

--- a/tests/test_bench_dryrun.py
+++ b/tests/test_bench_dryrun.py
@@ -7,8 +7,13 @@ def test_bench_dry_run_basic(run_cli, make_bench_config, recipes_dir, tmp_path):
     config_path = make_bench_config(tmp_path)
     recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
     rc, stdout, stderr = run_cli(
-        "bench", recipe, "--variants", "RTX5090",
-        "--config", config_path, "--dry-run",
+        "bench",
+        recipe,
+        "--variants",
+        "RTX5090",
+        "--config",
+        config_path,
+        "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
     assert "[dry-run]" in stdout
@@ -18,8 +23,13 @@ def test_bench_dry_run_deploy_then_benchmark(run_cli, make_bench_config, recipes
     config_path = make_bench_config(tmp_path)
     recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
     rc, stdout, stderr = run_cli(
-        "bench", recipe, "--variants", "RTX5090",
-        "--config", config_path, "--dry-run",
+        "bench",
+        recipe,
+        "--variants",
+        "RTX5090",
+        "--config",
+        config_path,
+        "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
 
@@ -45,8 +55,13 @@ def test_bench_variant_filter(run_cli, make_bench_config, recipes_dir, tmp_path)
     config_path = make_bench_config(tmp_path)
     recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
     rc, stdout, stderr = run_cli(
-        "bench", recipe, "--variants", "RTX5090",
-        "--config", config_path, "--dry-run",
+        "bench",
+        recipe,
+        "--variants",
+        "RTX5090",
+        "--config",
+        config_path,
+        "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
     assert "RTX5090" in stdout
@@ -57,8 +72,14 @@ def test_bench_multiple_recipes(run_cli, make_bench_config, recipes_dir, tmp_pat
     recipe1 = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
     recipe2 = os.path.join(recipes_dir, "GLM-4.6-FP8")
     rc, stdout, stderr = run_cli(
-        "bench", recipe1, recipe2, "--variants", "RTX5090",
-        "--config", config_path, "--dry-run",
+        "bench",
+        recipe1,
+        recipe2,
+        "--variants",
+        "RTX5090",
+        "--config",
+        config_path,
+        "--dry-run",
     )
     # Should succeed even if some variants are missing (warned on stderr)
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -4,7 +4,6 @@ import yaml
 
 from deplodock.deploy import generate_compose, generate_nginx_conf
 
-
 # ── generate_compose ────────────────────────────────────────────────
 
 

--- a/tests/test_deploy_cloud.py
+++ b/tests/test_deploy_cloud.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from deplodock.deploy.recipe import load_recipe
-from deplodock.provisioning.cloud import resolve_vm_spec, delete_cloud_vm
+from deplodock.provisioning.cloud import delete_cloud_vm, resolve_vm_spec
 from deplodock.provisioning.types import VMConnectionInfo
 
 
@@ -14,7 +14,7 @@ def _load_entries(entries):
     """Pre-load recipe configs from raw entries for resolve_vm_spec."""
     loaded = []
     for entry in entries:
-        config = load_recipe(entry['recipe'], variant=entry.get('variant'))
+        config = load_recipe(entry["recipe"], variant=entry.get("variant"))
         loaded.append((entry, config))
     return loaded
 
@@ -33,8 +33,15 @@ def test_resolve_vm_spec_max_gpu_count(tmp_path):
     """Uses max gpu_count across all entries."""
     recipe = {
         "model": {"name": "test/model"},
-        "backend": {"vllm": {"image": "vllm/vllm-openai:latest", "tensor_parallel_size": 1,
-                              "pipeline_parallel_size": 1, "gpu_memory_utilization": 0.9, "extra_args": ""}},
+        "backend": {
+            "vllm": {
+                "image": "vllm/vllm-openai:latest",
+                "tensor_parallel_size": 1,
+                "pipeline_parallel_size": 1,
+                "gpu_memory_utilization": 0.9,
+                "extra_args": "",
+            }
+        },
         "variants": {
             "1x": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
             "2x": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 2},
@@ -56,8 +63,15 @@ def test_resolve_vm_spec_mixed_gpus_raises(tmp_path):
     """Raises ValueError when recipes target different GPUs."""
     recipe = {
         "model": {"name": "test/model"},
-        "backend": {"vllm": {"image": "vllm/vllm-openai:latest", "tensor_parallel_size": 1,
-                              "pipeline_parallel_size": 1, "gpu_memory_utilization": 0.9, "extra_args": ""}},
+        "backend": {
+            "vllm": {
+                "image": "vllm/vllm-openai:latest",
+                "tensor_parallel_size": 1,
+                "pipeline_parallel_size": 1,
+                "gpu_memory_utilization": 0.9,
+                "extra_args": "",
+            }
+        },
         "variants": {
             "rtx": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
             "h100": {"gpu": "NVIDIA H100 80GB", "gpu_count": 1},
@@ -78,8 +92,15 @@ def test_resolve_vm_spec_missing_gpu_raises(tmp_path):
     """Raises ValueError when recipe has no gpu field."""
     recipe = {
         "model": {"name": "test/model"},
-        "backend": {"vllm": {"image": "vllm/vllm-openai:latest", "tensor_parallel_size": 1,
-                              "pipeline_parallel_size": 1, "gpu_memory_utilization": 0.9, "extra_args": ""}},
+        "backend": {
+            "vllm": {
+                "image": "vllm/vllm-openai:latest",
+                "tensor_parallel_size": 1,
+                "pipeline_parallel_size": 1,
+                "gpu_memory_utilization": 0.9,
+                "extra_args": "",
+            }
+        },
     }
     with open(tmp_path / "recipe.yaml", "w") as f:
         yaml.dump(recipe, f)

--- a/tests/test_deploy_cloud_dryrun.py
+++ b/tests/test_deploy_cloud_dryrun.py
@@ -2,15 +2,17 @@
 
 import os
 
-
 # ── deploy cloud dry-run ─────────────────────────────────────────
 
 
 def test_deploy_cloud_dry_run(run_cli, recipes_dir):
     rc, stdout, stderr = run_cli(
-        "deploy", "cloud",
-        "--recipe", os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
-        "--variant", "RTX5090",
+        "deploy",
+        "cloud",
+        "--recipe",
+        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
+        "--variant",
+        "RTX5090",
         "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
@@ -19,9 +21,12 @@ def test_deploy_cloud_dry_run(run_cli, recipes_dir):
 
 def test_deploy_cloud_dry_run_deploy_steps(run_cli, recipes_dir):
     rc, stdout, stderr = run_cli(
-        "deploy", "cloud",
-        "--recipe", os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
-        "--variant", "RTX5090",
+        "deploy",
+        "cloud",
+        "--recipe",
+        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
+        "--variant",
+        "RTX5090",
         "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
@@ -36,8 +41,10 @@ def test_deploy_cloud_dry_run_deploy_steps(run_cli, recipes_dir):
 def test_deploy_cloud_no_variant_fails(run_cli, recipes_dir):
     """Without a variant, no gpu field -> error."""
     rc, stdout, stderr = run_cli(
-        "deploy", "cloud",
-        "--recipe", os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
+        "deploy",
+        "cloud",
+        "--recipe",
+        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
         "--dry-run",
     )
     assert rc != 0

--- a/tests/test_deploy_dryrun.py
+++ b/tests/test_deploy_dryrun.py
@@ -4,16 +4,19 @@ import os
 
 import yaml
 
-
 # ── SSH deploy ──────────────────────────────────────────────────────
 
 
 def test_ssh_deploy(run_cli, recipes_dir):
     rc, stdout, stderr = run_cli(
-        "deploy", "ssh",
-        "--recipe", os.path.join(recipes_dir, "GLM-4.6-FP8"),
-        "--variant", "8xH200",
-        "--server", "user@1.2.3.4",
+        "deploy",
+        "ssh",
+        "--recipe",
+        os.path.join(recipes_dir, "GLM-4.6-FP8"),
+        "--variant",
+        "8xH200",
+        "--server",
+        "user@1.2.3.4",
         "--dry-run",
     )
     assert rc == 0
@@ -25,30 +28,37 @@ def test_ssh_deploy(run_cli, recipes_dir):
 
 def test_ssh_deploy_command_sequence(run_cli, recipes_dir):
     rc, stdout, _ = run_cli(
-        "deploy", "ssh",
-        "--recipe", os.path.join(recipes_dir, "GLM-4.6-FP8"),
-        "--variant", "8xH200",
-        "--server", "user@1.2.3.4",
+        "deploy",
+        "ssh",
+        "--recipe",
+        os.path.join(recipes_dir, "GLM-4.6-FP8"),
+        "--variant",
+        "8xH200",
+        "--server",
+        "user@1.2.3.4",
         "--dry-run",
     )
     assert rc == 0
     lines = stdout.strip().split("\n")
-    dry_run_lines = [l for l in lines if l.startswith("[dry-run]")]
+    dry_run_lines = [line for line in lines if line.startswith("[dry-run]")]
 
     # Verify correct sequence: mkdir, scp compose, scp nginx, pull, download, down, up, health
-    assert any("mkdir" in l for l in dry_run_lines)
-    assert any("docker-compose.yaml" in l for l in dry_run_lines)
-    assert any("docker compose pull" in l for l in dry_run_lines)
-    assert any("huggingface-cli download" in l for l in dry_run_lines)
-    assert any("docker compose down" in l for l in dry_run_lines)
-    assert any("docker compose up" in l for l in dry_run_lines)
+    assert any("mkdir" in line for line in dry_run_lines)
+    assert any("docker-compose.yaml" in line for line in dry_run_lines)
+    assert any("docker compose pull" in line for line in dry_run_lines)
+    assert any("huggingface-cli download" in line for line in dry_run_lines)
+    assert any("docker compose down" in line for line in dry_run_lines)
+    assert any("docker compose up" in line for line in dry_run_lines)
 
 
 def test_ssh_teardown(run_cli, recipes_dir):
     rc, stdout, _ = run_cli(
-        "deploy", "ssh",
-        "--recipe", os.path.join(recipes_dir, "GLM-4.6-FP8"),
-        "--server", "user@1.2.3.4",
+        "deploy",
+        "ssh",
+        "--recipe",
+        os.path.join(recipes_dir, "GLM-4.6-FP8"),
+        "--server",
+        "user@1.2.3.4",
         "--dry-run",
         "--teardown",
     )
@@ -62,9 +72,12 @@ def test_ssh_teardown(run_cli, recipes_dir):
 
 def test_local_deploy(run_cli, recipes_dir):
     rc, stdout, _ = run_cli(
-        "deploy", "local",
-        "--recipe", os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
-        "--variant", "RTX5090",
+        "deploy",
+        "local",
+        "--recipe",
+        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
+        "--variant",
+        "RTX5090",
         "--dry-run",
     )
     assert rc == 0
@@ -75,8 +88,10 @@ def test_local_deploy(run_cli, recipes_dir):
 
 def test_local_teardown(run_cli, recipes_dir):
     rc, stdout, _ = run_cli(
-        "deploy", "local",
-        "--recipe", os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
+        "deploy",
+        "local",
+        "--recipe",
+        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
         "--dry-run",
         "--teardown",
     )
@@ -90,15 +105,21 @@ def test_local_teardown(run_cli, recipes_dir):
 def test_different_variants_produce_different_compose(run_cli, recipes_dir):
     """Different variants should produce different compose configurations."""
     rc1, stdout1, _ = run_cli(
-        "deploy", "local",
-        "--recipe", os.path.join(recipes_dir, "GLM-4.6-FP8"),
-        "--variant", "8xH200",
+        "deploy",
+        "local",
+        "--recipe",
+        os.path.join(recipes_dir, "GLM-4.6-FP8"),
+        "--variant",
+        "8xH200",
         "--dry-run",
     )
     rc2, stdout2, _ = run_cli(
-        "deploy", "local",
-        "--recipe", os.path.join(recipes_dir, "GLM-4.6-FP8"),
-        "--variant", "8xH100",
+        "deploy",
+        "local",
+        "--recipe",
+        os.path.join(recipes_dir, "GLM-4.6-FP8"),
+        "--variant",
+        "8xH100",
         "--dry-run",
     )
     assert rc1 == 0
@@ -110,9 +131,12 @@ def test_different_variants_produce_different_compose(run_cli, recipes_dir):
 
 def test_single_gpu_variant(run_cli, recipes_dir):
     rc, stdout, _ = run_cli(
-        "deploy", "local",
-        "--recipe", os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
-        "--variant", "RTX5090",
+        "deploy",
+        "local",
+        "--recipe",
+        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
+        "--variant",
+        "RTX5090",
         "--dry-run",
     )
     assert rc == 0
@@ -124,26 +148,34 @@ def test_multi_instance_variant(run_cli, tmp_path):
     """A single-GPU model on a 4-GPU variant produces 4 instances with nginx."""
     recipe = {
         "model": {"name": "test/model"},
-        "backend": {"vllm": {
-            "image": "vllm/vllm-openai:latest",
-            "tensor_parallel_size": 1,
-            "pipeline_parallel_size": 1,
-            "gpu_memory_utilization": 0.9,
-            "extra_args": "--max-model-len 8192",
-        }},
-        "variants": {"4xH100": {
-            "gpu": "NVIDIA H100 80GB",
-            "gpu_count": 4,
-        }},
+        "backend": {
+            "vllm": {
+                "image": "vllm/vllm-openai:latest",
+                "tensor_parallel_size": 1,
+                "pipeline_parallel_size": 1,
+                "gpu_memory_utilization": 0.9,
+                "extra_args": "--max-model-len 8192",
+            }
+        },
+        "variants": {
+            "4xH100": {
+                "gpu": "NVIDIA H100 80GB",
+                "gpu_count": 4,
+            }
+        },
     }
     with open(tmp_path / "recipe.yaml", "w") as f:
         yaml.dump(recipe, f)
 
     rc, stdout, _ = run_cli(
-        "deploy", "ssh",
-        "--recipe", str(tmp_path),
-        "--variant", "4xH100",
-        "--server", "user@host",
+        "deploy",
+        "ssh",
+        "--recipe",
+        str(tmp_path),
+        "--variant",
+        "4xH100",
+        "--server",
+        "user@host",
         "--dry-run",
     )
     assert rc == 0
@@ -153,9 +185,12 @@ def test_multi_instance_variant(run_cli, tmp_path):
 
 def test_unknown_variant_fails(run_cli, recipes_dir):
     rc, _, stderr = run_cli(
-        "deploy", "local",
-        "--recipe", os.path.join(recipes_dir, "GLM-4.6-FP8"),
-        "--variant", "nonexistent",
+        "deploy",
+        "local",
+        "--recipe",
+        os.path.join(recipes_dir, "GLM-4.6-FP8"),
+        "--variant",
+        "nonexistent",
         "--dry-run",
     )
     assert rc != 0

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -2,7 +2,6 @@
 
 from deplodock.hardware import GPU_INSTANCE_TYPES, GPU_SHORT_NAMES, gpu_short_name, resolve_instance_type
 
-
 # ── resolve_instance_type ────────────────────────────────────────
 
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from deplodock.planner import BenchmarkTask, ExecutionGroup
+from deplodock.planner import BenchmarkTask
 from deplodock.planner.group_by_model_and_gpu import GroupByModelAndGpuPlanner
 
 
@@ -33,11 +33,11 @@ def test_task_recipe_name():
 def test_task_recipe_name_trailing_slash():
     task = _make_task(recipe_dir="/recipes/Qwen3-Coder-30B/")
     # os.path.basename strips trailing slash correctly
-    assert task.recipe_name == ""  or task.recipe_name == "Qwen3-Coder-30B"
+    assert task.recipe_name == "" or task.recipe_name == "Qwen3-Coder-30B"
 
 
 def test_task_result_path():
-    task = _make_task(recipe_dir="/recipes/MyModel", gpu="NVIDIA GeForce RTX 5090", gpu_count=1)
+    _make_task(recipe_dir="/recipes/MyModel", gpu="NVIDIA GeForce RTX 5090", gpu_count=1)
     task_obj = BenchmarkTask(
         recipe_dir="/recipes/MyModel",
         variant="RTX5090",

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from deplodock.deploy import load_recipe, deep_merge
-
+from deplodock.deploy import deep_merge, load_recipe
 
 # ── deep_merge ──────────────────────────────────────────────────────
 

--- a/tests/test_vm_cloudrift.py
+++ b/tests/test_vm_cloudrift.py
@@ -3,23 +3,21 @@
 Response fixtures are captured from real CloudRift API calls.
 """
 
-import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from deplodock.provisioning.cloudrift import (
+    API_VERSION,
+    DEFAULT_CLOUDINIT_URL,
+    DEFAULT_IMAGE_URL,
+    _add_ssh_key,
     _api_request,
-    _rent_instance,
-    _terminate_instance,
+    _ensure_ssh_key,
     _get_instance_info,
     _list_ssh_keys,
-    _add_ssh_key,
-    _ensure_ssh_key,
     _print_connection_info,
-    API_VERSION,
-    DEFAULT_IMAGE_URL,
-    DEFAULT_CLOUDINIT_URL,
+    _rent_instance,
+    _terminate_instance,
 )
-
 
 API_KEY = "test-api-key"
 API_URL = "https://api.test.cloudrift.ai"
@@ -42,9 +40,7 @@ SSH_KEYS_LIST_RESPONSE = {
     ]
 }
 
-RENT_RESPONSE = {
-    "instance_ids": ["c4bf5e16-1063-11f1-9096-5f6ae8f8983f"]
-}
+RENT_RESPONSE = {"instance_ids": ["c4bf5e16-1063-11f1-9096-5f6ae8f8983f"]}
 
 INSTANCE_ACTIVE_RESPONSE = {
     "instances": [
@@ -133,8 +129,7 @@ def test_api_request_dry_run(capsys):
 def test_rent_instance_payload(mock_api):
     mock_api.return_value = RENT_RESPONSE
 
-    result = _rent_instance(API_KEY, "rtx49-7c-kn.1", ["ssh-ed25519 AAAA user@host"],
-                            ports=[22, 8000], api_url=API_URL)
+    result = _rent_instance(API_KEY, "rtx49-7c-kn.1", ["ssh-ed25519 AAAA user@host"], ports=[22, 8000], api_url=API_URL)
 
     call_data = mock_api.call_args[0][2]
     assert call_data["selector"] == {"ByInstanceTypeAndLocation": {"instance_type": "rtx49-7c-kn.1"}}
@@ -171,9 +166,12 @@ def test_terminate_instance_payload(mock_api):
     _terminate_instance(API_KEY, "inst-123", api_url=API_URL)
 
     mock_api.assert_called_once_with(
-        "POST", "/api/v1/instances/terminate",
+        "POST",
+        "/api/v1/instances/terminate",
         {"selector": {"ById": ["inst-123"]}},
-        API_KEY, API_URL, False,
+        API_KEY,
+        API_URL,
+        False,
     )
 
 
@@ -220,9 +218,12 @@ def test_add_ssh_key(mock_api):
     result = _add_ssh_key(API_KEY, "my-key", "ssh-ed25519 AAAA", api_url=API_URL)
 
     mock_api.assert_called_once_with(
-        "POST", "/api/v1/ssh-keys/add",
+        "POST",
+        "/api/v1/ssh-keys/add",
         {"name": "my-key", "public_key": "ssh-ed25519 AAAA"},
-        API_KEY, API_URL, False,
+        API_KEY,
+        API_URL,
+        False,
     )
     assert result["ssh_key"]["id"] == "key-new"
 

--- a/tests/test_vm_dryrun.py
+++ b/tests/test_vm_dryrun.py
@@ -6,10 +6,15 @@
 
 def test_vm_create_dry_run(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--zone", "us-central1-a",
-        "--machine-type", "a2-highgpu-1g",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--zone",
+        "us-central1-a",
+        "--machine-type",
+        "a2-highgpu-1g",
         "--dry-run",
     )
     assert rc == 0
@@ -23,10 +28,15 @@ def test_vm_create_dry_run(run_cli):
 
 def test_vm_create_dry_run_with_wait_ssh(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--zone", "us-central1-a",
-        "--machine-type", "e2-micro",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--zone",
+        "us-central1-a",
+        "--machine-type",
+        "e2-micro",
         "--wait-ssh",
         "--dry-run",
     )
@@ -39,11 +49,17 @@ def test_vm_create_dry_run_with_wait_ssh(run_cli):
 
 def test_vm_create_dry_run_with_gcloud_args(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--zone", "us-central1-a",
-        "--machine-type", "e2-micro",
-        "--gcloud-args", "--no-service-account --no-scopes",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--zone",
+        "us-central1-a",
+        "--machine-type",
+        "e2-micro",
+        "--gcloud-args",
+        "--no-service-account --no-scopes",
         "--dry-run",
     )
     assert rc == 0
@@ -53,12 +69,18 @@ def test_vm_create_dry_run_with_gcloud_args(run_cli):
 
 def test_vm_create_dry_run_with_ssh_gateway(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--zone", "us-central1-a",
-        "--machine-type", "e2-micro",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--zone",
+        "us-central1-a",
+        "--machine-type",
+        "e2-micro",
         "--wait-ssh",
-        "--ssh-gateway", "gcp-ssh-gateway",
+        "--ssh-gateway",
+        "gcp-ssh-gateway",
         "--dry-run",
     )
     assert rc == 0
@@ -67,9 +89,13 @@ def test_vm_create_dry_run_with_ssh_gateway(run_cli):
 
 def test_vm_delete_dry_run(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "delete", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--zone", "us-central1-a",
+        "vm",
+        "delete",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--zone",
+        "us-central1-a",
         "--dry-run",
     )
     assert rc == 0
@@ -84,9 +110,13 @@ def test_vm_delete_dry_run(run_cli):
 
 def test_vm_create_missing_instance(run_cli):
     rc, _, stderr = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--zone", "us-central1-a",
-        "--machine-type", "e2-micro",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--zone",
+        "us-central1-a",
+        "--machine-type",
+        "e2-micro",
     )
     assert rc != 0
     assert "--instance" in stderr
@@ -94,9 +124,13 @@ def test_vm_create_missing_instance(run_cli):
 
 def test_vm_create_missing_zone(run_cli):
     rc, _, stderr = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--machine-type", "e2-micro",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--machine-type",
+        "e2-micro",
     )
     assert rc != 0
     assert "--zone" in stderr
@@ -104,9 +138,13 @@ def test_vm_create_missing_zone(run_cli):
 
 def test_vm_create_missing_machine_type(run_cli):
     rc, _, stderr = run_cli(
-        "vm", "create", "gcp-flex-start",
-        "--instance", "my-gpu-vm",
-        "--zone", "us-central1-a",
+        "vm",
+        "create",
+        "gcp-flex-start",
+        "--instance",
+        "my-gpu-vm",
+        "--zone",
+        "us-central1-a",
     )
     assert rc != 0
     assert "--machine-type" in stderr
@@ -165,10 +203,15 @@ def test_vm_create_cloudrift_dry_run(run_cli, tmp_path):
     key_file.write_text("ssh-ed25519 AAAA test@host\n")
 
     rc, stdout, _ = run_cli(
-        "vm", "create", "cloudrift",
-        "--instance-type", "rtx4090.1",
-        "--ssh-key", str(key_file),
-        "--api-key", "test-key",
+        "vm",
+        "create",
+        "cloudrift",
+        "--instance-type",
+        "rtx4090.1",
+        "--ssh-key",
+        str(key_file),
+        "--api-key",
+        "test-key",
         "--dry-run",
     )
     assert rc == 0
@@ -180,9 +223,13 @@ def test_vm_create_cloudrift_dry_run(run_cli, tmp_path):
 
 def test_vm_delete_cloudrift_dry_run(run_cli):
     rc, stdout, _ = run_cli(
-        "vm", "delete", "cloudrift",
-        "--instance-id", "inst-123",
-        "--api-key", "test-key",
+        "vm",
+        "delete",
+        "cloudrift",
+        "--instance-id",
+        "inst-123",
+        "--api-key",
+        "test-key",
         "--dry-run",
     )
     assert rc == 0

--- a/tests/test_vm_gcp_flex_start.py
+++ b/tests/test_vm_gcp_flex_start.py
@@ -3,11 +3,10 @@
 from deplodock.provisioning.gcp_flex_start import (
     _gcloud_create_cmd,
     _gcloud_delete_cmd,
-    _gcloud_status_cmd,
     _gcloud_external_ip_cmd,
     _gcloud_ssh_check_cmd,
+    _gcloud_status_cmd,
 )
-
 
 # ── Command builder tests ─────────────────────────────────────────
 
@@ -15,17 +14,27 @@ from deplodock.provisioning.gcp_flex_start import (
 def test_gcloud_create_cmd():
     cmd = _gcloud_create_cmd("my-vm", "us-central1-a", "a2-highgpu-1g")
     assert cmd == [
-        "gcloud", "compute", "instances", "create", "my-vm",
-        "--zone", "us-central1-a",
-        "--machine-type", "a2-highgpu-1g",
+        "gcloud",
+        "compute",
+        "instances",
+        "create",
+        "my-vm",
+        "--zone",
+        "us-central1-a",
+        "--machine-type",
+        "a2-highgpu-1g",
         "--provisioning-model=FLEX_START",
         "--maintenance-policy=TERMINATE",
         "--reservation-affinity=none",
-        "--image-family", "debian-12",
-        "--image-project", "debian-cloud",
-        "--max-run-duration", "7d",
+        "--image-family",
+        "debian-12",
+        "--image-project",
+        "debian-cloud",
+        "--max-run-duration",
+        "7d",
         "--instance-termination-action=DELETE",
-        "--request-valid-for-duration", "2h",
+        "--request-valid-for-duration",
+        "2h",
     ]
 
 
@@ -40,7 +49,9 @@ def test_gcloud_create_cmd_spot_no_duration_flags():
 
 def test_gcloud_create_cmd_with_gcloud_args():
     cmd = _gcloud_create_cmd(
-        "my-vm", "us-central1-a", "e2-micro",
+        "my-vm",
+        "us-central1-a",
+        "e2-micro",
         extra_gcloud_args="--no-service-account --no-scopes",
     )
     assert cmd[-2:] == ["--no-service-account", "--no-scopes"]
@@ -48,7 +59,9 @@ def test_gcloud_create_cmd_with_gcloud_args():
 
 def test_gcloud_create_cmd_custom_options():
     cmd = _gcloud_create_cmd(
-        "my-vm", "us-central1-a", "e2-micro",
+        "my-vm",
+        "us-central1-a",
+        "e2-micro",
         max_run_duration="1h",
         termination_action="STOP",
         image_family="ubuntu-2204-lts",
@@ -72,36 +85,66 @@ def test_gcloud_delete_cmd():
 def test_gcloud_status_cmd():
     cmd = _gcloud_status_cmd("my-vm", "us-central1-a")
     assert cmd == [
-        "gcloud", "compute", "instances", "describe", "my-vm",
-        "--zone", "us-central1-a", "--format", "value(status)",
+        "gcloud",
+        "compute",
+        "instances",
+        "describe",
+        "my-vm",
+        "--zone",
+        "us-central1-a",
+        "--format",
+        "value(status)",
     ]
 
 
 def test_gcloud_external_ip_cmd():
     cmd = _gcloud_external_ip_cmd("my-vm", "us-central1-a")
     assert cmd == [
-        "gcloud", "compute", "instances", "describe", "my-vm",
-        "--zone", "us-central1-a",
-        "--format", "value(networkInterfaces[0].accessConfigs[0].natIP)",
+        "gcloud",
+        "compute",
+        "instances",
+        "describe",
+        "my-vm",
+        "--zone",
+        "us-central1-a",
+        "--format",
+        "value(networkInterfaces[0].accessConfigs[0].natIP)",
     ]
 
 
 def test_gcloud_ssh_check_cmd():
     cmd = _gcloud_ssh_check_cmd("my-vm", "us-central1-a")
     assert cmd == [
-        "gcloud", "compute", "ssh", "my-vm",
-        "--zone", "us-central1-a", "--command", "true",
-        "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
-        "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
+        "gcloud",
+        "compute",
+        "ssh",
+        "my-vm",
+        "--zone",
+        "us-central1-a",
+        "--command",
+        "true",
+        "--ssh-flag=-o",
+        "--ssh-flag=ConnectTimeout=5",
+        "--ssh-flag=-o",
+        "--ssh-flag=StrictHostKeyChecking=no",
     ]
 
 
 def test_gcloud_ssh_check_cmd_with_gateway():
     cmd = _gcloud_ssh_check_cmd("my-vm", "us-central1-a", ssh_gateway="gcp-ssh-gateway")
     assert cmd == [
-        "gcloud", "compute", "ssh", "my-vm",
-        "--zone", "us-central1-a", "--command", "true",
-        "--ssh-flag=-o", "--ssh-flag=ConnectTimeout=5",
-        "--ssh-flag=-o", "--ssh-flag=StrictHostKeyChecking=no",
-        "--ssh-flag=-o", "--ssh-flag=ProxyJump=gcp-ssh-gateway",
+        "gcloud",
+        "compute",
+        "ssh",
+        "my-vm",
+        "--zone",
+        "us-central1-a",
+        "--command",
+        "true",
+        "--ssh-flag=-o",
+        "--ssh-flag=ConnectTimeout=5",
+        "--ssh-flag=-o",
+        "--ssh-flag=StrictHostKeyChecking=no",
+        "--ssh-flag=-o",
+        "--ssh-flag=ProxyJump=gcp-ssh-gateway",
     ]

--- a/utils/download_model.py
+++ b/utils/download_model.py
@@ -1,8 +1,8 @@
 import os
 import time
-from huggingface_hub import snapshot_download
 from argparse import ArgumentParser
-from tqdm.auto import tqdm
+
+from huggingface_hub import snapshot_download
 
 
 def download_and_track(repo_id, local_dir=None):
@@ -77,10 +77,8 @@ def download_and_track(repo_id, local_dir=None):
 # Example usage:
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument('--model-name', default="meta-llama/Llama-3.1-8B-Instruct",
-                        help='HuggingFace model repository ID')
-    parser.add_argument("--hg-dir", default="../models",
-                        help='Directory to download the model to')
+    parser.add_argument("--model-name", default="meta-llama/Llama-3.1-8B-Instruct", help="HuggingFace model repository ID")
+    parser.add_argument("--hg-dir", default="../models", help="Directory to download the model to")
     args = parser.parse_args()
 
     download_and_track(args.model_name, local_dir=args.hg_dir)


### PR DESCRIPTION
## Summary

- Extract business logic from CLI command handlers into reusable library modules (`deplodock/deploy/`, `deplodock/provisioning/`, `deplodock/benchmark/`, `deplodock/report/`)
- Consolidate SSH transport into the provisioning module
- Add Ruff linter and formatter with CI integration — configured in `pyproject.toml` with rules E, F, W, I, UP, B
- Add `make lint` and `make format` targets to the Makefile
- Add a `lint` job to the GitHub Actions CI workflow
- Fix all existing lint violations across the codebase (import sorting, unused imports, bare excepts, deprecated typing imports, ambiguous variable names)
- Update README.md, CLAUDE.md, and STYLE.md to document the new tooling

## Test plan

- [x] `make lint` passes with zero errors
- [x] `make format` is a no-op (already formatted)
- [x] `pytest tests/ -v` — all 131 tests pass
- [x] CI workflow is valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)