### PR TITLE
Replace variants with matrices for benchmark parameter sweeps

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -30,8 +30,8 @@ Use triple-quote docstrings for modules and public functions. Keep them
 to one line when the purpose is obvious:
 
 ```python
-def load_recipe(recipe_dir, variant=None):
-    """Load recipe.yaml from recipe_dir, optionally deep-merging a variant."""
+def load_recipe(recipe_dir):
+    """Load recipe.yaml and return base Recipe (no matrix expansion)."""
 ```
 
 Use `Args:` / `Returns:` sections only when parameters or return values

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -41,7 +41,7 @@ def handle_bench(args):
     no_teardown = args.no_teardown
 
     # Enumerate tasks from recipe dirs
-    tasks = enumerate_tasks(args.recipes, variants_filter=args.variants)
+    tasks = enumerate_tasks(args.recipes)
     if not tasks:
         root_logger.error("Error: No benchmark tasks found.")
         sys.exit(1)
@@ -139,12 +139,6 @@ def register_bench_command(subparsers):
         "recipes",
         nargs="+",
         help="Recipe directories to benchmark",
-    )
-    parser.add_argument(
-        "--variants",
-        nargs="+",
-        default=None,
-        help="Variant names to run (default: all variants in each recipe)",
     )
     parser.add_argument(
         "--ssh-key",

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -18,18 +18,18 @@ from deplodock.recipe import load_recipe
 
 def handle_cloud(args):
     """CLI handler for 'deploy cloud'."""
-    recipe = load_recipe(args.recipe, variant=args.variant)
+    recipe = load_recipe(args.recipe)
 
-    if not recipe.gpu:
-        print("Error: recipe must have a 'gpu' field (use a variant with GPU info).", file=sys.stderr)
+    if not recipe.deploy.gpu:
+        print("Error: recipe must have a 'deploy.gpu' field for cloud provisioning.", file=sys.stderr)
         sys.exit(1)
 
     ssh_key = os.path.expanduser(args.ssh_key)
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
 
     conn = provision_cloud_vm(
-        gpu_name=recipe.gpu,
-        gpu_count=recipe.gpu_count,
+        gpu_name=recipe.deploy.gpu,
+        gpu_count=recipe.deploy.gpu_count,
         ssh_key=ssh_key,
         server_name=args.name,
         dry_run=args.dry_run,
@@ -57,7 +57,6 @@ def register_cloud_target(subparsers):
     """Register the cloud deploy target."""
     parser = subparsers.add_parser("cloud", help="Provision a cloud VM and deploy via SSH")
     parser.add_argument("--recipe", required=True, help="Path to recipe directory")
-    parser.add_argument("--variant", default=None, help="Hardware variant (e.g. RTX5090)")
     parser.add_argument("--name", default="cloud-deploy", help="VM name prefix (default: cloud-deploy)")
     parser.add_argument("--ssh-key", default="~/.ssh/id_ed25519", help="SSH private key path")
     parser.add_argument("--hf-token", default=None, help="HuggingFace token (default: $HF_TOKEN)")

--- a/deplodock/commands/deploy/local.py
+++ b/deplodock/commands/deploy/local.py
@@ -11,7 +11,6 @@ from deplodock.recipe import load_recipe
 def handle_local(args):
     """Handle the local deploy target."""
     recipe_dir = args.recipe
-    variant = args.variant
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
     model_dir = args.model_dir
     dry_run = args.dry_run
@@ -26,7 +25,7 @@ def handle_local(args):
     if teardown:
         return run_teardown(run_cmd)
 
-    recipe = load_recipe(recipe_dir, variant=variant)
+    recipe = load_recipe(recipe_dir)
 
     success = run_deploy(
         run_cmd=run_cmd,
@@ -46,7 +45,6 @@ def register_local_target(subparsers):
     """Register the local deploy target."""
     parser = subparsers.add_parser("local", help="Deploy locally via docker compose")
     parser.add_argument("--recipe", required=True, help="Path to recipe directory")
-    parser.add_argument("--variant", default=None, help="Hardware variant (e.g. 8xH200)")
     parser.add_argument("--hf-token", default=None, help="HuggingFace token (default: $HF_TOKEN)")
     parser.add_argument("--model-dir", default="/mnt/models", help="Model cache directory")
     parser.add_argument("--teardown", action="store_true", help="Stop containers instead of deploying")

--- a/deplodock/commands/deploy/ssh.py
+++ b/deplodock/commands/deploy/ssh.py
@@ -16,7 +16,7 @@ from deplodock.recipe import load_recipe
 
 def handle_ssh(args):
     """Handle the SSH deploy target."""
-    recipe = load_recipe(args.recipe, variant=args.variant)
+    recipe = load_recipe(args.recipe)
     params = DeployParams(
         server=args.server,
         ssh_key=args.ssh_key,
@@ -39,7 +39,6 @@ def register_ssh_target(subparsers):
     """Register the SSH deploy target."""
     parser = subparsers.add_parser("ssh", help="Deploy via SSH to a remote server")
     parser.add_argument("--recipe", required=True, help="Path to recipe directory")
-    parser.add_argument("--variant", default=None, help="Hardware variant (e.g. 8xH200)")
     parser.add_argument("--hf-token", default=None, help="HuggingFace token (default: $HF_TOKEN)")
     parser.add_argument("--model-dir", default="/mnt/models", help="Model cache directory")
     parser.add_argument("--teardown", action="store_true", help="Stop containers instead of deploying")

--- a/deplodock/deploy/compose.py
+++ b/deplodock/deploy/compose.py
@@ -5,13 +5,13 @@ from deplodock.recipe.types import Recipe
 
 
 def calculate_num_instances(recipe: Recipe) -> int:
-    """Calculate number of instances from recipe gpu_count and parallelism."""
+    """Calculate number of instances from recipe deploy.gpu_count and parallelism."""
     gpus_per_instance = recipe.engine.llm.gpus_per_instance
 
-    if recipe.gpu_count is None or recipe.gpu is None:
+    if recipe.deploy.gpu_count is None or recipe.deploy.gpu is None:
         return 1
 
-    return max(1, recipe.gpu_count // gpus_per_instance)
+    return max(1, recipe.deploy.gpu_count // gpus_per_instance)
 
 
 def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_device_ids=None):

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -33,13 +33,13 @@ def resolve_vm_spec(loaded_configs, server_name=None):
 
     for entry, recipe in loaded_configs:
         recipe_path = entry["recipe"]
-        variant = entry.get("variant")
+        variant = entry.get("variant", "")
 
-        entry_gpu = recipe.gpu
-        entry_gpu_count = recipe.gpu_count
+        entry_gpu = recipe.deploy.gpu
+        entry_gpu_count = recipe.deploy.gpu_count
 
         if entry_gpu is None:
-            raise ValueError(f"Recipe '{recipe_path}' variant '{variant}' is missing 'gpu' field")
+            raise ValueError(f"Recipe '{recipe_path}' variant '{variant}' is missing 'deploy.gpu' field")
 
         if gpu_name is None:
             gpu_name = entry_gpu

--- a/deplodock/recipe/__init__.py
+++ b/deplodock/recipe/__init__.py
@@ -1,9 +1,23 @@
 """Recipe loading and configuration."""
 
 from deplodock.recipe.engines import banned_extra_arg_flags, build_engine_args
-from deplodock.recipe.recipe import deep_merge, load_recipe, validate_extra_args
+from deplodock.recipe.matrix import (
+    PARAM_ABBREVIATIONS,
+    build_override,
+    dot_to_nested,
+    expand_matrix_entry,
+    matrix_label,
+)
+from deplodock.recipe.recipe import (
+    _load_raw_config,
+    _validate_and_build,
+    deep_merge,
+    load_recipe,
+    validate_extra_args,
+)
 from deplodock.recipe.types import (
     BenchmarkConfig,
+    DeployConfig,
     EngineConfig,
     LLMConfig,
     ModelConfig,
@@ -14,15 +28,23 @@ from deplodock.recipe.types import (
 
 __all__ = [
     "BenchmarkConfig",
+    "DeployConfig",
     "EngineConfig",
     "LLMConfig",
     "ModelConfig",
+    "PARAM_ABBREVIATIONS",
     "Recipe",
     "SglangConfig",
     "VllmConfig",
+    "_load_raw_config",
+    "_validate_and_build",
     "banned_extra_arg_flags",
     "build_engine_args",
+    "build_override",
     "deep_merge",
+    "dot_to_nested",
+    "expand_matrix_entry",
     "load_recipe",
+    "matrix_label",
     "validate_extra_args",
 ]

--- a/deplodock/recipe/matrix.py
+++ b/deplodock/recipe/matrix.py
@@ -1,0 +1,94 @@
+"""Matrix expansion: broadcast + zip semantics for benchmark parameter sweeps."""
+
+# Abbreviations for common parameter names in auto-generated run identifiers.
+PARAM_ABBREVIATIONS = {
+    "max_concurrency": "c",
+    "num_prompts": "n",
+    "random_input_len": "in",
+    "random_output_len": "out",
+    "max_concurrent_requests": "mcr",
+    "context_length": "ctx",
+}
+
+
+def dot_to_nested(key: str, value) -> dict:
+    """Convert a dot-notation key + value into a nested dict.
+
+    Example: dot_to_nested("engine.llm.max_concurrent_requests", 256)
+    returns {"engine": {"llm": {"max_concurrent_requests": 256}}}
+    """
+    parts = key.split(".")
+    result = current = {}
+    for part in parts[:-1]:
+        current[part] = {}
+        current = current[part]
+    current[parts[-1]] = value
+    return result
+
+
+def expand_matrix_entry(entry: dict) -> list[dict]:
+    """Expand one matrix entry using broadcast + zip semantics.
+
+    Scalars are broadcast to all runs. Lists are zipped together (all lists
+    in one entry must have the same length). Returns a list of flat dicts
+    mapping dot-notation keys to scalar values (one dict per run).
+    """
+    scalar_keys = {}
+    list_keys = {}
+
+    for key, value in entry.items():
+        if isinstance(value, list):
+            list_keys[key] = value
+        else:
+            scalar_keys[key] = value
+
+    if not list_keys:
+        return [dict(scalar_keys)]
+
+    # Validate all lists have the same length
+    lengths = {k: len(v) for k, v in list_keys.items()}
+    unique_lengths = set(lengths.values())
+    if len(unique_lengths) != 1:
+        detail = ", ".join(f"{k}={n}" for k, n in lengths.items())
+        raise ValueError(f"All lists in a matrix entry must have the same length, got: {detail}")
+
+    n = unique_lengths.pop()
+    combinations = []
+    for i in range(n):
+        combo = dict(scalar_keys)
+        for key, values in list_keys.items():
+            combo[key] = values[i]
+        combinations.append(combo)
+
+    return combinations
+
+
+def matrix_label(combination: dict, variable_keys: set) -> str:
+    """Generate a filename-safe label from the variable (list) params of a combination.
+
+    Only variable keys (those that came from lists) contribute to the label.
+    Returns empty string for single-point entries (all scalars).
+    """
+    if not variable_keys:
+        return ""
+
+    parts = []
+    for key in sorted(variable_keys):
+        value = combination[key]
+        # Use last path segment for abbreviation lookup
+        last_segment = key.rsplit(".", 1)[-1]
+        abbrev = PARAM_ABBREVIATIONS.get(last_segment, last_segment)
+        parts.append(f"{abbrev}{value}")
+
+    return "_".join(parts)
+
+
+def build_override(combination: dict) -> dict:
+    """Convert a flat dot-notation combination into a nested dict for deep_merge."""
+    from deplodock.recipe.recipe import deep_merge
+
+    result = {}
+    for key, value in combination.items():
+        nested = dot_to_nested(key, value)
+        result = deep_merge(result, nested)
+    return result

--- a/deplodock/recipe/types.py
+++ b/deplodock/recipe/types.py
@@ -98,14 +98,21 @@ class BenchmarkConfig:
 
 
 @dataclass
+class DeployConfig:
+    """Optional deploy section — GPU info for cloud provisioning."""
+
+    gpu: str | None = None
+    gpu_count: int = 1
+
+
+@dataclass
 class Recipe:
     """Complete recipe configuration."""
 
     model: ModelConfig = field(default_factory=ModelConfig)
     engine: EngineConfig = field(default_factory=EngineConfig)
     benchmark: BenchmarkConfig = field(default_factory=BenchmarkConfig)
-    gpu: str | None = None
-    gpu_count: int = 1
+    deploy: DeployConfig = field(default_factory=DeployConfig)
 
     @classmethod
     def from_dict(cls, d: dict) -> "Recipe":
@@ -140,12 +147,17 @@ class Recipe:
             random_output_len=bench_dict.get("random_output_len", 8000),
         )
 
+        deploy_dict = d.get("deploy", {})
+        deploy = DeployConfig(
+            gpu=deploy_dict.get("gpu"),
+            gpu_count=deploy_dict.get("gpu_count", 1),
+        )
+
         return cls(
             model=model,
             engine=EngineConfig(llm=llm),
             benchmark=benchmark,
-            gpu=d.get("gpu"),
-            gpu_count=d.get("gpu_count", 1),
+            deploy=deploy,
         )
 
     @property

--- a/recipes/GLM-4.5-Air-AWQ-4bit/recipe.yaml
+++ b/recipes/GLM-4.5-Air-AWQ-4bit/recipe.yaml
@@ -18,54 +18,30 @@ benchmark:
   random_input_len: 8000
   random_output_len: 8000
 
-variants:
-  B200:
-    gpu: "NVIDIA B200"
-    gpu_count: 1
-    benchmark:
-      max_concurrency: 256
-      num_prompts: 512
-  H200:
-    gpu: "NVIDIA H200 141GB"
-    gpu_count: 1
-    benchmark:
-      max_concurrency: 256
-      num_prompts: 512
-  H100:
-    gpu: "NVIDIA H100 80GB"
-    gpu_count: 1
-    engine:
-      llm:
-        vllm:
-          extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
-  Pro6000:
-    gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
-    gpu_count: 1
-    engine:
-      llm:
-        vllm:
-          extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
-  4xRTX5090:
-    gpu: "NVIDIA GeForce RTX 5090"
-    gpu_count: 4
-    engine:
-      llm:
-        pipeline_parallel_size: 4
-        vllm:
-          extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
-  4xRTX4090:
-    gpu: "NVIDIA GeForce RTX 4090"
-    gpu_count: 4
-    engine:
-      llm:
-        pipeline_parallel_size: 4
-        vllm:
-          extra_args: "--dtype float16 --tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel"
-  2xL40S:
-    gpu: "NVIDIA L40S"
-    gpu_count: 2
-    engine:
-      llm:
-        pipeline_parallel_size: 2
-        vllm:
-          extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
+matrices:
+  - deploy.gpu: "NVIDIA B200"
+    deploy.gpu_count: 1
+    benchmark.max_concurrency: 256
+    benchmark.num_prompts: 512
+  - deploy.gpu: "NVIDIA H200 141GB"
+    deploy.gpu_count: 1
+    benchmark.max_concurrency: 256
+    benchmark.num_prompts: 512
+  - deploy.gpu: "NVIDIA H100 80GB"
+    deploy.gpu_count: 1
+    engine.llm.vllm.extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
+    deploy.gpu_count: 1
+    engine.llm.vllm.extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 4
+    engine.llm.pipeline_parallel_size: 4
+    engine.llm.vllm.extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"
+  - deploy.gpu: "NVIDIA GeForce RTX 4090"
+    deploy.gpu_count: 4
+    engine.llm.pipeline_parallel_size: 4
+    engine.llm.vllm.extra_args: "--dtype float16 --tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel"
+  - deploy.gpu: "NVIDIA L40S"
+    deploy.gpu_count: 2
+    engine.llm.pipeline_parallel_size: 2
+    engine.llm.vllm.extra_args: "--tool-call-parser glm45 --reasoning-parser glm45 --enable-expert-parallel --kv-cache-dtype fp8"

--- a/recipes/GLM-4.6-FP8/recipe.yaml
+++ b/recipes/GLM-4.6-FP8/recipe.yaml
@@ -18,39 +18,23 @@ benchmark:
   random_input_len: 8000
   random_output_len: 8000
 
-variants:
-  8xH200:
-    gpu: "NVIDIA H200 141GB"
-    gpu_count: 8
-    benchmark:
-      max_concurrency: 256
-      num_prompts: 512
-  8xB200:
-    gpu: "NVIDIA B200"
-    gpu_count: 8
-    engine:
-      llm:
-        vllm:
-          extra_args: "--kv-cache-dtype fp8 --enable-expert-parallel"
-    benchmark:
-      max_concurrency: 256
-      num_prompts: 512
-  8xH100:
-    gpu: "NVIDIA H100 80GB"
-    gpu_count: 8
-    engine:
-      llm:
-        max_concurrent_requests: 256
-        vllm:
-          extra_args: "--kv-cache-dtype fp8"
-  8xPro6000:
-    gpu: "NVIDIA RTX PRO 6000 Server Edition"
-    gpu_count: 8
-    engine:
-      llm:
-        max_concurrent_requests: 256
-        vllm:
-          extra_args: "--kv-cache-dtype fp8"
-    benchmark:
-      max_concurrency: 64
-      num_prompts: 128
+matrices:
+  - deploy.gpu: "NVIDIA H200 141GB"
+    deploy.gpu_count: 8
+    benchmark.max_concurrency: 256
+    benchmark.num_prompts: 512
+  - deploy.gpu: "NVIDIA B200"
+    deploy.gpu_count: 8
+    engine.llm.vllm.extra_args: "--kv-cache-dtype fp8 --enable-expert-parallel"
+    benchmark.max_concurrency: 256
+    benchmark.num_prompts: 512
+  - deploy.gpu: "NVIDIA H100 80GB"
+    deploy.gpu_count: 8
+    engine.llm.max_concurrent_requests: 256
+    engine.llm.vllm.extra_args: "--kv-cache-dtype fp8"
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Server Edition"
+    deploy.gpu_count: 8
+    engine.llm.max_concurrent_requests: 256
+    engine.llm.vllm.extra_args: "--kv-cache-dtype fp8"
+    benchmark.max_concurrency: 64
+    benchmark.num_prompts: 128

--- a/recipes/Meta-Llama-3.3-70B-Instruct-AWQ-INT4/recipe.yaml
+++ b/recipes/Meta-Llama-3.3-70B-Instruct-AWQ-INT4/recipe.yaml
@@ -17,22 +17,14 @@ benchmark:
   random_input_len: 4000
   random_output_len: 4000
 
-variants:
-  2xRTX4090:
-    gpu: "NVIDIA GeForce RTX 4090"
-    gpu_count: 2
-  2xRTX5090:
-    gpu: "NVIDIA GeForce RTX 5090"
-    gpu_count: 2
-  2xL40S:
-    gpu: "NVIDIA L40S"
-    gpu_count: 2
-    engine:
-      llm:
-        pipeline_parallel_size: 1
-  Pro6000:
-    gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
-    gpu_count: 1
-    engine:
-      llm:
-        pipeline_parallel_size: 1
+matrices:
+  - deploy.gpu: "NVIDIA GeForce RTX 4090"
+    deploy.gpu_count: 2
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 2
+  - deploy.gpu: "NVIDIA L40S"
+    deploy.gpu_count: 2
+    engine.llm.pipeline_parallel_size: 1
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Workstation Edition"
+    deploy.gpu_count: 1
+    engine.llm.pipeline_parallel_size: 1

--- a/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -16,32 +16,20 @@ benchmark:
   random_input_len: 4000
   random_output_len: 4000
 
-variants:
-  RTX4090:
-    gpu: "NVIDIA GeForce RTX 4090"
-    gpu_count: 1
-  RTX5090:
-    gpu: "NVIDIA GeForce RTX 5090"
-    gpu_count: 1
-  Pro6000:
-    gpu: "NVIDIA RTX PRO 6000 Server Edition"
-    gpu_count: 1
-  L40S:
-    gpu: "NVIDIA L40S"
-    gpu_count: 1
-  RTX5090_sglang:
-    gpu: "NVIDIA GeForce RTX 5090"
-    gpu_count: 1
-    engine:
-      llm:
-        sglang:
-          image: "lmsysorg/sglang:latest"
-          extra_args: "--quantization moe_wna16"
-  L40S_sglang:
-    gpu: "NVIDIA L40S"
-    gpu_count: 1
-    engine:
-      llm:
-        sglang:
-          image: "lmsysorg/sglang:latest"
-          extra_args: "--quantization moe_wna16"
+matrices:
+  - deploy.gpu: "NVIDIA GeForce RTX 4090"
+    deploy.gpu_count: 1
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 1
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Server Edition"
+    deploy.gpu_count: 1
+  - deploy.gpu: "NVIDIA L40S"
+    deploy.gpu_count: 1
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 1
+    engine.llm.sglang.image: "lmsysorg/sglang:latest"
+    engine.llm.sglang.extra_args: "--quantization moe_wna16"
+  - deploy.gpu: "NVIDIA L40S"
+    deploy.gpu_count: 1
+    engine.llm.sglang.image: "lmsysorg/sglang:latest"
+    engine.llm.sglang.extra_args: "--quantization moe_wna16"

--- a/recipes/Qwen3-Coder-480B-A35B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-480B-A35B-Instruct-AWQ/recipe.yaml
@@ -18,27 +18,18 @@ benchmark:
   random_input_len: 8000
   random_output_len: 8000
 
-variants:
-  4xH200:
-    gpu: "NVIDIA H200 141GB"
-    gpu_count: 4
-    benchmark:
-      max_concurrency: 256
-      num_prompts: 512
-  4xB200:
-    gpu: "NVIDIA B200"
-    gpu_count: 4
-  4xH100:
-    gpu: "NVIDIA H100 80GB"
-    gpu_count: 4
-  4xPro6000:
-    gpu: "NVIDIA RTX PRO 6000 Server Edition"
-    gpu_count: 4
-    engine:
-      llm:
-        max_concurrent_requests: 256
-        vllm:
-          extra_args: "--enable-expert-parallel"
-    benchmark:
-      max_concurrency: 64
-      num_prompts: 128
+matrices:
+  - deploy.gpu: "NVIDIA H200 141GB"
+    deploy.gpu_count: 4
+    benchmark.max_concurrency: 256
+    benchmark.num_prompts: 512
+  - deploy.gpu: "NVIDIA B200"
+    deploy.gpu_count: 4
+  - deploy.gpu: "NVIDIA H100 80GB"
+    deploy.gpu_count: 4
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Server Edition"
+    deploy.gpu_count: 4
+    engine.llm.max_concurrent_requests: 256
+    engine.llm.vllm.extra_args: "--enable-expert-parallel"
+    benchmark.max_concurrency: 64
+    benchmark.num_prompts: 128

--- a/tests/benchmark/test_bench_dryrun.py
+++ b/tests/benchmark/test_bench_dryrun.py
@@ -9,8 +9,6 @@ def test_bench_dry_run_basic(run_cli, make_bench_config, recipes_dir, tmp_path):
     rc, stdout, stderr = run_cli(
         "bench",
         recipe,
-        "--variants",
-        "RTX5090",
         "--config",
         config_path,
         "--dry-run",
@@ -25,8 +23,6 @@ def test_bench_dry_run_deploy_then_benchmark(run_cli, make_bench_config, recipes
     rc, stdout, stderr = run_cli(
         "bench",
         recipe,
-        "--variants",
-        "RTX5090",
         "--config",
         config_path,
         "--dry-run",
@@ -38,7 +34,7 @@ def test_bench_dry_run_deploy_then_benchmark(run_cli, make_bench_config, recipes
     assert "docker compose up" in stdout
 
     # Verify benchmark step appears with recipe params
-    assert "vllm bench serve" in stdout
+    assert "bench serve" in stdout
     assert "--random-input-len 4000" in stdout
     assert "--random-output-len 4000" in stdout
 
@@ -47,24 +43,8 @@ def test_bench_dry_run_deploy_then_benchmark(run_cli, make_bench_config, recipes
 
     # Verify order: pull before bench, bench before teardown
     pull_idx = stdout.index("docker compose pull")
-    bench_idx = stdout.index("vllm bench serve")
+    bench_idx = stdout.index("bench serve")
     assert pull_idx < bench_idx
-
-
-def test_bench_variant_filter(run_cli, make_bench_config, recipes_dir, tmp_path):
-    config_path = make_bench_config(tmp_path)
-    recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
-    rc, stdout, stderr = run_cli(
-        "bench",
-        recipe,
-        "--variants",
-        "RTX5090",
-        "--config",
-        config_path,
-        "--dry-run",
-    )
-    assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
-    assert "RTX5090" in stdout
 
 
 def test_bench_multiple_recipes(run_cli, make_bench_config, recipes_dir, tmp_path):
@@ -75,13 +55,10 @@ def test_bench_multiple_recipes(run_cli, make_bench_config, recipes_dir, tmp_pat
         "bench",
         recipe1,
         recipe2,
-        "--variants",
-        "RTX5090",
         "--config",
         config_path,
         "--dry-run",
     )
-    # Should succeed even if some variants are missing (warned on stderr)
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
 
 
@@ -91,8 +68,6 @@ def test_bench_no_teardown_dry_run(run_cli, make_bench_config, recipes_dir, tmp_
     rc, stdout, stderr = run_cli(
         "bench",
         recipe,
-        "--variants",
-        "RTX5090",
         "--config",
         config_path,
         "--dry-run",
@@ -101,7 +76,7 @@ def test_bench_no_teardown_dry_run(run_cli, make_bench_config, recipes_dir, tmp_
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
 
     # With --no-teardown, per-task teardown should be skipped
-    assert "vllm bench serve" in stdout
+    assert "bench serve" in stdout
     assert "Tearing down..." not in stdout
     assert "Skipping VM deletion (--no-teardown)" in stdout
 
@@ -110,7 +85,6 @@ def test_bench_help(run_cli):
     rc, stdout, _ = run_cli("bench", "--help")
     assert rc == 0
     assert "recipes" in stdout
-    assert "--variants" in stdout
     assert "--ssh-key" in stdout
     assert "--dry-run" in stdout
     assert "--config" in stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ def make_bench_config(recipes_dir):
 
 @pytest.fixture
 def tmp_recipe_dir(tmp_path):
-    """Create a temp directory with a sample recipe.yaml."""
+    """Create a temp directory with a sample recipe.yaml using matrices format."""
     recipe = {
         "model": {"huggingface": "test-org/test-model"},
         "engine": {
@@ -83,41 +83,27 @@ def tmp_recipe_dir(tmp_path):
             "random_input_len": 4000,
             "random_output_len": 4000,
         },
-        "variants": {
-            "RTX5090": {
-                "gpu": "NVIDIA GeForce RTX 5090",
-                "gpu_count": 1,
+        "matrices": [
+            {
+                "deploy.gpu": "NVIDIA GeForce RTX 5090",
+                "deploy.gpu_count": 1,
             },
-            "8xH200": {
-                "gpu": "NVIDIA H200 141GB",
-                "gpu_count": 8,
-                "engine": {
-                    "llm": {
-                        "tensor_parallel_size": 8,
-                        "context_length": 16384,
-                        "vllm": {
-                            "extra_args": "--kv-cache-dtype fp8",
-                        },
-                    }
-                },
-                "benchmark": {
-                    "random_input_len": 8000,
-                    "random_output_len": 8000,
-                },
+            {
+                "deploy.gpu": "NVIDIA H200 141GB",
+                "deploy.gpu_count": 8,
+                "engine.llm.tensor_parallel_size": 8,
+                "engine.llm.context_length": 16384,
+                "engine.llm.vllm.extra_args": "--kv-cache-dtype fp8",
+                "benchmark.random_input_len": 8000,
+                "benchmark.random_output_len": 8000,
             },
-            "4xH100": {
-                "gpu": "NVIDIA H100 80GB",
-                "gpu_count": 4,
-                "engine": {
-                    "llm": {
-                        "tensor_parallel_size": 4,
-                        "vllm": {
-                            "extra_args": "--kv-cache-dtype fp8",
-                        },
-                    }
-                },
+            {
+                "deploy.gpu": "NVIDIA H100 80GB",
+                "deploy.gpu_count": 4,
+                "engine.llm.tensor_parallel_size": 4,
+                "engine.llm.vllm.extra_args": "--kv-cache-dtype fp8",
             },
-        },
+        ],
     }
 
     recipe_path = tmp_path / "recipe.yaml"

--- a/tests/deploy/test_deploy_cloud_dryrun.py
+++ b/tests/deploy/test_deploy_cloud_dryrun.py
@@ -2,31 +2,62 @@
 
 import os
 
+import yaml
+
 # ── deploy cloud dry-run ─────────────────────────────────────────
 
 
-def test_deploy_cloud_dry_run(run_cli, recipes_dir):
+def test_deploy_cloud_dry_run(run_cli, tmp_path):
+    """Cloud deploy works with a recipe that has deploy.gpu in base config."""
+    recipe = {
+        "model": {"huggingface": "test-org/test-model"},
+        "engine": {
+            "llm": {
+                "tensor_parallel_size": 1,
+                "vllm": {"image": "vllm/vllm-openai:latest"},
+            }
+        },
+        "deploy": {
+            "gpu": "NVIDIA GeForce RTX 5090",
+            "gpu_count": 1,
+        },
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+
     rc, stdout, stderr = run_cli(
         "deploy",
         "cloud",
         "--recipe",
-        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
-        "--variant",
-        "RTX5090",
+        str(tmp_path),
         "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
     assert "[dry-run]" in stdout
 
 
-def test_deploy_cloud_dry_run_deploy_steps(run_cli, recipes_dir):
+def test_deploy_cloud_dry_run_deploy_steps(run_cli, tmp_path):
+    recipe = {
+        "model": {"huggingface": "test-org/test-model"},
+        "engine": {
+            "llm": {
+                "tensor_parallel_size": 1,
+                "vllm": {"image": "vllm/vllm-openai:latest"},
+            }
+        },
+        "deploy": {
+            "gpu": "NVIDIA GeForce RTX 5090",
+            "gpu_count": 1,
+        },
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+
     rc, stdout, stderr = run_cli(
         "deploy",
         "cloud",
         "--recipe",
-        os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ"),
-        "--variant",
-        "RTX5090",
+        str(tmp_path),
         "--dry-run",
     )
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
@@ -38,8 +69,8 @@ def test_deploy_cloud_dry_run_deploy_steps(run_cli, recipes_dir):
     assert "dry-run (not deployed)" in stdout
 
 
-def test_deploy_cloud_no_variant_fails(run_cli, recipes_dir):
-    """Without a variant, no gpu field -> error."""
+def test_deploy_cloud_no_gpu_fails(run_cli, recipes_dir):
+    """Without deploy.gpu in base config, cloud deploy fails."""
     rc, stdout, stderr = run_cli(
         "deploy",
         "cloud",
@@ -58,7 +89,6 @@ def test_deploy_cloud_help(run_cli):
     rc, stdout, _ = run_cli("deploy", "cloud", "--help")
     assert rc == 0
     assert "--recipe" in stdout
-    assert "--variant" in stdout
     assert "--ssh-key" in stdout
     assert "--dry-run" in stdout
     assert "--name" in stdout

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -7,11 +7,11 @@ from deplodock.planner.group_by_model_and_gpu import GroupByModelAndGpuPlanner
 from deplodock.recipe import ModelConfig, Recipe
 
 
-def _make_task(model="org/model-a", gpu="NVIDIA GeForce RTX 5090", gpu_count=1, recipe_dir="/r"):
+def _make_task(model="org/model-a", gpu="NVIDIA GeForce RTX 5090", gpu_count=1, recipe_dir="/r", variant="rtx5090"):
     """Helper to build a BenchmarkTask with minimal config."""
     return BenchmarkTask(
         recipe_dir=recipe_dir,
-        variant="V1",
+        variant=variant,
         recipe=Recipe(model=ModelConfig(huggingface=model)),
         gpu_name=gpu,
         gpu_count=gpu_count,
@@ -40,13 +40,25 @@ def test_task_recipe_name_trailing_slash():
 def test_task_result_path():
     task_obj = BenchmarkTask(
         recipe_dir="/recipes/MyModel",
-        variant="RTX5090",
+        variant="rtx5090",
         recipe=Recipe(model=ModelConfig(huggingface="org/my-model")),
         gpu_name="NVIDIA GeForce RTX 5090",
         gpu_count=1,
     )
     result = task_obj.result_path(Path("/run/123"))
-    assert result == Path("/run/123/MyModel/RTX5090_vllm_benchmark.txt")
+    assert result == Path("/run/123/MyModel/rtx5090_vllm_benchmark.txt")
+
+
+def test_task_result_path_with_matrix_label():
+    task_obj = BenchmarkTask(
+        recipe_dir="/recipes/MyModel",
+        variant="rtx5090_c128",
+        recipe=Recipe(model=ModelConfig(huggingface="org/my-model")),
+        gpu_name="NVIDIA GeForce RTX 5090",
+        gpu_count=1,
+    )
+    result = task_obj.result_path(Path("/run/123"))
+    assert result == Path("/run/123/MyModel/rtx5090_c128_vllm_benchmark.txt")
 
 
 # ── GroupByModelAndGpuPlanner ─────────────────────────────────────

--- a/tests/recipe/test_matrix.py
+++ b/tests/recipe/test_matrix.py
@@ -1,0 +1,140 @@
+"""Unit tests for matrix expansion logic."""
+
+import pytest
+
+from deplodock.recipe.matrix import (
+    PARAM_ABBREVIATIONS,
+    build_override,
+    dot_to_nested,
+    expand_matrix_entry,
+    matrix_label,
+)
+
+# ── dot_to_nested ──────────────────────────────────────────────────
+
+
+def test_dot_to_nested_single_level():
+    result = dot_to_nested("gpu", "NVIDIA RTX 5090")
+    assert result == {"gpu": "NVIDIA RTX 5090"}
+
+
+def test_dot_to_nested_two_levels():
+    result = dot_to_nested("deploy.gpu", "NVIDIA RTX 5090")
+    assert result == {"deploy": {"gpu": "NVIDIA RTX 5090"}}
+
+
+def test_dot_to_nested_three_levels():
+    result = dot_to_nested("engine.llm.max_concurrent_requests", 256)
+    assert result == {"engine": {"llm": {"max_concurrent_requests": 256}}}
+
+
+# ── expand_matrix_entry ────────────────────────────────────────────
+
+
+def test_expand_all_scalars():
+    entry = {"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}
+    result = expand_matrix_entry(entry)
+    assert result == [{"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}]
+
+
+def test_expand_single_list():
+    entry = {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": [1, 2, 4]}
+    result = expand_matrix_entry(entry)
+    assert len(result) == 3
+    assert result[0] == {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 1}
+    assert result[1] == {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 2}
+    assert result[2] == {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 4}
+
+
+def test_expand_multiple_lists_zipped():
+    entry = {
+        "deploy.gpu": "NVIDIA RTX 5090",
+        "engine.llm.max_concurrent_requests": [128, 256],
+        "benchmark.max_concurrency": [128, 256],
+    }
+    result = expand_matrix_entry(entry)
+    assert len(result) == 2
+    assert result[0]["engine.llm.max_concurrent_requests"] == 128
+    assert result[0]["benchmark.max_concurrency"] == 128
+    assert result[1]["engine.llm.max_concurrent_requests"] == 256
+    assert result[1]["benchmark.max_concurrency"] == 256
+
+
+def test_expand_mismatched_list_lengths_raises():
+    entry = {
+        "benchmark.max_concurrency": [1, 2, 4],
+        "benchmark.num_prompts": [100, 200],
+    }
+    with pytest.raises(ValueError, match="same length"):
+        expand_matrix_entry(entry)
+
+
+# ── matrix_label ───────────────────────────────────────────────────
+
+
+def test_matrix_label_no_variables():
+    combo = {"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}
+    assert matrix_label(combo, set()) == ""
+
+
+def test_matrix_label_single_variable():
+    combo = {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 128}
+    label = matrix_label(combo, {"benchmark.max_concurrency"})
+    assert label == "c128"
+
+
+def test_matrix_label_multiple_variables():
+    combo = {
+        "deploy.gpu": "NVIDIA RTX 5090",
+        "engine.llm.max_concurrent_requests": 256,
+        "benchmark.max_concurrency": 128,
+    }
+    label = matrix_label(combo, {"engine.llm.max_concurrent_requests", "benchmark.max_concurrency"})
+    assert "c128" in label
+    assert "mcr256" in label
+
+
+def test_matrix_label_unknown_key_uses_last_segment():
+    combo = {"engine.llm.some_new_param": 42}
+    label = matrix_label(combo, {"engine.llm.some_new_param"})
+    assert label == "some_new_param42"
+
+
+def test_param_abbreviations_coverage():
+    """Known params all have abbreviations."""
+    assert "max_concurrency" in PARAM_ABBREVIATIONS
+    assert "num_prompts" in PARAM_ABBREVIATIONS
+    assert "random_input_len" in PARAM_ABBREVIATIONS
+    assert "random_output_len" in PARAM_ABBREVIATIONS
+    assert "max_concurrent_requests" in PARAM_ABBREVIATIONS
+    assert "context_length" in PARAM_ABBREVIATIONS
+
+
+# ── build_override ─────────────────────────────────────────────────
+
+
+def test_build_override_simple():
+    combo = {"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}
+    result = build_override(combo)
+    assert result == {"deploy": {"gpu": "NVIDIA RTX 5090", "gpu_count": 1}}
+
+
+def test_build_override_deep():
+    combo = {
+        "deploy.gpu": "NVIDIA RTX 5090",
+        "engine.llm.max_concurrent_requests": 256,
+        "benchmark.max_concurrency": 128,
+    }
+    result = build_override(combo)
+    assert result["deploy"]["gpu"] == "NVIDIA RTX 5090"
+    assert result["engine"]["llm"]["max_concurrent_requests"] == 256
+    assert result["benchmark"]["max_concurrency"] == 128
+
+
+def test_build_override_merges_same_prefix():
+    combo = {
+        "engine.llm.max_concurrent_requests": 256,
+        "engine.llm.context_length": 8192,
+    }
+    result = build_override(combo)
+    assert result == {"engine": {"llm": {"max_concurrent_requests": 256, "context_length": 8192}}}

--- a/tests/recipe/test_types.py
+++ b/tests/recipe/test_types.py
@@ -1,6 +1,7 @@
 """Unit tests for recipe dataclass types."""
 
 from deplodock.recipe import (
+    DeployConfig,
     LLMConfig,
     Recipe,
     SglangConfig,
@@ -81,6 +82,21 @@ def test_llm_optional_fields_default_none():
     assert llm.max_concurrent_requests is None
 
 
+# ── DeployConfig ──────────────────────────────────────────────────
+
+
+def test_deploy_config_defaults():
+    cfg = DeployConfig()
+    assert cfg.gpu is None
+    assert cfg.gpu_count == 1
+
+
+def test_deploy_config_custom():
+    cfg = DeployConfig(gpu="NVIDIA H200", gpu_count=8)
+    assert cfg.gpu == "NVIDIA H200"
+    assert cfg.gpu_count == 8
+
+
 # ── Recipe.from_dict ──────────────────────────────────────────────
 
 
@@ -90,8 +106,8 @@ def test_from_dict_minimal():
     assert recipe.model.huggingface == "org/model"
     assert recipe.model_name == "org/model"
     assert recipe.engine.llm.tensor_parallel_size == 1
-    assert recipe.gpu is None
-    assert recipe.gpu_count == 1
+    assert recipe.deploy.gpu is None
+    assert recipe.deploy.gpu_count == 1
 
 
 def test_from_dict_full():
@@ -116,8 +132,10 @@ def test_from_dict_full():
             "random_input_len": 2000,
             "random_output_len": 3000,
         },
-        "gpu": "NVIDIA H200",
-        "gpu_count": 8,
+        "deploy": {
+            "gpu": "NVIDIA H200",
+            "gpu_count": 8,
+        },
     }
     recipe = Recipe.from_dict(d)
     assert recipe.engine.llm.tensor_parallel_size == 8
@@ -128,8 +146,8 @@ def test_from_dict_full():
     assert recipe.engine.llm.vllm.extra_args == "--kv-cache-dtype fp8"
     assert recipe.benchmark.max_concurrency == 64
     assert recipe.benchmark.num_prompts == 128
-    assert recipe.gpu == "NVIDIA H200"
-    assert recipe.gpu_count == 8
+    assert recipe.deploy.gpu == "NVIDIA H200"
+    assert recipe.deploy.gpu_count == 8
 
 
 def test_from_dict_sglang():


### PR DESCRIPTION
## Summary

- Replaces the `variants` system with `matrices` — a list of benchmark configurations using broadcast + zip semantics with dot-notation parameter paths
- Adds `DeployConfig` dataclass encapsulating GPU info under `recipe.deploy`
- Removes `--variant` flag from all deploy commands and `--variants` from bench CLI
- Adds new `deplodock/recipe/matrix.py` module with `expand_matrix_entry()`, `dot_to_nested()`, `matrix_label()`, `build_override()`
- Migrates all 5 existing recipes from `variants:` to `matrices:` format
- Updates all tests (192 passing), documentation, and architecture files

## Motivation

Running benchmarks is fast; provisioning VMs and downloading models is slow. The old `variants` system mapped each named variant to exactly one benchmark config — to sweep concurrency (1, 2, 4, 8, 16...), you'd need verbose duplicate variants. Also, correlated sweeps (varying `engine.llm.max_concurrent_requests` and `benchmark.max_concurrency` together) were impossible without manual duplication.

## New recipe format

```yaml
matrices:
  # Concurrency sweep (8 runs from one entry)
  - deploy.gpu: "NVIDIA GeForce RTX 5090"
    benchmark.max_concurrency: [1, 2, 4, 8, 16, 32, 64, 128]

  # Correlated engine+bench sweep (3 zip runs)
  - deploy.gpu: "NVIDIA GeForce RTX 5090"
    engine.llm.max_concurrent_requests: [128, 256, 512]
    benchmark.max_concurrency: [128, 256, 512]
```

## Test plan

- [x] `make test` — 192 tests pass
- [x] `make lint` — clean
- [ ] Manual: `deplodock bench recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ --dry-run` — verify correct task enumeration
- [ ] Manual: `deplodock deploy ssh --recipe recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ --dry-run --server test@host` — verify deploy works without variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)