### PR TITLE
Fix per-group log files missing provisioning and deploy logs

### DIFF
--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -36,6 +36,7 @@ class _BenchConsoleFormatter(logging.Formatter):
     """
 
     def format(self, record):
+        saved_name = record.name
         if record.name.startswith("deplodock."):
             # Library logger: show last segment only
             record.name = record.name.rsplit(".", 1)[-1]
@@ -43,7 +44,9 @@ class _BenchConsoleFormatter(logging.Formatter):
             # Bench group logger: split into [server] [model]
             server, model = record.name.split(".", 1)
             record.name = f"{server}] [{model}"
-        return super().format(record)
+        result = super().format(record)
+        record.name = saved_name
+        return result
 
 
 def setup_logging():

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -108,6 +108,10 @@ async def run_execution_group(
 
     logger.info(f"Starting group: {group.gpu_name} x{group.gpu_count} ({len(group.tasks)} tasks)")
 
+    # Set active_run_dir early so provisioning logs are captured by the group handler
+    if group.tasks and group.tasks[0].run_dir is not None:
+        active_run_dir.set(group.tasks[0].run_dir)
+
     conn = None
     try:
         conn = await provision_cloud_vm(

--- a/tests/benchmark/test_bench_dryrun.py
+++ b/tests/benchmark/test_bench_dryrun.py
@@ -1,5 +1,6 @@
 """Dry-run tests for the bench command."""
 
+import glob
 import os
 from pathlib import Path
 
@@ -121,6 +122,85 @@ def test_bench_experiment_dry_run(run_cli, make_bench_config, project_root, tmp_
     # Results should go directly into the experiment dir
     expected_parent = str(Path(experiment).resolve())
     assert expected_parent in stdout
+
+
+def test_bench_group_log_captures_provisioning(run_cli, make_bench_config, tmp_path):
+    """Per-group log files should contain provisioning and deploy logs."""
+    import shutil
+
+    import yaml
+
+    # Create a minimal recipe in tmp_path so we don't pollute the repo
+    recipe_dir = tmp_path / "TestRecipe"
+    recipe_dir.mkdir()
+    recipe = {
+        "model": {"huggingface": "test-org/test-model"},
+        "engine": {
+            "llm": {
+                "tensor_parallel_size": 1,
+                "pipeline_parallel_size": 1,
+                "gpu_memory_utilization": 0.9,
+                "context_length": 8192,
+                "vllm": {"image": "vllm/vllm-openai:latest"},
+            }
+        },
+        "benchmark": {
+            "max_concurrency": 128,
+            "num_prompts": 256,
+            "random_input_len": 4000,
+            "random_output_len": 4000,
+        },
+        "matrices": [
+            {"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 1},
+        ],
+    }
+    (recipe_dir / "recipe.yaml").write_text(yaml.dump(recipe))
+
+    config_path = make_bench_config(tmp_path)
+    rc, stdout, stderr = run_cli(
+        "bench",
+        str(recipe_dir),
+        "--config",
+        config_path,
+        "--dry-run",
+    )
+    assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
+
+    # Find the per-group log file (benchmark_rtx5090_x_1.log)
+    group_logs = glob.glob(str(recipe_dir / "*/benchmark_rtx5090_x_1.log"))
+    assert group_logs, f"No per-group log file found under {recipe_dir}"
+
+    log = Path(group_logs[0]).read_text()
+
+    # Group logger messages (rtx5090_x_1.*)
+    assert "Starting group:" in log, f"Group start missing.\nLog:\n{log}"
+    assert "Deploying model..." in log, f"Deploy start missing.\nLog:\n{log}"
+    assert "Running benchmark..." in log, f"Benchmark start missing.\nLog:\n{log}"
+    assert "Tearing down..." in log, f"Teardown missing.\nLog:\n{log}"
+
+    # Cloud provisioning (deplodock.provisioning.cloudrift)
+    assert "Creating CloudRift instance" in log, f"CloudRift provisioning missing.\nLog:\n{log}"
+
+    # Remote provisioning (deplodock.provisioning.remote)
+    assert "install docker" in log, f"Remote provisioning missing.\nLog:\n{log}"
+    assert "install nvidia-container-toolkit" in log, f"NVIDIA toolkit provisioning missing.\nLog:\n{log}"
+
+    # Deploy orchestration (deplodock.deploy.orchestrate)
+    assert "Pulling images" in log, f"Image pull missing.\nLog:\n{log}"
+    assert "Downloading model" in log, f"Model download missing.\nLog:\n{log}"
+    assert "Cleaning up old containers" in log, f"Container cleanup missing.\nLog:\n{log}"
+    assert "Starting services" in log, f"Service start missing.\nLog:\n{log}"
+    assert "Waiting for health check" in log, f"Health check missing.\nLog:\n{log}"
+    assert "Teardown complete." in log, f"Teardown complete missing.\nLog:\n{log}"
+
+    # SSH transport (deplodock.provisioning.ssh_transport)
+    assert "docker compose pull" in log, f"SSH docker compose pull missing.\nLog:\n{log}"
+    assert "docker compose up" in log, f"SSH docker compose up missing.\nLog:\n{log}"
+
+    # Clean up run dirs created in tmp_path
+    for d in recipe_dir.iterdir():
+        if d.is_dir() and d.name != "recipe.yaml":
+            shutil.rmtree(d)
 
 
 def test_bench_help(run_cli):


### PR DESCRIPTION
## Summary
- **Bug 1**: `active_run_dir` context var was only set inside the per-task loop, so all provisioning logs (VM creation, `provision_remote`) emitted before the loop were rejected by `_GroupNameFilter` — they only went to `benchmark.log`
- **Bug 2**: `_BenchConsoleFormatter.format()` mutated `record.name` in-place (e.g. `deplodock.deploy.orchestrate` → `orchestrate`). Since the console handler runs first, file handlers saw the mangled name and `_GroupNameFilter` rejected all `deplodock.*` logs from group files
- Added `test_bench_group_log_captures_provisioning` that asserts group log files contain logs from all sources: group logger, cloud provisioning, remote provisioning, deploy orchestration, and SSH transport

## Test plan
- [x] `make test` — 211 tests pass (210 existing + 1 new)
- [x] `make lint` — clean
- [x] Verified with a manual dry-run that group log files now contain full provisioning and deploy output

🤖 Generated with [Claude Code](https://claude.com/claude-code)