### PR TITLE
Add cross-product matrix expansion and --filter flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Or for a specific test file:
 - `deplodock deploy ssh ...` — deploy to remote server via SSH
 - `deplodock deploy cloud ...` — provision a cloud VM and deploy via SSH
 - `deplodock bench recipes/* ...` — deploy + benchmark + teardown on cloud VMs (recipe dirs as positional args)
+- `deplodock bench recipes/* --filter "KEY=PATTERN"` — run only variants matching the filter (fnmatch glob, repeatable, AND logic)
 - `deplodock bench experiments/...` — run an experiment (results stored in the experiment dir)
 - `deplodock teardown <run_dir>` — clean up VMs left running by `bench --no-teardown`
 - `deplodock vm create gcp ...` — create a GCP GPU VM

--- a/README.md
+++ b/README.md
@@ -111,28 +111,57 @@ benchmark:
   random_input_len: 8000
   random_output_len: 8000
 
+# Simple single-point entry (implicit zip)
 matrices:
-  # Simple single-point entry
-  - deploy.gpu: "NVIDIA H200 141GB"
-    deploy.gpu_count: 8
-
-  # Override engine and benchmark settings
-  - deploy.gpu: "NVIDIA H100 80GB"
-    deploy.gpu_count: 8
-    engine.llm.max_concurrent_requests: 256
-    benchmark.max_concurrency: 64
-
-  # Concurrency sweep (8 runs from one entry)
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    benchmark.max_concurrency: [1, 2, 4, 8, 16, 32, 64, 128]
-
-  # Correlated engine+bench sweep (3 zip runs)
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    engine.llm.max_concurrent_requests: [128, 256, 512]
-    benchmark.max_concurrency: [128, 256, 512]
+  deploy.gpu: "NVIDIA H200 141GB"
+  deploy.gpu_count: 8
 ```
 
-Matrix entries use **dot-notation** for all parameter paths. Scalars are broadcast; lists are zipped (all lists in one entry must have the same length). `deploy.gpu` is required in each entry.
+#### Cross-Product and Zip Combinators
+
+The `matrices` section supports two combinators for generating benchmark variants:
+
+- **`cross`**: Cartesian product of all list-valued axes. Scalars are broadcast.
+- **`zip`**: Element-wise pairing of equal-length lists. Scalars are broadcast.
+
+A plain `matrices` dict (no `cross`/`zip` key) is an implicit `zip`.
+
+```yaml
+# Cross-product: 3 GPUs × 2 configs = 6 variants
+matrices:
+  cross:
+    deploy.gpu_count: 1                    # scalar → broadcast
+    deploy.gpu:                            # list → cross-product axis
+      - "NVIDIA GeForce RTX 5090"
+      - "NVIDIA H100 80GB"
+      - "NVIDIA H200 141GB"
+    zip:                                   # zip sub-dict → one compound axis
+      engine.llm.max_concurrent_requests: [128, 512]
+      benchmark.max_concurrency: [128, 512]
+```
+
+```yaml
+# Concurrency sweep (zip: 8 runs from one entry)
+matrices:
+  deploy.gpu: "NVIDIA GeForce RTX 5090"
+  engine.llm.max_concurrent_requests: [1, 2, 4, 8, 16, 32, 64, 128]
+  benchmark.max_concurrency: [1, 2, 4, 8, 16, 32, 64, 128]
+```
+
+Within a `cross` node: scalars broadcast, lists are independent axes (cartesian product), nested `zip` dicts bundle their lists into one compound axis. Within a `zip` node: scalars broadcast, lists are zipped element-wise (must all be the same length). `cross`/`zip` keys are only treated as combinators when their value is a dict.
+
+Matrix entries use **dot-notation** for all parameter paths. `deploy.gpu` is required.
+
+#### Variant Filtering
+
+Use `--filter` to run a subset of variants:
+
+```bash
+deplodock bench recipes/my-recipe --filter "deploy.gpu=*5090*"
+deplodock bench recipes/my-recipe --filter "deploy.gpu=*5090*" --filter "batches=1"
+```
+
+Multiple `--filter` flags use AND logic. Values are matched with fnmatch glob patterns against the expanded parameter values.
 
 `deploy.driver_version` and `deploy.cuda_version` (optional) request a specific NVIDIA driver / CUDA toolkit on the target host. If the installed version already matches (prefix-match — `"550"` matches `550.127.05`), provisioning is a no-op. On a mismatch, a remote (`ssh`/`cloud`) deploy installs the requested version, reboots the host, and waits for SSH to come back. Local deploys refuse to run privileged commands and will error out instead — these fields are intended for remote machines only.
 
@@ -156,15 +185,14 @@ Keys already managed by the compose template (`image`, `volumes`, `ports`, `heal
 
 ### SGLang Matrix Entry Example
 
-To benchmark with SGLang alongside vLLM, add a matrix entry with `engine.llm.sglang.*` overrides:
+To benchmark with SGLang alongside vLLM, use a cross-product with the engine image:
 
 ```yaml
 matrices:
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+  cross:
+    deploy.gpu: "NVIDIA GeForce RTX 5090"
     deploy.gpu_count: 1
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    deploy.gpu_count: 1
-    engine.llm.sglang.image: "lmsysorg/sglang:v0.5.9"
+    engine.llm.sglang.image: ["", "lmsysorg/sglang:v0.5.9"]
 ```
 
 ### Named Fields → CLI Flags
@@ -196,9 +224,9 @@ command:
   timeout: 60
 
 matrices:
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    deploy.gpu_count: 1
-    marker: [a, b, c]
+  deploy.gpu: "NVIDIA GeForce RTX 5090"
+  deploy.gpu_count: 1
+  marker: [a, b, c]
 ```
 
 The `run` template uses `string.Template` `$var` syntax. Substitution variables are the variant params (flattened to leaf names — `deploy.gpu` → `gpu`, `marker` → `marker`) plus harness-injected `$task_dir`, `$gpu_device_ids`, and `$repo_dir` (when staging is configured). `command` and `engine.llm` are mutually exclusive.

--- a/deplodock/benchmark/tasks.py
+++ b/deplodock/benchmark/tasks.py
@@ -7,18 +7,23 @@ import yaml
 
 from deplodock.planner import BenchmarkTask
 from deplodock.planner.variant import Variant
-from deplodock.recipe.matrix import build_override, expand_matrix_entry
+from deplodock.recipe.matrix import build_override, expand_matrix, filter_combinations
 from deplodock.recipe.recipe import _validate_and_build, deep_merge
 
 logger = logging.getLogger(__name__)
 
 
-def enumerate_tasks(recipe_dirs) -> list[BenchmarkTask]:
+def enumerate_tasks(recipe_dirs, filters=None) -> list[BenchmarkTask]:
     """Build BenchmarkTask list from recipe dirs using matrices.
 
-    For each recipe dir, reads the raw YAML, extracts matrices entries,
-    expands each entry via broadcast + zip, and builds a BenchmarkTask
+    For each recipe dir, reads the raw YAML, extracts the matrices spec,
+    expands it via cross/zip combinators, and builds a BenchmarkTask
     per combination.
+
+    Args:
+        recipe_dirs: List of recipe directory paths.
+        filters: Optional list of (key, glob_pattern) tuples for variant
+            filtering (AND logic).
     """
     tasks = []
     for recipe_dir in recipe_dirs:
@@ -30,34 +35,35 @@ def enumerate_tasks(recipe_dirs) -> list[BenchmarkTask]:
         with open(recipe_path) as f:
             raw = yaml.safe_load(f)
 
-        matrices = raw.get("matrices", [])
+        matrices = raw.get("matrices")
         if not matrices:
             logger.warning(f"Warning: No matrices in {recipe_dir}, skipping.")
             continue
 
         base_config = {k: v for k, v in raw.items() if k != "matrices"}
 
-        for entry in matrices:
-            combinations = expand_matrix_entry(entry)
+        combinations = expand_matrix(matrices)
+        if filters:
+            combinations = filter_combinations(combinations, filters)
 
-            for combo in combinations:
-                override = build_override(combo)
-                merged = deep_merge(base_config, override)
-                recipe = _validate_and_build(merged)
+        for combo in combinations:
+            override = build_override(combo)
+            merged = deep_merge(base_config, override)
+            recipe = _validate_and_build(merged)
 
-                if recipe.deploy.gpu is None:
-                    logger.warning(
-                        f"Warning: matrix entry in {recipe_dir} missing 'deploy.gpu', skipping.",
-                    )
-                    continue
-
-                variant = Variant(params=combo)
-                tasks.append(
-                    BenchmarkTask(
-                        recipe_dir=recipe_dir,
-                        variant=variant,
-                        recipe=recipe,
-                    )
+            if recipe.deploy.gpu is None:
+                logger.warning(
+                    f"Warning: matrix entry in {recipe_dir} missing 'deploy.gpu', skipping.",
                 )
+                continue
+
+            variant = Variant(params=combo)
+            tasks.append(
+                BenchmarkTask(
+                    recipe_dir=recipe_dir,
+                    variant=variant,
+                    recipe=recipe,
+                )
+            )
 
     return tasks

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -46,8 +46,19 @@ def handle_bench(args):
     ssh_targets = list(getattr(args, "ssh", None) or [])
     fixed_host_mode = use_local or bool(ssh_targets)
 
+    # Parse --filter flags
+    parsed_filters = None
+    if args.filters:
+        parsed_filters = []
+        for f in args.filters:
+            if "=" not in f:
+                root_logger.error(f"Invalid filter format: {f!r} (expected KEY=PATTERN)")
+                sys.exit(1)
+            key, pattern = f.split("=", 1)
+            parsed_filters.append((key, pattern))
+
     # Enumerate tasks from recipe dirs
-    tasks = enumerate_tasks(args.recipes)
+    tasks = enumerate_tasks(args.recipes, filters=parsed_filters)
     if not tasks:
         root_logger.error("Error: No benchmark tasks found.")
         sys.exit(1)
@@ -226,5 +237,13 @@ def register_bench_command(subparsers):
         "--billing-exempt",
         action="store_true",
         help="Skip billing for CloudRift instances (admin-only)",
+    )
+    parser.add_argument(
+        "--filter",
+        action="append",
+        default=None,
+        dest="filters",
+        metavar="KEY=PATTERN",
+        help="Filter variants by parameter value (fnmatch glob, repeatable, AND logic)",
     )
     parser.set_defaults(func=handle_bench)

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -8,38 +8,53 @@ The `recipe` package owns all recipe-related logic: YAML loading, matrix expansi
 
 - `types.py` — dataclasses: `Recipe`, `DeployConfig`, `ModelConfig`, `EngineConfig`, `LLMConfig`, `VllmConfig`, `SglangConfig`, `BenchmarkConfig`, `CommandConfig`
 - `recipe.py` — `deep_merge()`, `load_recipe()`, `resolve_for_hardware()`, `validate_extra_args()`, `_load_raw_config()`, `_validate_and_build()`
-- `matrix.py` — `expand_matrix_entry()`, `dot_to_nested()`, `build_override()`
+- `matrix.py` — `expand_matrix()`, `_expand_cross()`, `_expand_zip()`, `filter_combinations()`, `dot_to_nested()`, `build_override()`
 - `engines.py` — `VLLM_FLAG_MAP`, `SGLANG_FLAG_MAP`, `banned_extra_arg_flags()`, `build_engine_args()`
 
 ## Key Design Decisions
 
 ### Matrix Expansion for Benchmark Sweeps
 
-Recipes use `matrices` — a list of entries that define benchmark configurations with broadcast + zip semantics:
+Recipes use `matrices` — a dict that defines benchmark configurations using `cross` and `zip` combinators:
 
 ```yaml
+# Simple single-point entry (implicit zip, all scalars)
 matrices:
-  # Simple single-point entry (all scalars)
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+  deploy.gpu: "NVIDIA GeForce RTX 5090"
+  deploy.gpu_count: 1
+
+# Cross-product: 3 GPUs × 2 configs = 6 variants
+matrices:
+  cross:
     deploy.gpu_count: 1
+    deploy.gpu:
+      - "NVIDIA GeForce RTX 5090"
+      - "NVIDIA H100 80GB"
+      - "NVIDIA H200 141GB"
+    zip:
+      engine.llm.max_concurrent_requests: [128, 512]
+      benchmark.max_concurrency: [128, 512]
 
-  # Concurrency sweep (8 runs from one entry)
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    benchmark.max_concurrency: [1, 2, 4, 8, 16, 32, 64, 128]
-
-  # Correlated sweep (3 zip runs)
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    engine.llm.max_concurrent_requests: [128, 256, 512]
-    benchmark.max_concurrency: [128, 256, 512]
+# Concurrency sweep (zip: 8 runs)
+matrices:
+  deploy.gpu: "NVIDIA GeForce RTX 5090"
+  engine.llm.max_concurrent_requests: [1, 2, 4, 8, 16, 32, 64, 128]
+  benchmark.max_concurrency: [1, 2, 4, 8, 16, 32, 64, 128]
 ```
 
 Rules:
-- **Scalars** are broadcast to all runs in the entry
-- **Lists** are zipped together (all lists in one entry must have the same length)
-- **`deploy.gpu`** is required in each matrix entry
+- **`cross` node**: scalars broadcast, lists are independent cross-product axes, nested `zip` dicts are one compound axis
+- **`zip` node**: scalars broadcast, lists are zipped element-wise (must all be the same length), nested `cross` dicts are one zip axis
+- A plain dict (no `cross`/`zip` key) is an implicit `zip`
+- `cross`/`zip` keys are only combinators when their value is a dict
+- **`deploy.gpu`** is required
 - **Dot-notation** is used for all parameter paths (`deploy.gpu`, `engine.llm.max_concurrent_requests`, etc.)
 
-Each combination is converted to a nested override dict via `build_override()` and deep-merged with the base config.
+The entry point is `expand_matrix(matrices)` which dispatches to `_expand_cross()` or `_expand_zip()` recursively. Each resulting combination is converted to a nested override dict via `build_override()` and deep-merged with the base config.
+
+#### Variant Filtering
+
+`filter_combinations(combinations, filters)` applies `--filter KEY=PATTERN` flags (fnmatch glob, AND logic) after expansion, before building Recipe objects. This allows running a subset of variants (e.g. `--filter "deploy.gpu=*5090*"`).
 
 ### Deep Merge
 
@@ -56,8 +71,8 @@ engine:
 
 # matrix entry overrides only what changes
 matrices:
-  - deploy.gpu: "NVIDIA H100 80GB"
-    engine.llm.max_concurrent_requests: 256
+  deploy.gpu: "NVIDIA H100 80GB"
+  engine.llm.max_concurrent_requests: 256
 ```
 
 The merged result keeps `tensor_parallel_size: 8`, `context_length: 16384`, and the vllm block from the base, while adding `max_concurrent_requests: 256` from the matrix entry.
@@ -161,9 +176,9 @@ command:
   env: {FOO: bar}                  # optional, prepended as KEY=value to the command
 
 matrices:
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    deploy.gpu_count: 1
-    marker: [a, b, c]
+  deploy.gpu: "NVIDIA GeForce RTX 5090"
+  deploy.gpu_count: 1
+  marker: [a, b, c]
 ```
 
 The `run` template uses `string.Template` `$var` syntax. Substitution variables come from variant params (flattened to leaf names: `deploy.gpu` → `gpu`, `marker` → `marker`) plus harness-injected `$task_dir`, `$gpu_device_ids`, and `$repo_dir` (only when `stage` is non-empty). Conflicting leaf names (e.g. two matrix keys flattening to `gpu`) raise at substitution time.
@@ -193,8 +208,8 @@ Keys managed by the compose template (`image`, `container_name`, `entrypoint`, `
 Matrix overrides work naturally via deep merge:
 ```yaml
 matrices:
-  - deploy.gpu: "AMD Instinct MI350X"
-    engine.llm.docker_options:
+  deploy.gpu: "AMD Instinct MI350X"
+  engine.llm.docker_options:
       security_opt:
         - seccomp=unconfined
 ```
@@ -214,12 +229,14 @@ _load_raw_config(recipe_dir) -> raw dict
     +-- load_recipe(): strips matrices, calls _validate_and_build()
     |       -> base Recipe (for bench/cloud commands that don't need matrix resolution)
     |
-    +-- resolve_for_hardware(recipe_dir, gpu_name): finds first scalar matrix
-    |       entry matching gpu_name, deep_merges with base, calls _validate_and_build()
+    +-- resolve_for_hardware(recipe_dir, gpu_name): expands full matrix,
+    |       finds best combo matching gpu_name, deep_merges with base,
+    |       calls _validate_and_build()
     |       -> hardware-resolved Recipe (for deploy local/ssh commands)
     |
-    +-- enumerate_tasks(): reads matrices, expands each entry:
-            |-- expand_matrix_entry() -> list of combinations
+    +-- enumerate_tasks(): reads matrices, expands via cross/zip:
+            |-- expand_matrix() -> list of combinations
+            |-- filter_combinations() -> filtered list (if --filter flags)
             |-- Variant(params=combo) -> typed variant
             |-- build_override() -> nested override dict
             |-- deep_merge(base, override) -> merged config

--- a/deplodock/recipe/__init__.py
+++ b/deplodock/recipe/__init__.py
@@ -4,7 +4,8 @@ from deplodock.recipe.engines import banned_extra_arg_flags, build_engine_args
 from deplodock.recipe.matrix import (
     build_override,
     dot_to_nested,
-    expand_matrix_entry,
+    expand_matrix,
+    filter_combinations,
 )
 from deplodock.recipe.recipe import (
     _load_raw_config,
@@ -44,7 +45,8 @@ __all__ = [
     "build_override",
     "deep_merge",
     "dot_to_nested",
-    "expand_matrix_entry",
+    "expand_matrix",
+    "filter_combinations",
     "load_recipe",
     "resolve_for_hardware",
     "validate_docker_options",

--- a/deplodock/recipe/matrix.py
+++ b/deplodock/recipe/matrix.py
@@ -1,4 +1,18 @@
-"""Matrix expansion: broadcast + zip semantics for benchmark parameter sweeps."""
+"""Matrix expansion: cross-product and zip combinators for benchmark parameter sweeps.
+
+A matrix spec is a dict that can contain:
+- Scalar values: broadcast to all combinations
+- List values: in cross mode, each is an independent axis (cartesian product);
+  in zip mode, all must be same length and are paired element-wise
+- ``cross`` key (dict value): nested cross-product combinator
+- ``zip`` key (dict value): nested zip combinator
+
+The ``cross``/``zip`` keys are only treated as combinators when their value is
+a dict.  A scalar or list value for those keys is treated as a regular parameter.
+"""
+
+import itertools
+from fnmatch import fnmatch
 
 
 def dot_to_nested(key: str, value) -> dict:
@@ -16,41 +30,113 @@ def dot_to_nested(key: str, value) -> dict:
     return result
 
 
-def expand_matrix_entry(entry: dict) -> list[dict]:
-    """Expand one matrix entry using broadcast + zip semantics.
+def _expand_cross(node: dict) -> list[dict]:
+    """Expand a cross-product node.
 
-    Scalars are broadcast to all runs. Lists are zipped together (all lists
-    in one entry must have the same length). Returns a list of flat dicts
-    mapping dot-notation keys to scalar values (one dict per run).
+    Scalars are broadcast.  Lists become independent axes whose cartesian
+    product is computed.  Nested ``zip``/``cross`` sub-dicts are recursed and
+    their result becomes one axis.
     """
-    scalar_keys = {}
-    list_keys = {}
+    broadcast: dict = {}
+    axes: list[list[dict]] = []
 
-    for key, value in entry.items():
-        if isinstance(value, list):
-            list_keys[key] = value
+    for key, value in node.items():
+        if key == "cross" and isinstance(value, dict):
+            axes.append(_expand_cross(value))
+        elif key == "zip" and isinstance(value, dict):
+            axes.append(_expand_zip(value))
+        elif isinstance(value, list):
+            axes.append([{key: v} for v in value])
         else:
-            scalar_keys[key] = value
+            broadcast[key] = value
 
-    if not list_keys:
-        return [dict(scalar_keys)]
+    if not axes:
+        return [dict(broadcast)]
 
-    # Validate all lists have the same length
-    lengths = {k: len(v) for k, v in list_keys.items()}
-    unique_lengths = set(lengths.values())
-    if len(unique_lengths) != 1:
-        detail = ", ".join(f"{k}={n}" for k, n in lengths.items())
-        raise ValueError(f"All lists in a matrix entry must have the same length, got: {detail}")
+    combinations = []
+    for product_tuple in itertools.product(*axes):
+        combo = dict(broadcast)
+        for d in product_tuple:
+            combo.update(d)
+        combinations.append(combo)
+    return combinations
 
-    n = unique_lengths.pop()
+
+def _expand_zip(node: dict) -> list[dict]:
+    """Expand a zip node.
+
+    Scalars are broadcast.  Lists are zipped element-wise (must all have the
+    same length).  Nested ``cross``/``zip`` sub-dicts are recursed and their
+    result becomes one zip axis.
+    """
+    broadcast: dict = {}
+    axes: list[list[dict]] = []
+
+    for key, value in node.items():
+        if key == "cross" and isinstance(value, dict):
+            axes.append(_expand_cross(value))
+        elif key == "zip" and isinstance(value, dict):
+            axes.append(_expand_zip(value))
+        elif isinstance(value, list):
+            axes.append([{key: v} for v in value])
+        else:
+            broadcast[key] = value
+
+    if not axes:
+        return [dict(broadcast)]
+
+    lengths = [len(a) for a in axes]
+    if len(set(lengths)) != 1:
+        detail = ", ".join(f"axis {i} len={n}" for i, n in enumerate(lengths))
+        raise ValueError(f"All axes in a zip node must have the same length, got: {detail}")
+
+    n = lengths[0]
     combinations = []
     for i in range(n):
-        combo = dict(scalar_keys)
-        for key, values in list_keys.items():
-            combo[key] = values[i]
+        combo = dict(broadcast)
+        for axis in axes:
+            combo.update(axis[i])
         combinations.append(combo)
-
     return combinations
+
+
+def expand_matrix(matrices) -> list[dict]:
+    """Expand a matrices spec into a flat list of parameter combinations.
+
+    Accepts:
+    - A dict with a top-level ``cross`` key (dict value) → cross-product
+    - A dict with a top-level ``zip`` key (dict value) → zip
+    - A plain dict (no cross/zip) → implicit zip
+    - A list of dicts → legacy experiment format (each entry is an implicit
+      zip, results are concatenated)
+    """
+    if isinstance(matrices, list):
+        # Legacy experiment snapshot format
+        result = []
+        for entry in matrices:
+            result.extend(_expand_zip(entry))
+        return result
+
+    if not isinstance(matrices, dict):
+        raise TypeError(f"matrices must be a dict or list, got {type(matrices).__name__}")
+
+    if "cross" in matrices and isinstance(matrices["cross"], dict):
+        return _expand_cross(matrices["cross"])
+    if "zip" in matrices and isinstance(matrices["zip"], dict):
+        return _expand_zip(matrices["zip"])
+    return _expand_zip(matrices)
+
+
+def filter_combinations(
+    combinations: list[dict],
+    filters: list[tuple[str, str]],
+) -> list[dict]:
+    """Filter combinations by key=glob_pattern pairs (AND logic)."""
+    result = []
+    for combo in combinations:
+        if all(fnmatch(str(combo.get(key, "")), pattern) for key, pattern in filters):
+            result.append(combo)
+    return result
 
 
 def build_override(combination: dict) -> dict:

--- a/deplodock/recipe/recipe.py
+++ b/deplodock/recipe/recipe.py
@@ -112,7 +112,7 @@ def load_recipe(recipe_dir):
 def resolve_for_hardware(recipe_dir: str, gpu_name: str, gpu_count: int | None = None) -> "Recipe":
     """Load recipe and resolve the best matrix entry for the given hardware.
 
-    Matching priority (scalar entries only, sweeps with lists are skipped):
+    Expands the full matrix (cross/zip), then picks the best match:
     1. Exact match: deploy.gpu == gpu_name AND deploy.gpu_count == gpu_count
     2. Divisible match: deploy.gpu == gpu_name AND gpu_count is a multiple of
        the entry's deploy.gpu_count (for scale-out). Picks the largest entry
@@ -122,7 +122,7 @@ def resolve_for_hardware(recipe_dir: str, gpu_name: str, gpu_count: int | None =
     If no matrices section exists, returns the base recipe.
     Raises ValueError if no match is found.
     """
-    from deplodock.recipe.matrix import build_override
+    from deplodock.recipe.matrix import build_override, expand_matrix
 
     config = _load_raw_config(recipe_dir)
     matrices = config.pop("matrices", None)
@@ -130,18 +130,17 @@ def resolve_for_hardware(recipe_dir: str, gpu_name: str, gpu_count: int | None =
     if not matrices:
         return _validate_and_build(config)
 
-    # Collect scalar entries matching gpu_name
+    combinations = expand_matrix(matrices)
+
+    # Collect combinations matching gpu_name
     available_gpus = set()
     candidates = []
-    for entry in matrices:
-        gpu = entry.get("deploy.gpu")
+    for combo in combinations:
+        gpu = combo.get("deploy.gpu")
         if gpu is not None:
             available_gpus.add(gpu)
-        if gpu != gpu_name:
-            continue
-        if any(isinstance(v, list) for v in entry.values()):
-            continue
-        candidates.append(entry)
+        if gpu == gpu_name:
+            candidates.append(combo)
 
     if not candidates:
         raise ValueError(f"No matrix entry matches GPU '{gpu_name}'. Available GPUs: {', '.join(sorted(available_gpus))}")
@@ -153,10 +152,10 @@ def resolve_for_hardware(recipe_dir: str, gpu_name: str, gpu_count: int | None =
         return _validate_and_build(merged)
 
     # Try exact count match first
-    for entry in candidates:
-        entry_count = entry.get("deploy.gpu_count", 1)
+    for combo in candidates:
+        entry_count = combo.get("deploy.gpu_count", 1)
         if entry_count == gpu_count:
-            override = build_override(entry)
+            override = build_override(combo)
             merged = deep_merge(config, override)
             return _validate_and_build(merged)
 
@@ -164,10 +163,10 @@ def resolve_for_hardware(recipe_dir: str, gpu_name: str, gpu_count: int | None =
     # Pick largest entry count that divides evenly.
     best = None
     best_count = 0
-    for entry in candidates:
-        entry_count = entry.get("deploy.gpu_count", 1)
+    for combo in candidates:
+        entry_count = combo.get("deploy.gpu_count", 1)
         if gpu_count % entry_count == 0 and entry_count > best_count:
-            best = entry
+            best = combo
             best_count = entry_count
 
     if best is not None:
@@ -175,5 +174,5 @@ def resolve_for_hardware(recipe_dir: str, gpu_name: str, gpu_count: int | None =
         merged = deep_merge(config, override)
         return _validate_and_build(merged)
 
-    entry_counts = sorted({e.get("deploy.gpu_count", 1) for e in candidates})
+    entry_counts = sorted({c.get("deploy.gpu_count", 1) for c in candidates})
     raise ValueError(f"No matrix entry for GPU '{gpu_name}' matches gpu_count={gpu_count}. Available counts: {entry_counts}")

--- a/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
+++ b/recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ/recipe.yaml
@@ -18,5 +18,5 @@ benchmark:
   random_output_len: 4000
 
 matrices:
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    deploy.gpu_count: 1
+  deploy.gpu: "NVIDIA GeForce RTX 5090"
+  deploy.gpu_count: 1

--- a/recipes/Qwen3-Coder-Next-FP8/recipe.yaml
+++ b/recipes/Qwen3-Coder-Next-FP8/recipe.yaml
@@ -18,5 +18,5 @@ benchmark:
   random_output_len: 4000
 
 matrices:
-  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Server Edition"
-    deploy.gpu_count: 1
+  deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Server Edition"
+  deploy.gpu_count: 1

--- a/recipes/Qwen3.5-122B-A10B-FP8/recipe.yaml
+++ b/recipes/Qwen3.5-122B-A10B-FP8/recipe.yaml
@@ -12,6 +12,6 @@ engine:
       extra_args: "--enable-prefix-caching --language-model-only --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3"
 
 matrices:
-  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-    deploy.gpu_count: 8
-    engine.llm.context_length: 262144
+  deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
+  deploy.gpu_count: 8
+  engine.llm.context_length: 262144

--- a/recipes/Qwen3.5-397B-A17B-FP8/recipe.yaml
+++ b/recipes/Qwen3.5-397B-A17B-FP8/recipe.yaml
@@ -15,6 +15,6 @@ engine:
         SGLANG_ENABLE_JIT_DEEPGEMM: 0
 
 matrices:
-  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-    deploy.gpu_count: 8
-    engine.llm.context_length: 262144
+  deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
+  deploy.gpu_count: 8
+  engine.llm.context_length: 262144

--- a/recipes/sgemm_cublas_vs_tma/RESULTS.md
+++ b/recipes/sgemm_cublas_vs_tma/RESULTS.md
@@ -4,11 +4,11 @@ Three GPU-prefixed run directories. Each contains the JSON traces, markdown
 reports, and (where available) `ncu` diagnostic dumps that back the numbers
 in the [companion blog post](https://github.com/cloudrift-ai/deplodock/tree/main/scripts/diagnostics).
 
-| Directory | GPU | Run date | Notes |
-|---|---|---|---|
-| `rtx5090_2026-04-07_16-42-49/` | NVIDIA GeForce RTX 5090 (sm_120, 170 SMs) | 2026-04-07 | Local dev box, driver 595.58.03, CUDA 13.2.51, cuBLAS 13.3.0. Single-mode + batched-mode reports. Numbers in the article's headline 5090 tables match this run exactly. |
+| Directory                      | GPU                                                   | Run date   | Notes                                                                                                                                                                                      |
+|--------------------------------|-------------------------------------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `rtx5090_2026-04-07_16-42-49/` | NVIDIA GeForce RTX 5090 (sm_120, 170 SMs)             | 2026-04-07 | Local dev box, driver 595.58.03, CUDA 13.2.51, cuBLAS 13.3.0. Single-mode + batched-mode reports. Numbers in the article's headline 5090 tables match this run exactly.                    |
 | `pro6000_2026-04-07_21-29-59/` | NVIDIA RTX PRO 6000 Blackwell Max-Q (sm_120, 188 SMs) | 2026-04-07 | CloudRift VM, same driver/CUDA/cuBLAS as the 5090 run. Single-mode + batched-mode reports + diagnostics (cuBLAS kernel dump, SASS histogram). Numbers match the article's Pro 6000 tables. |
-| `h200_2026-04-07_19-39-24/` | NVIDIA H200 (sm_90, 132 SMs) | 2026-04-07 | Remote SSH host, same driver/CUDA/cuBLAS. Single-mode + batched-mode reports + diagnostics. Numbers match the article's H200 tables. |
+| `h200_2026-04-07_19-39-24/`    | NVIDIA H200 (sm_90, 132 SMs)                          | 2026-04-07 | Remote SSH host, same driver/CUDA/cuBLAS. Single-mode + batched-mode reports + diagnostics. Numbers match the article's H200 tables.                                                       |
 
 ## What's inside each run directory
 
@@ -32,7 +32,8 @@ ncu data captured by [`scripts/diagnostics/ncu_compare.sh`](../../scripts/diagno
 ## Reproducing
 
 ```bash
-deplodock bench recipes/sgemm_cublas_vs_tma --local        # 5090 (or whatever you have locally)
+deplodock bench recipes/sgemm_cublas_vs_tma --local        # all GPUs in the recipe
+deplodock bench recipes/sgemm_cublas_vs_tma --local --filter "deploy.gpu=*5090*"  # RTX 5090 only
 deplodock bench recipes/sgemm_cublas_vs_tma --ssh user@host  # remote H200 / Pro 6000
 ```
 

--- a/recipes/sgemm_cublas_vs_tma/RESULTS.md
+++ b/recipes/sgemm_cublas_vs_tma/RESULTS.md
@@ -32,9 +32,8 @@ ncu data captured by [`scripts/diagnostics/ncu_compare.sh`](../../scripts/diagno
 ## Reproducing
 
 ```bash
-deplodock bench recipes/sgemm_cublas_vs_tma --local        # all GPUs in the recipe
-deplodock bench recipes/sgemm_cublas_vs_tma --local --filter "deploy.gpu=*5090*"  # RTX 5090 only
-deplodock bench recipes/sgemm_cublas_vs_tma --ssh user@host  # remote H200 / Pro 6000
+deplodock bench recipes/sgemm_cublas_vs_tma --local --filter "deploy.gpu=*5090*"              # RTX 5090 only
+deplodock bench recipes/sgemm_cublas_vs_tma --ssh user@host --filter "deploy.gpu=*PRO 6000*"  # Remote Pro 6000
 ```
 
 The recipe pins driver 595.58.03 and CUDA 13.2 for cloud reproductions.

--- a/recipes/sgemm_cublas_vs_tma/recipe.yaml
+++ b/recipes/sgemm_cublas_vs_tma/recipe.yaml
@@ -39,70 +39,17 @@ command:
   timeout: 1800
 
 matrices:
-  # Single-GEMM sweep. 256 and 512 are excluded: at those sizes the per-call
-  # duration is sub-millisecond, the GPU clock governor never engages boost,
-  # and the SM clock fluctuates between idle (~260 MHz) and steady (~2400 MHz)
-  # within a single benchmark run — the resulting variance dominates any real
-  # signal. They're still measured in batched mode below where the longer
-  # duration keeps the clock pinned.
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
-    deploy.gpu_count: 1
-    # Pin the toolchain so cloud runs reproduce the article's numbers exactly.
-    # The harness skips reinstall if the requested versions are already on the
-    # host (which is the case for `--local` runs against this dev box), so this
-    # is free for local benchmarking and load-bearing only on fresh cloud VMs.
-    deploy.driver_version: "595.58.03"
-    deploy.cuda_version: "13.2"
-    strategy: adaptive
-    sizes: "1024,2048,4096,8192,16384"
-    batches: "1"
-    iterations: 30
-    git_rev: "feature/mini-gpu-compiler@local"
-  - deploy.gpu: "NVIDIA GeForce RTX 5090"
+  cross:
     deploy.gpu_count: 1
     deploy.driver_version: "595.58.03"
     deploy.cuda_version: "13.2"
     strategy: adaptive
-    sizes: "256,512,1024,2048,4096,8192"
-    batches: "4,8,16"
-    iterations: 20
     git_rev: "feature/mini-gpu-compiler@local"
-  - deploy.gpu: "NVIDIA H200 141GB"
-    deploy.gpu_count: 1
-    deploy.driver_version: "595.58.03"
-    deploy.cuda_version: "13.2"
-    strategy: adaptive
-    sizes: "1024,2048,4096,8192,16384"
-    batches: "1"
-    iterations: 30
-    git_rev: "feature/mini-gpu-compiler@local"
-  - deploy.gpu: "NVIDIA H200 141GB"
-    deploy.gpu_count: 1
-    deploy.driver_version: "595.58.03"
-    deploy.cuda_version: "13.2"
-    strategy: adaptive
-    sizes: "256,512,1024,2048,4096,8192"
-    batches: "4,8,16"
-    iterations: 20
-    git_rev: "feature/mini-gpu-compiler@local"
-  # RTX PRO 6000 Blackwell Max-Q (sm_120) — same architecture as 5090 but 188 SMs
-  # vs 170, different wave quantization. Per-GPU tuning profile in tuning.py
-  # picks TM=24 at 4096+ instead of the 5090's TM=20/28.
-  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-    deploy.gpu_count: 1
-    deploy.driver_version: "595.58.03"
-    deploy.cuda_version: "13.2"
-    strategy: adaptive
-    sizes: "1024,2048,4096,8192,16384"
-    batches: "1"
-    iterations: 30
-    git_rev: "feature/mini-gpu-compiler@local"
-  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-    deploy.gpu_count: 1
-    deploy.driver_version: "595.58.03"
-    deploy.cuda_version: "13.2"
-    strategy: adaptive
-    sizes: "256,512,1024,2048,4096,8192"
-    batches: "4,8,16"
-    iterations: 20
-    git_rev: "feature/mini-gpu-compiler@local"
+    deploy.gpu:
+      - "NVIDIA GeForce RTX 5090"
+      - "NVIDIA H200 141GB"
+      - "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
+    zip:
+      sizes:      ["1024,2048,4096,8192,16384", "256,512,1024,2048,4096,8192"]
+      batches:    ["1",                          "4,8,16"]
+      iterations: [30,                           20]

--- a/tests/recipe/test_matrix.py
+++ b/tests/recipe/test_matrix.py
@@ -3,9 +3,12 @@
 import pytest
 
 from deplodock.recipe.matrix import (
+    _expand_cross,
+    _expand_zip,
     build_override,
     dot_to_nested,
-    expand_matrix_entry,
+    expand_matrix,
+    filter_combinations,
 )
 
 # ── dot_to_nested ──────────────────────────────────────────────────
@@ -26,45 +29,266 @@ def test_dot_to_nested_three_levels():
     assert result == {"engine": {"llm": {"max_concurrent_requests": 256}}}
 
 
-# ── expand_matrix_entry ────────────────────────────────────────────
+# ── _expand_cross ─────────────────────────────────────────────────
 
 
-def test_expand_all_scalars():
-    entry = {"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}
-    result = expand_matrix_entry(entry)
-    assert result == [{"deploy.gpu": "NVIDIA RTX 5090", "deploy.gpu_count": 1}]
+def test_cross_all_scalars():
+    result = _expand_cross({"a": 1, "b": 2})
+    assert result == [{"a": 1, "b": 2}]
 
 
-def test_expand_single_list():
-    entry = {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": [1, 2, 4]}
-    result = expand_matrix_entry(entry)
-    assert len(result) == 3
-    assert result[0] == {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 1}
-    assert result[1] == {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 2}
-    assert result[2] == {"deploy.gpu": "NVIDIA RTX 5090", "benchmark.max_concurrency": 4}
+def test_cross_one_list():
+    result = _expand_cross({"a": 1, "b": [10, 20]})
+    assert result == [{"a": 1, "b": 10}, {"a": 1, "b": 20}]
 
 
-def test_expand_multiple_lists_zipped():
-    entry = {
-        "deploy.gpu": "NVIDIA RTX 5090",
-        "engine.llm.max_concurrent_requests": [128, 256],
-        "benchmark.max_concurrency": [128, 256],
-    }
-    result = expand_matrix_entry(entry)
+def test_cross_two_lists():
+    result = _expand_cross({"a": [1, 2], "b": [10, 20]})
+    assert len(result) == 4
+    assert {"a": 1, "b": 10} in result
+    assert {"a": 1, "b": 20} in result
+    assert {"a": 2, "b": 10} in result
+    assert {"a": 2, "b": 20} in result
+
+
+def test_cross_with_nested_zip():
+    """zip inside cross bundles its lists into one compound axis."""
+    result = _expand_cross(
+        {
+            "gpu": ["A", "B"],
+            "zip": {
+                "sizes": ["small", "large"],
+                "iters": [10, 30],
+            },
+        }
+    )
+    assert len(result) == 4  # 2 gpus × 2 zip combos
+    assert {"gpu": "A", "sizes": "small", "iters": 10} in result
+    assert {"gpu": "A", "sizes": "large", "iters": 30} in result
+    assert {"gpu": "B", "sizes": "small", "iters": 10} in result
+    assert {"gpu": "B", "sizes": "large", "iters": 30} in result
+
+
+def test_cross_empty_list_produces_nothing():
+    result = _expand_cross({"a": 1, "b": []})
+    assert result == []
+
+
+def test_cross_single_element_list():
+    result = _expand_cross({"a": [1], "b": [10, 20]})
     assert len(result) == 2
-    assert result[0]["engine.llm.max_concurrent_requests"] == 128
-    assert result[0]["benchmark.max_concurrency"] == 128
-    assert result[1]["engine.llm.max_concurrent_requests"] == 256
-    assert result[1]["benchmark.max_concurrency"] == 256
+    assert result == [{"a": 1, "b": 10}, {"a": 1, "b": 20}]
 
 
-def test_expand_mismatched_list_lengths_raises():
-    entry = {
-        "benchmark.max_concurrency": [1, 2, 4],
-        "benchmark.num_prompts": [100, 200],
-    }
+# ── _expand_zip ───────────────────────────────────────────────────
+
+
+def test_zip_all_scalars():
+    result = _expand_zip({"a": 1, "b": 2})
+    assert result == [{"a": 1, "b": 2}]
+
+
+def test_zip_single_list():
+    result = _expand_zip({"a": "x", "b": [1, 2, 3]})
+    assert len(result) == 3
+    assert result[0] == {"a": "x", "b": 1}
+    assert result[2] == {"a": "x", "b": 3}
+
+
+def test_zip_multiple_lists():
+    result = _expand_zip(
+        {
+            "deploy.gpu": "RTX",
+            "mcr": [128, 256],
+            "mc": [128, 256],
+        }
+    )
+    assert len(result) == 2
+    assert result[0] == {"deploy.gpu": "RTX", "mcr": 128, "mc": 128}
+    assert result[1] == {"deploy.gpu": "RTX", "mcr": 256, "mc": 256}
+
+
+def test_zip_mismatched_lengths_raises():
     with pytest.raises(ValueError, match="same length"):
-        expand_matrix_entry(entry)
+        _expand_zip({"a": [1, 2, 3], "b": [10, 20]})
+
+
+def test_zip_with_nested_cross_mismatched_raises():
+    """cross inside zip that produces different length raises."""
+    with pytest.raises(ValueError, match="same length"):
+        _expand_zip(
+            {
+                "x": [1, 2],
+                "cross": {"a": ["p", "q"], "b": ["r", "s"]},
+            }
+        )
+
+
+def test_zip_with_nested_cross():
+    """cross inside zip becomes one zip axis."""
+    result = _expand_zip(
+        {
+            "x": [1, 2],
+            "cross": {"a": ["p", "q"]},
+        }
+    )
+    assert len(result) == 2
+    assert result[0] == {"x": 1, "a": "p"}
+    assert result[1] == {"x": 2, "a": "q"}
+
+
+# ── expand_matrix (entry point) ──────────────────────────────────
+
+
+def test_expand_matrix_with_cross_key():
+    matrices = {
+        "cross": {
+            "a": 1,
+            "b": [10, 20],
+        },
+    }
+    result = expand_matrix(matrices)
+    assert len(result) == 2
+    assert result == [{"a": 1, "b": 10}, {"a": 1, "b": 20}]
+
+
+def test_expand_matrix_with_zip_key():
+    matrices = {
+        "zip": {
+            "a": "x",
+            "b": [1, 2],
+            "c": [3, 4],
+        },
+    }
+    result = expand_matrix(matrices)
+    assert len(result) == 2
+    assert result[0] == {"a": "x", "b": 1, "c": 3}
+
+
+def test_expand_matrix_implicit_zip():
+    """Plain dict without cross/zip key → implicit zip."""
+    matrices = {
+        "deploy.gpu": "RTX 5090",
+        "deploy.gpu_count": 1,
+    }
+    result = expand_matrix(matrices)
+    assert result == [{"deploy.gpu": "RTX 5090", "deploy.gpu_count": 1}]
+
+
+def test_expand_matrix_legacy_list():
+    """List of dicts → legacy experiment format, each entry is implicit zip."""
+    matrices = [
+        {"deploy.gpu": "RTX 5090", "deploy.gpu_count": 1, "mcr": [8, 16]},
+        {"deploy.gpu": "H200", "deploy.gpu_count": 1},
+    ]
+    result = expand_matrix(matrices)
+    assert len(result) == 3  # 2 from first entry + 1 from second
+    assert result[0] == {"deploy.gpu": "RTX 5090", "deploy.gpu_count": 1, "mcr": 8}
+    assert result[1] == {"deploy.gpu": "RTX 5090", "deploy.gpu_count": 1, "mcr": 16}
+    assert result[2] == {"deploy.gpu": "H200", "deploy.gpu_count": 1}
+
+
+def test_expand_matrix_invalid_type_raises():
+    with pytest.raises(TypeError, match="dict or list"):
+        expand_matrix("not a dict")
+
+
+# ── filter_combinations ──────────────────────────────────────────
+
+
+def test_filter_exact_match():
+    combos = [
+        {"deploy.gpu": "RTX 5090", "x": 1},
+        {"deploy.gpu": "H200", "x": 2},
+    ]
+    result = filter_combinations(combos, [("deploy.gpu", "RTX 5090")])
+    assert len(result) == 1
+    assert result[0]["deploy.gpu"] == "RTX 5090"
+
+
+def test_filter_glob_pattern():
+    combos = [
+        {"deploy.gpu": "NVIDIA GeForce RTX 5090", "x": 1},
+        {"deploy.gpu": "NVIDIA H200 141GB", "x": 2},
+    ]
+    result = filter_combinations(combos, [("deploy.gpu", "*5090*")])
+    assert len(result) == 1
+    assert result[0]["x"] == 1
+
+
+def test_filter_multiple_and():
+    combos = [
+        {"gpu": "A", "size": "1024"},
+        {"gpu": "A", "size": "2048"},
+        {"gpu": "B", "size": "1024"},
+    ]
+    result = filter_combinations(combos, [("gpu", "A"), ("size", "1024")])
+    assert len(result) == 1
+    assert result[0] == {"gpu": "A", "size": "1024"}
+
+
+def test_filter_no_match():
+    combos = [{"gpu": "A"}, {"gpu": "B"}]
+    result = filter_combinations(combos, [("gpu", "C")])
+    assert result == []
+
+
+def test_filter_missing_key():
+    """Missing key defaults to empty string — only matches empty-string patterns."""
+    combos = [{"gpu": "A"}, {"gpu": "B"}]
+    result = filter_combinations(combos, [("nonexistent", "something")])
+    assert result == []
+
+
+def test_filter_numeric_value():
+    combos = [{"x": 1}, {"x": 2}]
+    result = filter_combinations(combos, [("x", "1")])
+    assert len(result) == 1
+
+
+# ── Integration: sgemm cross-product recipe ──────────────────────
+
+
+def test_sgemm_cross_product():
+    """The sgemm recipe cross-product should produce 6 combinations (3 GPUs × 2 configs)."""
+    matrices = {
+        "cross": {
+            "deploy.gpu_count": 1,
+            "deploy.driver_version": "595.58.03",
+            "deploy.cuda_version": "13.2",
+            "strategy": "adaptive",
+            "git_rev": "feature/mini-gpu-compiler@local",
+            "deploy.gpu": [
+                "NVIDIA GeForce RTX 5090",
+                "NVIDIA H200 141GB",
+                "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+            ],
+            "zip": {
+                "sizes": ["1024,2048,4096,8192,16384", "256,512,1024,2048,4096,8192"],
+                "batches": ["1", "4,8,16"],
+                "iterations": [30, 20],
+            },
+        },
+    }
+    result = expand_matrix(matrices)
+    assert len(result) == 6
+
+    # All should have the broadcast scalars
+    for combo in result:
+        assert combo["deploy.gpu_count"] == 1
+        assert combo["deploy.driver_version"] == "595.58.03"
+        assert combo["strategy"] == "adaptive"
+
+    # Check specific combos
+    rtx5090_single = [c for c in result if c["deploy.gpu"] == "NVIDIA GeForce RTX 5090" and c["batches"] == "1"]
+    assert len(rtx5090_single) == 1
+    assert rtx5090_single[0]["sizes"] == "1024,2048,4096,8192,16384"
+    assert rtx5090_single[0]["iterations"] == 30
+
+    h200_batched = [c for c in result if c["deploy.gpu"] == "NVIDIA H200 141GB" and c["batches"] == "4,8,16"]
+    assert len(h200_batched) == 1
+    assert h200_batched[0]["sizes"] == "256,512,1024,2048,4096,8192"
+    assert h200_batched[0]["iterations"] == 20
 
 
 # ── build_override ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `cross` and `zip` combinators to recipe `matrices` for expressing cartesian products and element-wise pairings, eliminating duplication across multi-GPU/multi-config sweeps
- Add `--filter KEY=PATTERN` flag to `bench` command for running a subset of expanded variants (fnmatch glob, repeatable, AND logic)
- Migrate all 5 source recipes to new dict-based format; legacy list format still supported for experiment snapshots

## Test plan

- [x] All 402 tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [ ] `deplodock bench recipes/sgemm_cublas_vs_tma --dry-run` produces 6 tasks (3 GPUs x 2 configs)
- [ ] `deplodock bench recipes/sgemm_cublas_vs_tma --dry-run --filter "deploy.gpu=*5090*"` produces 2 tasks
- [ ] `deplodock bench recipes/Qwen3-Coder-30B-A3B-Instruct-AWQ --dry-run` still works
- [ ] Re-running an existing experiment with old list format still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)