### PR TITLE
Add --gpu-concurrency flag to bench command

### DIFF
--- a/.github/workflows/experiment.yml
+++ b/.github/workflows/experiment.yml
@@ -20,6 +20,7 @@ jobs:
       pr_head_repo: ${{ steps.pr-meta.outputs.pr_head_repo }}
       is_fork: ${{ steps.pr-meta.outputs.is_fork }}
       experiments: ${{ steps.detect.outputs.experiments }}
+      gpu_concurrency: ${{ steps.detect.outputs.gpu_concurrency }}
     steps:
       - name: Check permissions
         uses: actions/github-script@v7
@@ -96,9 +97,11 @@ jobs:
           script: |
             const experiments = JSON.parse('${{ steps.detect.outputs.experiments }}');
             const list = experiments.map(e => `- \`${e}\``).join('\n');
+            const gpuConcurrency = '${{ steps.detect.outputs.gpu_concurrency }}';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const concurrencyLine = gpuConcurrency > 1 ? `\n**GPU concurrency:** ${gpuConcurrency}` : '';
             const body = `### Experiment benchmark started\n\n` +
-              `**Experiments:**\n${list}\n\n` +
+              `**Experiments:**\n${list}${concurrencyLine}\n\n` +
               `**Triggered by:** @${context.payload.comment.user.login}\n` +
               `**Workflow run:** [View logs](${runUrl})`;
             await github.rest.issues.createComment({
@@ -112,7 +115,7 @@ jobs:
     needs: gate
     if: needs.gate.outputs.experiments != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 1440
     steps:
       - name: Generate app token
         id: app-token
@@ -157,8 +160,13 @@ jobs:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
         run: |
           experiments='${{ needs.gate.outputs.experiments }}'
+          gpu_concurrency='${{ needs.gate.outputs.gpu_concurrency }}'
           dirs=$(echo "$experiments" | python -c "import sys, json; print(' '.join(json.load(sys.stdin)))")
-          ./venv/bin/deplodock bench $dirs
+          cmd="./venv/bin/deplodock bench $dirs"
+          if [ "$gpu_concurrency" -gt 1 ] 2>/dev/null; then
+            cmd="$cmd --gpu-concurrency $gpu_concurrency"
+          fi
+          $cmd
 
       - name: Collect and commit results
         if: always()

--- a/README.md
+++ b/README.md
@@ -202,8 +202,9 @@ External developers can submit experiments via pull requests. A maintainer trigg
 ### Trigger Modes
 
 ```
-/run-experiment                                          # Auto-detect: benchmarks all experiments changed in the PR
-/run-experiment experiments/MyModel/my_experiment         # Explicit: benchmark specific experiment(s)
+/run-experiment                                                        # Auto-detect: benchmarks all experiments changed in the PR
+/run-experiment experiments/MyModel/my_experiment                       # Explicit: benchmark specific experiment(s)
+/run-experiment experiments/MyModel/my_experiment --gpu-concurrency 2   # Split groups across 2 VMs each
 ```
 
 Only users with **write** or **admin** access to the repository can trigger benchmarks.
@@ -382,14 +383,15 @@ deplodock bench recipes/* --max-workers 2                    # Limit parallel ex
 deplodock bench recipes/* --dry-run                          # Preview commands
 ```
 
-| Flag            | Default             | Description                            |
-|-----------------|---------------------|----------------------------------------|
-| `recipes`       | (required)          | Recipe directories (positional args)   |
-| `--ssh-key`     | `~/.ssh/id_ed25519` | SSH private key path                   |
-| `--config`      | `config.yaml`       | Path to configuration file             |
-| `--max-workers` | num groups          | Max parallel execution groups          |
-| `--dry-run`     | false               | Print commands without executing       |
-| `--no-teardown` | false               | Skip teardown and VM deletion (saves `instances.json` for later cleanup) |
+| Flag                 | Default             | Description                            |
+|----------------------|---------------------|----------------------------------------|
+| `recipes`            | (required)          | Recipe directories (positional args)   |
+| `--ssh-key`          | `~/.ssh/id_ed25519` | SSH private key path                   |
+| `--config`           | `config.yaml`       | Path to configuration file             |
+| `--max-workers`      | num groups          | Max parallel execution groups          |
+| `--gpu-concurrency`  | 1                   | Split each (model, GPU) group across up to N VMs |
+| `--dry-run`          | false               | Print commands without executing       |
+| `--no-teardown`      | false               | Skip teardown and VM deletion (saves `instances.json` for later cleanup) |
 
 Results are always stored in `{recipe_dir}/{timestamp}_{hash}/` — each recipe directory holds its own run directories alongside `recipe.yaml`.
 

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Groups benchmark tasks into execution groups for VM allocation.
 - `BenchmarkPlanner` — ABC with `plan(tasks) -> list[ExecutionGroup]`
 
 **Implementations:**
-- `planner/group_by_model_and_gpu.py` — `GroupByModelAndGpuPlanner`: groups by (model_name, gpu_name) tuple. Same model on same GPU shares a VM to reuse cached weights. Max gpu_count determines VM size; tasks sorted descending.
+- `planner/group_by_model_and_gpu.py` — `GroupByModelAndGpuPlanner(gpu_concurrency=1)`: groups by (model_name, gpu_name) tuple. Same model on same GPU shares a VM to reuse cached weights. Max gpu_count determines VM size; tasks sorted descending. With `gpu_concurrency > 1`, each group is split into up to N sub-groups via round-robin, each provisioning its own VM (trades weight-cache reuse for wall-clock time).
 
 ### `commands/` — CLI Layer (thin handlers only)
 

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -72,10 +72,13 @@ def handle_bench(args):
     root_logger.info("")
 
     # Plan execution groups
-    planner = GroupByModelAndGpuPlanner()
+    gpu_concurrency = args.gpu_concurrency
+    planner = GroupByModelAndGpuPlanner(gpu_concurrency=gpu_concurrency)
     groups = planner.plan(tasks)
 
     root_logger.info(f"Running {len(tasks)} benchmark task(s) in {len(groups)} execution group(s)")
+    if gpu_concurrency > 1:
+        root_logger.info(f"GPU concurrency: {gpu_concurrency} (groups split across multiple VMs)")
     root_logger.info(f"Parallel mode (max workers: {args.max_workers or len(groups)})")
     root_logger.info("")
 
@@ -162,6 +165,12 @@ def register_bench_command(subparsers):
         type=int,
         default=None,
         help="Maximum number of parallel execution groups (default: number of groups)",
+    )
+    parser.add_argument(
+        "--gpu-concurrency",
+        type=int,
+        default=1,
+        help="Split each (model, GPU) group across up to N VMs (default: 1)",
     )
     parser.add_argument(
         "--dry-run",

--- a/deplodock/planner/group_by_model_and_gpu.py
+++ b/deplodock/planner/group_by_model_and_gpu.py
@@ -3,6 +3,10 @@
 Same LLM model on same GPU type shares a VM so model weights are cached
 across different GPU-count benchmarks. Different models on the same GPU
 type get separate VMs.
+
+With gpu_concurrency > 1, each (model, gpu) group is split into up to N
+sub-groups via round-robin, each provisioning its own VM. This trades
+weight-cache reuse for wall-clock time.
 """
 
 from deplodock.planner import BenchmarkPlanner, ExecutionGroup
@@ -10,6 +14,9 @@ from deplodock.planner import BenchmarkPlanner, ExecutionGroup
 
 class GroupByModelAndGpuPlanner(BenchmarkPlanner):
     """Group tasks by (model_name, gpu_name) tuple."""
+
+    def __init__(self, gpu_concurrency: int = 1):
+        self.gpu_concurrency = max(1, gpu_concurrency)
 
     def plan(self, tasks):
         groups = {}
@@ -20,12 +27,31 @@ class GroupByModelAndGpuPlanner(BenchmarkPlanner):
         result = []
         for (_model, gpu), group_tasks in groups.items():
             group_tasks.sort(key=lambda t: t.gpu_count, reverse=True)
-            max_count = max(t.gpu_count for t in group_tasks)
-            result.append(
-                ExecutionGroup(
-                    gpu_name=gpu,
-                    gpu_count=max_count,
-                    tasks=group_tasks,
+
+            n_splits = min(self.gpu_concurrency, len(group_tasks))
+            if n_splits <= 1:
+                max_count = max(t.gpu_count for t in group_tasks)
+                result.append(
+                    ExecutionGroup(
+                        gpu_name=gpu,
+                        gpu_count=max_count,
+                        tasks=group_tasks,
+                    )
                 )
-            )
+            else:
+                # Round-robin into sub-groups
+                sub_groups: list[list] = [[] for _ in range(n_splits)]
+                for i, task in enumerate(group_tasks):
+                    sub_groups[i % n_splits].append(task)
+
+                for sub in sub_groups:
+                    if sub:
+                        max_count = max(t.gpu_count for t in sub)
+                        result.append(
+                            ExecutionGroup(
+                                gpu_name=gpu,
+                                gpu_count=max_count,
+                                tasks=sub,
+                            )
+                        )
         return result


### PR DESCRIPTION
## Summary

- Adds `--gpu-concurrency N` to `deplodock bench` which splits each `(model, GPU)` group into up to N sub-groups via round-robin, each provisioning its own VM — trades weight-cache reuse for wall-clock time
- Supports `--gpu-concurrency N` in `/run-experiment` CI comments (parsed by `detect-experiments.py`, passed through workflow)
- Increases benchmark job timeout from 3h to 24h to accommodate longer parallel runs

## Test plan

- [x] `make test` — 199 tests pass (5 new planner tests for concurrency splitting)
- [x] `make lint` — clean
- [ ] `deplodock bench recipes/SomeRecipe --gpu-concurrency 2 --dry-run` — verify logs show group splitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)