### PR TITLE
Rename gcp-flex-start CLI subcommand to gcp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,9 @@ pytest tests/test_recipe.py -v
 - `deplodock deploy cloud ...` — provision a cloud VM and deploy via SSH
 - `deplodock bench recipes/* ...` — deploy + benchmark + teardown on cloud VMs (recipe dirs as positional args)
 - `deplodock report ...` — generate Excel reports from benchmark results
-- `deplodock vm create gcp-flex-start ...` — create a GCP flex-start GPU VM
+- `deplodock vm create gcp ...` — create a GCP GPU VM
 - `deplodock vm create cloudrift ...` — create a CloudRift GPU VM
-- `deplodock vm delete gcp-flex-start ...` — delete a GCP flex-start GPU VM
+- `deplodock vm delete gcp ...` — delete a GCP GPU VM
 - `deplodock vm delete cloudrift ...` — delete a CloudRift GPU VM
 
 ## Key Make Targets

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 setup:
 	@if [ ! -d "venv" ]; then \
 		echo "Creating virtual environment..."; \
-		python3 -m venv venv; \
+		python3.12 -m venv venv; \
 		echo "Installing Python dependencies..."; \
 		./venv/bin/pip install -e ".[dev]"; \
 		echo "✅ Setup complete!"; \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tools for deploying and benchmarking LLM inference on GPU servers.
     - [deploy/](deplodock/commands/deploy/) — `deploy local`, `deploy ssh`, `deploy cloud` commands
     - [bench/](deplodock/commands/bench/) — `bench` command
     - [report/](deplodock/commands/report/) — `report` command
-    - [vm/](deplodock/commands/vm/) — `vm create/delete` commands (GCP flex-start, CloudRift)
+    - [vm/](deplodock/commands/vm/) — `vm create/delete` commands (GCP, CloudRift)
   - [deploy/](deplodock/deploy/) — Deploy library (recipe loading, compose generation, orchestration)
   - [provisioning/](deplodock/provisioning/) — Cloud provisioning, SSH transport, VM lifecycle
   - [benchmark/](deplodock/benchmark/) — Benchmark tracking, config, task enumeration, execution
@@ -179,15 +179,15 @@ deplodock deploy cloud --recipe <path> --variant <name> [--name <vm-name>] [--dr
 
 ## VM Management
 
-The `vm` command manages cloud GPU VM lifecycles. Supports GCP flex-start and CloudRift providers. Instances are ephemeral — `delete` removes them entirely.
+The `vm` command manages cloud GPU VM lifecycles. Supports GCP and CloudRift providers. Instances are ephemeral — `delete` removes them entirely.
 
-### GCP Flex-Start
+### GCP
 
 ```bash
-deplodock vm create gcp-flex-start --instance my-gpu-vm --zone us-central1-a --machine-type a2-highgpu-1g
-deplodock vm create gcp-flex-start --instance my-gpu-vm --zone us-central1-a --machine-type e2-micro --wait-ssh
-deplodock vm create gcp-flex-start --instance my-gpu-vm --zone us-central1-a --machine-type e2-micro --gcloud-args "--no-service-account --no-scopes" --dry-run
-deplodock vm delete gcp-flex-start --instance my-gpu-vm --zone us-central1-a
+deplodock vm create gcp --instance my-gpu-vm --zone us-central1-a --machine-type a2-highgpu-1g
+deplodock vm create gcp --instance my-gpu-vm --zone us-central1-a --machine-type e2-micro --wait-ssh
+deplodock vm create gcp --instance my-gpu-vm --zone us-central1-a --machine-type e2-micro --gcloud-args "--no-service-account --no-scopes" --dry-run
+deplodock vm delete gcp --instance my-gpu-vm --zone us-central1-a
 ```
 
 #### GCP Create Flags

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -44,7 +44,7 @@ VM lifecycle management and cloud provisioning.
 - `remote.py` — `provision_remote()` (install Docker, NVIDIA toolkit)
 - `cloud.py` — `resolve_vm_spec()`, `provision_cloud_vm()`, `delete_cloud_vm()`
 - `cloudrift.py` — CloudRift REST API provider
-- `gcp_flex_start.py` — GCP flex-start gcloud provider
+- `gcp.py` — GCP gcloud provider
 
 ### `deplodock/benchmark/` — Benchmark Library
 
@@ -133,10 +133,10 @@ deplodock
 +-- report       -- generate Excel reports from benchmark results
 +-- vm
     +-- create
-    |   +-- gcp-flex-start
+    |   +-- gcp
     |   +-- cloudrift
     +-- delete
-        +-- gcp-flex-start
+        +-- gcp
         +-- cloudrift
 ```
 

--- a/deplodock/commands/vm/__init__.py
+++ b/deplodock/commands/vm/__init__.py
@@ -9,7 +9,7 @@ def register_vm_command(subparsers):
     from deplodock.commands.vm.cloudrift import (
         register_delete_target as register_cloudrift_delete,
     )
-    from deplodock.commands.vm.gcp_flex_start import register_create_target, register_delete_target
+    from deplodock.commands.vm.gcp import register_create_target, register_delete_target
 
     vm_parser = subparsers.add_parser("vm", help="Manage cloud VM instances")
 

--- a/deplodock/commands/vm/gcp.py
+++ b/deplodock/commands/vm/gcp.py
@@ -1,8 +1,8 @@
-"""GCP flex-start provider CLI handlers."""
+"""GCP provider CLI handlers."""
 
 import sys
 
-from deplodock.provisioning.gcp_flex_start import (
+from deplodock.provisioning.gcp import (
     # Re-export business logic for backward compatibility
     create_instance,
     delete_instance,
@@ -12,7 +12,7 @@ from deplodock.provisioning.gcp_flex_start import (
 
 
 def handle_create(args):
-    """CLI handler for 'vm create gcp-flex-start'."""
+    """CLI handler for 'vm create gcp'."""
     conn = create_instance(
         instance=args.instance,
         zone=args.zone,
@@ -35,7 +35,7 @@ def handle_create(args):
 
 
 def handle_delete(args):
-    """CLI handler for 'vm delete gcp-flex-start'."""
+    """CLI handler for 'vm delete gcp'."""
     success = delete_instance(
         instance=args.instance,
         zone=args.zone,
@@ -49,8 +49,8 @@ def handle_delete(args):
 
 
 def register_create_target(subparsers):
-    """Register the gcp-flex-start provider under 'vm create'."""
-    parser = subparsers.add_parser("gcp-flex-start", help="Create a GCP GPU VM")
+    """Register the gcp provider under 'vm create'."""
+    parser = subparsers.add_parser("gcp", help="Create a GCP GPU VM")
     parser.add_argument("--instance", required=True, help="GCP instance name")
     parser.add_argument("--zone", required=True, help="GCP zone (e.g. us-central1-a)")
     parser.add_argument("--machine-type", required=True, help="Machine type (e.g. a2-highgpu-1g)")
@@ -80,8 +80,8 @@ def register_create_target(subparsers):
 
 
 def register_delete_target(subparsers):
-    """Register the gcp-flex-start provider under 'vm delete'."""
-    parser = subparsers.add_parser("gcp-flex-start", help="Delete a GCP flex-start GPU VM")
+    """Register the gcp provider under 'vm delete'."""
+    parser = subparsers.add_parser("gcp", help="Delete a GCP GPU VM")
     parser.add_argument("--instance", required=True, help="GCP instance name")
     parser.add_argument("--zone", required=True, help="GCP zone (e.g. us-central1-a)")
     parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -10,7 +10,7 @@ import shlex
 
 from deplodock.hardware import GPU_INSTANCE_TYPES, resolve_instance_type
 from deplodock.provisioning import cloudrift as cr_provider
-from deplodock.provisioning import gcp_flex_start as gcp_provider
+from deplodock.provisioning import gcp as gcp_provider
 
 
 def resolve_vm_spec(loaded_configs, server_name=None):

--- a/deplodock/provisioning/gcp.py
+++ b/deplodock/provisioning/gcp.py
@@ -1,4 +1,4 @@
-"""GCP flex-start provider: create/delete GPU VMs using gcloud compute."""
+"""GCP provider: create/delete GPU VMs using gcloud compute."""
 
 import shlex
 import sys

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -25,7 +25,7 @@ tests/
 ├── provisioning/
 │   ├── test_cloud.py        # resolve_vm_spec(), delete_cloud_vm(), VMConnectionInfo
 │   ├── test_cloudrift.py    # CloudRift API helpers
-│   ├── test_gcp_flex_start.py  # GCP command builders
+│   ├── test_gcp.py             # GCP command builders
 │   └── test_vm_dryrun.py    # vm create/delete CLI dry-run
 └── report/
     └── test_report.py       # collect_tasks_from_manifests(), parse_benchmark_result()
@@ -49,7 +49,7 @@ Test individual functions in isolation with synthetic inputs.
 | `benchmark/test_manifest.py` | `deplodock.benchmark.write_manifest()`, `read_manifest()` — round-trip serialization |
 | `report/test_report.py` | `deplodock.report.collect_tasks_from_manifests()`, `parse_benchmark_result()` — manifest-based report data collection |
 | `provisioning/test_cloudrift.py` | `deplodock.provisioning.cloudrift._api_request()`, `_rent_instance()`, etc. — CloudRift API helpers |
-| `provisioning/test_gcp_flex_start.py` | `deplodock.provisioning.gcp_flex_start._gcloud_*_cmd()` — GCP command builders |
+| `provisioning/test_gcp.py` | `deplodock.provisioning.gcp._gcloud_*_cmd()` — GCP command builders |
 
 Unit tests use **fixtures from `conftest.py`** (`tmp_recipe_dir`, `sample_config`, `sample_config_multi`) to supply pre-built recipe directories and config dicts.
 
@@ -62,7 +62,7 @@ Test the full CLI pipeline end-to-end by invoking `deplodock` as a subprocess wi
 | `deploy/test_deploy_dryrun.py` | `deploy ssh`, `deploy local` — dry-run output, command sequence, variant resolution, teardown, CLI help |
 | `deploy/test_deploy_cloud_dryrun.py` | `deploy cloud` — dry-run output, deploy steps, error handling, CLI help |
 | `benchmark/test_bench_dryrun.py` | `bench` — dry-run output, deploy->benchmark->teardown sequence, variant filtering, CLI help |
-| `provisioning/test_vm_dryrun.py` | `vm create/delete gcp-flex-start`, `vm create/delete cloudrift` — dry-run output, argparse validation, CLI help |
+| `provisioning/test_vm_dryrun.py` | `vm create/delete gcp`, `vm create/delete cloudrift` — dry-run output, argparse validation, CLI help |
 
 CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench_config`** (a factory for temporary `config.yaml` files). Both are defined in `conftest.py`.
 

--- a/tests/provisioning/test_gcp.py
+++ b/tests/provisioning/test_gcp.py
@@ -1,6 +1,6 @@
-"""Unit tests for GCP flex-start command builders."""
+"""Unit tests for GCP command builders."""
 
-from deplodock.provisioning.gcp_flex_start import (
+from deplodock.provisioning.gcp import (
     _gcloud_create_cmd,
     _gcloud_delete_cmd,
     _gcloud_external_ip_cmd,

--- a/tests/provisioning/test_vm_dryrun.py
+++ b/tests/provisioning/test_vm_dryrun.py
@@ -8,7 +8,7 @@ def test_vm_create_dry_run(run_cli):
     rc, stdout, _ = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--zone",
@@ -30,7 +30,7 @@ def test_vm_create_dry_run_with_wait_ssh(run_cli):
     rc, stdout, _ = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--zone",
@@ -51,7 +51,7 @@ def test_vm_create_dry_run_with_gcloud_args(run_cli):
     rc, stdout, _ = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--zone",
@@ -71,7 +71,7 @@ def test_vm_create_dry_run_with_ssh_gateway(run_cli):
     rc, stdout, _ = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--zone",
@@ -91,7 +91,7 @@ def test_vm_delete_dry_run(run_cli):
     rc, stdout, _ = run_cli(
         "vm",
         "delete",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--zone",
@@ -112,7 +112,7 @@ def test_vm_create_missing_instance(run_cli):
     rc, _, stderr = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--zone",
         "us-central1-a",
         "--machine-type",
@@ -126,7 +126,7 @@ def test_vm_create_missing_zone(run_cli):
     rc, _, stderr = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--machine-type",
@@ -140,7 +140,7 @@ def test_vm_create_missing_machine_type(run_cli):
     rc, _, stderr = run_cli(
         "vm",
         "create",
-        "gcp-flex-start",
+        "gcp",
         "--instance",
         "my-gpu-vm",
         "--zone",
@@ -163,11 +163,11 @@ def test_vm_help(run_cli):
 def test_vm_create_help(run_cli):
     rc, stdout, _ = run_cli("vm", "create", "--help")
     assert rc == 0
-    assert "gcp-flex-start" in stdout
+    assert "gcp" in stdout
 
 
-def test_vm_create_gcp_flex_start_help(run_cli):
-    rc, stdout, _ = run_cli("vm", "create", "gcp-flex-start", "--help")
+def test_vm_create_gcp_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "create", "gcp", "--help")
     assert rc == 0
     assert "--instance" in stdout
     assert "--zone" in stdout
@@ -181,8 +181,8 @@ def test_vm_create_gcp_flex_start_help(run_cli):
     assert "--ssh-gateway" in stdout
 
 
-def test_vm_delete_gcp_flex_start_help(run_cli):
-    rc, stdout, _ = run_cli("vm", "delete", "gcp-flex-start", "--help")
+def test_vm_delete_gcp_help(run_cli):
+    rc, stdout, _ = run_cli("vm", "delete", "gcp", "--help")
     assert rc == 0
     assert "--instance" in stdout
     assert "--zone" in stdout


### PR DESCRIPTION
## Summary
- Rename `gcp-flex-start` CLI subcommand to `gcp` since the provider already supports multiple provisioning models (FLEX_START, SPOT, STANDARD) via `--provisioning-model`
- Rename source files: `gcp_flex_start.py` → `gcp.py` in commands, provisioning, and tests
- Pin `make setup` venv creation to `python3.12` (was `python3` which resolved to 3.9 on some systems)

## Test plan
- [x] All 131 tests pass (`pytest tests/ -v`)
- [x] Lint clean (`make lint`)
- [x] `deplodock vm create gcp --help` shows GCP create options
- [x] `deplodock vm delete gcp --help` shows GCP delete options

🤖 Generated with [Claude Code](https://claude.com/claude-code)