### PR TITLE
Introduce Variant class to preserve raw matrix params

### DIFF
--- a/deplodock/benchmark/results.py
+++ b/deplodock/benchmark/results.py
@@ -3,7 +3,6 @@
 import re
 from dataclasses import asdict, dataclass
 
-from deplodock.hardware import gpu_short_name
 from deplodock.redact import redact_secrets
 
 
@@ -204,9 +203,9 @@ def compose_json_result(
     return {
         "task": {
             "recipe_dir": task.recipe_dir,
-            "variant": task.variant,
+            "variant": str(task.variant),
             "gpu_name": task.gpu_name,
-            "gpu_short": gpu_short_name(task.gpu_name),
+            "gpu_short": task.gpu_short,
             "gpu_count": task.gpu_count,
         },
         "recipe": asdict(task.recipe),

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -56,7 +56,7 @@ def format_task_yaml(task: BenchmarkTask) -> str:
     """
     data = {
         "recipe_dir": task.recipe_dir,
-        "variant": task.variant,
+        "variant": str(task.variant),
         "gpu_name": task.gpu_name,
         "gpu_count": task.gpu_count,
         "recipe": asdict(task.recipe),

--- a/deplodock/planner/__init__.py
+++ b/deplodock/planner/__init__.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 
 from deplodock.hardware import gpu_short_name
+from deplodock.planner.variant import Variant
 from deplodock.recipe.types import Recipe
 
 
@@ -18,11 +19,24 @@ class BenchmarkTask:
     """One recipe+variant combination to benchmark."""
 
     recipe_dir: str
-    variant: str
+    variant: Variant
     recipe: Recipe
-    gpu_name: str
-    gpu_count: int
     run_dir: Path | None = None
+
+    @property
+    def gpu_name(self) -> str:
+        """Full GPU name from recipe deploy config."""
+        return self.recipe.deploy.gpu
+
+    @property
+    def gpu_count(self) -> int:
+        """GPU count from recipe deploy config."""
+        return self.recipe.deploy.gpu_count
+
+    @property
+    def gpu_short(self) -> str:
+        """Short GPU name from variant."""
+        return self.variant.gpu_short
 
     @property
     def task_id(self) -> str:
@@ -53,10 +67,10 @@ class BenchmarkTask:
         return {
             "task_id": self.task_id,
             "recipe_dir": self.recipe_dir,
-            "variant": self.variant,
+            "variant": str(self.variant),
             "recipe_name": self.recipe_name,
             "gpu_name": self.gpu_name,
-            "gpu_short": gpu_short_name(self.gpu_name),
+            "gpu_short": self.gpu_short,
             "gpu_count": self.gpu_count,
             "model_name": self.model_name,
             "result_file": str(self.result_path().relative_to(self.run_dir)),

--- a/deplodock/planner/variant.py
+++ b/deplodock/planner/variant.py
@@ -1,0 +1,54 @@
+"""Variant: typed benchmark variant with raw matrix params."""
+
+from dataclasses import dataclass
+
+from deplodock.hardware import gpu_short_name
+
+
+def _abbreviate(snake_case_name: str) -> str:
+    """Abbreviate a snake_case name by taking the first letter of each word.
+
+    Examples: max_concurrent_requests → mcr, num_prompts → np, max_concurrency → mc
+    """
+    return "".join(word[0] for word in snake_case_name.split("_"))
+
+
+@dataclass(frozen=True)
+class Variant:
+    """A benchmark variant: one specific matrix combination.
+
+    Preserves the raw matrix params dict and derives the GPU short name,
+    GPU count, and string label via properties.
+    """
+
+    params: dict
+
+    @property
+    def gpu_short(self) -> str:
+        """Short GPU name (e.g. 'rtx5090')."""
+        return gpu_short_name(self.params["deploy.gpu"])
+
+    @property
+    def gpu_count(self) -> int:
+        """Number of GPUs for this variant."""
+        return self.params.get("deploy.gpu_count", 1)
+
+    def __str__(self) -> str:
+        gpu_part = f"{self.gpu_short}x{self.gpu_count}"
+        non_deploy = {k: v for k, v in self.params.items() if not k.startswith("deploy.")}
+        if not non_deploy:
+            return gpu_part
+        parts = []
+        for key in sorted(non_deploy):
+            last_segment = key.rsplit(".", 1)[-1]
+            abbrev = _abbreviate(last_segment)
+            parts.append(f"{abbrev}{non_deploy[key]}")
+        return f"{gpu_part}_{'_'.join(parts)}"
+
+    def __eq__(self, other):
+        if isinstance(other, Variant):
+            return self.params == other.params
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.params.items())))

--- a/deplodock/recipe/__init__.py
+++ b/deplodock/recipe/__init__.py
@@ -2,11 +2,9 @@
 
 from deplodock.recipe.engines import banned_extra_arg_flags, build_engine_args
 from deplodock.recipe.matrix import (
-    PARAM_ABBREVIATIONS,
     build_override,
     dot_to_nested,
     expand_matrix_entry,
-    matrix_label,
 )
 from deplodock.recipe.recipe import (
     _load_raw_config,
@@ -32,7 +30,6 @@ __all__ = [
     "EngineConfig",
     "LLMConfig",
     "ModelConfig",
-    "PARAM_ABBREVIATIONS",
     "Recipe",
     "SglangConfig",
     "VllmConfig",
@@ -45,6 +42,5 @@ __all__ = [
     "dot_to_nested",
     "expand_matrix_entry",
     "load_recipe",
-    "matrix_label",
     "validate_extra_args",
 ]

--- a/deplodock/recipe/matrix.py
+++ b/deplodock/recipe/matrix.py
@@ -1,15 +1,5 @@
 """Matrix expansion: broadcast + zip semantics for benchmark parameter sweeps."""
 
-# Abbreviations for common parameter names in auto-generated run identifiers.
-PARAM_ABBREVIATIONS = {
-    "max_concurrency": "c",
-    "num_prompts": "n",
-    "random_input_len": "in",
-    "random_output_len": "out",
-    "max_concurrent_requests": "mcr",
-    "context_length": "ctx",
-}
-
 
 def dot_to_nested(key: str, value) -> dict:
     """Convert a dot-notation key + value into a nested dict.
@@ -61,26 +51,6 @@ def expand_matrix_entry(entry: dict) -> list[dict]:
         combinations.append(combo)
 
     return combinations
-
-
-def matrix_label(combination: dict, variable_keys: set) -> str:
-    """Generate a filename-safe label from the variable (list) params of a combination.
-
-    Only variable keys (those that came from lists) contribute to the label.
-    Returns empty string for single-point entries (all scalars).
-    """
-    if not variable_keys:
-        return ""
-
-    parts = []
-    for key in sorted(variable_keys):
-        value = combination[key]
-        # Use last path segment for abbreviation lookup
-        last_segment = key.rsplit(".", 1)[-1]
-        abbrev = PARAM_ABBREVIATIONS.get(last_segment, last_segment)
-        parts.append(f"{abbrev}{value}")
-
-    return "_".join(parts)
 
 
 def build_override(combination: dict) -> dict:

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -26,7 +26,8 @@ tests/
 │   ├── test_deploy_dryrun.py        # deploy ssh/local CLI dry-run
 │   └── test_recipe.py       # load_recipe(), deep_merge(), validate_extra_args()
 ├── planner/
-│   └── test_planner.py      # BenchmarkTask, GroupByModelAndGpuPlanner
+│   ├── test_planner.py      # BenchmarkTask, GroupByModelAndGpuPlanner
+│   └── test_variant.py      # Variant class, _abbreviate()
 ├── provisioning/
 │   ├── test_cloud.py        # resolve_vm_spec(), delete_cloud_vm(), VMConnectionInfo
 │   ├── test_cloudrift.py    # CloudRift API helpers
@@ -47,7 +48,8 @@ Test individual functions in isolation with synthetic inputs.
 | `deploy/test_recipe.py` | `deplodock.recipe.load_recipe()`, `deep_merge()`, `validate_extra_args()` — recipe loading, variant resolution, YAML parsing, extra_args validation |
 | `deploy/test_compose.py` | `deplodock.deploy.generate_compose()`, `generate_nginx_conf()` — Docker Compose and nginx config generation, `gpu_device_ids` support |
 | `provisioning/test_cloud.py` | `deplodock.provisioning.cloud.resolve_vm_spec()`, `delete_cloud_vm()`, `VMConnectionInfo` — cloud provisioning unit tests |
-| `planner/test_planner.py` | `BenchmarkTask`, `GroupByModelAndGpuPlanner` — task properties (`recipe_name`, `result_path`), grouping logic, sorting |
+| `planner/test_planner.py` | `BenchmarkTask`, `GroupByModelAndGpuPlanner` — task properties (`recipe_name`, `result_path`, `gpu_name`, `gpu_count`, `gpu_short`), grouping logic, sorting |
+| `planner/test_variant.py` | `Variant` — `__str__`, `gpu_short`, `gpu_count`, `__eq__`, `__hash__`, `_abbreviate()` |
 | `test_hardware.py` | `resolve_instance_type()`, `gpu_short_name()`, `GPU_INSTANCE_TYPES` — hardware lookup tables |
 | `test_redact.py` | `deplodock.redact.redact_secrets()`, `SecretRedactingFilter` — value-based secret redaction for text and log records |
 | `benchmark/test_code_hash.py` | `BenchmarkTask.compute_code_hash()` — determinism, hex format |

--- a/tests/benchmark/test_results.py
+++ b/tests/benchmark/test_results.py
@@ -10,6 +10,7 @@ from deplodock.benchmark.results import (
     parse_system_info,
 )
 from deplodock.planner import BenchmarkTask
+from deplodock.planner.variant import Variant
 from deplodock.recipe.types import Recipe
 
 # ── Sample benchmark output (from real vLLM bench serve) ──────────
@@ -186,12 +187,17 @@ def _make_task(tmp_path: Path) -> BenchmarkTask:
             "deploy": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
         }
     )
+    variant = Variant(
+        params={
+            "deploy.gpu": "NVIDIA GeForce RTX 5090",
+            "deploy.gpu_count": 1,
+            "benchmark.max_concurrency": 8,
+        }
+    )
     return BenchmarkTask(
         recipe_dir="experiments/TestModel/test_experiment",
-        variant="rtx5090_c8",
+        variant=variant,
         recipe=recipe,
-        gpu_name="NVIDIA GeForce RTX 5090",
-        gpu_count=1,
         run_dir=tmp_path,
     )
 
@@ -210,7 +216,7 @@ def test_compose_json_result(tmp_path):
 
     # task section
     assert result["task"]["recipe_dir"] == "experiments/TestModel/test_experiment"
-    assert result["task"]["variant"] == "rtx5090_c8"
+    assert result["task"]["variant"] == "rtx5090x1_mc8"
     assert result["task"]["gpu_name"] == "NVIDIA GeForce RTX 5090"
     assert result["task"]["gpu_short"] == "rtx5090"
     assert result["task"]["gpu_count"] == 1

--- a/tests/benchmark/test_tasks_json.py
+++ b/tests/benchmark/test_tasks_json.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 from deplodock.planner import BenchmarkTask
+from deplodock.planner.variant import Variant
 
 
 def _make_task(variant, gpu_name, gpu_count, model_name, recipe_dir="/recipes/TestModel", run_dir=None):
@@ -10,12 +11,12 @@ def _make_task(variant, gpu_name, gpu_count, model_name, recipe_dir="/recipes/Te
     recipe = MagicMock()
     recipe.model_name = model_name
     recipe.engine.llm.engine_name = "vllm"
+    recipe.deploy.gpu = gpu_name
+    recipe.deploy.gpu_count = gpu_count
     task = BenchmarkTask(
         recipe_dir=recipe_dir,
         variant=variant,
         recipe=recipe,
-        gpu_name=gpu_name,
-        gpu_count=gpu_count,
     )
     if run_dir is not None:
         task.run_dir = run_dir
@@ -23,8 +24,16 @@ def _make_task(variant, gpu_name, gpu_count, model_name, recipe_dir="/recipes/Te
 
 
 def test_tasks_json_round_trip(tmp_path):
+    variant = Variant(
+        params={
+            "deploy.gpu": "NVIDIA GeForce RTX 5090",
+            "deploy.gpu_count": 1,
+            "benchmark.max_concurrency": 8,
+            "engine.llm.max_concurrent_requests": 8,
+        }
+    )
     task = _make_task(
-        variant="rtx5090_c8_mcr8",
+        variant=variant,
         gpu_name="NVIDIA GeForce RTX 5090",
         gpu_count=1,
         model_name="QuantTrio/Qwen3-Coder-30B-A3B-Instruct-AWQ",
@@ -34,17 +43,19 @@ def test_tasks_json_round_trip(tmp_path):
 
     result = BenchmarkTask.read_tasks_json(tmp_path)
     assert len(result) == 1
-    assert result[0]["variant"] == "rtx5090_c8_mcr8"
+    assert result[0]["variant"] == str(variant)
     assert result[0]["gpu_name"] == "NVIDIA GeForce RTX 5090"
-    assert result[0]["task_id"] == "TestModel/rtx5090_c8_mcr8"
+    assert result[0]["task_id"] == f"TestModel/{variant}"
 
 
 def test_tasks_json_multiple(tmp_path):
-    t1 = _make_task(variant="V1", gpu_name="G", gpu_count=1, model_name="m", run_dir=tmp_path)
-    t2 = _make_task(variant="V2", gpu_name="G", gpu_count=2, model_name="m", run_dir=tmp_path)
+    v1 = Variant(params={"deploy.gpu": "G", "deploy.gpu_count": 1})
+    v2 = Variant(params={"deploy.gpu": "G", "deploy.gpu_count": 2})
+    t1 = _make_task(variant=v1, gpu_name="G", gpu_count=1, model_name="m", run_dir=tmp_path)
+    t2 = _make_task(variant=v2, gpu_name="G", gpu_count=2, model_name="m", run_dir=tmp_path)
     BenchmarkTask.write_tasks_json(tmp_path, [t1, t2])
 
     result = BenchmarkTask.read_tasks_json(tmp_path)
     assert len(result) == 2
-    assert result[0]["variant"] == "V1"
+    assert result[0]["variant"] == str(v1)
     assert result[1]["gpu_count"] == 2

--- a/tests/planner/test_variant.py
+++ b/tests/planner/test_variant.py
@@ -1,0 +1,158 @@
+"""Unit tests for the Variant class."""
+
+from deplodock.planner.variant import Variant, _abbreviate
+
+# ── _abbreviate ──────────────────────────────────────────────────
+
+
+def test_abbreviate_single_word():
+    assert _abbreviate("prompts") == "p"
+
+
+def test_abbreviate_two_words():
+    assert _abbreviate("num_prompts") == "np"
+
+
+def test_abbreviate_three_words():
+    assert _abbreviate("max_concurrent_requests") == "mcr"
+
+
+def test_abbreviate_max_concurrency():
+    assert _abbreviate("max_concurrency") == "mc"
+
+
+def test_abbreviate_random_input_len():
+    assert _abbreviate("random_input_len") == "ril"
+
+
+def test_abbreviate_context_length():
+    assert _abbreviate("context_length") == "cl"
+
+
+# ── Variant.__str__ ──────────────────────────────────────────────
+
+
+def test_str_deploy_only():
+    v = Variant(params={"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 1})
+    assert str(v) == "rtx5090x1"
+
+
+def test_str_deploy_multi_gpu():
+    v = Variant(params={"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 4})
+    assert str(v) == "rtx5090x4"
+
+
+def test_str_with_one_non_deploy_param():
+    v = Variant(
+        params={
+            "deploy.gpu": "NVIDIA GeForce RTX 5090",
+            "deploy.gpu_count": 1,
+            "benchmark.max_concurrency": 128,
+        }
+    )
+    assert str(v) == "rtx5090x1_mc128"
+
+
+def test_str_with_multiple_non_deploy_params():
+    v = Variant(
+        params={
+            "deploy.gpu": "NVIDIA GeForce RTX 5090",
+            "deploy.gpu_count": 1,
+            "benchmark.max_concurrency": 8,
+            "engine.llm.max_concurrent_requests": 8,
+            "benchmark.num_prompts": 80,
+        }
+    )
+    result = str(v)
+    assert result.startswith("rtx5090x1_")
+    assert "mc8" in result
+    assert "mcr8" in result
+    assert "np80" in result
+
+
+def test_str_params_sorted():
+    v = Variant(
+        params={
+            "deploy.gpu": "NVIDIA GeForce RTX 5090",
+            "benchmark.num_prompts": 80,
+            "benchmark.max_concurrency": 8,
+        }
+    )
+    result = str(v)
+    # benchmark.max_concurrency sorts before benchmark.num_prompts
+    assert result == "rtx5090x1_mc8_np80"
+
+
+def test_str_default_gpu_count():
+    """gpu_count defaults to 1 when not in params."""
+    v = Variant(params={"deploy.gpu": "NVIDIA GeForce RTX 5090"})
+    assert str(v) == "rtx5090x1"
+
+
+# ── Variant.gpu_short ────────────────────────────────────────────
+
+
+def test_gpu_short_known():
+    v = Variant(params={"deploy.gpu": "NVIDIA GeForce RTX 5090"})
+    assert v.gpu_short == "rtx5090"
+
+
+def test_gpu_short_h100():
+    v = Variant(params={"deploy.gpu": "NVIDIA H100 80GB"})
+    assert v.gpu_short == "h100"
+
+
+# ── Variant.gpu_count ────────────────────────────────────────────
+
+
+def test_gpu_count_explicit():
+    v = Variant(params={"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 4})
+    assert v.gpu_count == 4
+
+
+def test_gpu_count_default():
+    v = Variant(params={"deploy.gpu": "NVIDIA GeForce RTX 5090"})
+    assert v.gpu_count == 1
+
+
+# ── Variant.__eq__ ───────────────────────────────────────────────
+
+
+def test_eq_same_params():
+    v1 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    v2 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    assert v1 == v2
+
+
+def test_eq_different_params():
+    v1 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    v2 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 2})
+    assert v1 != v2
+
+
+def test_eq_not_implemented_for_str():
+    v = Variant(params={"deploy.gpu": "GPU_A"})
+    assert v != "some_string"
+
+
+# ── Variant.__hash__ ─────────────────────────────────────────────
+
+
+def test_hash_consistent():
+    v1 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    v2 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    assert hash(v1) == hash(v2)
+
+
+def test_hash_different_for_different_params():
+    v1 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    v2 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 2})
+    assert hash(v1) != hash(v2)
+
+
+def test_usable_in_set():
+    v1 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    v2 = Variant(params={"deploy.gpu": "GPU_A", "deploy.gpu_count": 1})
+    v3 = Variant(params={"deploy.gpu": "GPU_B", "deploy.gpu_count": 1})
+    s = {v1, v2, v3}
+    assert len(s) == 2

--- a/tests/recipe/test_matrix.py
+++ b/tests/recipe/test_matrix.py
@@ -3,11 +3,9 @@
 import pytest
 
 from deplodock.recipe.matrix import (
-    PARAM_ABBREVIATIONS,
     build_override,
     dot_to_nested,
     expand_matrix_entry,
-    matrix_label,
 )
 
 # ── dot_to_nested ──────────────────────────────────────────────────
@@ -67,47 +65,6 @@ def test_expand_mismatched_list_lengths_raises():
     }
     with pytest.raises(ValueError, match="same length"):
         expand_matrix_entry(entry)
-
-
-# ── matrix_label ───────────────────────────────────────────────────
-
-
-def test_matrix_label_no_variables():
-    combo = {"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}
-    assert matrix_label(combo, set()) == ""
-
-
-def test_matrix_label_single_variable():
-    combo = {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 128}
-    label = matrix_label(combo, {"benchmark.max_concurrency"})
-    assert label == "c128"
-
-
-def test_matrix_label_multiple_variables():
-    combo = {
-        "deploy.gpu": "NVIDIA RTX 5090",
-        "engine.llm.max_concurrent_requests": 256,
-        "benchmark.max_concurrency": 128,
-    }
-    label = matrix_label(combo, {"engine.llm.max_concurrent_requests", "benchmark.max_concurrency"})
-    assert "c128" in label
-    assert "mcr256" in label
-
-
-def test_matrix_label_unknown_key_uses_last_segment():
-    combo = {"engine.llm.some_new_param": 42}
-    label = matrix_label(combo, {"engine.llm.some_new_param"})
-    assert label == "some_new_param42"
-
-
-def test_param_abbreviations_coverage():
-    """Known params all have abbreviations."""
-    assert "max_concurrency" in PARAM_ABBREVIATIONS
-    assert "num_prompts" in PARAM_ABBREVIATIONS
-    assert "random_input_len" in PARAM_ABBREVIATIONS
-    assert "random_output_len" in PARAM_ABBREVIATIONS
-    assert "max_concurrent_requests" in PARAM_ABBREVIATIONS
-    assert "context_length" in PARAM_ABBREVIATIONS
 
 
 # ── build_override ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add frozen `Variant` dataclass (`deplodock/planner/variant.py`) that stores raw matrix params dict and derives `gpu_short`, `gpu_count`, and label string via properties
- Replace `BenchmarkTask.variant: str` with `Variant` object; remove redundant `gpu_name`/`gpu_count` fields (now properties delegating to `recipe.deploy`)
- Remove `PARAM_ABBREVIATIONS` dict and `matrix_label()` from `matrix.py` — abbreviation now uses a first-letter-per-word heuristic in `Variant.__str__`
- **Breaking change**: variant string format changes (e.g. `rtx5090_c8_mcr8` → `rtx5090x1_mc8_mcr8`) since ALL params appear in the label, not just variable ones

## Test plan

- [x] All 228 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] New `tests/planner/test_variant.py` with 21 tests covering `_abbreviate()`, `__str__`, `gpu_short`, `gpu_count`, `__eq__`, `__hash__`
- [x] Updated existing tests in `test_planner.py`, `test_tasks_json.py`, `test_results.py`, `test_matrix.py`
- [x] Updated ARCHITECTURE.md files for recipe and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)