### PR TITLE
Convert codebase to native async with timeouts

### DIFF
--- a/deplodock/benchmark/system_info.py
+++ b/deplodock/benchmark/system_info.py
@@ -61,12 +61,12 @@ docker info --format \
 """
 
 
-def collect_system_info(run_cmd) -> str:
+async def collect_system_info(run_cmd) -> str:
     """Collect system information from a remote server via SSH.
 
     Returns the output wrapped in section delimiters, or empty string on failure.
     """
-    rc, output, _ = run_cmd(SYSTEM_INFO_CMD, stream=False)
+    rc, output, _ = await run_cmd(SYSTEM_INFO_CMD, stream=False, timeout=120)
     if rc != 0:
         logger.warning("Failed to collect system info")
         return ""

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -82,7 +82,7 @@ def compose_result(
     return "\n\n".join(sections) + "\n"
 
 
-def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
+async def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
     """Run vllm bench serve on the remote server and return output.
 
     Returns:
@@ -123,5 +123,5 @@ def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
     )
 
     bench_command_str = build_bench_command(recipe)
-    rc, output, _ = run_cmd(bench_cmd, stream=False)
+    rc, output, _ = await run_cmd(bench_cmd, stream=False, timeout=3600)
     return rc == 0, output, bench_command_str

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -94,7 +94,15 @@ Groups benchmark tasks into execution groups for VM allocation.
 
 ### `commands/` — CLI Layer (thin handlers only)
 
-Each command module contains only argparse registration and `handle_*` functions that delegate to library packages.
+Each command module contains only argparse registration and `handle_*` functions that delegate to library packages. CLI handlers use `asyncio.run()` to bridge sync argparse entry points into async internals:
+
+```python
+def handle_foo(args):
+    asyncio.run(_handle_foo(args))
+
+async def _handle_foo(args):
+    await ...
+```
 
 **Command modules:**
 - `commands/bench/` — `handle_bench()`, `register_bench_command()`
@@ -122,7 +130,7 @@ Create per-recipe run directories:
 GroupByModelAndGpuPlanner.plan() -> list[ExecutionGroup]
     |
     v
-asyncio.gather(*groups)  -- each group runs in a thread:
+asyncio.gather(*groups)  -- each group runs as async task:
     |
     v
 provision_cloud_vm() -> VMConnectionInfo

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -1,5 +1,6 @@
 """Cloud deploy target CLI handler."""
 
+import asyncio
 import logging
 import os
 import sys
@@ -21,6 +22,10 @@ logger = logging.getLogger(__name__)
 
 def handle_cloud(args):
     """CLI handler for 'deploy cloud'."""
+    asyncio.run(_handle_cloud(args))
+
+
+async def _handle_cloud(args):
     recipe = load_recipe(args.recipe)
 
     if not recipe.deploy.gpu:
@@ -30,7 +35,7 @@ def handle_cloud(args):
     ssh_key = os.path.expanduser(args.ssh_key)
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
 
-    conn = provision_cloud_vm(
+    conn = await provision_cloud_vm(
         gpu_name=recipe.deploy.gpu,
         gpu_count=recipe.deploy.gpu_count,
         ssh_key=ssh_key,
@@ -50,9 +55,9 @@ def handle_cloud(args):
         hf_token=hf_token,
         dry_run=args.dry_run,
     )
-    provision_remote(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
+    await provision_remote(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
 
-    if not deploy_entry(params):
+    if not await deploy_entry(params):
         sys.exit(1)
 
 

--- a/deplodock/commands/deploy/local.py
+++ b/deplodock/commands/deploy/local.py
@@ -1,5 +1,6 @@
 """Local deploy target CLI handler."""
 
+import asyncio
 import os
 import sys
 
@@ -10,6 +11,10 @@ from deplodock.recipe import load_recipe
 
 def handle_local(args):
     """Handle the local deploy target."""
+    asyncio.run(_handle_local(args))
+
+
+async def _handle_local(args):
     recipe_dir = args.recipe
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
     model_dir = args.model_dir
@@ -23,11 +28,11 @@ def handle_local(args):
     write_file = make_write_file(deploy_dir, dry_run=dry_run)
 
     if teardown:
-        return run_teardown(run_cmd)
+        return await run_teardown(run_cmd)
 
     recipe = load_recipe(recipe_dir)
 
-    success = run_deploy(
+    success = await run_deploy(
         run_cmd=run_cmd,
         write_file=write_file,
         recipe=recipe,

--- a/deplodock/commands/deploy/ssh.py
+++ b/deplodock/commands/deploy/ssh.py
@@ -1,5 +1,6 @@
 """SSH deploy target CLI handler."""
 
+import asyncio
 import os
 import sys
 
@@ -16,6 +17,10 @@ from deplodock.recipe import load_recipe
 
 def handle_ssh(args):
     """Handle the SSH deploy target."""
+    asyncio.run(_handle_ssh(args))
+
+
+async def _handle_ssh(args):
     recipe = load_recipe(args.recipe)
     params = DeployParams(
         server=args.server,
@@ -26,12 +31,12 @@ def handle_ssh(args):
         hf_token=args.hf_token or os.environ.get("HF_TOKEN", ""),
         dry_run=args.dry_run,
     )
-    provision_remote(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
+    await provision_remote(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
 
     if args.teardown:
-        return teardown_entry(params)
+        return await teardown_entry(params)
 
-    if not deploy_entry(params):
+    if not await deploy_entry(params):
         sys.exit(1)
 
 

--- a/deplodock/commands/teardown.py
+++ b/deplodock/commands/teardown.py
@@ -1,5 +1,6 @@
 """Teardown command: clean up VMs left running by --no-teardown."""
 
+import asyncio
 import json
 import logging
 import sys
@@ -14,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 def handle_teardown(args):
     """Handle the teardown command."""
+    asyncio.run(_handle_teardown(args))
+
+
+async def _handle_teardown(args):
     run_dir = Path(args.run_dir)
     instances_path = run_dir / "instances.json"
     ssh_key = args.ssh_key
@@ -44,7 +49,7 @@ def handle_teardown(args):
         if address:
             logger.info(f"  Stopping containers on {address}...")
             run_cmd = make_run_cmd(address, ssh_key, ssh_port)
-            run_teardown(run_cmd)
+            await run_teardown(run_cmd)
 
         # Delete VM
         if provider and instance_id:
@@ -59,7 +64,7 @@ def handle_teardown(args):
                     delete_info = (provider, instance_id, zone)
                 else:
                     delete_info = (provider, instance_id)
-                delete_cloud_vm(delete_info)
+                await delete_cloud_vm(delete_info)
                 logger.info("  VM deleted.")
             except Exception as e:
                 logger.error(f"  ERROR deleting VM: {e}")

--- a/deplodock/commands/vm/cloudrift.py
+++ b/deplodock/commands/vm/cloudrift.py
@@ -1,5 +1,6 @@
 """CloudRift provider CLI handlers."""
 
+import asyncio
 import logging
 import os
 import sys
@@ -31,9 +32,13 @@ def _resolve_api_key(args_api_key):
 
 def handle_create(args):
     """CLI handler for 'vm create cloudrift'."""
+    asyncio.run(_handle_create(args))
+
+
+async def _handle_create(args):
     api_key = _resolve_api_key(args.api_key)
     ports = [int(p) for p in args.ports.split(",")] if args.ports else None
-    conn = create_instance(
+    conn = await create_instance(
         api_key=api_key,
         instance_type=args.instance_type,
         ssh_key_path=args.ssh_key,
@@ -49,8 +54,12 @@ def handle_create(args):
 
 def handle_delete(args):
     """CLI handler for 'vm delete cloudrift'."""
+    asyncio.run(_handle_delete(args))
+
+
+async def _handle_delete(args):
     api_key = _resolve_api_key(args.api_key)
-    success = delete_instance(
+    success = await delete_instance(
         api_key=api_key,
         instance_id=args.instance_id,
         api_url=args.api_url,

--- a/deplodock/commands/vm/gcp.py
+++ b/deplodock/commands/vm/gcp.py
@@ -1,9 +1,9 @@
 """GCP provider CLI handlers."""
 
+import asyncio
 import sys
 
 from deplodock.provisioning.gcp import (
-    # Re-export business logic for backward compatibility
     create_instance,
     delete_instance,
 )
@@ -13,7 +13,11 @@ from deplodock.provisioning.gcp import (
 
 def handle_create(args):
     """CLI handler for 'vm create gcp'."""
-    conn = create_instance(
+    asyncio.run(_handle_create(args))
+
+
+async def _handle_create(args):
+    conn = await create_instance(
         instance=args.instance,
         zone=args.zone,
         machine_type=args.machine_type,
@@ -36,7 +40,11 @@ def handle_create(args):
 
 def handle_delete(args):
     """CLI handler for 'vm delete gcp'."""
-    success = delete_instance(
+    asyncio.run(_handle_delete(args))
+
+
+async def _handle_delete(args):
+    success = await delete_instance(
         instance=args.instance,
         zone=args.zone,
         dry_run=args.dry_run,

--- a/deplodock/deploy/local.py
+++ b/deplodock/deploy/local.py
@@ -1,8 +1,8 @@
 """Local transport: run commands and write files locally."""
 
+import asyncio
 import logging
 import os
-import subprocess
 
 logger = logging.getLogger(__name__)
 
@@ -10,24 +10,27 @@ logger = logging.getLogger(__name__)
 def make_run_cmd(deploy_dir, dry_run=False):
     """Create a run_cmd callable for local execution."""
 
-    def run_cmd(command, stream=True):
+    async def run_cmd(command, stream=True, timeout=600):
         if dry_run:
             logger.info(f"[dry-run] {command}")
             return 0, "", ""
 
         try:
-            result = subprocess.run(
+            proc = await asyncio.create_subprocess_shell(
                 command,
-                shell=True,
                 cwd=deploy_dir,
-                capture_output=not stream,
-                text=True,
-                stdout=None if stream else subprocess.PIPE,
-                stderr=None if stream else subprocess.PIPE,
+                stdout=None if stream else asyncio.subprocess.PIPE,
+                stderr=None if stream else asyncio.subprocess.PIPE,
             )
-            stdout = "" if stream else (result.stdout or "")
-            stderr = "" if stream else (result.stderr or "")
-            return result.returncode, stdout, stderr
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            stdout = "" if stream else (stdout_bytes.decode() if stdout_bytes else "")
+            stderr = "" if stream else (stderr_bytes.decode() if stderr_bytes else "")
+            return proc.returncode, stdout, stderr
+        except TimeoutError:
+            logger.error(f"Command timed out after {timeout}s: {command}")
+            proc.kill()
+            await proc.wait()
+            return 1, "", ""
         except Exception as e:
             logger.error(f"Error running command: {e}")
             return 1, "", ""
@@ -38,7 +41,7 @@ def make_run_cmd(deploy_dir, dry_run=False):
 def make_write_file(deploy_dir, dry_run=False):
     """Create a write_file callable for local file writes."""
 
-    def write_file(path, content):
+    async def write_file(path, content):
         full_path = os.path.join(deploy_dir, path)
         if dry_run:
             logger.info(f"[dry-run] write {full_path}")

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -55,7 +55,7 @@ def resolve_vm_spec(loaded_configs, server_name=None):
     return gpu_name, max_gpu_count
 
 
-def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None, server_name=None, dry_run=False, logger=None):
+async def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None, server_name=None, dry_run=False, logger=None):
     """Provision a cloud VM for the given GPU requirements.
 
     Looks up the provider from the hardware table and dispatches to the
@@ -85,7 +85,7 @@ def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None, serv
         if dry_run:
             logger.info(f"[dry-run] create instance type={instance_type} ssh_key={pub_key_path}")
 
-        conn = cr_provider.create_instance(
+        conn = await cr_provider.create_instance(
             api_key=api_key or "",
             instance_type=instance_type,
             ssh_key_path=pub_key_path,
@@ -146,7 +146,7 @@ def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None, serv
 
         extra_gcloud_args = " ".join(extra_parts) if extra_parts else None
 
-        conn = gcp_provider.create_instance(
+        conn = await gcp_provider.create_instance(
             instance=instance_name,
             zone=zone,
             machine_type=instance_type,
@@ -165,7 +165,7 @@ def provision_cloud_vm(gpu_name, gpu_count, ssh_key, providers_config=None, serv
         raise ValueError(f"Unknown provider: {provider}")
 
 
-def delete_cloud_vm(delete_info, dry_run=False):
+async def delete_cloud_vm(delete_info, dry_run=False):
     """Delete a cloud VM using the info from VMConnectionInfo.delete_info."""
     provider = delete_info[0]
 
@@ -175,9 +175,9 @@ def delete_cloud_vm(delete_info, dry_run=False):
             logger.info(f"[dry-run] cloudrift: terminate instance {instance_id}")
             return
         api_key = os.environ.get("CLOUDRIFT_API_KEY", "")
-        cr_provider.delete_instance(api_key, instance_id)
+        await cr_provider.delete_instance(api_key, instance_id)
 
     elif provider == "gcp":
         instance_name = delete_info[1]
         zone = delete_info[2]
-        gcp_provider.delete_instance(instance_name, zone, dry_run=dry_run)
+        await gcp_provider.delete_instance(instance_name, zone, dry_run=dry_run)

--- a/deplodock/provisioning/remote.py
+++ b/deplodock/provisioning/remote.py
@@ -1,14 +1,14 @@
 """Remote server provisioning: install Docker, NVIDIA toolkit, etc."""
 
+import asyncio
 import logging
-import subprocess
 
 from deplodock.provisioning.ssh_transport import ssh_base_args
 
 logger = logging.getLogger(__name__)
 
 
-def provision_remote(server, ssh_key, ssh_port, dry_run=False):
+async def provision_remote(server, ssh_key, ssh_port, dry_run=False):
     """Ensure the remote server is ready for deployment.
 
     Steps (each checks before installing):
@@ -19,39 +19,50 @@ def provision_remote(server, ssh_key, ssh_port, dry_run=False):
     """
     REMOTE_DEPLOY_DIR = "~/deploy"
 
-    def _run_ssh(command, capture=False):
+    async def _run_ssh(command, capture=False, timeout=600):
         args = ssh_base_args(server, ssh_key, ssh_port)
         args.append(command)
-        result = subprocess.run(args, capture_output=True, text=True)
-        if result.returncode != 0 and result.stderr:
-            logger.error(f"SSH error ({server}): {result.stderr.strip()}")
-        if capture:
-            return result.returncode, result.stdout.strip()
-        return result.returncode, ""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            if proc.returncode != 0 and stderr_bytes:
+                logger.error(f"SSH error ({server}): {stderr_bytes.decode().strip()}")
+            if capture:
+                return proc.returncode, stdout_bytes.decode().strip() if stdout_bytes else ""
+            return proc.returncode, ""
+        except TimeoutError:
+            logger.error(f"SSH command timed out after {timeout}s: {command}")
+            proc.kill()
+            await proc.wait()
+            return 1, ""
 
     # 1. Create deploy directory
     if dry_run:
         logger.info(f"[dry-run] ssh {server}: mkdir -p {REMOTE_DEPLOY_DIR}")
     else:
-        _run_ssh(f"mkdir -p {REMOTE_DEPLOY_DIR}")
+        await _run_ssh(f"mkdir -p {REMOTE_DEPLOY_DIR}")
 
     # 2. Install Docker if not found
     if dry_run:
         logger.info(f"[dry-run] ssh {server}: install docker (if not present)")
     else:
-        rc, _ = _run_ssh("command -v docker", capture=True)
+        rc, _ = await _run_ssh("command -v docker", capture=True)
         if rc != 0:
             logger.info("Installing Docker...")
-            _run_ssh("curl -fsSL https://get.docker.com | sudo sh")
+            await _run_ssh("curl -fsSL https://get.docker.com | sudo sh")
 
     # 3. Install NVIDIA Container Toolkit if not found
     if dry_run:
         logger.info(f"[dry-run] ssh {server}: install nvidia-container-toolkit (if not present)")
     else:
-        rc, _ = _run_ssh("command -v nvidia-ctk", capture=True)
+        rc, _ = await _run_ssh("command -v nvidia-ctk", capture=True)
         if rc != 0:
             logger.info("Installing NVIDIA Container Toolkit...")
-            _run_ssh(
+            await _run_ssh(
                 "curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey"
                 " | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
                 " && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list"
@@ -67,4 +78,4 @@ def provision_remote(server, ssh_key, ssh_port, dry_run=False):
     if dry_run:
         logger.info(f"[dry-run] ssh {server}: add user to docker group")
     else:
-        _run_ssh("groups | grep -q docker || sudo usermod -aG docker $(whoami)")
+        await _run_ssh("groups | grep -q docker || sudo usermod -aG docker $(whoami)")

--- a/deplodock/provisioning/shell.py
+++ b/deplodock/provisioning/shell.py
@@ -1,17 +1,18 @@
 """Shell command execution helper."""
 
+import asyncio
 import logging
-import subprocess
 
 logger = logging.getLogger(__name__)
 
 
-def run_shell_cmd(command, dry_run=False):
+async def run_shell_cmd(command, dry_run=False, timeout=600):
     """Run a shell command and return (returncode, stdout, stderr).
 
     Args:
         command: list of command arguments
         dry_run: if True, print the command instead of executing
+        timeout: maximum seconds to wait for the command
 
     Returns:
         (returncode, stdout, stderr) tuple
@@ -21,8 +22,20 @@ def run_shell_cmd(command, dry_run=False):
         return 0, "", ""
 
     try:
-        result = subprocess.run(command, capture_output=True, text=True)
-        return result.returncode, result.stdout, result.stderr
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        stdout = stdout_bytes.decode() if stdout_bytes else ""
+        stderr = stderr_bytes.decode() if stderr_bytes else ""
+        return proc.returncode, stdout, stderr
+    except TimeoutError:
+        logger.error(f"Command timed out after {timeout}s: {' '.join(command)}")
+        proc.kill()
+        await proc.wait()
+        return 1, "", ""
     except FileNotFoundError:
         logger.error(f"Error: '{command[0]}' not found. Is it installed and on PATH?")
         return 1, "", f"'{command[0]}' not found"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,21 +9,24 @@ description = "Deploy and benchmark LLM inference on GPU servers using vLLM"
 requires-python = ">=3.12"
 dependencies = [
     "huggingface_hub[cli,hf_transfer]",
+    "httpx",
     "openpyxl",
     "pandas",
     "pyyaml",
-    "requests",
 ]
 
 [project.optional-dependencies]
-test = ["pytest"]
-dev = ["pytest", "ruff"]
+test = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "ruff"]
 
 [tool.setuptools.packages.find]
 include = ["deplodock*"]
 
 [project.scripts]
 deplodock = "deplodock.deplodock:main"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 140

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-All tests use **pytest** and live in the `tests/` directory, organized into subdirectories that mirror the `deplodock/` source tree. Tests are designed to run without GPU hardware, Docker, or network access — every external interaction is avoided via dry-run mode or by testing pure functions directly.
+All tests use **pytest** with **pytest-asyncio** (`asyncio_mode = "auto"` in `pyproject.toml`) and live in the `tests/` directory, organized into subdirectories that mirror the `deplodock/` source tree. Tests are designed to run without GPU hardware, Docker, or network access — every external interaction is avoided via dry-run mode or by testing pure functions directly.
 
 ## Directory Structure
 
@@ -86,6 +86,7 @@ CLI tests use the **`run_cli` fixture** (a subprocess wrapper) and **`make_bench
 
 ## Conventions
 
+- **Async tests** — tests for async functions are plain `async def` (no decorator needed; `asyncio_mode = "auto"` handles it). Mock async callables with `AsyncMock`.
 - **No mocking** — dry-run mode is the primary strategy for testing command orchestration without side effects.
 - **Real recipes** — CLI dry-run tests use recipes from the `recipes/` directory to catch config drift.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.

--- a/tests/provisioning/test_cloud.py
+++ b/tests/provisioning/test_cloud.py
@@ -126,16 +126,16 @@ def test_resolve_vm_spec_missing_gpu_raises(tmp_path):
 # ── delete_cloud_vm ──────────────────────────────────────────────
 
 
-def test_delete_cloud_vm_cloudrift_dry_run(caplog):
+async def test_delete_cloud_vm_cloudrift_dry_run(caplog):
     with caplog.at_level("INFO"):
-        delete_cloud_vm(("cloudrift", "test-instance-id"), dry_run=True)
+        await delete_cloud_vm(("cloudrift", "test-instance-id"), dry_run=True)
     assert "[dry-run]" in caplog.text
     assert "test-instance-id" in caplog.text
 
 
-def test_delete_cloud_vm_gcp_dry_run(caplog):
+async def test_delete_cloud_vm_gcp_dry_run(caplog):
     with caplog.at_level("INFO"):
-        delete_cloud_vm(("gcp", "bench-test", "us-central1-b"), dry_run=True)
+        await delete_cloud_vm(("gcp", "bench-test", "us-central1-b"), dry_run=True)
     assert "[dry-run]" in caplog.text
     assert "bench-test" in caplog.text
 


### PR DESCRIPTION
## Summary
- Replace all `subprocess.run()` calls with `asyncio.create_subprocess_exec/shell` + `asyncio.wait_for()` timeouts across 14 source files
- Replace `requests` with `httpx.AsyncClient` in CloudRift provider
- Remove `asyncio.to_thread()` workaround in bench execution — groups now run as native async tasks
- CLI handlers use `asyncio.run()` to bridge sync argparse entry points into async internals
- Add `pytest-asyncio` with `asyncio_mode = "auto"` for async test support

## Timeout defaults

| Call site | Timeout |
|-----------|---------|
| `run_cmd` (local/SSH) | 600s |
| `scp_file` | 300s |
| `run_shell_cmd` (gcloud) | 600s |
| Docker image pull | 1800s |
| Model download | 3600s |
| Docker compose down | 300s |
| Docker compose up | 1800s |
| Health poll (per curl) | 30s |
| Smoke test | 60s |
| Benchmark workload | 3600s |
| System info collection | 120s |

## Test plan
- [x] `make test` — 194/194 tests pass
- [x] `make lint` — clean
- [x] `deplodock deploy local --recipe recipes/... --dry-run` — works
- [x] `deplodock bench recipes/* --dry-run` — works

🤖 Generated with [Claude Code](https://claude.com/claude-code)