### PR TITLE
Redact secrets at log-handler level, not logger level

### DIFF
--- a/deplodock/benchmark/bench_logging.py
+++ b/deplodock/benchmark/bench_logging.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 from deplodock.planner import ExecutionGroup
-from deplodock.redact import SecretRedactingFilter
+from deplodock.redact import install_redaction
 
 active_run_dir: contextvars.ContextVar[Path | None] = contextvars.ContextVar("active_run_dir", default=None)
 
@@ -62,8 +62,8 @@ def setup_logging():
     console_handler = logging.StreamHandler(sys.stdout)
     console_formatter = _BenchConsoleFormatter("[%(name)s] %(message)s")
     console_handler.setFormatter(console_formatter)
+    install_redaction(console_handler)
     root_logger.addHandler(console_handler)
-    root_logger.addFilter(SecretRedactingFilter())
 
 
 def add_file_handler(run_dir: Path) -> str:
@@ -84,6 +84,7 @@ def add_file_handler(run_dir: Path) -> str:
     )
     file_handler.setFormatter(file_formatter)
     file_handler.addFilter(_RunDirFilter(run_dir))
+    install_redaction(file_handler)
     logging.getLogger().addHandler(file_handler)
 
     return str(log_file)
@@ -130,6 +131,7 @@ def add_group_file_handler(run_dir: Path, group_label: str) -> logging.Handler:
     )
     file_handler.setFormatter(file_formatter)
     file_handler.addFilter(_GroupNameFilter(group_label, run_dir))
+    install_redaction(file_handler)
     logging.getLogger().addHandler(file_handler)
 
     return file_handler

--- a/deplodock/benchmark/execution.py
+++ b/deplodock/benchmark/execution.py
@@ -31,6 +31,7 @@ from deplodock.provisioning.host import RemoteHost
 from deplodock.provisioning.remote import provision_remote
 from deplodock.provisioning.ssh_transport import REMOTE_DEPLOY_DIR, make_run_cmd
 from deplodock.provisioning.staging import stage_to_remote
+from deplodock.redact import register_secret
 
 OnTaskDone = Callable[[BenchmarkTask, bool], Awaitable[None]]
 
@@ -104,6 +105,7 @@ async def run_execution_group(
     instance_info = None
     model_dir = config["benchmark"].get("model_dir", "/hf_models")
     hf_token = os.environ.get("HF_TOKEN", "")
+    register_secret(hf_token)
     providers_config = config.get("providers", {})
 
     group_label = group.label

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -16,6 +16,7 @@ commands/vm ────► provisioning (create/delete instances)
 - `deplodock/deploy/` — compose generation, deploy orchestration
 - `deplodock/provisioning/` — VM types, SSH polling, shell helpers, cloud providers
 - `deplodock/logging_setup.py` — CLI logging setup (`setup_cli_logging()`)
+- `deplodock/redact.py` — `redact_secrets()`, `SecretRedactingFilter`, `install_redaction()` (attach the filter to a handler — must be a handler, not a logger, so child-logger records that propagate up are still redacted), `register_secret()` (call after resolving any secret from a CLI flag — `--hf-token`, `--api-key` — or env var so its value is added to the redaction set)
 - `deplodock/benchmark/` — config, logging, workload, tasks, execution, structured JSON results
 
 ## Layers

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -15,6 +15,7 @@ from deplodock.provisioning.cloud import (
 from deplodock.provisioning.host import RemoteHost
 from deplodock.provisioning.remote import provision_remote
 from deplodock.recipe import resolve_for_hardware
+from deplodock.redact import register_secret
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ async def _handle_cloud(args):
 
     ssh_key = os.path.expanduser(args.ssh_key)
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
+    register_secret(hf_token)
 
     providers_config = None
     if args.billing_exempt:

--- a/deplodock/commands/deploy/local.py
+++ b/deplodock/commands/deploy/local.py
@@ -11,6 +11,7 @@ from deplodock.detect import detect_local_gpus
 from deplodock.provisioning.host import LocalHost
 from deplodock.provisioning.remote import provision_remote
 from deplodock.recipe import resolve_for_hardware
+from deplodock.redact import register_secret
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ def handle_local(args):
 async def _handle_local(args):
     recipe_dir = args.recipe
     hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
+    register_secret(hf_token)
     model_dir = args.model_dir
     dry_run = args.dry_run
     teardown = args.teardown

--- a/deplodock/commands/deploy/ssh.py
+++ b/deplodock/commands/deploy/ssh.py
@@ -17,6 +17,7 @@ from deplodock.provisioning.host import RemoteHost
 from deplodock.provisioning.remote import provision_remote
 from deplodock.provisioning.ssh_target import parse_ssh_target
 from deplodock.recipe import resolve_for_hardware
+from deplodock.redact import register_secret
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +58,15 @@ async def _handle_ssh(args):
     strategy_cls = STRATEGIES[args.scale_out_strategy]
     recipe = strategy_cls().apply(recipe, gpu_count)
 
+    hf_token = args.hf_token or os.environ.get("HF_TOKEN", "")
+    register_secret(hf_token)
     params = DeployParams(
         server=server,
         ssh_key=args.ssh_key,
         ssh_port=port,
         recipe=recipe,
         model_dir=args.model_dir,
-        hf_token=args.hf_token or os.environ.get("HF_TOKEN", ""),
+        hf_token=hf_token,
         dry_run=args.dry_run,
     )
     skip_nvidia = recipe.deploy.gpu is not None and recipe.deploy.gpu.startswith("AMD")

--- a/deplodock/commands/vm/cloudrift.py
+++ b/deplodock/commands/vm/cloudrift.py
@@ -11,6 +11,7 @@ from deplodock.provisioning.cloudrift import (
     create_instance,
     delete_instance,
 )
+from deplodock.redact import register_secret
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ def _resolve_api_key(args_api_key):
     if not api_key:
         logger.error("Error: CloudRift API key required. Use --api-key or set CLOUDRIFT_API_KEY.")
         sys.exit(1)
+    register_secret(api_key)
     return api_key
 
 

--- a/deplodock/logging_setup.py
+++ b/deplodock/logging_setup.py
@@ -3,7 +3,7 @@
 import logging
 import sys
 
-from deplodock.redact import SecretRedactingFilter
+from deplodock.redact import install_redaction
 
 
 def setup_cli_logging():
@@ -17,5 +17,5 @@ def setup_cli_logging():
     root.handlers.clear()
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(logging.Formatter("%(message)s"))
+    install_redaction(handler)
     root.addHandler(handler)
-    root.addFilter(SecretRedactingFilter())

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -21,6 +21,7 @@ from deplodock.hardware import (
 )
 from deplodock.provisioning import cloudrift as cr_provider
 from deplodock.provisioning import gcp as gcp_provider
+from deplodock.redact import register_secret
 
 DEFAULT_PROVISION_RETRIES = 3
 PROVISION_RETRY_DELAY = 10  # seconds
@@ -138,6 +139,7 @@ async def _provision_once(provider, instance_type, gpu_name, gpu_count, ssh_key,
         api_key = os.environ.get("CLOUDRIFT_API_KEY")
         if not api_key and not dry_run:
             raise RuntimeError("CLOUDRIFT_API_KEY env var required for CloudRift provisioning")
+        register_secret(api_key or "")
 
         pub_key_path = f"{ssh_key}.pub"
 
@@ -190,6 +192,7 @@ async def _provision_once(provider, instance_type, gpu_name, gpu_count, ssh_key,
             os.environ.get("GCP_SERVICE_ACCOUNT", ""),
         )
         if service_account:
+            register_secret(service_account)
             extra_parts.append(f"--service-account={service_account}")
             extra_parts.append("--scopes=https://www.googleapis.com/auth/cloud-platform")
 
@@ -251,6 +254,7 @@ async def delete_cloud_vm(delete_info, dry_run=False):
             logger.info(f"[dry-run] cloudrift: terminate instance {instance_id}")
             return
         api_key = os.environ.get("CLOUDRIFT_API_KEY", "")
+        register_secret(api_key)
         await cr_provider.delete_instance(api_key, instance_id)
 
     elif provider == "gcp":

--- a/deplodock/redact.py
+++ b/deplodock/redact.py
@@ -15,9 +15,12 @@ _SECRET_ENV_VARS = [
 
 _MIN_SECRET_LENGTH = 8  # skip short values to avoid false positives
 
+# Values registered explicitly (e.g. resolved from a CLI flag that may not be in env).
+_explicit_secrets: set[str] = set()
+
 
 def _collect_secret_values() -> set[str]:
-    values = set()
+    values = set(_explicit_secrets)
     for var in _SECRET_ENV_VARS:
         val = os.environ.get(var, "")
         if len(val) >= _MIN_SECRET_LENGTH:
@@ -41,6 +44,19 @@ def _get_patterns() -> list[re.Pattern]:
     return _patterns
 
 
+def register_secret(value: str) -> None:
+    """Register an additional value to be redacted from logs.
+
+    Use at every site that resolves a secret from a CLI flag or other source
+    that may not be in os.environ when the redactor first scans (e.g. tokens
+    passed via `--hf-token`, `--api-key`).
+    """
+    global _patterns
+    if value and len(value) >= _MIN_SECRET_LENGTH and value not in _explicit_secrets:
+        _explicit_secrets.add(value)
+        _patterns = None  # invalidate cache so next redaction picks it up
+
+
 def redact_secrets(text: str) -> str:
     """Replace known secret env var values with '***'."""
     for pattern in _get_patterns():
@@ -57,9 +73,13 @@ def _apply(text: str, patterns: list[re.Pattern]) -> str:
 class SecretRedactingFilter(logging.Filter):
     """Logging filter that replaces secret values in log records with '***'.
 
-    Attaches to the root logger so all handlers benefit.
-    Handles both f-string messages (msg is pre-formatted) and
-    %-style messages (msg + args).
+    Must be attached to *Handlers*, not Loggers. Logger-level filters only run
+    on records originating from that logger; records propagating up from a
+    child logger bypass them. Handler-level filters run on every record the
+    handler processes, so they catch the propagation path too.
+
+    Use ``install_redaction(handler)`` rather than ``handler.addFilter(...)``
+    directly to keep wiring uniform across the codebase.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
@@ -72,3 +92,12 @@ class SecretRedactingFilter(logging.Filter):
                 elif isinstance(record.args, tuple):
                     record.args = tuple(_apply(str(a), patterns) if isinstance(a, str) else a for a in record.args)
         return True
+
+
+def install_redaction(handler: logging.Handler) -> None:
+    """Attach a SecretRedactingFilter to the given handler.
+
+    Always prefer this over Logger.addFilter(): only handler-attached filters
+    run for records that propagate up from child loggers.
+    """
+    handler.addFilter(SecretRedactingFilter())

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -90,7 +90,7 @@ Test individual functions in isolation with synthetic inputs.
 | `planner/test_variant.py` | `Variant` — `__str__`, `gpu_short`, `gpu_count`, `__eq__`, `__hash__`, `_abbreviate()` |
 | `test_detect.py` | `_parse_sysfs_output()`, `detect_local_gpus()`, `detect_remote_gpus()` — PCI sysfs GPU detection, mixed GPU errors, mock SSH |
 | `test_hardware.py` | `resolve_instance_type()`, `gpu_short_name()`, `GPU_INSTANCE_TYPES` — hardware lookup tables |
-| `test_redact.py` | `deplodock.redact.redact_secrets()`, `SecretRedactingFilter` — value-based secret redaction for text and log records |
+| `test_redact.py` | `deplodock.redact.redact_secrets()`, `SecretRedactingFilter`, `install_redaction()`, `register_secret()` — value-based secret redaction for text and log records, plus end-to-end propagation through a real `FileHandler` (regression test for child-logger records bypassing logger-level filters) |
 | `benchmark/test_code_hash.py` | `BenchmarkTask.compute_code_hash()` — determinism, hex format |
 | `benchmark/test_run_dir.py` | `BenchmarkTask.create_run_dir()` — directory creation, naming format |
 | `benchmark/test_tasks_json.py` | `BenchmarkTask.write_tasks_json()`, `read_tasks_json()` — tasks.json round-trip |

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -3,12 +3,13 @@
 import logging
 
 import deplodock.redact as redact_module
-from deplodock.redact import SecretRedactingFilter, redact_secrets
+from deplodock.redact import SecretRedactingFilter, install_redaction, redact_secrets, register_secret
 
 
 def _reset_cache():
-    """Reset the module-level pattern cache so env changes take effect."""
+    """Reset the module-level pattern cache and explicit-secrets set."""
     redact_module._patterns = None
+    redact_module._explicit_secrets.clear()
 
 
 # ── redact_secrets ──────────────────────────────────────────────
@@ -98,5 +99,115 @@ def test_secret_redacting_filter_with_args(monkeypatch):
     )
     filt.filter(record)
     assert record.args == ("***",)
+
+    _reset_cache()
+
+
+# ── install_redaction: end-to-end through a real handler ─────────
+
+
+def test_install_redaction_through_file_handler(monkeypatch, tmp_path):
+    """Regression: child-logger records propagating to a file handler must
+    still be redacted. Logger-level filters miss this path; handler-level
+    filters (what install_redaction installs) catch it.
+    """
+    monkeypatch.setenv("HF_TOKEN", "hf_PropagationTestToken123")
+    _reset_cache()
+
+    log_file = tmp_path / "out.log"
+    handler = logging.FileHandler(log_file, encoding="utf-8")
+    install_redaction(handler)
+
+    root = logging.getLogger()
+    prev_level = root.level
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    try:
+        # Emit from a *child* logger to exercise propagation through callHandlers.
+        child = logging.getLogger("deplodock.provisioning.ssh_transport")
+        child.info("[dry-run] ssh host: docker run -e HUGGING_FACE_HUB_TOKEN=hf_PropagationTestToken123 ...")
+        handler.flush()
+    finally:
+        root.removeHandler(handler)
+        handler.close()
+        root.setLevel(prev_level)
+
+    contents = log_file.read_text()
+    assert "hf_PropagationTestToken123" not in contents
+    assert "***" in contents
+
+    _reset_cache()
+
+
+# ── register_secret: values not in env ──────────────────────────
+
+
+def test_register_secret_redacts_value_not_in_env(monkeypatch):
+    for var in redact_module._SECRET_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    _reset_cache()
+
+    register_secret("cli_only_secret_AAAAAA")
+    assert redact_secrets("token=cli_only_secret_AAAAAA done") == "token=*** done"
+
+    _reset_cache()
+
+
+def test_register_secret_short_values_ignored(monkeypatch):
+    for var in redact_module._SECRET_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    _reset_cache()
+
+    register_secret("short")
+    assert redact_secrets("value=short here") == "value=short here"
+
+    _reset_cache()
+
+
+def test_register_secret_invalidates_cache(monkeypatch):
+    for var in redact_module._SECRET_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    _reset_cache()
+
+    # Prime the cache while no secrets are known.
+    assert redact_secrets("placeholder") == "placeholder"
+
+    register_secret("late_registered_value_BBBB")
+    # Cache should have been invalidated; the new value is now redacted.
+    assert redact_secrets("v=late_registered_value_BBBB") == "v=***"
+
+    _reset_cache()
+
+
+def test_register_secret_propagates_through_file_handler(monkeypatch, tmp_path):
+    """A value registered via register_secret() (e.g. from --hf-token / --api-key
+    that wasn't in os.environ) is still redacted from file-handler output.
+    """
+    for var in redact_module._SECRET_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    _reset_cache()
+
+    register_secret("cr_cli_flag_secret_CCCCCC")
+
+    log_file = tmp_path / "out.log"
+    handler = logging.FileHandler(log_file, encoding="utf-8")
+    install_redaction(handler)
+
+    root = logging.getLogger()
+    prev_level = root.level
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    try:
+        child = logging.getLogger("deplodock.provisioning.cloudrift")
+        child.info("X-API-Key: cr_cli_flag_secret_CCCCCC")
+        handler.flush()
+    finally:
+        root.removeHandler(handler)
+        handler.close()
+        root.setLevel(prev_level)
+
+    contents = log_file.read_text()
+    assert "cr_cli_flag_secret_CCCCCC" not in contents
+    assert "***" in contents
 
     _reset_cache()


### PR DESCRIPTION
Logger-attached filters only run on records originating from that logger; records propagating up from a child logger bypass them and reach the root's handlers unredacted. As a result, a real HF token recently leaked into benchmark.log through the deplodock.provisioning.ssh_transport dry-run command print, even though SecretRedactingFilter was installed on the root logger.

Move the filter to handlers via a new install_redaction() helper, and add register_secret() so values resolved from --hf-token / --api-key CLI flags are also redacted (env-var-only allowlist scan misses these). Wire register_secret() into every secret resolution site: HF token (deploy ssh/cloud/local + bench execution), CloudRift API key (vm/cloudrift + provisioning/cloud), GCP service account.

Add a regression test that exercises the propagation path through a real FileHandler -- the previous tests only invoked filter() directly.