### PR TITLE
Fixes from Kimi K2.5 B200 branch

### DIFF
--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -150,8 +150,10 @@ async def run_execution_group(
             task_logger = _get_group_logger(group, model_name)
             task_logger.info(f"Recipe: {task.recipe_dir} (variant: {task.variant})")
 
-            # Set GPU device IDs if task needs fewer GPUs than group
-            gpu_device_ids = list(range(task.gpu_count)) if task.gpu_count < group.gpu_count else None
+            # Always set explicit GPU device IDs so the container only sees
+            # the GPUs the task needs — the provisioned VM may have more GPUs
+            # than requested (e.g. B200 only available as 8-GPU instances).
+            gpu_device_ids = list(range(task.gpu_count))
 
             params = DeployParams(
                 server=conn.address,

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -40,6 +40,7 @@ def build_bench_command(recipe: Recipe) -> str:
     return (
         f"vllm bench serve\n"
         f"    --model {model_name}\n"
+        f"    --trust-remote-code\n"
         f"    --max-concurrency {bench.max_concurrency}\n"
         f"    --num-prompts {bench.num_prompts}\n"
         f"    --random-input-len {bench.random_input_len}\n"
@@ -115,6 +116,7 @@ async def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
         f"docker run --rm --network host --entrypoint bash {image} -c '"
         f"vllm bench serve "
         f"--model {model_name} "
+        f"--trust-remote-code "
         f"--base-url http://localhost:{port} "
         f"--max-concurrency {bench.max_concurrency} "
         f"--num-prompts {bench.num_prompts} "


### PR DESCRIPTION
always use the number of GPUs in the benchmark
add --trust-remote-code to vllm bench serve