### PR TITLE
Add --billing-exempt flag for no-cost CloudRift rentals

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,4 @@ providers:
     # API key: defaults to $CLOUDRIFT_API_KEY env var
     image_url_nvidia: "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-gpu-580-129-20251015-183936.img"
     image_url_amd: "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-rocm-64-20260220-025112.img"
+    # billing_exempt: true  # admin-only, skip billing

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -36,6 +36,9 @@ def handle_bench(args):
     config = load_config(args.config)
     validate_config(config)
 
+    if args.billing_exempt:
+        config.setdefault("providers", {}).setdefault("cloudrift", {})["billing_exempt"] = True
+
     ssh_key = _expand_path(args.ssh_key)
     dry_run = args.dry_run
     no_teardown = args.no_teardown
@@ -218,5 +221,10 @@ def register_bench_command(subparsers):
         "--commit-results",
         action="store_true",
         help="Git commit and push result files after each task completes",
+    )
+    parser.add_argument(
+        "--billing-exempt",
+        action="store_true",
+        help="Skip billing for CloudRift instances (admin-only)",
     )
     parser.set_defaults(func=handle_bench)

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -33,10 +33,15 @@ async def _handle_cloud(args):
     ssh_key = os.path.expanduser(args.ssh_key)
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
 
+    providers_config = None
+    if args.billing_exempt:
+        providers_config = {"cloudrift": {"billing_exempt": True}}
+
     conn = await provision_cloud_vm(
         gpu_name=recipe.deploy.gpu,
         gpu_count=recipe.deploy.gpu_count,
         ssh_key=ssh_key,
+        providers_config=providers_config,
         server_name=args.name,
         dry_run=args.dry_run,
     )
@@ -74,6 +79,7 @@ def register_cloud_target(subparsers):
     parser.add_argument("--hf-token", default=None, help="HuggingFace token (default: $HF_TOKEN)")
     parser.add_argument("--model-dir", default="/hf_models", help="Model cache directory")
     parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
+    parser.add_argument("--billing-exempt", action="store_true", help="Skip billing for CloudRift (admin-only)")
     parser.add_argument("--gpu", required=True, help="GPU name (selects matching matrix entry)")
     parser.add_argument("--gpu-count", type=int, required=True, help="GPU count (selects matching matrix entry)")
     parser.set_defaults(func=handle_cloud)

--- a/deplodock/commands/vm/cloudrift.py
+++ b/deplodock/commands/vm/cloudrift.py
@@ -47,6 +47,7 @@ async def _handle_create(args):
         timeout=args.timeout,
         api_url=args.api_url,
         dry_run=args.dry_run,
+        billing_exempt=args.billing_exempt,
     )
     if conn is None:
         sys.exit(1)
@@ -83,6 +84,7 @@ def register_create_target(subparsers):
     parser.add_argument("--api-url", default=DEFAULT_API_URL, help=f"API base URL (default: {DEFAULT_API_URL})")
     parser.add_argument("--timeout", type=int, default=600, help="Seconds to wait for Active status (default: 600)")
     parser.add_argument("--dry-run", action="store_true", help="Print requests without executing")
+    parser.add_argument("--billing-exempt", action="store_true", help="Skip billing (admin-only)")
     parser.set_defaults(func=handle_create)
 
 

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -121,6 +121,7 @@ async def _provision_once(provider, instance_type, gpu_name, gpu_count, ssh_key,
         is_amd = gpu_name.startswith("AMD")
         image_url = cr_config.get("image_url_amd") if is_amd else cr_config.get("image_url_nvidia")
         image_kwargs = {"image_url": image_url} if image_url else {}
+        billing_exempt = cr_config.get("billing_exempt", False)
 
         conn = await cr_provider.create_instance(
             api_key=api_key or "",
@@ -132,6 +133,7 @@ async def _provision_once(provider, instance_type, gpu_name, gpu_count, ssh_key,
             fail_statuses={"Inactive"},
             wait_ssh=True,
             ssh_private_key_path=ssh_key,
+            billing_exempt=billing_exempt,
             **image_kwargs,
         )
         return conn

--- a/deplodock/provisioning/cloudrift.py
+++ b/deplodock/provisioning/cloudrift.py
@@ -53,6 +53,7 @@ async def _rent_instance(
     ports=None,
     api_url=DEFAULT_API_URL,
     dry_run=False,
+    billing_exempt=False,
 ):
     """Rent a new CloudRift VM instance.
 
@@ -79,6 +80,8 @@ async def _rent_instance(
         },
         "with_public_ip": True,
     }
+    if billing_exempt:
+        data["billing_exempt"] = True
     return await _api_request("POST", "/api/v1/instances/rent", data, api_key, api_url, dry_run)
 
 
@@ -279,6 +282,7 @@ async def create_instance(
     fail_statuses=None,
     wait_ssh=False,
     ssh_private_key_path=None,
+    billing_exempt=False,
 ):
     """Create a CloudRift VM instance.
 
@@ -302,7 +306,16 @@ async def create_instance(
         with open(ssh_key_path) as f:
             public_key = f.read().strip()
 
-    result = await _rent_instance(api_key, instance_type, [public_key], image_url=image_url, ports=ports, api_url=api_url, dry_run=dry_run)
+    result = await _rent_instance(
+        api_key,
+        instance_type,
+        [public_key],
+        image_url=image_url,
+        ports=ports,
+        api_url=api_url,
+        dry_run=dry_run,
+        billing_exempt=billing_exempt,
+    )
     if dry_run:
         logger.info("[dry-run] Would wait for Active status, then print connection info.")
         return VMConnectionInfo(

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Test individual functions in isolation with synthetic inputs.
 | `deploy/test_recipe.py` | `deplodock.recipe.load_recipe()`, `deep_merge()`, `validate_extra_args()`, `validate_docker_options()`, `resolve_for_hardware()` — recipe loading, variant resolution, YAML parsing, extra_args validation, docker_options validation, hardware-aware matrix resolution |
 | `deploy/test_scale_out.py` | `DataParallelismScaleOutStrategy`, `ReplicaParallelismScaleOutStrategy` — scale-out strategy application, GPU count validation, immutability |
 | `deploy/test_compose.py` | `deplodock.deploy.generate_compose()`, `generate_nginx_conf()` — Docker Compose and nginx config generation, `gpu_device_ids` support, `docker_options` rendering |
-| `provisioning/test_cloud.py` | `deplodock.provisioning.cloud.resolve_vm_spec()`, `delete_cloud_vm()`, `VMConnectionInfo` — cloud provisioning unit tests |
+| `provisioning/test_cloud.py` | `deplodock.provisioning.cloud.resolve_vm_spec()`, `delete_cloud_vm()`, `_provision_once()`, `VMConnectionInfo` — cloud provisioning unit tests |
 | `planner/test_planner.py` | `BenchmarkTask`, `GroupByModelAndGpuPlanner` — task properties (`recipe_name`, `result_path`, `gpu_name`, `gpu_count`, `gpu_short`), grouping logic, sorting |
 | `planner/test_variant.py` | `Variant` — `__str__`, `gpu_short`, `gpu_count`, `__eq__`, `__hash__`, `_abbreviate()` |
 | `test_detect.py` | `_parse_sysfs_output()`, `detect_local_gpus()`, `detect_remote_gpus()` — PCI sysfs GPU detection, mixed GPU errors, mock SSH |

--- a/tests/provisioning/test_cloud.py
+++ b/tests/provisioning/test_cloud.py
@@ -1,9 +1,12 @@
 """Unit tests for deploy/cloud module: resolve_vm_spec, provision_cloud_vm, delete_cloud_vm."""
 
+import logging
+from unittest.mock import AsyncMock, patch
+
 import pytest
 import yaml
 
-from deplodock.provisioning.cloud import delete_cloud_vm, resolve_vm_spec
+from deplodock.provisioning.cloud import _provision_once, delete_cloud_vm, resolve_vm_spec
 from deplodock.provisioning.types import VMConnectionInfo
 from deplodock.recipe import load_recipe
 
@@ -158,3 +161,44 @@ def test_vm_connection_info_defaults():
     assert conn.ssh_port == 22
     assert conn.port_mappings == []
     assert conn.delete_info == ()
+
+
+# ── _provision_once ─────────────────────────────────────────────
+
+
+@patch.dict("os.environ", {"CLOUDRIFT_API_KEY": "test-key"})
+@patch("deplodock.provisioning.cloud.cr_provider.create_instance", new_callable=AsyncMock)
+async def test_provision_once_cloudrift_billing_exempt(mock_create, tmp_path):
+    """billing_exempt in providers_config is forwarded to create_instance."""
+    key_file = tmp_path / "id_ed25519"
+    key_file.write_text("private-key")
+    pub_file = tmp_path / "id_ed25519.pub"
+    pub_file.write_text("ssh-ed25519 AAAA test@host\n")
+
+    mock_create.return_value = VMConnectionInfo(host="1.2.3.4", username="user", ssh_port=22222)
+
+    providers_config = {"cloudrift": {"billing_exempt": True}}
+
+    conn = await _provision_once(
+        "cloudrift", "rtx4090.1", "NVIDIA RTX 4090", 1, str(key_file), providers_config, "test", False, logging.getLogger()
+    )
+
+    assert conn is not None
+    assert mock_create.call_args.kwargs["billing_exempt"] is True
+
+
+@patch.dict("os.environ", {"CLOUDRIFT_API_KEY": "test-key"})
+@patch("deplodock.provisioning.cloud.cr_provider.create_instance", new_callable=AsyncMock)
+async def test_provision_once_cloudrift_no_billing_exempt(mock_create, tmp_path):
+    """billing_exempt defaults to False when not in providers_config."""
+    key_file = tmp_path / "id_ed25519"
+    key_file.write_text("private-key")
+    pub_file = tmp_path / "id_ed25519.pub"
+    pub_file.write_text("ssh-ed25519 AAAA test@host\n")
+
+    mock_create.return_value = VMConnectionInfo(host="1.2.3.4", username="user", ssh_port=22222)
+
+    conn = await _provision_once("cloudrift", "rtx4090.1", "NVIDIA RTX 4090", 1, str(key_file), {}, "test", False, logging.getLogger())
+
+    assert conn is not None
+    assert mock_create.call_args.kwargs["billing_exempt"] is False

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -161,6 +161,26 @@ async def test_rent_instance_no_ports(mock_api):
     assert call_data["with_public_ip"] is True
 
 
+@patch("deplodock.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_billing_exempt(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(API_KEY, "rtx49-7c-kn.1", ["ssh-ed25519 AAAA user@host"], api_url=API_URL, billing_exempt=True)
+
+    call_data = mock_api.call_args[0][2]
+    assert call_data["billing_exempt"] is True
+
+
+@patch("deplodock.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_no_billing_exempt_by_default(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(API_KEY, "rtx49-7c-kn.1", ["ssh-ed25519 AAAA user@host"], api_url=API_URL)
+
+    call_data = mock_api.call_args[0][2]
+    assert "billing_exempt" not in call_data
+
+
 # ── _terminate_instance ───────────────────────────────────────────
 
 

--- a/tests/provisioning/test_vm_dryrun.py
+++ b/tests/provisioning/test_vm_dryrun.py
@@ -221,6 +221,28 @@ def test_vm_create_cloudrift_dry_run(run_cli, tmp_path):
     assert "instances/rent" in stdout
 
 
+def test_vm_create_cloudrift_billing_exempt_dry_run(run_cli, tmp_path):
+    key_file = tmp_path / "id_ed25519.pub"
+    key_file.write_text("ssh-ed25519 AAAA test@host\n")
+
+    rc, stdout, _ = run_cli(
+        "vm",
+        "create",
+        "cloudrift",
+        "--instance-type",
+        "rtx4090.1",
+        "--ssh-key",
+        str(key_file),
+        "--api-key",
+        "test-key",
+        "--billing-exempt",
+        "--dry-run",
+    )
+    assert rc == 0
+    assert "[dry-run]" in stdout
+    assert "billing_exempt" in stdout
+
+
 def test_vm_delete_cloudrift_dry_run(run_cli):
     rc, stdout, _ = run_cli(
         "vm",
@@ -253,6 +275,7 @@ def test_vm_create_cloudrift_help(run_cli):
     assert "--timeout" in stdout
     assert "--dry-run" in stdout
     assert "--api-url" in stdout
+    assert "--billing-exempt" in stdout
 
 
 def test_vm_delete_cloudrift_help(run_cli):


### PR DESCRIPTION
Thread billing_exempt through the CloudRift provisioning stack so admin accounts can rent instances without billing. Exposed via --billing-exempt on vm create cloudrift, deploy cloud, and bench commands, plus providers.cloudrift.billing_exempt in config.yaml.