### PR TITLE
fix: ensure all benchmark results are committed and pushed

### DIFF
--- a/.github/scripts/format-results.py
+++ b/.github/scripts/format-results.py
@@ -7,7 +7,20 @@ task_id + pass/fail status based on whether the result file exists.
 
 import argparse
 import json
+import subprocess
 from pathlib import Path
+
+
+def _is_tracked_in_git(path: Path) -> bool:
+    """Check if a file is tracked (committed) in git."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", str(path)],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
 
 
 def find_latest_run_dir(experiment_dir: str) -> Path | None:
@@ -51,9 +64,14 @@ def format_comment(experiments: list[str]) -> str:
         for t in tasks:
             task_id = t.get("task_id", t.get("result_file", "unknown"))
             result_path = run_dir / t["result_file"]
-            if result_path.exists():
+            in_git = _is_tracked_in_git(result_path)
+            if in_git:
                 any_results = True
                 lines.append(f"| `{task_id}` | pass |")
+            elif result_path.exists():
+                any_results = True
+                all_succeeded = False
+                lines.append(f"| `{task_id}` | pass (uncommitted) |")
             else:
                 all_succeeded = False
                 lines.append(f"| `{task_id}` | fail |")

--- a/.github/workflows/experiment.yml
+++ b/.github/workflows/experiment.yml
@@ -245,14 +245,13 @@ jobs:
 
           # Force-add any uncommitted results (catch-up for anything missed)
           git add --force $result_files
-          if git diff --cached --quiet; then
-            echo "No new results to commit"
-            exit 0
-          fi
-
-          git commit -m "bench: collect remaining results
+          if ! git diff --cached --quiet; then
+            git commit -m "bench: collect remaining results
 
           Triggered by /run-experiment in PR #${{ needs.gate.outputs.pr_number }}"
+          fi
+
+          # Always push — catches any unpushed per-task commits
           git push || echo "::warning::Failed to push results to PR branch (fork may not allow edits from maintainers)"
 
       - name: Format result comment

--- a/deplodock/commands/bench/committer.py
+++ b/deplodock/commands/bench/committer.py
@@ -44,6 +44,12 @@ class GitCommitter:
 
             logger.info(f"Committed: {message}")
 
+            # Pull --rebase before push to handle concurrent updates
+            rc, _, stderr = await run_shell_cmd(["git", "pull", "--rebase"], timeout=60)
+            if rc != 0:
+                logger.warning(f"git pull --rebase failed: {stderr}")
+                return
+
             # Push (warn on failure, never raise)
             rc, _, stderr = await run_shell_cmd(["git", "push"], timeout=60)
             if rc != 0:


### PR DESCRIPTION
## Summary

- **Catch-up step always pushes**: removed early exit when no new staged changes, so locally-committed-but-unpushed per-task results get pushed
- **Committer pulls before push**: added `git pull --rebase` before `git push` in the per-task committer to handle remote branch divergence
- **format-results.py checks git, not filesystem**: uses `git ls-files --error-unmatch` to verify results are committed; shows "pass (uncommitted)" for results on disk but not in git

## Test plan

- [x] `make test` — 249 passed
- [x] `make lint` — clean
- [ ] Manual trace: if `git push` fails on task 1, the catch-up step now pushes the local commit
- [ ] Verify PR comment correctly reports uncommitted results after a partial push failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)