### PR TITLE
Unified-diff rule trace at -vv (>>> t:NNN markers)

### DIFF
--- a/deplodock/commands/compile.py
+++ b/deplodock/commands/compile.py
@@ -15,6 +15,7 @@ from deplodock.compiler.pipeline import (
     TENSOR_PASSES,
     TILE_PASSES,
 )
+from deplodock.compiler.pipeline.rule_diff import PASS_SHORTHAND
 
 if TYPE_CHECKING:
     from deplodock.compiler.graph import Graph
@@ -39,16 +40,12 @@ _DEFAULT_PASSES = LOOP_PASSES
 
 # Single-letter shortcuts for each pass. Passing a contiguous string of
 # these letters to --passes is equivalent to the expanded comma list
-# (e.g. 'dolft' expands to the full front-to-tile pipeline).
-_PASS_SHORTCUTS = {
-    "d": "frontend/decomposition",
-    "o": "frontend/optimization",
-    "l": "loop/lifting",
-    "f": "loop/fusion",
-    "t": "lowering/tile",
-    "k": "lowering/kernel",
-    "c": "lowering/cuda",
-}
+# (e.g. 'dolft' expands to the full front-to-tile pipeline). The same
+# letters are used as the prefix in ``-vv`` diff markers (e.g.
+# ``>>> t:005_blockify_launch``); the canonical mapping lives in
+# ``compiler/pipeline/rule_diff.PASS_SHORTHAND`` so the engine can build
+# the marker names without depending on the CLI layer.
+_PASS_SHORTCUTS = {short: full for full, short in PASS_SHORTHAND.items()}
 
 
 def register_compile_command(subparsers):
@@ -110,8 +107,31 @@ def register_compile_command(subparsers):
         help=(
             "Increase verbosity. Default (no flag): only the requested IR is printed. "
             "-v: also pass timings and per-rule applied counts. "
-            "-vv: also a snapshot of every rule application (matched subgraph + rewritten fragment)."
+            "-vv: also a unified-diff snapshot of every rule application, bracketed by "
+            "``>>> <pass>:NNN_rulename`` / ``<<< <pass>:NNN_rulename`` markers (pass shorthands: "
+            "d=decomposition, o=optimization, l=lifting, f=fusion, t=tile, k=kernel, c=cuda). "
+            "Diffs go to stdout (no ``2>&1`` needed). "
+            "Slice one pass: ``... -vv | awk '/^>>> t:/,/^<<< t:/'``. "
+            "Slice one rule: ``... -vv | awk '/^>>> t:005/,/^<<< t:005/'``."
         ),
+    )
+    parser.add_argument(
+        "--color",
+        choices=["auto", "always", "never"],
+        default="auto",
+        help="Colorize the -vv diff body. ``auto`` (default) uses ANSI when stdout is a tty and NO_COLOR is unset.",
+    )
+    parser.add_argument(
+        "--diff-context",
+        type=int,
+        default=2,
+        help="Unified-diff context lines for -vv rule snapshots (default: 2).",
+    )
+    parser.add_argument(
+        "--diff-max-lines",
+        type=int,
+        default=200,
+        help="If a single rule's -vv diff exceeds N lines, fall back to full before/after (default: 200).",
     )
     parser.set_defaults(func=handle_compile)
 
@@ -138,7 +158,16 @@ def handle_compile(args):
 
     from deplodock.compiler.pipeline import run_pipeline
     from deplodock.compiler.pipeline.dump import CompilerDump
+    from deplodock.compiler.pipeline.rule_diff import RuleRenderConfig, set_config, should_use_color
     from deplodock.compiler.target import apply_target_arg
+
+    set_config(
+        RuleRenderConfig(
+            color=should_use_color(sys.stdout, args.color),
+            context=args.diff_context,
+            max_lines=args.diff_max_lines,
+        )
+    )
 
     apply_target_arg(args)
     passes = _resolve_passes(args)

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -8,6 +8,7 @@ Pattern-based rewrite engine + pass directories + dump hooks.
 pipeline/
 ├── engine.py      # Pattern, Match, match_pattern, run_rule, run_pass, run_pipeline, splice
 ├── dump.py        # CompilerDump + on_pass dispatch
+├── rule_diff.py   # Per-rule unified-diff renderer for ``compile -vv`` output
 └── passes/
     ├── frontend/
     │   ├── decomposition/  # frontend ops → tensor-IR primitives
@@ -108,6 +109,28 @@ each op's own `pretty_body()`. Node ids accumulate `merged_` per
 fusion step and a leading `lift_` from lifting; `_canonical_node_id`
 collapses both for display, and the rendered body is rewritten with
 the same map so `Load`/`Write` references match.
+
+## Per-rule diff output (`rule_diff.py`)
+
+At `compile -vv` (DEBUG log level) the engine emits one block per rule application: a unified diff between the
+matched subgraph before the rewrite and the rewritten fragment, bracketed by `>>> <pass>:NNN_rulename` and
+`<<< <pass>:NNN_rulename` markers on their own lines. The `<pass>` prefix is the single-letter shorthand from
+`PASS_SHORTHAND` (`d`=decomposition, `o`=optimization, `l`=lifting, `f`=fusion, `t`=tile, `k`=kernel, `c`=cuda) —
+the same letters the CLI accepts in `--passes dolft`. Skipped rules (`RuleSkipped` exception) collapse to a
+one-liner `--- <pass>:NNN_rulename skipped at <root>: <reason>`.
+
+`PASS_SHORTHAND` is the single source of truth: `commands/compile.py` imports it to build its `--passes` shortcut
+expander, so the CLI flag and the `-vv` marker prefix can never drift.
+
+The bracketing makes per-rule and per-pass slicing trivial — `awk '/^>>> t:005/,/^<<< t:005/'` extracts a
+single rule's diff and `awk '/^>>> t:/,/^<<< t:/'` extracts the entire tile-lowering pass. ANSI color (`+` green, `-` red, `@@` cyan) is applied only inside the diff body, so the markers
+stay plain ASCII and `awk` matches reliably even on colored output. Color follows
+`compile --color {auto,always,never}` (default `auto`: tty-aware, honors `NO_COLOR`); diff context and a
+fallback line cap are tuned via `--diff-context N` and `--diff-max-lines N`. `RuleRenderConfig` is set once from
+`commands/compile.py:handle_compile` via `rule_diff.set_config()`.
+
+The structured `.rules.json` dump under `DEPLODOCK_DUMP_DIR` is unaffected — the diff is purely a presentation
+layer for the human-readable `_rule_texts` channel.
 
 ## Fragment splice (`engine._apply_replacement`)
 

--- a/deplodock/compiler/pipeline/dump.py
+++ b/deplodock/compiler/pipeline/dump.py
@@ -307,7 +307,14 @@ def format_kernels(graph: Graph) -> str:
     that share a ``kernel_name`` are emitted only once. The surrounding
     syntax identifies the IR level, so block headers stay minimal:
     ``=== N: <name> ===``.
+
+    Scalar ``ConstantOp`` inputs are inlined as literals: header
+    ``in_k = load <buf>[0]`` lines for scalar constants are dropped, and
+    the literal value is substituted at every use site in the body.
+    Behaves like ``RenderCtx.literal_constants`` does for the cuda
+    renderer — same idea, applied to the human-readable IR dump.
     """
+    from deplodock.compiler.ir.base import ConstantOp
     from deplodock.compiler.ir.cuda import CudaOp
 
     rename_map = {nid: _canonical_node_id(nid) for nid in graph.nodes if _canonical_node_id(nid) != nid}
@@ -330,6 +337,13 @@ def format_kernels(graph: Graph) -> str:
             name = op.name
         else:
             name = f"{rename_map.get(nid, nid)} -> {node.output.name}"
+        # Inline scalar constants before applying the canonicalization
+        # rename: Load.input fields carry the producer's pre-rename id
+        # (e.g. ``mul_1_c1``), which is also the graph node id we look
+        # up here.
+        scalar_inputs = _scalar_constant_inputs(graph, node, ConstantOp)
+        if scalar_inputs:
+            body = _inline_scalar_loads(body, scalar_inputs)
         # Apply the same canonicalization to the rendered body so Load/Write
         # references to peer nodes use clean names too. Replace longest names
         # first to avoid prefix-eating ``merged_lift_n0`` before ``merged_merged_lift_n0``.
@@ -340,6 +354,39 @@ def format_kernels(graph: Graph) -> str:
         blocks.append("")
         i += 1
     return "\n".join(blocks)
+
+
+def _scalar_constant_inputs(graph, node, constant_op_type) -> dict[str, float]:
+    """``{producer_id: value}`` for every direct input of ``node`` whose
+    producer is a 0-D ``ConstantOp`` with a captured scalar value."""
+    out: dict[str, float] = {}
+    for inp in node.inputs:
+        if inp not in graph.nodes:
+            continue
+        op = graph.nodes[inp].op
+        if isinstance(op, constant_op_type) and op.value is not None:
+            out[inp] = float(op.value)
+    return out
+
+
+def _inline_scalar_loads(body: str, scalar_inputs: dict[str, float]) -> str:
+    """Drop ``in_k = load <buf>[0]`` lines whose buf is a scalar constant
+    and substitute the literal value at every use site in the body."""
+    import re
+
+    pat = re.compile(r"^(\s*)(\w+)\s*=\s*load\s+(\S+)\[0\]\s*$")
+    name_to_lit: dict[str, str] = {}
+    out_lines: list[str] = []
+    for line in body.splitlines():
+        m = pat.match(line)
+        if m and m.group(3) in scalar_inputs:
+            name_to_lit[m.group(2)] = format(scalar_inputs[m.group(3)], "g")
+            continue
+        out_lines.append(line)
+    if not name_to_lit:
+        return body
+    name_pat = re.compile(r"\b(" + "|".join(re.escape(n) for n in name_to_lit) + r")\b")
+    return "\n".join(name_pat.sub(lambda m: name_to_lit[m.group(1)], ln) for ln in out_lines)
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/pipeline/engine.py
+++ b/deplodock/compiler/pipeline/engine.py
@@ -480,7 +480,13 @@ def _format_nodes(nodes: list, graph: Graph) -> str:
     """Render a list of nodes as readable text. Kernel-IR ops use their
     own ``pretty_body``; everything else falls back to a ``name: ClsName(args)``
     one-liner. Scalar ``ConstantOp`` inputs are inlined as literals (same
-    treatment as ``format_kernels`` — see ``_inline_scalar_loads``)."""
+    treatment as ``format_kernels`` — see ``_inline_scalar_loads``).
+
+    The leading ``kernel <name>  inputs: ...  outputs: ...`` header that
+    ``TileOp.pretty_body`` prepends is stripped here: this path already
+    emits ``<output> = TileOp(<inputs>)`` one line above, so the kernel
+    header would just duplicate the same info and shift the body's
+    indent by 4 spaces, ballooning the diff."""
     from deplodock.compiler.graph import _fmt_op
     from deplodock.compiler.ir.base import ConstantOp, InputOp
     from deplodock.compiler.pipeline.dump import _inline_scalar_loads, _scalar_constant_inputs
@@ -499,8 +505,19 @@ def _format_nodes(nodes: list, graph: Graph) -> str:
         scalar_inputs = _scalar_constant_inputs(graph, node, ConstantOp)
         if scalar_inputs:
             body = _inline_scalar_loads(body, scalar_inputs)
-        lines.extend(f"  {line}" for line in body.splitlines())
+        body_lines = body.splitlines()
+        if body_lines and body_lines[0].lstrip().startswith("kernel ") and " inputs: " in body_lines[0] and " outputs: " in body_lines[0]:
+            body_lines = [_dedent(ln, 4) for ln in body_lines[1:]]
+        lines.extend(f"  {line}" for line in body_lines)
     return "\n".join(lines)
+
+
+def _dedent(line: str, n: int) -> str:
+    """Strip up to ``n`` leading spaces from ``line``."""
+    i = 0
+    while i < n and i < len(line) and line[i] == " ":
+        i += 1
+    return line[i:]
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/pipeline/engine.py
+++ b/deplodock/compiler/pipeline/engine.py
@@ -445,9 +445,11 @@ def _node_to_dict(node) -> dict:
 def _format_nodes(nodes: list, graph: Graph) -> str:
     """Render a list of nodes as readable text. Kernel-IR ops use their
     own ``pretty_body``; everything else falls back to a ``name: ClsName(args)``
-    one-liner."""
+    one-liner. Scalar ``ConstantOp`` inputs are inlined as literals (same
+    treatment as ``format_kernels`` — see ``_inline_scalar_loads``)."""
     from deplodock.compiler.graph import _fmt_op
     from deplodock.compiler.ir.base import ConstantOp, InputOp
+    from deplodock.compiler.pipeline.dump import _inline_scalar_loads, _scalar_constant_inputs
 
     lines: list[str] = []
     for node in nodes:
@@ -460,6 +462,9 @@ def _format_nodes(nodes: list, graph: Graph) -> str:
             continue
         arg_names = [graph.nodes[inp].output.name for inp in node.inputs if inp in graph.nodes]
         lines.append(f"{node.output.name} = {type(op).__name__}({', '.join(arg_names)})")
+        scalar_inputs = _scalar_constant_inputs(graph, node, ConstantOp)
+        if scalar_inputs:
+            body = _inline_scalar_loads(body, scalar_inputs)
         lines.extend(f"  {line}" for line in body.splitlines())
     return "\n".join(lines)
 

--- a/deplodock/compiler/pipeline/engine.py
+++ b/deplodock/compiler/pipeline/engine.py
@@ -311,6 +311,10 @@ def _apply_rules(
                     # before/after render text.
                     debug_on = logger.isEnabledFor(logging.DEBUG)
                     pre_ops = {nid: graph.nodes[nid].op for nid in match.consumed if nid in graph.nodes}
+                    # Output-name → pre-rewrite node id so the formatter
+                    # can follow renames (rules like ``tileify`` mutate
+                    # the op AND ``rename_node`` to a friendlier id).
+                    pre_names = {graph.nodes[nid].output.name: nid for nid in pre_ops if nid in graph.nodes}
                     kwargs = _build_rewrite_kwargs(rule, graph, match)
                     if kwargs is None:
                         continue
@@ -330,7 +334,7 @@ def _apply_rules(
                         # from ``graph.nodes`` even though the rule did
                         # apply).
                         if any(nid not in graph.nodes or graph.nodes[nid].op is not pre_ops[nid] for nid in pre_ops):
-                            text = _format_inplace_application(rule.name, graph, match, pre_ops, pass_name=pass_name)
+                            text = _format_inplace_application(rule.name, graph, match, pre_ops, pass_name=pass_name, pre_names=pre_names)
                             if debug_on:
                                 from deplodock.compiler.pipeline.rule_diff import emit
 
@@ -385,22 +389,52 @@ def _format_rule_application(name: str, graph: Graph, match: Match, fragment: Gr
     return render_rule_diff(display_name(pass_name, name), before, after, header=f"matched at {match.root_node_id}")
 
 
-def _format_inplace_application(name: str, graph: Graph, match: Match, pre_ops: dict, *, pass_name: str | None = None) -> str:
+def _format_inplace_application(
+    name: str,
+    graph: Graph,
+    match: Match,
+    pre_ops: dict,
+    *,
+    pass_name: str | None = None,
+    pre_names: dict[str, str] | None = None,
+) -> str:
     """Snapshot for rules that mutate ``node.op`` in place and return
-    None (e.g. lowering/tile). Renders the before/after of the mutated
+    None (e.g. lowering/tile). Renders before/after of the mutated
     nodes as a unified diff by swapping their op temporarily for the
-    "before" view."""
+    "before" view.
+
+    Some rules (notably ``tileify``) mutate the op AND rename the node
+    to a friendlier id. ``pre_names`` (output-name → pre-rewrite id)
+    lets the formatter resolve a renamed-away id to its post-rewrite
+    counterpart by matching on output name, which is preserved across
+    ``rename_node``."""
     from deplodock.compiler.pipeline.rule_diff import display_name, render_rule_diff
 
-    mutated = [nid for nid, prev in pre_ops.items() if nid in graph.nodes and graph.nodes[nid].op is not prev]
-    post_ops = {nid: graph.nodes[nid].op for nid in mutated}
-    for nid in mutated:
-        graph.nodes[nid].op = pre_ops[nid]
-    before_nodes = [graph.nodes[nid] for nid in graph.topological_order() if nid in mutated]
+    # Build a "current id" for each pre_ops entry, following any rename
+    # that happened during the rewrite.
+    name_to_post_id = {graph.nodes[nid].output.name: nid for nid in graph.nodes} if pre_names else {}
+    pre_to_post: dict[str, str] = {}
+    for nid in pre_ops:
+        if nid in graph.nodes:
+            pre_to_post[nid] = nid
+        elif pre_names is not None:
+            for out_name, old_id in pre_names.items():
+                if old_id == nid and out_name in name_to_post_id:
+                    pre_to_post[nid] = name_to_post_id[out_name]
+                    break
+
+    mutated_pre = [nid for nid in pre_ops if nid in pre_to_post and graph.nodes[pre_to_post[nid]].op is not pre_ops[nid]]
+    post_ids = [pre_to_post[nid] for nid in mutated_pre]
+    post_ops = {pid: graph.nodes[pid].op for pid in post_ids}
+    # Render "before": swap each post-id node's op back to the pre op.
+    for nid in mutated_pre:
+        graph.nodes[pre_to_post[nid]].op = pre_ops[nid]
+    before_nodes = [graph.nodes[pid] for pid in graph.topological_order() if pid in post_ids]
     before = _format_nodes(before_nodes, graph)
-    for nid in mutated:
-        graph.nodes[nid].op = post_ops[nid]
-    after_nodes = [graph.nodes[nid] for nid in graph.topological_order() if nid in mutated]
+    # Restore.
+    for pid in post_ids:
+        graph.nodes[pid].op = post_ops[pid]
+    after_nodes = [graph.nodes[pid] for pid in graph.topological_order() if pid in post_ids]
     after = _format_nodes(after_nodes, graph)
     return render_rule_diff(display_name(pass_name, name), before, after, header=f"matched at {match.root_node_id} (in-place)")
 

--- a/deplodock/compiler/pipeline/engine.py
+++ b/deplodock/compiler/pipeline/engine.py
@@ -29,7 +29,6 @@ from typing import TYPE_CHECKING
 
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
-from deplodock.compiler.pipeline.dump import _canonical_node_id
 
 if TYPE_CHECKING:
     from deplodock.compiler.pipeline.dump import CompilerDump
@@ -319,7 +318,9 @@ def _apply_rules(
                         fragment = rule.rewrite(**kwargs)
                     except RuleSkipped as exc:
                         if debug_on:
-                            logger.debug("rule %s skipped at %s: %s", rule.name, _canonical_node_id(match.root_node_id), exc.reason)
+                            from deplodock.compiler.pipeline.rule_diff import display_name, emit, format_skipped
+
+                            emit(format_skipped(display_name(pass_name, rule.name), match.root_node_id, exc.reason))
                         rewrite_time += time.monotonic() - t1
                         continue
                     if fragment is None:
@@ -329,18 +330,22 @@ def _apply_rules(
                         # from ``graph.nodes`` even though the rule did
                         # apply).
                         if any(nid not in graph.nodes or graph.nodes[nid].op is not pre_ops[nid] for nid in pre_ops):
-                            text = _format_inplace_application(rule.name, graph, match, pre_ops)
+                            text = _format_inplace_application(rule.name, graph, match, pre_ops, pass_name=pass_name)
                             if debug_on:
-                                logger.debug(text)
+                                from deplodock.compiler.pipeline.rule_diff import emit
+
+                                emit(text)
                             if dump is not None and pass_idx is not None and pass_name is not None:
                                 record = _record_inplace_application(graph, match, pre_ops)
                                 dump.on_rule(pass_idx, pass_name, rule.name, record, text)
                             applied += 1
                         rewrite_time += time.monotonic() - t1
                         continue
-                    text = _format_rule_application(rule.name, graph, match, fragment)
+                    text = _format_rule_application(rule.name, graph, match, fragment, pass_name=pass_name)
                     if debug_on:
-                        logger.debug(text)
+                        from deplodock.compiler.pipeline.rule_diff import emit
+
+                        emit(text)
                     if dump is not None and pass_idx is not None and pass_name is not None:
                         record = _record_rule_application(graph, match, fragment)
                         dump.on_rule(pass_idx, pass_name, rule.name, record, text)
@@ -364,42 +369,40 @@ def _apply_rules(
 # ---------------------------------------------------------------------------
 
 
-def _format_rule_application(name: str, graph: Graph, match: Match, fragment: Graph) -> str:
-    """Render a one-rule-application snapshot: matched subgraph (the
-    nodes selected from the host graph) + rewritten fragment. Kernel
+def _format_rule_application(name: str, graph: Graph, match: Match, fragment: Graph, *, pass_name: str | None = None) -> str:
+    """Render a one-rule-application snapshot as a unified diff bracketed
+    by ``>>> name`` / ``<<< name`` markers (see ``rule_diff``). Kernel
     ops (LoopOp/TileOp/KernelOp/CudaOp) are pretty-printed via their
     dedicated printers rather than dumped as a body repr."""
+    from deplodock.compiler.pipeline.rule_diff import display_name, render_rule_diff
+
     matched_ids: set[str] = set(match.consumed) | set(match.nodes.values())
     matched_ids.add(match.root_node_id)
-
-    lines = [f"=== rule {name} matched at {_canonical_node_id(match.root_node_id)} ==="]
-    lines.append("before:")
     matched_nodes = [graph.nodes[nid] for nid in graph.topological_order() if nid in matched_ids and nid in graph.nodes]
-    lines.extend(f"    {line}" for line in _format_nodes(matched_nodes, graph).splitlines())
-    lines.append("after:")
+    before = _format_nodes(matched_nodes, graph)
     frag_nodes = [fragment.nodes[nid] for nid in fragment.topological_order()]
-    lines.extend(f"    {line}" for line in _format_nodes(frag_nodes, fragment).splitlines())
-    return "\n".join(lines)
+    after = _format_nodes(frag_nodes, fragment)
+    return render_rule_diff(display_name(pass_name, name), before, after, header=f"matched at {match.root_node_id}")
 
 
-def _format_inplace_application(name: str, graph: Graph, match: Match, pre_ops: dict) -> str:
+def _format_inplace_application(name: str, graph: Graph, match: Match, pre_ops: dict, *, pass_name: str | None = None) -> str:
     """Snapshot for rules that mutate ``node.op`` in place and return
-    None (e.g. lowering/tile). Renders before/after of the mutated
-    nodes by swapping their op temporarily for the "before" view."""
+    None (e.g. lowering/tile). Renders the before/after of the mutated
+    nodes as a unified diff by swapping their op temporarily for the
+    "before" view."""
+    from deplodock.compiler.pipeline.rule_diff import display_name, render_rule_diff
+
     mutated = [nid for nid, prev in pre_ops.items() if nid in graph.nodes and graph.nodes[nid].op is not prev]
-    lines = [f"=== rule {name} matched at {_canonical_node_id(match.root_node_id)} (in-place) ==="]
-    lines.append("before:")
     post_ops = {nid: graph.nodes[nid].op for nid in mutated}
     for nid in mutated:
         graph.nodes[nid].op = pre_ops[nid]
     before_nodes = [graph.nodes[nid] for nid in graph.topological_order() if nid in mutated]
-    lines.extend(f"    {line}" for line in _format_nodes(before_nodes, graph).splitlines())
+    before = _format_nodes(before_nodes, graph)
     for nid in mutated:
         graph.nodes[nid].op = post_ops[nid]
-    lines.append("after:")
     after_nodes = [graph.nodes[nid] for nid in graph.topological_order() if nid in mutated]
-    lines.extend(f"    {line}" for line in _format_nodes(after_nodes, graph).splitlines())
-    return "\n".join(lines)
+    after = _format_nodes(after_nodes, graph)
+    return render_rule_diff(display_name(pass_name, name), before, after, header=f"matched at {match.root_node_id} (in-place)")
 
 
 def _record_rule_application(graph: Graph, match: Match, fragment: Graph) -> dict:

--- a/deplodock/compiler/pipeline/rule_diff.py
+++ b/deplodock/compiler/pipeline/rule_diff.py
@@ -1,0 +1,196 @@
+"""Diff-style renderer for per-rule ``-vv`` output in the rewrite engine.
+
+The engine snapshots each rule's matched subgraph before and after the
+rewrite and hands both to :func:`render_rule_diff`, which emits a unified
+diff bracketed by ``>>> NNN_rulename`` / ``<<< NNN_rulename`` markers.
+The bracketing makes it trivial to slice one rule out of a long ``-vv``
+log with ``awk '/^>>> 005_/,/^<<< 005_/'``.
+
+Color (ANSI) is applied only inside the diff body so the markers stay
+plain ASCII and ``awk`` matches reliably even on colored output. Color
+follows ``--color {auto,always,never}`` and honors the standard
+``NO_COLOR`` environment variable when ``auto``.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import sys
+from dataclasses import dataclass
+from typing import IO
+
+_RED = "\x1b[31m"
+_GREEN = "\x1b[32m"
+_CYAN = "\x1b[36m"
+_RESET = "\x1b[0m"
+
+# Single-letter pass shorthands. Single source of truth — the CLI's
+# ``--passes d,o,l`` shortcut expander imports the inverse mapping from
+# here. Used in ``-vv`` diff markers (e.g. ``>>> t:005_blockify_launch``)
+# so a reader can slice an entire pass with ``awk '/^>>> t:/,/^<<< t:/'``
+# or one rule with ``awk '/^>>> t:005/,/^<<< t:005/'``.
+PASS_SHORTHAND = {
+    "frontend/decomposition": "d",
+    "frontend/optimization": "o",
+    "loop/lifting": "l",
+    "loop/fusion": "f",
+    "lowering/tile": "t",
+    "lowering/kernel": "k",
+    "lowering/cuda": "c",
+}
+
+
+def display_name(pass_name: str | None, rule_name: str) -> str:
+    """``<shorthand>:<rule>`` if the pass is known, else just ``<rule>``."""
+    short = PASS_SHORTHAND.get(pass_name or "")
+    return f"{short}:{rule_name}" if short else rule_name
+
+
+@dataclass
+class RuleRenderConfig:
+    """How to render per-rule ``-vv`` output.
+
+    ``color`` is the resolved boolean (already accounts for ``auto`` /
+    ``NO_COLOR`` / tty detection). ``context`` is the unified-diff context
+    line count. ``max_lines`` caps a single rule's diff before falling
+    back to a full pre/post listing inside the same markers.
+    """
+
+    color: bool = False
+    context: int = 2
+    max_lines: int = 200
+
+
+_config = RuleRenderConfig()
+
+
+def set_config(cfg: RuleRenderConfig) -> None:
+    """Install the active render config (called once from the CLI)."""
+    global _config
+    _config = cfg
+
+
+def get_config() -> RuleRenderConfig:
+    return _config
+
+
+def should_use_color(stream: IO, mode: str) -> bool:
+    """Resolve ``--color {auto,always,never}`` against a stream + env.
+
+    ``auto`` → true iff ``stream`` is a tty and ``NO_COLOR`` is unset.
+    """
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def render_rule_diff(
+    name: str,
+    before: str,
+    after: str,
+    *,
+    header: str = "",
+    cfg: RuleRenderConfig | None = None,
+) -> str:
+    """Render one rule application as a marker-bracketed unified diff.
+
+    Output shape:
+
+        >>> NNN_rulename
+        @@ <header> @@         (only when ``header`` is non-empty)
+        @@ -a,b +c,d @@
+         context
+        -removed
+        +added
+         context
+        <<< NNN_rulename
+
+    When the diff body would exceed ``cfg.max_lines``, falls back to
+    printing the full ``before:`` / ``after:`` blocks inside the same
+    markers with a leading suppression note.
+    """
+    cfg = cfg or _config
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    diff_lines = list(
+        difflib.unified_diff(
+            before_lines,
+            after_lines,
+            n=cfg.context,
+            lineterm="",
+        )
+    )
+    # Drop the unified_diff file headers (``--- ``/``+++ ``); we use our
+    # own ``>>> name``/``<<< name`` markers instead.
+    diff_body = [ln for ln in diff_lines if not (ln.startswith("--- ") or ln.startswith("+++ "))]
+
+    out: list[str] = [f">>> {name}"]
+    if header:
+        out.append(f"@@ {header} @@")
+
+    if len(diff_body) > cfg.max_lines:
+        out.append(f"# diff suppressed: {len(diff_body)} lines > --diff-max-lines {cfg.max_lines}")
+        out.append("before:")
+        out.extend(f"  {ln}" for ln in before_lines)
+        out.append("after:")
+        out.extend(f"  {ln}" for ln in after_lines)
+    else:
+        out.extend(_colorize(ln, cfg.color) for ln in diff_body)
+
+    out.append(f"<<< {name}")
+    return "\n".join(out)
+
+
+def emit(text: str) -> None:
+    """Write a per-rule diff or skipped one-liner to stdout.
+
+    Diffs go to stdout (not via ``logger.debug``) so users can pipe
+    ``compile -vv`` through ``grep`` / ``awk`` without needing
+    ``2>&1``. The IR result also lands on stdout but appears after the
+    pipeline finishes — the marker-bracketed range patterns slice
+    cleanly around it.
+    """
+    print(text, flush=True)
+
+
+def format_skipped(name: str, root: str, reason: str) -> str:
+    """One-liner for rules that matched but raised ``RuleSkipped``.
+
+    Uses ``---`` to stay visually distinct from ``>>>``/``<<<`` blocks
+    and to make it greppable on its own (``grep '^--- 004_'``).
+    """
+    return f"--- {name} skipped at {root}: {reason}"
+
+
+def _colorize(line: str, color: bool) -> str:
+    if not color or not line:
+        return line
+    if line.startswith("+"):
+        return f"{_GREEN}{line}{_RESET}"
+    if line.startswith("-"):
+        return f"{_RED}{line}{_RESET}"
+    if line.startswith("@@"):
+        return f"{_CYAN}{line}{_RESET}"
+    return line
+
+
+__all__ = [
+    "PASS_SHORTHAND",
+    "RuleRenderConfig",
+    "display_name",
+    "format_skipped",
+    "get_config",
+    "render_rule_diff",
+    "set_config",
+    "should_use_color",
+]
+
+
+# Convenience: when this module is imported, default color resolution
+# considers stdout (where ``emit()`` writes the diff text).
+_config.color = should_use_color(sys.stdout, "auto")

--- a/tests/compiler/passes/test_matmul_rules.py
+++ b/tests/compiler/passes/test_matmul_rules.py
@@ -119,10 +119,11 @@ def test_pure_elementwise_does_not_fire_split_k(recording_dump):
 # --- engine: RuleSkipped exception path ------------------------------
 
 
-def test_rule_skipped_logs_reason_and_continues(caplog):
+def test_rule_skipped_logs_reason_and_continues(capsys):
     """A rule that raises ``RuleSkipped`` is treated as no-op; the
-    engine logs the reason at DEBUG and proceeds. We verify both:
-    pipeline still completes, and the reason text is in the debug log.
+    engine emits the reason on stdout (so users can ``grep`` ``-vv``
+    output without ``2>&1``) and proceeds. We verify both: pipeline
+    still completes, and the reason text is on stdout.
     """
     import logging
 
@@ -133,11 +134,17 @@ def test_rule_skipped_logs_reason_and_continues(caplog):
     g.outputs = ["o"]
 
     # Pure elementwise → tile_matmul_k raises RuleSkipped (no matmul-shaped
-    # reduce) and cooperative_reduce raises (no reduce Loop).
-    with caplog.at_level(logging.DEBUG, logger="deplodock.compiler.pipeline.engine"):
+    # reduce) and cooperative_reduce raises (no reduce Loop). The engine's
+    # ``debug_on`` gate keys off the engine logger's level — bump that to
+    # DEBUG so ``emit`` actually fires.
+    logging.getLogger("deplodock.compiler.pipeline.engine").setLevel(logging.DEBUG)
+    try:
         run_pipeline(g, TILE_PASSES)
+    finally:
+        logging.getLogger("deplodock.compiler.pipeline.engine").setLevel(logging.NOTSET)
 
-    skip_messages = [r.message for r in caplog.records if "skipped" in r.message]
+    out = capsys.readouterr().out
+    skip_messages = [ln for ln in out.splitlines() if ln.startswith("--- ") and "skipped" in ln]
     assert any("tile_matmul_k" in m for m in skip_messages), skip_messages
     assert any("cooperative_reduce" in m for m in skip_messages), skip_messages
 

--- a/tests/compiler/test_compile_cli.py
+++ b/tests/compiler/test_compile_cli.py
@@ -102,8 +102,11 @@ def test_compile_dump_dir_writes_rule_application_files(run_cli, tmp_path):
     fusion_json = dump / "04_loop_fusion__001_merge_loop_ops.rules.json"
     assert fusion_txt.exists() and fusion_json.exists()
     text = fusion_txt.read_text()
-    assert "=== rule 001_merge_loop_ops matched at" in text
-    assert "before:" in text and "after:" in text
+    # Diff-style rendering with bracketing markers (see pipeline/rule_diff.py);
+    # the ``f:`` prefix is the loop/fusion pass shorthand.
+    assert ">>> f:001_merge_loop_ops" in text
+    assert "<<< f:001_merge_loop_ops" in text
+    assert "@@ matched at" in text
 
     records = json.loads(fusion_json.read_text())
     assert isinstance(records, list) and records

--- a/tests/compiler/test_rule_diff.py
+++ b/tests/compiler/test_rule_diff.py
@@ -1,0 +1,90 @@
+"""Unit tests for the per-rule diff renderer used at ``compile -vv``."""
+
+from __future__ import annotations
+
+import io
+
+from deplodock.compiler.pipeline.rule_diff import (
+    PASS_SHORTHAND,
+    RuleRenderConfig,
+    display_name,
+    format_skipped,
+    render_rule_diff,
+    should_use_color,
+)
+
+
+def test_render_rule_diff_brackets_with_markers():
+    out = render_rule_diff("005_blockify", "a\nb\nc\n", "a\nB\nc\n", cfg=RuleRenderConfig(color=False))
+    lines = out.splitlines()
+    assert lines[0] == ">>> 005_blockify"
+    assert lines[-1] == "<<< 005_blockify"
+    assert any(ln.startswith("-b") for ln in lines)
+    assert any(ln.startswith("+B") for ln in lines)
+    # No file-header noise from unified_diff.
+    assert not any(ln.startswith(("--- ", "+++ ")) for ln in lines)
+
+
+def test_render_rule_diff_includes_header_when_provided():
+    out = render_rule_diff("001_x", "a\n", "b\n", header="matched at root7", cfg=RuleRenderConfig(color=False))
+    assert "@@ matched at root7 @@" in out
+
+
+def test_render_rule_diff_color_wraps_diff_lines():
+    cfg = RuleRenderConfig(color=True)
+    out = render_rule_diff("001_x", "a\n", "b\n", cfg=cfg)
+    assert "\x1b[31m-a\x1b[0m" in out
+    assert "\x1b[32m+b\x1b[0m" in out
+    # Markers stay plain ASCII so awk slicing keeps working.
+    assert "\x1b" not in out.splitlines()[0]
+    assert "\x1b" not in out.splitlines()[-1]
+
+
+def test_render_rule_diff_max_lines_falls_back_to_full_listing():
+    cfg = RuleRenderConfig(color=False, context=2, max_lines=3)
+    before = "\n".join(f"old{i}" for i in range(20))
+    after = "\n".join(f"new{i}" for i in range(20))
+    out = render_rule_diff("002_big", before, after, cfg=cfg)
+    assert "diff suppressed" in out
+    assert "before:" in out
+    assert "after:" in out
+    # Markers still present so slicing is unaffected.
+    assert out.startswith(">>> 002_big")
+    assert out.endswith("<<< 002_big")
+
+
+def test_format_skipped_uses_dashed_marker():
+    assert format_skipped("004_coop_reduce", "rootX", "no reduce loop") == "--- 004_coop_reduce skipped at rootX: no reduce loop"
+
+
+def test_display_name_prefixes_known_pass():
+    assert display_name("lowering/tile", "005_blockify_launch") == "t:005_blockify_launch"
+    assert display_name("loop/fusion", "001_merge_loop_ops") == "f:001_merge_loop_ops"
+    # Unknown / missing pass falls back to the bare rule name.
+    assert display_name(None, "001_x") == "001_x"
+    assert display_name("not/a/pass", "001_x") == "001_x"
+
+
+def test_pass_shorthand_matches_cli_shortcut_inverse():
+    # Single source of truth: commands/compile.py builds its --passes
+    # shortcut expander by inverting PASS_SHORTHAND.
+    from deplodock.commands.compile import _PASS_SHORTCUTS
+
+    assert _PASS_SHORTCUTS == {short: full for full, short in PASS_SHORTHAND.items()}
+
+
+def test_should_use_color_modes(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    tty = io.StringIO()
+    tty.isatty = lambda: True  # type: ignore[method-assign]
+    notty = io.StringIO()
+    notty.isatty = lambda: False  # type: ignore[method-assign]
+
+    assert should_use_color(tty, "auto") is True
+    assert should_use_color(notty, "auto") is False
+    assert should_use_color(notty, "always") is True
+    assert should_use_color(tty, "never") is False
+
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert should_use_color(tty, "auto") is False
+    assert should_use_color(tty, "always") is True  # explicit override


### PR DESCRIPTION
## Summary
- Replace the per-rule ``=== rule X matched ===`` / ``before:`` / ``after:`` block at ``compile -vv`` with a unified-diff snapshot bracketed by ``>>> t:NNN_name`` / ``<<< t:NNN_name`` markers (skipped rules render as ``--- t:NNN_name skipped at … : reason``).
- New ``deplodock/compiler/pipeline/rule_diff.py`` centralizes formatting (color, context lines, max-line truncation), wired through ``compile.py`` via ``--color``, ``--diff-context``, ``--diff-max-lines``.
- The new format makes every snippet in the Tile-IR blog post easy to grep: ``awk '/^>>> t:NNN/,/^<<< t:NNN/'`` filters one rule's diff cleanly.
- Engine plumbing: rule applications, in-place mutations, and ``RuleSkipped`` paths all flow through the new emitter; cross-IR rule diffs and constant inlining in kernel renders are fixed along the way.

Rebased onto current ``main`` — conflicts resolved against PR #116's tile-pass renumbering / rule renames (``tile_matmul_k`` is the rule that now skips on pure-elementwise inputs).

## Test plan
- [x] ``make lint`` clean
- [x] ``make test`` — 804 passed / 159 skipped
- [x] Smoke: ``deplodock compile -c '…' --target sm_80 --ir tile -vv`` emits the ``>>> t:NNN`` / ``<<< t:NNN`` markers for every fired rule and ``--- t:NNN skipped …`` for every refused one
- [ ] Confirm GitHub Actions CI passes on the rebased branch