### PR TITLE
Add SGLang engine support to deploy pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Deplodock is a Python tool for deploying and benchmarking LLM inference on GPU servers using vLLM. It provides a CLI for local and remote (SSH) deployment of models via Docker Compose, plus automated benchmarking across multiple servers.
+Deplodock is a Python tool for deploying and benchmarking LLM inference on GPU servers. It supports vLLM and SGLang engines, provides a CLI for local and remote (SSH) deployment of models via Docker Compose, plus automated benchmarking across multiple servers.
 
 See `README.md` for full project structure, recipe format, and CLI usage.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,13 @@ See `README.md` for full project structure, recipe format, and CLI usage.
 ## Running Tests
 
 ```bash
-pytest tests/ -v
+make test
 ```
 
 Or for a specific test file:
 
 ```bash
-pytest tests/test_recipe.py -v
+./venv/bin/pytest tests/test_recipe.py -v
 ```
 
 ## CLI Commands

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Deplodock
 
-Tools for deploying and benchmarking LLM inference on GPU servers.
+Tools for deploying and benchmarking LLM inference on GPU servers. Supports **vLLM** and **SGLang** engines.
 
 ## Project Structure
 
@@ -19,6 +19,8 @@ Tools for deploying and benchmarking LLM inference on GPU servers.
   - [planner/](deplodock/planner/) — Groups benchmark tasks into execution groups for VM allocation
   - [report/](deplodock/report/) — Excel report generation from benchmark results
 - [recipes/](recipes/) — Model deploy recipes (YAML configs per model)
+- [docs/](docs/) — Technical notes and engine-specific guides
+  - [sglang-awq-moe.md](docs/sglang-awq-moe.md) — SGLang quantization for AWQ MoE models
 - [tests/](tests/) — pytest tests (see [ARCHITECTURE.md](tests/ARCHITECTURE.md))
 - [utils/](utils/) — Standalone utility scripts
 - [config.yaml](config.yaml) — Benchmark configuration
@@ -111,6 +113,27 @@ variants:
 ```
 
 Engine-agnostic fields (`tensor_parallel_size`, `context_length`, etc.) live at `engine.llm`. Engine-specific fields (`image`, `extra_args`) nest under `engine.llm.vllm` or `engine.llm.sglang`.
+
+### SGLang Variant Example
+
+To add an SGLang variant alongside vLLM variants, add a `sglang` key under `engine.llm` in the variant:
+
+```yaml
+variants:
+  RTX5090:
+    gpu: "NVIDIA GeForce RTX 5090"
+    gpu_count: 1
+  RTX5090_sglang:
+    gpu: "NVIDIA GeForce RTX 5090"
+    gpu_count: 1
+    engine:
+      llm:
+        sglang:
+          image: "lmsysorg/sglang:latest"
+          extra_args: "--quantization moe_wna16"  # Required for AWQ MoE models
+```
+
+For AWQ-quantized MoE models on SGLang, `--quantization moe_wna16` is required in `extra_args`. See [docs/sglang-awq-moe.md](docs/sglang-awq-moe.md) for details.
 
 ### Named Fields → CLI Flags
 

--- a/README.md
+++ b/README.md
@@ -137,34 +137,15 @@ For AWQ-quantized MoE models on SGLang, `--quantization moe_wna16` is required i
 
 ### Named Fields → CLI Flags
 
-| Recipe YAML key | vLLM CLI flag | SGLang CLI flag |
-|---|---|---|
-| `tensor_parallel_size` | `--tensor-parallel-size` | `--tp` |
-| `pipeline_parallel_size` | `--pipeline-parallel-size` | `--dp` |
-| `gpu_memory_utilization` | `--gpu-memory-utilization` | `--mem-fraction-static` |
-| `context_length` | `--max-model-len` | `--context-length` |
-| `max_concurrent_requests` | `--max-num-seqs` | `--max-running-requests` |
+| Recipe YAML key           | vLLM CLI flag              | SGLang CLI flag          |
+|---------------------------|----------------------------|--------------------------|
+| `tensor_parallel_size`    | `--tensor-parallel-size`   | `--tp`                   |
+| `pipeline_parallel_size`  | `--pipeline-parallel-size` | `--dp`                   |
+| `gpu_memory_utilization`  | `--gpu-memory-utilization` | `--mem-fraction-static`  |
+| `context_length`          | `--max-model-len`          | `--context-length`       |
+| `max_concurrent_requests` | `--max-num-seqs`           | `--max-running-requests` |
 
 These flags must **not** appear in `extra_args` — `load_recipe()` validates this and raises an error on duplicates.
-
-### Variant Naming
-
-Variants use hardware-descriptive names for per-instance GPU setup:
-- `H200` — 1 GPU
-- `8xH200` — 8 GPUs (tensor parallel)
-- `4xH100` — 4 GPUs
-
-Format: `[<gpus>x]<GPU_TYPE>`. Multi-instance deployment is automatic when variant GPUs exceed per-instance needs.
-
-### Available Recipes
-
-| Recipe | Model | Config |
-|--------|-------|--------|
-| `GLM-4.6-FP8` | zai-org/GLM-4.6-FP8 | TP=8, dense FP8 |
-| `GLM-4.5-Air-AWQ-4bit` | cpatonn/GLM-4.5-Air-AWQ-4bit | TP=1, MoE |
-| `Qwen3-Coder-480B-A35B-Instruct-AWQ` | QuantTrio/Qwen3-Coder-480B-A35B-Instruct-AWQ | TP=4, large MoE |
-| `Qwen3-Coder-30B-A3B-Instruct-AWQ` | QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ | TP=1, small MoE |
-| `Meta-Llama-3.3-70B-Instruct-AWQ-INT4` | ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4 | PP=2, dense |
 
 ## Deploy Targets
 
@@ -194,29 +175,29 @@ deplodock deploy cloud --recipe <path> --variant <name> [--name <vm-name>] [--dr
 
 ### Common Flags
 
-| Flag | Required | Default | Description |
-|------|----------|---------|-------------|
-| `--recipe` | Yes | - | Path to recipe directory |
-| `--variant` | No | - | Hardware variant (e.g. 8xH200) |
-| `--hf-token` | No | `$HF_TOKEN` | HuggingFace token |
-| `--model-dir` | No | `/mnt/models` | Model cache dir |
-| `--teardown` | No | false | Stop containers instead of deploying |
-| `--dry-run` | No | false | Print commands without executing |
+| Flag          | Required  | Default       | Description                          |
+|---------------|-----------|---------------|--------------------------------------|
+| `--recipe`    | Yes       | -             | Path to recipe directory             |
+| `--variant`   | No        | -             | Hardware variant (e.g. 8xH200)       |
+| `--hf-token`  | No        | `$HF_TOKEN`   | HuggingFace token                    |
+| `--model-dir` | No        | `/mnt/models` | Model cache dir                      |
+| `--teardown`  | No        | false         | Stop containers instead of deploying |
+| `--dry-run`   | No        | false         | Print commands without executing     |
 
 ### SSH-only Flags
 
-| Flag | Required | Default | Description |
-|------|----------|---------|-------------|
-| `--server` | Yes | - | SSH address (user@host) |
-| `--ssh-key` | No | `~/.ssh/id_ed25519` | SSH key path |
-| `--ssh-port` | No | 22 | SSH port |
+| Flag         | Required  | Default             | Description             |
+|--------------|-----------|---------------------|-------------------------|
+| `--server`   | Yes       | -                   | SSH address (user@host) |
+| `--ssh-key`  | No        | `~/.ssh/id_ed25519` | SSH key path            |
+| `--ssh-port` | No        | 22                  | SSH port                |
 
 ### Cloud-only Flags
 
-| Flag | Required | Default | Description |
-|------|----------|---------|-------------|
-| `--name` | No | `cloud-deploy` | VM name prefix |
-| `--ssh-key` | No | `~/.ssh/id_ed25519` | SSH private key path |
+| Flag        | Required  | Default             | Description          |
+|-------------|-----------|---------------------|----------------------|
+| `--name`    | No        | `cloud-deploy`      | VM name prefix       |
+| `--ssh-key` | No        | `~/.ssh/id_ed25519` | SSH private key path |
 
 ## VM Management
 
@@ -233,31 +214,31 @@ deplodock vm delete gcp --instance my-gpu-vm --zone us-central1-a
 
 #### GCP Create Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--instance` | (required) | GCP instance name |
-| `--zone` | (required) | GCP zone (e.g. us-central1-a) |
-| `--machine-type` | (required) | Machine type (e.g. a2-highgpu-1g) |
-| `--provisioning-model` | `FLEX_START` | Provisioning model (`FLEX_START`, `SPOT`, or `STANDARD`) |
-| `--max-run-duration` | `7d` | Max VM run time (10m–7d) |
-| `--request-valid-for-duration` | `2h` | How long to wait for capacity |
-| `--termination-action` | `DELETE` | Action when max-run-duration expires (`STOP` or `DELETE`) |
-| `--image-family` | `debian-12` | Boot disk image family |
-| `--image-project` | `debian-cloud` | Boot disk image project |
-| `--gcloud-args` | - | Extra args passed to `gcloud compute instances create` |
-| `--timeout` | `14400` | How long to poll for RUNNING status (seconds) |
-| `--wait-ssh` | false | Wait for SSH after VM is RUNNING |
-| `--wait-ssh-timeout` | `300` | SSH wait timeout in seconds |
-| `--ssh-gateway` | - | SSH gateway host for ProxyJump (e.g. gcp-ssh-gateway) |
-| `--dry-run` | false | Print commands without executing |
+| Flag                           | Default        | Description                                               |
+|--------------------------------|----------------|-----------------------------------------------------------|
+| `--instance`                   | (required)     | GCP instance name                                         |
+| `--zone`                       | (required)     | GCP zone (e.g. us-central1-a)                             |
+| `--machine-type`               | (required)     | Machine type (e.g. a2-highgpu-1g)                         |
+| `--provisioning-model`         | `FLEX_START`   | Provisioning model (`FLEX_START`, `SPOT`, or `STANDARD`)  |
+| `--max-run-duration`           | `7d`           | Max VM run time (10m–7d)                                  |
+| `--request-valid-for-duration` | `2h`           | How long to wait for capacity                             |
+| `--termination-action`         | `DELETE`       | Action when max-run-duration expires (`STOP` or `DELETE`) |
+| `--image-family`               | `debian-12`    | Boot disk image family                                    |
+| `--image-project`              | `debian-cloud` | Boot disk image project                                   |
+| `--gcloud-args`                | -              | Extra args passed to `gcloud compute instances create`    |
+| `--timeout`                    | `14400`        | How long to poll for RUNNING status (seconds)             |
+| `--wait-ssh`                   | false          | Wait for SSH after VM is RUNNING                          |
+| `--wait-ssh-timeout`           | `300`          | SSH wait timeout in seconds                               |
+| `--ssh-gateway`                | -              | SSH gateway host for ProxyJump (e.g. gcp-ssh-gateway)     |
+| `--dry-run`                    | false          | Print commands without executing                          |
 
 #### GCP Delete Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--instance` | (required) | GCP instance name |
-| `--zone` | (required) | GCP zone (e.g. us-central1-a) |
-| `--dry-run` | false | Print commands without executing |
+| Flag         | Default    | Description                      |
+|--------------|------------|----------------------------------|
+| `--instance` | (required) | GCP instance name                |
+| `--zone`     | (required) | GCP zone (e.g. us-central1-a)    |
+| `--dry-run`  | false      | Print commands without executing |
 
 GCP project is inferred from `gcloud` config (no `--project` flag needed).
 
@@ -270,23 +251,23 @@ deplodock vm delete cloudrift --instance-id <id>
 
 #### CloudRift Create Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--instance-type` | (required) | Instance type (e.g. rtx4090.1) |
-| `--ssh-key` | (required) | Path to SSH public key file |
-| `--api-key` | `$CLOUDRIFT_API_KEY` | CloudRift API key |
-| `--image-url` | Ubuntu 24.04 | VM image URL |
-| `--ports` | `22,8000` | Comma-separated ports to open |
-| `--timeout` | `600` | Seconds to wait for Active status |
-| `--dry-run` | false | Print requests without executing |
+| Flag              | Default              | Description                       |
+|-------------------|----------------------|-----------------------------------|
+| `--instance-type` | (required)           | Instance type (e.g. rtx4090.1)    |
+| `--ssh-key`       | (required)           | Path to SSH public key file       |
+| `--api-key`       | `$CLOUDRIFT_API_KEY` | CloudRift API key                 |
+| `--image-url`     | Ubuntu 24.04         | VM image URL                      |
+| `--ports`         | `22,8000`            | Comma-separated ports to open     |
+| `--timeout`       | `600`                | Seconds to wait for Active status |
+| `--dry-run`       | false                | Print requests without executing  |
 
 #### CloudRift Delete Flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--instance-id` | (required) | CloudRift instance ID |
-| `--api-key` | `$CLOUDRIFT_API_KEY` | CloudRift API key |
-| `--dry-run` | false | Print requests without executing |
+| Flag            | Default              | Description                      |
+|-----------------|----------------------|----------------------------------|
+| `--instance-id` | (required)           | CloudRift instance ID            |
+| `--api-key`     | `$CLOUDRIFT_API_KEY` | CloudRift API key                |
+| `--dry-run`     | false                | Print requests without executing |
 
 ## Benchmarking
 
@@ -325,14 +306,14 @@ deplodock bench recipes/* --max-workers 2                    # Limit parallel ex
 deplodock bench recipes/* --dry-run                          # Preview commands
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `recipes` | (required) | Recipe directories (positional args) |
-| `--variants` | all | Variant names to run (space-separated) |
-| `--ssh-key` | `~/.ssh/id_ed25519` | SSH private key path |
-| `--config` | `config.yaml` | Path to configuration file |
-| `--max-workers` | num groups | Max parallel execution groups |
-| `--dry-run` | false | Print commands without executing |
+| Flag            | Default             | Description                            |
+|-----------------|---------------------|----------------------------------------|
+| `recipes`       | (required)          | Recipe directories (positional args)   |
+| `--variants`    | all                 | Variant names to run (space-separated) |
+| `--ssh-key`     | `~/.ssh/id_ed25519` | SSH private key path                   |
+| `--config`      | `config.yaml`       | Path to configuration file             |
+| `--max-workers` | num groups          | Max parallel execution groups          |
+| `--dry-run`     | false               | Print commands without executing       |
 
 ### Generate Reports
 
@@ -341,16 +322,16 @@ deplodock report                                      # Default: results/ -> res
 deplodock report --results-dir results/custom --output results/custom/report.xlsx
 ```
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--config` | `config.yaml` | Path to configuration file |
-| `--results-dir` | `results` | Directory containing benchmark results |
-| `--output` | `results/benchmark_report.xlsx` | Output Excel file path |
+| Flag            | Default                         | Description                            |
+|-----------------|---------------------------------|----------------------------------------|
+| `--config`      | `config.yaml`                   | Path to configuration file             |
+| `--results-dir` | `results`                       | Directory containing benchmark results |
+| `--output`      | `results/benchmark_report.xlsx` | Output Excel file path                 |
 
 ## Running Tests
 
 ```bash
-pytest tests/ -v
+make test
 ```
 
 ## Linting & Formatting

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -38,7 +38,11 @@ def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
         )
 
     model_name = recipe.model_name
+    # vllm bench serve is an HTTP client that works against any OpenAI-compatible
+    # endpoint, so we always use the vLLM image for benchmarking.
     image = recipe.engine.llm.image
+    if recipe.engine.llm.engine_name != "vllm":
+        image = "vllm/vllm-openai:latest"
 
     num_instances = calculate_num_instances(recipe)
     port = 8080 if num_instances > 1 else 8000

--- a/deplodock/deploy/compose.py
+++ b/deplodock/deploy/compose.py
@@ -24,6 +24,7 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
     model_name = recipe.model_name
     image = llm.image
     engine = llm.engine_name
+    entrypoint = llm.entrypoint
     gpus_per_instance = llm.gpus_per_instance
 
     engine_args = build_engine_args(llm, model_name)
@@ -46,10 +47,11 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
             gpu_config = f"device_ids: [{gpu_ids_yaml}]"
             port = 8000 + i
 
+        entrypoint_line = f"\n    entrypoint: {entrypoint}" if entrypoint else ""
         services += f"""
   {engine}_{i}:
     image: {image}
-    container_name: {engine}_{i}
+    container_name: {engine}_{i}{entrypoint_line}
     deploy:
       resources:
         reservations:

--- a/deplodock/deploy/compose.py
+++ b/deplodock/deploy/compose.py
@@ -23,6 +23,7 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
     llm = recipe.engine.llm
     model_name = recipe.model_name
     image = llm.image
+    engine = llm.engine_name
     gpus_per_instance = llm.gpus_per_instance
 
     engine_args = build_engine_args(llm, model_name)
@@ -46,9 +47,9 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
             port = 8000 + i
 
         services += f"""
-  vllm_{i}:
+  {engine}_{i}:
     image: {image}
-    container_name: vllm_{i}
+    container_name: {engine}_{i}
     deploy:
       resources:
         reservations:
@@ -76,7 +77,7 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
 """
 
     if num_instances > 1:
-        depends = "\n".join(f"      vllm_{i}:\n        condition: service_healthy" for i in range(num_instances))
+        depends = "\n".join(f"      {engine}_{i}:\n        condition: service_healthy" for i in range(num_instances))
         services += f"""
   nginx:
     image: nginx:alpine
@@ -92,9 +93,9 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
     return services
 
 
-def generate_nginx_conf(num_instances):
+def generate_nginx_conf(num_instances, engine="vllm"):
     """Generate nginx config with least_conn upstream."""
-    upstream_servers = "\n".join(f"        server vllm_{i}:8000;" for i in range(num_instances))
+    upstream_servers = "\n".join(f"        server {engine}_{i}:8000;" for i in range(num_instances))
 
     return f"""worker_processes auto;
 
@@ -103,7 +104,7 @@ events {{
 }}
 
 http {{
-    upstream vllm_backend {{
+    upstream llm_backend {{
         least_conn;
 {upstream_servers}
     }}
@@ -112,7 +113,7 @@ http {{
         listen 8080;
 
         location / {{
-            proxy_pass http://vllm_backend;
+            proxy_pass http://llm_backend;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
             proxy_set_header Host $host;

--- a/deplodock/deploy/orchestrate.py
+++ b/deplodock/deploy/orchestrate.py
@@ -74,6 +74,8 @@ def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, host, d
     rc, _, _ = run_cmd("docker compose up -d --wait --wait-timeout 1800")
     if rc != 0:
         print("Failed to start services", file=sys.stderr)
+        print("Container logs:", file=sys.stderr)
+        run_cmd("docker compose logs --tail=100")
         return False
 
     # Step 5: Poll health

--- a/deplodock/deploy/orchestrate.py
+++ b/deplodock/deploy/orchestrate.py
@@ -37,7 +37,7 @@ def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, host, d
 
     # Generate and write nginx config if multi-instance
     if num_instances > 1:
-        nginx_content = generate_nginx_conf(num_instances)
+        nginx_content = generate_nginx_conf(num_instances, engine=recipe.engine.llm.engine_name)
         write_file("nginx.conf", nginx_content)
 
     port = 8080 if num_instances > 1 else 8000

--- a/deplodock/planner/__init__.py
+++ b/deplodock/planner/__init__.py
@@ -28,8 +28,9 @@ class BenchmarkTask:
         return os.path.basename(self.recipe_dir)
 
     def result_path(self, run_dir) -> Path:
-        """Full result path: run_dir / recipe_name / {variant}_vllm_benchmark.txt."""
-        return Path(run_dir) / self.recipe_name / f"{self.variant}_vllm_benchmark.txt"
+        """Full result path: run_dir / recipe_name / {variant}_{engine}_benchmark.txt."""
+        engine = self.recipe.engine.llm.engine_name
+        return Path(run_dir) / self.recipe_name / f"{self.variant}_{engine}_benchmark.txt"
 
 
 @dataclass

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -58,13 +58,21 @@ This design provides:
 
 Users must not duplicate named fields in `extra_args`. The `validate_extra_args()` function enforces this by:
 
-1. Building a banned set from the active engine's flag map (`VLLM_FLAG_MAP` or `SGLANG_FLAG_MAP`) plus hardcoded flags (`--trust-remote-code`, `--host`, `--port`, `--model`, `--served-model-name`).
+1. Building a banned set from the active engine's flag map (`VLLM_FLAG_MAP` or `SGLANG_FLAG_MAP`) plus hardcoded flags (`--trust-remote-code`, `--host`, `--port`, `--model`, `--model-path`, `--served-model-name`).
 2. Tokenizing the `extra_args` string and checking each token (handling both `--flag value` and `--flag=value` forms).
 3. Raising `ValueError` listing all offending flags if any are found.
 
 This validation runs inside `load_recipe()` before returning the `Recipe`, so invalid configs fail fast at load time rather than at Docker runtime.
 
 `extra_args` is the escape hatch for engine-specific flags that don't have a named field (e.g. `--kv-cache-dtype fp8`, `--enable-expert-parallel`). It is passed through verbatim to `build_engine_args()`.
+
+### Engine-Specific Model Flag
+
+`build_engine_args()` emits the model path using the flag expected by each engine:
+- vLLM: `--model {name}`
+- SGLang: `--model-path {name}`
+
+Both `--model` and `--model-path` are in the hardcoded banned set, so they cannot appear in `extra_args` regardless of which engine is active.
 
 ### Engine-Specific Nesting
 

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -78,6 +78,10 @@ Both `--model` and `--model-path` are in the hardcoded banned set, so they canno
 
 Engine-specific config (`image`, `extra_args`) nests under `engine.llm.vllm` or `engine.llm.sglang`, while engine-agnostic config lives at `engine.llm`. `LLMConfig.engine_name` is determined by which sub-config is present (SGLang takes priority if both exist). The `image` and `extra_args` properties delegate to the active engine's config.
 
+### SGLang Quantization for AWQ MoE Models
+
+SGLang does not automatically detect AWQ quantization for MoE architectures. For AWQ-quantized MoE models, `--quantization moe_wna16` must be passed via `extra_args`. See [/docs/sglang-awq-moe.md](/docs/sglang-awq-moe.md) for full details and tested configurations.
+
 ## Data Flow
 
 ```

--- a/deplodock/recipe/engines.py
+++ b/deplodock/recipe/engines.py
@@ -27,6 +27,7 @@ _HARDCODED_FLAGS = {
     "--host",
     "--port",
     "--model",
+    "--model-path",
     "--served-model-name",
 }
 
@@ -54,7 +55,7 @@ def build_engine_args(llm: LLMConfig, model_name: str) -> list[str]:
         "--port 8000",
         f"{flag_map['tensor_parallel_size']} {llm.tensor_parallel_size}",
         f"{flag_map['pipeline_parallel_size']} {llm.pipeline_parallel_size}",
-        f"--model {model_name}",
+        f"--model-path {model_name}" if llm.engine_name == "sglang" else f"--model {model_name}",
         f"--served-model-name {model_name}",
     ]
 

--- a/deplodock/recipe/types.py
+++ b/deplodock/recipe/types.py
@@ -53,6 +53,17 @@ class LLMConfig:
         return VllmConfig().image
 
     @property
+    def entrypoint(self) -> str | None:
+        """Docker entrypoint override for the active engine.
+
+        vLLM images have a built-in entrypoint; SGLang images do not,
+        so we must provide one explicitly.
+        """
+        if self.sglang is not None:
+            return "python3 -m sglang.launch_server"
+        return None
+
+    @property
     def extra_args(self) -> str:
         """Extra CLI flags for the active engine."""
         if self.sglang is not None:

--- a/docs/sglang-awq-moe.md
+++ b/docs/sglang-awq-moe.md
@@ -1,0 +1,74 @@
+# SGLang + AWQ MoE Models
+
+## Problem
+
+SGLang does not automatically detect AWQ quantization for Mixture of Experts (MoE) models. When loading an AWQ-quantized MoE model (e.g. `QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ`), SGLang loads all weights at full precision (bf16/fp16), consuming ~30 GB instead of the expected ~16 GB. This causes OOM on GPUs with 32 GB or less.
+
+vLLM handles this correctly without any extra flags.
+
+## Symptoms
+
+Container exits shortly after startup with logs like:
+
+```
+Load weight end. dtype=torch.bfloat16, avail mem=0.41 GB, mem usage=30.28 GB.
+RuntimeError: Not enough memory. Please try to increase --mem-fraction-static.
+```
+
+The key indicator is `mem usage=30.28 GB` — the model weights are not quantized despite being an AWQ checkpoint.
+
+## Quantization Flags That Do NOT Work for MoE
+
+| Flag | Result |
+|------|--------|
+| `--quantization awq` | `ValueError: torch.bfloat16 is not supported for quantization method awq` |
+| `--quantization awq_marlin` | Loads at full bf16 precision, OOM |
+| `--quantization awq_marlin --dtype float16` | Loads at full fp16 precision, OOM |
+
+These methods handle dense (non-MoE) model quantization but do not apply to expert weights in MoE architectures.
+
+## Solution
+
+Use `--quantization moe_wna16`:
+
+```yaml
+engine:
+  llm:
+    sglang:
+      image: "lmsysorg/sglang:latest"
+      extra_args: "--quantization moe_wna16"
+```
+
+This correctly quantizes the MoE expert weights:
+
+```
+Load weight end. dtype=torch.bfloat16, avail mem=14.90 GB, mem usage=15.79 GB.
+```
+
+With `moe_wna16`, the model uses ~15.8 GB (properly quantized) vs ~30.3 GB (unquantized), leaving enough memory for KV cache and CUDA graphs.
+
+## When to Use `moe_wna16`
+
+Use `--quantization moe_wna16` in `extra_args` when **all** of the following apply:
+
+1. Engine is **SGLang** (vLLM handles AWQ MoE automatically)
+2. Model uses **AWQ quantization** (check the model name or `config.json`)
+3. Model has a **Mixture of Experts** architecture (e.g. Qwen3MoE, Mixtral)
+
+For non-MoE AWQ models on SGLang, `--quantization awq` or `--quantization awq_marlin` should work fine.
+
+## SGLang Server Arguments Reference
+
+Full list of SGLang quantization methods and server arguments:
+https://github.com/sgl-project/sglang/blob/main/docs/advanced_features/server_arguments.md
+
+Notable MoE-related quantization options:
+- `moe_wna16` — WnA16 quantization for MoE expert weights (works with AWQ checkpoints)
+- `quark_int4fp8_moe` — INT4/FP8 mixed quantization for MoE
+
+## Tested Configuration
+
+- Model: `QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ` (Qwen3MoE, 30B params, 3B active)
+- GPU: NVIDIA GeForce RTX 5090 (32 GB)
+- Image: `lmsysorg/sglang:latest`
+- Result: Server starts, serves inference, ~15.8 GB model memory usage

--- a/docs/sglang-awq-moe.md
+++ b/docs/sglang-awq-moe.md
@@ -19,11 +19,11 @@ The key indicator is `mem usage=30.28 GB` — the model weights are not quantize
 
 ## Quantization Flags That Do NOT Work for MoE
 
-| Flag | Result |
-|------|--------|
-| `--quantization awq` | `ValueError: torch.bfloat16 is not supported for quantization method awq` |
-| `--quantization awq_marlin` | Loads at full bf16 precision, OOM |
-| `--quantization awq_marlin --dtype float16` | Loads at full fp16 precision, OOM |
+| Flag                                        | Result                                                                    |
+|---------------------------------------------|---------------------------------------------------------------------------|
+| `--quantization awq`                        | `ValueError: torch.bfloat16 is not supported for quantization method awq` |
+| `--quantization awq_marlin`                 | Loads at full bf16 precision, OOM                                         |
+| `--quantization awq_marlin --dtype float16` | Loads at full fp16 precision, OOM                                         |
 
 These methods handle dense (non-MoE) model quantization but do not apply to expert weights in MoE architectures.
 

--- a/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -36,6 +36,7 @@ variants:
       llm:
         sglang:
           image: "lmsysorg/sglang:latest"
+          extra_args: "--quantization moe_wna16"
   L40S_sglang:
     gpu: "NVIDIA L40S"
     gpu_count: 1
@@ -43,3 +44,4 @@ variants:
       llm:
         sglang:
           image: "lmsysorg/sglang:latest"
+          extra_args: "--quantization moe_wna16"

--- a/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -29,3 +29,17 @@ variants:
   L40S:
     gpu: "NVIDIA L40S"
     gpu_count: 1
+  RTX5090_sglang:
+    gpu: "NVIDIA GeForce RTX 5090"
+    gpu_count: 1
+    engine:
+      llm:
+        sglang:
+          image: "lmsysorg/sglang:latest"
+  L40S_sglang:
+    gpu: "NVIDIA L40S"
+    gpu_count: 1
+    engine:
+      llm:
+        sglang:
+          image: "lmsysorg/sglang:latest"

--- a/results/qwen3_coder_awq_sglang_vs_vllm/Qwen3-Coder-30B-A3B-Instruct-AWQ/RTX5090_sglang_sglang_benchmark.txt
+++ b/results/qwen3_coder_awq_sglang_vs_vllm/Qwen3-Coder-30B-A3B-Instruct-AWQ/RTX5090_sglang_sglang_benchmark.txt
@@ -1,0 +1,25 @@
+============ Serving Benchmark Result ============
+Successful requests:                     256       
+Failed requests:                         0         
+Maximum request concurrency:             128       
+Benchmark duration (s):                  2559.35   
+Total input tokens:                      1024000   
+Total generated tokens:                  1024000   
+Request throughput (req/s):              0.10      
+Output token throughput (tok/s):         400.10    
+Peak output token throughput (tok/s):    561.00    
+Peak concurrent requests:                144.00    
+Total token throughput (tok/s):          800.20    
+---------------Time to First Token----------------
+Mean TTFT (ms):                          688882.12 
+Median TTFT (ms):                        791156.37 
+P99 TTFT (ms):                           1103785.57
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          87.14     
+Median TPOT (ms):                        48.15     
+P99 TPOT (ms):                           288.64    
+---------------Inter-token Latency----------------
+Mean ITL (ms):                           87.13     
+Median ITL (ms):                         45.96     
+P99 ITL (ms):                            54.58     
+==================================================

--- a/results/qwen3_coder_awq_sglang_vs_vllm/Qwen3-Coder-30B-A3B-Instruct-AWQ/RTX5090_vllm_benchmark.txt
+++ b/results/qwen3_coder_awq_sglang_vs_vllm/Qwen3-Coder-30B-A3B-Instruct-AWQ/RTX5090_vllm_benchmark.txt
@@ -1,0 +1,25 @@
+============ Serving Benchmark Result ============
+Successful requests:                     256       
+Failed requests:                         0         
+Maximum request concurrency:             128       
+Benchmark duration (s):                  947.36    
+Total input tokens:                      1024000   
+Total generated tokens:                  1024000   
+Request throughput (req/s):              0.27      
+Output token throughput (tok/s):         1080.90   
+Peak output token throughput (tok/s):    1740.00   
+Peak concurrent requests:                132.00    
+Total token throughput (tok/s):          2161.80   
+---------------Time to First Token----------------
+Mean TTFT (ms):                          283458.59 
+Median TTFT (ms):                        360595.79 
+P99 TTFT (ms):                           437245.62 
+-----Time per Output Token (excl. 1st token)------
+Mean TPOT (ms):                          21.46     
+Median TPOT (ms):                        17.90     
+P99 TPOT (ms):                           34.12     
+---------------Inter-token Latency----------------
+Mean ITL (ms):                           21.46     
+Median ITL (ms):                         16.02     
+P99 ITL (ms):                            123.10    
+==================================================

--- a/results/qwen3_coder_awq_sglang_vs_vllm/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/results/qwen3_coder_awq_sglang_vs_vllm/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -1,0 +1,47 @@
+model:
+  huggingface: "QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ"
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    context_length: 8192
+    vllm:
+      image: "vllm/vllm-openai:latest"
+
+benchmark:
+  max_concurrency: 128
+  num_prompts: 256
+  random_input_len: 4000
+  random_output_len: 4000
+
+variants:
+  RTX4090:
+    gpu: "NVIDIA GeForce RTX 4090"
+    gpu_count: 1
+  RTX5090:
+    gpu: "NVIDIA GeForce RTX 5090"
+    gpu_count: 1
+  Pro6000:
+    gpu: "NVIDIA RTX PRO 6000 Server Edition"
+    gpu_count: 1
+  L40S:
+    gpu: "NVIDIA L40S"
+    gpu_count: 1
+  RTX5090_sglang:
+    gpu: "NVIDIA GeForce RTX 5090"
+    gpu_count: 1
+    engine:
+      llm:
+        sglang:
+          image: "lmsysorg/sglang:latest"
+          extra_args: "--quantization moe_wna16"
+  L40S_sglang:
+    gpu: "NVIDIA L40S"
+    gpu_count: 1
+    engine:
+      llm:
+        sglang:
+          image: "lmsysorg/sglang:latest"
+          extra_args: "--quantization moe_wna16"

--- a/results/qwen3_coder_awq_sglang_vs_vllm/manifest.json
+++ b/results/qwen3_coder_awq_sglang_vs_vllm/manifest.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2026-02-24T19:13:50",
+  "code_hash": "06eb05ade9c704576462cb843ac96b54ff75c10129d4691e4ac0e5bc414a96f2",
+  "recipes": [
+    "Qwen3-Coder-30B-A3B-Instruct-AWQ"
+  ],
+  "tasks": [
+    {
+      "recipe": "Qwen3-Coder-30B-A3B-Instruct-AWQ",
+      "variant": "RTX5090",
+      "gpu_name": "NVIDIA GeForce RTX 5090",
+      "gpu_short": "rtx5090",
+      "gpu_count": 1,
+      "model_name": "QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ",
+      "result_file": "Qwen3-Coder-30B-A3B-Instruct-AWQ/RTX5090_vllm_benchmark.txt",
+      "status": "completed"
+    },
+    {
+      "recipe": "Qwen3-Coder-30B-A3B-Instruct-AWQ",
+      "variant": "RTX5090_sglang",
+      "gpu_name": "NVIDIA GeForce RTX 5090",
+      "gpu_short": "rtx5090",
+      "gpu_count": 1,
+      "model_name": "QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ",
+      "result_file": "Qwen3-Coder-30B-A3B-Instruct-AWQ/RTX5090_sglang_sglang_benchmark.txt",
+      "status": "completed"
+    }
+  ]
+}

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -80,7 +80,8 @@ CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench
 | `run_cli` | session | Callable that invokes `python -m deplodock.deplodock` as a subprocess |
 | `make_bench_config` | function | Factory that writes a temp `config.yaml` for bench tests (benchmark section only) |
 | `tmp_recipe_dir` | function | Temp directory with a sample `recipe.yaml` for unit tests |
-| `sample_config` | function | Single-instance config dict for compose tests |
+| `sample_config` | function | Single-instance vLLM config dict for compose tests |
+| `sample_config_sglang` | function | Single-instance SGLang config dict for compose tests |
 | `sample_config_multi` | function | Multi-instance config dict for compose tests |
 
 ## Conventions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,31 @@ def sample_config():
 
 
 @pytest.fixture
+def sample_config_sglang():
+    """Return a resolved config dict for SGLang compose generation."""
+    return {
+        "model": {"huggingface": "test-org/test-model"},
+        "engine": {
+            "llm": {
+                "tensor_parallel_size": 1,
+                "pipeline_parallel_size": 1,
+                "gpu_memory_utilization": 0.9,
+                "context_length": 8192,
+                "sglang": {
+                    "image": "lmsysorg/sglang:latest",
+                },
+            }
+        },
+        "benchmark": {
+            "max_concurrency": 128,
+            "num_prompts": 256,
+            "random_input_len": 4000,
+            "random_output_len": 4000,
+        },
+    }
+
+
+@pytest.fixture
 def sample_config_multi():
     """Return a resolved config dict for multi-instance testing."""
     return {

--- a/tests/deploy/test_compose.py
+++ b/tests/deploy/test_compose.py
@@ -174,12 +174,20 @@ def test_compose_sglang_single_instance(sample_config_sglang):
     assert "sglang_0:" in result
     assert "vllm_0:" not in result
     assert "lmsysorg/sglang:latest" in result
+    assert "entrypoint: python3 -m sglang.launch_server" in result
     assert "--model-path test-org/test-model" in result
     assert "--model test-org/test-model" not in result
     assert "--tp 1" in result
     assert "--dp 1" in result
     assert "--mem-fraction-static 0.9" in result
     assert "--context-length 8192" in result
+
+
+def test_compose_vllm_no_entrypoint(sample_config):
+    """vLLM compose should not have an entrypoint override."""
+    recipe = Recipe.from_dict(sample_config)
+    result = generate_compose(recipe, "/mnt/models", "test-token", num_instances=1)
+    assert "entrypoint:" not in result
 
 
 def test_compose_sglang_parses_as_valid_yaml(sample_config_sglang):

--- a/tests/recipe/test_engines.py
+++ b/tests/recipe/test_engines.py
@@ -119,6 +119,20 @@ def test_build_args_sglang_basic():
     assert "--trust-remote-code" in args
 
 
+def test_build_args_sglang_uses_model_path():
+    llm = LLMConfig(sglang=SglangConfig())
+    args = build_engine_args(llm, "org/model")
+    assert "--model-path org/model" in args
+    assert "--model org/model" not in args
+
+
+def test_build_args_vllm_uses_model_not_model_path():
+    llm = LLMConfig(vllm=VllmConfig())
+    args = build_engine_args(llm, "org/model")
+    assert "--model org/model" in args
+    assert "--model-path org/model" not in args
+
+
 def test_build_args_sglang_context_length():
     llm = LLMConfig(context_length=8192, sglang=SglangConfig())
     args = build_engine_args(llm, "org/model")
@@ -129,3 +143,9 @@ def test_build_args_sglang_max_concurrent():
     llm = LLMConfig(max_concurrent_requests=128, sglang=SglangConfig())
     args = build_engine_args(llm, "org/model")
     assert "--max-running-requests 128" in args
+
+
+def test_banned_flags_include_model_path():
+    """--model-path must be banned for both engines."""
+    assert "--model-path" in banned_extra_arg_flags("vllm")
+    assert "--model-path" in banned_extra_arg_flags("sglang")


### PR DESCRIPTION
## Summary

- Make deploy pipeline engine-agnostic: service names use `{engine}_0` prefix instead of hardcoded `vllm_0`, nginx upstream renamed to `llm_backend`
- Emit `--model-path` for SGLang and `--model` for vLLM in `build_engine_args()`, add `--model-path` to banned extra_args flags
- Use vLLM image for benchmarking regardless of engine (it's an HTTP client against any OpenAI-compatible endpoint)
- Add `RTX5090_sglang` and `L40S_sglang` variants to the Qwen recipe

## Test plan

- [x] All 180 existing + new tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [ ] Manual: `deplodock deploy local --recipe recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ --variant RTX5090_sglang --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)