### PR TITLE
Fix: use venv Python for task summary in CI

### DIFF
--- a/.github/workflows/experiment.yml
+++ b/.github/workflows/experiment.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Summarize tasks from dry run
         id: summarize
         run: |
-          python3 -c "
+          ./venv/bin/python3 -c "
           import json, os, sys, uuid
           import yaml
 


### PR DESCRIPTION
## Summary
- The "Summarize tasks from dry run" step in the experiment workflow uses `import yaml` (PyYAML), which is only installed in the venv via `make setup`
- Changed `python3 -c` to `./venv/bin/python3 -c` so it picks up the venv with PyYAML installed

## Test plan
- [ ] Merge to main, then re-trigger `/run-experiment` on a PR — the gate job should pass the summarize step

🤖 Generated with [Claude Code](https://claude.com/claude-code)