### PR TITLE
Add intermediate results, run-dir logging, --no-teardown, and teardown command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Or for a specific test file:
 - `deplodock deploy ssh ...` — deploy to remote server via SSH
 - `deplodock deploy cloud ...` — provision a cloud VM and deploy via SSH
 - `deplodock bench recipes/* ...` — deploy + benchmark + teardown on cloud VMs (recipe dirs as positional args)
+- `deplodock teardown <run_dir>` — clean up VMs left running by `bench --no-teardown`
 - `deplodock report ...` — generate Excel reports from benchmark results
 - `deplodock vm create gcp ...` — create a GCP GPU VM
 - `deplodock vm create cloudrift ...` — create a CloudRift GPU VM

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup clean bench bench-force logs clean-logs test-compose report report-nov2025 lint format
+.PHONY: help setup clean bench bench-force test-compose report report-nov2025 lint format
 
 help:
 	@echo "Server Benchmark Makefile"
@@ -11,8 +11,6 @@ help:
 	@echo "  bench-force    - Run benchmarks in parallel (force re-run, skip cached results)"
 	@echo "  report         - Generate Excel report from benchmark results"
 	@echo "  report-nov2025 - Generate Excel report from Nov 2025 results (pro6000_l40s_h100_h200_11_2025)"
-	@echo "  logs           - Show the latest benchmark log"
-	@echo "  clean-logs     - Remove all log files"
 	@echo "  clean          - Remove virtual environment and generated files"
 	@echo "  test-compose   - Test docker-compose generation with sample config"
 
@@ -68,25 +66,6 @@ report-jan2026: setup
 		--output results/pro6000_h100_h200_b200_01_2026/benchmark_report.xlsx
 
 
-
-logs:
-	@if [ ! -d "logs" ]; then \
-		echo "❌ No logs directory found."; \
-		exit 1; \
-	fi
-	@LATEST_LOG=$$(ls -t logs/benchmark_*.log 2>/dev/null | head -1); \
-	if [ -z "$$LATEST_LOG" ]; then \
-		echo "❌ No log files found."; \
-		exit 1; \
-	fi; \
-	echo "📝 Showing: $$LATEST_LOG"; \
-	echo ""; \
-	cat "$$LATEST_LOG"
-
-clean-logs:
-	@echo "Removing log files..."
-	rm -rf logs/
-	@echo "✅ Logs cleaned!"
 
 clean:
 	@echo "Removing virtual environment and generated files..."

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Tools for deploying and benchmarking LLM inference on GPU servers. Supports **vL
   - [commands/](deplodock/commands/) — CLI layer (thin argparse handlers, see [ARCHITECTURE.md](deplodock/commands/ARCHITECTURE.md))
     - [deploy/](deplodock/commands/deploy/) — `deploy local`, `deploy ssh`, `deploy cloud` commands
     - [bench/](deplodock/commands/bench/) — `bench` command
+    - [teardown.py](deplodock/commands/teardown.py) — `teardown` command
     - [report/](deplodock/commands/report/) — `report` command
     - [vm/](deplodock/commands/vm/) — `vm create/delete` commands (GCP, CloudRift)
   - [recipe/](deplodock/recipe/) — Recipe loading, dataclass types, engine flag mapping (see [ARCHITECTURE.md](deplodock/recipe/ARCHITECTURE.md))
@@ -279,7 +280,7 @@ The `bench` command accepts recipe directories as positional arguments. It loads
 
 ```yaml
 benchmark:
-  local_results_dir: "results"
+  local_results_dir: "results/intermediate"
   model_dir: "/hf_models"
 
 pricing:
@@ -314,6 +315,21 @@ deplodock bench recipes/* --dry-run                          # Preview commands
 | `--config`      | `config.yaml`       | Path to configuration file             |
 | `--max-workers` | num groups          | Max parallel execution groups          |
 | `--dry-run`     | false               | Print commands without executing       |
+| `--no-teardown` | false               | Skip teardown and VM deletion (saves `instances.json` for later cleanup) |
+
+### Teardown
+
+Clean up VMs left running by `bench --no-teardown`:
+
+```bash
+deplodock teardown results/intermediate/2026-02-24_12-00-00_abc12345
+deplodock teardown results/intermediate/2026-02-24_12-00-00_abc12345 --ssh-key ~/.ssh/id_ed25519
+```
+
+| Flag       | Default             | Description                       |
+|------------|---------------------|-----------------------------------|
+| `run_dir`  | (required)          | Run directory with `instances.json` (positional arg) |
+| `--ssh-key`| `~/.ssh/id_ed25519` | SSH private key path              |
 
 ### Generate Reports
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@
 
 # Global benchmark settings
 benchmark:
-  local_results_dir: "results"
+  local_results_dir: "results/intermediate"
   model_dir: "/hf_models"
 
 # GPU Pricing ($ per hour per GPU)

--- a/deplodock/benchmark/__init__.py
+++ b/deplodock/benchmark/__init__.py
@@ -1,6 +1,6 @@
 """Benchmark library: tracking, config, logging, workload, tasks, execution."""
 
-from deplodock.benchmark.bench_logging import _get_group_logger, setup_logging
+from deplodock.benchmark.bench_logging import _get_group_logger, add_file_handler, setup_logging
 from deplodock.benchmark.config import _expand_path, load_config, validate_config
 from deplodock.benchmark.execution import _run_groups, run_execution_group
 from deplodock.benchmark.tasks import _task_meta, enumerate_tasks
@@ -24,6 +24,7 @@ __all__ = [
     "validate_config",
     "_expand_path",
     "setup_logging",
+    "add_file_handler",
     "_get_group_logger",
     "extract_benchmark_results",
     "run_benchmark_workload",

--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -2,41 +2,21 @@
 
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
 
 from deplodock.hardware import gpu_short_name
 from deplodock.planner import ExecutionGroup
 
-# Global log file path
-LOG_FILE = None
 
+def setup_logging():
+    """Setup logging with console output only.
 
-def setup_logging() -> str:
-    """Setup logging with timestamped log file and console output.
-
-    Returns:
-        Path to the log file
+    Call add_file_handler() after the run directory is created to attach
+    a file handler that writes directly into the run directory.
     """
-    global LOG_FILE
-
-    log_dir = Path("logs")
-    log_dir.mkdir(exist_ok=True)
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    LOG_FILE = log_dir / f"benchmark_{timestamp}.log"
-
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
     root_logger.handlers.clear()
-
-    file_handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
-    file_formatter = logging.Formatter(
-        "[%(asctime)s] [%(name)s] %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    file_handler.setFormatter(file_formatter)
-    root_logger.addHandler(file_handler)
 
     console_handler = logging.StreamHandler(sys.stdout)
 
@@ -51,7 +31,24 @@ def setup_logging() -> str:
     console_handler.setFormatter(console_formatter)
     root_logger.addHandler(console_handler)
 
-    return str(LOG_FILE)
+
+def add_file_handler(run_dir: Path) -> str:
+    """Add a file handler that writes to {run_dir}/benchmark.log.
+
+    Returns:
+        Path to the log file.
+    """
+    log_file = run_dir / "benchmark.log"
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_formatter = logging.Formatter(
+        "[%(asctime)s] [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    file_handler.setFormatter(file_formatter)
+    logging.getLogger().addHandler(file_handler)
+
+    return str(log_file)
 
 
 def _get_group_logger(group: ExecutionGroup, model_name: str | None = None) -> logging.Logger:

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -64,7 +64,7 @@ Benchmark tracking, configuration, task enumeration, and execution.
 **Modules:**
 - `tracking.py` — `compute_code_hash()`, `create_run_dir()`, `write_manifest()`, `read_manifest()`
 - `config.py` — `load_config()`, `validate_config()`, `_expand_path()`
-- `bench_logging.py` — `setup_logging()`, `_get_group_logger()`
+- `bench_logging.py` — `setup_logging()`, `add_file_handler()`, `_get_group_logger()`
 - `workload.py` — `extract_benchmark_results()`, `run_benchmark_workload()`
 - `tasks.py` — `enumerate_tasks()`, `_task_meta()`
 - `execution.py` — `run_execution_group()`, `_run_groups()`
@@ -101,6 +101,7 @@ Each command module contains only argparse registration and `handle_*` functions
 - `commands/deploy/local.py` — `handle_local()`, `register_local_target()`
 - `commands/deploy/cloud.py` — `handle_cloud()`, `register_cloud_target()`
 - `commands/report/` — `handle_report()`, `register_report_command()`
+- `commands/teardown.py` — `handle_teardown()`, `register_teardown_command()`
 - `commands/vm/` — `register_vm_command()`, CLI handlers for each provider
 
 ## Data Flow
@@ -126,10 +127,10 @@ For each task in group:
     +-- deploy(DeployParams) -> compose up
     +-- run_benchmark_workload()
     +-- save results
-    +-- teardown()
+    +-- teardown() (skipped with --no-teardown)
     |
     v
-delete_cloud_vm(conn.delete_info)
+delete_cloud_vm(conn.delete_info) (skipped with --no-teardown; writes instances.json)
 ```
 
 ## CLI Command Tree
@@ -141,6 +142,7 @@ deplodock
 |   +-- ssh      -- deploy to remote server via SSH
 |   +-- cloud    -- provision cloud VM + deploy via SSH
 +-- bench        -- deploy + benchmark + teardown on cloud VMs
++-- teardown     -- clean up VMs left by bench --no-teardown
 +-- report       -- generate Excel reports from benchmark results
 +-- vm
     +-- create

--- a/deplodock/commands/teardown.py
+++ b/deplodock/commands/teardown.py
@@ -1,0 +1,89 @@
+"""Teardown command: clean up VMs left running by --no-teardown."""
+
+import json
+import sys
+from pathlib import Path
+
+from deplodock.deploy.orchestrate import run_teardown
+from deplodock.provisioning.cloud import delete_cloud_vm
+from deplodock.provisioning.ssh_transport import make_run_cmd
+
+
+def handle_teardown(args):
+    """Handle the teardown command."""
+    run_dir = Path(args.run_dir)
+    instances_path = run_dir / "instances.json"
+    ssh_key = args.ssh_key
+
+    if not instances_path.exists():
+        print(f"No instances.json found in {run_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    instances = json.loads(instances_path.read_text())
+    if not instances:
+        print("instances.json is empty — nothing to tear down.")
+        return
+
+    print(f"Tearing down {len(instances)} instance(s) from {run_dir}")
+    print()
+
+    errors = []
+    for inst in instances:
+        label = inst.get("group_label", "unknown")
+        address = inst.get("address", "")
+        ssh_port = inst.get("ssh_port", 22)
+        provider = inst.get("provider")
+        instance_id = inst.get("instance_id")
+
+        print(f"[{label}] {address} ({provider}: {instance_id})")
+
+        # Docker compose down
+        if address:
+            print(f"  Stopping containers on {address}...")
+            run_cmd = make_run_cmd(address, ssh_key, ssh_port)
+            run_teardown(run_cmd)
+
+        # Delete VM
+        if provider and instance_id:
+            print(f"  Deleting VM ({provider}: {instance_id})...")
+            try:
+                if provider == "gcp":
+                    zone = inst.get("zone")
+                    if not zone:
+                        print(f"  WARNING: missing zone for GCP instance {instance_id}", file=sys.stderr)
+                        errors.append(label)
+                        continue
+                    delete_info = (provider, instance_id, zone)
+                else:
+                    delete_info = (provider, instance_id)
+                delete_cloud_vm(delete_info)
+                print("  VM deleted.")
+            except Exception as e:
+                print(f"  ERROR deleting VM: {e}", file=sys.stderr)
+                errors.append(label)
+                continue
+
+    if errors:
+        print(f"\nFailed to clean up {len(errors)} instance(s): {', '.join(errors)}")
+        sys.exit(1)
+    else:
+        instances_path.unlink()
+        print(f"\nAll instances cleaned up. Removed {instances_path}")
+
+
+def register_teardown_command(subparsers):
+    """Register the teardown subcommand."""
+    parser = subparsers.add_parser(
+        "teardown",
+        help="Tear down VMs left running by 'bench --no-teardown'",
+    )
+    parser.add_argument(
+        "run_dir",
+        help="Run directory containing instances.json",
+    )
+    parser.add_argument(
+        "--ssh-key",
+        default="~/.ssh/id_ed25519",
+        help="SSH private key path (default: ~/.ssh/id_ed25519)",
+    )
+    parser.set_defaults(func=handle_teardown)

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -8,6 +8,7 @@ from deplodock.commands.deploy.cloud import register_cloud_target
 from deplodock.commands.deploy.local import register_local_target
 from deplodock.commands.deploy.ssh import register_ssh_target
 from deplodock.commands.report import register_report_command
+from deplodock.commands.teardown import register_teardown_command
 from deplodock.commands.vm import register_vm_command
 
 
@@ -23,9 +24,10 @@ def main():
     register_ssh_target(deploy_subparsers)
     register_cloud_target(deploy_subparsers)
 
-    # bench and report subcommands
+    # bench, report, teardown, vm subcommands
     register_bench_command(subparsers)
     register_report_command(subparsers)
+    register_teardown_command(subparsers)
     register_vm_command(subparsers)
 
     args = parser.parse_args()

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -66,7 +66,7 @@ Test the full CLI pipeline end-to-end by invoking `deplodock` as a subprocess wi
 |------|--------|
 | `deploy/test_deploy_dryrun.py` | `deploy ssh`, `deploy local` — dry-run output, command sequence, variant resolution, teardown, CLI help |
 | `deploy/test_deploy_cloud_dryrun.py` | `deploy cloud` — dry-run output, deploy steps, error handling, CLI help |
-| `benchmark/test_bench_dryrun.py` | `bench` — dry-run output, deploy->benchmark->teardown sequence, variant filtering, CLI help |
+| `benchmark/test_bench_dryrun.py` | `bench` — dry-run output, deploy->benchmark->teardown sequence, variant filtering, `--no-teardown` flag, CLI help; `teardown` — CLI help |
 | `provisioning/test_vm_dryrun.py` | `vm create/delete gcp`, `vm create/delete cloudrift` — dry-run output, argparse validation, CLI help |
 
 CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench_config`** (a factory for temporary `config.yaml` files). Both are defined in `conftest.py`.


### PR DESCRIPTION
## Summary

- **Intermediate results directory**: `config.yaml` now points `local_results_dir` to `results/intermediate` so WIP results are separated from curated ones
- **Logs in run directory**: `setup_logging()` is now console-only; `add_file_handler(run_dir)` attaches a file handler writing `benchmark.log` directly into the run directory after it's created. Removed `make logs` / `make clean-logs` targets.
- **`--no-teardown` flag on bench**: Skips per-task teardown and VM deletion, saves `instances.json` with connection/provider info for later cleanup
- **`deplodock teardown <run_dir>` command**: Reads `instances.json`, SSHs to `docker compose down`, deletes VMs, and removes `instances.json` on success

## Test plan

- [x] `make test` — all 183 tests pass (including 2 new: `--no-teardown` dry-run, teardown help)
- [x] `make lint` — clean
- [x] `deplodock bench --help` shows `--no-teardown`
- [x] `deplodock teardown --help` shows `run_dir` and `--ssh-key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)