### PR TITLE
Add $CLOUDRIFT_API_URL env var for CloudRift API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ deplodock vm delete cloudrift --instance-id <id>
 | `--instance-type` | (required)           | Instance type (e.g. rtx4090.1)    |
 | `--ssh-key`       | (required)           | Path to SSH public key file       |
 | `--api-key`       | `$CLOUDRIFT_API_KEY` | CloudRift API key                 |
+| `--api-url`       | `$CLOUDRIFT_API_URL` or `https://api.cloudrift.ai` | CloudRift API base URL |
 | `--image-url`     | Ubuntu 24.04         | VM image URL                      |
 | `--ports`         | `22,8000`            | Comma-separated ports to open     |
 | `--timeout`       | `600`                | Seconds to wait for Active status |
@@ -422,6 +423,7 @@ deplodock vm delete cloudrift --instance-id <id>
 |-----------------|----------------------|----------------------------------|
 | `--instance-id` | (required)           | CloudRift instance ID            |
 | `--api-key`     | `$CLOUDRIFT_API_KEY` | CloudRift API key                |
+| `--api-url`     | `$CLOUDRIFT_API_URL` or `https://api.cloudrift.ai` | CloudRift API base URL |
 | `--dry-run`     | false                | Print requests without executing |
 
 ## Benchmarking

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ providers:
     # service_account: defaults to $GCP_SERVICE_ACCOUNT env var
   cloudrift:
     # API key: defaults to $CLOUDRIFT_API_KEY env var
+    # API URL: defaults to $CLOUDRIFT_API_URL env var, else https://api.cloudrift.ai
     image_url_nvidia: "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-gpu-580-129-20251015-183936.img"
     image_url_amd: "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-rocm-64-20260220-025112.img"
     # billing_exempt: true  # admin-only, skip billing

--- a/deplodock/commands/vm/cloudrift.py
+++ b/deplodock/commands/vm/cloudrift.py
@@ -81,7 +81,11 @@ def register_create_target(subparsers):
     parser.add_argument("--api-key", default=None, help="CloudRift API key (fallback: CLOUDRIFT_API_KEY env var)")
     parser.add_argument("--image-url", default=DEFAULT_IMAGE_URL, help="VM image URL (default: Ubuntu 24.04)")
     parser.add_argument("--ports", default="22,8000", help="Comma-separated ports to open (default: 22,8000)")
-    parser.add_argument("--api-url", default=DEFAULT_API_URL, help=f"API base URL (default: {DEFAULT_API_URL})")
+    parser.add_argument(
+        "--api-url",
+        default=DEFAULT_API_URL,
+        help="API base URL (fallback: $CLOUDRIFT_API_URL, default: https://api.cloudrift.ai)",
+    )
     parser.add_argument("--timeout", type=int, default=600, help="Seconds to wait for Active status (default: 600)")
     parser.add_argument("--dry-run", action="store_true", help="Print requests without executing")
     parser.add_argument("--billing-exempt", action="store_true", help="Skip billing (admin-only)")
@@ -93,6 +97,10 @@ def register_delete_target(subparsers):
     parser = subparsers.add_parser("cloudrift", help="Delete a CloudRift GPU VM")
     parser.add_argument("--instance-id", required=True, help="CloudRift instance ID")
     parser.add_argument("--api-key", default=None, help="CloudRift API key (fallback: CLOUDRIFT_API_KEY env var)")
-    parser.add_argument("--api-url", default=DEFAULT_API_URL, help=f"API base URL (default: {DEFAULT_API_URL})")
+    parser.add_argument(
+        "--api-url",
+        default=DEFAULT_API_URL,
+        help="API base URL (fallback: $CLOUDRIFT_API_URL, default: https://api.cloudrift.ai)",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print requests without executing")
     parser.set_defaults(func=handle_delete)

--- a/deplodock/provisioning/cloudrift.py
+++ b/deplodock/provisioning/cloudrift.py
@@ -12,7 +12,7 @@ from deplodock.provisioning.types import VMConnectionInfo
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_API_URL = "https://api.cloudrift.ai"
+DEFAULT_API_URL = os.environ.get("CLOUDRIFT_API_URL", "https://api.cloudrift.ai")
 DEFAULT_IMAGE_URL = "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-gpu-580-129-20251015-183936.img"
 DEFAULT_CLOUDINIT_URL = "https://storage.googleapis.com/cloudrift-vm-disks/cloudinit/ubuntu-base.cloudinit"
 API_VERSION = "~upcoming"

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -321,3 +321,32 @@ def test_log_connection_info_no_port_mappings(caplog):
         _log_connection_info(instance)
     assert "ssh riftuser@1.2.3.4" in caplog.text
     assert "abc123" not in caplog.text  # password must not be logged
+
+
+# ── DEFAULT_API_URL env var ──────────────────────────────────────
+
+
+def test_default_api_url_env_var_override(monkeypatch):
+    """DEFAULT_API_URL honors CLOUDRIFT_API_URL env var at import time."""
+    import importlib
+
+    from deplodock.provisioning import cloudrift
+
+    monkeypatch.setenv("CLOUDRIFT_API_URL", "https://api.staging.cloudrift.ai")
+    try:
+        importlib.reload(cloudrift)
+        assert cloudrift.DEFAULT_API_URL == "https://api.staging.cloudrift.ai"
+    finally:
+        monkeypatch.delenv("CLOUDRIFT_API_URL", raising=False)
+        importlib.reload(cloudrift)
+
+
+def test_default_api_url_fallback(monkeypatch):
+    """DEFAULT_API_URL falls back to https://api.cloudrift.ai when env var unset."""
+    import importlib
+
+    from deplodock.provisioning import cloudrift
+
+    monkeypatch.delenv("CLOUDRIFT_API_URL", raising=False)
+    importlib.reload(cloudrift)
+    assert cloudrift.DEFAULT_API_URL == "https://api.cloudrift.ai"


### PR DESCRIPTION
Lets users point deplodock at a non-production CloudRift endpoint (staging / local mock / custom proxy) via a single env var, without threading a new CLI flag through commands that don't accept one. DEFAULT_API_URL now reads from $CLOUDRIFT_API_URL at import time and propagates automatically to vm create/delete, deploy cloud, and bench through the existing kwarg-default chain. Precedence: --api-url CLI flag > $CLOUDRIFT_API_URL > https://api.cloudrift.ai.