### PR TITLE
Enrich benchmark result files with metadata

### DIFF
--- a/deplodock/benchmark/__init__.py
+++ b/deplodock/benchmark/__init__.py
@@ -3,6 +3,7 @@
 from deplodock.benchmark.bench_logging import _get_group_logger, add_file_handler, setup_logging
 from deplodock.benchmark.config import _expand_path, load_config, validate_config
 from deplodock.benchmark.execution import _run_groups, run_execution_group
+from deplodock.benchmark.system_info import collect_system_info
 from deplodock.benchmark.tasks import _task_meta, enumerate_tasks
 from deplodock.benchmark.tracking import (
     compute_code_hash,
@@ -11,7 +12,10 @@ from deplodock.benchmark.tracking import (
     write_manifest,
 )
 from deplodock.benchmark.workload import (
+    build_bench_command,
+    compose_result,
     extract_benchmark_results,
+    format_task_yaml,
     run_benchmark_workload,
 )
 
@@ -26,7 +30,11 @@ __all__ = [
     "setup_logging",
     "add_file_handler",
     "_get_group_logger",
+    "collect_system_info",
+    "build_bench_command",
+    "compose_result",
     "extract_benchmark_results",
+    "format_task_yaml",
     "run_benchmark_workload",
     "enumerate_tasks",
     "_task_meta",

--- a/deplodock/benchmark/system_info.py
+++ b/deplodock/benchmark/system_info.py
@@ -1,0 +1,73 @@
+"""Collect system information from remote servers."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_INFO_CMD = r"""
+echo "=== HOSTNAME ==="
+hostname
+
+echo ""
+echo "=== OS ==="
+cat /etc/os-release 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== KERNEL ==="
+uname -r
+
+echo ""
+echo "=== CPU INFORMATION ==="
+lscpu 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== CPU COUNT ==="
+nproc 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== MEMORY ==="
+free -h 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== GPU INFORMATION ==="
+nvidia-smi --query-gpu=name,memory.total,driver_version,pstate,temperature.gpu,utilization.gpu \
+  --format=csv,noheader 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== GPU DETAILS ==="
+nvidia-smi 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== DISK USAGE ==="
+df -h 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== BLOCK DEVICES ==="
+lsblk 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== UPTIME ==="
+uptime 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== DOCKER VERSION ==="
+docker --version 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== DOCKER INFO ==="
+docker info --format \
+  '{{.ServerVersion}} | OS: {{.OperatingSystem}} | Containers: {{.Containers}} | Images: {{.Images}}' \
+  2>/dev/null || echo "N/A"
+"""
+
+
+def collect_system_info(run_cmd) -> str:
+    """Collect system information from a remote server via SSH.
+
+    Returns the output wrapped in section delimiters, or empty string on failure.
+    """
+    rc, output, _ = run_cmd(SYSTEM_INFO_CMD, stream=False)
+    if rc != 0:
+        logger.warning("Failed to collect system info")
+        return ""
+    return output

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -1,9 +1,20 @@
 """Benchmark workload execution."""
 
 import logging
+from dataclasses import asdict
+
+import yaml
 
 from deplodock.deploy.compose import calculate_num_instances
+from deplodock.planner import BenchmarkTask
 from deplodock.recipe.types import Recipe
+
+SECTION_DELIMITER = "=" * 50
+
+
+def _section(title: str, content: str) -> str:
+    """Wrap content in a section with title delimiters."""
+    return f"============ {title} ============\n{content}\n{SECTION_DELIMITER}"
 
 
 def extract_benchmark_results(output: str) -> str:
@@ -15,25 +26,77 @@ def extract_benchmark_results(output: str) -> str:
     return output[idx:]
 
 
+def build_bench_command(recipe: Recipe) -> str:
+    """Build the vllm bench serve command string (without docker wrapper).
+
+    Returns the bench command as a human-readable multi-line string.
+    """
+    bench = recipe.benchmark
+    model_name = recipe.model_name
+    num_instances = calculate_num_instances(recipe)
+    port = 8080 if num_instances > 1 else 8000
+
+    return (
+        f"vllm bench serve\n"
+        f"    --model {model_name}\n"
+        f"    --max-concurrency {bench.max_concurrency}\n"
+        f"    --num-prompts {bench.num_prompts}\n"
+        f"    --random-input-len {bench.random_input_len}\n"
+        f"    --random-output-len {bench.random_output_len}\n"
+        f"    --base-url http://localhost:{port}"
+    )
+
+
+def format_task_yaml(task: BenchmarkTask) -> str:
+    """Serialize BenchmarkTask metadata to a YAML block.
+
+    Includes recipe_dir, variant, gpu_name, gpu_count, and the full recipe.
+    Excludes run_dir (ephemeral).
+    """
+    data = {
+        "recipe_dir": task.recipe_dir,
+        "variant": task.variant,
+        "gpu_name": task.gpu_name,
+        "gpu_count": task.gpu_count,
+        "recipe": asdict(task.recipe),
+    }
+    return yaml.dump(data, default_flow_style=False, sort_keys=False).rstrip()
+
+
+def compose_result(
+    task: BenchmarkTask,
+    benchmark_output: str,
+    compose_content: str,
+    bench_command: str,
+    system_info: str,
+) -> str:
+    """Assemble the full result file from all sections."""
+    sections = [
+        _section("Benchmark Task", format_task_yaml(task)),
+        benchmark_output.rstrip(),
+        _section("Docker Compose Configuration", compose_content.rstrip()),
+        _section("Benchmark Command", bench_command),
+    ]
+    if system_info:
+        sections.append(_section("System Information", system_info.rstrip()))
+    return "\n\n".join(sections) + "\n"
+
+
 def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
     """Run vllm bench serve on the remote server and return output.
 
     Returns:
-        (success: bool, output: str)
+        (success: bool, output: str, bench_command: str)
     """
     bench = recipe.benchmark
-    max_concurrency = bench.max_concurrency
-    num_prompts = bench.num_prompts
-    random_input_len = bench.random_input_len
-    random_output_len = bench.random_output_len
 
     # Warn if input + output lengths risk exceeding context_length
     context_length = recipe.engine.llm.context_length
-    if context_length is not None and random_input_len + random_output_len >= context_length:
+    if context_length is not None and bench.random_input_len + bench.random_output_len >= context_length:
         logging.getLogger().warning(
-            f"benchmark random_input_len ({random_input_len}) + "
-            f"random_output_len ({random_output_len}) = "
-            f"{random_input_len + random_output_len} >= "
+            f"benchmark random_input_len ({bench.random_input_len}) + "
+            f"random_output_len ({bench.random_output_len}) = "
+            f"{bench.random_input_len + bench.random_output_len} >= "
             f"context_length ({context_length})"
         )
 
@@ -52,12 +115,13 @@ def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
         f"vllm bench serve "
         f"--model {model_name} "
         f"--base-url http://localhost:{port} "
-        f"--max-concurrency {max_concurrency} "
-        f"--num-prompts {num_prompts} "
-        f"--random-input-len {random_input_len} "
-        f"--random-output-len {random_output_len}"
+        f"--max-concurrency {bench.max_concurrency} "
+        f"--num-prompts {bench.num_prompts} "
+        f"--random-input-len {bench.random_input_len} "
+        f"--random-output-len {bench.random_output_len}"
         f"'"
     )
 
+    bench_command_str = build_bench_command(recipe)
     rc, output, _ = run_cmd(bench_cmd, stream=False)
-    return rc == 0, output
+    return rc == 0, output, bench_command_str


### PR DESCRIPTION
## Summary
- Benchmark result files now include five sections: task YAML metadata, serving benchmark output, Docker Compose configuration, benchmark command, and system hardware info
- New `system_info.py` module collects hostname, OS, CPU, memory, GPU, disk, and Docker info from remote servers via SSH
- Refactored `workload.py` with `build_bench_command()`, `format_task_yaml()`, and `compose_result()` to assemble rich result files

## Test plan
- [x] `make test` — all 194 tests pass
- [x] `make lint` — clean
- [x] Dry-run mode unaffected (system_info returns empty, result files not written)

🤖 Generated with [Claude Code](https://claude.com/claude-code)