### PR TITLE
Add generic command workload for bench harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ matrices:
 
 These flags must **not** appear in `extra_args` — `load_recipe()` validates this and raises an error on duplicates.
 
+### Command Recipes (Generic Workload)
+
+A recipe may declare a `command` block instead of `engine.llm` to run an arbitrary tool on the provisioned VM (e.g. a microbenchmark, a profiling sweep, or `nvidia-smi`). The harness expands the matrix, renders the command template per variant, runs it on the VM, and pulls back result files.
+
+```yaml
+command:
+  stage: ["scripts"]              # repo paths to ship to the VM; empty = no staging
+  run: |
+    nvidia-smi --query-gpu=name,memory.used --format=csv > $task_dir/result.csv
+    echo "marker,$marker" >> $task_dir/result.csv
+  result_files:                    # filenames or shell globs (expanded on the remote)
+    - result.csv
+    - "*.log"
+  timeout: 60
+
+matrices:
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 1
+    marker: [a, b, c]
+```
+
+The `run` template uses `string.Template` `$var` syntax. Substitution variables are the variant params (flattened to leaf names — `deploy.gpu` → `gpu`, `marker` → `marker`) plus harness-injected `$task_dir`, `$gpu_device_ids`, and `$repo_dir` (when staging is configured). `command` and `engine.llm` are mutually exclusive.
+
+Staging uses `git ls-files --cached --others --exclude-standard <paths>` so unversioned edits ride along without a commit, while gitignored files are excluded. Each pulled result file lands in the run directory as `{variant}_{basename}`.
+
 ## Experiments
 
 Experiments are self-contained parameter sweeps that live in `experiments/`. Each experiment directory contains a `recipe.yaml` and stores its results alongside it. The directory structure follows `experiments/{model_name}/{experiment_name}/`.

--- a/deplodock/benchmark/command_workload.py
+++ b/deplodock/benchmark/command_workload.py
@@ -1,0 +1,151 @@
+"""Generic command workload: render and run a templated shell command on a remote VM.
+
+Used by recipes whose `command` block declares a `run` template and a list of
+`result_files` to pull back. The harness flattens variant params to leaf names,
+substitutes them into the template via `string.Template`, runs the rendered
+command on the provisioned VM, then scp's matching result files back to the
+local run directory.
+"""
+
+import logging
+import shlex
+from pathlib import Path
+from string import Template
+
+from deplodock.planner import BenchmarkTask
+from deplodock.planner.variant import Variant
+
+logger = logging.getLogger(__name__)
+
+
+def _leaf_name(key: str) -> str:
+    """Take the last dot-separated segment of a matrix key (e.g. 'deploy.gpu' → 'gpu')."""
+    return key.rsplit(".", 1)[-1]
+
+
+def build_substitution_map(
+    variant: Variant,
+    gpu_device_ids: list[int],
+    repo_dir: str | None,
+    task_dir: str,
+) -> dict[str, str]:
+    """Build the substitution map for a command template.
+
+    Variant params are flattened to their leaf names; conflicts (two keys
+    sharing a leaf) raise ValueError. Harness keys $task_dir, $gpu_device_ids,
+    and $repo_dir (when staging is configured) are injected.
+    """
+    subs: dict[str, str] = {}
+    seen_sources: dict[str, str] = {}
+    for key, value in variant.params.items():
+        leaf = _leaf_name(key)
+        if leaf in seen_sources:
+            raise ValueError(
+                f"variant params have conflicting leaf name '{leaf}': '{seen_sources[leaf]}' and '{key}' both flatten to the same name."
+            )
+        seen_sources[leaf] = key
+        subs[leaf] = str(value)
+
+    subs["task_dir"] = task_dir
+    subs["gpu_device_ids"] = ",".join(str(i) for i in gpu_device_ids)
+    if repo_dir is not None:
+        subs["repo_dir"] = repo_dir
+    return subs
+
+
+def render_command(template: str, subs: dict[str, str]) -> str:
+    """Render a string.Template command, raising a friendly error on missing vars."""
+    try:
+        return Template(template).substitute(subs)
+    except KeyError as e:
+        missing = e.args[0]
+        raise ValueError(f"command template references undefined variable: ${missing}") from None
+
+
+async def _expand_remote_glob(run_cmd, task_dir: str, pattern: str) -> list[str]:
+    """List files matching `pattern` inside `task_dir` on the remote VM.
+
+    Returns absolute remote paths. Empty list when nothing matches (the
+    `|| true` swallows the ls failure).
+    """
+    safe_pattern = shlex.quote(pattern)
+    # Use printf to get newline-delimited absolute paths.
+    cmd = (
+        f"sh -c 'cd {shlex.quote(task_dir)} && "
+        f'for f in {pattern}; do [ -e "$f" ] && printf "%s/%s\\n" {shlex.quote(task_dir)} "$f"; done\' '
+        f"# pattern={safe_pattern}"
+    )
+    rc, stdout, _ = await run_cmd(cmd, stream=False)
+    if rc != 0 or not stdout:
+        return []
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+async def run_command_workload(
+    task: BenchmarkTask,
+    run_cmd,
+    repo_dir: str | None,
+    task_dir: str,
+    gpu_device_ids: list[int],
+    server: str,
+    ssh_key: str,
+    ssh_port: int,
+    dry_run: bool = False,
+) -> tuple[bool, dict]:
+    """Run one command-recipe task on the remote VM.
+
+    Returns (success, info) where info contains the rendered command and a
+    list of locally-pulled result paths.
+    """
+    from deplodock.provisioning.ssh_transport import scp_from_remote
+
+    cmd_cfg = task.recipe.command
+    assert cmd_cfg is not None, "run_command_workload requires a command recipe"
+
+    subs = build_substitution_map(task.variant, gpu_device_ids, repo_dir, task_dir)
+    rendered = render_command(cmd_cfg.run, subs)
+
+    # Prepend env exports if any.
+    if cmd_cfg.env:
+        env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in cmd_cfg.env.items())
+        rendered_with_env = f"{env_prefix} {rendered}"
+    else:
+        rendered_with_env = rendered
+
+    # Ensure task_dir exists.
+    await run_cmd(f"mkdir -p {shlex.quote(task_dir)}")
+
+    logger.info(f"Running command for {task.variant}:\n{rendered}")
+    rc, _, _ = await run_cmd(rendered_with_env, log_output=True, timeout=cmd_cfg.timeout)
+    success = rc == 0
+    info: dict = {"rendered_command": rendered, "result_paths": []}
+
+    if not success:
+        logger.error(f"Command failed (rc={rc}) for {task.variant}")
+        return False, info
+
+    if dry_run:
+        return True, info
+
+    # Pull back result files (with glob expansion on the remote).
+    for pattern in cmd_cfg.result_files:
+        # If the pattern contains no glob metachars, treat it literally; else expand.
+        if any(c in pattern for c in "*?["):
+            remote_paths = await _expand_remote_glob(run_cmd, task_dir, pattern)
+            if not remote_paths:
+                logger.warning(f"result_files pattern '{pattern}' matched no files in {task_dir}")
+                continue
+        else:
+            remote_paths = [f"{task_dir}/{pattern}"]
+
+        for remote_path in remote_paths:
+            basename = Path(remote_path).name
+            local_path = task.run_dir / f"{task.variant}_{basename}"
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            rc_scp, stderr = await scp_from_remote(server, ssh_key, ssh_port, remote_path, str(local_path))
+            if rc_scp != 0:
+                logger.warning(f"scp_from_remote failed for {remote_path}: {stderr}")
+                continue
+            info["result_paths"].append(str(local_path))
+
+    return True, info

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -5,8 +5,10 @@ import json
 import logging
 import os
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 
 from deplodock.benchmark.bench_logging import _get_group_logger, active_run_dir, add_group_file_handler
+from deplodock.benchmark.command_workload import run_command_workload
 from deplodock.benchmark.results import compose_json_result
 from deplodock.benchmark.system_info import collect_system_info
 from deplodock.benchmark.workload import compose_result, extract_benchmark_results, run_benchmark_workload
@@ -26,7 +28,8 @@ from deplodock.provisioning.cloud import (
     provision_cloud_vm,
 )
 from deplodock.provisioning.remote import provision_remote
-from deplodock.provisioning.ssh_transport import make_run_cmd
+from deplodock.provisioning.ssh_transport import REMOTE_DEPLOY_DIR, make_run_cmd
+from deplodock.provisioning.staging import stage_to_remote
 
 OnTaskDone = Callable[[BenchmarkTask, bool], Awaitable[None]]
 
@@ -138,6 +141,33 @@ async def run_execution_group(
         sysinfo_run_cmd = make_run_cmd(conn.address, ssh_key, conn.ssh_port, dry_run=dry_run)
         system_info = await collect_system_info(sysinfo_run_cmd)
 
+        # Stage repo files once per group for command recipes that request it.
+        repo_dir_remote: str | None = None
+        stage_paths_union: list[str] = []
+        for t in group.tasks:
+            if t.recipe.kind == "command" and t.recipe.command and t.recipe.command.stage:
+                for p in t.recipe.command.stage:
+                    if p not in stage_paths_union:
+                        stage_paths_union.append(p)
+        if stage_paths_union:
+            repo_dir_remote = f"{REMOTE_DEPLOY_DIR}/{group_label}/repo"
+            try:
+                await stage_to_remote(
+                    Path.cwd(),
+                    stage_paths_union,
+                    conn.address,
+                    ssh_key,
+                    conn.ssh_port,
+                    repo_dir_remote,
+                    dry_run=dry_run,
+                )
+            except Exception as e:
+                logger.error(f"Staging failed: {e}")
+                for task in group.tasks:
+                    task_results.append((task, False))
+                    await _invoke_callback(on_task_done, task, False, logger)
+                return task_results, None
+
         for task in group.tasks:
             active_run_dir.set(task.run_dir)
             recipe = task.recipe
@@ -154,6 +184,29 @@ async def run_execution_group(
             # the GPUs the task needs — the provisioned VM may have more GPUs
             # than requested (e.g. B200 only available as 8-GPU instances).
             gpu_device_ids = list(range(task.gpu_count))
+
+            # ── Command-recipe dispatch ───────────────────────────────
+            if recipe.kind == "command":
+                run_cmd = make_run_cmd(conn.address, ssh_key, conn.ssh_port, dry_run=dry_run)
+                task_dir_remote = f"{REMOTE_DEPLOY_DIR}/{group_label}/{task.variant}"
+                try:
+                    cmd_success, _info = await run_command_workload(
+                        task,
+                        run_cmd,
+                        repo_dir=repo_dir_remote,
+                        task_dir=task_dir_remote,
+                        gpu_device_ids=gpu_device_ids,
+                        server=conn.address,
+                        ssh_key=ssh_key,
+                        ssh_port=conn.ssh_port,
+                        dry_run=dry_run,
+                    )
+                except Exception as e:
+                    task_logger.error(f"Command workload error: {e}")
+                    cmd_success = False
+                task_results.append((task, cmd_success))
+                await _invoke_callback(on_task_done, task, cmd_success, task_logger)
+                continue
 
             params = DeployParams(
                 server=conn.address,

--- a/deplodock/planner/__init__.py
+++ b/deplodock/planner/__init__.py
@@ -53,12 +53,20 @@ class BenchmarkTask:
         return os.path.basename(self.recipe_dir)
 
     def result_path(self) -> Path:
-        """Full result path: run_dir / {variant}_{engine}_benchmark.txt."""
+        """Full result path: run_dir / {variant}_{engine}_benchmark.txt.
+
+        For command recipes, this is the captured-stdout log path; the
+        actual result files are named by the command workload's scp-back logic.
+        """
+        if self.recipe.kind == "command":
+            return self.run_dir / f"{self.variant}_command.log"
         engine = self.recipe.engine.llm.engine_name
         return self.run_dir / f"{self.variant}_{engine}_benchmark.txt"
 
     def json_result_path(self) -> Path:
         """Full result path: run_dir / {variant}_{engine}_benchmark.json."""
+        if self.recipe.kind == "command":
+            return self.run_dir / f"{self.variant}_command.json"
         engine = self.recipe.engine.llm.engine_name
         return self.run_dir / f"{self.variant}_{engine}_benchmark.json"
 

--- a/deplodock/planner/group_by_model_and_gpu.py
+++ b/deplodock/planner/group_by_model_and_gpu.py
@@ -21,7 +21,12 @@ class GroupByModelAndGpuPlanner(BenchmarkPlanner):
     def plan(self, tasks):
         groups = {}
         for task in tasks:
-            key = (task.model_name, task.gpu_name)
+            # Command recipes have no model weights to amortize, so group on
+            # GPU only. Inference recipes still group on (model, gpu).
+            if task.recipe.kind == "command":
+                key = ("", task.gpu_name)
+            else:
+                key = (task.model_name, task.gpu_name)
             groups.setdefault(key, []).append(task)
 
         result = []

--- a/deplodock/provisioning/__init__.py
+++ b/deplodock/provisioning/__init__.py
@@ -13,7 +13,13 @@ from deplodock.provisioning.ssh_transport import (
     make_run_cmd,
     make_write_file,
     scp_file,
+    scp_from_remote,
     ssh_base_args,
+)
+from deplodock.provisioning.staging import (
+    build_stage_tar,
+    enumerate_staged_files,
+    stage_to_remote,
 )
 from deplodock.provisioning.types import VMConnectionInfo
 
@@ -26,6 +32,10 @@ __all__ = [
     "make_run_cmd",
     "make_write_file",
     "scp_file",
+    "scp_from_remote",
+    "stage_to_remote",
+    "enumerate_staged_files",
+    "build_stage_tar",
     "REMOTE_DEPLOY_DIR",
     "resolve_vm_spec",
     "provision_cloud_vm",

--- a/deplodock/provisioning/ssh_transport.py
+++ b/deplodock/provisioning/ssh_transport.py
@@ -134,6 +134,45 @@ async def scp_file(local_path, server, ssh_key, ssh_port, remote_path, timeout=3
         return 1, "timeout"
 
 
+async def scp_from_remote(server, ssh_key, ssh_port, remote_path, local_path, timeout=300):
+    """Copy a file FROM the remote server via SCP. Mirror of scp_file()."""
+    scp_args = [
+        "scp",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ServerAliveInterval=30",
+        "-o",
+        "ServerAliveCountMax=20",
+        "-o",
+        "TCPKeepAlive=no",
+    ]
+    if ssh_key:
+        scp_args += ["-i", ssh_key]
+    if ssh_port and ssh_port != 22:
+        scp_args += ["-P", str(ssh_port)]
+    scp_args += [f"{server}:{remote_path}", local_path]
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *scp_args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        stderr = stderr_bytes.decode() if stderr_bytes else ""
+        return proc.returncode, stderr
+    except TimeoutError:
+        logger.error(f"SCP timed out after {timeout}s: {server}:{remote_path} -> {local_path}")
+        proc.kill()
+        await proc.wait()
+        return 1, "timeout"
+
+
 def make_write_file(server, ssh_key, ssh_port, dry_run=False):
     """Create a write_file callable that SCPs files to the remote server."""
 

--- a/deplodock/provisioning/staging.py
+++ b/deplodock/provisioning/staging.py
@@ -1,0 +1,102 @@
+"""Stage local repo files to a remote VM via git ls-files + tar over SSH.
+
+Used by command-workload recipes that declare a non-empty `command.stage` list.
+The local repo's `git ls-files --cached --others --exclude-standard <paths>`
+output is the source of truth — tracked + untracked files are included, but
+gitignored files are excluded. This lets a user iterate on a script and run
+it on the remote without committing first.
+"""
+
+import asyncio
+import io
+import logging
+import tarfile
+from pathlib import Path
+
+from deplodock.provisioning.ssh_transport import ssh_base_args
+
+logger = logging.getLogger(__name__)
+
+
+async def enumerate_staged_files(repo_root: Path, stage_paths: list[str]) -> list[str]:
+    """Run `git ls-files --cached --others --exclude-standard -- <paths>`.
+
+    Returns a sorted, deduplicated list of repo-relative file paths.
+    Empty `stage_paths` returns an empty list.
+    """
+    if not stage_paths:
+        return []
+    args = [
+        "git",
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        *stage_paths,
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        cwd=str(repo_root),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"git ls-files failed: {stderr.decode().strip()}")
+    files = sorted({line for line in stdout.decode().splitlines() if line})
+    return files
+
+
+def build_stage_tar(repo_root: Path, files: list[str]) -> bytes:
+    """Build an in-memory gzipped tar containing the given repo-relative files."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for rel in files:
+            full = repo_root / rel
+            if not full.exists():
+                continue
+            tar.add(str(full), arcname=rel)
+    return buf.getvalue()
+
+
+async def stage_to_remote(
+    repo_root: Path,
+    stage_paths: list[str],
+    server: str,
+    ssh_key: str,
+    ssh_port: int,
+    remote_dir: str,
+    dry_run: bool = False,
+) -> None:
+    """Stream a tar of staged files into `remote_dir` on the remote VM.
+
+    No-op when `stage_paths` is empty.
+    """
+    if not stage_paths:
+        return
+
+    files = await enumerate_staged_files(repo_root, stage_paths)
+    if not files:
+        logger.warning(f"stage_to_remote: no files matched {stage_paths}")
+        return
+
+    if dry_run:
+        logger.info(f"[dry-run] stage {len(files)} files to {server}:{remote_dir}")
+        return
+
+    tar_bytes = build_stage_tar(repo_root, files)
+
+    ssh_args = ssh_base_args(server, ssh_key, ssh_port)
+    ssh_args.append(f"mkdir -p {remote_dir} && tar xzf - -C {remote_dir}")
+
+    proc = await asyncio.create_subprocess_exec(
+        *ssh_args,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate(input=tar_bytes)
+    if proc.returncode != 0:
+        raise RuntimeError(f"stage_to_remote failed (rc={proc.returncode}): {stderr.decode().strip()}")
+    logger.info(f"Staged {len(files)} files to {server}:{remote_dir}")

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -6,7 +6,7 @@ The `recipe` package owns all recipe-related logic: YAML loading, matrix expansi
 
 ## Modules
 
-- `types.py` — dataclasses: `Recipe`, `DeployConfig`, `ModelConfig`, `EngineConfig`, `LLMConfig`, `VllmConfig`, `SglangConfig`, `BenchmarkConfig`
+- `types.py` — dataclasses: `Recipe`, `DeployConfig`, `ModelConfig`, `EngineConfig`, `LLMConfig`, `VllmConfig`, `SglangConfig`, `BenchmarkConfig`, `CommandConfig`
 - `recipe.py` — `deep_merge()`, `load_recipe()`, `resolve_for_hardware()`, `validate_extra_args()`, `_load_raw_config()`, `_validate_and_build()`
 - `matrix.py` — `expand_matrix_entry()`, `dot_to_nested()`, `build_override()`
 - `engines.py` — `VLLM_FLAG_MAP`, `SGLANG_FLAG_MAP`, `banned_extra_arg_flags()`, `build_engine_args()`
@@ -143,6 +143,32 @@ engine:
 ```
 
 Each key-value pair is rendered as a `- KEY=VALUE` line in the `environment` section of the generated Docker Compose file.
+
+### Command Recipes (Generic Workload)
+
+In addition to inference recipes (`engine.llm` block), a recipe may declare a `command` block to run an arbitrary tool on the provisioned VM. The two are mutually exclusive — `_validate_and_build()` raises if both are set. `Recipe.kind` is `"command"` when `command` is set, else `"inference"`.
+
+```yaml
+command:
+  stage: ["scripts"]              # repo paths to ship to the VM (git ls-files); empty = no staging
+  run: |
+    nvidia-smi --query-gpu=name --format=csv > $task_dir/result.csv
+    echo "marker,$marker" >> $task_dir/result.csv
+  result_files:                    # filenames or shell globs; expanded on the remote
+    - result.csv
+    - "*.log"
+  timeout: 60
+  env: {FOO: bar}                  # optional, prepended as KEY=value to the command
+
+matrices:
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 1
+    marker: [a, b, c]
+```
+
+The `run` template uses `string.Template` `$var` syntax. Substitution variables come from variant params (flattened to leaf names: `deploy.gpu` → `gpu`, `marker` → `marker`) plus harness-injected `$task_dir`, `$gpu_device_ids`, and `$repo_dir` (only when `stage` is non-empty). Conflicting leaf names (e.g. two matrix keys flattening to `gpu`) raise at substitution time.
+
+Command recipes skip `validate_extra_args()` since they don't go through engine flag mapping.
 
 ### SGLang Quantization for AWQ MoE Models
 

--- a/deplodock/recipe/__init__.py
+++ b/deplodock/recipe/__init__.py
@@ -16,6 +16,7 @@ from deplodock.recipe.recipe import (
 )
 from deplodock.recipe.types import (
     BenchmarkConfig,
+    CommandConfig,
     DeployConfig,
     EngineConfig,
     LLMConfig,
@@ -27,6 +28,7 @@ from deplodock.recipe.types import (
 
 __all__ = [
     "BenchmarkConfig",
+    "CommandConfig",
     "DeployConfig",
     "EngineConfig",
     "LLMConfig",

--- a/deplodock/recipe/recipe.py
+++ b/deplodock/recipe/recipe.py
@@ -47,6 +47,16 @@ def _load_raw_config(recipe_dir) -> dict:
 
 def _validate_and_build(config: dict) -> Recipe:
     """Validate extra_args and build Recipe from config dict."""
+    has_command = "command" in config and config["command"] is not None
+    has_engine_llm = bool(config.get("engine", {}).get("llm"))
+
+    if has_command and has_engine_llm:
+        raise ValueError("Recipe must specify exactly one of 'engine.llm' or 'command', not both.")
+
+    if has_command:
+        # Command recipes don't go through engine extra_args validation.
+        return Recipe.from_dict(config)
+
     llm_dict = config.get("engine", {}).get("llm", {})
     if "sglang" in llm_dict:
         engine = "sglang"

--- a/deplodock/recipe/types.py
+++ b/deplodock/recipe/types.py
@@ -110,6 +110,33 @@ class BenchmarkConfig:
 
 
 @dataclass
+class CommandConfig:
+    """Generic command workload configuration.
+
+    Used by command-style recipes that run an arbitrary tool on the
+    provisioned VM (instead of deploying an inference server).
+
+    Fields:
+        stage: Repo paths to stage to the remote VM (via git ls-files +
+            tar). Empty list = no staging; $repo_dir is unavailable.
+        run: Shell command template (string.Template $-syntax). Substituted
+            with variant params (flattened to leaf names) plus injected
+            $task_dir, $repo_dir, $gpu_device_ids.
+        result_files: List of result file names or shell globs (e.g.
+            "result.json", "*.log"). Globs expand on the remote; each
+            matched file is pulled back as {variant}_{basename}.
+        timeout: Per-task command timeout in seconds.
+        env: Extra environment variables to set on the remote command.
+    """
+
+    stage: list[str] = field(default_factory=list)
+    run: str = ""
+    result_files: list[str] = field(default_factory=list)
+    timeout: int = 1800
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
 class DeployConfig:
     """Optional deploy section — GPU info for cloud provisioning."""
 
@@ -125,6 +152,12 @@ class Recipe:
     engine: EngineConfig = field(default_factory=EngineConfig)
     benchmark: BenchmarkConfig = field(default_factory=BenchmarkConfig)
     deploy: DeployConfig = field(default_factory=DeployConfig)
+    command: CommandConfig | None = None
+
+    @property
+    def kind(self) -> str:
+        """Recipe kind: 'command' if a command block is set, else 'inference'."""
+        return "command" if self.command is not None else "inference"
 
     @classmethod
     def from_dict(cls, d: dict) -> "Recipe":
@@ -166,11 +199,23 @@ class Recipe:
             gpu_count=deploy_dict.get("gpu_count", 1),
         )
 
+        command = None
+        cmd_dict = d.get("command")
+        if cmd_dict is not None:
+            command = CommandConfig(
+                stage=list(cmd_dict.get("stage", [])),
+                run=cmd_dict.get("run", ""),
+                result_files=list(cmd_dict.get("result_files", [])),
+                timeout=cmd_dict.get("timeout", 1800),
+                env=dict(cmd_dict.get("env", {})),
+            )
+
         return cls(
             model=model,
             engine=EngineConfig(llm=llm),
             benchmark=benchmark,
             deploy=deploy,
+            command=command,
         )
 
     @property

--- a/experiments/test_command/recipe.yaml
+++ b/experiments/test_command/recipe.yaml
@@ -1,0 +1,15 @@
+command:
+  stage: []
+  run: |
+    nvidia-smi --query-gpu=name,memory.used,temperature.gpu,utilization.gpu \
+      --format=csv > $task_dir/result.csv
+    echo "marker,$marker" >> $task_dir/result.csv
+  result_files:
+    - result.csv
+    - "*.log"
+  timeout: 60
+
+matrices:
+  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+    deploy.gpu_count: 1
+    marker: [a, b, c]

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -17,7 +17,8 @@ tests/
 │   ├── test_code_hash.py    # BenchmarkTask.compute_code_hash()
 │   ├── test_tasks_json.py   # BenchmarkTask.write_tasks_json(), read_tasks_json()
 │   ├── test_run_dir.py      # BenchmarkTask.create_run_dir()
-│   └── test_results.py      # parse_benchmark_metrics(), parse_system_info(), compose_json_result()
+│   ├── test_results.py      # parse_benchmark_metrics(), parse_system_info(), compose_json_result()
+│   └── test_command_workload.py # build_substitution_map(), render_command()
 ├── recipe/
 │   ├── test_types.py        # Recipe.from_dict(), LLMConfig properties, dataclass defaults
 │   └── test_engines.py      # build_engine_args(), banned_extra_arg_flags()
@@ -34,6 +35,7 @@ tests/
 │   ├── test_cloud.py        # resolve_vm_spec(), delete_cloud_vm(), VMConnectionInfo
 │   ├── test_cloudrift.py    # CloudRift API helpers
 │   ├── test_gcp.py             # GCP command builders
+│   ├── test_staging.py      # enumerate_staged_files(), build_stage_tar()
 │   └── test_vm_dryrun.py    # vm create/delete CLI dry-run
 ├── scripts/
 │   └── test_plot_mcr_sweep.py  # load_results() from scripts/plot_mcr_sweep.py

--- a/tests/benchmark/test_bench_dryrun.py
+++ b/tests/benchmark/test_bench_dryrun.py
@@ -203,6 +203,47 @@ def test_bench_group_log_captures_provisioning(run_cli, make_bench_config, tmp_p
             shutil.rmtree(d)
 
 
+def test_bench_command_recipe_dry_run(run_cli, make_bench_config, tmp_path):
+    """A command recipe expands its template and dispatches the command path."""
+    import yaml
+
+    recipe_dir = tmp_path / "CmdRecipe"
+    recipe_dir.mkdir()
+    recipe = {
+        "command": {
+            "stage": [],
+            "run": "echo marker=$marker > $task_dir/result.csv\n",
+            "result_files": ["result.csv"],
+            "timeout": 30,
+        },
+        "matrices": [
+            {
+                "deploy.gpu": "NVIDIA GeForce RTX 5090",
+                "deploy.gpu_count": 1,
+                "marker": ["a", "b", "c"],
+            }
+        ],
+    }
+    (recipe_dir / "recipe.yaml").write_text(yaml.dump(recipe))
+
+    config_path = make_bench_config(tmp_path)
+    rc, stdout, stderr = run_cli(
+        "bench",
+        str(recipe_dir),
+        "--config",
+        config_path,
+        "--dry-run",
+    )
+    assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
+    # Each variant's rendered command should appear with $marker substituted.
+    assert "marker=a" in stdout
+    assert "marker=b" in stdout
+    assert "marker=c" in stdout
+    # Inference-path machinery should not be invoked for command recipes.
+    assert "bench serve" not in stdout
+    assert "docker compose pull" not in stdout
+
+
 def test_bench_help(run_cli):
     rc, stdout, _ = run_cli("bench", "--help")
     assert rc == 0

--- a/tests/benchmark/test_command_workload.py
+++ b/tests/benchmark/test_command_workload.py
@@ -1,0 +1,52 @@
+"""Unit tests for the command workload module (pure functions)."""
+
+import pytest
+
+from deplodock.benchmark.command_workload import build_substitution_map, render_command
+from deplodock.planner.variant import Variant
+
+
+def _variant(params):
+    return Variant(params=params)
+
+
+def test_build_substitution_map_flattens_dot_keys():
+    v = _variant({"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 1, "marker": "a"})
+    subs = build_substitution_map(v, [0], repo_dir="/tmp/repo", task_dir="/tmp/task")
+    assert subs["gpu"] == "NVIDIA GeForce RTX 5090"
+    assert subs["gpu_count"] == "1"
+    assert subs["marker"] == "a"
+    assert subs["task_dir"] == "/tmp/task"
+    assert subs["repo_dir"] == "/tmp/repo"
+    assert subs["gpu_device_ids"] == "0"
+
+
+def test_build_substitution_map_no_repo_dir():
+    v = _variant({"deploy.gpu": "x", "deploy.gpu_count": 1})
+    subs = build_substitution_map(v, [0, 1], repo_dir=None, task_dir="/t")
+    assert "repo_dir" not in subs
+    assert subs["gpu_device_ids"] == "0,1"
+
+
+def test_build_substitution_map_leaf_conflict():
+    v = _variant({"deploy.gpu": "x", "deploy.gpu_count": 1, "extra.gpu": "y"})
+    with pytest.raises(ValueError, match="conflicting leaf name 'gpu'"):
+        build_substitution_map(v, [0], repo_dir=None, task_dir="/t")
+
+
+def test_render_command_basic():
+    out = render_command("echo $marker > $task_dir/out", {"marker": "a", "task_dir": "/tmp"})
+    assert out == "echo a > /tmp/out"
+
+
+def test_render_command_missing_var():
+    with pytest.raises(ValueError, match=r"undefined variable: \$missing"):
+        render_command("echo $missing", {"task_dir": "/tmp"})
+
+
+def test_render_command_repo_dir_unavailable():
+    """When staging is empty, $repo_dir is omitted from subs and triggers a friendly error."""
+    v = _variant({"deploy.gpu": "x", "deploy.gpu_count": 1})
+    subs = build_substitution_map(v, [0], repo_dir=None, task_dir="/t")
+    with pytest.raises(ValueError, match=r"undefined variable: \$repo_dir"):
+        render_command("cd $repo_dir && make", subs)

--- a/tests/deploy/test_recipe.py
+++ b/tests/deploy/test_recipe.py
@@ -257,3 +257,43 @@ def test_load_recipe_rejects_banned_extra_args(tmp_path):
 
     with pytest.raises(ValueError, match="--max-model-len"):
         load_recipe(str(tmp_path))
+
+
+# ── command recipes ────────────────────────────────────────────────
+
+
+def test_load_recipe_command_only(tmp_path):
+    recipe = {
+        "command": {
+            "run": "nvidia-smi > $task_dir/result.csv",
+            "result_files": ["result.csv"],
+        },
+        "deploy": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+    r = load_recipe(str(tmp_path))
+    assert r.kind == "command"
+    assert r.command.run == "nvidia-smi > $task_dir/result.csv"
+
+
+def test_load_recipe_command_and_engine_mutually_exclusive(tmp_path):
+    recipe = {
+        "command": {"run": "echo hi"},
+        "engine": {"llm": {"vllm": {}}},
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+    with pytest.raises(ValueError, match="exactly one"):
+        load_recipe(str(tmp_path))
+
+
+def test_load_recipe_command_skips_extra_args_validation(tmp_path):
+    recipe = {
+        "command": {"run": "echo hi"},
+        "deploy": {"gpu": "NVIDIA GeForce RTX 5090"},
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+    r = load_recipe(str(tmp_path))
+    assert r.kind == "command"

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -6,7 +6,7 @@ from deplodock.planner import BenchmarkTask, ExecutionGroup
 from deplodock.planner.group_by_model_and_gpu import GroupByModelAndGpuPlanner
 from deplodock.planner.variant import Variant
 from deplodock.recipe import ModelConfig, Recipe
-from deplodock.recipe.types import DeployConfig
+from deplodock.recipe.types import CommandConfig, DeployConfig
 
 
 def _make_task(model="org/model-a", gpu="NVIDIA GeForce RTX 5090", gpu_count=1, recipe_dir="/r", variant=None):
@@ -78,6 +78,38 @@ def test_task_gpu_properties():
 
 
 # ── GroupByModelAndGpuPlanner ─────────────────────────────────────
+
+
+def _make_command_task(gpu="GPU_A", gpu_count=1, marker="a"):
+    variant = Variant(params={"deploy.gpu": gpu, "deploy.gpu_count": gpu_count, "marker": marker})
+    return BenchmarkTask(
+        recipe_dir="/r",
+        variant=variant,
+        recipe=Recipe(
+            deploy=DeployConfig(gpu=gpu, gpu_count=gpu_count),
+            command=CommandConfig(run="echo hi"),
+        ),
+    )
+
+
+def test_command_tasks_grouped_by_gpu_only():
+    planner = GroupByModelAndGpuPlanner()
+    tasks = [
+        _make_command_task(gpu="GPU_A", marker="a"),
+        _make_command_task(gpu="GPU_A", marker="b"),
+        _make_command_task(gpu="GPU_B", marker="c"),
+    ]
+    groups = planner.plan(tasks)
+    assert len(groups) == 2
+    by_gpu = {g.gpu_name: g for g in groups}
+    assert len(by_gpu["GPU_A"].tasks) == 2
+    assert len(by_gpu["GPU_B"].tasks) == 1
+
+
+def test_command_task_result_path_is_log():
+    t = _make_command_task()
+    t.run_dir = Path("/run/x")
+    assert t.result_path().name.endswith("_command.log")
 
 
 def test_same_model_same_gpu_one_group():

--- a/tests/provisioning/test_staging.py
+++ b/tests/provisioning/test_staging.py
@@ -1,0 +1,81 @@
+"""Unit tests for the staging module (git ls-files + tar)."""
+
+import asyncio
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from deplodock.provisioning.staging import (
+    build_stage_tar,
+    enumerate_staged_files,
+)
+
+
+def _git(repo: Path, *args):
+    subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "HOME": "/tmp",
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    _git(tmp_path, "init", "-q", "-b", "main")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "tracked.py").write_text("print('hi')\n")
+    (tmp_path / "scripts" / "untracked.py").write_text("print('new')\n")
+    (tmp_path / "scripts" / "ignored.log").write_text("noise\n")
+    (tmp_path / ".gitignore").write_text("*.log\n")
+    (tmp_path / "other.txt").write_text("outside scope\n")
+    _git(tmp_path, "add", "scripts/tracked.py", ".gitignore", "other.txt")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+    return tmp_path
+
+
+def test_enumerate_empty_stage_paths(repo):
+    files = asyncio.run(enumerate_staged_files(repo, []))
+    assert files == []
+
+
+def test_enumerate_includes_tracked_and_untracked_excludes_ignored(repo):
+    files = asyncio.run(enumerate_staged_files(repo, ["scripts"]))
+    assert "scripts/tracked.py" in files
+    assert "scripts/untracked.py" in files
+    assert "scripts/ignored.log" not in files
+    # Other path-scoped: should not include other.txt.
+    assert "other.txt" not in files
+
+
+def test_enumerate_dot_includes_everything_tracked(repo):
+    files = asyncio.run(enumerate_staged_files(repo, ["."]))
+    assert "scripts/tracked.py" in files
+    assert "other.txt" in files
+    assert "scripts/untracked.py" in files
+    assert "scripts/ignored.log" not in files
+
+
+def test_build_stage_tar_roundtrip(repo):
+    files = asyncio.run(enumerate_staged_files(repo, ["scripts"]))
+    tar_bytes = build_stage_tar(repo, files)
+    members = {}
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
+        for m in tar.getmembers():
+            f = tar.extractfile(m)
+            if f is not None:
+                members[m.name] = f.read().decode()
+    assert members["scripts/tracked.py"] == "print('hi')\n"
+    assert members["scripts/untracked.py"] == "print('new')\n"
+    assert "scripts/ignored.log" not in members

--- a/tests/recipe/test_types.py
+++ b/tests/recipe/test_types.py
@@ -1,12 +1,53 @@
 """Unit tests for recipe dataclass types."""
 
 from deplodock.recipe import (
+    CommandConfig,
     DeployConfig,
     LLMConfig,
     Recipe,
     SglangConfig,
     VllmConfig,
 )
+
+
+def test_command_config_defaults():
+    cfg = CommandConfig()
+    assert cfg.stage == []
+    assert cfg.run == ""
+    assert cfg.result_files == []
+    assert cfg.timeout == 1800
+    assert cfg.env == {}
+
+
+def test_recipe_kind_inference_default():
+    assert Recipe().kind == "inference"
+
+
+def test_recipe_kind_command():
+    r = Recipe(command=CommandConfig(run="echo hi"))
+    assert r.kind == "command"
+
+
+def test_from_dict_command():
+    d = {
+        "command": {
+            "stage": ["scripts"],
+            "run": "echo $marker",
+            "result_files": ["result.csv", "*.log"],
+            "timeout": 60,
+            "env": {"FOO": "bar"},
+        },
+        "deploy": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
+    }
+    r = Recipe.from_dict(d)
+    assert r.kind == "command"
+    assert r.command.stage == ["scripts"]
+    assert r.command.run == "echo $marker"
+    assert r.command.result_files == ["result.csv", "*.log"]
+    assert r.command.timeout == 60
+    assert r.command.env == {"FOO": "bar"}
+    assert r.deploy.gpu == "NVIDIA GeForce RTX 5090"
+
 
 # ── VllmConfig / SglangConfig ────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Recipes can declare a `command` block (mutually exclusive with `engine.llm`) to run an arbitrary templated shell command on the provisioned VM, with `string.Template` substitution from variant params + injected `\$task_dir`/`\$gpu_device_ids`/`\$repo_dir`.
- Result files support shell globs (expanded on the remote) and are scp'd back as `{variant}_{basename}`. Optional staging streams `git ls-files` (tracked + untracked, gitignore-respecting) through tar over SSH so unversioned edits ship without a commit.
- One-line dispatch in `run_execution_group()`; inference path is untouched. Planner groups command tasks by GPU only.

## Test plan
- [x] `make test` (294 passing, 20 new)
- [x] `make lint`
- [x] `deplodock bench experiments/test_command --dry-run` expands 3 variants under one `rtx5090_x_1` group with rendered commands
- [ ] Live cloud run on RTX 5090 (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)