### PR TITLE
Log instance ID and details in bench per-runner logs

### DIFF
--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -130,7 +130,8 @@ async def run_execution_group(
                 await _invoke_callback(on_task_done, task, False, logger)
             return task_results, None
 
-        logger.info(f"VM provisioned: {conn.address}:{conn.ssh_port}")
+        instance_id_str = f" (instance_id={conn.delete_info[1]})" if conn.delete_info else ""
+        logger.info(f"VM provisioned: {conn.address}:{conn.ssh_port}{instance_id_str}")
         await provision_remote(conn.address, ssh_key, conn.ssh_port, dry_run=dry_run)
 
         # Collect system info once per execution group

--- a/deplodock/provisioning/cloudrift.py
+++ b/deplodock/provisioning/cloudrift.py
@@ -323,6 +323,7 @@ async def create_instance(
         return None
 
     logger.info("Instance is Active.")
+    logger.info(f"Instance details: {json.dumps(info, indent=2)}")
     conn = _extract_connection_info(info, delete_info=("cloudrift", instance_id))
     _log_connection_info(info)
 


### PR DESCRIPTION
## Summary
- Log instance ID at the group logger level in `execution.py` so it appears only in the correct per-runner log file (e.g. `benchmark_rtx5090_x_1_r02.log`)
- Dump full CloudRift instance JSON response after activation in `cloudrift.py` for post-mortem debugging (node_id, resource_info, VM details, etc.)

## Context
During the `qwen3-coder-5090-ctx-sweep` experiment, runner r02 hit a CUDA device failure mid-run. All 8 runners' provisioning logs were interleaved in each per-runner log file with no way to correlate instance IDs to specific runners, making it impossible to identify which physical GPU was affected.

## Test plan
- [x] `make test` — 239 passed
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)