### PR TITLE
Add per-group log files and unique labels for parallel benchmarks

### DIFF
--- a/deplodock/benchmark/__init__.py
+++ b/deplodock/benchmark/__init__.py
@@ -1,6 +1,11 @@
 """Benchmark library: config, logging, workload, tasks, execution."""
 
-from deplodock.benchmark.bench_logging import _get_group_logger, add_file_handler, setup_logging
+from deplodock.benchmark.bench_logging import (
+    _get_group_logger,
+    add_file_handler,
+    add_group_file_handler,
+    setup_logging,
+)
 from deplodock.benchmark.config import _expand_path, load_config, validate_config
 from deplodock.benchmark.execution import _run_groups, run_execution_group
 from deplodock.benchmark.results import (
@@ -31,6 +36,7 @@ __all__ = [
     "_expand_path",
     "setup_logging",
     "add_file_handler",
+    "add_group_file_handler",
     "_get_group_logger",
     "collect_system_info",
     "build_bench_command",

--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -5,7 +5,6 @@ import logging
 import sys
 from pathlib import Path
 
-from deplodock.hardware import gpu_short_name
 from deplodock.planner import ExecutionGroup
 from deplodock.redact import SecretRedactingFilter
 
@@ -135,8 +134,7 @@ def add_group_file_handler(run_dir: Path, group_label: str) -> logging.Handler:
 
 def _get_group_logger(group: ExecutionGroup, model_name: str | None = None) -> logging.Logger:
     """Get a logger for an execution group."""
-    short = gpu_short_name(group.gpu_name)
-    group_label = f"{short}_x_{group.gpu_count}"
+    group_label = group.label
     if model_name:
         short_model = model_name.split("/")[-1] if "/" in model_name else model_name
         return logging.getLogger(f"{group_label}.{short_model}")

--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -87,6 +87,52 @@ def add_file_handler(run_dir: Path) -> str:
     return str(log_file)
 
 
+class _GroupNameFilter(logging.Filter):
+    """Only pass records from loggers matching a specific execution group.
+
+    Accepts records where:
+    - record.name starts with group_label (group logger and its children)
+    - record.name starts with "deplodock." AND active_run_dir matches run_dir
+      (so deploy/provisioning logs for this group are included)
+    """
+
+    def __init__(self, group_label: str, run_dir: Path):
+        self.group_label = group_label
+        self.run_dir = run_dir
+
+    def filter(self, record):
+        if record.name.startswith(self.group_label):
+            return True
+        if record.name.startswith("deplodock."):
+            current = active_run_dir.get()
+            return current == self.run_dir
+        return False
+
+
+def add_group_file_handler(run_dir: Path, group_label: str) -> logging.Handler:
+    """Add a file handler for a specific execution group.
+
+    Writes to {run_dir}/benchmark_{group_label}.log, capturing only
+    log records from loggers whose name starts with group_label
+    or from deplodock.* loggers when active_run_dir matches.
+
+    Returns:
+        The handler, so the caller can remove it later.
+    """
+    log_file = run_dir / f"benchmark_{group_label}.log"
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_formatter = logging.Formatter(
+        "[%(asctime)s] [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    file_handler.setFormatter(file_formatter)
+    file_handler.addFilter(_GroupNameFilter(group_label, run_dir))
+    logging.getLogger().addHandler(file_handler)
+
+    return file_handler
+
+
 def _get_group_logger(group: ExecutionGroup, model_name: str | None = None) -> logging.Logger:
     """Get a logger for an execution group."""
     short = gpu_short_name(group.gpu_name)

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -20,7 +20,6 @@ from deplodock.deploy import (
     teardown as teardown_entry,
 )
 from deplodock.deploy.compose import generate_compose
-from deplodock.hardware import gpu_short_name
 from deplodock.planner import BenchmarkTask, ExecutionGroup
 from deplodock.provisioning.cloud import (
     delete_cloud_vm,
@@ -97,8 +96,7 @@ async def run_execution_group(
     hf_token = os.environ.get("HF_TOKEN", "")
     providers_config = config.get("providers", {})
 
-    short = gpu_short_name(group.gpu_name)
-    group_label = f"{short}_x_{group.gpu_count}"
+    group_label = group.label
     logger = _get_group_logger(group)
 
     # Attach per-group log file if we have a run_dir from the first task

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -6,7 +6,7 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 
-from deplodock.benchmark.bench_logging import _get_group_logger, active_run_dir
+from deplodock.benchmark.bench_logging import _get_group_logger, active_run_dir, add_group_file_handler
 from deplodock.benchmark.results import compose_json_result
 from deplodock.benchmark.system_info import collect_system_info
 from deplodock.benchmark.workload import compose_result, extract_benchmark_results, run_benchmark_workload
@@ -100,6 +100,14 @@ async def run_execution_group(
     short = gpu_short_name(group.gpu_name)
     group_label = f"{short}_x_{group.gpu_count}"
     logger = _get_group_logger(group)
+
+    # Attach per-group log file if we have a run_dir from the first task
+    group_handler = None
+    if group.tasks:
+        run_dir = group.tasks[0].run_dir
+        if run_dir is not None:
+            group_handler = add_group_file_handler(run_dir, group_label)
+
     logger.info(f"Starting group: {group.gpu_name} x{group.gpu_count} ({len(group.tasks)} tasks)")
 
     conn = None
@@ -195,6 +203,9 @@ async def run_execution_group(
 
     finally:
         active_run_dir.set(None)
+        if group_handler is not None:
+            logging.getLogger().removeHandler(group_handler)
+            group_handler.close()
         if conn is not None and conn.delete_info:
             if no_teardown:
                 instance_info = _build_instance_info(group, group_label, conn)

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -63,7 +63,7 @@ Benchmark configuration, task enumeration, and execution.
 
 **Modules:**
 - `config.py` — `load_config()`, `validate_config()`, `_expand_path()`
-- `bench_logging.py` — `setup_logging()`, `add_file_handler()`, `_get_group_logger()`, `active_run_dir` context var, `_RunDirFilter`, `_BenchConsoleFormatter`
+- `bench_logging.py` — `setup_logging()`, `add_file_handler()`, `add_group_file_handler()`, `_get_group_logger()`, `active_run_dir` context var, `_RunDirFilter`, `_GroupNameFilter`, `_BenchConsoleFormatter`
 - `workload.py` — `extract_benchmark_results()`, `run_benchmark_workload()`
 - `tasks.py` — `enumerate_tasks()`
 - `execution.py` — `run_execution_group()`, `_run_groups()`, `OnTaskDone` callback type

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -75,7 +75,7 @@ Groups benchmark tasks into execution groups for VM allocation.
 
 **Abstract interface (`planner/__init__.py`):**
 - `BenchmarkTask` — one recipe+variant combination (recipe_dir, variant, recipe, gpu_name, gpu_count); includes `task_id` property, `to_dict()`, `setup_run_dir()`, and static methods for run directory management (`compute_code_hash()`, `create_run_dir()`, `write_tasks_json()`, `read_tasks_json()`)
-- `ExecutionGroup` — group of tasks sharing one VM (gpu_name, gpu_count, tasks)
+- `ExecutionGroup` — group of tasks sharing one VM (gpu_name, gpu_count, tasks, index); `gpu_short` property returns short GPU name, `label` property returns unique label (e.g. `rtx5090_x_8` or `rtx5090_x_8_r01` when index is set)
 - `BenchmarkPlanner` — ABC with `plan(tasks) -> list[ExecutionGroup]`
 
 **Implementations:**

--- a/deplodock/planner/__init__.py
+++ b/deplodock/planner/__init__.py
@@ -111,6 +111,20 @@ class ExecutionGroup:
     gpu_name: str
     gpu_count: int
     tasks: list[BenchmarkTask] = field(default_factory=list)
+    index: int | None = None
+
+    @property
+    def gpu_short(self) -> str:
+        """Short GPU name (e.g. 'rtx5090')."""
+        return gpu_short_name(self.gpu_name)
+
+    @property
+    def label(self) -> str:
+        """Unique group label (e.g. 'rtx5090_x_8' or 'rtx5090_x_8_r01')."""
+        base = f"{self.gpu_short}_x_{self.gpu_count}"
+        if self.index is not None:
+            return f"{base}_r{self.index:02d}"
+        return base
 
 
 class BenchmarkPlanner(ABC):

--- a/deplodock/planner/group_by_model_and_gpu.py
+++ b/deplodock/planner/group_by_model_and_gpu.py
@@ -44,7 +44,7 @@ class GroupByModelAndGpuPlanner(BenchmarkPlanner):
                 for i, task in enumerate(group_tasks):
                     sub_groups[i % n_splits].append(task)
 
-                for sub in sub_groups:
+                for idx, sub in enumerate(sub_groups):
                     if sub:
                         max_count = max(t.gpu_count for t in sub)
                         result.append(
@@ -52,6 +52,7 @@ class GroupByModelAndGpuPlanner(BenchmarkPlanner):
                                 gpu_name=gpu,
                                 gpu_count=max_count,
                                 tasks=sub,
+                                index=idx + 1,
                             )
                         )
         return result


### PR DESCRIPTION
## Summary

When running execution groups in parallel (`gpu_concurrency > 1`), groups with the same GPU type collide on logger names, log files, and GCP instance names. This PR fixes that in two steps:

- **Per-group log files**: each execution group now writes a dedicated `benchmark_{group_label}.log` alongside the shared `benchmark.log`, using a `_GroupNameFilter` to route records. Adds `add_group_file_handler()` and wires it up in `run_execution_group()`
- **Unique group labels via `index`**: add an `index` field and `label`/`gpu_short` properties to `ExecutionGroup`. When `gpu_concurrency > 1`, sub-groups get `index=1, 2, ...` producing labels like `rtx5090_x_8_r01`, `rtx5090_x_8_r02`. Single groups keep `index=None` (no suffix, backward-compatible). Replace manual label construction in `bench_logging.py` and `execution.py` with `group.label`

### Before
```
benchmark.log               ← all groups interleaved
benchmark_rtx5090_x_8.log   ← collision when 2 groups share same GPU
bench-rtx5090-x-8           ← GCP name collision
```

### After
```
benchmark.log                   ← all groups (unchanged)
benchmark_rtx5090_x_8_r01.log  ← group 1 only
benchmark_rtx5090_x_8_r02.log  ← group 2 only
bench-rtx5090-x-8-r01          ← unique GCP instance name
bench-rtx5090-x-8-r02          ← unique GCP instance name
```

## Test plan

- [x] New tests: `test_execution_group_label`, `test_execution_group_gpu_short`, `test_gpu_concurrency_unique_labels`
- [x] All 210 tests pass (`make test`)
- [x] Lint clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)