### PR TITLE
Add CI benchmark workflow for /run-experiment

### DIFF
--- a/.github/scripts/detect-experiments.py
+++ b/.github/scripts/detect-experiments.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Detect experiment directories from a /run-experiment comment or git diff.
+
+Two modes:
+- Explicit: /run-experiment experiments/Foo/bar experiments/Baz/qux
+- Auto-detect: /run-experiment (no args) — finds changed experiments via git diff
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_explicit_paths(comment: str) -> list[str]:
+    """Extract experiment paths from the comment text after /run-experiment."""
+    parts = comment.strip().split()
+    # First token is /run-experiment, rest are paths
+    return [p for p in parts[1:] if p.startswith("experiments/")]
+
+
+def detect_from_diff(base: str, head: str) -> list[str]:
+    """Find experiment directories with changes between base and head."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    changed_files = result.stdout.strip().splitlines()
+
+    experiment_dirs = set()
+    for filepath in changed_files:
+        if not filepath.startswith("experiments/"):
+            continue
+        # Walk up from the changed file to find the directory containing recipe.yaml
+        path = Path(filepath)
+        for parent in [path.parent, *path.parent.parents]:
+            if str(parent) == "experiments" or str(parent) == ".":
+                break
+            if (parent / "recipe.yaml").exists():
+                experiment_dirs.add(str(parent))
+                break
+
+    return sorted(experiment_dirs)
+
+
+def validate_experiments(dirs: list[str]) -> list[str]:
+    """Filter to directories that contain a recipe.yaml."""
+    valid = []
+    for d in dirs:
+        if Path(d, "recipe.yaml").exists():
+            valid.append(d)
+        else:
+            print(f"Warning: {d} does not contain recipe.yaml, skipping", file=sys.stderr)
+    return valid
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect experiments for CI benchmark")
+    parser.add_argument("--comment", required=True, help="The /run-experiment comment text")
+    parser.add_argument("--base", required=True, help="Base ref for git diff (e.g. origin/main)")
+    parser.add_argument("--head", required=True, help="Head ref for git diff (e.g. HEAD)")
+    args = parser.parse_args()
+
+    # Try explicit paths first
+    explicit = parse_explicit_paths(args.comment)
+    if explicit:
+        experiments = validate_experiments(explicit)
+        mode = "explicit"
+    else:
+        experiments = detect_from_diff(args.base, args.head)
+        experiments = validate_experiments(experiments)
+        mode = "auto-detect"
+
+    if not experiments:
+        print(f"Error: No experiments found ({mode} mode)", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Detected experiments ({mode}):")
+    for exp in experiments:
+        print(f"  - {exp}")
+
+    # Write to GITHUB_OUTPUT
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"experiments={json.dumps(experiments)}\n")
+    else:
+        # Running locally — just print the JSON
+        print(json.dumps(experiments))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/format-results.py
+++ b/.github/scripts/format-results.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Format benchmark results as a markdown PR comment.
+
+Reads manifest.json from experiment run directories and extracts metrics
+from benchmark result files (throughput, TTFT, TPOT).
+"""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def find_latest_run_dir(experiment_dir: str) -> Path | None:
+    """Find the most recent timestamped run directory in an experiment."""
+    exp_path = Path(experiment_dir)
+    run_dirs = sorted(exp_path.glob("[0-9][0-9][0-9][0-9]-*/"), reverse=True)
+    for run_dir in run_dirs:
+        if (run_dir / "manifest.json").exists():
+            return run_dir
+    return None
+
+
+def parse_result_file(filepath: Path) -> dict:
+    """Extract metrics from a benchmark result .txt file."""
+    metrics = {}
+    try:
+        content = filepath.read_text()
+    except FileNotFoundError:
+        return metrics
+
+    patterns = {
+        "total_throughput": r"Total [Tt]oken throughput \(tok/s\):\s+([\d.]+)",
+        "output_throughput": r"Output token throughput \(tok/s\):\s+([\d.]+)",
+        "request_throughput": r"Request throughput \(req/s\):\s+([\d.]+)",
+        "mean_ttft_ms": r"Mean TTFT \(ms\):\s+([\d.]+)",
+        "mean_tpot_ms": r"Mean TPOT \(ms\):\s+([\d.]+)",
+    }
+    for key, pattern in patterns.items():
+        match = re.search(pattern, content)
+        if match:
+            metrics[key] = float(match.group(1))
+
+    return metrics
+
+
+def format_comment(experiments: list[str]) -> str:
+    """Build a markdown comment summarizing benchmark results."""
+    lines = ["### Experiment benchmark results\n"]
+
+    all_succeeded = True
+    any_results = False
+    failed_tasks = []
+
+    for experiment in experiments:
+        exp_name = experiment.rstrip("/")
+        run_dir = find_latest_run_dir(experiment)
+
+        if not run_dir:
+            lines.append(f"#### `{exp_name}`\n")
+            lines.append("> No results found.\n")
+            all_succeeded = False
+            continue
+
+        manifest = json.loads((run_dir / "manifest.json").read_text())
+        tasks = manifest.get("tasks", [])
+
+        if not tasks:
+            lines.append(f"#### `{exp_name}`\n")
+            lines.append("> No tasks in manifest.\n")
+            continue
+
+        completed = [t for t in tasks if t.get("status") == "completed"]
+        failed = [t for t in tasks if t.get("status") != "completed"]
+
+        if failed:
+            all_succeeded = False
+            for t in failed:
+                failed_tasks.append(f"`{exp_name}` — {t.get('result_file', 'unknown')} ({t.get('status', 'unknown')})")
+
+        if completed:
+            any_results = True
+            lines.append(f"#### `{exp_name}`\n")
+            lines.append("| Result | GPU | Throughput (tok/s) | TTFT (ms) | TPOT (ms) |")
+            lines.append("|--------|-----|--------------------|-----------|-----------|")
+
+            for task in completed:
+                result_file = task.get("result_file", "")
+                gpu_short = task.get("gpu_short", "?")
+                gpu_count = task.get("gpu_count", 1)
+                gpu_label = f"{gpu_short} x{gpu_count}" if gpu_count > 1 else gpu_short
+
+                # Result file is relative to the recipe subdir inside the run dir
+                # Try both: directly in run_dir, and in recipe subdir
+                filepath = run_dir / result_file
+                if not filepath.exists():
+                    recipe_name = task.get("recipe", "")
+                    filepath = run_dir / recipe_name / result_file
+
+                metrics = parse_result_file(filepath)
+                throughput = f"{metrics['total_throughput']:.1f}" if "total_throughput" in metrics else "—"
+                ttft = f"{metrics['mean_ttft_ms']:.1f}" if "mean_ttft_ms" in metrics else "—"
+                tpot = f"{metrics['mean_tpot_ms']:.2f}" if "mean_tpot_ms" in metrics else "—"
+
+                lines.append(f"| `{result_file}` | {gpu_label} | {throughput} | {ttft} | {tpot} |")
+
+            lines.append("")
+
+    # Status summary
+    if all_succeeded and any_results:
+        status = "All benchmarks completed successfully."
+    elif any_results:
+        status = "Some benchmarks failed (see below)."
+    else:
+        status = "No benchmark results were produced."
+
+    lines.insert(1, f"\n{status}\n")
+
+    # Failed tasks section
+    if failed_tasks:
+        lines.append("#### Failed tasks\n")
+        for ft in failed_tasks:
+            lines.append(f"- {ft}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Format benchmark results as PR comment")
+    parser.add_argument("--experiments", required=True, help="JSON array of experiment directories")
+    parser.add_argument("--output", required=True, help="Output file path for the markdown comment")
+    args = parser.parse_args()
+
+    experiments = json.loads(args.experiments)
+    comment = format_comment(experiments)
+
+    Path(args.output).write_text(comment)
+    print(f"Wrote result comment to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/experiment.yml
+++ b/.github/workflows/experiment.yml
@@ -1,0 +1,240 @@
+name: Run Experiment
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: experiment-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/run-experiment')
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr-meta.outputs.pr_number }}
+      pr_head_ref: ${{ steps.pr-meta.outputs.pr_head_ref }}
+      pr_head_repo: ${{ steps.pr-meta.outputs.pr_head_repo }}
+      is_fork: ${{ steps.pr-meta.outputs.is_fork }}
+      experiments: ${{ steps.detect.outputs.experiments }}
+    steps:
+      - name: Check permissions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            const allowed = ['admin', 'write'];
+            if (!allowed.includes(data.permission)) {
+              core.setFailed(`User ${context.payload.comment.user.login} does not have write access (has: ${data.permission})`);
+            }
+
+      - name: Extract PR metadata
+        id: pr-meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('pr_number', pr.number);
+            core.setOutput('pr_head_ref', pr.head.ref);
+            core.setOutput('pr_head_repo', pr.head.repo.full_name);
+            core.setOutput('is_fork', pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`);
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.EXPERIMENT_APP_ID }}
+          private-key: ${{ secrets.EXPERIMENT_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ steps.pr-meta.outputs.pr_head_repo }}
+          ref: ${{ steps.pr-meta.outputs.pr_head_ref }}
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.repository.default_branch }}
+
+      - name: Detect experiments
+        id: detect
+        run: |
+          python .github/scripts/detect-experiments.py \
+            --comment "${{ github.event.comment.body }}" \
+            --base "origin/${{ github.event.repository.default_branch }}" \
+            --head "HEAD"
+
+      - name: Add reaction to trigger comment
+        uses: actions/github-script@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Post acknowledgement comment
+        uses: actions/github-script@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const experiments = JSON.parse('${{ steps.detect.outputs.experiments }}');
+            const list = experiments.map(e => `- \`${e}\``).join('\n');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `### Experiment benchmark started\n\n` +
+              `**Experiments:**\n${list}\n\n` +
+              `**Triggered by:** @${context.payload.comment.user.login}\n` +
+              `**Workflow run:** [View logs](${runUrl})`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  benchmark:
+    needs: gate
+    if: needs.gate.outputs.experiments != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.EXPERIMENT_APP_ID }}
+          private-key: ${{ secrets.EXPERIMENT_APP_PRIVATE_KEY }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ needs.gate.outputs.pr_head_repo }}
+          ref: ${{ needs.gate.outputs.pr_head_ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: make setup
+
+      - name: Generate ephemeral SSH key
+        run: |
+          ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N "" -q
+          echo "SSH_PUB_KEY=$(cat ~/.ssh/id_ed25519.pub)" >> "$GITHUB_ENV"
+
+      - name: Setup GCP credentials
+        if: secrets.GCP_SERVICE_ACCOUNT_KEY != ''
+        run: |
+          echo '${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}' > /tmp/gcp-key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> "$GITHUB_ENV"
+          echo "GCP_SERVICE_ACCOUNT=${{ secrets.GCP_SERVICE_ACCOUNT }}" >> "$GITHUB_ENV"
+
+      - name: Run benchmarks
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
+        run: |
+          experiments='${{ needs.gate.outputs.experiments }}'
+          dirs=$(echo "$experiments" | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))")
+          ./venv/bin/deplodock bench $dirs
+
+      - name: Collect and commit results
+        if: always()
+        run: |
+          experiments='${{ needs.gate.outputs.experiments }}'
+          dirs=$(echo "$experiments" | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))")
+
+          # Find new run directories (timestamped dirs with manifest.json)
+          result_files=""
+          for dir in $dirs; do
+            for run_dir in "$dir"/[0-9][0-9][0-9][0-9]-*/; do
+              if [ -f "$run_dir/manifest.json" ]; then
+                result_files="$result_files $run_dir"
+              fi
+            done
+          done
+
+          if [ -z "$result_files" ]; then
+            echo "No result directories found"
+            exit 0
+          fi
+
+          # Force-add results (gitignored by default)
+          git add --force $result_files
+          if git diff --cached --quiet; then
+            echo "No new results to commit"
+            exit 0
+          fi
+
+          git config user.name "deplodock-experiment-bot"
+          git config user.email "deplodock-experiment-bot[bot]@users.noreply.github.com"
+          git commit -m "Add experiment benchmark results
+
+          Triggered by /run-experiment in PR #${{ needs.gate.outputs.pr_number }}"
+          git push || echo "::warning::Failed to push results to PR branch (fork may not allow edits from maintainers)"
+
+      - name: Format result comment
+        id: format
+        if: always()
+        run: |
+          experiments='${{ needs.gate.outputs.experiments }}'
+          python .github/scripts/format-results.py \
+            --experiments "$experiments" \
+            --output /tmp/benchmark-comment.md
+
+      - name: Upload results as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: experiment-results
+          path: |
+            experiments/**/[0-9][0-9][0-9][0-9]-*/
+          if-no-files-found: warn
+
+      - name: Post result comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            let body;
+            try {
+              body = fs.readFileSync('/tmp/benchmark-comment.md', 'utf8');
+            } catch {
+              body = '### Experiment benchmark results\n\n' +
+                '> **Error:** Could not generate result summary. ' +
+                'Check the [workflow run](' +
+                `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}` +
+                ') for details.';
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.gate.outputs.pr_number }},
+              body,
+            });
+
+      - name: Cleanup GCP credentials
+        if: always()
+        run: rm -f /tmp/gcp-key.json

--- a/README.md
+++ b/README.md
@@ -188,6 +188,43 @@ experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090/
       ...
 ```
 
+## CI Benchmark Workflow
+
+External developers can submit experiments via pull requests. A maintainer triggers benchmarks by commenting `/run-experiment` on the PR.
+
+### How It Works
+
+1. **Submit a PR** with an experiment definition in `experiments/{model}/{experiment}/recipe.yaml`
+2. **A maintainer reviews** and comments `/run-experiment` on the PR
+3. **CI runs benchmarks** on cloud GPUs, commits results back to the PR branch
+4. **Review results** in the PR comment summary and committed files
+
+### Trigger Modes
+
+```
+/run-experiment                                          # Auto-detect: benchmarks all experiments changed in the PR
+/run-experiment experiments/MyModel/my_experiment         # Explicit: benchmark specific experiment(s)
+```
+
+Only users with **write** or **admin** access to the repository can trigger benchmarks.
+
+### Fork PRs
+
+For the workflow to push results back to a fork's branch, the PR must have **"Allow edits from maintainers"** checked (this is the GitHub default). If unchecked, results are still available as downloadable workflow artifacts.
+
+### Setup
+
+The workflow requires a GitHub App for authentication. See `.github/workflows/experiment.yml` for the full configuration. Required repository secrets:
+
+| Secret | Description |
+|--------|-------------|
+| `EXPERIMENT_APP_ID` | GitHub App ID |
+| `EXPERIMENT_APP_PRIVATE_KEY` | GitHub App private key (.pem) |
+| `HF_TOKEN` | HuggingFace API token |
+| `CLOUDRIFT_API_KEY` | CloudRift API key (if using CloudRift GPUs) |
+| `GCP_SERVICE_ACCOUNT_KEY` | GCP service account JSON key (if using GCP GPUs) |
+| `GCP_SERVICE_ACCOUNT` | GCP service account email (if using GCP GPUs) |
+
 ## Deploy Targets
 
 ### Local


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (`.github/workflows/experiment.yml`) triggered by `/run-experiment` PR comments
- Add experiment detection script that parses explicit paths from comments or auto-detects from git diff
- Add result formatter that reads manifests and benchmark files to post a summary table on the PR
- Document the CI benchmark workflow in README (trigger modes, fork PR behavior, required secrets)

### How it works

1. External developer opens a PR with `experiments/{model}/{experiment}/recipe.yaml`
2. Maintainer reviews and comments `/run-experiment` (explicit paths or auto-detect from diff)
3. `gate` job validates write/admin permissions, detects experiments, posts acknowledgement
4. `benchmark` job provisions cloud GPUs via `deplodock bench`, commits results back to PR branch, posts formatted summary comment
5. Uses GitHub App token for fork PR support (push + comment)

### New files

- `.github/workflows/experiment.yml` — two-job workflow (gate + benchmark)
- `.github/scripts/detect-experiments.py` — experiment detection (explicit paths or git diff)
- `.github/scripts/format-results.py` — markdown result formatter for PR comments

## Test plan

- [ ] Create test branch with a cheap experiment recipe, open PR, comment `/run-experiment`
- [ ] Verify gate job validates permissions and detects experiments
- [ ] Verify benchmark job runs, results committed, summary comment posted
- [ ] Test explicit path: `/run-experiment experiments/specific/path`
- [ ] Test failure case: recipe with invalid GPU to verify failure comment
- [ ] Test fork PR with "Allow edits from maintainers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)