### PR TITLE
Bench-kernels rebuild + LDS.128 vectorization + tile-class refinements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ test: setup
 	./venv/bin/pytest tests/ -v -n auto --dist=loadgroup
 
 bench-kernels: setup
-	./venv/bin/pytest tests/perf/ -m perf -v -p no:randomly --no-header
+	@rm -f /tmp/deplodock-gpu.lock
+	./venv/bin/pytest tests/perf/ -m perf -v -p no:randomly --no-header -n auto --dist=loadgroup
 
 bench: setup
 	@echo "Running benchmarks..."

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -130,11 +130,32 @@ def handle_run(args):
 
     if dump:
         dump.dump_benchmark(bench)
+        _dump_bench_compare(dump.dir, results, args.warmup, args.iters)
 
     _print_table(results)
     _print_kernel_stats(compiled, bench)
     if args.profile:
-        _run_ncu_profile(args)
+        _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
+
+
+def _dump_bench_compare(dump_dir, results: dict, warmup: int, iters: int) -> None:
+    """Persist the eager / torch.compile / deplodock comparison table
+    so downstream tooling (``make bench-kernels``) can parse one file
+    per case instead of grepping kernel stdout."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    eager_us = results.get("Eager PyTorch")
+    payload = {
+        "warmup": warmup,
+        "iters": iters,
+        "backends": {name: {"latency_us": us} for name, us in results.items()},
+    }
+    if eager_us:
+        for name, us in results.items():
+            payload["backends"][name]["speedup_vs_eager"] = (eager_us / us) if us else 0.0
+    out = _Path(dump_dir) / "60_bench_compare.json"
+    out.write_text(_json.dumps(payload, indent=2, default=str))
 
 
 def _print_kernel_stats(graph, bench):
@@ -240,14 +261,33 @@ def _theoretical_occupancy(regs_per_thread: int, smem_per_block: int, threads_pe
 
 _NCU_RECURSE_GUARD = "DEPLODOCK_NCU_CHILD"
 
+# Curated ncu metric set — verified to populate on RTX 5090 (sm_120) +
+# TMA kernels. ``--set detailed`` is broken there (``SpeedOfLight_Roofline``
+# divides by zero, ``SourceCounters`` / ``PCSamplingData`` need missing
+# ``smsp__pcsamp_*`` metrics) so we enumerate explicit metrics instead.
+# Add to this list to surface new columns in the perf summary; the
+# downstream parser keys on metric names directly.
+_NCU_METRICS = (
+    "gpu__time_duration.sum",
+    "sm__warps_active.avg.pct_of_peak_sustained_active",
+    "l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_ld.sum",
+    "l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_st.sum",
+    "dram__throughput.avg.pct_of_peak_sustained_elapsed",
+    "sm__throughput.avg.pct_of_peak_sustained_elapsed",
+    "sm__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
+    "smsp__inst_executed_pipe_lsu.sum",
+    "launch__registers_per_thread",
+)
 
-def _run_ncu_profile(args):
-    """Re-launch the same ``deplodock run`` invocation under ``ncu`` and
-    pass the detailed-page text output through verbatim. ncu's own
-    per-section breakdown (Speed-of-Light, Occupancy, Memory Workload,
-    Compute Workload, Scheduler Stats, Warp State, Source Counters,
-    plus per-kernel optimization hints) is far richer than any single
-    metric set we'd curate, so we just relay it.
+
+def _run_ncu_profile(args, *, dump_dir=None):
+    """Re-launch the same ``deplodock run`` invocation under ``ncu`` to
+    collect a curated set of hardware counters (occupancy, bank
+    conflicts, SM/DRAM/FMA throughput, register pressure). Output is
+    captured in CSV form; when ``DEPLODOCK_DUMP_DIR`` (or ``--dump-dir``
+    propagated as ``dump_dir``) is set, the raw CSV and a parsed
+    per-kernel JSON are written there. Otherwise the counters print to
+    stdout in the same CSV form for one-shot inspection.
 
     Spawns one extra subprocess at minimal iter count — ncu's per-launch
     overhead is huge (10-100×). The ``DEPLODOCK_NCU_CHILD`` env var
@@ -256,10 +296,12 @@ def _run_ncu_profile(args):
     Skipped silently when ``ncu`` is not on PATH. ncu's own stderr is
     relayed when it fails (typical failure: NVIDIA's perf-counter
     permission gate)."""
+    import json as _json
     import os
     import shutil
     import subprocess
     import sys
+    from pathlib import Path as _Path
 
     if os.environ.get(_NCU_RECURSE_GUARD):
         return
@@ -271,47 +313,38 @@ def _run_ncu_profile(args):
 
     env = dict(os.environ)
     env[_NCU_RECURSE_GUARD] = "1"
+    # The ncu child process re-runs trace + compile, which would
+    # ``shutil.rmtree`` the parent's dump dir from ``CompilerDump``'s
+    # ``__post_init__``. Drop the env var for the child so the parent's
+    # ``60_*.json`` (bench results) survive — ncu output is captured via
+    # stdout and saved by the parent below.
+    env.pop("DEPLODOCK_DUMP_DIR", None)
 
-    # Explicit section list — `--set detailed` pulls in two sections that
-    # break on TMA kernels in ncu 2025.3.1: `SpeedOfLight_Roofline`
-    # (`float division by zero`) and `SourceCounters` /
-    # `PCSamplingData` (missing `smsp__pcsamp_*` metrics). Either one
-    # raises and poisons every subsequent section to NaN. Enumerating
-    # the sections that work sidesteps both.
-    sections = (
-        "SpeedOfLight",
-        "ComputeWorkloadAnalysis",
-        "MemoryWorkloadAnalysis",
-        "LaunchStats",
-        "Occupancy",
-    )
     cmd: list[str] = [
         ncu,
+        "--csv",
         "--target-processes",
         "all",
-        "--page",
-        "details",
+        "--metrics",
+        ",".join(_NCU_METRICS),
+        sys.executable,
+        "-m",
+        "deplodock.deplodock",
+        "run",
     ]
-    for s in sections:
-        cmd.extend(["--section", s])
-    cmd.extend(
-        [
-            sys.executable,
-            "-m",
-            "deplodock.deplodock",
-            "run",
-        ]
-    )
     if args.code is not None:
         cmd.extend(["--code", args.code])
     elif args.ir is not None:
         cmd.extend(["--ir", args.ir])
-    # Minimal iters — ncu's overhead means we only want one launch per kernel.
-    cmd.extend(["--warmup", "1", "--iters", "1"])
+    # ncu's per-launch overhead means we want one or two launches per
+    # kernel — enough for the counters to populate, not so many that
+    # the run drags out. Match ``deplodock run --bench``'s minimal
+    # warmup so the profiled launches see a realistic-ish steady state.
+    cmd.extend(["--warmup", "2", "--iters", "3"])
 
     print()
     print("=" * 80)
-    print("ncu --set detailed (per-kernel hardware analysis)")
+    print("ncu --csv (curated hardware metrics)")
     print("=" * 80)
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=600)
@@ -319,14 +352,88 @@ def _run_ncu_profile(args):
         logger.warning("ncu profiling timed out")
         return
 
-    # ncu writes its analysis to stdout. Relay it directly. If ncu failed,
-    # show stderr too so the user sees the diagnostic.
-    if result.stdout.strip():
-        print(result.stdout)
+    # ncu writes ``==PROF==`` status lines first, then a CSV table
+    # starting at the ``"ID"`` header. Split the two so we can save just
+    # the CSV part as a file and surface the status lines for
+    # diagnostics.
+    stdout = result.stdout
+    lines = stdout.splitlines()
+    csv_start = None
+    for i, line in enumerate(lines):
+        if line.startswith('"ID"'):
+            csv_start = i
+            break
+    if csv_start is None:
+        if stdout.strip():
+            print(stdout)
+        if result.returncode != 0:
+            logger.warning("ncu exit=%d", result.returncode)
+            if result.stderr.strip():
+                print(result.stderr, file=sys.stderr)
+        return
+
+    csv_text = "\n".join(lines[csv_start:]) + "\n"
+    status_text = "\n".join(lines[:csv_start])
+
+    parsed = _parse_ncu_csv(csv_text)
+
+    if dump_dir is not None:
+        out_dir = _Path(dump_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "61_ncu_metrics.csv").write_text(csv_text)
+        (out_dir / "61_ncu_metrics.json").write_text(_json.dumps(parsed, indent=2, default=str))
+        print(f"ncu metrics → {out_dir / '61_ncu_metrics.csv'}")
+        print(f"ncu metrics → {out_dir / '61_ncu_metrics.json'}")
+    else:
+        # No dump dir: relay the CSV (and status lines) so ad-hoc
+        # ``deplodock run --profile`` invocations still surface the data.
+        if status_text.strip():
+            print(status_text)
+        print(csv_text)
+
     if result.returncode != 0:
         logger.warning("ncu exit=%d", result.returncode)
         if result.stderr.strip():
             print(result.stderr, file=sys.stderr)
+
+
+def _parse_ncu_csv(csv_text: str) -> dict:
+    """Reduce ncu's launch-by-launch CSV into per-kernel metric dicts.
+
+    Each row in the CSV is one (kernel, metric) datum for one launch;
+    multi-launch profiling produces many rows per (kernel, metric) which
+    we aggregate: ``.sum`` and ``smsp__*`` counters get summed, every
+    other metric (percentages, per-thread regs) gets averaged. Returns
+    ``{kernel_name: {metric_name: numeric_value}}`` ready to be merged
+    with the bench-comparison JSON downstream.
+    """
+    import csv as _csv
+    import io as _io
+
+    reader = _csv.DictReader(_io.StringIO(csv_text))
+    per_kernel: dict[str, dict[str, list[float]]] = {}
+    for row in reader:
+        kname = row.get("Kernel Name", "")
+        metric = row.get("Metric Name", "")
+        raw = row.get("Metric Value", "").replace(",", "")
+        if not (kname and metric and raw):
+            continue
+        try:
+            val = float(raw)
+        except ValueError:
+            continue
+        per_kernel.setdefault(kname, {}).setdefault(metric, []).append(val)
+
+    out: dict[str, dict[str, float]] = {}
+    for kname, metrics in per_kernel.items():
+        reduced: dict[str, float] = {}
+        for metric, vals in metrics.items():
+            if metric.endswith(".sum") or metric.startswith("smsp__"):
+                reduced[metric] = sum(vals)
+            else:
+                reduced[metric] = sum(vals) / len(vals)
+        out[kname] = reduced
+    return out
 
 
 def _detect_stage(graph) -> str:
@@ -428,7 +535,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
             dump.dump_benchmark(bench)
         _print_kernel_stats(graph, bench)
     if args.profile:
-        _run_ncu_profile(args)
+        _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
 
 
 def _bind_inputs(compiled, module, example_args, example_kwargs):

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -126,14 +126,17 @@ def handle_run(args):
     cuda_args = tuple(a.to("cuda") if isinstance(a, torch.Tensor) else a for a in example_args)
     cuda_kwargs = _to_cuda_kwargs(example_kwargs)
 
-    # Hold the cross-process GPU lock for the full bench + profile
-    # window. Trace, compile, dump-write all run unlocked so concurrent
-    # ``deplodock run`` invocations (parallel ``make bench-kernels``)
-    # overlap on the CPU; only the kernel-launch phases serialize, so
-    # iteration timing isn't perturbed by another worker hammering the
-    # SMs.
+    # Build torch_fns (incl. ~0.8s torch.compile / Inductor JIT)
+    # *outside* the GPU lock so concurrent ``deplodock run`` workers
+    # can do their CPU-bound JITs in parallel. The few GPU launches
+    # the compile-side warmup issues are noisy but go untimed; the
+    # measurement loop below holds the lock for accurate iter timing.
+    torch_fns = _build_torch_fns(cuda_module, cuda_args, cuda_kwargs, args.warmup)
+
     with _gpu_lock():
-        results, bench = _bench_interleaved(cuda_module, cuda_args, cuda_kwargs, backend, compiled, args.warmup, args.iters)
+        results, bench = _bench_interleaved(
+            cuda_module, cuda_args, cuda_kwargs, backend, compiled, args.warmup, args.iters, torch_fns=torch_fns
+        )
 
         if dump:
             dump.dump_benchmark(bench)
@@ -695,7 +698,29 @@ def _check_accuracy(outputs, eager_out):
         sys.exit(1)
 
 
-def _bench_interleaved(module, args, kwargs, backend, compiled_graph, warmup, iters):
+def _build_torch_fns(module, args, kwargs, warmup):
+    """Pre-build the per-backend ``torch_fns`` dict, including the
+    ``torch.compile`` JIT step (which is mostly Inductor CPU work plus
+    a few warmup launches). Pulled out of the timed bench loop so
+    parallel ``deplodock run`` invocations can do their JITs
+    concurrently — the GPU lock then only wraps the actual measurement
+    iters where launches must be serialized for accurate timing.
+    """
+    import torch
+
+    torch_fns: dict[str, callable] = {"Eager PyTorch": lambda: module(*args, **kwargs)}
+    try:
+        compiled_module = torch.compile(module)
+        for _ in range(warmup + 5):
+            with torch.no_grad():
+                compiled_module(*args, **kwargs)
+        torch_fns["torch.compile"] = lambda: compiled_module(*args, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("torch.compile failed: %s", e)
+    return torch_fns
+
+
+def _bench_interleaved(module, args, kwargs, backend, compiled_graph, warmup, iters, *, torch_fns=None):
     """Time eager / torch.compile / deplodock by alternating one iter of
     each per loop step. All three see the same warm GPU state across the
     measurement window — same clocks, same caches, same thermal drift —
@@ -711,18 +736,17 @@ def _bench_interleaved(module, args, kwargs, backend, compiled_graph, warmup, it
     Per-iter ``torch.cuda.Event``s queue on the (legacy) default
     stream; cupy's default stream is the same NULL stream, so events
     from both libraries see all preceding work.
+
+    ``torch_fns`` is the pre-built backend closure dict from
+    :func:`_build_torch_fns`. Callers (``handle_run``) build it
+    *outside* the GPU lock so the slow torch.compile JIT runs in
+    parallel with peer workers; the lock then wraps only this
+    measurement loop.
     """
     import torch
 
-    torch_fns: dict[str, callable] = {"Eager PyTorch": lambda: module(*args, **kwargs)}
-    try:
-        compiled_module = torch.compile(module)
-        for _ in range(warmup + 5):
-            with torch.no_grad():
-                compiled_module(*args, **kwargs)
-        torch_fns["torch.compile"] = lambda: compiled_module(*args, **kwargs)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("torch.compile failed: %s", e)
+    if torch_fns is None:
+        torch_fns = _build_torch_fns(module, args, kwargs, warmup)
 
     torch_events: dict[str, list[tuple[torch.cuda.Event, torch.cuda.Event]]] = {name: [] for name in torch_fns}
 

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -126,16 +126,52 @@ def handle_run(args):
     cuda_args = tuple(a.to("cuda") if isinstance(a, torch.Tensor) else a for a in example_args)
     cuda_kwargs = _to_cuda_kwargs(example_kwargs)
 
-    results, bench = _bench_interleaved(cuda_module, cuda_args, cuda_kwargs, backend, compiled, args.warmup, args.iters)
+    # Hold the cross-process GPU lock for the full bench + profile
+    # window. Trace, compile, dump-write all run unlocked so concurrent
+    # ``deplodock run`` invocations (parallel ``make bench-kernels``)
+    # overlap on the CPU; only the kernel-launch phases serialize, so
+    # iteration timing isn't perturbed by another worker hammering the
+    # SMs.
+    with _gpu_lock():
+        results, bench = _bench_interleaved(cuda_module, cuda_args, cuda_kwargs, backend, compiled, args.warmup, args.iters)
 
-    if dump:
-        dump.dump_benchmark(bench)
-        _dump_bench_compare(dump.dir, results, args.warmup, args.iters)
+        if dump:
+            dump.dump_benchmark(bench)
+            _dump_bench_compare(dump.dir, results, args.warmup, args.iters)
 
-    _print_table(results)
-    _print_kernel_stats(compiled, bench)
-    if args.profile:
-        _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
+        _print_table(results)
+        _print_kernel_stats(compiled, bench)
+        if args.profile:
+            _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
+
+
+def _gpu_lock():
+    """Cross-process advisory lock on a single GPU. Activated when
+    ``DEPLODOCK_GPU_LOCK`` is set (path of the lock file); a no-op
+    otherwise so ad-hoc ``deplodock run`` invocations don't pay any
+    coordination overhead. The path holds an ``flock`` (via
+    ``filelock.FileLock``) for the duration of the ``with`` block —
+    other waiters block, avoiding interleaved kernel launches that
+    would corrupt iter timings.
+    """
+    import contextlib
+    import os as _os
+
+    path = _os.environ.get("DEPLODOCK_GPU_LOCK")
+    if not path:
+
+        @contextlib.contextmanager
+        def _noop():
+            yield
+
+        return _noop()
+
+    from pathlib import Path as _Path
+
+    from filelock import FileLock
+
+    _Path(path).parent.mkdir(parents=True, exist_ok=True)
+    return FileLock(path)
 
 
 def _dump_bench_compare(dump_dir, results: dict, warmup: int, iters: int) -> None:
@@ -525,17 +561,18 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         finite = np.isfinite(arr).all()
         logger.info("Output %s: shape=%s finite=%s mean=%.4f", nid, arr.shape, bool(finite), float(arr.mean()))
 
-    if args.bench:
-        bench = backend.benchmark(graph, warmup=max(3, args.warmup // 5), num_iters=max(10, args.iters // 5))
-        print()
-        print(f"{'Backend':<24s} {'Latency (us)':>12s}")
-        print("-" * 38)
-        print(f"{'Deplodock':<24s} {bench.time_ms * 1000:>12.0f}")
-        if dump:
-            dump.dump_benchmark(bench)
-        _print_kernel_stats(graph, bench)
-    if args.profile:
-        _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
+    with _gpu_lock():
+        if args.bench:
+            bench = backend.benchmark(graph, warmup=max(3, args.warmup // 5), num_iters=max(10, args.iters // 5))
+            print()
+            print(f"{'Backend':<24s} {'Latency (us)':>12s}")
+            print("-" * 38)
+            print(f"{'Deplodock':<24s} {bench.time_ms * 1000:>12.0f}")
+            if dump:
+                dump.dump_benchmark(bench)
+            _print_kernel_stats(graph, bench)
+        if args.profile:
+            _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
 
 
 def _bind_inputs(compiled, module, example_args, example_kwargs):

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -9,6 +9,7 @@ the same shape as ``scripts/bench_block.py`` but for arbitrary inline ops.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,18 @@ def register_run_command(subparsers):
     )
     parser.add_argument("--warmup", type=int, default=10, help="Warmup iterations for --bench (default: 10).")
     parser.add_argument("--iters", type=int, default=100, help="Measurement iterations for --bench (default: 100).")
+    parser.add_argument(
+        "--bench-backends",
+        default=None,
+        help=(
+            "Comma-separated subset of backends to time under --bench: any of "
+            "``eager``, ``tcompile`` (a.k.a. ``torch.compile`` / ``compile``), "
+            "``deplodock``. Falls back to ``DEPLODOCK_BENCH_BACKENDS`` env var, "
+            "then to the default ``eager,deplodock`` (drops the ~0.8 s "
+            "torch.compile JIT from the per-case cost). ``deplodock`` is "
+            "implicit even if omitted."
+        ),
+    )
     parser.add_argument("--seed", type=int, default=0, help="RNG seed for --ir random inputs (default: 0).")
     parser.add_argument("--dump-dir", default=None, help="Directory to dump intermediate compilation artifacts.")
     parser.add_argument("--debug", action="store_true", help="Per-launch tensor dumps in the deplodock backend.")
@@ -112,12 +125,26 @@ def handle_run(args):
 
     input_data = _bind_inputs(compiled, module, example_args, example_kwargs)
 
-    run_result = backend.run(compiled, input_data=input_data)
-    if dump and backend.last_debug_result is not None:
-        dump.dump_per_launch_values(backend.last_debug_result.per_launch)
+    # Skip the accuracy check + eager forward when running as the ncu
+    # child of a ``--profile`` invocation: the parent already verified
+    # accuracy outside ncu, and re-running the eager reference under
+    # ncu (a) wastes ~5-10 s of ncu overhead per cuBLAS launch and
+    # (b) pollutes the captured CSV with cutlass / cuBLAS kernel rows
+    # the perf summary then has to filter out. The child only needs to
+    # launch the deplodock kernels so ncu can sample our metrics.
+    skip_accuracy = os.environ.get(_NCU_RECURSE_GUARD) == "1"
 
-    eager_out = _eager_output(module, example_args, example_kwargs)
-    _check_accuracy(run_result.outputs, eager_out)
+    if not skip_accuracy:
+        run_result = backend.run(compiled, input_data=input_data)
+        if dump and backend.last_debug_result is not None:
+            dump.dump_per_launch_values(backend.last_debug_result.per_launch)
+
+        eager_out = _eager_output(module, example_args, example_kwargs)
+        _check_accuracy(run_result.outputs, eager_out)
+    else:
+        # ncu child needs at least one deplodock launch for metrics
+        # to populate; skip the eager comparison.
+        backend.run(compiled, input_data=input_data)
 
     if not args.bench:
         return
@@ -126,12 +153,14 @@ def handle_run(args):
     cuda_args = tuple(a.to("cuda") if isinstance(a, torch.Tensor) else a for a in example_args)
     cuda_kwargs = _to_cuda_kwargs(example_kwargs)
 
-    # Build torch_fns (incl. ~0.8s torch.compile / Inductor JIT)
-    # *outside* the GPU lock so concurrent ``deplodock run`` workers
-    # can do their CPU-bound JITs in parallel. The few GPU launches
-    # the compile-side warmup issues are noisy but go untimed; the
-    # measurement loop below holds the lock for accurate iter timing.
-    torch_fns = _build_torch_fns(cuda_module, cuda_args, cuda_kwargs, args.warmup)
+    # Build torch_fns (incl. ~0.8s torch.compile / Inductor JIT when
+    # ``tcompile`` is in the selected backends) *outside* the GPU lock
+    # so concurrent ``deplodock run`` workers can do their CPU-bound
+    # JITs in parallel. The few GPU launches the compile-side warmup
+    # issues are noisy but go untimed; the measurement loop below
+    # holds the lock for accurate iter timing.
+    backends = _resolve_backends(args.bench_backends)
+    torch_fns = _build_torch_fns(cuda_module, cuda_args, cuda_kwargs, args.warmup, backends=backends)
 
     with _gpu_lock():
         results, bench = _bench_interleaved(
@@ -445,6 +474,11 @@ def _parse_ncu_csv(csv_text: str) -> dict:
     other metric (percentages, per-thread regs) gets averaged. Returns
     ``{kernel_name: {metric_name: numeric_value}}`` ready to be merged
     with the bench-comparison JSON downstream.
+
+    Filters to deplodock-emitted kernels (``k_*`` naming convention) —
+    the ncu child runs in the same process as the eager-reference
+    accuracy check, which would otherwise contribute cutlass / cuBLAS
+    rows that contaminate the per-row aggregate.
     """
     import csv as _csv
     import io as _io
@@ -456,6 +490,8 @@ def _parse_ncu_csv(csv_text: str) -> dict:
         metric = row.get("Metric Name", "")
         raw = row.get("Metric Value", "").replace(",", "")
         if not (kname and metric and raw):
+            continue
+        if not kname.startswith("k_"):
             continue
         try:
             val = float(raw)
@@ -698,33 +734,75 @@ def _check_accuracy(outputs, eager_out):
         sys.exit(1)
 
 
-def _build_torch_fns(module, args, kwargs, warmup):
+_BACKEND_ALIASES = {
+    "eager": "eager",
+    "deplodock": "deplodock",
+    "tcompile": "tcompile",
+    "torch.compile": "tcompile",
+    "compile": "tcompile",
+}
+
+
+def _resolve_backends(cli_value: str | None) -> set[str]:
+    """Pick which bench backends to time. Precedence:
+
+    1. ``--bench-backends`` CLI arg (comma-separated).
+    2. ``DEPLODOCK_BENCH_BACKENDS`` env var (same syntax).
+    3. Default ``eager,deplodock`` — torch.compile is excluded so the
+       per-case wall time isn't dominated by a ~0.8 s Inductor JIT
+       that most users don't need on every run.
+
+    ``deplodock`` is always included even if omitted (the kernel under
+    test is the point of the bench). Returns the canonical backend
+    keys ``{"eager", "tcompile", "deplodock"}``.
+    """
+    raw = cli_value or os.environ.get("DEPLODOCK_BENCH_BACKENDS") or "eager,deplodock"
+    selected: set[str] = {"deplodock"}
+    for tok in raw.split(","):
+        tok = tok.strip().lower()
+        if not tok:
+            continue
+        canonical = _BACKEND_ALIASES.get(tok)
+        if canonical is None:
+            logger.error("unknown bench backend %r — choose from %s", tok, sorted(set(_BACKEND_ALIASES.values())))
+            sys.exit(1)
+        selected.add(canonical)
+    return selected
+
+
+def _build_torch_fns(module, args, kwargs, warmup, *, backends: set[str]):
     """Pre-build the per-backend ``torch_fns`` dict, including the
-    ``torch.compile`` JIT step (which is mostly Inductor CPU work plus
-    a few warmup launches). Pulled out of the timed bench loop so
-    parallel ``deplodock run`` invocations can do their JITs
-    concurrently — the GPU lock then only wraps the actual measurement
-    iters where launches must be serialized for accurate timing.
+    ``torch.compile`` JIT step when requested. The JIT (mostly
+    Inductor CPU work plus a few warmup launches) sits *outside* the
+    GPU lock in ``handle_run`` so parallel workers can compile
+    concurrently — the lock then only wraps the actual measurement
+    iters.
+
+    Returns only the torch-side closures; deplodock's bench loop is
+    driven separately by ``backend.benchmark`` in ``_bench_interleaved``.
     """
     import torch
 
-    torch_fns: dict[str, callable] = {"Eager PyTorch": lambda: module(*args, **kwargs)}
-    try:
-        compiled_module = torch.compile(module)
-        for _ in range(warmup + 5):
-            with torch.no_grad():
-                compiled_module(*args, **kwargs)
-        torch_fns["torch.compile"] = lambda: compiled_module(*args, **kwargs)
-    except Exception as e:  # noqa: BLE001
-        logger.warning("torch.compile failed: %s", e)
+    torch_fns: dict[str, callable] = {}
+    if "eager" in backends:
+        torch_fns["Eager PyTorch"] = lambda: module(*args, **kwargs)
+    if "tcompile" in backends:
+        try:
+            compiled_module = torch.compile(module)
+            for _ in range(warmup + 5):
+                with torch.no_grad():
+                    compiled_module(*args, **kwargs)
+            torch_fns["torch.compile"] = lambda: compiled_module(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("torch.compile failed: %s", e)
     return torch_fns
 
 
-def _bench_interleaved(module, args, kwargs, backend, compiled_graph, warmup, iters, *, torch_fns=None):
-    """Time eager / torch.compile / deplodock by alternating one iter of
-    each per loop step. All three see the same warm GPU state across the
-    measurement window — same clocks, same caches, same thermal drift —
-    instead of running in three sequential phases that each get a
+def _bench_interleaved(module, args, kwargs, backend, compiled_graph, warmup, iters, *, torch_fns):
+    """Time the selected backends by alternating one iter of each per
+    loop step. All backends see the same warm GPU state across the
+    measurement window — same clocks, same caches, same thermal drift
+    — instead of running in sequential phases that each get a
     different steady state.
 
     Driven by ``backend.benchmark(on_iter=...)``: deplodock is the
@@ -738,15 +816,11 @@ def _bench_interleaved(module, args, kwargs, backend, compiled_graph, warmup, it
     from both libraries see all preceding work.
 
     ``torch_fns`` is the pre-built backend closure dict from
-    :func:`_build_torch_fns`. Callers (``handle_run``) build it
-    *outside* the GPU lock so the slow torch.compile JIT runs in
-    parallel with peer workers; the lock then wraps only this
-    measurement loop.
+    :func:`_build_torch_fns` (``handle_run`` builds it outside the
+    GPU lock so the slow ``torch.compile`` JIT runs concurrently with
+    peer workers; the lock then wraps only this measurement loop).
     """
     import torch
-
-    if torch_fns is None:
-        torch_fns = _build_torch_fns(module, args, kwargs, warmup)
 
     torch_events: dict[str, list[tuple[torch.cuda.Event, torch.cuda.Event]]] = {name: [] for name in torch_fns}
 

--- a/deplodock/compiler/ir/stmt/base.py
+++ b/deplodock/compiler/ir/stmt/base.py
@@ -325,8 +325,94 @@ def pretty_body(body: Body, indent: str = "") -> list[str]:
 
 
 def render_body(body: Body, ctx: RenderCtx) -> list[str]:
-    """Flatten ``stmt.render(ctx)`` over a body sequence."""
+    """Flatten ``stmt.render(ctx)`` over a body sequence.
+
+    Vectorizes runs of N=4 (or N=2) consecutive ``Load`` stmts whose
+    indices match in every higher dim and form ``e0, e0+1, ...`` on the
+    last dim into a single ``ld.shared.v4`` (``LDS.128``) emit. Each lane
+    receives 4 fp32 in a single instruction, and the warp-wide phase
+    structure of an LDS.128 (4 phases of 8 lanes × 32 fp32) naturally
+    maps to 32 distinct banks per phase — eliminating the 4-way conflict
+    that plagues 4 separate scalar ``LDS.32`` reads at the same offsets.
+
+    Buffer-side prerequisites (16-byte alignment, fp32 dtype) are
+    enforced upstream — TMA-target ``Smem`` decls already get
+    ``__align__(16)``, and the renderer only emits ``float`` typed
+    Loads. The match is purely syntactic so degenerate cases (a Load
+    whose ``input`` resolves to a scalar literal constant, or a run
+    that doesn't form a contiguous index sequence) bypass cleanly.
+    """
     out: list[str] = []
-    for s in body:
-        out.extend(s.render(ctx))
+    i = 0
+    n = len(body)
+    while i < n:
+        for run_n in (4, 2):
+            run = _vec_load_run(body, i, run_n, ctx)
+            if run is not None:
+                out.extend(run)
+                i += run_n
+                break
+        else:
+            out.extend(body[i].render(ctx))
+            i += 1
+    return out
+
+
+def _vec_load_run(body: Body, start: int, n: int, ctx: RenderCtx) -> list[str] | None:
+    """If ``body[start:start+n]`` matches the consecutive-Load pattern,
+    return the rendered ``float<n>`` vector load + per-lane unpacks.
+    Otherwise return ``None`` so :func:`render_body` falls back to the
+    per-stmt path."""
+    from deplodock.compiler.ir.stmt.leaves import Load  # local — avoid cycle
+
+    if start + n > len(body):
+        return None
+    loads = body[start : start + n]
+    if not all(isinstance(s, Load) for s in loads):
+        return None
+    if any(s.is_literal(ctx.literal_constants) for s in loads):
+        return None
+    inputs = {s.input for s in loads}
+    if len(inputs) != 1:
+        return None
+    rank = len(loads[0].index)
+    if rank == 0 or any(len(s.index) != rank for s in loads[1:]):
+        return None
+    higher = loads[0].index[:-1]
+    for s in loads[1:]:
+        if s.index[:-1] != higher:
+            return None
+    # Compare last-dim expressions via affine decomposition: same var
+    # coefficients, anchor differing by exactly ``k``. ``simplify`` alone
+    # doesn't fold ``(a*4 + k) - (a*4)`` to ``k`` (it only handles
+    # literal-only arithmetic), so we extract the affine form and
+    # subtract the anchors instead.
+    from deplodock.compiler.ir.expr import affine_form  # local — keep base.py minimal
+
+    inner_0 = loads[0].index[-1]
+    free = inner_0.free_vars()
+    for s in loads[1:]:
+        free = free | s.index[-1].free_vars()
+    af0 = affine_form(inner_0, free)
+    if af0 is None:
+        return None
+    anchor_0, coeffs_0 = af0
+    for k, s in enumerate(loads):
+        if k == 0:
+            continue
+        af = affine_form(s.index[-1], free)
+        if af is None:
+            return None
+        anchor_k, coeffs_k = af
+        if coeffs_k != coeffs_0:
+            return None
+        diff = BinaryExpr("-", anchor_k, anchor_0).simplify(SimplifyCtx.empty())
+        if not (isinstance(diff, Literal) and isinstance(diff.value, int) and diff.value == k):
+            return None
+    flat = render_index(loads[0].input, loads[0].index, ctx)
+    pad = _pad(ctx.indent)
+    vname = f"_v_{loads[0].name}"
+    components = ("x", "y", "z", "w")[:n]
+    out = [f"{pad}float{n} {vname} = *reinterpret_cast<const float{n}*>(&{loads[0].input}[{flat}]);"]
+    out.extend(f"{pad}float {s.name} = {vname}.{c};" for s, c in zip(loads, components, strict=True))
     return out

--- a/deplodock/compiler/ir/stmt/blocks.py
+++ b/deplodock/compiler/ir/stmt/blocks.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 from deplodock.compiler.ir.axis import BIND_BLOCK, BIND_THREAD, Axis, BoundAxis
 from deplodock.compiler.ir.expr import Expr, _float_lit
-from deplodock.compiler.ir.stmt.base import INDENT, RenderCtx, Stmt, _pad, pretty_body
+from deplodock.compiler.ir.stmt.base import INDENT, RenderCtx, Stmt, _pad, pretty_body, render_body
 from deplodock.compiler.ir.stmt.body import Body
 from deplodock.compiler.ir.stmt.leaves import Accum
 
@@ -93,8 +93,7 @@ class Loop(Stmt):
             out.append(f"{pad}#pragma unroll")
         out.append(f"{pad}for (int {var} = 0; {var} < {extent}; {var}++) {{")
         inner = ctx.child()
-        for s in self.body:
-            out.extend(s.render(inner))
+        out.extend(render_body(self.body, inner))
         out.append(f"{pad}}}")
         return out
 
@@ -178,8 +177,7 @@ class Tile(Stmt):
                 inner_pad = _pad(inner.indent)
                 out.append(f"{inner_pad}int lane = threadIdx.x & 31;")
                 out.append(f"{inner_pad}int warp = threadIdx.x >> 5;")
-            for s in self.body:
-                out.extend(s.render(inner))
+            out.extend(render_body(self.body, inner))
             out.append(f"{pad}}}")
             return out
 
@@ -191,8 +189,7 @@ class Tile(Stmt):
             f"{pad}if (tid < {n_threads}) {{",
         ]
         out.extend(_render_thread_axis_decode(self.thread_axes, inner))
-        for s in self.body:
-            out.extend(s.render(inner))
+        out.extend(render_body(self.body, inner))
         out.append(f"{pad}}}")
         return out
 
@@ -318,8 +315,7 @@ class StridedLoop(Stmt):
             out.append(f"{pad}#pragma unroll")
         out.append(f"{pad}for (int {var} = {start_str}; {var} < {int(self.axis.extent)}; {var} += {step_str}) {{")
         inner = ctx.child()
-        for s in self.body:
-            out.extend(s.render(inner))
+        out.extend(render_body(self.body, inner))
         out.append(f"{pad}}}")
         return out
 
@@ -378,13 +374,10 @@ class Cond(Stmt):
         pad = _pad(ctx.indent)
         cond = self.cond.render(ctx)
         inner = ctx.child()
-        body: list[str] = []
-        for s in self.body:
-            body.extend(s.render(inner))
+        body = render_body(self.body, inner)
         out = [f"{pad}if ({cond}) {{", *body, f"{pad}}}"]
         if self.else_body:
             out[-1] = f"{pad}}} else {{"
-            for s in self.else_body:
-                out.extend(s.render(inner))
+            out.extend(render_body(self.else_body, inner))
             out.append(f"{pad}}}")
         return out

--- a/deplodock/compiler/pipeline/passes/loop/fusion/001_merge_loop_ops.py
+++ b/deplodock/compiler/pipeline/passes/loop/fusion/001_merge_loop_ops.py
@@ -133,6 +133,24 @@ def _count_loads_from(consumer_op: LoopOp, producer_buf: str) -> int:
     return sum(1 for ld in consumer_op.body.loads if ld.input == producer_buf)
 
 
+def _reduce_with_n_buffers(loop_op: LoopOp) -> int:
+    """Maximum distinct buffer Loads under any single reduce ``Loop`` in
+    ``loop_op``'s body. ``0`` if no reduce loop has any Load.
+
+    Pure matmul: 2 (a, b). matmul_add (epilogue-fused): still 2 (the
+    residual loads outside the reduce). silu_mul_matmul (prologue
+    fused into the K-reduce): 3 (g, u, w). The 3-or-more case is what
+    the fused-prologue guard above refuses.
+    """
+    max_n = 0
+    for s in loop_op.body.iter():
+        if isinstance(s, Loop) and s.is_reduce:
+            bufs = {ld.input for ld in s.body.of_type(Load)}
+            if len(bufs) > max_n:
+                max_n = len(bufs)
+    return max_n
+
+
 PATTERN = [
     Pattern("producer", LoopOp),
     Pattern("consumer", LoopOp),
@@ -191,6 +209,18 @@ def rewrite(graph: Graph, match: Match, producer: Node, consumer: Node) -> Graph
         raise RuleSkipped(f"work blowup: post={post_work} > {_BLOWUP_FACTOR}× pre={pre_work}")
     if post_reads > _BLOWUP_FACTOR * pre_reads:
         raise RuleSkipped(f"read blowup: post={post_reads} > {_BLOWUP_FACTOR}× pre={pre_reads}")
+
+    # Fused-prologue-into-matmul guard: when the merged op has a reduce
+    # loop whose body Loads ≥3 distinct buffers, the matmul will compile
+    # under the fused-prologue tile class (BN=64, BM=64, F=4×4) instead
+    # of the default ``F=8×4``. The fused tile halves arithmetic
+    # intensity per thread (16 outputs vs 32) — fine when the prologue
+    # is unavoidable, but here we have the choice. Sweep on ``silu_mul
+    # _matmul.qwen.{s128, s512}`` shows the 2-kernel solution
+    # (silu_mul → temp + matmul) ≈30% faster than the fused single
+    # kernel; refuse this fusion and let the two LoopOps stay separate.
+    if _reduce_with_n_buffers(merged) >= 3:
+        raise RuleSkipped("fused result has ≥3 buffer Loads inside a reduce loop (matmul-prologue fusion); 2-kernel solution is faster")
 
     # Broadcast-materialization guard: fusing a compute-bearing producer into
     # a pure-indexmap consumer whose output volume exceeds the producer's

--- a/deplodock/compiler/pipeline/passes/loop/fusion/001_merge_loop_ops.py
+++ b/deplodock/compiler/pipeline/passes/loop/fusion/001_merge_loop_ops.py
@@ -133,24 +133,6 @@ def _count_loads_from(consumer_op: LoopOp, producer_buf: str) -> int:
     return sum(1 for ld in consumer_op.body.loads if ld.input == producer_buf)
 
 
-def _reduce_with_n_buffers(loop_op: LoopOp) -> int:
-    """Maximum distinct buffer Loads under any single reduce ``Loop`` in
-    ``loop_op``'s body. ``0`` if no reduce loop has any Load.
-
-    Pure matmul: 2 (a, b). matmul_add (epilogue-fused): still 2 (the
-    residual loads outside the reduce). silu_mul_matmul (prologue
-    fused into the K-reduce): 3 (g, u, w). The 3-or-more case is what
-    the fused-prologue guard above refuses.
-    """
-    max_n = 0
-    for s in loop_op.body.iter():
-        if isinstance(s, Loop) and s.is_reduce:
-            bufs = {ld.input for ld in s.body.of_type(Load)}
-            if len(bufs) > max_n:
-                max_n = len(bufs)
-    return max_n
-
-
 PATTERN = [
     Pattern("producer", LoopOp),
     Pattern("consumer", LoopOp),
@@ -209,18 +191,6 @@ def rewrite(graph: Graph, match: Match, producer: Node, consumer: Node) -> Graph
         raise RuleSkipped(f"work blowup: post={post_work} > {_BLOWUP_FACTOR}× pre={pre_work}")
     if post_reads > _BLOWUP_FACTOR * pre_reads:
         raise RuleSkipped(f"read blowup: post={post_reads} > {_BLOWUP_FACTOR}× pre={pre_reads}")
-
-    # Fused-prologue-into-matmul guard: when the merged op has a reduce
-    # loop whose body Loads ≥3 distinct buffers, the matmul will compile
-    # under the fused-prologue tile class (BN=64, BM=64, F=4×4) instead
-    # of the default ``F=8×4``. The fused tile halves arithmetic
-    # intensity per thread (16 outputs vs 32) — fine when the prologue
-    # is unavoidable, but here we have the choice. Sweep on ``silu_mul
-    # _matmul.qwen.{s128, s512}`` shows the 2-kernel solution
-    # (silu_mul → temp + matmul) ≈30% faster than the fused single
-    # kernel; refuse this fusion and let the two LoopOps stay separate.
-    if _reduce_with_n_buffers(merged) >= 3:
-        raise RuleSkipped("fused result has ≥3 buffer Loads inside a reduce loop (matmul-prologue fusion); 2-kernel solution is faster")
 
     # Broadcast-materialization guard: fusing a compute-bearing producer into
     # a pure-indexmap consumer whose output volume exceeds the producer's

--- a/deplodock/compiler/pipeline/passes/lowering/tile/008b_chunk_register_tile_for_banks.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/008b_chunk_register_tile_for_banks.py
@@ -1,0 +1,281 @@
+"""Chunk the N register-tile into ``LDS.128``-sized strips when ``F_N > 4``.
+
+After ``008_register_tile`` commits the canonical ``(THREAD-outer | RF-inner)``
+ordering on the N axis, body Loads on the B operand stage read column
+``Var(lane) * F_N + c`` for ``c=0..F_N-1``. Two regimes:
+
+* ``F_N <= 4`` (canonical default): lane ``l`` reads the contiguous strip
+  ``[F_N*l, F_N*l+F_N-1]``. nvcc auto-vectorizes the unrolled scalar reads
+  into a single ``ld.shared.v4`` per K-iter — and within each LDS.128
+  phase (8 lanes × 4 fp32) the warp covers 32 distinct banks, so no
+  conflicts. **No transform needed; pass skips.**
+
+* ``F_N > 4`` (e.g. F_N=8): lane ``l`` reads ``[8l..8l+7]``. Each LDS.128
+  carries 4 fp32, so the per-thread N-strip splits into ``F_N/4``
+  successive LDS.128. *Within* one LDS.128 phase, the 8 lanes are
+  stride-``F_N`` apart (lane 0 → cols 0-3, lane 1 → 8-11, …, lane 4
+  wraps). 8 lanes × 4 fp32 = 32 fp32 of accesses, but with that stride
+  they land on only 16 banks → 2-way conflict per phase, 8-way per
+  LDS.128. ncu confirms 25 M+ conflicts on this shape.
+
+Fix: keep each LDS.128 reading 4 *contiguous* fp32 (so the phase covers
+32 distinct banks), but spread the ``F_N/4`` LDS.128's *across the
+N-tile* instead of stacking them at lane-stride F_N. Lane ``l`` now owns
+``F_N/4`` chunks of 4 cols each, the chunks spaced ``4 * lane_ext``
+apart inside the BN-wide tile (which is exactly ``F_N/4`` chunks ×
+``4 * lane_ext`` cols since ``BN = F_N * lane_ext``). For the canonical
+``F_N=8, lane_ext=16`` (``BN=128``) shape, the chunk stride is 64.
+
+Rewrite (applied to every Load + Write index expression containing
+``Var(lane) * F_N + Literal(c)``):
+
+    Var(lane) * F_N + Literal(c)
+        →   4 * Var(lane) + Literal((c // 4) * (4 * lane_ext) + (c % 4))
+
+For ``F_N=8, lane_ext=16``:
+
+    c=0..3 → ``4*lane + c``           (chunk 0, cols 0..63 of the tile)
+    c=4..7 → ``4*lane + 64 + (c-4)``  (chunk 1, cols 64..127 of the tile)
+
+Per LDS.128 phase: 8 lanes read 32 contiguous fp32 (one chunk), 32
+distinct banks, **0 conflicts**. The Write to global memory follows
+the same per-thread mapping, so each chunk's lane-to-output assignment
+is also stride-1 (improved coalescing vs the F_N-stride default).
+
+Lane axis: the larger-extent THREAD axis (the N axis post-008; the M
+axis sits at extent ``BM/F_M``, N at ``BN/F_N``, and ``BN >= BM`` by
+convention). M-axis register tile is left alone — M loads broadcast
+within a warp at this point and don't carry a fixable conflict.
+
+Skips when:
+
+* The picked axis has no body Load with stride F > 4 divisible by 4.
+  Captures the ``F_N <= 4`` no-op case and any non-canonical shape.
+* Bank-conflict analysis (reusing ``013_pad_smem``'s analyzer) says
+  ``post < pre`` doesn't hold.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace as dc_replace
+
+from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.axis import BIND_THREAD, Axis
+from deplodock.compiler.ir.expr import BinaryExpr, Expr, Literal, Var, affine_form
+from deplodock.compiler.ir.stmt import Body, Load, Stmt, Tile, Write
+from deplodock.compiler.ir.tile.ir import BufferedStage, Stage, TileOp
+from deplodock.compiler.pipeline.engine import Pattern, RuleSkipped
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import (
+    load_thread_axis_coeffs,
+    loads_reading,
+    max_bank_conflict,
+    single_tile,
+)
+
+logger = logging.getLogger(__name__)
+
+# ``LDS.128`` carries 4 fp32 per lane. The chunk size in this pass is
+# the maximum-vector-load width; we keep each per-thread N-chunk that
+# size so nvcc can keep emitting LDS.128 + the warp's 8-lane phase
+# covers exactly 32 banks.
+_LDS128_FLOATS = 4
+
+PATTERN = [Pattern("root", TileOp)]
+
+
+def rewrite(graph: Graph, root: Node) -> Graph | None:
+    new_body = _maybe_rewrite(root.op.body)
+    if new_body is None:
+        return None
+    root.op = TileOp(body=new_body, name=root.op.name)
+    return None
+
+
+def _maybe_rewrite(body: Body) -> Body | None:
+    idx, tile = single_tile(body)
+
+    thread_axes = tuple(ba.axis for ba in tile.axes if ba.bind == BIND_THREAD)
+    if len(thread_axes) < 2:
+        raise RuleSkipped("need >=2 THREAD axes (matmul-shaped tile)")
+
+    # Pick the lane axis: the THREAD axis tied to the *N dim of B*. In
+    # the canonical post-008 layout that's the larger-extent THREAD axis
+    # (the M axis sits at extent BM/F_M, the N axis at BN/F_N, with BN
+    # >= BM by convention). We confirm via the access pattern that the
+    # picked axis appears in some Stage Load with stride F divisible by
+    # ``_LDS128_FLOATS`` and > _LDS128_FLOATS — otherwise the chunked
+    # rewrite is a no-op or doesn't apply.
+    sorted_threads = sorted(thread_axes, key=lambda ax: int(ax.extent))
+    candidates: list[tuple[Axis, int]] = []
+    for ax in reversed(sorted_threads):  # try N (largest) first
+        F = _infer_lane_stride(tile.body, ax.name)
+        if F is None or F <= _LDS128_FLOATS or F % _LDS128_FLOATS != 0:
+            continue
+        candidates.append((ax, F))
+    if not candidates:
+        raise RuleSkipped(f"no THREAD axis has Load-stride F divisible by {_LDS128_FLOATS} and > {_LDS128_FLOATS}")
+    lane, F = candidates[0]
+    lane_ext = int(lane.extent)
+
+    if not _swap_helps_any_stage(tile, thread_axes, lane.name, F, lane_ext):
+        raise RuleSkipped("no Stage has a fixable lane-stride bank conflict")
+
+    chunk_stride = _LDS128_FLOATS * lane_ext
+    new_tile = Tile(axes=tile.axes, body=_rewrite_body(tile.body, lane.name, F, chunk_stride))
+    logger.info(
+        "chunk N register-tile on lane=%s F=%d -> stride=%d, chunks=%d (chunk_stride=%d, BN=%d)",
+        lane.name,
+        F,
+        _LDS128_FLOATS,
+        F // _LDS128_FLOATS,
+        chunk_stride,
+        lane_ext * F,
+    )
+    return body[:idx] + (new_tile,) + body[idx + 1 :]
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def _infer_lane_stride(body: Body, lane_var: str) -> int | None:
+    """Coefficient of ``Var(lane_var)`` across all body Loads' index dims.
+
+    Returns ``None`` when no Load depends on the lane var or the
+    coefficients aren't uniform — same conservatism as the original
+    swap pass, since a per-Load mixed-stride rewrite isn't produced
+    by ``008``.
+    """
+    seen: set[int] = set()
+    for s in body.iter():
+        if not isinstance(s, Load):
+            continue
+        for e in s.index:
+            if lane_var not in e.free_vars():
+                continue
+            af = affine_form(e, {lane_var})
+            if af is None:
+                return None
+            _, coeffs = af
+            c = coeffs.get(lane_var, 0)
+            if c != 0:
+                seen.add(c)
+    if len(seen) != 1:
+        return None
+    (F,) = seen
+    return F
+
+
+def _swap_helps_any_stage(tile: Tile, thread_axes: tuple[Axis, ...], lane_var: str, F: int, lane_ext: int) -> bool:
+    """At least one Stage has a fixable bank conflict that the chunked
+    rewrite would drive lower. Reuses the affine analyzer from
+    ``013_pad_smem``.
+
+    Note the analyzer is a coarse predictor — it counts bank conflicts
+    treating each Load as a single-element access (i.e. as if hardware
+    issued LDS.32). For ``F=4`` with LDS.128 the hardware actually
+    collapses 4 lanes' contiguous reads into one 32-bank phase (no
+    conflict) but the analyzer still scores ``F=4`` as 4-way. So we
+    just check ``post < pre`` — if the rewrite at least doesn't worsen
+    the analyzer's score, the hardware will see a real improvement
+    (no more cross-phase 8-way collisions for ``F>=8``).
+    """
+    for s in tile.body.iter():
+        if not isinstance(s, Stage):
+            continue
+        loads = loads_reading(tile.body, s.name)
+        if not loads:
+            continue
+        n_axes = len(s.axes)
+        leading_phase = isinstance(s, BufferedStage)
+        coeffs_pre = load_thread_axis_coeffs(loads, n_axes, thread_axes, leading_phase_dim=leading_phase)
+        if coeffs_pre is None:
+            continue
+        extents = tuple(int(ax.extent) for ax in s.axes)
+        pre = max_bank_conflict(coeffs_pre, extents, thread_axes)
+        if pre <= 1:
+            continue
+        chunk_stride = _LDS128_FLOATS * lane_ext
+        rewritten = [_rewrite_load_index(ld, lane_var, F, chunk_stride) for ld in loads]
+        coeffs_post = load_thread_axis_coeffs(rewritten, n_axes, thread_axes, leading_phase_dim=leading_phase)
+        if coeffs_post is None:
+            continue
+        post = max_bank_conflict(coeffs_post, extents, thread_axes)
+        if post < pre:
+            logger.debug("Stage %s: bank conflict %d -> %d under chunk rewrite", s.name, pre, post)
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Rewrite
+# ---------------------------------------------------------------------------
+
+
+def _rewrite_body(body: Body, lane_var: str, F: int, chunk_stride: int) -> Body:
+    return body.map(lambda s: _rewrite_stmt(s, lane_var, F, chunk_stride))
+
+
+def _rewrite_stmt(s: Stmt, lane_var: str, F: int, chunk_stride: int) -> Stmt:
+    if isinstance(s, Load):
+        return _rewrite_load_index(s, lane_var, F, chunk_stride)
+    if isinstance(s, Write):
+        new_idx = tuple(_chunk_expr(e, lane_var, F, chunk_stride) for e in s.index)
+        if new_idx != s.index:
+            return dc_replace(s, index=new_idx)
+    return s
+
+
+def _rewrite_load_index(ld: Load, lane_var: str, F: int, chunk_stride: int) -> Load:
+    new_idx = tuple(_chunk_expr(e, lane_var, F, chunk_stride) for e in ld.index)
+    if new_idx == ld.index:
+        return ld
+    return dc_replace(ld, index=new_idx)
+
+
+def _chunk_expr(e: Expr, lane_var: str, F: int, chunk_stride: int) -> Expr:
+    """Rewrite ``Var(lane_var) * F + Literal(c)`` into
+    ``_LDS128_FLOATS * Var(lane_var) + Literal(off)`` where
+    ``off = (c // 4) * chunk_stride + (c % 4)``. The bare-``Var(lane)
+    * F`` form (the c=0 replica) lowers to ``_LDS128_FLOATS *
+    Var(lane)``. ``chunk_stride = _LDS128_FLOATS * lane_ext`` so the
+    chunks tile the BN-wide N tile evenly. Other subtrees pass through.
+    """
+    if lane_var not in e.free_vars():
+        return e
+
+    if isinstance(e, BinaryExpr) and e.op == "+":
+        for left, right in ((e.left, e.right), (e.right, e.left)):
+            if _matches_lane_mul(left, lane_var, F) and isinstance(right, Literal) and isinstance(right.value, int):
+                c = right.value
+                chunk_idx, within = divmod(c, _LDS128_FLOATS)
+                off = chunk_idx * chunk_stride + within
+                return BinaryExpr(
+                    "+",
+                    BinaryExpr("*", Var(lane_var), Literal(_LDS128_FLOATS, "int")),
+                    Literal(off, "int"),
+                )
+        return BinaryExpr("+", _chunk_expr(e.left, lane_var, F, chunk_stride), _chunk_expr(e.right, lane_var, F, chunk_stride))
+
+    if isinstance(e, BinaryExpr) and e.op == "-":
+        return BinaryExpr("-", _chunk_expr(e.left, lane_var, F, chunk_stride), _chunk_expr(e.right, lane_var, F, chunk_stride))
+
+    if _matches_lane_mul(e, lane_var, F):
+        return BinaryExpr("*", Var(lane_var), Literal(_LDS128_FLOATS, "int"))
+
+    if isinstance(e, BinaryExpr):
+        return BinaryExpr(e.op, _chunk_expr(e.left, lane_var, F, chunk_stride), _chunk_expr(e.right, lane_var, F, chunk_stride))
+
+    return e
+
+
+def _matches_lane_mul(e: Expr, lane_var: str, F: int) -> bool:
+    """``Var(lane_var) * Literal(F)`` (either operand order)."""
+    if not isinstance(e, BinaryExpr) or e.op != "*":
+        return False
+    for var_side, lit_side in ((e.left, e.right), (e.right, e.left)):
+        if isinstance(var_side, Var) and var_side.name == lane_var and isinstance(lit_side, Literal) and lit_side.value == F:
+            return True
+    return False

--- a/deplodock/compiler/tuning.py
+++ b/deplodock/compiler/tuning.py
@@ -187,6 +187,34 @@ def _has_fused_prologue(stmts) -> bool:
     return False
 
 
+def _external_input_count(stmts) -> int:
+    """Distinct external buffers a Tile body references — sum of
+    ``Stage.buf`` (staged inputs) plus any direct ``Load.input`` that
+    doesn't name a Stage.
+
+    Pure ``matmul`` = 2 (a, b). ``matmul_add`` = 3 (a, b, residual).
+    ``silu_mul_matmul`` = 3 (g, u, w). The default-large class is
+    gated on ``count == 2`` to keep extra epilogue Loads (which steal
+    register slots per-output-cell) from forcing F=8×8 — sweep showed
+    ``matmul_add.tinyllama.o_proj.s512`` regressing 0.80× → 0.72×
+    when the residual Load piles on the F=8×8 accumulator tile
+    (regs 118 → 209, occ 33% → 17%).
+    """
+    from deplodock.compiler.ir.stmt import Load
+    from deplodock.compiler.ir.stmt.body import Body
+    from deplodock.compiler.ir.tile.ir import Stage
+
+    body = Body.coerce(stmts)
+    stage_names = {s.name for s in body.iter() if isinstance(s, Stage)}
+    bufs: set[str] = set()
+    for s in body.iter():
+        if isinstance(s, Stage):
+            bufs.add(s.buf)
+        elif isinstance(s, Load) and s.input not in stage_names:
+            bufs.add(s.input)
+    return len(bufs)
+
+
 def _logical_output_extents(tile: Tile) -> list[int]:
     """Recover the pre-blockify output extents from a (possibly
     blockified) ``Tile``. Walks ``tile.axes`` folding adjacent
@@ -244,7 +272,7 @@ def _tile_class(tile: Tile | None) -> str:
         return "huge"
     if n <= _COMPACT_N_MAX:
         return "compact"
-    if m >= _DEFAULT_LARGE_M_MIN:
+    if m >= _DEFAULT_LARGE_M_MIN and _external_input_count(tile.body) == 2:
         return "default-large"
     return "default"
 

--- a/deplodock/compiler/tuning.py
+++ b/deplodock/compiler/tuning.py
@@ -82,6 +82,16 @@ _TILE_SHAPE_HUGE = (128, 128)
 _F_PER_AXIS_HUGE = (16, 4)
 _TILE_SHAPE_COMPACT = (64, 64)
 _F_PER_AXIS_COMPACT = (8, 4)
+# "Fused-prologue" class: the matmul-reduce body has a third buffer
+# being loaded inside the K-loop (e.g. ``silu_mul_matmul`` reads g, u,
+# *and* w each K-iter to compute the fused ``silu(g)*u`` operand). The
+# extra Load chain plus the per-K-iter prologue values eat registers
+# the matmul's F=8x4 accumulator tile would normally use, dropping
+# occupancy from the register-file headroom. Sweep on RTX 5090 fp32 +
+# silu_mul_matmul.qwen.{s128,s512} cuts the case from 0.17× → 0.37×
+# (s128, 2039µs → 933µs) and 0.12× → 0.28× (s512, 9270µs → 3920µs).
+_TILE_SHAPE_FUSED = (64, 64)
+_F_PER_AXIS_FUSED = (4, 4)
 _HUGE_M_MIN = 256
 _HUGE_N_MIN = 8192
 _COMPACT_N_MAX = 1024
@@ -138,6 +148,32 @@ def _has_matmul_reduce(stmts) -> bool:
     )
 
 
+def _has_fused_prologue(stmts) -> bool:
+    """True iff some matmul-reduce loop's body has ``≥3`` distinct
+    buffer Loads — i.e. a fused prologue feeds extra operand values
+    into the reduction (``silu_mul_matmul``: ``g_smem, u_smem,
+    w_smem``). Pure ``matmul`` and ``matmul_add`` (epilogue-fused)
+    have exactly 2 buffer Loads inside the K-reduce; the residual /
+    bias of ``matmul_add`` is loaded *outside* the reduce loop and
+    doesn't push register pressure inside it.
+
+    The extra buffer Load is a structural proxy for "operand values
+    held across K iters that compete with the F-tile accumulators for
+    register space" — exactly the case where the canonical F=8×4
+    tile starves occupancy. ``_default_tile`` switches to F=4×4 BN=64
+    for these.
+    """
+    from deplodock.compiler.ir.stmt import Load, Loop
+    from deplodock.compiler.ir.stmt.body import Body
+
+    for s in Body.coerce(stmts).iter():
+        if isinstance(s, Loop) and s.is_reduce:
+            bufs = {ld.input for ld in s.body.of_type(Load)}
+            if len(bufs) >= 3:
+                return True
+    return False
+
+
 def _logical_output_extents(tile: Tile) -> list[int]:
     """Recover the pre-blockify output extents from a (possibly
     blockified) ``Tile``. Walks ``tile.axes`` folding adjacent
@@ -167,11 +203,21 @@ def _matmul_M(tile: Tile) -> int:
 
 
 def _tile_class(tile: Tile | None) -> str:
-    """``"huge" | "compact" | "default"`` — picks the matmul tile class
-    from the logical output extents. Non-matmul tiles fall to ``"default"``
-    (the env vars wouldn't apply anyway)."""
+    """``"fused" | "huge" | "compact" | "default"`` — picks the matmul
+    tile class from the logical output extents and body structure.
+    Non-matmul tiles fall to ``"default"`` (the env vars wouldn't
+    apply anyway).
+
+    ``"fused"`` is checked first because a fused-prologue matmul
+    (``silu_mul_matmul``) can have output extents that would otherwise
+    classify it as ``huge`` / ``default``, but its register pressure
+    profile is fundamentally different — the standard tiles starve
+    occupancy.
+    """
     if tile is None or not _has_matmul_reduce(tile.body):
         return "default"
+    if _has_fused_prologue(tile.body):
+        return "fused"
     extents = _logical_output_extents(tile)
     if len(extents) < 2:
         return "default"
@@ -187,6 +233,8 @@ def _default_tile(tile: Tile | None) -> tuple[tuple[int, int], tuple[int, int]]:
     """``((BN, BM), (F_M, F_N))`` defaults for the matmul tile, picked
     by ``_tile_class``."""
     cls = _tile_class(tile)
+    if cls == "fused":
+        return _TILE_SHAPE_FUSED, _F_PER_AXIS_FUSED
     if cls == "huge":
         return _TILE_SHAPE_HUGE, _F_PER_AXIS_HUGE
     if cls == "compact":

--- a/deplodock/compiler/tuning.py
+++ b/deplodock/compiler/tuning.py
@@ -92,6 +92,19 @@ _F_PER_AXIS_COMPACT = (8, 4)
 # (s128, 2039µs → 933µs) and 0.12× → 0.28× (s512, 9270µs → 3920µs).
 _TILE_SHAPE_FUSED = (64, 64)
 _F_PER_AXIS_FUSED = (4, 4)
+# "Default-large" class: default-class shapes with enough M to fill
+# the grid benefit from doubling the per-thread N register tile from
+# F_N=4 → F_N=8. The chunk pass (``008b``) keeps LDS.128 vectorized
+# and prevents the F_N=8 bank-conflict cliff. Sweep on RTX 5090 fp32:
+# qwen.q_proj.s512 0.87× → 0.92× (286 → 266µs), qwen.down_proj.s512
+# 0.79× → 0.86× (1434 → 1331µs), tl.gate_proj.s512 0.95× → 0.99×.
+# Small-M cases (s32) regress because the grid is too small to
+# amortize the extra register pressure (e.g. tl.q_proj.s32 1.47×
+# → 1.32×); the threshold ``_DEFAULT_LARGE_M_MIN = 128`` gates the
+# upgrade to cases where it actually wins.
+_TILE_SHAPE_DEFAULT_LARGE = (128, 64)
+_F_PER_AXIS_DEFAULT_LARGE = (8, 8)
+_DEFAULT_LARGE_M_MIN = 128
 _HUGE_M_MIN = 256
 _HUGE_N_MIN = 8192
 _COMPACT_N_MAX = 1024
@@ -203,16 +216,21 @@ def _matmul_M(tile: Tile) -> int:
 
 
 def _tile_class(tile: Tile | None) -> str:
-    """``"fused" | "huge" | "compact" | "default"`` — picks the matmul
-    tile class from the logical output extents and body structure.
-    Non-matmul tiles fall to ``"default"`` (the env vars wouldn't
-    apply anyway).
+    """``"fused" | "huge" | "compact" | "default-large" | "default"``
+    — picks the matmul tile class from the logical output extents and
+    body structure. Non-matmul tiles fall to ``"default"`` (the env
+    vars wouldn't apply anyway).
 
     ``"fused"`` is checked first because a fused-prologue matmul
     (``silu_mul_matmul``) can have output extents that would otherwise
     classify it as ``huge`` / ``default``, but its register pressure
     profile is fundamentally different — the standard tiles starve
     occupancy.
+
+    ``"default-large"`` is the default-class subclass for M ≥ 128 +
+    N > _COMPACT_N_MAX + N < _HUGE_N_MIN. F_N=8 (vs F_N=4) doubles
+    arithmetic intensity per thread; the chunk pass (``008b``) keeps
+    LDS.128 vectorized.
     """
     if tile is None or not _has_matmul_reduce(tile.body):
         return "default"
@@ -226,6 +244,8 @@ def _tile_class(tile: Tile | None) -> str:
         return "huge"
     if n <= _COMPACT_N_MAX:
         return "compact"
+    if m >= _DEFAULT_LARGE_M_MIN:
+        return "default-large"
     return "default"
 
 
@@ -239,6 +259,8 @@ def _default_tile(tile: Tile | None) -> tuple[tuple[int, int], tuple[int, int]]:
         return _TILE_SHAPE_HUGE, _F_PER_AXIS_HUGE
     if cls == "compact":
         return _TILE_SHAPE_COMPACT, _F_PER_AXIS_COMPACT
+    if cls == "default-large":
+        return _TILE_SHAPE_DEFAULT_LARGE, _F_PER_AXIS_DEFAULT_LARGE
     return _TILE_SHAPE_DEFAULT, _F_PER_AXIS_DEFAULT
 
 

--- a/docs/warp-specialized-fused-prologue.md
+++ b/docs/warp-specialized-fused-prologue.md
@@ -1,0 +1,263 @@
+# Warp-Specialized Fused-Prologue Kernels (`setmaxnreg`)
+
+## Why
+
+Fused-prologue matmuls — `silu_mul_matmul` (down_proj on a SiLU-gated MLP),
+`gelu_mul_matmul`, `bias_relu_matmul`, etc. — currently lose 2-3× to the
+equivalent two-kernel sequence (`silu_mul → temp; matmul(temp, w)`) on
+RTX 5090 fp32. The fused kernel is structurally forced into a worse
+schedule than the pure matmul:
+
+| Aspect | Pure matmul (`F=8×4 BN=128`) | Fused `silu_mul_matmul` (`F=4×4 BN=64`) |
+|---|---|---|
+| Outputs / thread | 32 | 16 |
+| Arithmetic intensity / CTA | 1.0× | 0.5× |
+| Regs / thread | 80 | 80 (after fused-class fix; was 145) |
+| Occupancy | 50 % | 50 % |
+| FMA% | ~65 % | ~46 % |
+| SiLU pipeline ↔ FMA dependency chain inside K-loop | n/a | 5 stages × F_M live values |
+
+The wall isn't bank conflicts (~5 % overhead) and it isn't pure
+register pressure once we drop to `F=4×4`. The wall is that **every
+K-iteration of the inner loop carries a serial `LDS_g → neg → exp →
+add → rcp → mul_g → mul_u → A → mul_w → accum` chain**, the SFU
+(`exp`, `rcp`) competes with the FMA pipe for issue bandwidth on the
+same warp scheduler, and the per-CTA tile shape is forced down to
+make the live SiLU values fit. Defusion solves all three at once but
+costs an extra global-memory round-trip on the `A` operand.
+
+The Hopper / Blackwell answer is **warp specialization with dynamic
+register reallocation** (`setmaxnreg.dec/inc.sync.aligned.u32`).
+Producer warps run the fused prologue (silu·u) into an in-CTA
+ping-pong smem buffer; consumer warps run the canonical matmul over
+that buffer at the standard `F=8×4` tile. The producer/consumer
+warp-groups have *different register budgets*: producers release
+their reg-file slice with `setmaxnreg.dec`, consumers claim it with
+`setmaxnreg.inc`. Same kernel, no global-memory round-trip on `A`,
+but the consumer body looks identical to a pure-matmul kernel.
+
+## Goal
+
+Get `silu_mul_matmul` (and the rest of the fused-prologue family) to
+**≥ 0.85× of cuBLAS** on the qwen.s512 / s128 cases (currently
+0.28-0.39× with the fused-class tile fix, 0.80-0.87× with the
+banned defusion-via-fusion-guard hack).
+
+## Sketch of the target Tile IR
+
+```
+matmul = TileOp(silu_one, g, u, w)
+  kernel k_silu_mul_matmul_warp_specialized
+
+      Tile(axes=(a0:N_block=BLOCK, a1:M_block=BLOCK)):
+
+          # Warp-group declarations (new IR)
+          WarpGroup(name="producer", warps=4, max_regs=40)
+          WarpGroup(name="consumer", warps=8, max_regs=240)
+
+          # Multi-stage producer→consumer A buffer (new IR)
+          PipelineBuffer(name="A_smem",
+                         extents=(BM=64, BK=32),
+                         buffer_count=4,
+                         producer_signal="A_full",
+                         consumer_signal="A_empty")
+
+          WarpGroupBody("producer"):
+              setmaxnreg.dec(40)
+              for a4 in 0..K_outer:
+                  TmaBufferedStage(g_smem, ...)        # standard TMA load
+                  TmaBufferedStage(u_smem, ...)
+                  AsyncWait(g_smem, u_smem)
+                  PipelineWait("A_empty")              # consumer drained slot?
+                  for r,k: A_smem[slot][r,k] = silu(g[r,k]) * u[r,k]
+                  PipelineSignal("A_full")             # consumer can read
+
+          WarpGroupBody("consumer"):
+              setmaxnreg.inc(240)
+              register_acc[8][4]                       # F=8×4
+              for a4 in 0..K_outer:
+                  TmaBufferedStage(w_smem, slab=(BK, BN=128))
+                  PipelineWait("A_full")
+                  for a5 in 0..BK:
+                      A_r = load A_smem[slot][m_t*8 + r, a5]   for r=0..7
+                      w_c = load w_smem[a5, n_t*4 + c]         for c=0..3
+                      acc[r][c] += A_r * w_c                    # pure FMA, no SFU
+                  PipelineSignal("A_empty")
+              # epilogue
+              for r,c: matmul[...] = acc[r][c]
+```
+
+The consumer body is **byte-for-byte the canonical matmul body** —
+no SiLU pipeline in its instruction stream at all. The producer body
+is a tight elementwise loop that uses the SFU at peak. The two warp
+groups talk through `A_smem` + mbarriers and never serialize on data
+dependencies.
+
+## Why this beats both fused and defused
+
+| | Current fused | Defused (banned) | Warp-specialized |
+|---|---|---|---|
+| Matmul tile | F=4×4 BN=64 | F=8×4 BN=128 (cuBLAS-class) | F=8×4 BN=128 |
+| Outputs / thread (consumer) | 16 | 32 | 32 |
+| SiLU pipeline location | inline in K-loop body | separate kernel | producer warps (concurrent) |
+| Cross-pipe data dep in inner loop | yes (silu→FMA) | no | no |
+| `A` tensor traffic | smem-only | global write+read (~M·K·8 B) | smem-only (ping-pong) |
+| Producer/consumer parallelism | none | sequential kernels | concurrent warp-groups |
+| Expected ratio vs cuBLAS | 0.4× | 0.9× | **0.85-0.95×** |
+
+The warp-specialized kernel inherits the matmul-quality ratio of
+defusion *without* the global-memory round-trip, because the SFU
+producer work runs concurrently with consumer FMA work rather than
+sequentially.
+
+## What's missing
+
+We need five compiler pieces. Listed in dependency order:
+
+### 1. Warp-group IR primitives
+
+New `Stmt` types in `ir/tile/ir.py`:
+
+- `WarpGroup(name, warps, max_regs)` — declares a contiguous range
+  of warps within the CTA assigned to a body. Lowers to a
+  warp-id range check + `setmaxnreg` PTX intrinsic.
+- `WarpGroupBody(group_name, body)` — body executed only by the
+  named group; siblings can run different `WarpGroupBody`s
+  concurrently.
+- `PipelineBuffer(name, extents, buffer_count, producer_signal,
+  consumer_signal)` — multi-slot smem buffer for producer→consumer
+  hand-off. Like `BufferedStage` but with paired mbarriers per
+  slot.
+- `PipelineWait(signal)` / `PipelineSignal(signal)` — per-slot
+  mbarrier ops, parameterized by the current slot index (rotating
+  modulo `buffer_count`).
+
+### 2. Tile-IR pass `00X_warp_specialize_fused_prologue.py`
+
+Detect the fused-prologue pattern (the same `_has_fused_prologue`
+predicate already used by the fused-class tile pick), then rewrite:
+
+- Split the body into a "producer subtree" (loads + prologue
+  compute, ending in a `Stage`-like store of A) and a "consumer
+  subtree" (the matmul loop).
+- Wrap each in a `WarpGroupBody`.
+- Replace the producer's terminal Stage with a `PipelineBuffer`
+  store; replace the consumer's load of the prologue output with
+  a `PipelineBuffer` load.
+- Pick warp counts (typical: 4 producer + 8 consumer) and register
+  budgets (40 / 240) based on the matmul tile (currently
+  `F=8×4` → 240 regs/consumer, leaves headroom).
+
+Skip when the prologue itself is a non-trivial reduction (the
+producer would need its own internal sync), when the matmul has
+small K (pipeline drain dominates), or when smem won't fit a
+`buffer_count=4` ping-pong.
+
+### 3. Materializer / Kernel-IR lowering for warp-groups
+
+`passes/lowering/kernel/001_materialize_tile.py` extension:
+
+- A `WarpGroup` declaration emits a per-warp-id branch dispatching
+  to each `WarpGroupBody`.
+- `setmaxnreg.dec/inc.sync.aligned.u32 N` lowered as inline-PTX
+  asm wrappers, similar to how `MbarrierArriveExpectTx` is
+  emitted today (see `_TMA_PRELUDE` in `kernel/render.py`).
+- `PipelineBuffer` lowered to (a) a `Smem` decl with
+  `buffer_count` slots, (b) `MbarrierInit` for each slot's pair
+  of full/empty mbars, (c) per-iter slot-index update.
+- `PipelineWait("full" / "empty")` lowered to
+  `mbarrier.try_wait.parity` on the matched mbar — the same
+  primitive the existing TMA path uses; we already have
+  `mbarrier_wait_parity` in `_TMA_PRELUDE`.
+
+### 4. CUDA renderer plumbing
+
+- `__launch_bounds__` becomes per-CTA, but each warp-group's
+  register count is set via `setmaxnreg`. The static
+  `__launch_bounds__` should reflect the *consumer* group's
+  budget (the larger one), so PTXAS schedules accordingly.
+- A small alignment guard at kernel entry: `setmaxnreg` requires
+  warp-aligned dispatch, so we need an `if (warp_id < N_PROD)
+  setmaxnreg.dec(40); else setmaxnreg.inc(240);` prelude before
+  any of the warp-group bodies run.
+- The `_NCU_METRICS` set already covers `launch__registers_per_thread`;
+  the warp-specialized kernel will report the *consumer* count
+  (the producer's smaller count is invisible to ncu's per-launch
+  reporting).
+
+### 5. Tuning fixtures + perf coverage
+
+- Add a `warp_specialize_fused` tuning knob in `tuning.py`
+  (default-on for sm_90+, off below — Ampere doesn't have
+  `setmaxnreg`).
+- The existing `naive_attn` perf cases regression-net the SDPA
+  fusion path; for the warp-specialized path, the existing
+  `silu_mul_matmul.*` cases cover it directly. Add at least one
+  `gelu_mul_matmul`-shaped case (different prologue) so the pass
+  is exercised on more than one elementwise.
+
+## Validation plan
+
+Phase 1 — IR + lowering (no perf gate):
+- Hand-write a `silu_mul_matmul.qwen.s128`-shaped Tile IR with the
+  warp-group form, run through compile + lowering, confirm the
+  emitted PTX has `setmaxnreg.dec.sync.aligned.u32` and
+  `setmaxnreg.inc.sync.aligned.u32` in the right places.
+- Smoke-test correctness against eager (the existing
+  `_check_accuracy` path).
+
+Phase 2 — pass that auto-creates the warp-group form:
+- Sweep on `silu_mul_matmul.qwen.{s32, s128, s512}` and
+  `silu_mul_matmul.tinyllama.{s32, s128, s512}`. Target
+  ≥ 0.80× of cuBLAS on each (≥ 0.85× on the larger ones).
+- Run `make bench-kernels` to confirm no regression on
+  `naive_attn`, the matmul cluster, sdpa.
+
+Phase 3 — extend to other fused-prologue shapes:
+- `gelu_mul_matmul`, `bias_add_matmul`, `tanh_matmul` — same pass
+  applies. The producer body just runs different elementwise ops.
+- A `matmul_silu_mul_add` (epilogue + prologue together) would
+  also fit, but is one shape removed from this work.
+
+## Risk / open questions
+
+- **smem budget for `buffer_count=4`** on the qwen.s512 case:
+  `BM=64 × BK=32 × 4 buffers × 4 B = 32 KB` for `A_smem`, plus
+  `g_smem + u_smem + w_smem`. Static-smem cap is 48 KB; we'd need
+  dynamic smem (extern `__shared__` + `cudaFuncAttributeMaxDynamicSharedMemorySize`).
+  Already supported by the existing materializer — see
+  `STATIC_SMEM_CAP` in `kernel/render.py`.
+- **producer warp count** (4 vs 2 vs 1): too few producers can't
+  keep up with the consumer's SFU-free FMA pipe; too many waste
+  registers. Likely needs a small tuning sweep, parameterized
+  the same way `register_tile_shape` is.
+- **pipeline drain on small K**: with K_outer < `buffer_count`, the
+  pipeline never reaches steady state. The pass should skip
+  warp-specialization on the small-K cases (s32 shapes).
+- **fp16 / bf16 future**: warp specialization combined with `wgmma`
+  (Hopper warp-group MMA) is the canonical CUTLASS-style kernel,
+  but we'd have to cross the SIMT-FMA → tensor-core line first.
+  For now: SIMT-FMA consumer body works on every sm_90+ GPU.
+
+## Estimated scope
+
+- New IR primitives: ~150 LOC across `ir/tile/ir.py` and
+  `ir/kernel/ir.py`.
+- New tile pass `00X_warp_specialize_fused_prologue.py`: ~250 LOC.
+- Materializer extension: ~150 LOC in
+  `passes/lowering/kernel/001_materialize_tile.py`.
+- Renderer + PTX preludes: ~80 LOC in `kernel/render.py`.
+- Tests + tuning fixture: ~100 LOC.
+
+Total: ~700 LOC of new code plus ~50 LOC of edits to existing
+materializer paths. Comparable in size to the existing TMA / mbar
+path that's already in the tree.
+
+## When to do this
+
+Now (this branch) is too soon — the LDS.128 vectorization, chunk
+pass, fused-prologue tile class, and `naive_attn` regression net
+already extend the perf-tuning surface meaningfully. This warp-
+specialization work is its own multi-week effort and should land
+on a separate branch with the perf bench-kernels infra committed
+first as the regression baseline.

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -1,0 +1,194 @@
+"""Visualize smem bank conflicts under different swizzle strategies.
+
+Simulates a warp's 32 lanes accessing a 2D smem stage at one inner-loop
+iteration, applies a chosen swizzle formula to the column index, and
+plots three panels comparing:
+
+(a) No swizzle (TMA default).
+(b) Hardware swizzle (TMA_SWIZZLE=1 with the hardware-fixed XOR).
+(c) Per-lane K-rotation (proposed software fix).
+
+Each panel shows:
+
+- A *lane → bank* matrix (32×32). Cell (l, b) is filled if lane ``l``
+  lands in bank ``b``. Multiple lanes in one column = conflict.
+- A bank histogram (lanes-per-bank).
+
+Defaults match the matmul_add tile shape we've been profiling:
+``(rows=128, cols=16)``, lanes index rows at stride 4 (``F_M=4``).
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+
+WARP_SIZE = 32
+BANKS = 32
+
+
+@dataclass
+class AccessPattern:
+    """``(lane, k_iter) → (row, col)`` mapping for a 2D smem stage."""
+
+    rows: int
+    cols: int
+    row_fn: Callable[[int, int], int]
+    col_fn: Callable[[int, int], int]
+
+
+def warp_banks(pat: AccessPattern, k_iter: int, swizzle: Callable[[int, int, int], int]) -> list[int]:
+    """Per-lane bank id for the warp at iteration ``k_iter``."""
+    banks = []
+    for lane in range(WARP_SIZE):
+        row = pat.row_fn(lane, k_iter)
+        col = pat.col_fn(lane, k_iter)
+        col_phys = swizzle(lane, row, col)
+        addr = row * pat.cols + col_phys
+        banks.append(addr % BANKS)
+    return banks
+
+
+def plot_panel(ax_matrix, ax_hist, banks: list[int], title: str, formula: str) -> None:
+    """Two stacked subplots: lane→bank matrix, bank histogram."""
+    matrix = np.zeros((WARP_SIZE, BANKS), dtype=int)
+    for lane, bank in enumerate(banks):
+        matrix[lane, bank] = 1
+    ax_matrix.imshow(matrix, cmap="Greens", aspect="equal", vmin=0, vmax=1)
+    ax_matrix.set_xticks(range(0, BANKS, 4))
+    ax_matrix.set_yticks(range(0, WARP_SIZE, 4))
+    ax_matrix.set_xlabel("bank id")
+    ax_matrix.set_ylabel("lane id")
+    ax_matrix.grid(which="major", color="#cccccc", linewidth=0.3, alpha=0.5)
+    ax_matrix.set_axisbelow(True)
+    ax_matrix.set_title(f"{title}\n{formula}", fontsize=10)
+
+    bank_counts = [0] * BANKS
+    for bank in banks:
+        bank_counts[bank] += 1
+    max_way = max(bank_counts)
+    avg_way = sum(c for c in bank_counts if c > 0) / sum(1 for c in bank_counts if c > 0)
+    colors = ["#d62728" if c > 1 else "#2ca02c" if c == 1 else "#dddddd" for c in bank_counts]
+    ax_hist.bar(range(BANKS), bank_counts, color=colors)
+    ax_hist.set_xlim(-0.5, BANKS - 0.5)
+    ax_hist.set_ylim(0, max(max_way, 4) + 0.5)
+    ax_hist.axhline(1, color="gray", linestyle="--", linewidth=0.7, alpha=0.5)
+    verdict_color = "#d62728" if max_way > 4 else "#ff7f0e" if max_way > 1 else "#2ca02c"
+    ax_hist.set_title(
+        f"max-way conflict: {max_way}   (avg {avg_way:.1f} lane/bank)",
+        fontsize=10,
+        color=verdict_color,
+        weight="bold",
+    )
+    ax_hist.set_xlabel("bank id")
+    ax_hist.set_ylabel("# lanes")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--rows", type=int, default=128, help="stage rows (BM or BN)")
+    p.add_argument("--cols", type=int, default=16, help="stage cols (BK)")
+    p.add_argument(
+        "--lane-stride",
+        type=int,
+        default=4,
+        help="lanes index rows at this stride (F_M / F_N register-tile factor)",
+    )
+    p.add_argument("--k-iter", type=int, default=0, help="K-loop iteration to visualize")
+    p.add_argument("--out", default="/tmp/bank_conflicts.png", help="output PNG path")
+    p.add_argument(
+        "--lane-axis",
+        choices=("row", "col"),
+        default="row",
+        help=(
+            "Which slab axis the warp lanes stride over. "
+            "'row' = a_smem-style (lane*F_M indexes rows, k_iter is col); "
+            "'col' = b_smem-style (lane*F_N indexes cols, k_iter is row)."
+        ),
+    )
+    args = p.parse_args()
+
+    if args.lane_axis == "row":
+        pat = AccessPattern(
+            rows=args.rows,
+            cols=args.cols,
+            row_fn=lambda lane, k: (lane * args.lane_stride) % args.rows,
+            col_fn=lambda lane, k: k,
+        )
+    else:
+        pat = AccessPattern(
+            rows=args.rows,
+            cols=args.cols,
+            row_fn=lambda lane, k: k,
+            col_fn=lambda lane, k: (lane * args.lane_stride) % args.cols,
+        )
+
+    def no_swizzle(lane: int, row: int, col: int) -> int:
+        return col
+
+    def hw_b64_swizzle(lane: int, row: int, col: int) -> int:
+        return col ^ ((row & 6) * 2)
+
+    bk_mask = args.cols - 1
+
+    def k_rotation(lane: int, row: int, col: int) -> int:
+        # Per-lane rotate. Useful when lanes stride rows: XOR by lane breaks the
+        # uniform-bank pattern caused by lane*stride mod 32 = 0.
+        return col ^ (lane & bk_mask)
+
+    def col_xor_high(lane: int, row: int, col: int) -> int:
+        # Storage-time XOR depending only on col. Drives the b_smem (lanes-
+        # stride-cols) pattern to 1-way for any (BN, F_N) where BN ≥ 32 and
+        # F_N · 32 ≤ BN. Key idea: col mod 32 repeats every WARP cols, so
+        # cols (lane*F_N+c) and ((lane+WARP/F_N)*F_N+c) collide on banks.
+        # XOR-ing in (col >> 5) injects col's high bits into the bank, which
+        # differ between the colliding lanes (they live in distinct 32-col
+        # strips). Bijective per row, so it's safe to apply symmetrically at
+        # store time and load time.
+        return col ^ (col >> 5)
+
+    panels = [
+        ("(a) No swizzle", "col_phys = col", no_swizzle),
+        ("(b) HW B64 swizzle", "col_phys = col ⊕ ((row & 6) · 2)", hw_b64_swizzle),
+        (
+            "(c) Per-lane K-rotation",
+            f"col_phys = col ⊕ (lane & {bk_mask})",
+            k_rotation,
+        ),
+        (
+            "(d) Col-only XOR swizzle",
+            "col_phys = col ⊕ (col >> 5)",
+            col_xor_high,
+        ),
+    ]
+
+    n = len(panels)
+    fig, axes = plt.subplots(2, n, figsize=(5 * n, 8), gridspec_kw={"height_ratios": [4, 1]})
+    for col_idx, (title, formula, swizzle) in enumerate(panels):
+        banks = warp_banks(pat, args.k_iter, swizzle)
+        plot_panel(axes[0, col_idx], axes[1, col_idx], banks, title, formula)
+
+    axis_desc = "rows" if args.lane_axis == "row" else "cols"
+    fig.suptitle(
+        f"smem bank conflicts at stage ({args.rows}×{args.cols}), "
+        f"lanes index {axis_desc} at stride {args.lane_stride}, k_iter = {args.k_iter}",
+        fontsize=12,
+    )
+    legend = [
+        mpatches.Patch(color="#2ca02c", label="1 lane (no conflict)"),
+        mpatches.Patch(color="#d62728", label=">1 lane (conflict)"),
+        mpatches.Patch(color="#dddddd", label="0 lanes"),
+    ]
+    fig.legend(handles=legend, loc="lower center", ncol=3, bbox_to_anchor=(0.5, -0.01))
+    plt.tight_layout(rect=(0, 0.03, 1, 0.97))
+    plt.savefig(args.out, dpi=130, bbox_inches="tight")
+    print(f"saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/perf/cases.py
+++ b/tests/perf/cases.py
@@ -72,6 +72,19 @@ class Case:
                 f"{preamble}; q=torch.randn({s[0]}); k=torch.randn({s[1]}); v=torch.randn({s[2]}); "
                 f"F.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa={gqa})"
             )
+        if self.op == "naive_attn":
+            # Block-style decomposition matching HF's NaiveSDPA path:
+            # qk = q @ k.T * scale; attn = softmax(qk + causal_mask); out = attn @ v.
+            # ``-1e9`` mask term keeps the trace fp32-clean (``-inf`` would
+            # canonicalize through eager but trip later passes).
+            seq = s[0][-2]
+            dh = s[0][-1]
+            return (
+                f"import math; {preamble}; "
+                f"q=torch.randn({s[0]}); k=torch.randn({s[1]}); v=torch.randn({s[2]}); "
+                f"mask=torch.full(({seq},{seq}), -1e9).triu(1); "
+                f"F.softmax(q @ k.transpose(-2,-1) * (1.0/math.sqrt({dh})) + mask, dim=-1) @ v"
+            )
         if self.op == "matmul_add":
             return f"{preamble}; x=torch.randn({s[0]}); w=torch.randn({s[1]}); r=torch.randn({s[2]}); torch.matmul(x,w)+r"
         if self.op == "silu_mul_matmul":
@@ -233,6 +246,40 @@ def _matmul_add_cases() -> list[Case]:
     return cases
 
 
+def _naive_attn_cases() -> list[Case]:
+    """Block-style naive attention (Q @ K.T scaled + mask → softmax →
+    @ V), separate from the ``F.scaled_dot_product_attention`` cases.
+
+    Distinct kernel path: HF's ``NaiveSDPA`` (used by ``bench_block``)
+    decomposes attention into the explicit qk-matmul + scale + mask +
+    softmax + av-matmul chain. Tracing this chain through deplodock
+    produces the ``k_scaled_dot_product_attention_qk_ew_pointwise``
+    kernel — a matmul-with-pointwise-epilogue. A previous iteration of
+    the loop-fusion guard made this kernel 13× slower in the block
+    bench (0.05× of eager); the standalone ``F.sdpa`` cases didn't
+    catch it because ``F.sdpa`` traces to ``SdpaOp`` and a different
+    decomposition. These cases pin the naive path so any regression
+    surfaces in ``make bench-kernels``.
+
+    Heads kept equal across Q/K/V (no GQA expansion via
+    ``repeat_interleave``, which doesn't trace cleanly through
+    deplodock today). The kernel shape and fusion pattern are the
+    same; only the multi-head broadcast differs.
+    """
+    cases: list[Case] = []
+    for tag, heads, dh in [("tinyllama", _TL_HEADS, _TL_DH), ("qwen", _Q_HEADS, _Q_DH)]:
+        for s in _SEQ_LENS:
+            cases.append(
+                Case(
+                    name=f"naive_attn.{tag}.s{s}",
+                    op="naive_attn",
+                    shapes=((1, heads, s, dh), (1, heads, s, dh), (1, heads, s, dh)),
+                    tags=(tag, "naive_attn", "attn"),
+                )
+            )
+    return cases
+
+
 def _silu_mul_matmul_cases() -> list[Case]:
     """SiLU-gated MLP fused with down_proj: ``(silu(gate) * up) @ W_down``.
 
@@ -254,7 +301,7 @@ def _silu_mul_matmul_cases() -> list[Case]:
 
 
 PRIMITIVE_CASES: list[Case] = _matmul_cases() + _rmsnorm_cases() + _softmax_cases() + _silu_mul_cases()
-FUSED_CASES: list[Case] = _sdpa_cases() + _matmul_add_cases() + _silu_mul_matmul_cases()
+FUSED_CASES: list[Case] = _sdpa_cases() + _naive_attn_cases() + _matmul_add_cases() + _silu_mul_matmul_cases()
 CASES: list[Case] = PRIMITIVE_CASES + FUSED_CASES
 
 
@@ -301,6 +348,18 @@ def build_torch_ref(case: Case) -> Callable[[], None]:
         v = _r(case.shapes[2])
         # GQA expansion handled by SDPA when enable_gqa=True (PyTorch ≥ 2.5).
         return lambda: F.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa=q.shape[-3] != k.shape[-3])
+
+    if case.op == "naive_attn":
+        import math
+
+        q = _r(case.shapes[0])
+        k = _r(case.shapes[1])
+        v = _r(case.shapes[2])
+        seq = q.shape[-2]
+        dh = q.shape[-1]
+        mask = torch.full((seq, seq), -1e9, device=device, dtype=dtype).triu(1)
+        scale = 1.0 / math.sqrt(dh)
+        return lambda: F.softmax(q @ k.transpose(-2, -1) * scale + mask, dim=-1) @ v
 
     if case.op == "matmul_add":
         x = _r(case.shapes[0])

--- a/tests/perf/cases.py
+++ b/tests/perf/cases.py
@@ -49,6 +49,55 @@ class Case:
     def shape_str(self) -> str:
         return " x ".join("(" + ",".join(str(d) for d in s) + ")" for s in self.shapes)
 
+    @property
+    def code(self) -> str:
+        """Inline ``deplodock run --code`` expression equivalent to this
+        case. Used by the perf bencher to drive ``deplodock run --bench
+        --profile`` per case so the benchmarking infra is shared with
+        the CLI. Each input tensor is materialized via ``torch.randn``
+        on the same shape; the final expression is what gets traced."""
+        s = self.shapes
+        preamble = "import torch; import torch.nn.functional as F"
+        if self.op == "matmul":
+            return f"{preamble}; a=torch.randn({s[0]}); b=torch.randn({s[1]}); torch.matmul(a,b)"
+        if self.op == "rmsnorm":
+            return f"{preamble}; x=torch.randn({s[0]}); w=torch.randn({s[1]}); F.rms_norm(x, {tuple(s[1])}, w, eps=1e-6)"
+        if self.op == "softmax":
+            return f"{preamble}; x=torch.randn({s[0]}); F.softmax(x, dim=-1)"
+        if self.op == "silu_mul":
+            return f"{preamble}; gate=torch.randn({s[0]}); up=torch.randn({s[1]}); F.silu(gate)*up"
+        if self.op == "sdpa":
+            gqa = "True" if s[0][-3] != s[1][-3] else "False"
+            return (
+                f"{preamble}; q=torch.randn({s[0]}); k=torch.randn({s[1]}); v=torch.randn({s[2]}); "
+                f"F.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa={gqa})"
+            )
+        if self.op == "matmul_add":
+            return f"{preamble}; x=torch.randn({s[0]}); w=torch.randn({s[1]}); r=torch.randn({s[2]}); torch.matmul(x,w)+r"
+        if self.op == "silu_mul_matmul":
+            return f"{preamble}; gate=torch.randn({s[0]}); up=torch.randn({s[1]}); w=torch.randn({s[2]}); torch.matmul(F.silu(gate)*up, w)"
+        raise ValueError(f"unknown op: {self.op}")
+
+    @property
+    def iters(self) -> int:
+        """Number of measured iterations the bencher should run for this
+        case. Heavy ops (~ms-scale per iter) drop to 20 to keep the suite
+        fast; everything else stays at 100. ``heavy`` is detected by
+        total input element count — the dominant factor in matmul /
+        silu_mul_matmul cost. Threshold (50 M elements) covers the
+        fp32-suite cases that empirically run > 1 ms each (qwen
+        gate/up/down_proj.s512 and silu_mul_matmul.{tinyllama,qwen}
+        s512)."""
+        total_elements = sum(_prod(s) for s in self.shapes)
+        return 20 if total_elements > 50_000_000 else 100
+
+
+def _prod(shape: tuple[int, ...]) -> int:
+    n = 1
+    for d in shape:
+        n *= d
+    return n
+
 
 # ---------------------------------------------------------------------------
 # Model dimensions

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -40,6 +40,15 @@ from tests.perf.cases import Case
 
 _RESULTS_DIR = Path(__file__).resolve().parent / ".results"
 
+# Cross-process advisory lock around the GPU iter loop in the
+# subprocess-driven bencher. Set on conftest import so every spawned
+# ``deplodock run --bench`` (across xdist workers and inside each
+# worker's per-case subprocess) coordinates on the same path. Trace,
+# compile, dump-write all run unlocked — only the kernel-launch phase
+# serializes. Override with ``DEPLODOCK_GPU_LOCK`` before invoking
+# ``make bench-kernels`` if a different path is desired.
+os.environ.setdefault("DEPLODOCK_GPU_LOCK", "/tmp/deplodock-gpu.lock")
+
 
 # ---------------------------------------------------------------------------
 # PerfRow + session collector
@@ -294,6 +303,36 @@ def _format_table(rows: list[PerfRow]) -> str:
     for r_cells in body:
         lines.append(_fmt(r_cells))
     return "\n".join(lines)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Worker-side hand-off for ``pytest-xdist`` runs.
+
+    Each xdist worker has its own ``config._perf_rows``; without this
+    hook only the controller's (empty) list reaches the terminal
+    summary. ``workeroutput`` is xdist's built-in dict for
+    worker→controller payloads — the controller picks it back up in
+    ``pytest_testnodedown``.
+    """
+    rows = getattr(session.config, "_perf_rows", [])
+    workeroutput = getattr(session.config, "workeroutput", None)
+    if workeroutput is not None and rows:
+        # Each row is a dataclass; serialize via asdict so the
+        # controller can rehydrate without sharing the class import.
+        workeroutput["perf_rows"] = [{**asdict(r), "tags": list(r.tags)} for r in rows]
+
+
+def pytest_testnodedown(node, error):
+    """Controller-side: drain a finished xdist worker's rows into the
+    controller's collector so ``pytest_terminal_summary`` sees all
+    cases (not just whichever ones happened to land on the controller).
+    """
+    payload = getattr(node, "workeroutput", {}).get("perf_rows", [])
+    if not payload:
+        return
+    rows = _collector(node.config)
+    for r in payload:
+        rows.append(PerfRow(**{**r, "tags": tuple(r.get("tags", ()))}))
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -6,18 +6,29 @@ requires_cuda]``. The ``perf`` marker is **deselected by default** —
 plain ``pytest tests/`` skips them so ``make test`` stays fast. Run
 explicitly with ``pytest -m perf`` (or ``make bench-kernels``).
 
-The ``bench_pair`` fixture builds a torch reference and a Deplodock
-graph from a ``Case``, times each with the same iteration count, and
-records a ``PerfRow`` into a session-scoped collector. After the
-session, ``pytest_terminal_summary`` prints one table sorted by ratio
-(worst losses first) and writes the same data to
-``tests/perf/.results/<utc-timestamp>.json``.
+The ``bench_pair`` fixture drives ``deplodock run --bench`` (and
+``--profile`` when ``DEPLODOCK_BENCH_NCU=1``) as a subprocess per
+``Case`` and parses the dump files (``DEPLODOCK_DUMP_DIR``-rooted) to
+build a ``PerfRow``. Reusing the CLI's bench infra keeps the
+torch / torch.compile / deplodock comparison and the ncu metrics on
+the same code path users invoke directly. Iteration count comes from
+``case.iters`` (heavy cases at 20, others at 100).
+
+After the session, ``pytest_terminal_summary`` prints a table sorted
+by ratio (worst losses first) and writes the same data to
+``tests/perf/.results/<utc-timestamp>.json``. With ncu enabled, extra
+columns (occupancy, bank conflicts, SM/DRAM/FMA throughput, regs) are
+appended.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
+import sys
+import tempfile
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -25,7 +36,7 @@ from pathlib import Path
 import pytest
 
 from tests.compiler.conftest import requires_cuda  # noqa: F401  (re-exported)
-from tests.perf.cases import Case, build_deplodock_graph, build_torch_ref
+from tests.perf.cases import Case
 
 _RESULTS_DIR = Path(__file__).resolve().parent / ".results"
 
@@ -46,6 +57,14 @@ class PerfRow:
     ratio: float  # torch_us / deplodock_us — >1 means deplodock wins
     launches: int
     tags: tuple[str, ...]
+    iters: int = 100
+    torch_compile_us: float | None = None
+    # Per-kernel ncu metrics keyed by kernel name. Populated only when
+    # the optional ncu pass runs (``DEPLODOCK_BENCH_NCU=1``). Each entry
+    # maps metric-name → numeric value (units are baked into the metric
+    # name; see ``deplodock.commands.run._NCU_METRICS``). ``None`` when
+    # not collected.
+    ncu: dict[str, dict[str, float]] | None = None
 
 
 def _collector(config) -> list[PerfRow]:
@@ -74,129 +93,147 @@ def pytest_collection_modifyitems(config, items):
 # ---------------------------------------------------------------------------
 
 
-# Trim fraction for the outlier-rejecting mean. Drops the top + bottom
-# ``_TRIM_FRAC`` of samples each before averaging — kills single-iter
-# outliers from queue contention or thermal blips that otherwise
-# dominate small-kernel ratios. With ``_TRIM_FRAC = 0.1`` and the
-# default 200 iters we keep the central 160 samples.
-_TRIM_FRAC = 0.1
-
-
-def _trimmed_mean_us(samples_ms: list[float]) -> float:
-    """Trimmed mean (us) — drops the top / bottom ``_TRIM_FRAC`` of samples."""
-    if not samples_ms:
-        return 0.0
-    s = sorted(samples_ms)
-    k = int(len(s) * _TRIM_FRAC)
-    kept = s[k : len(s) - k] if k > 0 else s
-    return (sum(kept) / len(kept)) * 1000.0
+def _ncu_enabled() -> bool:
+    if os.environ.get("DEPLODOCK_NCU_CHILD"):
+        return False
+    if os.environ.get("DEPLODOCK_BENCH_NCU", "") not in ("1", "true", "True"):
+        return False
+    return shutil.which("ncu") is not None
 
 
 @pytest.fixture
 def bench_pair(request):
     """Return a callable ``run(case, *, warmup, iters) -> PerfRow``.
 
-    Times the PyTorch eager reference and the Deplodock-compiled graph
-    on the same shape, **interleaving** them — each iteration runs the
-    torch closure first, then the Deplodock launches, so both backends
-    see the same warm GPU state (same SM clock, same L2 contents). The
-    Deplodock backend drives the loop via ``CudaBackend.benchmark(...,
-    on_iter=...)``; the torch run inside ``on_iter`` is timed with
-    ``torch.cuda.Event``.
-
-    Per-iter samples for both backends are averaged with a trimmed
-    mean — drop the top / bottom ``_TRIM_FRAC`` to reject single-iter
-    outliers from GPU queue contention or thermal blips. Default
-    ``iters=200`` (vs the historical 50) gives the trimmed mean ~160
-    samples per row, dropping the standard error from ~1.4% to ~0.6%.
+    Each call spawns ``deplodock run --code <case.code> --bench
+    [--profile]`` with a fresh ``DEPLODOCK_DUMP_DIR`` and parses the
+    resulting JSON / CSV. The CLI's ``--bench`` path interleaves
+    ``Eager PyTorch`` / ``torch.compile`` / ``Deplodock`` per iter so
+    all three see the same warm GPU state. ``--profile`` (gated by
+    ``DEPLODOCK_BENCH_NCU=1``) runs ncu once with a curated metric set
+    and dumps the per-kernel CSV/JSON to the same dir.
 
     Does not assert on the ratio — the suite tracks performance, it
     doesn't gate on it.
     """
 
-    def _run(case: Case, *, warmup: int = 10, iters: int = 100) -> PerfRow:
-        import torch
+    def _run(case: Case, *, warmup: int = 10, iters: int | None = None) -> PerfRow:
+        if iters is None:
+            iters = case.iters
 
-        from deplodock.compiler.backend.cuda.backend import CudaBackend
+        row = _bench_via_subprocess(case, warmup=warmup, iters=iters, profile=_ncu_enabled())
+        _collector(request.config).append(row)
+        return row
 
-        torch_fn = build_torch_ref(case)
-        graph = build_deplodock_graph(case)
-        backend = CudaBackend()
-        compiled = backend.compile(graph)
+    return _run
 
-        # Each on_iter call runs one torch iter, recording cuda events.
-        # The deplodock benchmark calls on_iter ``warmup + iters`` times
-        # — discard the first ``warmup`` samples so torch and deplodock
-        # average over the same set of measured iters.
-        torch_events: list[tuple[torch.cuda.Event, torch.cuda.Event]] = []
 
-        def on_iter() -> None:
-            start = torch.cuda.Event(enable_timing=True)
-            stop = torch.cuda.Event(enable_timing=True)
-            start.record()
-            torch_fn()
-            stop.record()
-            torch_events.append((start, stop))
+def _bench_via_subprocess(case: Case, *, warmup: int, iters: int, profile: bool) -> PerfRow:
+    """Spawn ``deplodock run --bench`` for one case and harvest the dumps."""
+    with tempfile.TemporaryDirectory(prefix=f"deplodock_bench_{case.name}_") as tmp:
+        cmd = [
+            sys.executable,
+            "-m",
+            "deplodock.deplodock",
+            "run",
+            "--code",
+            case.code,
+            "--bench",
+            "--warmup",
+            str(warmup),
+            "--iters",
+            str(iters),
+        ]
+        if profile:
+            cmd.append("--profile")
+        env = dict(os.environ)
+        env["DEPLODOCK_DUMP_DIR"] = tmp
+        env.pop("DEPLODOCK_NCU_CHILD", None)
 
-        # Capture per-launch deplodock samples so we can trimmed-mean
-        # them too. We re-drive the timing loop ourselves (mirroring
-        # ``benchmark_program``) instead of using ``backend.benchmark``
-        # so we get raw per-iter sums rather than a pre-averaged
-        # ``time_ms``. Per-launch attribution isn't needed at the row
-        # level here.
-        import cupy as cp
+        res = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=900)
+        if res.returncode != 0:
+            # Surface stderr so flaky-bench cases are diagnosable, but
+            # synthesize a minimal row so the suite doesn't abort.
+            sys.stderr.write(f"[bench {case.name}] exit={res.returncode}\n{res.stderr[-2000:]}\n")
+            return PerfRow(
+                name=case.name,
+                op=case.op,
+                shape=case.shape_str,
+                dtype=case.dtype,
+                torch_us=0.0,
+                deplodock_us=0.0,
+                ratio=0.0,
+                launches=0,
+                tags=case.tags,
+                iters=iters,
+            )
 
-        from deplodock.compiler.backend.cuda.program import _allocate, _compile, _launch, _prebuild_descriptors
+        bench = json.loads(Path(tmp, "60_bench_compare.json").read_text())
+        backends = bench["backends"]
+        torch_us = float(backends.get("Eager PyTorch", {}).get("latency_us", 0) or 0)
+        depl_us = float(backends.get("Deplodock", {}).get("latency_us", 0) or 0)
+        tcompile_us_raw = backends.get("torch.compile", {}).get("latency_us")
+        tcompile_us = float(tcompile_us_raw) if tcompile_us_raw is not None else None
 
-        compiled_program = _compile(compiled)
-        arrays = _allocate(compiled_program, None)
-        descs = _prebuild_descriptors(compiled_program, arrays)
+        launches = 0
+        bench_path = Path(tmp, "60_benchmark.json")
+        if bench_path.exists():
+            launches = int(json.loads(bench_path.read_text()).get("num_launches", 0))
 
-        for _ in range(warmup):
-            on_iter()
-            for li, launch in enumerate(compiled_program.launches):
-                _launch(launch, compiled_program, arrays, descs.get(li))
-        cp.cuda.runtime.deviceSynchronize()
+        ncu: dict[str, dict[str, float]] | None = None
+        ncu_path = Path(tmp, "61_ncu_metrics.json")
+        if ncu_path.exists():
+            ncu = json.loads(ncu_path.read_text())
 
-        n = len(compiled_program.launches)
-        starts = [cp.cuda.Event() for _ in range(n)]
-        stops = [cp.cuda.Event() for _ in range(n)]
-        deplodock_per_iter_ms: list[float] = []
-
-        for _ in range(iters):
-            on_iter()
-            for i, launch in enumerate(compiled_program.launches):
-                starts[i].record()
-                _launch(launch, compiled_program, arrays, descs.get(i))
-                stops[i].record()
-                stops[i].synchronize()
-            iter_ms = sum(cp.cuda.get_elapsed_time(starts[i], stops[i]) for i in range(n))
-            deplodock_per_iter_ms.append(iter_ms)
-
-        torch.cuda.synchronize()
-        measured = torch_events[warmup:]
-        torch_per_iter_ms = [s.elapsed_time(e) for s, e in measured]
-
-        torch_us = _trimmed_mean_us(torch_per_iter_ms)
-        deplodock_us = _trimmed_mean_us(deplodock_per_iter_ms)
-        launches = n
-
-        ratio = (torch_us / deplodock_us) if deplodock_us > 0 else 0.0
-        row = PerfRow(
+        ratio = (torch_us / depl_us) if depl_us > 0 else 0.0
+        return PerfRow(
             name=case.name,
             op=case.op,
             shape=case.shape_str,
             dtype=case.dtype,
             torch_us=torch_us,
-            deplodock_us=deplodock_us,
+            deplodock_us=depl_us,
             ratio=ratio,
             launches=launches,
             tags=case.tags,
+            iters=iters,
+            torch_compile_us=tcompile_us,
+            ncu=ncu,
         )
-        _collector(request.config).append(row)
-        return row
 
-    return _run
+
+# ---------------------------------------------------------------------------
+# Aggregate ncu metrics for the summary table
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_ncu(ncu: dict[str, dict[str, float]] | None) -> dict[str, float]:
+    """Per-row aggregate of the per-kernel ncu metrics for the summary
+    table. Sum durations and conflicts; time-weight the percentage
+    metrics so a fast minor kernel doesn't drag the average."""
+    if not ncu:
+        return {}
+    total_ns = sum(m.get("gpu__time_duration.sum", 0.0) for m in ncu.values())
+    total_conflicts_ld = sum(m.get("l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_ld.sum", 0.0) for m in ncu.values())
+    total_conflicts_st = sum(m.get("l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_st.sum", 0.0) for m in ncu.values())
+    total_lsu_inst = sum(m.get("smsp__inst_executed_pipe_lsu.sum", 0.0) for m in ncu.values())
+
+    def _wavg(metric: str) -> float:
+        if total_ns <= 0:
+            return 0.0
+        num = sum(m.get(metric, 0.0) * m.get("gpu__time_duration.sum", 0.0) for m in ncu.values())
+        return num / total_ns
+
+    return {
+        "ncu_us": total_ns / 1000.0,
+        "occ_pct": _wavg("sm__warps_active.avg.pct_of_peak_sustained_active"),
+        "sm_pct": _wavg("sm__throughput.avg.pct_of_peak_sustained_elapsed"),
+        "fma_pct": _wavg("sm__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active"),
+        "dram_pct": _wavg("dram__throughput.avg.pct_of_peak_sustained_elapsed"),
+        "conflicts": total_conflicts_ld + total_conflicts_st,
+        "lsu_inst": total_lsu_inst,
+        "regs": max((m.get("launch__registers_per_thread", 0.0) for m in ncu.values()), default=0.0),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -208,35 +245,54 @@ def _format_table(rows: list[PerfRow]) -> str:
     if not rows:
         return ""
     rows = sorted(rows, key=lambda r: r.ratio)  # losses first
-    headers = ("op", "case", "shape", "torch_us", "depl_us", "ratio", "launches")
-    widths = [
-        max(len(headers[0]), max(len(r.op) for r in rows)),
-        max(len(headers[1]), max(len(r.name) for r in rows)),
-        max(len(headers[2]), max(len(r.shape) for r in rows)),
-        len("torch_us"),
-        len("depl_us"),
-        len("ratio"),
-        len("launches"),
-    ]
+    has_ncu = any(r.ncu for r in rows)
+    has_compile = any(r.torch_compile_us is not None for r in rows)
 
-    def _fmt(cells: tuple[str, ...]) -> str:
-        return "  ".join(c.ljust(w) for c, w in zip(cells, widths, strict=True))
+    base_headers = ["op", "case", "shape", "torch_us"]
+    if has_compile:
+        base_headers.append("tcomp_us")
+    base_headers += ["depl_us", "ratio", "launches", "iters"]
+    ncu_headers = ["occ%", "sm%", "fma%", "dram%", "conflicts", "regs"] if has_ncu else []
+    headers = tuple(base_headers + ncu_headers)
+
+    aggregates = [_aggregate_ncu(r.ncu) for r in rows]
+
+    def _row_cells(r: PerfRow, agg: dict[str, float]) -> tuple[str, ...]:
+        base = [r.op, r.name, r.shape, f"{r.torch_us:>8.1f}"]
+        if has_compile:
+            base.append(f"{r.torch_compile_us:>8.1f}" if r.torch_compile_us is not None else "—")
+        base += [
+            f"{r.deplodock_us:>7.1f}",
+            f"{r.ratio:>5.2f}x",
+            f"{r.launches:>8d}",
+            f"{r.iters:>5d}",
+        ]
+        if not has_ncu:
+            return tuple(base)
+        if not agg:
+            return tuple(base + ["—"] * len(ncu_headers))
+        return tuple(
+            base
+            + [
+                f"{agg['occ_pct']:>4.0f}",
+                f"{agg['sm_pct']:>4.0f}",
+                f"{agg['fma_pct']:>4.0f}",
+                f"{agg['dram_pct']:>5.0f}",
+                f"{int(agg['conflicts']):>9,d}",
+                f"{int(agg['regs']):>4d}",
+            ]
+        )
+
+    body = [_row_cells(r, a) for r, a in zip(rows, aggregates, strict=True)]
+    cells = [headers] + body
+    widths = [max(len(c) for c in col) for col in zip(*cells, strict=True)]
+
+    def _fmt(row_cells: tuple[str, ...]) -> str:
+        return "  ".join(c.ljust(w) for c, w in zip(row_cells, widths, strict=True))
 
     lines = [_fmt(headers), _fmt(tuple("-" * w for w in widths))]
-    for r in rows:
-        lines.append(
-            _fmt(
-                (
-                    r.op,
-                    r.name,
-                    r.shape,
-                    f"{r.torch_us:>8.1f}",
-                    f"{r.deplodock_us:>7.1f}",
-                    f"{r.ratio:>5.2f}x",
-                    f"{r.launches:>8d}",
-                )
-            )
-        )
+    for r_cells in body:
+        lines.append(_fmt(r_cells))
     return "\n".join(lines)
 
 
@@ -245,17 +301,28 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not rows:
         return
     tw = terminalreporter
+
     tw.write_sep("=", "perf summary (sorted by ratio; >1.00x means deplodock wins)")
     tw.write_line(_format_table(rows))
 
-    # Persist JSON for cross-run diffing.
+    # Persist JSON for cross-run diffing. ncu metrics (when collected)
+    # are nested under each row's ``ncu`` field; aggregated convenience
+    # values are also written so downstream tooling doesn't need to
+    # duplicate the time-weighted-average reduction.
     _RESULTS_DIR.mkdir(exist_ok=True)
     stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%SZ")
     out = _RESULTS_DIR / f"{stamp}.json"
     payload = {
         "timestamp_utc": stamp,
         "git_rev": os.environ.get("DEPLODOCK_GIT_REV", ""),
-        "rows": [{**asdict(r), "tags": list(r.tags)} for r in rows],
+        "rows": [
+            {
+                **asdict(r),
+                "tags": list(r.tags),
+                "ncu_aggregate": _aggregate_ncu(r.ncu),
+            }
+            for r in rows
+        ],
     }
     out.write_text(json.dumps(payload, indent=2))
     tw.write_line(f"perf results saved to {out}")


### PR DESCRIPTION
## Summary

Three thematic groups of changes:

### 1. Bench-kernels infrastructure rebuild

`make bench-kernels` is now driven by `deplodock run --bench --profile` subprocess per case, parsing dump files instead of scraping stdout. Adds `tcomp_us` column (opt-in via `DEPLODOCK_BENCH_BACKENDS`), ncu metric columns (occ%/sm%/fma%/dram%/conflicts/regs, opt-in via `DEPLODOCK_BENCH_NCU=1`), and xdist + GPU file-lock parallelism. **78 cases in ~35 s** (was sequential ~30 s in-process; now parallel + richer metrics).

- `Case.iters` — heavy cases (>50 M total input elements) drop to 20 iters, others stay at 100.
- `--profile` switches from broken `--set detailed` to a curated metric set in CSV form, dumped under `DEPLODOCK_DUMP_DIR/61_ncu_metrics.{csv,json}`.
- `--bench` writes `60_bench_compare.json` with per-backend latencies.
- xdist workers hand off `PerfRow`s via `workeroutput` so the controller's terminal summary sees all rows.
- GPU file lock at `/tmp/deplodock-gpu.lock` serializes the kernel-launch phase across parallel workers; lock cleared at start of `make bench-kernels` so a leftover lock from an interrupted run doesn't deadlock.

### 2. Smem bank-conflict mitigations

- **Chunk pass** (`008b_chunk_register_tile_for_banks.py`): when `F_N > 4`, lane-stride `lane*F_N+c` is rewritten to `4*lane + (c//4)*4*lane_ext + (c%4)` so each LDS.128 reads one 4-fp32 chunk and the F_N/4 chunks tile across BN. Drops bank conflicts 25 M → 139 K on F=8×8 silu_mul_matmul.qwen.s128 (-99 %), keeps LDS.128 vectorization (128/128 LDS in SASS).
- **Render-time `float4` vectorization** in `render_body`: detects runs of consecutive scalar Loads, emits `*reinterpret_cast<const float4*>(...)`. Net SASS-identical for unrolled K-loops (nvcc auto-vectorizes), defensive for non-unrolled bodies.

### 3. Tile-picker refinements

- **Fused-prologue class** (a8e2dfa0): `silu_mul_matmul`-shape kernels (3+ buffer Loads in K-reduce) drop from `F=8×4 BN=128 BM=64` (regs 145, occ 17 %) to `F=4×4 BN=64 BM=64` (regs 80, occ 50 %). Fixes the SiLU-pipeline register cliff. Cuts silu_mul_matmul.qwen.s512 from 0.12× → 0.28× of cuBLAS, qwen.s128 0.18× → 0.39×.
- **Default-large class** (e5fc1966 + 5a27e357): pure matmuls with `M ≥ 128` get `F=8×8 BN=128 BM=64` (vs the old `F=8×4`). Doubles outputs/thread, keeps LDS.128 vectorized via the chunk pass. Wins +5-10 % on q_proj/down_proj/gate_proj at s128/s512. Gated to "exactly 2 input buffers" so matmul_add (3 inputs, residual Load steals registers) doesn't get caught.
- **`naive_attn` perf cases** (d37a9299): regression net for the HF-style attention path. The (now-reverted) fusion guard tanked this from 0.48× → 0.21× and bumped launches 2 → 3; the standalone `F.sdpa` cases couldn't catch it because they trace through a different decomposition.

## Result

Suite distribution after the iteration:

| Bucket | Count | %  |
|---|---|---|
| ≥ 0.95× of cuBLAS | 53 | 63 % |
| 0.80-0.95× | 21 | 25 % |
| 0.50-0.80× | 5 | 6 % |
| < 0.50× | 5 | 6 % |

The remaining < 0.80× cluster is dominated by:
- `silu_mul_matmul` (6 cases) — needs warp-specialization with `setmaxnreg` (designed in `docs/warp-specialized-fused-prologue.md`).
- `naive_attn` (2 cases) — needs Flash-Attention-style smem staging on the second reduce loop (the current lowering re-loads `mul`, `mask`, `v` from global per K-iter).

## Test plan

- [x] `make lint` clean
- [x] `make test` — 877 tests pass
- [x] `make bench-kernels` — 84 cases, no structural regressions
- [x] `DEPLODOCK_BENCH_NCU=1 make bench-kernels` — ncu metric collection works
- [x] `deplodock bench ./experiments/tinyllama-block/ --filter "dtype=fp32" --filter "seq_len=512" --local` — block bench at 0.67× of eager (no SDPA regression after revert)

## Files

- `deplodock/commands/run.py` — `--bench` writes JSON, `--profile` writes ncu CSV + parsed JSON, GPU file-lock around kernel launches, configurable backends, JIT outside lock.
- `deplodock/compiler/tuning.py` — fused / default-large tile classes + `_external_input_count` guard.
- `deplodock/compiler/pipeline/passes/lowering/tile/008b_chunk_register_tile_for_banks.py` — new chunk pass.
- `deplodock/compiler/ir/stmt/{base,blocks}.py` — render-time `float4` LDS.128 emission.
- `tests/perf/{conftest,cases}.py` — subprocess driver, ncu aggregation, naive_attn cases.
- `Makefile` — xdist + GPU lock cleanup for bench-kernels.
- `docs/warp-specialized-fused-prologue.md` — design doc for the next major fused-kernel optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)