### PR TITLE
Add MCR sweep plotting script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Tools for deploying and benchmarking LLM inference on GPU servers. Supports **vL
 - [docs/](docs/) — Technical notes and engine-specific guides
   - [sglang-awq-moe.md](docs/sglang-awq-moe.md) — SGLang quantization for AWQ MoE models
 - [tests/](tests/) — pytest tests (see [ARCHITECTURE.md](tests/ARCHITECTURE.md))
+- [scripts/](scripts/) — Analysis and visualization scripts
 - [utils/](utils/) — Standalone utility scripts
 - [config.yaml](config.yaml) — Benchmark configuration
 - [Makefile](Makefile) — Build automation

--- a/experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090/2026-03-03_02-07-22_417ad7f8/mcr_sweep.png
+++ b/experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090/2026-03-03_02-07-22_417ad7f8/mcr_sweep.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bce1fb0deacc117f150171acd36aa7712180b9e887e5033b46bfa8b30574d6a
+size 119366

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-asyncio"]
-dev = ["pytest", "pytest-asyncio", "ruff"]
+plot = ["matplotlib"]
+dev = ["pytest", "pytest-asyncio", "ruff", "matplotlib"]
 
 [tool.setuptools.packages.find]
 include = ["deplodock*"]

--- a/scripts/plot_mcr_sweep.py
+++ b/scripts/plot_mcr_sweep.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Plot benchmark metrics from an MCR (max concurrent requests) sweep experiment."""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+
+from deplodock.logging_setup import setup_cli_logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_results(results_dir):
+    """Load all benchmark JSON files from a results directory."""
+    results = []
+    for path in sorted(results_dir.glob("*_benchmark.json")):
+        with open(path) as f:
+            data = json.load(f)
+        # Some files may contain a list (e.g. tasks.json parsed wrong); skip those
+        if isinstance(data, list):
+            continue
+        mcr = data["recipe"]["benchmark"]["max_concurrency"]
+        metrics = data["metrics"]
+        results.append({"mcr": mcr, **metrics})
+    results.sort(key=lambda r: r["mcr"])
+    return results
+
+
+def plot_mcr_sweep(results, engine, model, gpu, output_path):
+    """Create a single plot with throughput, median TTFT, and median TPOT vs MCR."""
+    mcr_values = [r["mcr"] for r in results]
+    output_throughput = [r["output_token_throughput"] for r in results]
+    median_ttft = [r["median_ttft_ms"] for r in results]
+    median_tpot = [r["median_tpot_ms"] for r in results]
+
+    fig, ax1 = plt.subplots(figsize=(10, 6))
+    fig.suptitle(
+        f"{model} on {gpu} ({engine})\nOptimal Max Concurrent Requests Sweep",
+        fontsize=13,
+        fontweight="bold",
+        y=0.98,
+    )
+
+    marker_opts = dict(markersize=6, linewidth=2)
+    color_throughput = "#2563eb"
+    color_ttft = "#dc2626"
+    color_tpot = "#f59e0b"
+
+    # Left y-axis: throughput
+    ax1.set_xlabel("Max Concurrent Requests")
+    ax1.set_ylabel("Output Token Throughput (tok/s)", color=color_throughput)
+    ax1.plot(mcr_values, output_throughput, "o-", color=color_throughput, label="Throughput (tok/s)", **marker_opts)
+    ax1.tick_params(axis="y", labelcolor=color_throughput)
+    ax1.set_xticks(mcr_values)
+    ax1.yaxis.set_major_formatter(ticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+    ax1.grid(True, alpha=0.3)
+
+    # Annotate peak throughput
+    peak_idx = output_throughput.index(max(output_throughput))
+    ax1.annotate(
+        f"{output_throughput[peak_idx]:,.0f}",
+        (mcr_values[peak_idx], output_throughput[peak_idx]),
+        textcoords="offset points",
+        xytext=(0, 12),
+        ha="center",
+        fontsize=9,
+        fontweight="bold",
+        color=color_throughput,
+    )
+
+    # Right y-axis: latency (TTFT and TPOT)
+    ax2 = ax1.twinx()
+    ax2.set_ylabel("Latency (ms)")
+    ax2.plot(mcr_values, median_ttft, "s--", color=color_ttft, label="Median TTFT (ms)", **marker_opts)
+    ax2.plot(mcr_values, median_tpot, "^:", color=color_tpot, label="Median TPOT (ms)", **marker_opts)
+    ax2.tick_params(axis="y")
+
+    # Combined legend
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="center right")
+
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    logger.info("Saved plot to %s", output_path)
+
+
+def main():
+    setup_cli_logging()
+    parser = argparse.ArgumentParser(description="Plot MCR sweep benchmark results.")
+    parser.add_argument("results_dir", type=Path, help="Path to experiment results directory")
+    parser.add_argument(
+        "--engine",
+        default="vLLM",
+        help="Engine name for plot title (default: vLLM)",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model name for plot title (default: auto-detect from results)",
+    )
+    parser.add_argument(
+        "--gpu",
+        default=None,
+        help="GPU name for plot title (default: auto-detect from results)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file path (default: <results_dir>/mcr_sweep.png)",
+    )
+    args = parser.parse_args()
+
+    if not args.results_dir.is_dir():
+        logger.error("Error: %s is not a directory", args.results_dir)
+        sys.exit(1)
+
+    results = load_results(args.results_dir)
+    if not results:
+        logger.error("Error: no benchmark JSON files found in %s", args.results_dir)
+        sys.exit(1)
+
+    # Auto-detect model and GPU from first result file if not specified
+    first_json = next(args.results_dir.glob("*_benchmark.json"))
+    with open(first_json) as f:
+        first_data = json.load(f)
+    if isinstance(first_data, list):
+        first_data = first_data[0]
+
+    model = args.model or first_data["recipe"]["model"]["huggingface"].split("/")[-1]
+    gpu = args.gpu or first_data["task"].get("gpu_name", "GPU")
+    output_path = args.output or args.results_dir / "mcr_sweep.png"
+
+    plot_mcr_sweep(results, args.engine, model, gpu, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -33,6 +33,8 @@ tests/
 │   ├── test_cloudrift.py    # CloudRift API helpers
 │   ├── test_gcp.py             # GCP command builders
 │   └── test_vm_dryrun.py    # vm create/delete CLI dry-run
+├── scripts/
+│   └── test_plot_mcr_sweep.py  # load_results() from scripts/plot_mcr_sweep.py
 ```
 
 ## Test Layers
@@ -58,6 +60,7 @@ Test individual functions in isolation with synthetic inputs.
 | `benchmark/test_results.py` | `parse_benchmark_metrics()`, `parse_system_info()`, `compose_json_result()` — structured JSON result parsing and composition |
 | `provisioning/test_cloudrift.py` | `deplodock.provisioning.cloudrift._api_request()`, `_rent_instance()`, etc. — CloudRift API helpers |
 | `provisioning/test_gcp.py` | `deplodock.provisioning.gcp._gcloud_*_cmd()` — GCP command builders |
+| `scripts/test_plot_mcr_sweep.py` | `load_results()` — benchmark JSON loading and sorting from `scripts/plot_mcr_sweep.py` |
 
 Unit tests use **fixtures from `conftest.py`** (`tmp_recipe_dir`, `sample_config`, `sample_config_multi`) to supply pre-built recipe directories and config dicts.
 

--- a/tests/scripts/test_plot_mcr_sweep.py
+++ b/tests/scripts/test_plot_mcr_sweep.py
@@ -1,0 +1,128 @@
+"""Tests for scripts/plot_mcr_sweep.py — load_results() function."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Add scripts/ to sys.path so we can import the module directly
+@pytest.fixture(autouse=True)
+def _add_scripts_to_path():
+    scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
+    sys.path.insert(0, scripts_dir)
+    yield
+    sys.path.remove(scripts_dir)
+
+
+def _write_benchmark_json(directory, filename, mcr, output_throughput, mean_ttft, median_ttft, p99_ttft, mean_tpot, median_tpot, p99_tpot):
+    """Write a minimal benchmark JSON file."""
+    data = {
+        "task": {"gpu_name": "NVIDIA GeForce RTX 5090", "gpu_short": "rtx5090", "gpu_count": 1},
+        "recipe": {
+            "model": {"huggingface": "org/test-model"},
+            "benchmark": {"max_concurrency": mcr},
+        },
+        "metrics": {
+            "output_token_throughput": output_throughput,
+            "mean_ttft_ms": mean_ttft,
+            "median_ttft_ms": median_ttft,
+            "p99_ttft_ms": p99_ttft,
+            "mean_tpot_ms": mean_tpot,
+            "median_tpot_ms": median_tpot,
+            "p99_tpot_ms": p99_tpot,
+        },
+    }
+    path = directory / filename
+    path.write_text(json.dumps(data))
+    return path
+
+
+# --- load_results ---
+
+
+def test_load_results(tmp_path):
+    """load_results returns sorted results with correct metric values."""
+    from plot_mcr_sweep import load_results
+
+    # Write in non-sorted order to verify sorting
+    _write_benchmark_json(
+        tmp_path,
+        "mc16_benchmark.json",
+        mcr=16,
+        output_throughput=1200,
+        mean_ttft=100,
+        median_ttft=90,
+        p99_ttft=200,
+        mean_tpot=10,
+        median_tpot=9,
+        p99_tpot=15,
+    )
+    _write_benchmark_json(
+        tmp_path,
+        "mc8_benchmark.json",
+        mcr=8,
+        output_throughput=900,
+        mean_ttft=50,
+        median_ttft=45,
+        p99_ttft=100,
+        mean_tpot=8,
+        median_tpot=7,
+        p99_tpot=12,
+    )
+    _write_benchmark_json(
+        tmp_path,
+        "mc32_benchmark.json",
+        mcr=32,
+        output_throughput=1400,
+        mean_ttft=300,
+        median_ttft=250,
+        p99_ttft=600,
+        mean_tpot=15,
+        median_tpot=14,
+        p99_tpot=25,
+    )
+
+    results = load_results(tmp_path)
+
+    assert len(results) == 3
+    # Sorted by MCR
+    assert [r["mcr"] for r in results] == [8, 16, 32]
+    # Check metric values from first entry (mcr=8)
+    assert results[0]["output_token_throughput"] == 900
+    assert results[0]["mean_ttft_ms"] == 50
+    assert results[0]["mean_tpot_ms"] == 8
+
+
+def test_load_results_empty_dir(tmp_path):
+    """Empty directory returns empty list."""
+    from plot_mcr_sweep import load_results
+
+    results = load_results(tmp_path)
+    assert results == []
+
+
+def test_load_results_skips_non_benchmark(tmp_path):
+    """Non-benchmark files (like tasks.json) are ignored."""
+    from plot_mcr_sweep import load_results
+
+    # Write a tasks.json (should be ignored — doesn't match *_benchmark.json)
+    (tmp_path / "tasks.json").write_text(json.dumps([{"task": "foo"}]))
+    # Write a real benchmark file
+    _write_benchmark_json(
+        tmp_path,
+        "mc8_benchmark.json",
+        mcr=8,
+        output_throughput=900,
+        mean_ttft=50,
+        median_ttft=45,
+        p99_ttft=100,
+        mean_tpot=8,
+        median_tpot=7,
+        p99_tpot=12,
+    )
+
+    results = load_results(tmp_path)
+    assert len(results) == 1
+    assert results[0]["mcr"] == 8


### PR DESCRIPTION
## Summary

- Add `scripts/plot_mcr_sweep.py` — single-graph plot with throughput (left axis) and median TTFT/TPOT (right axis) vs max concurrent requests
- Configure git LFS for image files (`.png`, `.jpg`, `.jpeg`)
- Add `matplotlib` as optional dependency (`plot` extra, included in `dev`)
- Add generated MCR sweep plot for Qwen3-Coder-30B-A3B on RTX 5090 experiment
- Add tests for `load_results()` (sorted output, empty dir, non-benchmark file skipping)

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (249 tests)
- [x] Smoke test: `./venv/bin/python scripts/plot_mcr_sweep.py experiments/.../2026-03-03_02-07-22_417ad7f8 --engine vLLM` generates plot
- [x] Verify LFS tracking: `git lfs ls-files` shows the png

🤖 Generated with [Claude Code](https://claude.com/claude-code)