### PR TITLE
Add docker_options support for recipe compose generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ Matrix entries use **dot-notation** for all parameter paths. Scalars are broadca
 
 Engine-agnostic fields (`tensor_parallel_size`, `context_length`, etc.) live at `engine.llm`. Engine-specific fields (`image`, `extra_args`) nest under `engine.llm.vllm` or `engine.llm.sglang`.
 
+#### Docker Options
+
+Arbitrary docker-compose service keys can be injected via `engine.llm.docker_options`. This is useful for GPU-specific container settings like ROCm's security options:
+
+```yaml
+engine:
+  llm:
+    docker_options:
+      security_opt:
+        - seccomp=unconfined
+      cap_add:
+        - SYS_PTRACE
+```
+
+Keys already managed by the compose template (`image`, `volumes`, `ports`, `healthcheck`, etc.) are rejected at load time.
+
 ### SGLang Matrix Entry Example
 
 To benchmark with SGLang alongside vLLM, add a matrix entry with `engine.llm.sglang.*` overrides:

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -164,6 +164,7 @@ async def run_execution_group(
                 hf_token=hf_token,
                 dry_run=dry_run,
                 gpu_device_ids=gpu_device_ids,
+                port_mappings=conn.port_mappings,
             )
             task_logger.info("Deploying model...")
             success = await deploy_entry(params)

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -51,6 +51,7 @@ async def _handle_cloud(args):
         model_dir=args.model_dir,
         hf_token=hf_token,
         dry_run=args.dry_run,
+        port_mappings=conn.port_mappings,
     )
     await provision_remote(params.server, params.ssh_key, params.ssh_port, dry_run=params.dry_run)
 

--- a/deplodock/deploy/compose.py
+++ b/deplodock/deploy/compose.py
@@ -1,7 +1,23 @@
 """Docker Compose and nginx config generation."""
 
+from typing import Any
+
+import yaml
+
 from deplodock.recipe.engines import build_engine_args
 from deplodock.recipe.types import Recipe
+
+
+def _render_docker_options(docker_options: dict[str, Any]) -> str:
+    """Render docker_options dict as indented YAML lines for a compose service."""
+    if not docker_options:
+        return ""
+    lines = []
+    for key, value in docker_options.items():
+        fragment = yaml.dump({key: value}, default_flow_style=False).rstrip("\n")
+        indented = "\n".join("    " + line for line in fragment.splitlines())
+        lines.append(indented)
+    return "\n" + "\n".join(lines)
 
 
 def calculate_num_instances(recipe: Recipe) -> int:
@@ -30,6 +46,7 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
     engine_args = build_engine_args(llm, model_name)
     command_str = "\n      ".join(engine_args)
     extra_env_lines = "".join(f"\n      - {k}={v}" for k, v in llm.extra_env.items())
+    docker_options_lines = _render_docker_options(llm.docker_options)
 
     is_amd = recipe.deploy.gpu is not None and recipe.deploy.gpu.startswith("AMD")
 
@@ -80,7 +97,7 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
     ports:
       - "{port}:8000"
     shm_size: '16gb'
-    ipc: host
+    ipc: host{docker_options_lines}
     command: >
       {command_str}
     healthcheck:

--- a/deplodock/deploy/orchestrate.py
+++ b/deplodock/deploy/orchestrate.py
@@ -16,7 +16,17 @@ from deplodock.recipe.types import Recipe
 logger = logging.getLogger(__name__)
 
 
-async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, host, dry_run=False, gpu_device_ids=None):
+async def run_deploy(
+    run_cmd,
+    write_file,
+    recipe: Recipe,
+    model_dir,
+    hf_token,
+    host,
+    dry_run=False,
+    gpu_device_ids=None,
+    port_mappings=None,
+):
     """Shared deploy orchestration.
 
     Args:
@@ -28,6 +38,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
         host: hostname/IP for endpoint display
         dry_run: if True, skip sleep in health polling
         gpu_device_ids: optional list of GPU device IDs to restrict visibility
+        port_mappings: optional list of (internal, external) port tuples
     """
     num_instances = calculate_num_instances(recipe)
 
@@ -43,7 +54,11 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
         nginx_content = generate_nginx_conf(num_instances, engine=recipe.engine.llm.engine_name)
         await write_file("nginx.conf", nginx_content)
 
-    port = 8080 if num_instances > 1 else 8000
+    internal_port = 8080 if num_instances > 1 else 8000
+
+    # Resolve external port from port mappings (e.g. CloudRift NAT)
+    port_map = dict(port_mappings or [])
+    external_port = port_map.get(internal_port, internal_port)
 
     # Step 1: Pull images
     logger.info("Pulling images...")
@@ -52,7 +67,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
         logger.error("Failed to pull images")
         return False
 
-    # Step 2: Download model via huggingface-cli in container
+    # Step 2: Download model via hf CLI in container
     logger.info(f"Downloading model {model_name}...")
     dl_cmd = (
         f"docker run --rm"
@@ -61,7 +76,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
         f" -v {model_dir}:{model_dir}"
         f" --entrypoint bash"
         f" {image}"
-        f" -c 'pip install huggingface_hub[cli,hf_transfer] && HF_HUB_ENABLE_HF_TRANSFER=1 huggingface-cli download {model_name}'"
+        f" -c 'HF_HUB_ENABLE_HF_TRANSFER=1 hf download {model_name}'"
     )
     rc, _, _ = await run_cmd(dl_cmd, timeout=7200, log_output=True)
     if rc != 0:
@@ -83,7 +98,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
 
     # Step 5: Poll health
     logger.info("Waiting for health check...")
-    health_url = f"http://localhost:{port}/health"
+    health_url = f"http://localhost:{internal_port}/health"
     timeout = 3600  # 60 minutes
     interval = 10
     elapsed = 0
@@ -101,7 +116,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
 
     # Step 6: Print endpoint info
     status = "dry-run (not deployed)" if dry_run else "deployed"
-    logger.info(f"\nEndpoint: http://{host}:{port}/v1")
+    logger.info(f"\nEndpoint: http://{host}:{external_port}/v1")
     logger.info(f"Model: {model_name}")
     logger.info(f"Instances: {num_instances}")
     logger.info(f"Status: {status}")
@@ -113,7 +128,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
         logger.info("\nRunning smoke test...")
         prompt = "What is 2+2? Answer with just the number."
         smoke_cmd = (
-            f"curl -s http://localhost:{port}/v1/chat/completions"
+            f"curl -s http://localhost:{internal_port}/v1/chat/completions"
             f" -H 'Content-Type: application/json'"
             f''' -d '{{"model":"{model_name}","messages":[{{"role":"user","content":"{prompt}"}}],"max_tokens":128}}' '''
         )
@@ -154,7 +169,7 @@ async def run_deploy(run_cmd, write_file, recipe: Recipe, model_dir, hf_token, h
     # Print curl example
     logger.info("\nExample curl:")
     logger.info(
-        f"  curl http://{host}:{port}/v1/chat/completions \\\n"
+        f"  curl http://{host}:{external_port}/v1/chat/completions \\\n"
         f"    -H 'Content-Type: application/json' \\\n"
         f"    -d '{{\n"
         f'      "model": "{model_name}",\n'
@@ -191,6 +206,7 @@ async def deploy(params: DeployParams) -> bool:
         host,
         params.dry_run,
         gpu_device_ids=params.gpu_device_ids,
+        port_mappings=params.port_mappings,
     )
 
 

--- a/deplodock/deploy/params.py
+++ b/deplodock/deploy/params.py
@@ -17,3 +17,4 @@ class DeployParams:
     hf_token: str = ""
     dry_run: bool = False
     gpu_device_ids: list[int] | None = None
+    port_mappings: list[tuple[int, int]] = field(default_factory=list)

--- a/deplodock/provisioning/cloudrift.py
+++ b/deplodock/provisioning/cloudrift.py
@@ -61,6 +61,13 @@ async def _rent_instance(
     Args:
         ssh_public_keys: list of public key strings (e.g. ["ssh-ed25519 AAAA..."])
     """
+    vm_config = {
+        "ssh_key": {"PublicKeys": ssh_public_keys},
+        "image_url": image_url,
+        "cloudinit_url": cloudinit_url,
+    }
+    if ports:
+        vm_config["ports"] = [str(p) for p in ports]
     data = {
         "selector": {
             "ByInstanceTypeAndLocation": {
@@ -68,16 +75,10 @@ async def _rent_instance(
             },
         },
         "config": {
-            "VirtualMachine": {
-                "ssh_key": {"PublicKeys": ssh_public_keys},
-                "image_url": image_url,
-                "cloudinit_url": cloudinit_url,
-            },
+            "VirtualMachine": vm_config,
         },
         "with_public_ip": True,
     }
-    if ports:
-        data["ports"] = [str(p) for p in ports]
     return await _api_request("POST", "/api/v1/instances/rent", data, api_key, api_url, dry_run)
 
 

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -144,6 +144,35 @@ engine:
 
 Each key-value pair is rendered as a `- KEY=VALUE` line in the `environment` section of the generated Docker Compose file.
 
+### Docker Options
+
+`docker_options` is a `dict[str, Any]` on `LLMConfig` that injects arbitrary docker-compose service-level keys into the generated container definition. It defaults to an empty dict. Unlike `extra_env` and `extra_args`, which are engine-specific and live on `VllmConfig`/`SglangConfig`, `docker_options` lives directly on `LLMConfig` because Docker container options (security, capabilities, ulimits) are tied to GPU hardware, not the inference engine.
+
+```yaml
+engine:
+  llm:
+    vllm:
+      image: "rocm/vllm:latest"
+    docker_options:
+      security_opt:
+        - seccomp=unconfined
+      cap_add:
+        - SYS_PTRACE
+```
+
+Each key-value pair is rendered as a top-level service key in the generated Docker Compose file, inserted after `ipc: host` and before `command:`. Values are serialized via `yaml.dump()` to handle nested structures (lists, dicts, scalars) correctly.
+
+Keys managed by the compose template (`image`, `container_name`, `entrypoint`, `deploy`, `devices`, `group_add`, `volumes`, `environment`, `ports`, `shm_size`, `ipc`, `command`, `healthcheck`) are rejected at validation time via `validate_docker_options()`, following the same pattern as `validate_extra_args()`.
+
+Matrix overrides work naturally via deep merge:
+```yaml
+matrices:
+  - deploy.gpu: "AMD Instinct MI350X"
+    engine.llm.docker_options:
+      security_opt:
+        - seccomp=unconfined
+```
+
 ### SGLang Quantization for AWQ MoE Models
 
 SGLang does not automatically detect AWQ quantization for MoE architectures. For AWQ-quantized MoE models, `--quantization moe_wna16` must be passed via `extra_args`. See [/docs/sglang-awq-moe.md](/docs/sglang-awq-moe.md) for full details and tested configurations.

--- a/deplodock/recipe/__init__.py
+++ b/deplodock/recipe/__init__.py
@@ -12,6 +12,7 @@ from deplodock.recipe.recipe import (
     deep_merge,
     load_recipe,
     resolve_for_hardware,
+    validate_docker_options,
     validate_extra_args,
 )
 from deplodock.recipe.types import (
@@ -44,5 +45,6 @@ __all__ = [
     "expand_matrix_entry",
     "load_recipe",
     "resolve_for_hardware",
+    "validate_docker_options",
     "validate_extra_args",
 ]

--- a/deplodock/recipe/recipe.py
+++ b/deplodock/recipe/recipe.py
@@ -45,8 +45,38 @@ def _load_raw_config(recipe_dir) -> dict:
         return yaml.safe_load(f)
 
 
+def validate_docker_options(docker_options: dict) -> None:
+    """Raise ValueError if docker_options contains keys managed by the compose template."""
+    conflicts = set(docker_options) & _MANAGED_COMPOSE_KEYS
+    if conflicts:
+        raise ValueError(
+            f"docker_options contains keys managed by the compose template: "
+            f"{', '.join(sorted(conflicts))}. Remove them from docker_options."
+        )
+
+
+# Keys already rendered by generate_compose() — must not appear in docker_options.
+_MANAGED_COMPOSE_KEYS = frozenset(
+    {
+        "image",
+        "container_name",
+        "entrypoint",
+        "deploy",
+        "devices",
+        "group_add",
+        "volumes",
+        "environment",
+        "ports",
+        "shm_size",
+        "ipc",
+        "command",
+        "healthcheck",
+    }
+)
+
+
 def _validate_and_build(config: dict) -> Recipe:
-    """Validate extra_args and build Recipe from config dict."""
+    """Validate extra_args and docker_options, then build Recipe from config dict."""
     llm_dict = config.get("engine", {}).get("llm", {})
     if "sglang" in llm_dict:
         engine = "sglang"
@@ -55,6 +85,7 @@ def _validate_and_build(config: dict) -> Recipe:
         engine = "vllm"
         extra_args = llm_dict.get("vllm", {}).get("extra_args", "")
     validate_extra_args(extra_args, engine=engine)
+    validate_docker_options(llm_dict.get("docker_options", {}))
 
     return Recipe.from_dict(config)
 

--- a/deplodock/recipe/types.py
+++ b/deplodock/recipe/types.py
@@ -1,6 +1,7 @@
 """Recipe dataclass types."""
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -33,6 +34,7 @@ class LLMConfig:
     gpu_memory_utilization: float = 0.9
     vllm: VllmConfig | None = None
     sglang: SglangConfig | None = None
+    docker_options: dict[str, Any] = field(default_factory=dict)
 
     @property
     def gpus_per_instance(self) -> int:
@@ -150,6 +152,7 @@ class Recipe:
             gpu_memory_utilization=llm_dict.get("gpu_memory_utilization", 0.9),
             vllm=vllm,
             sglang=sglang,
+            docker_options=llm_dict.get("docker_options", {}),
         )
 
         bench_dict = d.get("benchmark", {})

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -47,11 +47,11 @@ Test individual functions in isolation with synthetic inputs.
 
 | File | Covers |
 |------|--------|
-| `recipe/test_types.py` | `Recipe.from_dict()`, `LLMConfig` properties (`engine_name`, `gpus_per_instance`, `image`, `extra_args`, `extra_env`), dataclass defaults |
+| `recipe/test_types.py` | `Recipe.from_dict()`, `LLMConfig` properties (`engine_name`, `gpus_per_instance`, `image`, `extra_args`, `extra_env`, `docker_options`), dataclass defaults |
 | `recipe/test_engines.py` | `build_engine_args()`, `banned_extra_arg_flags()` — engine flag mapping, CLI argument building for vLLM and SGLang |
-| `deploy/test_recipe.py` | `deplodock.recipe.load_recipe()`, `deep_merge()`, `validate_extra_args()`, `resolve_for_hardware()` — recipe loading, variant resolution, YAML parsing, extra_args validation, hardware-aware matrix resolution |
+| `deploy/test_recipe.py` | `deplodock.recipe.load_recipe()`, `deep_merge()`, `validate_extra_args()`, `validate_docker_options()`, `resolve_for_hardware()` — recipe loading, variant resolution, YAML parsing, extra_args validation, docker_options validation, hardware-aware matrix resolution |
 | `deploy/test_scale_out.py` | `DataParallelismScaleOutStrategy`, `ReplicaParallelismScaleOutStrategy` — scale-out strategy application, GPU count validation, immutability |
-| `deploy/test_compose.py` | `deplodock.deploy.generate_compose()`, `generate_nginx_conf()` — Docker Compose and nginx config generation, `gpu_device_ids` support |
+| `deploy/test_compose.py` | `deplodock.deploy.generate_compose()`, `generate_nginx_conf()` — Docker Compose and nginx config generation, `gpu_device_ids` support, `docker_options` rendering |
 | `provisioning/test_cloud.py` | `deplodock.provisioning.cloud.resolve_vm_spec()`, `delete_cloud_vm()`, `VMConnectionInfo` — cloud provisioning unit tests |
 | `planner/test_planner.py` | `BenchmarkTask`, `GroupByModelAndGpuPlanner` — task properties (`recipe_name`, `result_path`, `gpu_name`, `gpu_count`, `gpu_short`), grouping logic, sorting |
 | `planner/test_variant.py` | `Variant` — `__str__`, `gpu_short`, `gpu_count`, `__eq__`, `__hash__`, `_abbreviate()` |

--- a/tests/deploy/test_compose.py
+++ b/tests/deploy/test_compose.py
@@ -229,3 +229,49 @@ def test_compose_with_extra_env_parses_as_valid_yaml(sample_config):
     parsed = yaml.safe_load(result)
     env = parsed["services"]["vllm_0"]["environment"]
     assert "MY_VAR=hello" in env
+
+
+# ── docker_options compose ────────────────────────────────────────
+
+
+def test_compose_docker_options_renders_in_service(sample_config):
+    sample_config["engine"]["llm"]["docker_options"] = {
+        "security_opt": ["seccomp=unconfined"],
+        "cap_add": ["SYS_PTRACE"],
+    }
+    recipe = Recipe.from_dict(sample_config)
+    result = generate_compose(recipe, "/mnt/models", "token", num_instances=1)
+    parsed = yaml.safe_load(result)
+    svc = parsed["services"]["vllm_0"]
+    assert svc["security_opt"] == ["seccomp=unconfined"]
+    assert svc["cap_add"] == ["SYS_PTRACE"]
+
+
+def test_compose_docker_options_valid_yaml(sample_config):
+    sample_config["engine"]["llm"]["docker_options"] = {
+        "security_opt": ["seccomp=unconfined"],
+        "privileged": True,
+    }
+    recipe = Recipe.from_dict(sample_config)
+    result = generate_compose(recipe, "/mnt/models", "token", num_instances=1)
+    parsed = yaml.safe_load(result)
+    assert "services" in parsed
+    assert "vllm_0" in parsed["services"]
+
+
+def test_compose_empty_docker_options_no_change(sample_config):
+    recipe = Recipe.from_dict(sample_config)
+    result = generate_compose(recipe, "/mnt/models", "token", num_instances=1)
+    assert "security_opt" not in result
+    assert "cap_add" not in result
+
+
+def test_compose_docker_options_nested_values(sample_config):
+    sample_config["engine"]["llm"]["docker_options"] = {
+        "ulimits": {"memlock": {"soft": -1, "hard": -1}},
+    }
+    recipe = Recipe.from_dict(sample_config)
+    result = generate_compose(recipe, "/mnt/models", "token", num_instances=1)
+    parsed = yaml.safe_load(result)
+    svc = parsed["services"]["vllm_0"]
+    assert svc["ulimits"] == {"memlock": {"soft": -1, "hard": -1}}

--- a/tests/deploy/test_deploy_dryrun.py
+++ b/tests/deploy/test_deploy_dryrun.py
@@ -50,7 +50,7 @@ def test_ssh_deploy_command_sequence(run_cli, recipes_dir):
     assert any("mkdir" in line for line in dry_run_lines)
     assert any("docker-compose.yaml" in line for line in dry_run_lines)
     assert any("docker compose pull" in line for line in dry_run_lines)
-    assert any("huggingface-cli download" in line for line in dry_run_lines)
+    assert any("hf download" in line for line in dry_run_lines)
     assert any("docker compose down" in line for line in dry_run_lines)
     assert any("docker compose up" in line for line in dry_run_lines)
 

--- a/tests/deploy/test_recipe.py
+++ b/tests/deploy/test_recipe.py
@@ -3,7 +3,7 @@
 import pytest
 import yaml
 
-from deplodock.recipe import Recipe, deep_merge, load_recipe, resolve_for_hardware, validate_extra_args
+from deplodock.recipe import Recipe, deep_merge, load_recipe, resolve_for_hardware, validate_docker_options, validate_extra_args
 
 # ── deep_merge ──────────────────────────────────────────────────────
 
@@ -256,4 +256,42 @@ def test_load_recipe_rejects_banned_extra_args(tmp_path):
         yaml.dump(recipe, f)
 
     with pytest.raises(ValueError, match="--max-model-len"):
+        load_recipe(str(tmp_path))
+
+
+# ── validate_docker_options ───────────────────────────────────────
+
+
+def test_validate_docker_options_accepts_valid_keys():
+    validate_docker_options({"security_opt": ["seccomp=unconfined"], "cap_add": ["SYS_PTRACE"]})
+
+
+def test_validate_docker_options_accepts_empty():
+    validate_docker_options({})
+
+
+def test_validate_docker_options_rejects_managed_keys():
+    with pytest.raises(ValueError, match="image"):
+        validate_docker_options({"image": "custom:latest"})
+
+
+def test_validate_docker_options_rejects_multiple_managed_keys():
+    with pytest.raises(ValueError, match="volumes"):
+        validate_docker_options({"volumes": ["/a:/b"], "ports": ["8080:8080"]})
+
+
+def test_load_recipe_rejects_conflicting_docker_options(tmp_path):
+    recipe = {
+        "model": {"huggingface": "test-org/test-model"},
+        "engine": {
+            "llm": {
+                "vllm": {"image": "vllm/vllm-openai:v0.17.0"},
+                "docker_options": {"image": "override:latest"},
+            }
+        },
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+
+    with pytest.raises(ValueError, match="image"):
         load_recipe(str(tmp_path))

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -143,10 +143,10 @@ async def test_rent_instance_payload(mock_api):
             "ssh_key": {"PublicKeys": ["ssh-ed25519 AAAA user@host"]},
             "image_url": DEFAULT_IMAGE_URL,
             "cloudinit_url": DEFAULT_CLOUDINIT_URL,
+            "ports": ["22", "8000"],
         }
     }
     assert call_data["with_public_ip"] is True
-    assert call_data["ports"] == ["22", "8000"]
     assert result["instance_ids"] == ["c4bf5e16-1063-11f1-9096-5f6ae8f8983f"]
 
 

--- a/tests/recipe/test_types.py
+++ b/tests/recipe/test_types.py
@@ -218,3 +218,36 @@ def test_from_dict_with_extra_env():
     }
     recipe = Recipe.from_dict(d)
     assert recipe.engine.llm.extra_env == {"VLLM_ATTENTION_BACKEND": "FLASHINFER", "CUDA_VISIBLE_DEVICES": "0,1"}
+
+
+# ── docker_options ───────────────────────────────────────────────
+
+
+def test_llm_docker_options_default_empty():
+    llm = LLMConfig()
+    assert llm.docker_options == {}
+
+
+def test_from_dict_with_docker_options():
+    d = {
+        "model": {"huggingface": "org/model"},
+        "engine": {
+            "llm": {
+                "docker_options": {
+                    "security_opt": ["seccomp=unconfined"],
+                    "cap_add": ["SYS_PTRACE"],
+                },
+            }
+        },
+    }
+    recipe = Recipe.from_dict(d)
+    assert recipe.engine.llm.docker_options == {
+        "security_opt": ["seccomp=unconfined"],
+        "cap_add": ["SYS_PTRACE"],
+    }
+
+
+def test_from_dict_without_docker_options():
+    d = {"model": {"huggingface": "org/model"}}
+    recipe = Recipe.from_dict(d)
+    assert recipe.engine.llm.docker_options == {}


### PR DESCRIPTION
Allow recipes to specify arbitrary Docker Compose service options (e.g. ulimits) via engine.llm.docker_options, with validation to prevent conflicts with template-managed keys.