### PR TITLE
Migrate print() to Python logging throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Tools for deploying and benchmarking LLM inference on GPU servers. Supports **vL
 
 - [deplodock/](deplodock/) — Python package
   - [deplodock.py](deplodock/deplodock.py) — CLI entrypoint
+  - [logging_setup.py](deplodock/logging_setup.py) — CLI logging configuration
   - [hardware.py](deplodock/hardware.py) — GPU specs and instance type mapping
   - [commands/](deplodock/commands/) — CLI layer (thin argparse handlers, see [ARCHITECTURE.md](deplodock/commands/ARCHITECTURE.md))
     - [deploy/](deplodock/commands/deploy/) — `deploy local`, `deploy ssh`, `deploy cloud` commands

--- a/STYLE.md
+++ b/STYLE.md
@@ -9,12 +9,39 @@
 - `UPPER_SNAKE_CASE` for module-level constants.
 - Prefix private/internal helpers with underscore (e.g., `_ssh_base_args`).
 
-### Error Handling
+### Logging
 
-Print errors to stderr and exit for CLI-facing failures:
+All output goes through Python's `logging` module — never use `print()`.
+
+Each module gets a module-level logger:
 
 ```python
-print(f"Failed to pull images", file=sys.stderr)
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+Level mapping:
+
+| Pattern | Level |
+|---|---|
+| Normal output | `logger.info(...)` |
+| Warnings | `logger.warning(...)` |
+| Errors | `logger.error(...)` |
+
+Two logging configurations:
+
+- **Standalone CLI** (`setup_cli_logging()` in `logging_setup.py`): `%(message)s` format — output identical to `print()`.
+- **Bench** (`setup_logging()` in `bench_logging.py`): `[%(name)s] %(message)s` — prefixed output with module/group names.
+
+The bench formatter shows short module names for library loggers (`deplodock.deploy.orchestrate` → `[orchestrate]`) and split group loggers (`rtx5090_x_1.ModelName` → `[rtx5090_x_1] [ModelName]`).
+
+### Error Handling
+
+Log errors and return failure for operational errors:
+
+```python
+logger.error("Failed to pull images")
 return False
 ```
 

--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -1,11 +1,49 @@
 """Benchmark logging setup."""
 
+import contextvars
 import logging
 import sys
 from pathlib import Path
 
 from deplodock.hardware import gpu_short_name
 from deplodock.planner import ExecutionGroup
+
+active_run_dir: contextvars.ContextVar[Path | None] = contextvars.ContextVar("active_run_dir", default=None)
+
+
+class _RunDirFilter(logging.Filter):
+    """Only pass records that match this handler's run_dir.
+
+    Root-level messages (where active_run_dir is None) go to all handlers.
+    """
+
+    def __init__(self, run_dir: Path):
+        self.run_dir = run_dir
+
+    def filter(self, record):
+        current = active_run_dir.get()
+        if current is None:
+            return True
+        return current == self.run_dir
+
+
+class _BenchConsoleFormatter(logging.Formatter):
+    """Console formatter for bench output.
+
+    - ``deplodock.deploy.orchestrate`` → ``[orchestrate]``
+    - ``rtx5090_x_1.ModelName`` → ``[rtx5090_x_1] [ModelName]``
+    - ``root`` → no prefix (plain message)
+    """
+
+    def format(self, record):
+        if record.name.startswith("deplodock."):
+            # Library logger: show last segment only
+            record.name = record.name.rsplit(".", 1)[-1]
+        elif "." in record.name:
+            # Bench group logger: split into [server] [model]
+            server, model = record.name.split(".", 1)
+            record.name = f"{server}] [{model}"
+        return super().format(record)
 
 
 def setup_logging():
@@ -19,21 +57,16 @@ def setup_logging():
     root_logger.handlers.clear()
 
     console_handler = logging.StreamHandler(sys.stdout)
-
-    class CustomConsoleFormatter(logging.Formatter):
-        def format(self, record):
-            if "." in record.name:
-                server, model = record.name.split(".", 1)
-                record.name = f"{server}] [{model}"
-            return super().format(record)
-
-    console_formatter = CustomConsoleFormatter("[%(name)s] %(message)s")
+    console_formatter = _BenchConsoleFormatter("[%(name)s] %(message)s")
     console_handler.setFormatter(console_formatter)
     root_logger.addHandler(console_handler)
 
 
 def add_file_handler(run_dir: Path) -> str:
     """Add a file handler that writes to {run_dir}/benchmark.log.
+
+    A RunDirFilter is attached so that only messages for this run_dir
+    (or root-level messages) are written to the file.
 
     Returns:
         Path to the log file.
@@ -46,6 +79,7 @@ def add_file_handler(run_dir: Path) -> str:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     file_handler.setFormatter(file_formatter)
+    file_handler.addFilter(_RunDirFilter(run_dir))
     logging.getLogger().addHandler(file_handler)
 
     return str(log_file)

--- a/deplodock/benchmark/config.py
+++ b/deplodock/benchmark/config.py
@@ -1,9 +1,12 @@
 """Benchmark configuration loading and validation."""
 
+import logging
 import os
 import sys
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def load_config(config_path: str = "config.yaml") -> dict:
@@ -13,23 +16,23 @@ def load_config(config_path: str = "config.yaml") -> dict:
             config = yaml.safe_load(f)
         return config
     except FileNotFoundError:
-        print(f"Error: Config file '{config_path}' not found.")
+        logger.error(f"Error: Config file '{config_path}' not found.")
         sys.exit(1)
     except yaml.YAMLError as e:
-        print(f"Error parsing YAML config: {e}")
+        logger.error(f"Error parsing YAML config: {e}")
         sys.exit(1)
 
 
 def validate_config(config: dict) -> None:
     """Validate that required configuration fields are present."""
     if "benchmark" not in config:
-        print("Error: Missing 'benchmark' section in config.")
+        logger.error("Error: Missing 'benchmark' section in config.")
         sys.exit(1)
 
     required_benchmark_fields = ["local_results_dir"]
     for field in required_benchmark_fields:
         if field not in config["benchmark"]:
-            print(f"Error: Missing '{field}' in 'benchmark' section.")
+            logger.error(f"Error: Missing '{field}' in 'benchmark' section.")
             sys.exit(1)
 
 

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 
-from deplodock.benchmark.bench_logging import _get_group_logger
+from deplodock.benchmark.bench_logging import _get_group_logger, active_run_dir
 from deplodock.benchmark.tasks import _task_meta
 from deplodock.benchmark.workload import extract_benchmark_results, run_benchmark_workload
 from deplodock.deploy import (
@@ -94,6 +94,7 @@ def run_execution_group(
         provision_remote(conn.address, ssh_key, conn.ssh_port, dry_run=dry_run)
 
         for task in group.tasks:
+            active_run_dir.set(task.run_dir)
             recipe = task.recipe
             model_name = task.model_name
             result_path = task.result_path()
@@ -150,6 +151,7 @@ def run_execution_group(
                 teardown_entry(params)
 
     finally:
+        active_run_dir.set(None)
         if conn is not None and conn.delete_info:
             if no_teardown:
                 instance_info = _build_instance_info(group, group_label, conn)

--- a/deplodock/benchmark/tasks.py
+++ b/deplodock/benchmark/tasks.py
@@ -1,7 +1,7 @@
 """Benchmark task enumeration."""
 
+import logging
 import os
-import sys
 
 import yaml
 
@@ -9,6 +9,8 @@ from deplodock.hardware import gpu_short_name
 from deplodock.planner import BenchmarkTask
 from deplodock.recipe.matrix import build_override, expand_matrix_entry, matrix_label
 from deplodock.recipe.recipe import _validate_and_build, deep_merge
+
+logger = logging.getLogger(__name__)
 
 
 def _build_variant_name(gpu_name, combination, variable_keys):
@@ -31,7 +33,7 @@ def enumerate_tasks(recipe_dirs):
     for recipe_dir in recipe_dirs:
         recipe_path = os.path.join(recipe_dir, "recipe.yaml")
         if not os.path.isfile(recipe_path):
-            print(f"Warning: No recipe.yaml in {recipe_dir}, skipping.", file=sys.stderr)
+            logger.warning(f"Warning: No recipe.yaml in {recipe_dir}, skipping.")
             continue
 
         with open(recipe_path) as f:
@@ -39,7 +41,7 @@ def enumerate_tasks(recipe_dirs):
 
         matrices = raw.get("matrices", [])
         if not matrices:
-            print(f"Warning: No matrices in {recipe_dir}, skipping.", file=sys.stderr)
+            logger.warning(f"Warning: No matrices in {recipe_dir}, skipping.")
             continue
 
         base_config = {k: v for k, v in raw.items() if k != "matrices"}
@@ -56,9 +58,8 @@ def enumerate_tasks(recipe_dirs):
                 recipe = _validate_and_build(merged)
 
                 if recipe.deploy.gpu is None:
-                    print(
+                    logger.warning(
                         f"Warning: matrix entry in {recipe_dir} missing 'deploy.gpu', skipping.",
-                        file=sys.stderr,
                     )
                     continue
 

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -15,6 +15,7 @@ commands/vm ────► provisioning (create/delete instances)
 - `deplodock/recipe/` — recipe loading, dataclass types (`Recipe`, `LLMConfig`, etc.), engine flag mapping
 - `deplodock/deploy/` — compose generation, deploy orchestration
 - `deplodock/provisioning/` — VM types, SSH polling, shell helpers, cloud providers
+- `deplodock/logging_setup.py` — CLI logging setup (`setup_cli_logging()`)
 - `deplodock/benchmark/` — tracking, config, logging, workload, tasks, execution
 - `deplodock/report/` — parsing, pricing, collection, report generation
 
@@ -64,7 +65,7 @@ Benchmark tracking, configuration, task enumeration, and execution.
 **Modules:**
 - `tracking.py` — `compute_code_hash()`, `create_run_dir()`, `write_manifest()`, `read_manifest()`
 - `config.py` — `load_config()`, `validate_config()`, `_expand_path()`
-- `bench_logging.py` — `setup_logging()`, `add_file_handler()`, `_get_group_logger()`
+- `bench_logging.py` — `setup_logging()`, `add_file_handler()`, `_get_group_logger()`, `active_run_dir` context var, `_RunDirFilter`, `_BenchConsoleFormatter`
 - `workload.py` — `extract_benchmark_results()`, `run_benchmark_workload()`
 - `tasks.py` — `enumerate_tasks()`, `_task_meta()`
 - `execution.py` — `run_execution_group()`, `_run_groups()`

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -1,5 +1,6 @@
 """Cloud deploy target CLI handler."""
 
+import logging
 import os
 import sys
 
@@ -13,6 +14,8 @@ from deplodock.provisioning.cloud import (
 from deplodock.provisioning.remote import provision_remote
 from deplodock.recipe import load_recipe
 
+logger = logging.getLogger(__name__)
+
 # ── CLI handler ────────────────────────────────────────────────────
 
 
@@ -21,7 +24,7 @@ def handle_cloud(args):
     recipe = load_recipe(args.recipe)
 
     if not recipe.deploy.gpu:
-        print("Error: recipe must have a 'deploy.gpu' field for cloud provisioning.", file=sys.stderr)
+        logger.error("Error: recipe must have a 'deploy.gpu' field for cloud provisioning.")
         sys.exit(1)
 
     ssh_key = os.path.expanduser(args.ssh_key)
@@ -35,7 +38,7 @@ def handle_cloud(args):
         dry_run=args.dry_run,
     )
     if conn is None:
-        print("Error: VM provisioning failed.", file=sys.stderr)
+        logger.error("Error: VM provisioning failed.")
         sys.exit(1)
 
     params = DeployParams(

--- a/deplodock/commands/vm/cloudrift.py
+++ b/deplodock/commands/vm/cloudrift.py
@@ -1,5 +1,6 @@
 """CloudRift provider CLI handlers."""
 
+import logging
 import os
 import sys
 
@@ -10,6 +11,8 @@ from deplodock.provisioning.cloudrift import (
     delete_instance,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def _resolve_api_key(args_api_key):
     """Return the API key from the CLI flag or CLOUDRIFT_API_KEY env var.
@@ -18,7 +21,7 @@ def _resolve_api_key(args_api_key):
     """
     api_key = args_api_key or os.environ.get("CLOUDRIFT_API_KEY")
     if not api_key:
-        print("Error: CloudRift API key required. Use --api-key or set CLOUDRIFT_API_KEY.", file=sys.stderr)
+        logger.error("Error: CloudRift API key required. Use --api-key or set CLOUDRIFT_API_KEY.")
         sys.exit(1)
     return api_key
 

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -10,6 +10,7 @@ from deplodock.commands.deploy.ssh import register_ssh_target
 from deplodock.commands.report import register_report_command
 from deplodock.commands.teardown import register_teardown_command
 from deplodock.commands.vm import register_vm_command
+from deplodock.logging_setup import setup_cli_logging
 
 
 def main():
@@ -31,6 +32,7 @@ def main():
     register_vm_command(subparsers)
 
     args = parser.parse_args()
+    setup_cli_logging()
     args.func(args)
 
 

--- a/deplodock/deploy/local.py
+++ b/deplodock/deploy/local.py
@@ -1,8 +1,10 @@
 """Local transport: run commands and write files locally."""
 
+import logging
 import os
 import subprocess
-import sys
+
+logger = logging.getLogger(__name__)
 
 
 def make_run_cmd(deploy_dir, dry_run=False):
@@ -10,7 +12,7 @@ def make_run_cmd(deploy_dir, dry_run=False):
 
     def run_cmd(command, stream=True):
         if dry_run:
-            print(f"[dry-run] {command}")
+            logger.info(f"[dry-run] {command}")
             return 0, "", ""
 
         try:
@@ -27,7 +29,7 @@ def make_run_cmd(deploy_dir, dry_run=False):
             stderr = "" if stream else (result.stderr or "")
             return result.returncode, stdout, stderr
         except Exception as e:
-            print(f"Error running command: {e}", file=sys.stderr)
+            logger.error(f"Error running command: {e}")
             return 1, "", ""
 
     return run_cmd
@@ -39,7 +41,7 @@ def make_write_file(deploy_dir, dry_run=False):
     def write_file(path, content):
         full_path = os.path.join(deploy_dir, path)
         if dry_run:
-            print(f"[dry-run] write {full_path}")
+            logger.info(f"[dry-run] write {full_path}")
             return
         os.makedirs(os.path.dirname(full_path) or ".", exist_ok=True)
         with open(full_path, "w") as f:

--- a/deplodock/logging_setup.py
+++ b/deplodock/logging_setup.py
@@ -1,0 +1,18 @@
+"""CLI logging setup: simple %(message)s format for standalone commands."""
+
+import logging
+import sys
+
+
+def setup_cli_logging():
+    """Configure root logger with plain message format for CLI commands.
+
+    Produces output identical to print(). The bench command's setup_logging()
+    overrides this with a prefixed format.
+    """
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.handlers.clear()
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -12,6 +12,8 @@ from deplodock.hardware import GPU_INSTANCE_TYPES, resolve_instance_type
 from deplodock.provisioning import cloudrift as cr_provider
 from deplodock.provisioning import gcp as gcp_provider
 
+logger = logging.getLogger(__name__)
+
 
 def resolve_vm_spec(loaded_configs, server_name=None):
     """Resolve GPU type and count from pre-loaded recipe configs for VM provisioning.
@@ -170,7 +172,7 @@ def delete_cloud_vm(delete_info, dry_run=False):
     if provider == "cloudrift":
         instance_id = delete_info[1]
         if dry_run:
-            print(f"[dry-run] cloudrift: terminate instance {instance_id}")
+            logger.info(f"[dry-run] cloudrift: terminate instance {instance_id}")
             return
         api_key = os.environ.get("CLOUDRIFT_API_KEY", "")
         cr_provider.delete_instance(api_key, instance_id)

--- a/deplodock/provisioning/remote.py
+++ b/deplodock/provisioning/remote.py
@@ -1,9 +1,11 @@
 """Remote server provisioning: install Docker, NVIDIA toolkit, etc."""
 
+import logging
 import subprocess
-import sys
 
 from deplodock.provisioning.ssh_transport import ssh_base_args
+
+logger = logging.getLogger(__name__)
 
 
 def provision_remote(server, ssh_key, ssh_port, dry_run=False):
@@ -22,33 +24,33 @@ def provision_remote(server, ssh_key, ssh_port, dry_run=False):
         args.append(command)
         result = subprocess.run(args, capture_output=True, text=True)
         if result.returncode != 0 and result.stderr:
-            print(f"SSH error ({server}): {result.stderr.strip()}", file=sys.stderr)
+            logger.error(f"SSH error ({server}): {result.stderr.strip()}")
         if capture:
             return result.returncode, result.stdout.strip()
         return result.returncode, ""
 
     # 1. Create deploy directory
     if dry_run:
-        print(f"[dry-run] ssh {server}: mkdir -p {REMOTE_DEPLOY_DIR}")
+        logger.info(f"[dry-run] ssh {server}: mkdir -p {REMOTE_DEPLOY_DIR}")
     else:
         _run_ssh(f"mkdir -p {REMOTE_DEPLOY_DIR}")
 
     # 2. Install Docker if not found
     if dry_run:
-        print(f"[dry-run] ssh {server}: install docker (if not present)")
+        logger.info(f"[dry-run] ssh {server}: install docker (if not present)")
     else:
         rc, _ = _run_ssh("command -v docker", capture=True)
         if rc != 0:
-            print("Installing Docker...")
+            logger.info("Installing Docker...")
             _run_ssh("curl -fsSL https://get.docker.com | sudo sh")
 
     # 3. Install NVIDIA Container Toolkit if not found
     if dry_run:
-        print(f"[dry-run] ssh {server}: install nvidia-container-toolkit (if not present)")
+        logger.info(f"[dry-run] ssh {server}: install nvidia-container-toolkit (if not present)")
     else:
         rc, _ = _run_ssh("command -v nvidia-ctk", capture=True)
         if rc != 0:
-            print("Installing NVIDIA Container Toolkit...")
+            logger.info("Installing NVIDIA Container Toolkit...")
             _run_ssh(
                 "curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey"
                 " | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
@@ -63,6 +65,6 @@ def provision_remote(server, ssh_key, ssh_port, dry_run=False):
 
     # 4. Add user to docker group
     if dry_run:
-        print(f"[dry-run] ssh {server}: add user to docker group")
+        logger.info(f"[dry-run] ssh {server}: add user to docker group")
     else:
         _run_ssh("groups | grep -q docker || sudo usermod -aG docker $(whoami)")

--- a/deplodock/provisioning/shell.py
+++ b/deplodock/provisioning/shell.py
@@ -1,7 +1,9 @@
 """Shell command execution helper."""
 
+import logging
 import subprocess
-import sys
+
+logger = logging.getLogger(__name__)
 
 
 def run_shell_cmd(command, dry_run=False):
@@ -15,12 +17,12 @@ def run_shell_cmd(command, dry_run=False):
         (returncode, stdout, stderr) tuple
     """
     if dry_run:
-        print(f"[dry-run] {' '.join(command)}")
+        logger.info(f"[dry-run] {' '.join(command)}")
         return 0, "", ""
 
     try:
         result = subprocess.run(command, capture_output=True, text=True)
         return result.returncode, result.stdout, result.stderr
     except FileNotFoundError:
-        print(f"Error: '{command[0]}' not found. Is it installed and on PATH?", file=sys.stderr)
+        logger.error(f"Error: '{command[0]}' not found. Is it installed and on PATH?")
         return 1, "", f"'{command[0]}' not found"

--- a/deplodock/provisioning/ssh.py
+++ b/deplodock/provisioning/ssh.py
@@ -1,9 +1,11 @@
 """Provider-agnostic SSH readiness polling."""
 
-import sys
+import logging
 import time
 
 from deplodock.provisioning.ssh_transport import ssh_base_args
+
+logger = logging.getLogger(__name__)
 
 
 def wait_for_ssh(host, username, ssh_port, ssh_key_path, timeout=120, interval=5):
@@ -30,5 +32,5 @@ def wait_for_ssh(host, username, ssh_port, ssh_key_path, timeout=120, interval=5
         time.sleep(interval)
         elapsed += interval
 
-    print(f"Timeout after {timeout}s waiting for SSH connectivity to {address}:{ssh_port}", file=sys.stderr)
+    logger.error(f"Timeout after {timeout}s waiting for SSH connectivity to {address}:{ssh_port}")
     return False

--- a/tests/provisioning/test_cloud.py
+++ b/tests/provisioning/test_cloud.py
@@ -126,18 +126,18 @@ def test_resolve_vm_spec_missing_gpu_raises(tmp_path):
 # ── delete_cloud_vm ──────────────────────────────────────────────
 
 
-def test_delete_cloud_vm_cloudrift_dry_run(capsys):
-    delete_cloud_vm(("cloudrift", "test-instance-id"), dry_run=True)
-    output = capsys.readouterr().out
-    assert "[dry-run]" in output
-    assert "test-instance-id" in output
+def test_delete_cloud_vm_cloudrift_dry_run(caplog):
+    with caplog.at_level("INFO"):
+        delete_cloud_vm(("cloudrift", "test-instance-id"), dry_run=True)
+    assert "[dry-run]" in caplog.text
+    assert "test-instance-id" in caplog.text
 
 
-def test_delete_cloud_vm_gcp_dry_run(capsys):
-    delete_cloud_vm(("gcp", "bench-test", "us-central1-b"), dry_run=True)
-    output = capsys.readouterr().out
-    assert "[dry-run]" in output
-    assert "bench-test" in output
+def test_delete_cloud_vm_gcp_dry_run(caplog):
+    with caplog.at_level("INFO"):
+        delete_cloud_vm(("gcp", "bench-test", "us-central1-b"), dry_run=True)
+    assert "[dry-run]" in caplog.text
+    assert "bench-test" in caplog.text
 
 
 # ── VMConnectionInfo ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace all `print()` calls with `logging.getLogger(__name__)` across 15 library modules (deploy, provisioning, benchmark, report, commands)
- Add `setup_cli_logging()` in new `logging_setup.py` — standalone CLI commands get `%(message)s` format (identical output to `print()`)
- Bench command's `setup_logging()` overrides with `[%(name)s] %(message)s` format — library loggers now appear in bench output (e.g. `[orchestrate] Pulling images...`)
- Fix duplicate `benchmark.log` content across recipe run dirs: `_RunDirFilter` + `active_run_dir` context var routes log records to the correct file handler

## Test plan

- [x] `make test` — 194 tests pass (updated `capsys` → `caplog` in tests that checked print output)
- [x] `make lint` — clean
- [ ] Manual: `deplodock deploy ssh --dry-run` — verify CLI output unchanged
- [ ] Manual: `deplodock bench --dry-run recipes/*` — verify library messages appear with `[module]` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)