### PR TITLE
Add data_parallel_size and fix SGLang flag mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ matrices:
 | Recipe YAML key           | vLLM CLI flag              | SGLang CLI flag          |
 |---------------------------|----------------------------|--------------------------|
 | `tensor_parallel_size`    | `--tensor-parallel-size`   | `--tp`                   |
-| `pipeline_parallel_size`  | `--pipeline-parallel-size` | `--dp`                   |
+| `pipeline_parallel_size`  | `--pipeline-parallel-size` | `--pp`                   |
+| `data_parallel_size`      | `--data-parallel-size`     | `--dp`                   |
 | `gpu_memory_utilization`  | `--gpu-memory-utilization` | `--mem-fraction-static`  |
 | `context_length`          | `--max-model-len`          | `--context-length`       |
 | `max_concurrent_requests` | `--max-num-seqs`           | `--max-running-requests` |

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -92,7 +92,8 @@ Engine-agnostic serving parameters are promoted to first-class named fields on `
 | Field | vLLM flag | SGLang flag |
 |---|---|---|
 | `tensor_parallel_size` | `--tensor-parallel-size` | `--tp` |
-| `pipeline_parallel_size` | `--pipeline-parallel-size` | `--dp` |
+| `pipeline_parallel_size` | `--pipeline-parallel-size` | `--pp` |
+| `data_parallel_size` | `--data-parallel-size` | `--dp` |
 | `gpu_memory_utilization` | `--gpu-memory-utilization` | `--mem-fraction-static` |
 | `context_length` | `--max-model-len` | `--context-length` |
 | `max_concurrent_requests` | `--max-num-seqs` | `--max-running-requests` |
@@ -101,7 +102,7 @@ This design provides:
 
 1. **Type safety** — numeric values are validated at parse time, not when Docker fails.
 2. **Engine portability** — the same recipe field maps to different CLI flags per engine via `VLLM_FLAG_MAP` / `SGLANG_FLAG_MAP` in `engines.py`.
-3. **Computed properties** — `LLMConfig.gpus_per_instance` derives from `tensor_parallel_size * pipeline_parallel_size` without parsing strings.
+3. **Computed properties** — `LLMConfig.gpus_per_instance` derives from `tensor_parallel_size * pipeline_parallel_size * data_parallel_size` without parsing strings.
 4. **Deep merge support** — named fields participate in matrix merging naturally. An `extra_args` string cannot be partially overridden.
 
 ### Extra Args Ban Enforcement

--- a/deplodock/recipe/engines.py
+++ b/deplodock/recipe/engines.py
@@ -7,6 +7,7 @@ from deplodock.recipe.types import LLMConfig
 VLLM_FLAG_MAP = {
     "tensor_parallel_size": "--tensor-parallel-size",
     "pipeline_parallel_size": "--pipeline-parallel-size",
+    "data_parallel_size": "--data-parallel-size",
     "gpu_memory_utilization": "--gpu-memory-utilization",
     "context_length": "--max-model-len",
     "max_concurrent_requests": "--max-num-seqs",
@@ -14,7 +15,8 @@ VLLM_FLAG_MAP = {
 
 SGLANG_FLAG_MAP = {
     "tensor_parallel_size": "--tp",
-    "pipeline_parallel_size": "--dp",
+    "pipeline_parallel_size": "--pp",
+    "data_parallel_size": "--dp",
     "gpu_memory_utilization": "--mem-fraction-static",
     "context_length": "--context-length",
     "max_concurrent_requests": "--max-running-requests",
@@ -55,6 +57,7 @@ def build_engine_args(llm: LLMConfig, model_name: str) -> list[str]:
         "--port 8000",
         f"{flag_map['tensor_parallel_size']} {llm.tensor_parallel_size}",
         f"{flag_map['pipeline_parallel_size']} {llm.pipeline_parallel_size}",
+        f"{flag_map['data_parallel_size']} {llm.data_parallel_size}",
         f"--model-path {model_name}" if llm.engine_name == "sglang" else f"--model {model_name}",
         f"--served-model-name {model_name}",
     ]

--- a/deplodock/recipe/types.py
+++ b/deplodock/recipe/types.py
@@ -29,6 +29,7 @@ class LLMConfig:
     max_concurrent_requests: int | None = None
     tensor_parallel_size: int = 1
     pipeline_parallel_size: int = 1
+    data_parallel_size: int = 1
     gpu_memory_utilization: float = 0.9
     vllm: VllmConfig | None = None
     sglang: SglangConfig | None = None
@@ -36,7 +37,7 @@ class LLMConfig:
     @property
     def gpus_per_instance(self) -> int:
         """Number of GPUs consumed by one model instance."""
-        return self.tensor_parallel_size * self.pipeline_parallel_size
+        return self.tensor_parallel_size * self.pipeline_parallel_size * self.data_parallel_size
 
     @property
     def engine_name(self) -> str:
@@ -145,6 +146,7 @@ class Recipe:
             max_concurrent_requests=llm_dict.get("max_concurrent_requests"),
             tensor_parallel_size=llm_dict.get("tensor_parallel_size", 1),
             pipeline_parallel_size=llm_dict.get("pipeline_parallel_size", 1),
+            data_parallel_size=llm_dict.get("data_parallel_size", 1),
             gpu_memory_utilization=llm_dict.get("gpu_memory_utilization", 0.9),
             vllm=vllm,
             sglang=sglang,

--- a/tests/deploy/test_compose.py
+++ b/tests/deploy/test_compose.py
@@ -19,6 +19,7 @@ def test_compose_single_instance(sample_config):
     assert '"8000:8000"' in result
     assert "--tensor-parallel-size 1" in result
     assert "--pipeline-parallel-size 1" in result
+    assert "--data-parallel-size 1" in result
     assert "--model test-org/test-model" in result
     assert "--served-model-name test-org/test-model" in result
     assert "--max-model-len 8192" in result
@@ -178,6 +179,7 @@ def test_compose_sglang_single_instance(sample_config_sglang):
     assert "--model-path test-org/test-model" in result
     assert "--model test-org/test-model" not in result
     assert "--tp 1" in result
+    assert "--pp 1" in result
     assert "--dp 1" in result
     assert "--mem-fraction-static 0.9" in result
     assert "--context-length 8192" in result

--- a/tests/recipe/test_engines.py
+++ b/tests/recipe/test_engines.py
@@ -47,6 +47,7 @@ def test_build_args_vllm_basic():
     llm = LLMConfig(
         tensor_parallel_size=2,
         pipeline_parallel_size=1,
+        data_parallel_size=3,
         gpu_memory_utilization=0.9,
         vllm=VllmConfig(),
     )
@@ -56,6 +57,7 @@ def test_build_args_vllm_basic():
     assert "--port 8000" in args
     assert "--tensor-parallel-size 2" in args
     assert "--pipeline-parallel-size 1" in args
+    assert "--data-parallel-size 3" in args
     assert "--model org/model" in args
     assert "--served-model-name org/model" in args
 
@@ -109,12 +111,14 @@ def test_build_args_sglang_basic():
     llm = LLMConfig(
         tensor_parallel_size=4,
         pipeline_parallel_size=2,
+        data_parallel_size=3,
         gpu_memory_utilization=0.85,
         sglang=SglangConfig(),
     )
     args = build_engine_args(llm, "org/model")
     assert "--tp 4" in args
-    assert "--dp 2" in args
+    assert "--pp 2" in args
+    assert "--dp 3" in args
     assert "--mem-fraction-static 0.85" in args
     assert "--trust-remote-code" in args
 

--- a/tests/recipe/test_types.py
+++ b/tests/recipe/test_types.py
@@ -39,8 +39,8 @@ def test_llm_engine_name_sglang():
 
 
 def test_llm_gpus_per_instance():
-    llm = LLMConfig(tensor_parallel_size=4, pipeline_parallel_size=2)
-    assert llm.gpus_per_instance == 8
+    llm = LLMConfig(tensor_parallel_size=4, pipeline_parallel_size=2, data_parallel_size=3)
+    assert llm.gpus_per_instance == 24
 
 
 def test_llm_gpus_per_instance_defaults():
@@ -134,6 +134,7 @@ def test_from_dict_full():
             "llm": {
                 "tensor_parallel_size": 8,
                 "pipeline_parallel_size": 1,
+                "data_parallel_size": 2,
                 "gpu_memory_utilization": 0.95,
                 "context_length": 16384,
                 "max_concurrent_requests": 512,
@@ -156,6 +157,7 @@ def test_from_dict_full():
     }
     recipe = Recipe.from_dict(d)
     assert recipe.engine.llm.tensor_parallel_size == 8
+    assert recipe.engine.llm.data_parallel_size == 2
     assert recipe.engine.llm.gpu_memory_utilization == 0.95
     assert recipe.engine.llm.context_length == 16384
     assert recipe.engine.llm.max_concurrent_requests == 512


### PR DESCRIPTION
## Summary

- Add `data_parallel_size` as a first-class `LLMConfig` parameter (vLLM: `--data-parallel-size`, SGLang: `--dp`)
- Fix SGLang `pipeline_parallel_size` mapping from `--dp` (wrong) to `--pp` (correct)
- Update `gpus_per_instance` to `tp * pp * dp`

## Test plan

- [x] `make test` — all 249 tests pass
- [x] `make lint` — clean
- [x] No impact on existing recipes (all use `pipeline_parallel_size: 1`, so the `--dp` → `--pp` fix is a no-op at value 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)