### PR TITLE
Bank-conflict diagnostics + IR-driven smem visualizer

### DIFF
--- a/deplodock/compiler/diagnostics/__init__.py
+++ b/deplodock/compiler/diagnostics/__init__.py
@@ -1,0 +1,7 @@
+"""Static diagnostics over Tile IR — no GPU required.
+
+These helpers walk a compiled ``Graph`` and report properties that would
+otherwise need a profiler (ncu / nsys) to surface. Today's only module is
+``bank_conflicts`` (smem bank-conflict simulation per Stage); future
+modules might add occupancy estimation, smem footprint heatmaps, etc.
+"""

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -83,6 +83,8 @@ class BankConflictResult:
     cols: int
     pad: tuple[int, ...]
     smem_bytes: int
+    load_name: str  # SSA name of the body Load (e.g. ``in3``)
+    tile_op_name: str
     index_repr: tuple[str, ...]  # the cache-relative index of the simulated Load
     lane_banks: list[int]  # length WARP_SIZE
     lane_addrs: list[int]  # length WARP_SIZE — pre-mod linear smem address
@@ -262,6 +264,8 @@ def simulate(binding: StageBinding, k_iter: int = 0, warp_id: int = 0) -> BankCo
         cols=int(stage.axes[1].extent) if len(stage.axes) > 1 else 1,
         pad=tuple(int(p) for p in stage.pad),
         smem_bytes=stage.smem_bytes,
+        load_name=load.name,
+        tile_op_name=binding.tile_op_name,
         index_repr=tuple(e.pretty() for e in cache_idx),
         lane_banks=lane_banks,
         lane_addrs=lane_addrs,
@@ -280,11 +284,18 @@ def simulate_graph(
     stage_filter: set[str] | None = None,
     k_iter: int = 0,
     warp_id: int = 0,
+    load_filter: set[str] | None = None,
 ) -> list[BankConflictResult]:
-    """Convenience: bindings + simulate, dropping rank-mismatched probes."""
+    """Convenience: bindings + simulate, dropping rank-mismatched probes.
+
+    ``stage_filter`` keeps only Stages with these names; ``load_filter``
+    keeps only body Loads with these SSA names. Both filters AND.
+    """
     out: list[BankConflictResult] = []
     seen: set[tuple] = set()
     for binding in find_all_bindings(graph, stage_filter):
+        if load_filter is not None and binding.load.name not in load_filter:
+            continue
         key = (binding.tile_op_name, binding.stage.name, binding.load.name)
         if key in seen:
             continue

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -301,11 +301,13 @@ def simulate_graph(
     vectorizable Load runs (consecutive +0..+N-1 inner-element offsets)
     with their LDS.128-absorbed event counts.
     """
+    # Run simulation + chain detection on the un-load-filtered set: an
+    # LDS.128 chain spans sibling Loads of the same stage, so a single-
+    # Load drill-down still needs to see its siblings to know its real
+    # ``vec_group_size``. Apply ``load_filter`` only after annotation.
     out: list[BankConflictResult] = []
     seen: set[tuple] = set()
     for binding in find_all_bindings(graph, stage_filter):
-        if load_filter is not None and binding.load.name not in load_filter:
-            continue
         key = (binding.tile_op_name, binding.stage.name, binding.load.name)
         if key in seen:
             continue
@@ -314,6 +316,8 @@ def simulate_graph(
         if r is not None:
             out.append(r)
     annotate_lds128(out)
+    if load_filter is not None:
+        out = [r for r in out if r.load_name in load_filter]
     return out
 
 

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -108,6 +108,12 @@ class BankConflictResult:
     # ``("(0 * 8)", "5")``. Lets visualizers replace symbolic vars with
     # concrete values in the per-cell tooltip.
     full_sweep_subst_idx: dict[tuple[int, int], tuple[str, ...]] = field(default_factory=dict)
+    # Cells that participate in a *real* conflict at some k_iter — i.e.
+    # the LDS that touches the cell has > 1 distinct addresses on the
+    # cell's bank for that k_iter. Distinct from "potential conflict"
+    # which is only a layout property (rows aliasing on a bank). Empty
+    # iff this Load never has bank conflicts across the full sweep.
+    full_sweep_conflict_cells: set[tuple[int, int]] = field(default_factory=set)
 
 
 # ---------------------------------------------------------------------------
@@ -333,9 +339,10 @@ def simulate_graph(
     for r in out:
         binding = bindings_by_key.get((r.tile_op_name, r.stage_name, r.load_name))
         if binding is not None:
-            touched, subst = _full_sweep_touched(binding, warp_id=warp_id)
+            touched, subst, conflicts = _full_sweep_touched(binding, warp_id=warp_id)
             r.full_sweep_touched = touched
             r.full_sweep_subst_idx = subst
+            r.full_sweep_conflict_cells = conflicts
     if load_filter is not None:
         out = [r for r in out if r.load_name in load_filter]
     return out
@@ -343,23 +350,29 @@ def simulate_graph(
 
 def _full_sweep_touched(
     binding: StageBinding, warp_id: int = 0
-) -> tuple[dict[tuple[int, int], list[tuple[int, int]]], dict[tuple[int, int], tuple[str, ...]]]:
+) -> tuple[
+    dict[tuple[int, int], list[tuple[int, int]]],
+    dict[tuple[int, int], tuple[str, ...]],
+    set[tuple[int, int]],
+]:
     """Sweep the deepest enclosing loop axis; record every (row, col)
     cell touched by any (lane, k_iter) pair, plus a substituted index
     string (one per cache axis) using one example (k_iter, lane) that
-    reaches the cell.
+    reaches the cell, plus the set of cells that participate in a real
+    bank conflict at some k_iter (their LDS had > 1 distinct address on
+    the cell's bank).
 
     Returns ``({(row, col) -> [(k_iter, lane), ...]}, {(row, col) ->
-    ("(0 * 8)", "5")})``. Outer enclosing loops and block axes pinned
-    to 0; thread axes decoded per lane. Cell coordinates are
-    reconstructed from the linear smem address using ``alloc_extents``
-    (folds in pad), matching ``simulate``.
+    ("(0 * 8)", "5")}, conflict_cells)``. Outer enclosing loops and
+    block axes pinned to 0; thread axes decoded per lane. Cell
+    coordinates are reconstructed from the linear smem address using
+    ``alloc_extents`` (folds in pad), matching ``simulate``.
     """
     from deplodock.compiler.ir.expr import Literal
 
     stage, load, tile = binding.stage, binding.load, binding.tile
     if not stage.axes or len(load.index) < len(stage.axes):
-        return {}, {}
+        return {}, {}, set()
     cache_idx = tuple(load.index[-len(stage.axes) :])
 
     alloc = list(stage.alloc_extents)
@@ -381,25 +394,38 @@ def _full_sweep_touched(
 
     out: dict[tuple[int, int], list[tuple[int, int]]] = {}
     subst: dict[tuple[int, int], tuple[str, ...]] = {}
+    conflict_cells: set[tuple[int, int]] = set()
     for k in range(loop_extent):
         env_k = dict(base_env)
         if loop_axis_name is not None:
             env_k[loop_axis_name] = k
+        # Per-LDS bank-distinct-addrs accounting (one LDS = one Load at
+        # one k_iter) so we can flag cells that participate in real
+        # conflicts (their bank had > 1 distinct address in this LDS).
+        lds_addrs_per_bank: list[set[int]] = [set() for _ in range(BANKS)]
+        lds_cells: list[tuple[int, int, int]] = []  # (r, c, bank) per lane
         for lane in range(WARP_SIZE):
             env = dict(env_k)
             env.update(thread_axis_env(tile.thread_axes, warp_id * WARP_SIZE + lane))
             try:
                 coords = [int(idx.eval(env)) for idx in cache_idx]
             except (KeyError, TypeError):
-                return {}, {}
+                return {}, {}, set()
             addr = sum(c * s for c, s in zip(coords, strides, strict=True))
             r, c = divmod(addr, row_stride) if row_stride else (0, addr)
+            bank = addr % BANKS
             out.setdefault((r, c), []).append((k, lane))
+            lds_addrs_per_bank[bank].add(addr)
+            lds_cells.append((r, c, bank))
             # First (k, lane) wins as the example for substitution.
             if (r, c) not in subst:
                 lit_env = {name: Literal(v) for name, v in env.items()}
                 subst[(r, c)] = tuple(idx.substitute(lit_env).pretty() for idx in cache_idx)
-    return out, subst
+        # Mark cells that participate in a conflict at this k_iter.
+        for r, c, bank in lds_cells:
+            if len(lds_addrs_per_bank[bank]) > 1:
+                conflict_cells.add((r, c))
+    return out, subst, conflict_cells
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -92,8 +92,10 @@ class BankConflictResult:
     distinct_addrs: list[int]  # length BANKS — distinct addresses per bank
     max_way: int  # worst broadcast-corrected = max(distinct_addrs)
     raw_max_way: int  # max(counts) — upper bound w/o broadcast
-    conflict_events: int  # sum(distinct_addrs[b] - 1 for b with hits)
-    avg_way: float
+    conflict_events: int  # sum(distinct_addrs[b] - 1 for b with hits) — per-LDS.32 model
+    lds128_events: int = 0  # sum(max(0, distinct_addrs[b] - vec_width)); vec_width=1 if standalone, up to 4 if vectorized
+    vec_group_size: int = 1  # number of Loads that fuse into one LDS.(N×32) (1 = scalar LDS.32)
+    avg_way: float = 0.0
     enclosing_axes: tuple[str, ...] = ()
 
 
@@ -274,6 +276,10 @@ def simulate(binding: StageBinding, k_iter: int = 0, warp_id: int = 0) -> BankCo
         max_way=max_way,
         raw_max_way=raw_max_way,
         conflict_events=conflict_events,
+        # Initial scalar (LDS.32) value; ``annotate_lds128`` upgrades
+        # vectorizable runs in-place with the absorption-aware count.
+        lds128_events=conflict_events,
+        vec_group_size=1,
         avg_way=avg,
         enclosing_axes=tuple(ax.name for ax in binding.enclosing_loop_axes),
     )
@@ -290,6 +296,10 @@ def simulate_graph(
 
     ``stage_filter`` keeps only Stages with these names; ``load_filter``
     keeps only body Loads with these SSA names. Both filters AND.
+
+    After simulation, ``annotate_lds128`` runs in place to upgrade
+    vectorizable Load runs (consecutive +0..+N-1 inner-element offsets)
+    with their LDS.128-absorbed event counts.
     """
     out: list[BankConflictResult] = []
     seen: set[tuple] = set()
@@ -303,4 +313,69 @@ def simulate_graph(
         r = simulate(binding, k_iter=k_iter, warp_id=warp_id)
         if r is not None:
             out.append(r)
+    annotate_lds128(out)
     return out
+
+
+# ---------------------------------------------------------------------------
+# LDS.128 vectorization model
+# ---------------------------------------------------------------------------
+#
+# nvcc fuses N consecutive scalar fp32 loads from smem into a single
+# ``ld.shared.v4`` (LDS.128) when they read 4 contiguous fp32. The warp
+# drains in 4 cycles regardless — so the first ``vec_width`` distinct
+# addresses per bank are "absorbed" into the natural drain (no extra
+# replay cycle). Mirrors the cost model in ``compiler/autotune.py``
+# (``effective_b_conflict_cost``, empirically validated on
+# ``k_add_5_reduce``: 4-way @ F_N=4 ≈ 1-way @ F_N=1 wall-clock).
+#
+# Per-bank events under LDS.(N×32):
+#     events_at_bank = max(0, distinct_addrs_at_bank - vec_width)
+# with ``vec_width = min(N, 4)``.
+
+LDS128_VEC_WIDTH = 4
+
+
+def annotate_lds128(results: list[BankConflictResult]) -> None:
+    """In-place: detect vectorizable runs and rewrite ``lds128_events``.
+
+    Two Loads belong to the same LDS.128 chain iff for every lane,
+    ``B.lane_addrs[lane] - A.lane_addrs[lane] == 1`` — i.e. each lane
+    reads the next contiguous fp32. Greedy chain on unique address
+    signatures (so duplicate Loads from prologue/steady-state pipeline
+    phases don't break detection); cap each chain at ``LDS128_VEC_WIDTH``
+    (4). Standalone Loads keep ``vec_group_size = 1`` and
+    ``lds128_events == conflict_events``.
+    """
+    by_kernel_stage: dict[tuple[str, str], list[BankConflictResult]] = {}
+    for r in results:
+        by_kernel_stage.setdefault((r.tile_op_name, r.stage_name), []).append(r)
+
+    for group in by_kernel_stage.values():
+        # Bucket by address signature so duplicate Loads (same lane_addrs)
+        # are treated as one node in the chain graph.
+        sig_buckets: dict[tuple[int, ...], list[BankConflictResult]] = {}
+        for r in group:
+            sig_buckets.setdefault(tuple(r.lane_addrs), []).append(r)
+        # Order signatures by min addr — vectorizable signatures end up
+        # adjacent. For each signature, all duplicates share its
+        # vec_group_size.
+        sigs = sorted(sig_buckets.keys(), key=min)
+        i = 0
+        while i < len(sigs):
+            chain_sigs = [sigs[i]]
+            j = i + 1
+            while j < len(sigs) and len(chain_sigs) < LDS128_VEC_WIDTH:
+                prev, cur = chain_sigs[-1], sigs[j]
+                if all(b - a == 1 for a, b in zip(prev, cur, strict=True)):
+                    chain_sigs.append(cur)
+                    j += 1
+                else:
+                    break
+            if len(chain_sigs) > 1:
+                vec = len(chain_sigs)
+                for sig in chain_sigs:
+                    for r in sig_buckets[sig]:
+                        r.vec_group_size = vec
+                        r.lds128_events = sum(max(0, d - vec) for d in r.distinct_addrs)
+            i = j

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -32,7 +32,7 @@ on a real GPU run when the answer matters.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from deplodock.compiler.graph import Graph
 from deplodock.compiler.ir.axis import Axis
@@ -97,6 +97,11 @@ class BankConflictResult:
     vec_group_size: int = 1  # number of Loads that fuse into one LDS.(N×32) (1 = scalar LDS.32)
     avg_way: float = 0.0
     enclosing_axes: tuple[str, ...] = ()
+    # Per-(row, col) → list of (k_iter, lane_id) pairs that read this cell
+    # over the FULL inner-loop sweep (k_iter 0..loop_extent-1). Populated
+    # by ``annotate_full_sweep`` so visualizers can show every cell's
+    # access provenance, not just the one at k_iter=0.
+    full_sweep_touched: dict[tuple[int, int], list[tuple[int, int]]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -316,8 +321,64 @@ def simulate_graph(
         if r is not None:
             out.append(r)
     annotate_lds128(out)
+    # Compute the per-cell access map for each result by re-evaluating
+    # the same Load's index across the full inner-loop sweep.
+    bindings_by_key = {(b.tile_op_name, b.stage.name, b.load.name): b for b in find_all_bindings(graph, stage_filter)}
+    for r in out:
+        binding = bindings_by_key.get((r.tile_op_name, r.stage_name, r.load_name))
+        if binding is not None:
+            r.full_sweep_touched = _full_sweep_touched(binding, warp_id=warp_id)
     if load_filter is not None:
         out = [r for r in out if r.load_name in load_filter]
+    return out
+
+
+def _full_sweep_touched(binding: StageBinding, warp_id: int = 0) -> dict[tuple[int, int], list[tuple[int, int]]]:
+    """Sweep the deepest enclosing loop axis; record every (row, col)
+    cell touched by any (lane, k_iter) pair.
+
+    Returns ``{(row, col) -> [(k_iter, lane), ...]}``. Outer enclosing
+    loops and block axes pinned to 0; thread axes decoded per lane.
+    Cell coordinates are reconstructed from the linear smem address
+    using ``alloc_extents`` (folds in pad), matching ``simulate``.
+    """
+    stage, load, tile = binding.stage, binding.load, binding.tile
+    if not stage.axes or len(load.index) < len(stage.axes):
+        return {}
+    cache_idx = tuple(load.index[-len(stage.axes) :])
+
+    alloc = list(stage.alloc_extents)
+    strides = [1] * len(alloc)
+    for i in range(len(alloc) - 2, -1, -1):
+        strides[i] = strides[i + 1] * alloc[i + 1]
+    row_stride = strides[0] if strides else 1
+
+    enc = list(binding.enclosing_loop_axes)
+    if not enc:
+        loop_extent = 1
+        loop_axis_name = None
+    else:
+        loop_extent = int(enc[-1].extent)
+        loop_axis_name = enc[-1].name
+    base_env: dict[str, int] = {ax.name: 0 for ax in tile.block_axes}
+    for ax in enc[:-1]:
+        base_env.setdefault(ax.name, 0)
+
+    out: dict[tuple[int, int], list[tuple[int, int]]] = {}
+    for k in range(loop_extent):
+        env_k = dict(base_env)
+        if loop_axis_name is not None:
+            env_k[loop_axis_name] = k
+        for lane in range(WARP_SIZE):
+            env = dict(env_k)
+            env.update(thread_axis_env(tile.thread_axes, warp_id * WARP_SIZE + lane))
+            try:
+                coords = [int(idx.eval(env)) for idx in cache_idx]
+            except (KeyError, TypeError):
+                return {}
+            addr = sum(c * s for c, s in zip(coords, strides, strict=True))
+            r, c = divmod(addr, row_stride) if row_stride else (0, addr)
+            out.setdefault((r, c), []).append((k, lane))
     return out
 
 

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -102,6 +102,12 @@ class BankConflictResult:
     # by ``annotate_full_sweep`` so visualizers can show every cell's
     # access provenance, not just the one at k_iter=0.
     full_sweep_touched: dict[tuple[int, int], list[tuple[int, int]]] = field(default_factory=dict)
+    # Per-(row, col) → tuple of substituted index strings (one per cache
+    # axis) using one example (k_iter, lane) that reaches the cell.
+    # E.g. ``[(a2 * 8), a6]`` evaluated at lane=0 / k_iter=5 becomes
+    # ``("(0 * 8)", "5")``. Lets visualizers replace symbolic vars with
+    # concrete values in the per-cell tooltip.
+    full_sweep_subst_idx: dict[tuple[int, int], tuple[str, ...]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -327,24 +333,33 @@ def simulate_graph(
     for r in out:
         binding = bindings_by_key.get((r.tile_op_name, r.stage_name, r.load_name))
         if binding is not None:
-            r.full_sweep_touched = _full_sweep_touched(binding, warp_id=warp_id)
+            touched, subst = _full_sweep_touched(binding, warp_id=warp_id)
+            r.full_sweep_touched = touched
+            r.full_sweep_subst_idx = subst
     if load_filter is not None:
         out = [r for r in out if r.load_name in load_filter]
     return out
 
 
-def _full_sweep_touched(binding: StageBinding, warp_id: int = 0) -> dict[tuple[int, int], list[tuple[int, int]]]:
+def _full_sweep_touched(
+    binding: StageBinding, warp_id: int = 0
+) -> tuple[dict[tuple[int, int], list[tuple[int, int]]], dict[tuple[int, int], tuple[str, ...]]]:
     """Sweep the deepest enclosing loop axis; record every (row, col)
-    cell touched by any (lane, k_iter) pair.
+    cell touched by any (lane, k_iter) pair, plus a substituted index
+    string (one per cache axis) using one example (k_iter, lane) that
+    reaches the cell.
 
-    Returns ``{(row, col) -> [(k_iter, lane), ...]}``. Outer enclosing
-    loops and block axes pinned to 0; thread axes decoded per lane.
-    Cell coordinates are reconstructed from the linear smem address
-    using ``alloc_extents`` (folds in pad), matching ``simulate``.
+    Returns ``({(row, col) -> [(k_iter, lane), ...]}, {(row, col) ->
+    ("(0 * 8)", "5")})``. Outer enclosing loops and block axes pinned
+    to 0; thread axes decoded per lane. Cell coordinates are
+    reconstructed from the linear smem address using ``alloc_extents``
+    (folds in pad), matching ``simulate``.
     """
+    from deplodock.compiler.ir.expr import Literal
+
     stage, load, tile = binding.stage, binding.load, binding.tile
     if not stage.axes or len(load.index) < len(stage.axes):
-        return {}
+        return {}, {}
     cache_idx = tuple(load.index[-len(stage.axes) :])
 
     alloc = list(stage.alloc_extents)
@@ -365,6 +380,7 @@ def _full_sweep_touched(binding: StageBinding, warp_id: int = 0) -> dict[tuple[i
         base_env.setdefault(ax.name, 0)
 
     out: dict[tuple[int, int], list[tuple[int, int]]] = {}
+    subst: dict[tuple[int, int], tuple[str, ...]] = {}
     for k in range(loop_extent):
         env_k = dict(base_env)
         if loop_axis_name is not None:
@@ -375,11 +391,15 @@ def _full_sweep_touched(binding: StageBinding, warp_id: int = 0) -> dict[tuple[i
             try:
                 coords = [int(idx.eval(env)) for idx in cache_idx]
             except (KeyError, TypeError):
-                return {}
+                return {}, {}
             addr = sum(c * s for c, s in zip(coords, strides, strict=True))
             r, c = divmod(addr, row_stride) if row_stride else (0, addr)
             out.setdefault((r, c), []).append((k, lane))
-    return out
+            # First (k, lane) wins as the example for substitution.
+            if (r, c) not in subst:
+                lit_env = {name: Literal(v) for name, v in env.items()}
+                subst[(r, c)] = tuple(idx.substitute(lit_env).pretty() for idx in cache_idx)
+    return out, subst
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -1,0 +1,267 @@
+"""Static smem bank-conflict simulator over Tile IR.
+
+For a given (TileOp, Stage) pair, evaluate every body ``Load`` of the
+staged buffer for each warp lane at one inner-loop iteration. The
+per-lane smem address is computed by:
+
+1. Decoding ``threadIdx.x = warp_id*32 + lane`` into thread-axis values
+   using the same flattening as ``Tile.render`` in ``ir/stmt/blocks.py``
+   (``_render_thread_axis_decode``: outermost = ``tid // inner_prod``,
+   inner = ``(tid // stride) % extent``, rightmost = ``tid % extent``).
+2. Binding the deepest enclosing ``Loop`` / ``StridedLoop`` axis to the
+   user-supplied ``k_iter`` value; outer block axes and outer loop axes
+   are bound to 0 (we visualize one CTA at one fixed iteration).
+3. Substituting that env into the Load's index ``Expr``s via
+   ``Expr.eval`` — i.e. running the compiler's own evaluator, not a
+   reimplementation.
+4. Linearizing the cache coordinates against ``Stage.alloc_extents``
+   (which already folds in ``Stage.pad`` as added row stride) and
+   taking ``addr % 32`` to get the bank id (banks are 32 fp32-wide).
+
+For ``BufferedStage`` subtypes the leading slot dim of the Load index
+is dropped — it's CTA-uniform at one cycle and doesn't shift the bank
+pattern.
+
+This is a static model: it predicts what a *coalesced* warp access
+would do under the IR's declared smem layout. It does not model
+sub-warp scheduling, register-file pressure, or LDS.32 vs LDS.128
+issue width — confirm against ncu (``smsp__sass_l1tex_data_bank_conflicts_pipe_lsu_mem_shared_op_ld``)
+on a real GPU run when the answer matters.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from deplodock.compiler.graph import Graph
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Expr
+from deplodock.compiler.ir.stmt import Cond, Load, Loop, StridedLoop, Tile
+from deplodock.compiler.ir.tile.ir import Stage, TileOp
+
+WARP_SIZE = 32
+BANKS = 32
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StageBinding:
+    """One ``(Stage, body-Load reading it)`` pair plus its surrounding context."""
+
+    stage: Stage
+    load: Load
+    tile: Tile
+    enclosing_loop_axes: tuple[Axis, ...]  # outermost-first
+    tile_op_name: str = ""
+
+
+@dataclass
+class BankConflictResult:
+    """Per-lane bank id + summary statistics for one StageBinding."""
+
+    stage_name: str
+    buf: str
+    stage_class: str
+    rows: int
+    cols: int
+    pad: tuple[int, ...]
+    smem_bytes: int
+    index_repr: tuple[str, ...]  # the cache-relative index of the simulated Load
+    lane_banks: list[int]  # length WARP_SIZE
+    counts: list[int]  # length BANKS — lanes per bank
+    max_way: int
+    avg_way: float
+    enclosing_axes: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# IR walk
+# ---------------------------------------------------------------------------
+
+
+def find_stage_bindings(tile_op: TileOp, stage_filter: set[str] | None = None) -> list[StageBinding]:
+    """Walk ``tile_op`` and yield one StageBinding per (Stage, Load) pair.
+
+    Each ``Stage`` declared inside the (single) ``Tile`` body is matched
+    against every body ``Load`` whose ``input`` is the staged name. The
+    enclosing ``Loop`` / ``StridedLoop`` axes are propagated so callers
+    can pin the inner-iter axis at simulation time.
+    """
+    out: list[StageBinding] = []
+    for top in tile_op.body:
+        if not isinstance(top, Tile):
+            continue
+        stages: dict[str, Stage] = {}
+        for s in _walk(top.body):
+            if isinstance(s, Stage) and (stage_filter is None or s.name in stage_filter):
+                stages.setdefault(s.name, s)
+        for load, axes in _walk_loads(top.body, ()):
+            if load.input in stages:
+                out.append(
+                    StageBinding(
+                        stage=stages[load.input],
+                        load=load,
+                        tile=top,
+                        enclosing_loop_axes=axes,
+                        tile_op_name=tile_op.name or "",
+                    )
+                )
+    return out
+
+
+def find_all_bindings(graph: Graph, stage_filter: set[str] | None = None) -> list[StageBinding]:
+    """Run ``find_stage_bindings`` over every TileOp in ``graph``."""
+    out: list[StageBinding] = []
+    for node in graph.nodes.values():
+        if isinstance(node.op, TileOp):
+            out.extend(find_stage_bindings(node.op, stage_filter))
+    return out
+
+
+def _walk(body) -> Iterable:
+    for s in body:
+        yield s
+        for attr in ("body", "else_body"):
+            inner = getattr(s, attr, None)
+            if isinstance(inner, tuple) and inner and hasattr(inner[0], "deps"):
+                yield from _walk(inner)
+
+
+def _walk_loads(body, axes: tuple[Axis, ...]):
+    for s in body:
+        if isinstance(s, Load):
+            yield s, axes
+        if isinstance(s, (Loop, StridedLoop)):
+            yield from _walk_loads(s.body, (*axes, s.axis))
+        elif isinstance(s, Tile):
+            yield from _walk_loads(s.body, axes)
+        elif isinstance(s, Cond):
+            yield from _walk_loads(s.body, axes)
+            yield from _walk_loads(s.else_body, axes)
+
+
+# ---------------------------------------------------------------------------
+# Thread-axis decode (mirrors ir/stmt/blocks.py::_render_thread_axis_decode)
+# ---------------------------------------------------------------------------
+
+
+def thread_axis_env(thread_axes: tuple[Axis, ...], tid: int) -> dict[str, int]:
+    """Reproduce the runtime decode of ``threadIdx.x`` into per-axis ints.
+
+    Identical to ``_render_thread_axis_decode`` in ``ir/stmt/blocks.py``:
+    outermost axis = ``tid // inner_prod``, inner axes get
+    ``(tid // stride) % extent`` with ``stride`` doubling rightward,
+    and a single-axis tile collapses to ``tid``.
+    """
+    if not thread_axes:
+        return {}
+    extents = [int(ax.extent) for ax in thread_axes]
+    if len(extents) == 1:
+        return {thread_axes[0].name: tid}
+    inner_prod = 1
+    for e in extents[1:]:
+        inner_prod *= e
+    env: dict[str, int] = {thread_axes[0].name: tid // inner_prod}
+    stride = 1
+    for ax, e in zip(reversed(thread_axes[1:]), reversed(extents[1:]), strict=True):
+        env[ax.name] = tid % e if stride == 1 else (tid // stride) % e
+        stride *= e
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Per-binding simulation
+# ---------------------------------------------------------------------------
+
+
+def simulate(binding: StageBinding, k_iter: int = 0, warp_id: int = 0) -> BankConflictResult | None:
+    """Compute per-lane bank ids for one ``StageBinding``.
+
+    Returns ``None`` if the cache rank can't be reconciled (e.g. the
+    Load index is shorter than ``Stage.axes``) or if any index Expr
+    references a Var the env can't bind.
+    """
+    stage, load, tile = binding.stage, binding.load, binding.tile
+
+    # Buffered stages prefix the Load index with slot/phase dims that
+    # are CTA-uniform at one moment — they don't change the bank
+    # pattern. Take the trailing ``len(stage.axes)`` entries.
+    if not stage.axes:
+        return None
+    if len(load.index) < len(stage.axes):
+        return None
+    cache_idx: tuple[Expr, ...] = tuple(load.index[-len(stage.axes) :])
+
+    # Strides over alloc_extents (cache extents + per-axis pad).
+    alloc = list(stage.alloc_extents)
+    strides = [1] * len(alloc)
+    for i in range(len(alloc) - 2, -1, -1):
+        strides[i] = strides[i + 1] * alloc[i + 1]
+
+    # Base env: zero out block axes and outer enclosing loops; pin the
+    # innermost loop axis to ``k_iter``.
+    base_env: dict[str, int] = {ax.name: 0 for ax in tile.block_axes}
+    enc = list(binding.enclosing_loop_axes)
+    if enc:
+        for ax in enc[:-1]:
+            base_env.setdefault(ax.name, 0)
+        base_env[enc[-1].name] = k_iter
+
+    lane_banks: list[int] = []
+    for lane in range(WARP_SIZE):
+        env = dict(base_env)
+        env.update(thread_axis_env(tile.thread_axes, warp_id * WARP_SIZE + lane))
+        try:
+            coords = [int(idx.eval(env)) for idx in cache_idx]
+        except (KeyError, TypeError):
+            return None
+        addr = sum(c * s for c, s in zip(coords, strides, strict=True))
+        lane_banks.append(addr % BANKS)
+
+    counts = [0] * BANKS
+    for b in lane_banks:
+        counts[b] += 1
+    max_way = max(counts)
+    nz = [c for c in counts if c > 0]
+    avg = sum(nz) / len(nz) if nz else 0.0
+
+    return BankConflictResult(
+        stage_name=stage.name,
+        buf=stage.buf,
+        stage_class=type(stage).__name__,
+        rows=int(stage.axes[0].extent),
+        cols=int(stage.axes[1].extent) if len(stage.axes) > 1 else 1,
+        pad=tuple(int(p) for p in stage.pad),
+        smem_bytes=stage.smem_bytes,
+        index_repr=tuple(e.pretty() for e in cache_idx),
+        lane_banks=lane_banks,
+        counts=counts,
+        max_way=max_way,
+        avg_way=avg,
+        enclosing_axes=tuple(ax.name for ax in binding.enclosing_loop_axes),
+    )
+
+
+def simulate_graph(
+    graph: Graph,
+    stage_filter: set[str] | None = None,
+    k_iter: int = 0,
+    warp_id: int = 0,
+) -> list[BankConflictResult]:
+    """Convenience: bindings + simulate, dropping rank-mismatched probes."""
+    out: list[BankConflictResult] = []
+    seen: set[tuple] = set()
+    for binding in find_all_bindings(graph, stage_filter):
+        key = (binding.tile_op_name, binding.stage.name, binding.load.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        r = simulate(binding, k_iter=k_iter, warp_id=warp_id)
+        if r is not None:
+            out.append(r)
+    return out

--- a/deplodock/compiler/diagnostics/bank_conflicts.py
+++ b/deplodock/compiler/diagnostics/bank_conflicts.py
@@ -62,7 +62,19 @@ class StageBinding:
 
 @dataclass
 class BankConflictResult:
-    """Per-lane bank id + summary statistics for one StageBinding."""
+    """Per-lane bank id + summary statistics for one StageBinding.
+
+    Hardware semantics: when multiple lanes target the *same address* in
+    a bank, the load is broadcast and only one cycle is spent. The
+    actual ``l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_ld``
+    counter increments by ``(distinct_addrs_at_bank - 1)`` per warp-LDS,
+    summed across banks. ``max_way`` here is that worst-bank value
+    (i.e. ``max(distinct_addrs_at_bank)``) — same-address broadcasts
+    don't count.
+
+    ``raw_max_way`` is ``max(lanes_at_bank)`` — the upper bound assuming
+    no broadcasting. Useful for cross-checking the broadcast model.
+    """
 
     stage_name: str
     buf: str
@@ -73,8 +85,12 @@ class BankConflictResult:
     smem_bytes: int
     index_repr: tuple[str, ...]  # the cache-relative index of the simulated Load
     lane_banks: list[int]  # length WARP_SIZE
+    lane_addrs: list[int]  # length WARP_SIZE — pre-mod linear smem address
     counts: list[int]  # length BANKS — lanes per bank
-    max_way: int
+    distinct_addrs: list[int]  # length BANKS — distinct addresses per bank
+    max_way: int  # worst broadcast-corrected = max(distinct_addrs)
+    raw_max_way: int  # max(counts) — upper bound w/o broadcast
+    conflict_events: int  # sum(distinct_addrs[b] - 1 for b with hits)
     avg_way: float
     enclosing_axes: tuple[str, ...] = ()
 
@@ -213,6 +229,7 @@ def simulate(binding: StageBinding, k_iter: int = 0, warp_id: int = 0) -> BankCo
         base_env[enc[-1].name] = k_iter
 
     lane_banks: list[int] = []
+    lane_addrs: list[int] = []
     for lane in range(WARP_SIZE):
         env = dict(base_env)
         env.update(thread_axis_env(tile.thread_axes, warp_id * WARP_SIZE + lane))
@@ -221,12 +238,19 @@ def simulate(binding: StageBinding, k_iter: int = 0, warp_id: int = 0) -> BankCo
         except (KeyError, TypeError):
             return None
         addr = sum(c * s for c, s in zip(coords, strides, strict=True))
+        lane_addrs.append(addr)
         lane_banks.append(addr % BANKS)
 
     counts = [0] * BANKS
-    for b in lane_banks:
+    addrs_per_bank: list[set[int]] = [set() for _ in range(BANKS)]
+    for lane, (b, a) in enumerate(zip(lane_banks, lane_addrs, strict=True)):
+        del lane  # unused
         counts[b] += 1
-    max_way = max(counts)
+        addrs_per_bank[b].add(a)
+    distinct_addrs = [len(s) for s in addrs_per_bank]
+    raw_max_way = max(counts)
+    max_way = max(distinct_addrs) if distinct_addrs else 0
+    conflict_events = sum(d - 1 for d in distinct_addrs if d > 0)
     nz = [c for c in counts if c > 0]
     avg = sum(nz) / len(nz) if nz else 0.0
 
@@ -240,8 +264,12 @@ def simulate(binding: StageBinding, k_iter: int = 0, warp_id: int = 0) -> BankCo
         smem_bytes=stage.smem_bytes,
         index_repr=tuple(e.pretty() for e in cache_idx),
         lane_banks=lane_banks,
+        lane_addrs=lane_addrs,
         counts=counts,
+        distinct_addrs=distinct_addrs,
         max_way=max_way,
+        raw_max_way=raw_max_way,
+        conflict_events=conflict_events,
         avg_way=avg,
         enclosing_axes=tuple(ax.name for ax in binding.enclosing_loop_axes),
     )

--- a/deplodock/compiler/graph.py
+++ b/deplodock/compiler/graph.py
@@ -213,6 +213,12 @@ def _deserialize_field(k, v):
 
 def _eval_stmt(s: str):
     scope = _stmt_eval_scope()
+    # ``repr(enum_value)`` produces ``<SwizzleMode.NONE: 'NONE'>`` which
+    # isn't eval-able. Rewrite to the dotted form before eval.
+    if "<" in s and ":" in s:
+        import re as _re
+
+        s = _re.sub(r"<([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*): [^>]+>", r"\1.\2", s)
     return eval(s, scope)
 
 
@@ -261,7 +267,9 @@ def _stmt_eval_scope() -> dict:
         BufferedStage,
         Combine,
         Stage,
+        SwizzleMode,
         TemplateAddressing,
+        TmaBufferedStage,
     )
 
     _STMT_EVAL_SCOPE = {
@@ -290,6 +298,8 @@ def _stmt_eval_scope() -> dict:
         "Stage": Stage,
         "BufferedStage": BufferedStage,
         "AsyncBufferedStage": AsyncBufferedStage,
+        "TmaBufferedStage": TmaBufferedStage,
+        "SwizzleMode": SwizzleMode,
         "AffineAddressing": AffineAddressing,
         "TemplateAddressing": TemplateAddressing,
         "Combine": Combine,

--- a/deplodock/compiler/pipeline/passes/lowering/tile/006_chunk_reduce.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/006_chunk_reduce.py
@@ -46,6 +46,7 @@ reduce-Loop is left alone.
 
 from __future__ import annotations
 
+import os
 from dataclasses import replace
 
 from deplodock.compiler.graph import Graph, Node
@@ -68,6 +69,10 @@ _BK_CANDIDATES = (128, 64, 32, 16, 8)
 
 
 def rewrite(graph: Graph, root: Node) -> Graph | None:
+    # Diagnostic gate for visualizing pipeline behavior with this pass
+    # disabled (e.g. smem-layout before/after diffs).
+    if os.environ.get("DEPLODOCK_DISABLE_CHUNK_REDUCE") == "1":
+        raise RuleSkipped("disabled via DEPLODOCK_DISABLE_CHUNK_REDUCE=1")
     new_body = _maybe_rewrite(root.op.body)
     if new_body is None:
         return None

--- a/deplodock/compiler/pipeline/passes/lowering/tile/008b_chunk_register_tile_for_banks.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/008b_chunk_register_tile_for_banks.py
@@ -58,6 +58,7 @@ Skips when:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import replace as dc_replace
 
 from deplodock.compiler.graph import Graph, Node
@@ -85,6 +86,8 @@ PATTERN = [Pattern("root", TileOp)]
 
 
 def rewrite(graph: Graph, root: Node) -> Graph | None:
+    if os.environ.get("DEPLODOCK_DISABLE_CHUNK_REGISTER_TILE") == "1":
+        raise RuleSkipped("disabled via DEPLODOCK_DISABLE_CHUNK_REGISTER_TILE=1")
     new_body = _maybe_rewrite(root.op.body)
     if new_body is None:
         return None

--- a/deplodock/compiler/pipeline/passes/lowering/tile/013_pad_smem.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/013_pad_smem.py
@@ -61,6 +61,7 @@ The pass:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import replace as dc_replace
 
 from deplodock.compiler.graph import Graph, Node
@@ -90,6 +91,10 @@ _MAX_PADDED_SLAB_BYTES = 20 * 1024
 
 
 def rewrite(graph: Graph, root: Node) -> Graph | None:
+    # Diagnostic gate for visualizing pipeline behavior with this pass
+    # disabled (e.g. smem-conflict before/after diffs).
+    if os.environ.get("DEPLODOCK_DISABLE_PAD_SMEM") == "1":
+        raise RuleSkipped("disabled via DEPLODOCK_DISABLE_PAD_SMEM=1")
     new_body = _maybe_rewrite(root.op.body)
     if new_body is None:
         return None

--- a/scripts/diff_perf_results.py
+++ b/scripts/diff_perf_results.py
@@ -1,0 +1,73 @@
+"""Diff two ``tests/perf/.results/*.json`` files and surface kernels that
+got slower (or faster) under different pass-gate configs.
+
+Usage::
+
+    python scripts/diff_perf_results.py BASELINE.json DEGRADED.json [--top N]
+
+Prints a table sorted by relative slowdown (degraded_us / baseline_us)
+descending — biggest losers first. Cases that exist in only one run
+appear with an annotation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load(path: str) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+def _by_name(d: dict) -> dict[str, dict]:
+    return {row["name"]: row for row in d.get("rows", [])}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("baseline")
+    p.add_argument("degraded")
+    p.add_argument("--top", type=int, default=20, help="rows to print on each side (default 20)")
+    p.add_argument("--threshold", type=float, default=1.05, help="relative-slowdown threshold to flag (default 1.05x)")
+    args = p.parse_args()
+
+    base = _by_name(_load(args.baseline))
+    deg = _by_name(_load(args.degraded))
+    common = sorted(set(base) & set(deg))
+
+    rows = []
+    for name in common:
+        b_us = base[name].get("deplodock_us")
+        d_us = deg[name].get("deplodock_us")
+        if not b_us or not d_us:
+            continue
+        slowdown = d_us / b_us
+        rows.append((slowdown, name, b_us, d_us, base[name].get("op", "")))
+
+    rows.sort(reverse=True)
+
+    print(f"{'slowdown':>9}  {'op':10}  {'case':45}  {'base_us':>10}  {'deg_us':>10}")
+    print("-" * 95)
+    flagged = [r for r in rows if r[0] >= args.threshold]
+    print(f"# {len(flagged)} cases with slowdown ≥ {args.threshold}x  (showing top {args.top})")
+    for slowdown, name, b_us, d_us, op in rows[: args.top]:
+        marker = "  ←" if slowdown >= args.threshold else ""
+        print(f"{slowdown:>8.2f}x  {op:10}  {name:45}  {b_us:>10.1f}  {d_us:>10.1f}{marker}")
+    if len(rows) > args.top:
+        print(f"... ({len(rows) - args.top} more, smallest slowdown {rows[-1][0]:.2f}x)")
+
+    only_base = sorted(set(base) - set(deg))
+    only_deg = sorted(set(deg) - set(base))
+    if only_base:
+        print(f"\nin baseline only: {only_base[:5]}{' …' if len(only_base) > 5 else ''}")
+    if only_deg:
+        print(f"in degraded only: {only_deg[:5]}{' …' if len(only_deg) > 5 else ''}")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sweep_pass_gates.py
+++ b/scripts/sweep_pass_gates.py
@@ -1,0 +1,127 @@
+"""Sweep the perf-suite cases under (chunk_reduce, pad_smem) gate matrix.
+
+For each case in ``tests/perf/cases.py`` and each combo of
+``DEPLODOCK_DISABLE_CHUNK_REDUCE`` / ``DEPLODOCK_DISABLE_PAD_SMEM``,
+runs the tile pipeline and sums broadcast-corrected
+``conflict_events`` across all (Stage, Load) bindings. Used to surface
+cases where one pass dominates the conflict reduction.
+
+Output: a CSV-ish table on stdout, plus ``--json`` to dump full
+per-stage records for downstream report rendering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Make tests.perf importable when running from repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from deplodock.compiler.diagnostics.bank_conflicts import find_all_bindings, simulate  # noqa: E402
+from deplodock.compiler.pipeline import TILE_PASSES, run_pipeline  # noqa: E402
+from tests.perf.cases import FUSED_CASES, PRIMITIVE_CASES, build_deplodock_graph  # noqa: E402
+
+CONFIGS = [
+    ("baseline", {}),
+    ("no_chunk_reduce", {"DEPLODOCK_DISABLE_CHUNK_REDUCE": "1"}),
+    ("no_pad_smem", {"DEPLODOCK_DISABLE_PAD_SMEM": "1"}),
+    ("no_chunk_no_pad", {"DEPLODOCK_DISABLE_CHUNK_REDUCE": "1", "DEPLODOCK_DISABLE_PAD_SMEM": "1"}),
+]
+
+GATES = ("DEPLODOCK_DISABLE_CHUNK_REDUCE", "DEPLODOCK_DISABLE_PAD_SMEM")
+
+
+def with_env(overrides: dict[str, str]):
+    saved = {k: os.environ.get(k) for k in GATES}
+
+    class Ctx:
+        def __enter__(self_):
+            for k in GATES:
+                os.environ[k] = overrides.get(k, "0")
+            return self_
+
+        def __exit__(self_, *_):
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    return Ctx()
+
+
+def total_events_per_kernel(graph) -> dict[str, dict[str, int]]:
+    """Map kernel_name → {stage_name → total_conflict_events}."""
+    out: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    seen = set()
+    for b in find_all_bindings(graph):
+        key = (b.tile_op_name, b.stage.name, b.load.name, tuple(b.enclosing_loop_axes))
+        if key in seen:
+            continue
+        seen.add(key)
+        r = simulate(b)
+        if r is None:
+            continue
+        out[b.tile_op_name][r.stage_name] += r.conflict_events
+    return {k: dict(v) for k, v in out.items()}
+
+
+def run_case(case, configs=CONFIGS) -> dict:
+    """Run ``case`` under each gate config; return per-config results."""
+    record = {"case": case.name, "op": case.op, "shapes": [list(s) for s in case.shapes]}
+    for cfg_name, env in configs:
+        try:
+            with with_env(env):
+                g = build_deplodock_graph(case)
+                run_pipeline(g, TILE_PASSES)
+                kernels = total_events_per_kernel(g)
+                total = sum(sum(s.values()) for s in kernels.values())
+                record[cfg_name] = {"total": total, "per_kernel": kernels}
+        except Exception as e:  # noqa: BLE001 — diagnostic helper
+            record[cfg_name] = {"error": f"{type(e).__name__}: {e}"}
+    return record
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--include", nargs="*", default=[], help="substring filters; empty = all")
+    p.add_argument("--exclude", nargs="*", default=[], help="substring filters")
+    p.add_argument("--max-cases", type=int, default=0, help="cap number of cases (0 = unlimited)")
+    p.add_argument("--json", default=None, help="write full records to this path")
+    args = p.parse_args()
+
+    cases = PRIMITIVE_CASES + FUSED_CASES
+    if args.include:
+        cases = [c for c in cases if any(t in c.name for t in args.include)]
+    if args.exclude:
+        cases = [c for c in cases if not any(t in c.name for t in args.exclude)]
+    if args.max_cases:
+        cases = cases[: args.max_cases]
+
+    print(f"{'case':45} {'baseline':>10} {'-chunk':>10} {'-pad':>10} {'-both':>10}")
+    print("-" * 90)
+    records = []
+    for case in cases:
+        rec = run_case(case)
+        records.append(rec)
+
+        def cell(cfg, rec=rec):
+            r = rec.get(cfg, {})
+            return r.get("total", "ERR") if isinstance(r, dict) else "ERR"
+
+        print(
+            f"{case.name:45} {cell('baseline'):>10} {cell('no_chunk_reduce'):>10} {cell('no_pad_smem'):>10} {cell('no_chunk_no_pad'):>10}"
+        )
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(records, indent=2))
+        print(f"saved {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -1,28 +1,24 @@
 """Bank-conflict visualizer driven by real Tile-IR ``Stage``s.
 
-Each input contributes one column. Within a column, every ``Stage`` ×
-``Load`` pair gets a card showing the warp's per-lane smem bank at one
-fixed inner-loop iteration. The simulation lives in
-``deplodock.compiler.diagnostics.bank_conflicts``; this script is a
-thin CLI + ECharts emitter.
+Takes one or more IR JSON paths and renders one column per input. Each
+column contains a card per ``(Stage, body-Load)`` pair showing the warp's
+per-lane smem bank at one inner-loop iteration. Simulation lives in
+``deplodock.compiler.diagnostics.bank_conflicts``; this script is a thin
+CLI + ECharts emitter.
 
-Modes:
+Workflow — produce IRs via the compiler with whatever pass gates you
+want, then feed the dumped JSONs in::
 
-  --ir PATH[:LABEL] (repeatable)
-      Load JSON dumps produced under ``DEPLODOCK_DUMP_DIR`` (any
-      post-tile-pass dump that contains ``TileOp`` nodes — typically
-      ``07_*_stage_inputs.json`` or later).
+    DEPLODOCK_DUMP_DIR=/tmp/dump_a deplodock compile MODEL --layer 0
+    DEPLODOCK_DISABLE_CHUNK_REDUCE=1 \\
+        DEPLODOCK_DUMP_DIR=/tmp/dump_b deplodock compile MODEL --layer 0
+    python scripts/visualize_bank_conflicts.py \\
+        -i /tmp/dump_a/14_lowering_tile.json:baseline \\
+        -i /tmp/dump_b/14_lowering_tile.json:no_chunk_reduce \\
+        --out /tmp/diff.html
 
-  --chunk-reduce-diff [--seq-len N]
-      Run the tile pipeline live on an SDPA(B=1, H=8, seq=N, d=64)
-      graph twice — with and without ``006_chunk_reduce`` enabled
-      (gated via ``DEPLODOCK_DISABLE_CHUNK_REDUCE``) — and compare.
-
-  --gate-matrix CASE_NAME
-      Run the named ``tests/perf/cases.py`` case under all four
-      combinations of ``006_chunk_reduce`` × ``013_pad_smem``
-      gate-on/off. Useful for surfacing which pass dominates the
-      conflict reduction.
+Any post-tile-pass dump works; pick the one whose Stages you want to
+inspect (typically the final tile-stage dump).
 """
 
 from __future__ import annotations
@@ -32,60 +28,12 @@ import json
 import os
 
 from deplodock.compiler.diagnostics.bank_conflicts import BankConflictResult, simulate_graph
-from deplodock.compiler.graph import Graph, Tensor
-from deplodock.compiler.ir.base import InputOp
-from deplodock.compiler.ir.frontend.ir import SdpaOp
-from deplodock.compiler.pipeline import TILE_PASSES, run_pipeline
+from deplodock.compiler.graph import Graph
 
 
 def graph_from_ir_path(path: str) -> Graph:
     with open(path) as f:
         return Graph.from_dict(json.load(f))
-
-
-def graph_from_sdpa(seq_len: int, disable_chunk_reduce: bool) -> Graph:
-    g = Graph()
-    for name in ("q", "k", "v"):
-        g.add_node(InputOp(), [], Tensor(name, (1, 8, seq_len, 64)), node_id=name)
-    g.add_node(SdpaOp(), ["q", "k", "v"], Tensor("o", (1, 8, seq_len, 64)), node_id="o")
-    g.inputs = ["q", "k", "v"]
-    g.outputs = ["o"]
-    prev = os.environ.get("DEPLODOCK_DISABLE_CHUNK_REDUCE")
-    os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = "1" if disable_chunk_reduce else "0"
-    try:
-        run_pipeline(g, TILE_PASSES)
-    finally:
-        if prev is None:
-            del os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"]
-        else:
-            os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = prev
-    return g
-
-
-def graph_from_perf_case(case_name: str, *, disable_chunk_reduce: bool, disable_pad_smem: bool) -> Graph:
-    """Build & compile a ``tests/perf/cases.py`` case under the given gate combo."""
-    import sys
-    from pathlib import Path
-
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from tests.perf.cases import FUSED_CASES, PRIMITIVE_CASES, build_deplodock_graph
-
-    cases = {c.name: c for c in PRIMITIVE_CASES + FUSED_CASES}
-    if case_name not in cases:
-        raise SystemExit(f"unknown case '{case_name}'. examples: {list(cases)[:5]}")
-    saved = {k: os.environ.get(k) for k in ("DEPLODOCK_DISABLE_CHUNK_REDUCE", "DEPLODOCK_DISABLE_PAD_SMEM")}
-    os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = "1" if disable_chunk_reduce else "0"
-    os.environ["DEPLODOCK_DISABLE_PAD_SMEM"] = "1" if disable_pad_smem else "0"
-    try:
-        g = build_deplodock_graph(cases[case_name])
-        run_pipeline(g, TILE_PASSES)
-        return g
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
 
 
 def _serialize(panels: list[BankConflictResult]) -> list[dict]:
@@ -268,13 +216,18 @@ def _parse_ir_arg(arg: str) -> tuple[str, str]:
 
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--ir", action="append", default=[], help="PATH[:LABEL] — repeatable")
-    p.add_argument("--chunk-reduce-diff", action="store_true", help="Run pipeline live with/without chunk_reduce on SDPA")
-    p.add_argument("--gate-matrix", default=None, help="Run a tests/perf case under 4 gate combos (chunk×pad)")
-    p.add_argument("--seq-len", type=int, default=512)
+    p.add_argument(
+        "-i",
+        "--ir",
+        action="append",
+        default=[],
+        required=True,
+        metavar="PATH[:LABEL]",
+        help="IR JSON dump (post-tile-pass). Repeat for side-by-side columns.",
+    )
     p.add_argument("--stage", action="append", default=[], help="filter Stage names (repeatable)")
     p.add_argument("--load", action="append", default=[], help="filter Load SSA names (repeatable, e.g. in3)")
-    p.add_argument("--list", action="store_true", help="print available (kernel, stage, load) probes and exit")
+    p.add_argument("--list", action="store_true", help="print available (kernel, stage, load) probes for the first IR and exit")
     p.add_argument("--k-iter", type=int, default=0)
     p.add_argument("--warp-id", type=int, default=0)
     p.add_argument("--out", default="/tmp/bank_conflicts.html")
@@ -282,18 +235,9 @@ def main() -> None:
 
     stage_filter = set(args.stage) if args.stage else None
     load_filter = set(args.load) if args.load else None
-    columns: list[dict] = []
 
     if args.list:
-        # Print available probes for the first config and exit.
-        if args.gate_matrix:
-            g = graph_from_perf_case(args.gate_matrix, disable_chunk_reduce=False, disable_pad_smem=False)
-        elif args.chunk_reduce_diff:
-            g = graph_from_sdpa(args.seq_len, disable_chunk_reduce=False)
-        elif args.ir:
-            g = graph_from_ir_path(_parse_ir_arg(args.ir[0])[0])
-        else:
-            p.error("--list requires one of --gate-matrix / --chunk-reduce-diff / --ir")
+        g = graph_from_ir_path(_parse_ir_arg(args.ir[0])[0])
         results = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
         print(f"{'kernel':32}  {'stage':18}  {'load':6}  {'max_way':>7}  {'events':>6}  index")
         print("-" * 100)
@@ -302,40 +246,16 @@ def main() -> None:
             print(f"{r.tile_op_name:32}  {r.stage_name:18}  {r.load_name:6}  {r.max_way:>7}  {r.conflict_events:>6}  ({idx})")
         return
 
-    if args.chunk_reduce_diff:
-        for label, disabled in (("chunk_reduce ENABLED", False), ("chunk_reduce DISABLED", True)):
-            print(f"running pipeline: {label}...")
-            g = graph_from_sdpa(args.seq_len, disable_chunk_reduce=disabled)
-            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
-            print(f"  → {len(panels)} stage probe(s)")
-            columns.append({"label": label, "panels": _serialize(panels)})
-        subtitle = f"SDPA(B=1, H=8, seq={args.seq_len}, d=64) · k_iter={args.k_iter} · warp={args.warp_id}"
-    elif args.gate_matrix:
-        combos = [
-            ("baseline (chunk✓ pad✓)", False, False),
-            ("no chunk_reduce", True, False),
-            ("no pad_smem", False, True),
-            ("no chunk + no pad", True, True),
-        ]
-        for label, no_chunk, no_pad in combos:
-            print(f"running {args.gate_matrix} | {label}...")
-            g = graph_from_perf_case(args.gate_matrix, disable_chunk_reduce=no_chunk, disable_pad_smem=no_pad)
-            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
-            total = sum(p.conflict_events for p in panels)
-            print(f"  → {len(panels)} probes, total conflict_events = {total}")
-            columns.append({"label": f"{label} · Σevents={total}", "panels": _serialize(panels)})
-        subtitle = f"{args.gate_matrix}  ·  k_iter={args.k_iter} · warp={args.warp_id}"
-    elif args.ir:
-        for arg in args.ir:
-            path, label = _parse_ir_arg(arg)
-            g = graph_from_ir_path(path)
-            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
-            print(f"{label}: {len(panels)} stage probe(s)")
-            columns.append({"label": label, "panels": _serialize(panels)})
-        subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"
-    else:
-        p.error("provide --ir PATH (repeatable), --chunk-reduce-diff, or --gate-matrix CASE")
+    columns: list[dict] = []
+    for arg in args.ir:
+        path, label = _parse_ir_arg(arg)
+        g = graph_from_ir_path(path)
+        panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
+        total = sum(p.conflict_events for p in panels)
+        print(f"{label}: {len(panels)} probes, Σevents={total}")
+        columns.append({"label": f"{label} · Σevents={total}", "panels": _serialize(panels)})
 
+    subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"
     emit_html(columns, subtitle, args.out)
     print(f"saved {args.out}")
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -196,6 +196,10 @@ HTML = """<!doctype html>
     font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
   .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}
   .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
+  .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:6px;
+    font-size:10px;color:var(--muted);}
+  .hist-legend span{display:inline-flex;align-items:center;gap:5px;}
+  .hist-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
@@ -206,12 +210,6 @@ HTML = """<!doctype html>
 <body>
   <div class="page">
     <div class="columns" id="columns"></div>
-    <div class="legend">
-      <span><i style="background:#3ddc84"></i> 1 lane (no conflict)</span>
-      <span><i style="background:#ffb454"></i> 2–4 lanes (mild)</span>
-      <span><i style="background:#ff5c7a"></i> &gt;4 lanes (heavy)</span>
-      <span><i style="background:#2a2d33"></i> 0 lanes</span>
-    </div>
   </div>
 <script>
 const PAYLOAD = __PAYLOAD__;
@@ -253,6 +251,11 @@ PAYLOAD.columns.forEach((col,ci)=>{
       <div class="card-formula">${p.formula}</div>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
+      <div class="hist-legend">
+        <span><i style="background:#3ddc84"></i>1 lane (no conflict)</span>
+        <span><i style="background:#ffb454"></i>2–4 lanes (mild)</span>
+        <span><i style="background:#ff5c7a"></i>&gt;4 lanes (heavy)</span>
+      </div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
       <div class="bank-legend" id="bl_${id}"></div>

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -263,16 +263,15 @@ PAYLOAD.columns.forEach((col,ci)=>{
       </div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="${(()=>{
-        // Natural-size square cells: pick the largest cell-size px
-        // that fits both maxW and maxH, then size the container to
-        // (cols*N + axisW) × (rows*N + axisH). Don't stretch — leave
-        // unused horizontal space for the iframe to be narrower.
+        // Cells are 3:1 wide rectangles when there's room; shrink
+        // cell_w toward cell_h (square) when the column gets narrow.
+        // cell_h is sized by row count (so the slab fits ≤ maxH);
+        // cell_w = min(3 × cell_h, fits_width).
         const axisW = 38, axisH = 24, maxH = 360, maxW = 380;
-        const N = Math.max(2, Math.min(6,
-          Math.floor((maxH - axisH) / p.layout.rows),
-          Math.floor((maxW - axisW) / p.layout.cols)));
-        const w = p.layout.cols * N + axisW;
-        const h = p.layout.rows * N + axisH;
+        const cellH = Math.max(2, Math.min(4, Math.floor((maxH - axisH) / p.layout.rows)));
+        const cellW = Math.max(cellH, Math.min(3 * cellH, Math.floor((maxW - axisW) / p.layout.cols)));
+        const w = p.layout.cols * cellW + axisW;
+        const h = p.layout.rows * cellH + axisH;
         return `width:${w}px; height:${h}px`;
       })()}"></div>
       ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -157,7 +157,7 @@ HTML = """<!doctype html>
   .v-ok{color:#3ddc84;} .v-ok .dot{background:#3ddc84;}
   .v-warn{color:#ffb454;} .v-warn .dot{background:#ffb454;}
   .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
-  .matrix{width:100%;height:240px;}
+  .matrix{width:100%;height:240px;margin-bottom:14px;}
   .hist{width:100%;height:100px;margin-top:4px;}
   .ladder{width:100%;margin-top:8px;}
   .ladder-title{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);
@@ -267,7 +267,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
       xAxis:{type:'category',data:[...Array(BANKS).keys()],
         axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
         axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
-      yAxis:{type:'value',splitLine:{lineStyle:{color:'#1c212b'}},
+      yAxis:{type:'value',min:0,max:8,splitLine:{lineStyle:{color:'#1c212b'}},
         axisLabel:{color:'#6b7280',fontSize:10},axisLine:{show:false},axisTick:{show:false}},
       series:[{type:'bar',data:p.distinct_addrs.map(c=>({value:c,itemStyle:{
         color:{type:'linear',x:0,y:0,x2:0,y2:1,

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -59,23 +59,20 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
         layout_cols = p.cols + pad_cols
         row_stride = p.cols + pad_cols
         smem_layout = [[(r * row_stride + c) % 32 for c in range(layout_cols)] for r in range(layout_rows)]
-        # Mark cells the warp actually touched in this LDS (row, col) pairs
-        # — drawn with a white outline overlay on top of the ladder.
-        # Reconstruct (row, col) per lane from the linear address.
-        touched: list[tuple[int, int]] = []
-        for addr in p.lane_addrs:
+        # Mark cells the warp actually touched in this LDS (row, col) →
+        # list of lanes that read the cell. Drawn with a white outline
+        # overlay on top of the ladder; tooltip shows the lanes (and they
+        # collapse to one entry when broadcast).
+        touched_map: dict[tuple[int, int], list[int]] = {}
+        for lane, addr in enumerate(p.lane_addrs):
             r, c = divmod(addr, row_stride)
             if 0 <= r < layout_rows and 0 <= c < layout_cols:
-                touched.append((r, c))
-        # Dedupe touched (lanes broadcast the same cell — show once).
-        touched_uniq = sorted(set(touched))
+                touched_map.setdefault((r, c), []).append(lane)
+        touched_entries = [{"r": r, "c": c, "lanes": lanes} for (r, c), lanes in sorted(touched_map.items())]
         out.append(
             {
                 "panel_title": f"{p.stage_name} ← {p.buf}",
-                "formula": (
-                    f"{p.stage_class}({p.rows}×{p.cols})  "
-                    + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")
-                ),
+                "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
                 "lane_banks": p.lane_banks,
                 "lane_addr_idx": lane_addr_idx,
                 "n_unique_addrs": len(unique_addrs),
@@ -98,15 +95,14 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
                     "data_cols": p.cols,
                     "row_stride": row_stride,
                     "banks": smem_layout,
-                    "touched": [list(t) for t in touched_uniq],
+                    "touched": touched_entries,
+                    "index_expr": ", ".join(p.index_repr),
+                    "load_name": p.load_name,
                 },
                 "notes": [
                     f"index = ({', '.join(p.index_repr)})",
                     f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
-                    (
-                        f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}"
-                        f"  (vec={p.vec_group_size})"
-                    ),
+                    (f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}  (vec={p.vec_group_size})"),
                 ],
             }
         )
@@ -271,12 +267,12 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const lEl = document.getElementById(`l_${id}`);
     const ldr = echarts.init(lEl, null, {renderer:'canvas'});
     const ldrData = [];
-    const touchedSet = new Set(lay.touched.map(([r,c]) => `${r},${c}`));
+    const touchedMap = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes]));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
-        const isTouched = touchedSet.has(`${r},${c}`);
+        const isTouched = touchedMap.has(`${r},${c}`);
         const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
         ldrData.push({
           value:[c, r, bank],
@@ -289,6 +285,18 @@ PAYLOAD.columns.forEach((col,ci)=>{
         });
       }
     }
+    // Compact a sorted list of ints into a "0-15, 17, 22-25" form for
+    // the tooltip — readable when 16 lanes broadcast one cell.
+    const compactRanges = arr => {
+      if (!arr.length) return '';
+      const parts = []; let s = arr[0], e = arr[0];
+      for (let i = 1; i < arr.length; i++) {
+        if (arr[i] === e + 1) { e = arr[i]; }
+        else { parts.push(s === e ? `${s}` : `${s}-${e}`); s = arr[i]; e = arr[i]; }
+      }
+      parts.push(s === e ? `${s}` : `${s}-${e}`);
+      return parts.join(', ');
+    };
     ldr.setOption({
       backgroundColor:'transparent',
       tooltip:{
@@ -296,10 +304,17 @@ PAYLOAD.columns.forEach((col,ci)=>{
         textStyle:{color:'#e8eaed', fontSize:12},
         formatter: pt => {
           const [c, r, bank] = pt.value;
-          const t = touchedSet.has(`${r},${c}`) ? '<br/><span style="color:#fff">★ accessed by warp</span>' : '';
+          const lanes = touchedMap.get(`${r},${c}`);
           const padTag = (c >= lay.data_cols || r >= lay.data_rows)
             ? '<br/><span style="color:#6b7280">padding</span>' : '';
-          return `row=<b>${r}</b>, col=<b>${c}</b><br/>bank <b>${bank}</b>${t}${padTag}`;
+          let access = '';
+          if (lanes) {
+            access =
+              `<br/><span style="color:#fff">★ accessed by warp</span>` +
+              `<br/>load <code style="color:#7dd3fc">${lay.load_name}[${lay.index_expr}]</code>` +
+              `<br/>lanes: <b>${compactRanges(lanes)}</b> (${lanes.length}×)`;
+          }
+          return `row=<b>${r}</b>, col=<b>${c}</b><br/>bank <b>${bank}</b>${access}${padTag}`;
         },
       },
       grid:{left:38, right:8, top:6, bottom:24},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -48,10 +48,11 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
     union_source = all_panels_for_union if all_panels_for_union is not None else panels
     # Build per-Stage union: (tile_op_name, stage_name) → {(r,c) → list of
     # (load_name, k_iter, lane, subst_idx_tuple)} merged across all body
-    # Loads of the Stage. Also a per-Stage set of cells that participate
-    # in a real conflict in any of the Stage's Loads.
+    # Loads of the Stage. Also a per-cell map of Loads whose LDS conflicts
+    # when touching that cell (so the tooltip can flag conflicts on the
+    # focused Load specifically).
     stage_union: dict[tuple[str, str], dict[tuple[int, int], list[tuple]]] = {}
-    stage_conflict_cells: dict[tuple[str, str], set[tuple[int, int]]] = {}
+    stage_conflict_loads: dict[tuple[str, str], dict[tuple[int, int], set[str]]] = {}
     for p in union_source:
         key = (p.tile_op_name, p.stage_name)
         u = stage_union.setdefault(key, {})
@@ -59,7 +60,9 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
             subst = p.full_sweep_subst_idx.get(cell, ())
             for k, lane in pairs:
                 u.setdefault(cell, []).append((p.load_name, k, lane, subst))
-        stage_conflict_cells.setdefault(key, set()).update(p.full_sweep_conflict_cells)
+        cmap = stage_conflict_loads.setdefault(key, {})
+        for cell in p.full_sweep_conflict_cells:
+            cmap.setdefault(cell, set()).add(p.load_name)
     out: list[dict] = []
     for p in panels:
         # Per-lane address-color index: same address → same color, regardless
@@ -105,7 +108,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
             for ln, _k, _l, s in entries:
                 subst_per_cell.setdefault((r, c), {}).setdefault(ln, tuple(s))
         all_cells = sorted(set(touched_now) | set(sweep_per_cell))
-        conflict_cells = stage_conflict_cells.get((p.tile_op_name, p.stage_name), set())
+        conflict_loads = stage_conflict_loads.get((p.tile_op_name, p.stage_name), {})
         touched_entries = [
             {
                 "r": r,
@@ -115,9 +118,8 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
                 "sweep": sweep_per_cell.get((r, c), []),
                 # subst_by_load: {load_name: [substituted_index_string, ...]}
                 "subst_by_load": {ln: list(s) for ln, s in subst_per_cell.get((r, c), {}).items()},
-                # True iff this cell participates in a real conflict at
-                # some (Load, k_iter) — its bank had > 1 distinct address.
-                "conflict": (r, c) in conflict_cells,
+                # Loads whose LDS conflicts when touching this cell.
+                "conflict_loads": sorted(conflict_loads.get((r, c), set())),
             }
             for (r, c) in all_cells
         ]
@@ -321,6 +323,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const focusCells = new Set(
       lay.touched.filter(t => t.subst_by_load && t.subst_by_load[focusLoad]).map(t => `${t.r},${t.c}`)
     );
+    const conflictLoadsByCell = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.conflict_loads || []]));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
@@ -362,7 +365,21 @@ PAYLOAD.columns.forEach((col,ci)=>{
             ([ln, subst]) => `<code style="color:#3ddc84">${ln}[${subst.join(', ')}]</code>`
           );
           const loadSection = substLines.length ? `<br/>${substLines.join('<br/>')}` : '';
-          return head + loadSection + padTag;
+          const conflicts = conflictLoadsByCell.get(k) || [];
+          let conflictTag = '';
+          if (conflicts.length) {
+            const inFocus = conflicts.includes(focusLoad);
+            const others = conflicts.filter(l => l !== focusLoad);
+            if (inFocus) {
+              conflictTag = `<br/><span style="color:#ff5c7a">⚠ conflict in <b>${focusLoad}</b>'s LDS at this k_iter</span>`;
+              if (others.length) {
+                conflictTag += `<br/><span style="color:#6b7280">(also: ${others.join(', ')})</span>`;
+              }
+            } else {
+              conflictTag = `<br/><span style="color:#ffb454">⚠ conflict in: ${conflicts.join(', ')}</span>`;
+            }
+          }
+          return head + loadSection + conflictTag + padTag;
         },
       },
       grid:{left:30, right:14, top:6, bottom:18},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -172,7 +172,10 @@ HTML = """<!doctype html>
   html,body{margin:0;background:transparent;color:var(--fg);
     font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
   .page{max-width:100%;margin:0;padding:0;}
-  .columns{display:grid;grid-template-columns:repeat(__NCOL__,1fr);gap:8px;}
+  /* Auto-sized columns: each column shrinks to its content width
+     (the punchcard / ladder), so the whole grid is no wider than the
+     plots need. Centered if the page has more horizontal room. */
+  .columns{display:grid;grid-template-columns:repeat(__NCOL__,auto);gap:16px;justify-content:center;}
   .col-head{text-align:center;font-size:11px;text-transform:uppercase;letter-spacing:.16em;
     color:var(--muted);padding:4px 0 6px;margin-bottom:6px;border-bottom:1px solid rgba(255,255,255,.06);}
   .col-head .label{color:#7dd3fc;font-weight:600;}

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -37,49 +37,31 @@ def graph_from_ir_path(path: str) -> Graph:
 
 
 def _serialize(panels: list[BankConflictResult]) -> list[dict]:
-    out: list[dict] = []
-    for p in panels:
-        # Per-bank stack of (address, lane_count) — the conventional view
-        # where stacked boxes in one column are literal bank conflicts.
-        bank_stacks: list[list[tuple[int, int]]] = [[] for _ in range(32)]
-        addr_lane_counts: dict[tuple[int, int], int] = {}
-        for lane, (bank, addr) in enumerate(zip(p.lane_banks, p.lane_addrs, strict=True)):
-            del lane
-            addr_lane_counts[(bank, addr)] = addr_lane_counts.get((bank, addr), 0) + 1
-        for (bank, addr), n_lanes in addr_lane_counts.items():
-            bank_stacks[bank].append((addr, n_lanes))
-        for stack in bank_stacks:
-            stack.sort()
-        out.append(
-            {
-                "panel_title": f"{p.stage_name} ← {p.buf}",
-                "formula": (
-                    f"{p.stage_class}({p.rows}×{p.cols})  "
-                    + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")
-                ),
-                "bank_stacks": [[list(t) for t in stack] for stack in bank_stacks],
-                "distinct_addrs": p.distinct_addrs,
-                "max_way": p.max_way,
-                "raw_max_way": p.raw_max_way,
-                "conflict_events": p.conflict_events,
-                "lds128_events": p.lds128_events,
-                "vec_group_size": p.vec_group_size,
-                "avg_way": p.avg_way,
-                "rows": p.rows,
-                "cols": p.cols,
-                "pad": list(p.pad),
-                "smem_bytes": p.smem_bytes,
-                "notes": [
-                    f"index = ({', '.join(p.index_repr)})",
-                    f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
-                    (
-                        f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}"
-                        f"  (vec={p.vec_group_size})"
-                    ),
-                ],
-            }
-        )
-    return out
+    return [
+        {
+            "panel_title": f"{p.stage_name} ← {p.buf}",
+            "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
+            "lane_banks": p.lane_banks,
+            "counts": p.counts,
+            "distinct_addrs": p.distinct_addrs,
+            "max_way": p.max_way,
+            "raw_max_way": p.raw_max_way,
+            "conflict_events": p.conflict_events,
+            "lds128_events": p.lds128_events,
+            "vec_group_size": p.vec_group_size,
+            "avg_way": p.avg_way,
+            "rows": p.rows,
+            "cols": p.cols,
+            "pad": list(p.pad),
+            "smem_bytes": p.smem_bytes,
+            "notes": [
+                f"index = ({', '.join(p.index_repr)})",
+                f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
+                (f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}  (vec={p.vec_group_size})"),
+            ],
+        }
+        for p in panels
+    ]
 
 
 HTML = """<!doctype html>
@@ -160,70 +142,39 @@ PAYLOAD.columns.forEach((col,ci)=>{
       <div class="card-formula">${p.formula}</div>
       <span class="card-verdict ${verdict(p.max_way)}"><span class="dot"></span>
         max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
-      <div class="matrix" id="m_${id}" style="height:${Math.min(240, 32 + Math.max(...p.distinct_addrs) * 22)}px"></div>
+      <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="card-notes">${p.notes.join('<br/>')}</div>`;
     colEl.appendChild(card);
 
-    // Conventional bank-conflict view: one box per UNIQUE address per
-    // bank, stacked vertically. Multiple boxes in the same column =
-    // serialized accesses (real bank conflict). Box label = lane count
-    // broadcasting that address.
     const m=echarts.init(document.getElementById(`m_${id}`),null,{renderer:'canvas'});
-    const maxStack = Math.max(1, ...p.distinct_addrs);
     const md=[];
-    for (let bank = 0; bank < BANKS; bank++) {
-      const stack = p.bank_stacks[bank];
-      const distinct = stack.length;
-      stack.forEach(([addr, lanes], slot) => {
-        md.push({
-          value: [bank, slot, distinct],
-          name: `bank ${bank}`,
-          addr: addr,
-          lanes: lanes,
-          distinct: distinct,
-          itemStyle: {color: cellColor(distinct), shadowBlur: 6, shadowColor: cellColor(distinct)+'66'},
-        });
-      });
-    }
+    for(let l=0;l<WARP;l++) for(let b=0;b<BANKS;b++)
+      md.push({value:[b,l,0],itemStyle:{color:palette.empty}});
+    p.lane_banks.forEach((bank,lane)=>{
+      // Color cells by distinct_addrs at that bank — broadcasts (multiple
+      // lanes at same address) are NOT conflicts and stay green.
+      const c=p.distinct_addrs[bank];
+      md.push({value:[bank,lane,c],itemStyle:{color:cellColor(c),shadowBlur:6,shadowColor:cellColor(c)+'88'}});
+    });
     m.setOption({
       backgroundColor:'transparent',
-      tooltip:{
-        backgroundColor:'#0e1014', borderColor:'#2a2d33',
-        textStyle:{color:'#e8eaed', fontSize:12},
-        formatter: pt => {
-          const d = pt.data;
-          const tag = d.distinct === 1
-            ? `<span style="color:#3ddc84">1 distinct addr — no conflict</span>`
-            : `<span style="color:${d.distinct <= 4 ? '#ffb454':'#ff5c7a'}">${d.distinct}-way conflict</span>`;
-          return `bank <b>${pt.value[0]}</b>, addr <b>${d.addr}</b><br/>` +
-                 `lanes broadcasting this addr: <b>${d.lanes}</b><br/>${tag}`;
-        },
-      },
-      grid:{left:38, right:8, top:8, bottom:28},
-      xAxis:{
-        type:'category', data:[...Array(BANKS).keys()],
-        name:'bank', nameLocation:'middle', nameGap:22,
-        nameTextStyle:{color:'#6b7280', fontSize:11},
-        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:10, interval:3},
-      },
-      yAxis:{
-        type:'category', data:[...Array(maxStack).keys()],
-        name:'distinct addr', nameLocation:'middle', nameGap:28,
-        nameTextStyle:{color:'#6b7280', fontSize:11},
-        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:10},
-      },
-      series:[{
-        type:'heatmap', data: md, progressive:0,
-        label:{show: true, color:'#0e1014', fontSize: 10, fontWeight: 600,
-               formatter: pp => `${pp.data.lanes}`},
-        itemStyle:{borderRadius:3, borderColor:'#161a21', borderWidth:1},
-        emphasis:{itemStyle:{borderColor:'#fff', borderWidth:1.5}},
-        animationDuration:500, animationEasing:'cubicOut',
-      }],
-    });
+      tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
+        formatter:pt=>{const [b,l,c]=pt.value;
+          return c===0?`bank ${b}<br/><span style="color:#6b7280">no lane</span>`
+                      :`lane <b>${l}</b> → bank <b>${b}</b><br/>contention: <b>${c}</b> lane(s)`;}},
+      grid:{left:38,right:8,top:8,bottom:28},
+      xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
+        nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},
+        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+      yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
+        nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:11},
+        axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
+        axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+      series:[{type:'heatmap',data:md,progressive:0,
+        itemStyle:{borderRadius:2,borderColor:'#161a21',borderWidth:1},
+        emphasis:{itemStyle:{borderColor:'#fff',borderWidth:1.5}},
+        animationDuration:500,animationEasing:'cubicOut'}]});
 
     const h=echarts.init(document.getElementById(`h_${id}`),null,{renderer:'canvas'});
     h.setOption({

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -185,7 +185,10 @@ HTML = """<!doctype html>
   .v-ok{color:#3ddc84;} .v-ok .dot{background:#3ddc84;}
   .v-warn{color:#ffb454;} .v-warn .dot{background:#ffb454;}
   .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
-  .matrix{width:100%;height:200px;margin-bottom:10px;}
+  /* Square punchcard: 32 banks × 32 lanes is intrinsically square
+     data. Capping width keeps cells visibly square instead of squashed
+     wide rectangles when the container is stretched. */
+  .matrix{width:100%;max-width:320px;aspect-ratio:1/1;height:auto;margin:0 auto 10px;}
   .hist{width:100%;height:80px;margin-top:2px;}
   .ladder{width:100%;margin-top:4px;}
   .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -302,10 +302,6 @@ PAYLOAD.columns.forEach((col,ci)=>{
             color: color,
             // Padding: very dim. Reachable-but-not-now: medium. Now: full.
             opacity: isPad ? 0.18 : (accessedNow ? 1.0 : (reachable ? 0.55 : 0.18)),
-            borderColor: accessedNow ? '#ffffff' : 'transparent',
-            borderWidth: accessedNow ? 2 : 0,
-            shadowBlur: accessedNow ? 8 : 0,
-            shadowColor: accessedNow ? '#ffffffaa' : 'transparent',
           },
         });
       }
@@ -363,12 +359,16 @@ PAYLOAD.columns.forEach((col,ci)=>{
             padTag;
         },
       },
-      grid:{left:8, right:8, top:6, bottom:8},
+      grid:{left:30, right:8, top:6, bottom:18},
       xAxis:{
-        type:'category', data:[...Array(lay.cols).keys()], show: false,
+        type:'category', data:[...Array(lay.cols).keys()],
+        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.cols/8) - 1)},
       },
       yAxis:{
-        type:'category', data:[...Array(lay.rows).keys()], inverse:true, show: false,
+        type:'category', data:[...Array(lay.rows).keys()], inverse:true,
+        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.rows/8) - 1)},
       },
       series:[{
         type:'heatmap', data: ldrData, progressive: 0,

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -1,192 +1,270 @@
-"""Visualize smem bank conflicts under different swizzle strategies.
+"""Bank-conflict visualizer driven by real Tile-IR ``Stage``s.
 
-Simulates a warp's 32 lanes accessing a 2D smem stage at one inner-loop
-iteration, applies a chosen swizzle formula to the column index, and
-plots three panels comparing:
+Each input contributes one column. Within a column, every ``Stage`` ×
+``Load`` pair gets a card showing the warp's per-lane smem bank at one
+fixed inner-loop iteration. The simulation lives in
+``deplodock.compiler.diagnostics.bank_conflicts``; this script is a
+thin CLI + ECharts emitter.
 
-(a) No swizzle (TMA default).
-(b) Hardware swizzle (TMA_SWIZZLE=1 with the hardware-fixed XOR).
-(c) Per-lane K-rotation (proposed software fix).
+Modes:
 
-Each panel shows:
+  --ir PATH[:LABEL] (repeatable)
+      Load JSON dumps produced under ``DEPLODOCK_DUMP_DIR`` (any
+      post-tile-pass dump that contains ``TileOp`` nodes — typically
+      ``07_*_stage_inputs.json`` or later).
 
-- A *lane → bank* matrix (32×32). Cell (l, b) is filled if lane ``l``
-  lands in bank ``b``. Multiple lanes in one column = conflict.
-- A bank histogram (lanes-per-bank).
-
-Defaults match the matmul_add tile shape we've been profiling:
-``(rows=128, cols=16)``, lanes index rows at stride 4 (``F_M=4``).
+  --chunk-reduce-diff [--seq-len N]
+      Run the tile pipeline live on an SDPA(B=1, H=8, seq=N, d=64)
+      graph twice — with and without ``006_chunk_reduce`` enabled
+      (gated via ``DEPLODOCK_DISABLE_CHUNK_REDUCE``) — and compare.
 """
 
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
-from dataclasses import dataclass
+import json
+import os
 
-import matplotlib.patches as mpatches
-import matplotlib.pyplot as plt
-import numpy as np
-
-WARP_SIZE = 32
-BANKS = 32
-
-
-@dataclass
-class AccessPattern:
-    """``(lane, k_iter) → (row, col)`` mapping for a 2D smem stage."""
-
-    rows: int
-    cols: int
-    row_fn: Callable[[int, int], int]
-    col_fn: Callable[[int, int], int]
+from deplodock.compiler.diagnostics.bank_conflicts import BankConflictResult, simulate_graph
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.frontend.ir import SdpaOp
+from deplodock.compiler.pipeline import TILE_PASSES, run_pipeline
 
 
-def warp_banks(pat: AccessPattern, k_iter: int, swizzle: Callable[[int, int, int], int]) -> list[int]:
-    """Per-lane bank id for the warp at iteration ``k_iter``."""
-    banks = []
-    for lane in range(WARP_SIZE):
-        row = pat.row_fn(lane, k_iter)
-        col = pat.col_fn(lane, k_iter)
-        col_phys = swizzle(lane, row, col)
-        addr = row * pat.cols + col_phys
-        banks.append(addr % BANKS)
-    return banks
+def graph_from_ir_path(path: str) -> Graph:
+    with open(path) as f:
+        return Graph.from_dict(json.load(f))
 
 
-def plot_panel(ax_matrix, ax_hist, banks: list[int], title: str, formula: str) -> None:
-    """Two stacked subplots: lane→bank matrix, bank histogram."""
-    matrix = np.zeros((WARP_SIZE, BANKS), dtype=int)
-    for lane, bank in enumerate(banks):
-        matrix[lane, bank] = 1
-    ax_matrix.imshow(matrix, cmap="Greens", aspect="equal", vmin=0, vmax=1)
-    ax_matrix.set_xticks(range(0, BANKS, 4))
-    ax_matrix.set_yticks(range(0, WARP_SIZE, 4))
-    ax_matrix.set_xlabel("bank id")
-    ax_matrix.set_ylabel("lane id")
-    ax_matrix.grid(which="major", color="#cccccc", linewidth=0.3, alpha=0.5)
-    ax_matrix.set_axisbelow(True)
-    ax_matrix.set_title(f"{title}\n{formula}", fontsize=10)
+def graph_from_sdpa(seq_len: int, disable_chunk_reduce: bool) -> Graph:
+    g = Graph()
+    for name in ("q", "k", "v"):
+        g.add_node(InputOp(), [], Tensor(name, (1, 8, seq_len, 64)), node_id=name)
+    g.add_node(SdpaOp(), ["q", "k", "v"], Tensor("o", (1, 8, seq_len, 64)), node_id="o")
+    g.inputs = ["q", "k", "v"]
+    g.outputs = ["o"]
+    prev = os.environ.get("DEPLODOCK_DISABLE_CHUNK_REDUCE")
+    os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = "1" if disable_chunk_reduce else "0"
+    try:
+        run_pipeline(g, TILE_PASSES)
+    finally:
+        if prev is None:
+            del os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"]
+        else:
+            os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = prev
+    return g
 
-    bank_counts = [0] * BANKS
-    for bank in banks:
-        bank_counts[bank] += 1
-    max_way = max(bank_counts)
-    avg_way = sum(c for c in bank_counts if c > 0) / sum(1 for c in bank_counts if c > 0)
-    colors = ["#d62728" if c > 1 else "#2ca02c" if c == 1 else "#dddddd" for c in bank_counts]
-    ax_hist.bar(range(BANKS), bank_counts, color=colors)
-    ax_hist.set_xlim(-0.5, BANKS - 0.5)
-    ax_hist.set_ylim(0, max(max_way, 4) + 0.5)
-    ax_hist.axhline(1, color="gray", linestyle="--", linewidth=0.7, alpha=0.5)
-    verdict_color = "#d62728" if max_way > 4 else "#ff7f0e" if max_way > 1 else "#2ca02c"
-    ax_hist.set_title(
-        f"max-way conflict: {max_way}   (avg {avg_way:.1f} lane/bank)",
-        fontsize=10,
-        color=verdict_color,
-        weight="bold",
+
+def _serialize(panels: list[BankConflictResult]) -> list[dict]:
+    return [
+        {
+            "panel_title": f"{p.stage_name} ← {p.buf}",
+            "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
+            "lane_banks": p.lane_banks,
+            "counts": p.counts,
+            "max_way": p.max_way,
+            "avg_way": p.avg_way,
+            "rows": p.rows,
+            "cols": p.cols,
+            "pad": list(p.pad),
+            "smem_bytes": p.smem_bytes,
+            "notes": [
+                f"index = ({', '.join(p.index_repr)})",
+                f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
+            ],
+        }
+        for p in panels
+    ]
+
+
+HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>smem bank conflicts (IR-driven)</title>
+<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
+<style>
+  :root { --bg:#0e1014; --panel:#161a21; --panel-2:#1c212b; --fg:#e8eaed; --muted:#6b7280; }
+  *{box-sizing:border-box;}
+  html,body{margin:0;background:var(--bg);color:var(--fg);
+    font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
+  .page{max-width:__MAXW__px;margin:0 auto;padding:48px 32px;}
+  .eyebrow{text-transform:uppercase;letter-spacing:.18em;font-size:11px;color:var(--muted);margin-bottom:8px;}
+  h1{font-size:28px;font-weight:600;margin:0 0 6px;letter-spacing:-.01em;}
+  .subtitle{color:var(--muted);font-size:14px;margin-bottom:36px;}
+  .columns{display:grid;grid-template-columns:repeat(__NCOL__,1fr);gap:22px;}
+  .col-head{text-align:center;font-size:12px;text-transform:uppercase;letter-spacing:.18em;
+    color:var(--muted);padding:8px 0;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,.06);}
+  .col-head .label{color:#7dd3fc;font-weight:600;}
+  .card{background:linear-gradient(180deg,var(--panel),var(--panel-2));
+    border:1px solid rgba(255,255,255,.04);border-radius:14px;padding:18px 16px 12px;
+    box-shadow:0 1px 0 rgba(255,255,255,.03) inset,0 8px 24px rgba(0,0,0,.35);margin-bottom:16px;}
+  .card-title{font-size:14px;font-weight:600;letter-spacing:-.01em;}
+  .card-formula{font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;color:var(--muted);margin-top:4px;}
+  .card-notes{font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:var(--muted);margin-top:6px;line-height:1.55;}
+  .card-verdict{display:inline-flex;align-items:center;gap:6px;margin-top:10px;padding:4px 10px;
+    border-radius:999px;font-size:12px;font-weight:600;background:rgba(255,255,255,.04);}
+  .dot{width:6px;height:6px;border-radius:50%;}
+  .v-ok{color:#3ddc84;} .v-ok .dot{background:#3ddc84;}
+  .v-warn{color:#ffb454;} .v-warn .dot{background:#ffb454;}
+  .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
+  .matrix{width:100%;height:240px;}
+  .hist{width:100%;height:100px;margin-top:4px;}
+  .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
+    background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
+  .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
+  .legend span{display:inline-flex;align-items:center;gap:8px;}
+  .legend i{width:10px;height:10px;border-radius:3px;display:inline-block;}
+</style>
+</head>
+<body>
+  <div class="page">
+    <div class="eyebrow">tile-IR bank-conflict probe</div>
+    <h1>smem bank conflicts</h1>
+    <div class="subtitle">__SUBTITLE__</div>
+    <div class="columns" id="columns"></div>
+    <div class="legend">
+      <span><i style="background:#3ddc84"></i> 1 lane (no conflict)</span>
+      <span><i style="background:#ffb454"></i> 2–4 lanes (mild)</span>
+      <span><i style="background:#ff5c7a"></i> &gt;4 lanes (heavy)</span>
+      <span><i style="background:#2a2d33"></i> 0 lanes</span>
+    </div>
+  </div>
+<script>
+const PAYLOAD = __PAYLOAD__;
+const WARP=32, BANKS=32;
+const palette={empty:'#2a2d33',ok:'#3ddc84',warn:'#ffb454',bad:'#ff5c7a'};
+const cellColor=c=>c===0?palette.empty:c===1?palette.ok:c<=4?palette.warn:palette.bad;
+const verdict=m=>m>4?'v-bad':m>1?'v-warn':'v-ok';
+
+const root=document.getElementById('columns');
+PAYLOAD.columns.forEach((col,ci)=>{
+  const colEl=document.createElement('div');
+  colEl.innerHTML=`<div class="col-head"><span class="label">${col.label}</span></div>`;
+  if(col.panels.length===0){
+    const e=document.createElement('div');e.className='empty';e.textContent='no Stages found';
+    colEl.appendChild(e);
+  }
+  col.panels.forEach((p,pi)=>{
+    const id=`c${ci}_p${pi}`;
+    const card=document.createElement('div');card.className='card';
+    card.innerHTML=`
+      <div class="card-title">${p.panel_title}</div>
+      <div class="card-formula">${p.formula}</div>
+      <span class="card-verdict ${verdict(p.max_way)}"><span class="dot"></span>
+        max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
+      <div class="matrix" id="m_${id}"></div>
+      <div class="hist" id="h_${id}"></div>
+      <div class="card-notes">${p.notes.join('<br/>')}</div>`;
+    colEl.appendChild(card);
+
+    const m=echarts.init(document.getElementById(`m_${id}`),null,{renderer:'canvas'});
+    const md=[];
+    for(let l=0;l<WARP;l++) for(let b=0;b<BANKS;b++)
+      md.push({value:[b,l,0],itemStyle:{color:palette.empty}});
+    p.lane_banks.forEach((bank,lane)=>{
+      const c=p.counts[bank];
+      md.push({value:[bank,lane,c],itemStyle:{color:cellColor(c),shadowBlur:6,shadowColor:cellColor(c)+'88'}});
+    });
+    m.setOption({
+      backgroundColor:'transparent',
+      tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
+        formatter:pt=>{const [b,l,c]=pt.value;
+          return c===0?`bank ${b}<br/><span style="color:#6b7280">no lane</span>`
+                      :`lane <b>${l}</b> → bank <b>${b}</b><br/>contention: <b>${c}</b> lane(s)`;}},
+      grid:{left:38,right:8,top:8,bottom:28},
+      xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
+        nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},
+        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+      yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
+        nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:11},
+        axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
+        axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+      series:[{type:'heatmap',data:md,progressive:0,
+        itemStyle:{borderRadius:2,borderColor:'#161a21',borderWidth:1},
+        emphasis:{itemStyle:{borderColor:'#fff',borderWidth:1.5}},
+        animationDuration:500,animationEasing:'cubicOut'}]});
+
+    const h=echarts.init(document.getElementById(`h_${id}`),null,{renderer:'canvas'});
+    h.setOption({
+      backgroundColor:'transparent',
+      tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
+        formatter:pt=>`bank <b>${pt.name}</b><br/>${pt.value} lane(s)`},
+      grid:{left:38,right:8,top:6,bottom:22},
+      xAxis:{type:'category',data:[...Array(BANKS).keys()],
+        axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
+        axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+      yAxis:{type:'value',splitLine:{lineStyle:{color:'#1c212b'}},
+        axisLabel:{color:'#6b7280',fontSize:10},axisLine:{show:false},axisTick:{show:false}},
+      series:[{type:'bar',data:p.counts.map(c=>({value:c,itemStyle:{
+        color:{type:'linear',x:0,y:0,x2:0,y2:1,
+          colorStops:[{offset:0,color:cellColor(c)},{offset:1,color:cellColor(c)+'55'}]},
+        borderRadius:[3,3,0,0]}})),barWidth:'70%',
+        animationDuration:600,animationEasing:'cubicOut'}]});
+    window.addEventListener('resize',()=>{m.resize();h.resize();});
+  });
+  root.appendChild(colEl);
+});
+</script>
+</body>
+</html>
+"""
+
+
+def emit_html(columns: list[dict], subtitle: str, out_path: str) -> None:
+    n = max(1, len(columns))
+    html = (
+        HTML.replace("__MAXW__", str(min(2200, 480 * n + 80)))
+        .replace("__NCOL__", str(n))
+        .replace("__SUBTITLE__", subtitle)
+        .replace("__PAYLOAD__", json.dumps({"columns": columns}))
     )
-    ax_hist.set_xlabel("bank id")
-    ax_hist.set_ylabel("# lanes")
+    with open(out_path, "w") as f:
+        f.write(html)
+
+
+def _parse_ir_arg(arg: str) -> tuple[str, str]:
+    if ":" in arg:
+        path, label = arg.rsplit(":", 1)
+        return path, label
+    return arg, os.path.basename(arg)
 
 
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--rows", type=int, default=128, help="stage rows (BM or BN)")
-    p.add_argument("--cols", type=int, default=16, help="stage cols (BK)")
-    p.add_argument(
-        "--lane-stride",
-        type=int,
-        default=4,
-        help="lanes index rows at this stride (F_M / F_N register-tile factor)",
-    )
-    p.add_argument("--k-iter", type=int, default=0, help="K-loop iteration to visualize")
-    p.add_argument("--out", default="/tmp/bank_conflicts.png", help="output PNG path")
-    p.add_argument(
-        "--lane-axis",
-        choices=("row", "col"),
-        default="row",
-        help=(
-            "Which slab axis the warp lanes stride over. "
-            "'row' = a_smem-style (lane*F_M indexes rows, k_iter is col); "
-            "'col' = b_smem-style (lane*F_N indexes cols, k_iter is row)."
-        ),
-    )
+    p.add_argument("--ir", action="append", default=[], help="PATH[:LABEL] — repeatable")
+    p.add_argument("--chunk-reduce-diff", action="store_true", help="Run pipeline live with/without chunk_reduce on SDPA")
+    p.add_argument("--seq-len", type=int, default=512)
+    p.add_argument("--stage", action="append", default=[], help="filter Stage names (repeatable)")
+    p.add_argument("--k-iter", type=int, default=0)
+    p.add_argument("--warp-id", type=int, default=0)
+    p.add_argument("--out", default="/tmp/bank_conflicts.html")
     args = p.parse_args()
 
-    if args.lane_axis == "row":
-        pat = AccessPattern(
-            rows=args.rows,
-            cols=args.cols,
-            row_fn=lambda lane, k: (lane * args.lane_stride) % args.rows,
-            col_fn=lambda lane, k: k,
-        )
+    stage_filter = set(args.stage) if args.stage else None
+    columns: list[dict] = []
+
+    if args.chunk_reduce_diff:
+        for label, disabled in (("chunk_reduce ENABLED", False), ("chunk_reduce DISABLED", True)):
+            print(f"running pipeline: {label}...")
+            g = graph_from_sdpa(args.seq_len, disable_chunk_reduce=disabled)
+            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id)
+            print(f"  → {len(panels)} stage probe(s)")
+            columns.append({"label": label, "panels": _serialize(panels)})
+        subtitle = f"SDPA(B=1, H=8, seq={args.seq_len}, d=64) · k_iter={args.k_iter} · warp={args.warp_id}"
+    elif args.ir:
+        for arg in args.ir:
+            path, label = _parse_ir_arg(arg)
+            g = graph_from_ir_path(path)
+            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id)
+            print(f"{label}: {len(panels)} stage probe(s)")
+            columns.append({"label": label, "panels": _serialize(panels)})
+        subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"
     else:
-        pat = AccessPattern(
-            rows=args.rows,
-            cols=args.cols,
-            row_fn=lambda lane, k: k,
-            col_fn=lambda lane, k: (lane * args.lane_stride) % args.cols,
-        )
+        p.error("provide --ir PATH (repeatable) or --chunk-reduce-diff")
 
-    def no_swizzle(lane: int, row: int, col: int) -> int:
-        return col
-
-    def hw_b64_swizzle(lane: int, row: int, col: int) -> int:
-        return col ^ ((row & 6) * 2)
-
-    bk_mask = args.cols - 1
-
-    def k_rotation(lane: int, row: int, col: int) -> int:
-        # Per-lane rotate. Useful when lanes stride rows: XOR by lane breaks the
-        # uniform-bank pattern caused by lane*stride mod 32 = 0.
-        return col ^ (lane & bk_mask)
-
-    def col_xor_high(lane: int, row: int, col: int) -> int:
-        # Storage-time XOR depending only on col. Drives the b_smem (lanes-
-        # stride-cols) pattern to 1-way for any (BN, F_N) where BN ≥ 32 and
-        # F_N · 32 ≤ BN. Key idea: col mod 32 repeats every WARP cols, so
-        # cols (lane*F_N+c) and ((lane+WARP/F_N)*F_N+c) collide on banks.
-        # XOR-ing in (col >> 5) injects col's high bits into the bank, which
-        # differ between the colliding lanes (they live in distinct 32-col
-        # strips). Bijective per row, so it's safe to apply symmetrically at
-        # store time and load time.
-        return col ^ (col >> 5)
-
-    panels = [
-        ("(a) No swizzle", "col_phys = col", no_swizzle),
-        ("(b) HW B64 swizzle", "col_phys = col ⊕ ((row & 6) · 2)", hw_b64_swizzle),
-        (
-            "(c) Per-lane K-rotation",
-            f"col_phys = col ⊕ (lane & {bk_mask})",
-            k_rotation,
-        ),
-        (
-            "(d) Col-only XOR swizzle",
-            "col_phys = col ⊕ (col >> 5)",
-            col_xor_high,
-        ),
-    ]
-
-    n = len(panels)
-    fig, axes = plt.subplots(2, n, figsize=(5 * n, 8), gridspec_kw={"height_ratios": [4, 1]})
-    for col_idx, (title, formula, swizzle) in enumerate(panels):
-        banks = warp_banks(pat, args.k_iter, swizzle)
-        plot_panel(axes[0, col_idx], axes[1, col_idx], banks, title, formula)
-
-    axis_desc = "rows" if args.lane_axis == "row" else "cols"
-    fig.suptitle(
-        f"smem bank conflicts at stage ({args.rows}×{args.cols}), "
-        f"lanes index {axis_desc} at stride {args.lane_stride}, k_iter = {args.k_iter}",
-        fontsize=12,
-    )
-    legend = [
-        mpatches.Patch(color="#2ca02c", label="1 lane (no conflict)"),
-        mpatches.Patch(color="#d62728", label=">1 lane (conflict)"),
-        mpatches.Patch(color="#dddddd", label="0 lanes"),
-    ]
-    fig.legend(handles=legend, loc="lower center", ncol=3, bbox_to_anchor=(0.5, -0.01))
-    plt.tight_layout(rect=(0, 0.03, 1, 0.97))
-    plt.savefig(args.out, dpi=130, bbox_inches="tight")
+    emit_html(columns, subtitle, args.out)
     print(f"saved {args.out}")
 
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -119,8 +119,6 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
                 },
                 "notes": [
                     f"index = ({', '.join(p.index_repr)})",
-                    f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
-                    (f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}  (vec={p.vec_group_size})"),
                 ],
             }
         )
@@ -215,7 +213,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
         max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
-      <div class="ladder-title">smem layout — bank per (row,col); hover the highlighted cells for load expr + lanes</div>
+      <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
       <div class="card-notes">${p.notes.join('<br/>')}</div>`;
     colEl.appendChild(card);
@@ -365,20 +363,12 @@ PAYLOAD.columns.forEach((col,ci)=>{
             padTag;
         },
       },
-      grid:{left:38, right:8, top:6, bottom:24},
+      grid:{left:8, right:8, top:6, bottom:8},
       xAxis:{
-        type:'category', data:[...Array(lay.cols).keys()],
-        name:'col', nameLocation:'middle', nameGap:18,
-        nameTextStyle:{color:'#6b7280', fontSize:10},
-        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.cols/8) - 1)},
+        type:'category', data:[...Array(lay.cols).keys()], show: false,
       },
       yAxis:{
-        type:'category', data:[...Array(lay.rows).keys()], inverse:true,
-        name:'row', nameLocation:'middle', nameGap:24,
-        nameTextStyle:{color:'#6b7280', fontSize:10},
-        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.rows/8) - 1)},
+        type:'category', data:[...Array(lay.rows).keys()], inverse:true, show: false,
       },
       series:[{
         type:'heatmap', data: ldrData, progressive: 0,

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -194,6 +194,7 @@ HTML = """<!doctype html>
     font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
   .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}
   .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
+  .bank-legend-shared{margin-top:14px;font-size:10px;}
   .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:6px;
     font-size:10px;color:var(--muted);}
   .hist-legend span{display:inline-flex;align-items:center;gap:5px;}
@@ -208,6 +209,7 @@ HTML = """<!doctype html>
 <body>
   <div class="page">
     <div class="columns" id="columns"></div>
+    <div class="bank-legend bank-legend-shared" id="shared-bank-legend"></div>
   </div>
 <script>
 const PAYLOAD = __PAYLOAD__;
@@ -255,7 +257,6 @@ PAYLOAD.columns.forEach((col,ci)=>{
       </div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
-      <div class="bank-legend" id="bl_${id}"></div>
       ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);
 
@@ -418,23 +419,27 @@ PAYLOAD.columns.forEach((col,ci)=>{
         animationDuration:400, animationEasing:'cubicOut',
       }],
     });
-    // Bank-color legend below the ladder. Only shows banks that
-    // actually appear in the smem layout (typically 0..31, but the
-    // legend trims to the unique banks present). Compact horizontal
-    // chips with the BANK_PALETTE color + "bank N" label.
-    const banksUsed = new Set();
-    for (let r = 0; r < lay.rows; r++) {
-      for (let c = 0; c < lay.cols; c++) banksUsed.add(lay.banks[r][c]);
-    }
-    const legend = document.getElementById(`bl_${id}`);
-    [...banksUsed].sort((a,b)=>a-b).forEach(bank => {
-      const chip = document.createElement('span');
-      chip.innerHTML = `<i style="background:${BANK_PALETTE[bank % BANK_PALETTE.length]}"></i>bank ${bank}`;
-      legend.appendChild(chip);
-    });
     window.addEventListener('resize',()=>{m.resize();h.resize();ldr.resize();});
   });
 });
+
+// One shared bank-color legend below all columns. Renders 8×4 chips
+// for every bank that appears in any panel's layout.
+(() => {
+  const banksUsed = new Set();
+  PAYLOAD.columns.forEach(col => col.panels.forEach(p => {
+    for (let r = 0; r < p.layout.rows; r++) {
+      for (let c = 0; c < p.layout.cols; c++) banksUsed.add(p.layout.banks[r][c]);
+    }
+  }));
+  const host = document.getElementById('shared-bank-legend');
+  if (!host) return;
+  [...banksUsed].sort((a,b)=>a-b).forEach(bank => {
+    const chip = document.createElement('span');
+    chip.innerHTML = `<i style="background:${BANK_PALETTE[bank % BANK_PALETTE.length]}"></i>bank ${bank}`;
+    host.appendChild(chip);
+  });
+})();
 </script>
 </body>
 </html>

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -454,7 +454,7 @@ def main() -> None:
         print(f"{label}: {len(panels)} probes, ΣLDS.32={scalar_total}  ΣLDS.128={vec_total}")
         columns.append(
             {
-                "label": f"{label} · ΣLDS.32={scalar_total}  ΣLDS.128={vec_total}",
+                "label": label,
                 "panels": _serialize(panels, all_panels_for_union=union_panels),
             }
         )

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -205,22 +205,22 @@ HTML = """<!doctype html>
   /* Square punchcard: 32 banks × 32 lanes is intrinsically square
      data. Capping width keeps cells visibly square instead of
      squashed into wide rectangles when the container is stretched. */
-  .matrix{width:100%;max-width:400px;aspect-ratio:1/1;height:auto;margin:0 auto 12px;}
+  .matrix{width:100%;max-width:440px;aspect-ratio:1/1;height:auto;margin:0 auto 12px;}
   /* Histogram shares the bank axis with the punchcard above —
      match its max-width so banks line up vertically. */
-  .hist{width:100%;max-width:400px;height:100px;margin:2px auto 0;}
+  .hist{width:100%;max-width:440px;height:110px;margin:2px auto 0;}
   .ladder{margin:6px auto 0;}
   .ladder-title{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
     margin-top:12px;margin-bottom:6px;}
-  .bank-legend{display:grid;grid-template-columns:repeat(8,auto);gap:4px 14px;margin-top:10px;
-    width:fit-content;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:var(--muted);}
-  .bank-legend span{display:inline-flex;align-items:center;gap:5px;white-space:nowrap;}
-  .bank-legend i{width:10px;height:10px;border-radius:2px;display:inline-block;flex-shrink:0;}
-  .bank-legend-shared{margin-top:18px;font-size:12px;}
-  .hist-legend{display:flex;flex-wrap:wrap;gap:5px 16px;margin:8px auto 0;
-    width:fit-content;font-size:12px;color:var(--muted);}
-  .hist-legend span{display:inline-flex;align-items:center;gap:6px;}
-  .hist-legend i{width:11px;height:11px;border-radius:2px;display:inline-block;}
+  .bank-legend{display:grid;grid-template-columns:repeat(8,auto);gap:6px 18px;margin-top:10px;
+    width:fit-content;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:14px;color:var(--muted);}
+  .bank-legend span{display:inline-flex;align-items:center;gap:6px;white-space:nowrap;}
+  .bank-legend i{width:13px;height:13px;border-radius:2px;display:inline-block;flex-shrink:0;}
+  .bank-legend-shared{margin-top:18px;font-size:14px;}
+  .hist-legend{display:flex;flex-wrap:wrap;gap:6px 22px;margin:10px auto 0;
+    width:fit-content;font-size:14px;color:var(--muted);}
+  .hist-legend span{display:inline-flex;align-items:center;gap:7px;}
+  .hist-legend i{width:14px;height:14px;border-radius:2px;display:inline-block;}
   .hist-legend-shared{margin-top:14px;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
@@ -263,16 +263,14 @@ const ADDR_PALETTE=['#fde047','#fb923c','#ef4444','#a3a3a3','#facc15','#fdba74',
 // and per-column plot cells. We render rows of HTML strings into the
 // grid in the right order.
 const root = document.getElementById('page-grid');
-root.style.gridTemplateColumns = `repeat(${PAYLOAD.columns.length}, auto)`;
-
-// Pick the representative stage / buf from the first non-empty panel.
-const firstPanel = PAYLOAD.columns.flatMap(c => c.panels)[0];
-const bufLabel = firstPanel ? firstPanel.buf_short : '';
+// Fixed-width columns so the two punchcards/histograms render at the
+// same size regardless of how long the col-head labels are.
+root.style.gridTemplateColumns = `repeat(${PAYLOAD.columns.length}, 440px)`;
 
 // 1) Shared punchcard title (above the column headings).
 const punTitle = document.createElement('div');
 punTitle.className = 'section-title';
-punTitle.textContent = `bank access punchcard — ${bufLabel}`;
+punTitle.textContent = 'bank access punchcard — access per (lane, bank)';
 root.appendChild(punTitle);
 
 // 2) Column headings.
@@ -390,13 +388,12 @@ PAYLOAD.columns.forEach((col, ci) => {
                                    : `<span style="color:#ff5c7a">${dist}-way conflict</span>`;
           return `lane <b>${l}</b> → bank <b>${b}</b>, addr <b>${addr}</b><br/>${verdict}`;
         }},
-      grid:{left:38,right:8,top:8,bottom:42},
-      xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
-        nameTextStyle:{color:'#6b7280',fontSize:13},axisLine:{lineStyle:{color:THEME.axisLine}},
-        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
-      yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
-        nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:13},
-        axisLine:{lineStyle:{color:THEME.axisLine}},axisTick:{show:false},
+      grid:{left:30,right:8,top:8,bottom:22},
+      xAxis:{type:'category',data:[...Array(BANKS).keys()],
+        axisLine:{show:false},axisTick:{show:false},
+        axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
+      yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,
+        axisLine:{show:false},axisTick:{show:false},
         axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       series:[{type:'heatmap',data:md,progressive:0,
         itemStyle:{borderRadius:2},
@@ -410,7 +407,7 @@ PAYLOAD.columns.forEach((col, ci) => {
         formatter:pt=>`bank <b>${pt.name}</b><br/>${pt.value} lane(s)`},
       grid:{left:38,right:8,top:6,bottom:22},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],
-        axisLine:{lineStyle:{color:THEME.axisLine}},axisTick:{show:false},
+        axisLine:{show:false},axisTick:{show:false},
         axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       yAxis:{type:'value',min:0,max:8,splitLine:{lineStyle:{color:THEME.splitLine}},
         axisLabel:{color:'#6b7280',fontSize:12},axisLine:{show:false},axisTick:{show:false}},
@@ -445,10 +442,12 @@ PAYLOAD.columns.forEach((col, ci) => {
         const isNow = (touchedNow.get(k) || []).length > 0;
         const color = isPad ? THEME.padCell : BANK_PALETTE[bank % BANK_PALETTE.length];
         const op = isNow ? THEME.opFocus : THEME.opFaint;
-        ldrData.push({
-          value:[c, r, bank],
-          itemStyle:{color: color, opacity: op},
-        });
+        const style = {color: color, opacity: op};
+        if (isNow) {
+          style.borderColor = THEME.focusBorder;
+          style.borderWidth = 1.5;
+        }
+        ldrData.push({value:[c, r, bank], itemStyle: style});
       }
     }
     ldr.setOption({
@@ -493,14 +492,14 @@ PAYLOAD.columns.forEach((col, ci) => {
       grid:{left:30, right:14, top:6, bottom:18},
       xAxis:{
         type:'category', data:[...Array(lay.cols).keys()],
-        axisLine:{lineStyle:{color:THEME.axisLine}}, axisTick:{show:false},
+        axisLine:{show:false}, axisTick:{show:false},
         axisLabel:{color:'#6b7280', fontSize:11,
           interval: Math.max(0, Math.floor(lay.cols/8) - 1),
           showMaxLabel: true, showMinLabel: true},
       },
       yAxis:{
         type:'category', data:[...Array(lay.rows).keys()], inverse:true,
-        axisLine:{lineStyle:{color:THEME.axisLine}}, axisTick:{show:false},
+        axisLine:{show:false}, axisTick:{show:false},
         axisLabel:{color:'#6b7280', fontSize:11,
           interval: Math.max(0, Math.floor(lay.rows/8) - 1),
           showMaxLabel: true, showMinLabel: true},
@@ -547,7 +546,8 @@ _THEMES = {
         "splitLine": "#1c212b",
         "padCell": "#3a3f48",
         "opFocus": 1.0,
-        "opFaint": 0.18,
+        "opFaint": 0.45,
+        "focusBorder": "#ffffff",
     },
     "light": {
         "empty": "#b8bec7",
@@ -557,7 +557,8 @@ _THEMES = {
         "splitLine": "#9ca3af",
         "padCell": "#64748b",
         "opFocus": 1.0,
-        "opFaint": 0.18,
+        "opFaint": 0.45,
+        "focusBorder": "#0f172a",
     },
 }
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -325,8 +325,8 @@ PAYLOAD.columns.forEach((col,ci)=>{
           value:[c, r, bank],
           itemStyle:{
             color: color,
-            // Reachable cells: full color. Padding / unreachable: dim.
-            opacity: (isPad || !reachable) ? 0.18 : 1.0,
+            // Reachable cells: medium-bright. Padding / unreachable: dim.
+            opacity: (isPad || !reachable) ? 0.18 : 0.7,
           },
         });
       }

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -171,7 +171,9 @@ HTML = """<!doctype html>
   *{box-sizing:border-box;}
   html,body{margin:0;background:transparent;color:var(--fg);
     font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
-  .page{max-width:100%;margin:0;padding:0;}
+  /* Center the column grid + shared legend horizontally; shrink to
+     content width so unused horizontal space sits outside the page. */
+  .page{display:flex;flex-direction:column;align-items:center;margin:0;padding:0;}
   /* Auto-sized columns: each column shrinks to its content width
      (the punchcard / ladder), so the whole grid is no wider than the
      plots need. Centered if the page has more horizontal room. */
@@ -199,8 +201,8 @@ HTML = """<!doctype html>
   .ladder{margin:4px auto 0;}
   .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
     margin-top:10px;margin-bottom:4px;}
-  .bank-legend{display:grid;grid-template-columns:repeat(8,1fr);gap:3px 6px;margin-top:8px;
-    font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
+  .bank-legend{display:grid;grid-template-columns:repeat(8,auto);gap:3px 12px;margin-top:8px;
+    width:fit-content;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
   .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}
   .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
   .bank-legend-shared{margin-top:14px;font-size:10px;}

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -126,6 +126,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
         out.append(
             {
                 "panel_title": f"{p.stage_name} ← {p.buf}",
+                "buf_short": p.buf,
                 "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
                 "lane_banks": p.lane_banks,
                 "lane_addr_idx": lane_addr_idx,
@@ -185,14 +186,13 @@ HTML = """<!doctype html>
   .v-ok{color:#3ddc84;} .v-ok .dot{background:#3ddc84;}
   .v-warn{color:#ffb454;} .v-warn .dot{background:#ffb454;}
   .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
-  /* Punchcard cells are 3:1 wide rectangles (96×32 nominal plot area
-     for a 32×32 bank×lane grid). The container fills available width
-     and scales height to maintain the aspect ratio, so cells stay
-     proportional regardless of column width. */
-  .matrix{width:100%;aspect-ratio:96/32;height:auto;margin:0 auto 10px;}
+  /* Square punchcard: 32 banks × 32 lanes is intrinsically square
+     data. Capping width keeps cells visibly square instead of
+     squashed into wide rectangles when the container is stretched. */
+  .matrix{width:100%;max-width:320px;aspect-ratio:1/1;height:auto;margin:0 auto 10px;}
   /* Histogram shares the bank axis with the punchcard above —
-     match its width so banks line up vertically. */
-  .hist{width:100%;height:80px;margin:2px auto 0;}
+     match its max-width so banks line up vertically. */
+  .hist{width:100%;max-width:320px;height:80px;margin:2px auto 0;}
   .ladder{margin:4px auto 0;}
   .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
     margin-top:10px;margin-bottom:4px;}
@@ -202,7 +202,7 @@ HTML = """<!doctype html>
   .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
   .bank-legend-shared{margin-top:14px;font-size:10px;}
   .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin:6px auto 0;
-    width:100%;font-size:10px;color:var(--muted);}
+    width:100%;max-width:320px;font-size:10px;color:var(--muted);}
   .hist-legend span{display:inline-flex;align-items:center;gap:5px;}
   .hist-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
@@ -253,7 +253,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const id=`c${ci}_p${pi}`;
     const card=document.createElement('div');card.className='card';
     card.innerHTML=`
-      <div class="ladder-title" style="margin-top:0">bank access punchcard — ${p.panel_title}</div>
+      <div class="ladder-title" style="margin-top:0">bank access punchcard — ${p.buf_short}</div>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="hist-legend">
@@ -263,15 +263,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
       </div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="${(()=>{
-        // Square cells: pick one cell-size px, then size container to
-        // (cols*N + axis_w) × (rows*N + axis_h). Caps cell-size if the
-        // total height would otherwise blow past 360px.
-        const axisW = 38, axisH = 24;
-        const maxH = 360;
-        const N = Math.max(3, Math.min(6, Math.floor((maxH - axisH) / p.layout.rows)));
-        const w = p.layout.cols * N + axisW;
+        // 3:1 wide rectangles for ladder cells (cell_w = 3 × cell_h).
+        // Container fills column; height = rows × cell_h + axis. Cell
+        // height is computed to keep total ≤ 360 px while ensuring the
+        // 3× wider cells don't exceed 100% column width.
+        const axisH = 24, maxH = 360;
+        const N = Math.max(2, Math.min(6, Math.floor((maxH - axisH) / p.layout.rows)));
         const h = p.layout.rows * N + axisH;
-        return `width:${w}px; height:${h}px`;
+        return `width:100%; height:${h}px`;
       })()}"></div>
       ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -59,16 +59,34 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
         layout_cols = p.cols + pad_cols
         row_stride = p.cols + pad_cols
         smem_layout = [[(r * row_stride + c) % 32 for c in range(layout_cols)] for r in range(layout_rows)]
-        # Mark cells the warp actually touched in this LDS (row, col) →
-        # list of lanes that read the cell. Drawn with a white outline
-        # overlay on top of the ladder; tooltip shows the lanes (and they
-        # collapse to one entry when broadcast).
-        touched_map: dict[tuple[int, int], list[int]] = {}
+        # Touched at the *current* k_iter (the one ``simulate`` was
+        # called with) — drawn with a white outline overlay.
+        touched_now: dict[tuple[int, int], list[int]] = {}
         for lane, addr in enumerate(p.lane_addrs):
             r, c = divmod(addr, row_stride)
             if 0 <= r < layout_rows and 0 <= c < layout_cols:
-                touched_map.setdefault((r, c), []).append(lane)
-        touched_entries = [{"r": r, "c": c, "lanes": lanes} for (r, c), lanes in sorted(touched_map.items())]
+                touched_now.setdefault((r, c), []).append(lane)
+        # Touched across the *full* inner-loop sweep — ``full_sweep_touched``
+        # was populated by ``simulate_graph`` and maps cells to all
+        # (k_iter, lane) pairs that visit them across the loop. Used to
+        # show every cell's access provenance in the tooltip.
+        full_sweep: dict[tuple[int, int], list[list[int]]] = {}
+        for (r, c), pairs in p.full_sweep_touched.items():
+            if 0 <= r < layout_rows and 0 <= c < layout_cols:
+                full_sweep[(r, c)] = [list(t) for t in pairs]
+        # Build a single entries list keyed by (r, c) carrying both
+        # views (current-iter lanes for outline, full-sweep pairs for
+        # tooltip).
+        all_cells = sorted(set(touched_now) | set(full_sweep))
+        touched_entries = [
+            {
+                "r": r,
+                "c": c,
+                "lanes_now": touched_now.get((r, c), []),
+                "sweep": full_sweep.get((r, c), []),
+            }
+            for (r, c) in all_cells
+        ]
         out.append(
             {
                 "panel_title": f"{p.stage_name} ← {p.buf}",
@@ -267,31 +285,33 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const lEl = document.getElementById(`l_${id}`);
     const ldr = echarts.init(lEl, null, {renderer:'canvas'});
     const ldrData = [];
-    const touchedMap = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes]));
+    // touchedNow: cells the warp accessed AT THE CURRENT k_iter (white outline)
+    // sweep: cells the warp accessed across the full inner-loop sweep
+    //   (tooltip shows the full provenance per cell)
+    const touchedNow = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes_now]));
+    const sweep = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.sweep]));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
-        const isTouched = touchedMap.has(`${r},${c}`);
+        const k = `${r},${c}`;
+        const accessedNow = touchedNow.has(k) && touchedNow.get(k).length > 0;
+        const reachable = sweep.has(k);
         const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
         ldrData.push({
           value:[c, r, bank],
           itemStyle:{
             color: color,
-            // Dim un-accessed cells so the white-outlined accessed
-            // cells visually pop — they are the ones with the rich
-            // tooltip (load expr + lanes).
-            opacity: isPad ? 0.18 : (isTouched ? 1.0 : 0.28),
-            borderColor: isTouched ? '#ffffff' : 'transparent',
-            borderWidth: isTouched ? 2 : 0,
-            shadowBlur: isTouched ? 8 : 0,
-            shadowColor: isTouched ? '#ffffffaa' : 'transparent',
+            // Padding: very dim. Reachable-but-not-now: medium. Now: full.
+            opacity: isPad ? 0.18 : (accessedNow ? 1.0 : (reachable ? 0.55 : 0.18)),
+            borderColor: accessedNow ? '#ffffff' : 'transparent',
+            borderWidth: accessedNow ? 2 : 0,
+            shadowBlur: accessedNow ? 8 : 0,
+            shadowColor: accessedNow ? '#ffffffaa' : 'transparent',
           },
         });
       }
     }
-    // Compact a sorted list of ints into a "0-15, 17, 22-25" form for
-    // the tooltip — readable when 16 lanes broadcast one cell.
     const compactRanges = arr => {
       if (!arr.length) return '';
       const parts = []; let s = arr[0], e = arr[0];
@@ -302,6 +322,25 @@ PAYLOAD.columns.forEach((col,ci)=>{
       parts.push(s === e ? `${s}` : `${s}-${e}`);
       return parts.join(', ');
     };
+    // Group sweep pairs by k_iter, list lane ranges per iter (compact
+    // when many iters — show first 6 + "+N more" if longer).
+    const formatSweep = pairs => {
+      if (!pairs.length) return '';
+      const byIter = new Map();
+      pairs.forEach(([k, l]) => {
+        if (!byIter.has(k)) byIter.set(k, []);
+        byIter.get(k).push(l);
+      });
+      const lines = [...byIter.keys()].sort((a,b)=>a-b).map(k => {
+        const lanes = byIter.get(k).sort((a,b)=>a-b);
+        return `k_iter=<b>${k}</b>: lanes ${compactRanges(lanes)} (${lanes.length}×)`;
+      });
+      const cap = 6;
+      if (lines.length > cap) {
+        return lines.slice(0, cap).join('<br/>') + `<br/><span style="color:#6b7280">… +${lines.length - cap} more iters</span>`;
+      }
+      return lines.join('<br/>');
+    };
     ldr.setOption({
       backgroundColor:'transparent',
       tooltip:{
@@ -309,17 +348,21 @@ PAYLOAD.columns.forEach((col,ci)=>{
         textStyle:{color:'#e8eaed', fontSize:12},
         formatter: pt => {
           const [c, r, bank] = pt.value;
-          const lanes = touchedMap.get(`${r},${c}`);
+          const k = `${r},${c}`;
           const padTag = (c >= lay.data_cols || r >= lay.data_rows)
-            ? '<br/><span style="color:#6b7280">padding</span>' : '';
-          let access = '';
-          if (lanes) {
-            access =
-              `<br/><span style="color:#fff">★ accessed by warp</span>` +
-              `<br/>load <code style="color:#7dd3fc">${lay.load_name}[${lay.index_expr}]</code>` +
-              `<br/>lanes: <b>${compactRanges(lanes)}</b> (${lanes.length}×)`;
+            ? '<br/><span style="color:#6b7280">padding (allocated, never accessed)</span>' : '';
+          const sweepPairs = sweep.get(k) || [];
+          const isNow = (touchedNow.get(k) || []).length > 0;
+          const head = `row=<b>${r}</b>, col=<b>${c}</b>, bank <b>${bank}</b>, addr <b>${r * lay.row_stride + c}</b>`;
+          if (!sweepPairs.length) {
+            return head + padTag + `<br/><span style="color:#6b7280">never read by warp ${0} (other warps own this row)</span>`;
           }
-          return `row=<b>${r}</b>, col=<b>${c}</b><br/>bank <b>${bank}</b>${access}${padTag}`;
+          const star = isNow ? `<br/><span style="color:#fff">★ accessed at the rendered k_iter</span>` : '';
+          return head +
+            `<br/>load <code style="color:#7dd3fc">${lay.load_name}[${lay.index_expr}]</code>` +
+            star +
+            `<br/>${formatSweep(sweepPairs)}` +
+            padTag;
         },
       },
       grid:{left:38, right:8, top:6, bottom:24},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -273,19 +273,40 @@ def main() -> None:
     p.add_argument("--gate-matrix", default=None, help="Run a tests/perf case under 4 gate combos (chunk×pad)")
     p.add_argument("--seq-len", type=int, default=512)
     p.add_argument("--stage", action="append", default=[], help="filter Stage names (repeatable)")
+    p.add_argument("--load", action="append", default=[], help="filter Load SSA names (repeatable, e.g. in3)")
+    p.add_argument("--list", action="store_true", help="print available (kernel, stage, load) probes and exit")
     p.add_argument("--k-iter", type=int, default=0)
     p.add_argument("--warp-id", type=int, default=0)
     p.add_argument("--out", default="/tmp/bank_conflicts.html")
     args = p.parse_args()
 
     stage_filter = set(args.stage) if args.stage else None
+    load_filter = set(args.load) if args.load else None
     columns: list[dict] = []
+
+    if args.list:
+        # Print available probes for the first config and exit.
+        if args.gate_matrix:
+            g = graph_from_perf_case(args.gate_matrix, disable_chunk_reduce=False, disable_pad_smem=False)
+        elif args.chunk_reduce_diff:
+            g = graph_from_sdpa(args.seq_len, disable_chunk_reduce=False)
+        elif args.ir:
+            g = graph_from_ir_path(_parse_ir_arg(args.ir[0])[0])
+        else:
+            p.error("--list requires one of --gate-matrix / --chunk-reduce-diff / --ir")
+        results = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
+        print(f"{'kernel':32}  {'stage':18}  {'load':6}  {'max_way':>7}  {'events':>6}  index")
+        print("-" * 100)
+        for r in sorted(results, key=lambda x: (x.tile_op_name, x.stage_name, x.load_name)):
+            idx = ", ".join(r.index_repr)
+            print(f"{r.tile_op_name:32}  {r.stage_name:18}  {r.load_name:6}  {r.max_way:>7}  {r.conflict_events:>6}  ({idx})")
+        return
 
     if args.chunk_reduce_diff:
         for label, disabled in (("chunk_reduce ENABLED", False), ("chunk_reduce DISABLED", True)):
             print(f"running pipeline: {label}...")
             g = graph_from_sdpa(args.seq_len, disable_chunk_reduce=disabled)
-            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id)
+            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
             print(f"  → {len(panels)} stage probe(s)")
             columns.append({"label": label, "panels": _serialize(panels)})
         subtitle = f"SDPA(B=1, H=8, seq={args.seq_len}, d=64) · k_iter={args.k_iter} · warp={args.warp_id}"
@@ -299,7 +320,7 @@ def main() -> None:
         for label, no_chunk, no_pad in combos:
             print(f"running {args.gate_matrix} | {label}...")
             g = graph_from_perf_case(args.gate_matrix, disable_chunk_reduce=no_chunk, disable_pad_smem=no_pad)
-            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id)
+            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
             total = sum(p.conflict_events for p in panels)
             print(f"  → {len(panels)} probes, total conflict_events = {total}")
             columns.append({"label": f"{label} · Σevents={total}", "panels": _serialize(panels)})
@@ -308,7 +329,7 @@ def main() -> None:
         for arg in args.ir:
             path, label = _parse_ir_arg(arg)
             g = graph_from_ir_path(path)
-            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id)
+            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
             print(f"{label}: {len(panels)} stage probe(s)")
             columns.append({"label": label, "panels": _serialize(panels)})
         subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -166,18 +166,16 @@ HTML = """<!doctype html>
 <title>smem bank conflicts (IR-driven)</title>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 <style>
-  :root { --bg:#0e1014; --panel:#161a21; --panel-2:#1c212b; --fg:#e8eaed; --muted:#6b7280; }
+  :root { --bg:transparent; --panel:transparent; --panel-2:transparent; --fg:#e8eaed; --muted:#6b7280; }
   *{box-sizing:border-box;}
-  html,body{margin:0;background:var(--bg);color:var(--fg);
+  html,body{margin:0;background:transparent;color:var(--fg);
     font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
-  .page{max-width:__MAXW__px;margin:0 auto;padding:24px;}
-  .columns{display:grid;grid-template-columns:repeat(__NCOL__,1fr);gap:22px;}
-  .col-head{text-align:center;font-size:12px;text-transform:uppercase;letter-spacing:.18em;
-    color:var(--muted);padding:8px 0;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,.06);}
+  .page{max-width:100%;margin:0;padding:0;}
+  .columns{display:grid;grid-template-columns:repeat(__NCOL__,1fr);gap:8px;}
+  .col-head{text-align:center;font-size:11px;text-transform:uppercase;letter-spacing:.16em;
+    color:var(--muted);padding:4px 0 6px;margin-bottom:6px;border-bottom:1px solid rgba(255,255,255,.06);}
   .col-head .label{color:#7dd3fc;font-weight:600;}
-  .card{background:linear-gradient(180deg,var(--panel),var(--panel-2));
-    border:1px solid rgba(255,255,255,.04);border-radius:14px;padding:18px 16px 12px;
-    box-shadow:0 1px 0 rgba(255,255,255,.03) inset,0 8px 24px rgba(0,0,0,.35);margin-bottom:16px;}
+  .card{background:transparent;border:none;border-radius:0;padding:0;box-shadow:none;margin-bottom:0;}
   .card-title{font-size:14px;font-weight:600;letter-spacing:-.01em;}
   .card-formula{font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;color:var(--muted);margin-top:4px;}
   .card-notes{font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:var(--muted);margin-top:6px;line-height:1.55;}
@@ -187,11 +185,11 @@ HTML = """<!doctype html>
   .v-ok{color:#3ddc84;} .v-ok .dot{background:#3ddc84;}
   .v-warn{color:#ffb454;} .v-warn .dot{background:#ffb454;}
   .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
-  .matrix{width:100%;height:240px;margin-bottom:14px;}
-  .hist{width:100%;height:100px;margin-top:4px;}
-  .ladder{width:100%;margin-top:8px;}
-  .ladder-title{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);
-    margin-top:14px;margin-bottom:6px;}
+  .matrix{width:100%;height:200px;margin-bottom:10px;}
+  .hist{width:100%;height:80px;margin-top:2px;}
+  .ladder{width:100%;margin-top:4px;}
+  .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
+    margin-top:10px;margin-bottom:4px;}
   .bank-legend{display:grid;grid-template-columns:repeat(8,1fr);gap:3px 6px;margin-top:8px;
     font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
   .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -177,9 +177,9 @@ HTML = """<!doctype html>
   /* Auto-sized columns: each column shrinks to its content width
      (the punchcard / ladder), so the whole grid is no wider than the
      plots need. Centered if the page has more horizontal room. */
-  .columns{display:grid;grid-template-columns:repeat(__NCOL__,auto);gap:16px;justify-content:center;}
-  .col-head{text-align:center;font-size:11px;text-transform:uppercase;letter-spacing:.16em;
-    color:var(--muted);padding:4px 0 6px;margin-bottom:6px;border-bottom:1px solid rgba(255,255,255,.06);}
+  .columns{display:grid;grid-template-columns:repeat(__NCOL__,auto);gap:20px;justify-content:center;}
+  .col-head{text-align:center;font-size:14px;text-transform:uppercase;letter-spacing:.16em;
+    color:var(--muted);padding:6px 0 8px;margin-bottom:8px;border-bottom:1px solid rgba(255,255,255,.06);}
   .col-head .label{color:#7dd3fc;font-weight:600;}
   .card{background:transparent;border:none;border-radius:0;padding:0;box-shadow:none;margin-bottom:0;}
   .card-title{font-size:14px;font-weight:600;letter-spacing:-.01em;}
@@ -194,22 +194,22 @@ HTML = """<!doctype html>
   /* Square punchcard: 32 banks × 32 lanes is intrinsically square
      data. Capping width keeps cells visibly square instead of
      squashed into wide rectangles when the container is stretched. */
-  .matrix{width:100%;max-width:320px;aspect-ratio:1/1;height:auto;margin:0 auto 10px;}
+  .matrix{width:100%;max-width:400px;aspect-ratio:1/1;height:auto;margin:0 auto 12px;}
   /* Histogram shares the bank axis with the punchcard above —
      match its max-width so banks line up vertically. */
-  .hist{width:100%;max-width:320px;height:80px;margin:2px auto 0;}
-  .ladder{margin:4px auto 0;}
-  .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
-    margin-top:10px;margin-bottom:4px;}
-  .bank-legend{display:grid;grid-template-columns:repeat(8,auto);gap:3px 12px;margin-top:8px;
-    width:fit-content;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
-  .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}
-  .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
-  .bank-legend-shared{margin-top:14px;font-size:10px;}
-  .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin:6px auto 0;
-    width:100%;max-width:320px;font-size:10px;color:var(--muted);}
-  .hist-legend span{display:inline-flex;align-items:center;gap:5px;}
-  .hist-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
+  .hist{width:100%;max-width:400px;height:100px;margin:2px auto 0;}
+  .ladder{margin:6px auto 0;}
+  .ladder-title{font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
+    margin-top:12px;margin-bottom:6px;}
+  .bank-legend{display:grid;grid-template-columns:repeat(8,auto);gap:4px 14px;margin-top:10px;
+    width:fit-content;font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:var(--muted);}
+  .bank-legend span{display:inline-flex;align-items:center;gap:5px;white-space:nowrap;}
+  .bank-legend i{width:10px;height:10px;border-radius:2px;display:inline-block;flex-shrink:0;}
+  .bank-legend-shared{margin-top:18px;font-size:12px;}
+  .hist-legend{display:flex;flex-wrap:wrap;gap:5px 16px;margin:8px auto 0;
+    width:100%;max-width:400px;font-size:12px;color:var(--muted);}
+  .hist-legend span{display:inline-flex;align-items:center;gap:6px;}
+  .hist-legend i{width:11px;height:11px;border-radius:2px;display:inline-block;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
@@ -272,8 +272,8 @@ PAYLOAD.columns.forEach((col,ci)=>{
         // cell_w toward cell_h (square) when the column gets narrow.
         // cell_h is sized by row count (so the slab fits ≤ maxH);
         // cell_w = min(3 × cell_h, fits_width).
-        const axisW = 38, axisH = 24, maxH = 360, maxW = 380;
-        const cellH = Math.max(2, Math.min(4, Math.floor((maxH - axisH) / p.layout.rows)));
+        const axisW = 44, axisH = 28, maxH = 450, maxW = 475;
+        const cellH = Math.max(3, Math.min(5, Math.floor((maxH - axisH) / p.layout.rows)));
         const cellW = Math.max(cellH, Math.min(3 * cellH, Math.floor((maxW - axisW) / p.layout.cols)));
         const w = p.layout.cols * cellW + axisW;
         const h = p.layout.rows * cellH + axisH;
@@ -312,12 +312,12 @@ PAYLOAD.columns.forEach((col,ci)=>{
         }},
       grid:{left:38,right:8,top:8,bottom:42},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
-        nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},
-        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
+        nameTextStyle:{color:'#6b7280',fontSize:13},axisLine:{lineStyle:{color:'#2a2d33'}},
+        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
-        nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:11},
+        nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:13},
         axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
-        axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
+        axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       series:[{type:'heatmap',data:md,progressive:0,
         itemStyle:{borderRadius:2,borderColor:'#161a21',borderWidth:1},
         emphasis:{itemStyle:{borderColor:'#fff',borderWidth:1.5}},
@@ -331,9 +331,9 @@ PAYLOAD.columns.forEach((col,ci)=>{
       grid:{left:38,right:8,top:6,bottom:22},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],
         axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
-        axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
+        axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       yAxis:{type:'value',min:0,max:8,splitLine:{lineStyle:{color:'#1c212b'}},
-        axisLabel:{color:'#6b7280',fontSize:10},axisLine:{show:false},axisTick:{show:false}},
+        axisLabel:{color:'#6b7280',fontSize:12},axisLine:{show:false},axisTick:{show:false}},
       series:[{type:'bar',data:p.distinct_addrs.map(c=>({value:c,itemStyle:{
         color:{type:'linear',x:0,y:0,x2:0,y2:1,
           colorStops:[{offset:0,color:cellColor(c)},{offset:1,color:cellColor(c)+'55'}]},
@@ -424,14 +424,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
       xAxis:{
         type:'category', data:[...Array(lay.cols).keys()],
         axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:9,
+        axisLabel:{color:'#6b7280', fontSize:11,
           interval: Math.max(0, Math.floor(lay.cols/8) - 1),
           showMaxLabel: true, showMinLabel: true},
       },
       yAxis:{
         type:'category', data:[...Array(lay.rows).keys()], inverse:true,
         axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:9,
+        axisLabel:{color:'#6b7280', fontSize:11,
           interval: Math.max(0, Math.floor(lay.rows/8) - 1),
           showMaxLabel: true, showMinLabel: true},
       },

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -17,6 +17,12 @@ Modes:
       Run the tile pipeline live on an SDPA(B=1, H=8, seq=N, d=64)
       graph twice — with and without ``006_chunk_reduce`` enabled
       (gated via ``DEPLODOCK_DISABLE_CHUNK_REDUCE``) — and compare.
+
+  --gate-matrix CASE_NAME
+      Run the named ``tests/perf/cases.py`` case under all four
+      combinations of ``006_chunk_reduce`` × ``013_pad_smem``
+      gate-on/off. Useful for surfacing which pass dominates the
+      conflict reduction.
 """
 
 from __future__ import annotations
@@ -54,6 +60,32 @@ def graph_from_sdpa(seq_len: int, disable_chunk_reduce: bool) -> Graph:
         else:
             os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = prev
     return g
+
+
+def graph_from_perf_case(case_name: str, *, disable_chunk_reduce: bool, disable_pad_smem: bool) -> Graph:
+    """Build & compile a ``tests/perf/cases.py`` case under the given gate combo."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from tests.perf.cases import FUSED_CASES, PRIMITIVE_CASES, build_deplodock_graph
+
+    cases = {c.name: c for c in PRIMITIVE_CASES + FUSED_CASES}
+    if case_name not in cases:
+        raise SystemExit(f"unknown case '{case_name}'. examples: {list(cases)[:5]}")
+    saved = {k: os.environ.get(k) for k in ("DEPLODOCK_DISABLE_CHUNK_REDUCE", "DEPLODOCK_DISABLE_PAD_SMEM")}
+    os.environ["DEPLODOCK_DISABLE_CHUNK_REDUCE"] = "1" if disable_chunk_reduce else "0"
+    os.environ["DEPLODOCK_DISABLE_PAD_SMEM"] = "1" if disable_pad_smem else "0"
+    try:
+        g = build_deplodock_graph(cases[case_name])
+        run_pipeline(g, TILE_PASSES)
+        return g
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 def _serialize(panels: list[BankConflictResult]) -> list[dict]:
@@ -237,6 +269,7 @@ def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--ir", action="append", default=[], help="PATH[:LABEL] — repeatable")
     p.add_argument("--chunk-reduce-diff", action="store_true", help="Run pipeline live with/without chunk_reduce on SDPA")
+    p.add_argument("--gate-matrix", default=None, help="Run a tests/perf case under 4 gate combos (chunk×pad)")
     p.add_argument("--seq-len", type=int, default=512)
     p.add_argument("--stage", action="append", default=[], help="filter Stage names (repeatable)")
     p.add_argument("--k-iter", type=int, default=0)
@@ -255,6 +288,21 @@ def main() -> None:
             print(f"  → {len(panels)} stage probe(s)")
             columns.append({"label": label, "panels": _serialize(panels)})
         subtitle = f"SDPA(B=1, H=8, seq={args.seq_len}, d=64) · k_iter={args.k_iter} · warp={args.warp_id}"
+    elif args.gate_matrix:
+        combos = [
+            ("baseline (chunk✓ pad✓)", False, False),
+            ("no chunk_reduce", True, False),
+            ("no pad_smem", False, True),
+            ("no chunk + no pad", True, True),
+        ]
+        for label, no_chunk, no_pad in combos:
+            print(f"running {args.gate_matrix} | {label}...")
+            g = graph_from_perf_case(args.gate_matrix, disable_chunk_reduce=no_chunk, disable_pad_smem=no_pad)
+            panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id)
+            total = sum(p.conflict_events for p in panels)
+            print(f"  → {len(panels)} probes, total conflict_events = {total}")
+            columns.append({"label": f"{label} · Σevents={total}", "panels": _serialize(panels)})
+        subtitle = f"{args.gate_matrix}  ·  k_iter={args.k_iter} · warp={args.warp_id}"
     elif args.ir:
         for arg in args.ir:
             path, label = _parse_ir_arg(arg)
@@ -264,7 +312,7 @@ def main() -> None:
             columns.append({"label": label, "panels": _serialize(panels)})
         subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"
     else:
-        p.error("provide --ir PATH (repeatable) or --chunk-reduce-diff")
+        p.error("provide --ir PATH (repeatable), --chunk-reduce-diff, or --gate-matrix CASE")
 
     emit_html(columns, subtitle, args.out)
     print(f"saved {args.out}")

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -245,7 +245,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
                                    : `<span style="color:#ff5c7a">${dist}-way conflict</span>`;
           return `lane <b>${l}</b> → bank <b>${b}</b>, addr-color <b>#${ai}</b><br/>${verdict}`;
         }},
-      grid:{left:38,right:8,top:8,bottom:28},
+      grid:{left:38,right:8,top:8,bottom:42},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
         nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},
         axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -329,19 +329,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
         const reachable = sweep.has(k);
         const isFocus = focusCells.has(k);
         const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
+        // Three opacity levels: focused-Load cells (top), other
+        // reachable cells (middle), padding/unreachable (bottom).
+        // Reading rule: two cells with the high-opacity rows in the
+        // same column sharing a color → conflict for that LDS.
+        const op = isPad ? 0.18 : (isFocus ? 0.95 : (reachable ? 0.32 : 0.18));
         ldrData.push({
           value:[c, r, bank],
-          itemStyle:{
-            color: color,
-            opacity: (isPad || !reachable) ? 0.18 : 0.7,
-            // White outline = "this Load (the focused one) touches the
-            // cell at some k_iter". Reading rule: when two outlined
-            // cells in the same column have the same color, the
-            // focused Load's LDS at that column produces a real
-            // conflict on that bank.
-            borderColor: isFocus ? '#ffffff' : 'transparent',
-            borderWidth: isFocus ? 1.5 : 0,
-          },
+          itemStyle:{color: color, opacity: op},
         });
       }
     }

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -46,6 +46,8 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
             "max_way": p.max_way,
             "raw_max_way": p.raw_max_way,
             "conflict_events": p.conflict_events,
+            "lds128_events": p.lds128_events,
+            "vec_group_size": p.vec_group_size,
             "avg_way": p.avg_way,
             "rows": p.rows,
             "cols": p.cols,
@@ -54,6 +56,7 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
             "notes": [
                 f"index = ({', '.join(p.index_repr)})",
                 f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
+                (f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}  (vec={p.vec_group_size})"),
             ],
         }
         for p in panels
@@ -239,11 +242,14 @@ def main() -> None:
     if args.list:
         g = graph_from_ir_path(_parse_ir_arg(args.ir[0])[0])
         results = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
-        print(f"{'kernel':32}  {'stage':18}  {'load':6}  {'max_way':>7}  {'events':>6}  index")
-        print("-" * 100)
+        print(f"{'kernel':32}  {'stage':18}  {'load':6}  {'max_way':>7}  {'LDS.32':>7}  {'LDS.128':>8}  {'vec':>3}  index")
+        print("-" * 120)
         for r in sorted(results, key=lambda x: (x.tile_op_name, x.stage_name, x.load_name)):
             idx = ", ".join(r.index_repr)
-            print(f"{r.tile_op_name:32}  {r.stage_name:18}  {r.load_name:6}  {r.max_way:>7}  {r.conflict_events:>6}  ({idx})")
+            print(
+                f"{r.tile_op_name:32}  {r.stage_name:18}  {r.load_name:6}  "
+                f"{r.max_way:>7}  {r.conflict_events:>7}  {r.lds128_events:>8}  {r.vec_group_size:>3}  ({idx})"
+            )
         return
 
     columns: list[dict] = []
@@ -251,9 +257,15 @@ def main() -> None:
         path, label = _parse_ir_arg(arg)
         g = graph_from_ir_path(path)
         panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
-        total = sum(p.conflict_events for p in panels)
-        print(f"{label}: {len(panels)} probes, Σevents={total}")
-        columns.append({"label": f"{label} · Σevents={total}", "panels": _serialize(panels)})
+        scalar_total = sum(p.conflict_events for p in panels)
+        vec_total = sum(p.lds128_events for p in panels)
+        print(f"{label}: {len(panels)} probes, ΣLDS.32={scalar_total}  ΣLDS.128={vec_total}")
+        columns.append(
+            {
+                "label": f"{label} · ΣLDS.32={scalar_total}  ΣLDS.128={vec_total}",
+                "panels": _serialize(panels),
+            }
+        )
 
     subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"
     emit_html(columns, subtitle, args.out)

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -319,15 +319,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
         const bank = lay.banks[r][c];
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
         const k = `${r},${c}`;
-        const accessedNow = touchedNow.has(k) && touchedNow.get(k).length > 0;
         const reachable = sweep.has(k);
         const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
         ldrData.push({
           value:[c, r, bank],
           itemStyle:{
             color: color,
-            // Padding: very dim. Reachable-but-not-now: medium. Now: full.
-            opacity: isPad ? 0.18 : (accessedNow ? 1.0 : (reachable ? 0.55 : 0.18)),
+            // Reachable cells: full color. Padding / unreachable: dim.
+            opacity: (isPad || !reachable) ? 0.18 : 1.0,
           },
         });
       }
@@ -348,17 +347,13 @@ PAYLOAD.columns.forEach((col,ci)=>{
           if (!sweepPairs.length) {
             return head + padTag + `<br/><span style="color:#6b7280">never read by warp 0 (other warps own this row)</span>`;
           }
-          const star = isNow ? `<br/><span style="color:#fff">★ accessed at the rendered k_iter</span>` : '';
-          // One substituted form per Load that hits this cell. The
-          // substituted index already encodes the k_iter (it's the
-          // last component, e.g. in6[((0*8)+2), 5] → k=5), so we
-          // don't repeat it as a separate "k_iter=..." line.
+          // One substituted form per Load that hits this cell.
           const substMap = substByLoad.get(k) || {};
           const substLines = Object.entries(substMap).sort().map(
             ([ln, subst]) => `<code style="color:#3ddc84">${ln}[${subst.join(', ')}]</code>`
           );
           const loadSection = substLines.length ? `<br/>${substLines.join('<br/>')}` : '';
-          return head + loadSection + star + padTag;
+          return head + loadSection + padTag;
         },
       },
       grid:{left:30, right:14, top:6, bottom:18},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -37,31 +37,49 @@ def graph_from_ir_path(path: str) -> Graph:
 
 
 def _serialize(panels: list[BankConflictResult]) -> list[dict]:
-    return [
-        {
-            "panel_title": f"{p.stage_name} ← {p.buf}",
-            "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
-            "lane_banks": p.lane_banks,
-            "counts": p.counts,
-            "distinct_addrs": p.distinct_addrs,
-            "max_way": p.max_way,
-            "raw_max_way": p.raw_max_way,
-            "conflict_events": p.conflict_events,
-            "lds128_events": p.lds128_events,
-            "vec_group_size": p.vec_group_size,
-            "avg_way": p.avg_way,
-            "rows": p.rows,
-            "cols": p.cols,
-            "pad": list(p.pad),
-            "smem_bytes": p.smem_bytes,
-            "notes": [
-                f"index = ({', '.join(p.index_repr)})",
-                f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
-                (f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}  (vec={p.vec_group_size})"),
-            ],
-        }
-        for p in panels
-    ]
+    out: list[dict] = []
+    for p in panels:
+        # Per-bank stack of (address, lane_count) — the conventional view
+        # where stacked boxes in one column are literal bank conflicts.
+        bank_stacks: list[list[tuple[int, int]]] = [[] for _ in range(32)]
+        addr_lane_counts: dict[tuple[int, int], int] = {}
+        for lane, (bank, addr) in enumerate(zip(p.lane_banks, p.lane_addrs, strict=True)):
+            del lane
+            addr_lane_counts[(bank, addr)] = addr_lane_counts.get((bank, addr), 0) + 1
+        for (bank, addr), n_lanes in addr_lane_counts.items():
+            bank_stacks[bank].append((addr, n_lanes))
+        for stack in bank_stacks:
+            stack.sort()
+        out.append(
+            {
+                "panel_title": f"{p.stage_name} ← {p.buf}",
+                "formula": (
+                    f"{p.stage_class}({p.rows}×{p.cols})  "
+                    + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")
+                ),
+                "bank_stacks": [[list(t) for t in stack] for stack in bank_stacks],
+                "distinct_addrs": p.distinct_addrs,
+                "max_way": p.max_way,
+                "raw_max_way": p.raw_max_way,
+                "conflict_events": p.conflict_events,
+                "lds128_events": p.lds128_events,
+                "vec_group_size": p.vec_group_size,
+                "avg_way": p.avg_way,
+                "rows": p.rows,
+                "cols": p.cols,
+                "pad": list(p.pad),
+                "smem_bytes": p.smem_bytes,
+                "notes": [
+                    f"index = ({', '.join(p.index_repr)})",
+                    f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
+                    (
+                        f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}"
+                        f"  (vec={p.vec_group_size})"
+                    ),
+                ],
+            }
+        )
+    return out
 
 
 HTML = """<!doctype html>
@@ -142,39 +160,70 @@ PAYLOAD.columns.forEach((col,ci)=>{
       <div class="card-formula">${p.formula}</div>
       <span class="card-verdict ${verdict(p.max_way)}"><span class="dot"></span>
         max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
-      <div class="matrix" id="m_${id}"></div>
+      <div class="matrix" id="m_${id}" style="height:${Math.min(240, 32 + Math.max(...p.distinct_addrs) * 22)}px"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="card-notes">${p.notes.join('<br/>')}</div>`;
     colEl.appendChild(card);
 
+    // Conventional bank-conflict view: one box per UNIQUE address per
+    // bank, stacked vertically. Multiple boxes in the same column =
+    // serialized accesses (real bank conflict). Box label = lane count
+    // broadcasting that address.
     const m=echarts.init(document.getElementById(`m_${id}`),null,{renderer:'canvas'});
+    const maxStack = Math.max(1, ...p.distinct_addrs);
     const md=[];
-    for(let l=0;l<WARP;l++) for(let b=0;b<BANKS;b++)
-      md.push({value:[b,l,0],itemStyle:{color:palette.empty}});
-    p.lane_banks.forEach((bank,lane)=>{
-      // Color cells by distinct_addrs at that bank — broadcasts (multiple
-      // lanes at same address) are NOT conflicts and stay green.
-      const c=p.distinct_addrs[bank];
-      md.push({value:[bank,lane,c],itemStyle:{color:cellColor(c),shadowBlur:6,shadowColor:cellColor(c)+'88'}});
-    });
+    for (let bank = 0; bank < BANKS; bank++) {
+      const stack = p.bank_stacks[bank];
+      const distinct = stack.length;
+      stack.forEach(([addr, lanes], slot) => {
+        md.push({
+          value: [bank, slot, distinct],
+          name: `bank ${bank}`,
+          addr: addr,
+          lanes: lanes,
+          distinct: distinct,
+          itemStyle: {color: cellColor(distinct), shadowBlur: 6, shadowColor: cellColor(distinct)+'66'},
+        });
+      });
+    }
     m.setOption({
       backgroundColor:'transparent',
-      tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
-        formatter:pt=>{const [b,l,c]=pt.value;
-          return c===0?`bank ${b}<br/><span style="color:#6b7280">no lane</span>`
-                      :`lane <b>${l}</b> → bank <b>${b}</b><br/>contention: <b>${c}</b> lane(s)`;}},
-      grid:{left:38,right:8,top:8,bottom:28},
-      xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
-        nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},
-        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
-      yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
-        nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:11},
-        axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
-        axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
-      series:[{type:'heatmap',data:md,progressive:0,
-        itemStyle:{borderRadius:2,borderColor:'#161a21',borderWidth:1},
-        emphasis:{itemStyle:{borderColor:'#fff',borderWidth:1.5}},
-        animationDuration:500,animationEasing:'cubicOut'}]});
+      tooltip:{
+        backgroundColor:'#0e1014', borderColor:'#2a2d33',
+        textStyle:{color:'#e8eaed', fontSize:12},
+        formatter: pt => {
+          const d = pt.data;
+          const tag = d.distinct === 1
+            ? `<span style="color:#3ddc84">1 distinct addr — no conflict</span>`
+            : `<span style="color:${d.distinct <= 4 ? '#ffb454':'#ff5c7a'}">${d.distinct}-way conflict</span>`;
+          return `bank <b>${pt.value[0]}</b>, addr <b>${d.addr}</b><br/>` +
+                 `lanes broadcasting this addr: <b>${d.lanes}</b><br/>${tag}`;
+        },
+      },
+      grid:{left:38, right:8, top:8, bottom:28},
+      xAxis:{
+        type:'category', data:[...Array(BANKS).keys()],
+        name:'bank', nameLocation:'middle', nameGap:22,
+        nameTextStyle:{color:'#6b7280', fontSize:11},
+        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLabel:{color:'#6b7280', fontSize:10, interval:3},
+      },
+      yAxis:{
+        type:'category', data:[...Array(maxStack).keys()],
+        name:'distinct addr', nameLocation:'middle', nameGap:28,
+        nameTextStyle:{color:'#6b7280', fontSize:11},
+        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLabel:{color:'#6b7280', fontSize:10},
+      },
+      series:[{
+        type:'heatmap', data: md, progressive:0,
+        label:{show: true, color:'#0e1014', fontSize: 10, fontWeight: 600,
+               formatter: pp => `${pp.data.lanes}`},
+        itemStyle:{borderRadius:3, borderColor:'#161a21', borderWidth:1},
+        emphasis:{itemStyle:{borderColor:'#fff', borderWidth:1.5}},
+        animationDuration:500, animationEasing:'cubicOut',
+      }],
+    });
 
     const h=echarts.init(document.getElementById(`h_${id}`),null,{renderer:'canvas'});
     h.setOption({

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -189,7 +189,9 @@ HTML = """<!doctype html>
      data. Capping width keeps cells visibly square instead of squashed
      wide rectangles when the container is stretched. */
   .matrix{width:100%;max-width:320px;aspect-ratio:1/1;height:auto;margin:0 auto 10px;}
-  .hist{width:100%;height:80px;margin-top:2px;}
+  /* Histogram shares the bank axis with the punchcard above —
+     match its max-width so banks line up vertically. */
+  .hist{width:100%;max-width:320px;height:80px;margin:2px auto 0;}
   .ladder{width:100%;margin-top:4px;}
   .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
     margin-top:10px;margin-bottom:4px;}

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -163,10 +163,7 @@ HTML = """<!doctype html>
   *{box-sizing:border-box;}
   html,body{margin:0;background:var(--bg);color:var(--fg);
     font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
-  .page{max-width:__MAXW__px;margin:0 auto;padding:48px 32px;}
-  .eyebrow{text-transform:uppercase;letter-spacing:.18em;font-size:11px;color:var(--muted);margin-bottom:8px;}
-  h1{font-size:28px;font-weight:600;margin:0 0 6px;letter-spacing:-.01em;}
-  .subtitle{color:var(--muted);font-size:14px;margin-bottom:36px;}
+  .page{max-width:__MAXW__px;margin:0 auto;padding:24px;}
   .columns{display:grid;grid-template-columns:repeat(__NCOL__,1fr);gap:22px;}
   .col-head{text-align:center;font-size:12px;text-transform:uppercase;letter-spacing:.18em;
     color:var(--muted);padding:8px 0;margin-bottom:12px;border-bottom:1px solid rgba(255,255,255,.06);}
@@ -197,9 +194,6 @@ HTML = """<!doctype html>
 </head>
 <body>
   <div class="page">
-    <div class="eyebrow">tile-IR bank-conflict probe</div>
-    <h1>smem bank conflicts</h1>
-    <div class="subtitle">__SUBTITLE__</div>
     <div class="columns" id="columns"></div>
     <div class="legend">
       <span><i style="background:#3ddc84"></i> 1 lane (no conflict)</span>
@@ -386,12 +380,11 @@ PAYLOAD.columns.forEach((col,ci)=>{
 """
 
 
-def emit_html(columns: list[dict], subtitle: str, out_path: str) -> None:
+def emit_html(columns: list[dict], out_path: str) -> None:
     n = max(1, len(columns))
     html = (
         HTML.replace("__MAXW__", str(min(2200, 480 * n + 80)))
         .replace("__NCOL__", str(n))
-        .replace("__SUBTITLE__", subtitle)
         .replace("__PAYLOAD__", json.dumps({"columns": columns}))
     )
     with open(out_path, "w") as f:
@@ -459,8 +452,7 @@ def main() -> None:
             }
         )
 
-    subtitle = f"k_iter={args.k_iter} · warp={args.warp_id} · {len(args.ir)} input IR(s)"
-    emit_html(columns, subtitle, args.out)
+    emit_html(columns, args.out)
     print(f"saved {args.out}")
 
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -64,6 +64,8 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
             "lane_banks": p.lane_banks,
             "counts": p.counts,
             "max_way": p.max_way,
+            "raw_max_way": p.raw_max_way,
+            "conflict_events": p.conflict_events,
             "avg_way": p.avg_way,
             "rows": p.rows,
             "cols": p.cols,

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -36,7 +36,27 @@ def graph_from_ir_path(path: str) -> Graph:
         return Graph.from_dict(json.load(f))
 
 
-def _serialize(panels: list[BankConflictResult]) -> list[dict]:
+def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[BankConflictResult] | None = None) -> list[dict]:
+    """Serialize ``panels`` to JSON-friendly dicts.
+
+    ``all_panels_for_union`` is the un-load-filtered list used to compute
+    the per-Stage union ladder. When ``--load`` filters the visible
+    cards, the ladder still shows the full Stage's footprint (i.e. cells
+    touched by every body Load of the Stage, not just the focused one).
+    Falls back to ``panels`` if not provided.
+    """
+    union_source = all_panels_for_union if all_panels_for_union is not None else panels
+    # Build per-Stage union: (tile_op_name, stage_name) → {(r,c) → list of
+    # (load_name, k_iter, lane, subst_idx_tuple)} merged across all body
+    # Loads of the Stage.
+    stage_union: dict[tuple[str, str], dict[tuple[int, int], list[tuple]]] = {}
+    for p in union_source:
+        key = (p.tile_op_name, p.stage_name)
+        u = stage_union.setdefault(key, {})
+        for cell, pairs in p.full_sweep_touched.items():
+            subst = p.full_sweep_subst_idx.get(cell, ())
+            for k, lane in pairs:
+                u.setdefault(cell, []).append((p.load_name, k, lane, subst))
     out: list[dict] = []
     for p in panels:
         # Per-lane address-color index: same address → same color, regardless
@@ -66,25 +86,31 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
             r, c = divmod(addr, row_stride)
             if 0 <= r < layout_rows and 0 <= c < layout_cols:
                 touched_now.setdefault((r, c), []).append(lane)
-        # Touched across the *full* inner-loop sweep — ``full_sweep_touched``
-        # was populated by ``simulate_graph`` and maps cells to all
-        # (k_iter, lane) pairs that visit them across the loop. Used to
-        # show every cell's access provenance in the tooltip.
-        full_sweep: dict[tuple[int, int], list[list[int]]] = {}
-        for (r, c), pairs in p.full_sweep_touched.items():
-            if 0 <= r < layout_rows and 0 <= c < layout_cols:
-                full_sweep[(r, c)] = [list(t) for t in pairs]
-        # Build a single entries list keyed by (r, c) carrying both
-        # views (current-iter lanes for outline, full-sweep pairs for
-        # tooltip).
-        all_cells = sorted(set(touched_now) | set(full_sweep))
+        # Per-Stage UNION across every body Load of the Stage: cell →
+        # list of (load_name, k_iter, lane, subst_idx_tuple). The
+        # ladder shows the union (so it answers "across the K loop,
+        # which cells does this Stage's body ever read"); the top
+        # heatmap stays per-Load (bank conflicts are per-LDS).
+        union = stage_union.get((p.tile_op_name, p.stage_name), {})
+        sweep_per_cell: dict[tuple[int, int], list[list]] = {}
+        subst_per_cell: dict[tuple[int, int], dict[str, tuple]] = {}
+        for (r, c), entries in union.items():
+            if not (0 <= r < layout_rows and 0 <= c < layout_cols):
+                continue
+            sweep_per_cell[(r, c)] = [[ln, k, lane] for (ln, k, lane, _s) in entries]
+            # Keep one substituted form per Load that hits the cell.
+            for ln, _k, _l, s in entries:
+                subst_per_cell.setdefault((r, c), {}).setdefault(ln, tuple(s))
+        all_cells = sorted(set(touched_now) | set(sweep_per_cell))
         touched_entries = [
             {
                 "r": r,
                 "c": c,
                 "lanes_now": touched_now.get((r, c), []),
-                "sweep": full_sweep.get((r, c), []),
-                "subst": list(p.full_sweep_subst_idx.get((r, c), ())),
+                # sweep: list of [load_name, k_iter, lane]
+                "sweep": sweep_per_cell.get((r, c), []),
+                # subst_by_load: {load_name: [substituted_index_string, ...]}
+                "subst_by_load": {ln: list(s) for ln, s in subst_per_cell.get((r, c), {}).items()},
             }
             for (r, c) in all_cells
         ]
@@ -287,7 +313,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
     //   (tooltip shows the full provenance per cell)
     const touchedNow = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes_now]));
     const sweep = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.sweep]));
-    const substMap = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.subst]));
+    const substByLoad = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.subst_by_load]));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
@@ -316,24 +342,32 @@ PAYLOAD.columns.forEach((col,ci)=>{
       parts.push(s === e ? `${s}` : `${s}-${e}`);
       return parts.join(', ');
     };
-    // Group sweep pairs by k_iter, list lane ranges per iter (compact
-    // when many iters — show first 6 + "+N more" if longer).
-    const formatSweep = pairs => {
-      if (!pairs.length) return '';
-      const byIter = new Map();
-      pairs.forEach(([k, l]) => {
+    // Group sweep entries by Load name, then by k_iter. Each entry is
+    // [load_name, k_iter, lane]. Renders one section per Load with up
+    // to ``cap`` k_iter lines below it.
+    const formatSweep = entries => {
+      if (!entries.length) return '';
+      const byLoad = new Map();
+      entries.forEach(([ln, k, l]) => {
+        if (!byLoad.has(ln)) byLoad.set(ln, new Map());
+        const byIter = byLoad.get(ln);
         if (!byIter.has(k)) byIter.set(k, []);
         byIter.get(k).push(l);
       });
-      const lines = [...byIter.keys()].sort((a,b)=>a-b).map(k => {
-        const lanes = byIter.get(k).sort((a,b)=>a-b);
-        return `k_iter=<b>${k}</b>: lanes ${compactRanges(lanes)} (${lanes.length}×)`;
-      });
-      const cap = 6;
-      if (lines.length > cap) {
-        return lines.slice(0, cap).join('<br/>') + `<br/><span style="color:#6b7280">… +${lines.length - cap} more iters</span>`;
+      const cap = 4;
+      const sections = [];
+      for (const [ln, byIter] of [...byLoad.entries()].sort()) {
+        const ks = [...byIter.keys()].sort((a,b)=>a-b);
+        const lines = ks.map(k => {
+          const lanes = byIter.get(k).sort((a,b)=>a-b);
+          return `&nbsp;&nbsp;k_iter=<b>${k}</b>: lanes ${compactRanges(lanes)} (${lanes.length}×)`;
+        });
+        const tail = lines.length > cap
+          ? lines.slice(0, cap).concat([`&nbsp;&nbsp;<span style="color:#6b7280">… +${lines.length - cap} more iters</span>`])
+          : lines;
+        sections.push(`<span style="color:#7dd3fc">${ln}</span>:<br/>${tail.join('<br/>')}`);
       }
-      return lines.join('<br/>');
+      return sections.join('<br/>');
     };
     ldr.setOption({
       backgroundColor:'transparent',
@@ -349,13 +383,19 @@ PAYLOAD.columns.forEach((col,ci)=>{
           const isNow = (touchedNow.get(k) || []).length > 0;
           const head = `row=<b>${r}</b>, col=<b>${c}</b>, bank <b>${bank}</b>, addr <b>${r * lay.row_stride + c}</b>`;
           if (!sweepPairs.length) {
-            return head + padTag + `<br/><span style="color:#6b7280">never read by warp ${0} (other warps own this row)</span>`;
+            return head + padTag + `<br/><span style="color:#6b7280">never read by warp 0 (other warps own this row)</span>`;
           }
           const star = isNow ? `<br/><span style="color:#fff">★ accessed at the rendered k_iter</span>` : '';
-          const subst = substMap.get(k) || [];
-          const substExpr = subst.length ? subst.join(', ') : lay.index_expr;
+          // One substituted form per Load that hits this cell.
+          const substMap = substByLoad.get(k) || {};
+          const substLines = Object.entries(substMap).sort().map(
+            ([ln, subst]) => `<code style="color:#3ddc84">${ln}[${subst.join(', ')}]</code>`
+          );
+          const loadSection = substLines.length
+            ? `<br/>${substLines.join('<br/>')}`
+            : '';
           return head +
-            `<br/>load <code style="color:#3ddc84">${lay.load_name}[${substExpr}]</code>` +
+            loadSection +
             star +
             `<br/>${formatSweep(sweepPairs)}` +
             padTag;
@@ -449,14 +489,18 @@ def main() -> None:
     for arg in args.ir:
         path, label = _parse_ir_arg(arg)
         g = graph_from_ir_path(path)
+        # Run twice when ``--load`` is set: once unfiltered (for the
+        # per-Stage union ladder) and once filtered (for the visible
+        # cards).
         panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
+        union_panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, None) if load_filter is not None else panels
         scalar_total = sum(p.conflict_events for p in panels)
         vec_total = sum(p.lds128_events for p in panels)
         print(f"{label}: {len(panels)} probes, ΣLDS.32={scalar_total}  ΣLDS.128={vec_total}")
         columns.append(
             {
                 "label": f"{label} · ΣLDS.32={scalar_total}  ΣLDS.128={vec_total}",
-                "panels": _serialize(panels),
+                "panels": _serialize(panels, all_panels_for_union=union_panels),
             }
         )
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -197,7 +197,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
         max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
-      <div class="ladder-title">smem layout — bank per (row,col), accessed cells outlined</div>
+      <div class="ladder-title">smem layout — bank per (row,col); hover the highlighted cells for load expr + lanes</div>
       <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
       <div class="card-notes">${p.notes.join('<br/>')}</div>`;
     colEl.appendChild(card);
@@ -278,9 +278,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
           value:[c, r, bank],
           itemStyle:{
             color: color,
-            opacity: isPad ? 0.45 : 1.0,
+            // Dim un-accessed cells so the white-outlined accessed
+            // cells visually pop — they are the ones with the rich
+            // tooltip (load expr + lanes).
+            opacity: isPad ? 0.18 : (isTouched ? 1.0 : 0.28),
             borderColor: isTouched ? '#ffffff' : 'transparent',
-            borderWidth: isTouched ? 1.5 : 0,
+            borderWidth: isTouched ? 2 : 0,
+            shadowBlur: isTouched ? 8 : 0,
+            shadowColor: isTouched ? '#ffffffaa' : 'transparent',
           },
         });
       }

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -247,8 +247,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const id=`c${ci}_p${pi}`;
     const card=document.createElement('div');card.className='card';
     card.innerHTML=`
-      <div class="card-title">${p.panel_title}</div>
-      <div class="card-formula">${p.formula}</div>
+      <div class="ladder-title" style="margin-top:0">bank access punchcard — ${p.panel_title}</div>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="hist-legend">

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -48,8 +48,10 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
     union_source = all_panels_for_union if all_panels_for_union is not None else panels
     # Build per-Stage union: (tile_op_name, stage_name) → {(r,c) → list of
     # (load_name, k_iter, lane, subst_idx_tuple)} merged across all body
-    # Loads of the Stage.
+    # Loads of the Stage. Also a per-Stage set of cells that participate
+    # in a real conflict in any of the Stage's Loads.
     stage_union: dict[tuple[str, str], dict[tuple[int, int], list[tuple]]] = {}
+    stage_conflict_cells: dict[tuple[str, str], set[tuple[int, int]]] = {}
     for p in union_source:
         key = (p.tile_op_name, p.stage_name)
         u = stage_union.setdefault(key, {})
@@ -57,6 +59,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
             subst = p.full_sweep_subst_idx.get(cell, ())
             for k, lane in pairs:
                 u.setdefault(cell, []).append((p.load_name, k, lane, subst))
+        stage_conflict_cells.setdefault(key, set()).update(p.full_sweep_conflict_cells)
     out: list[dict] = []
     for p in panels:
         # Per-lane address-color index: same address → same color, regardless
@@ -102,6 +105,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
             for ln, _k, _l, s in entries:
                 subst_per_cell.setdefault((r, c), {}).setdefault(ln, tuple(s))
         all_cells = sorted(set(touched_now) | set(sweep_per_cell))
+        conflict_cells = stage_conflict_cells.get((p.tile_op_name, p.stage_name), set())
         touched_entries = [
             {
                 "r": r,
@@ -111,6 +115,9 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
                 "sweep": sweep_per_cell.get((r, c), []),
                 # subst_by_load: {load_name: [substituted_index_string, ...]}
                 "subst_by_load": {ln: list(s) for ln, s in subst_per_cell.get((r, c), {}).items()},
+                # True iff this cell participates in a real conflict at
+                # some (Load, k_iter) — its bank had > 1 distinct address.
+                "conflict": (r, c) in conflict_cells,
             }
             for (r, c) in all_cells
         ]
@@ -231,7 +238,8 @@ PAYLOAD.columns.forEach((col,ci)=>{
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
-      <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
+      <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
+      ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);
 
     const m=echarts.init(document.getElementById(`m_${id}`),null,{renderer:'canvas'});
@@ -305,12 +313,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const touchedNow = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes_now]));
     const sweep = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.sweep]));
     const substByLoad = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.subst_by_load]));
+    const conflictCells = new Set(lay.touched.filter(t => t.conflict).map(t => `${t.r},${t.c}`));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
         const k = `${r},${c}`;
         const reachable = sweep.has(k);
+        const isConflict = conflictCells.has(k);
         const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
         ldrData.push({
           value:[c, r, bank],
@@ -318,6 +328,12 @@ PAYLOAD.columns.forEach((col,ci)=>{
             color: color,
             // Reachable cells: medium-bright. Padding / unreachable: dim.
             opacity: (isPad || !reachable) ? 0.18 : 0.7,
+            // Real-conflict cells (touched by an LDS where their bank
+            // had > 1 distinct addr) get a red outline. Layout-only
+            // potential (single-color column the warp never multi-
+            // exercises) stays unmarked.
+            borderColor: isConflict ? '#ff5c7a' : 'transparent',
+            borderWidth: isConflict ? 2 : 0,
           },
         });
       }
@@ -344,7 +360,10 @@ PAYLOAD.columns.forEach((col,ci)=>{
             ([ln, subst]) => `<code style="color:#3ddc84">${ln}[${subst.join(', ')}]</code>`
           );
           const loadSection = substLines.length ? `<br/>${substLines.join('<br/>')}` : '';
-          return head + loadSection + padTag;
+          const conflictTag = conflictCells.has(k)
+            ? `<br/><span style="color:#ff5c7a">⚠ real conflict — this LDS has &gt; 1 distinct addr on bank ${bank}</span>`
+            : '';
+          return head + loadSection + conflictTag + padTag;
         },
       },
       grid:{left:30, right:14, top:6, bottom:18},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -43,6 +43,7 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
             "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
             "lane_banks": p.lane_banks,
             "counts": p.counts,
+            "distinct_addrs": p.distinct_addrs,
             "max_way": p.max_way,
             "raw_max_way": p.raw_max_way,
             "conflict_events": p.conflict_events,
@@ -151,7 +152,9 @@ PAYLOAD.columns.forEach((col,ci)=>{
     for(let l=0;l<WARP;l++) for(let b=0;b<BANKS;b++)
       md.push({value:[b,l,0],itemStyle:{color:palette.empty}});
     p.lane_banks.forEach((bank,lane)=>{
-      const c=p.counts[bank];
+      // Color cells by distinct_addrs at that bank — broadcasts (multiple
+      // lanes at same address) are NOT conflicts and stay green.
+      const c=p.distinct_addrs[bank];
       md.push({value:[bank,lane,c],itemStyle:{color:cellColor(c),shadowBlur:6,shadowColor:cellColor(c)+'88'}});
     });
     m.setOption({
@@ -184,7 +187,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
         axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
       yAxis:{type:'value',splitLine:{lineStyle:{color:'#1c212b'}},
         axisLabel:{color:'#6b7280',fontSize:10},axisLine:{show:false},axisTick:{show:false}},
-      series:[{type:'bar',data:p.counts.map(c=>({value:c,itemStyle:{
+      series:[{type:'bar',data:p.distinct_addrs.map(c=>({value:c,itemStyle:{
         color:{type:'linear',x:0,y:0,x2:0,y2:1,
           colorStops:[{offset:0,color:cellColor(c)},{offset:1,color:cellColor(c)+'55'}]},
         borderRadius:[3,3,0,0]}})),barWidth:'70%',

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -176,6 +176,8 @@ const root=document.getElementById('columns');
 PAYLOAD.columns.forEach((col,ci)=>{
   const colEl=document.createElement('div');
   colEl.innerHTML=`<div class="col-head"><span class="label">${col.label}</span></div>`;
+  // Append BEFORE init so document.getElementById can find the chart hosts.
+  root.appendChild(colEl);
   if(col.panels.length===0){
     const e=document.createElement('div');e.className='empty';e.textContent='no Stages found';
     colEl.appendChild(e);
@@ -238,7 +240,6 @@ PAYLOAD.columns.forEach((col,ci)=>{
         animationDuration:600,animationEasing:'cubicOut'}]});
     window.addEventListener('resize',()=>{m.resize();h.resize();});
   });
-  root.appendChild(colEl);
 });
 </script>
 </body>

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -46,11 +46,6 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
     Falls back to ``panels`` if not provided.
     """
     union_source = all_panels_for_union if all_panels_for_union is not None else panels
-    # Build per-Stage union: (tile_op_name, stage_name) → {(r,c) → list of
-    # (load_name, k_iter, lane, subst_idx_tuple)} merged across all body
-    # Loads of the Stage. Also a per-cell map of Loads whose LDS conflicts
-    # when touching that cell (so the tooltip can flag conflicts on the
-    # focused Load specifically).
     stage_union: dict[tuple[str, str], dict[tuple[int, int], list[tuple]]] = {}
     stage_conflict_loads: dict[tuple[str, str], dict[tuple[int, int], set[str]]] = {}
     for p in union_source:
@@ -92,11 +87,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
             r, c = divmod(addr, row_stride)
             if 0 <= r < layout_rows and 0 <= c < layout_cols:
                 touched_now.setdefault((r, c), []).append(lane)
-        # Per-Stage UNION across every body Load of the Stage: cell →
-        # list of (load_name, k_iter, lane, subst_idx_tuple). The
-        # ladder shows the union (so it answers "across the K loop,
-        # which cells does this Stage's body ever read"); the top
-        # heatmap stays per-Load (bank conflicts are per-LDS).
+        # Per-Stage UNION across every body Load of the Stage.
         union = stage_union.get((p.tile_op_name, p.stage_name), {})
         sweep_per_cell: dict[tuple[int, int], list[list]] = {}
         subst_per_cell: dict[tuple[int, int], dict[str, tuple]] = {}
@@ -104,7 +95,6 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
             if not (0 <= r < layout_rows and 0 <= c < layout_cols):
                 continue
             sweep_per_cell[(r, c)] = [[ln, k, lane] for (ln, k, lane, _s) in entries]
-            # Keep one substituted form per Load that hits the cell.
             for ln, _k, _l, s in entries:
                 subst_per_cell.setdefault((r, c), {}).setdefault(ln, tuple(s))
         all_cells = sorted(set(touched_now) | set(sweep_per_cell))
@@ -129,6 +119,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
                 "buf_short": p.buf,
                 "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
                 "lane_banks": p.lane_banks,
+                "lane_addrs": list(p.lane_addrs),
                 "lane_addr_idx": lane_addr_idx,
                 "n_unique_addrs": len(unique_addrs),
                 "counts": p.counts,
@@ -161,27 +152,47 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
 
 
 HTML = """<!doctype html>
-<html lang="en">
+<html lang="en" data-theme="__THEME__">
 <head>
 <meta charset="utf-8" />
 <title>smem bank conflicts (IR-driven)</title>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
 <style>
-  :root { --bg:transparent; --panel:transparent; --panel-2:transparent; --fg:#e8eaed; --muted:#6b7280; }
+  :root[data-theme="dark"] {
+    --bg:transparent; --fg:#e8eaed; --muted:#6b7280;
+    --rule:rgba(255,255,255,.06); --label-accent:#7dd3fc;
+  }
+  :root[data-theme="light"] {
+    --bg:transparent; --fg:#1f2937; --muted:#4b5563;
+    --rule:rgba(0,0,0,.08); --label-accent:#0369a1;
+  }
   *{box-sizing:border-box;}
   html,body{margin:0;background:transparent;color:var(--fg);
     font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
   /* Center the column grid + shared legend horizontally; shrink to
      content width so unused horizontal space sits outside the page. */
   .page{display:flex;flex-direction:column;align-items:center;margin:0;padding:0;}
-  /* Auto-sized columns: each column shrinks to its content width
-     (the punchcard / ladder), so the whole grid is no wider than the
-     plots need. Centered if the page has more horizontal room. */
-  .columns{display:grid;grid-template-columns:repeat(__NCOL__,auto);gap:20px;justify-content:center;}
+  /* Single page-grid: N auto-sized columns (one per IR variant);
+     shared titles + legends span all columns. justify-content:center
+     so the whole block stays centered when the iframe is wider. */
+  .page-grid{display:grid;gap:8px 20px;justify-content:center;align-items:start;}
+  .page-grid > .col-head,
+  .page-grid > .matrix,
+  .page-grid > .hist,
+  .page-grid > .ladder{justify-self:center;}
+  .page-grid > .section-title{grid-column:1 / -1;}
+  .page-grid > .ladder,
+  .page-grid > .ladder-sub{grid-column:1 / -1;justify-self:center;}
+  .page-grid > .hist-legend-shared,
+  .page-grid > .bank-legend-shared{grid-column:1 / -1;justify-self:center;}
+  .ladder-sub{font-size:13px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
+    margin:14px 0 4px;text-align:center;}
+  .ladder-sub .label{color:var(--label-accent);font-weight:600;}
+  .section-title{font-size:16px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--fg);margin:22px 0 8px;text-align:left;}
   .col-head{text-align:center;font-size:14px;text-transform:uppercase;letter-spacing:.16em;
-    color:var(--muted);padding:6px 0 8px;margin-bottom:8px;border-bottom:1px solid rgba(255,255,255,.06);}
-  .col-head .label{color:#7dd3fc;font-weight:600;}
-  .card{background:transparent;border:none;border-radius:0;padding:0;box-shadow:none;margin-bottom:0;}
+    color:var(--muted);padding:6px 0 8px;border-bottom:1px solid var(--rule);min-width:200px;}
+  .col-head .label{color:var(--label-accent);font-weight:600;}
   .card-title{font-size:14px;font-weight:600;letter-spacing:-.01em;}
   .card-formula{font-family:'JetBrains Mono',ui-monospace,monospace;font-size:12px;color:var(--muted);margin-top:4px;}
   .card-notes{font-family:'JetBrains Mono',ui-monospace,monospace;font-size:11px;color:var(--muted);margin-top:6px;line-height:1.55;}
@@ -207,9 +218,10 @@ HTML = """<!doctype html>
   .bank-legend i{width:10px;height:10px;border-radius:2px;display:inline-block;flex-shrink:0;}
   .bank-legend-shared{margin-top:18px;font-size:12px;}
   .hist-legend{display:flex;flex-wrap:wrap;gap:5px 16px;margin:8px auto 0;
-    width:100%;max-width:400px;font-size:12px;color:var(--muted);}
+    width:fit-content;font-size:12px;color:var(--muted);}
   .hist-legend span{display:inline-flex;align-items:center;gap:6px;}
   .hist-legend i{width:11px;height:11px;border-radius:2px;display:inline-block;}
+  .hist-legend-shared{margin-top:14px;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
@@ -219,24 +231,26 @@ HTML = """<!doctype html>
 </head>
 <body>
   <div class="page">
-    <div class="columns" id="columns"></div>
-    <div class="bank-legend bank-legend-shared" id="shared-bank-legend"></div>
+    <div class="page-grid" id="page-grid"></div>
   </div>
 <script>
 const PAYLOAD = __PAYLOAD__;
+const THEME = __THEME_JS__;
 const WARP=32, BANKS=32;
-const palette={empty:'#2a2d33',ok:'#3ddc84',warn:'#ffb454',bad:'#ff5c7a'};
+const palette={empty:THEME.empty,ok:'#3ddc84',warn:'#ffb454',bad:'#ff5c7a'};
 const cellColor=c=>c===0?palette.empty:c===1?palette.ok:c<=4?palette.warn:palette.bad;
 const verdict=m=>m>4?'v-bad':m>1?'v-warn':'v-ok';
 // Two distinct palettes — keep "color = bank" (smem layout) and
 // "color = address" (punch card) visually independent so the reader
 // doesn't conflate them.
 //
-// BANK_PALETTE: 16-color rainbow used in the smem-layout ladder. Each
-// hue maps to a bank id (mod 16 — banks 0..15 use the first 16 hues,
-// banks 16..31 reuse them).
+// BANK_PALETTE: 32 distinct hues (one per smem bank). Same color =
+// same bank, so two highlighted cells sharing a color in the layout
+// land on the same bank — direct visual cue for a bank conflict.
 const BANK_PALETTE=['#7dd3fc','#3ddc84','#ffb454','#ff5c7a','#c084fc','#fcd34d','#67e8f9','#fb923c',
-                    '#a3e635','#f472b6','#60a5fa','#34d399','#fde047','#fb7185','#818cf8','#facc15'];
+                    '#a3e635','#f472b6','#60a5fa','#34d399','#fde047','#fb7185','#818cf8','#facc15',
+                    '#0ea5e9','#16a34a','#d97706','#dc2626','#9333ea','#ca8a04','#0891b2','#ea580c',
+                    '#65a30d','#db2777','#1d4ed8','#059669','#a16207','#be123c','#4338ca','#b45309'];
 // ADDR_PALETTE: warm-only palette (yellows, oranges, reds, browns) used
 // in the lane×bank punch card. A warp typically has 1-4 distinct
 // addresses per Load, so a short palette is fine. Warm-only avoids
@@ -244,43 +258,109 @@ const BANK_PALETTE=['#7dd3fc','#3ddc84','#ffb454','#ff5c7a','#c084fc','#fcd34d',
 // a glance which plot a color belongs to.
 const ADDR_PALETTE=['#fde047','#fb923c','#ef4444','#a3a3a3','#facc15','#fdba74','#dc2626','#78350f'];
 
-const root=document.getElementById('columns');
-PAYLOAD.columns.forEach((col,ci)=>{
-  const colEl=document.createElement('div');
-  colEl.innerHTML=`<div class="col-head"><span class="label">${col.label}</span></div>`;
-  // Append BEFORE init so document.getElementById can find the chart hosts.
-  root.appendChild(colEl);
-  if(col.panels.length===0){
-    const e=document.createElement('div');e.className='empty';e.textContent='no Stages found';
-    colEl.appendChild(e);
+// Layout: one page-grid with N columns (one per IR variant). Rows
+// alternate between shared titles (spanning all columns, left-justified)
+// and per-column plot cells. We render rows of HTML strings into the
+// grid in the right order.
+const root = document.getElementById('page-grid');
+root.style.gridTemplateColumns = `repeat(${PAYLOAD.columns.length}, auto)`;
+
+// Pick the representative stage / buf from the first non-empty panel.
+const firstPanel = PAYLOAD.columns.flatMap(c => c.panels)[0];
+const bufLabel = firstPanel ? firstPanel.buf_short : '';
+
+// 1) Shared punchcard title (above the column headings).
+const punTitle = document.createElement('div');
+punTitle.className = 'section-title';
+punTitle.textContent = `bank access punchcard — ${bufLabel}`;
+root.appendChild(punTitle);
+
+// 2) Column headings.
+PAYLOAD.columns.forEach(col => {
+  const head = document.createElement('div');
+  head.className = 'col-head';
+  head.innerHTML = `<span class="label">${col.label}</span>`;
+  root.appendChild(head);
+});
+
+// 3) Punchcards row.
+PAYLOAD.columns.forEach((col, ci) => {
+  if (!col.panels.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty';
+    empty.textContent = 'no Stages found';
+    root.appendChild(empty);
+  } else {
+    const matrix = document.createElement('div');
+    matrix.className = 'matrix';
+    matrix.id = `m_c${ci}_p0`;
+    root.appendChild(matrix);
   }
-  col.panels.forEach((p,pi)=>{
-    const id=`c${ci}_p${pi}`;
-    const card=document.createElement('div');card.className='card';
-    card.innerHTML=`
-      <div class="ladder-title" style="margin-top:0">bank access punchcard — ${p.buf_short}</div>
-      <div class="matrix" id="m_${id}"></div>
-      <div class="hist" id="h_${id}"></div>
-      <div class="hist-legend">
-        <span><i style="background:#3ddc84"></i>1 lane (no conflict)</span>
-        <span><i style="background:#ffb454"></i>2–4 lanes (mild)</span>
-        <span><i style="background:#ff5c7a"></i>&gt;4 lanes (heavy)</span>
-      </div>
-      <div class="ladder-title">smem layout — bank per (row, col)</div>
-      <div class="ladder" id="l_${id}" style="${(()=>{
-        // Cells are 3:1 wide rectangles when there's room; shrink
-        // cell_w toward cell_h (square) when the column gets narrow.
-        // cell_h is sized by row count (so the slab fits ≤ maxH);
-        // cell_w = min(3 × cell_h, fits_width).
-        const axisW = 44, axisH = 28, maxH = 450, maxW = 475;
-        const cellH = Math.max(3, Math.min(5, Math.floor((maxH - axisH) / p.layout.rows)));
-        const cellW = Math.max(cellH, Math.min(3 * cellH, Math.floor((maxW - axisW) / p.layout.cols)));
-        const w = p.layout.cols * cellW + axisW;
-        const h = p.layout.rows * cellH + axisH;
-        return `width:${w}px; height:${h}px`;
-      })()}"></div>
-      ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
-    colEl.appendChild(card);
+});
+
+// 4) Histograms row.
+PAYLOAD.columns.forEach((col, ci) => {
+  if (!col.panels.length) {
+    root.appendChild(document.createElement('div'));
+    return;
+  }
+  const hist = document.createElement('div');
+  hist.className = 'hist';
+  hist.id = `h_c${ci}_p0`;
+  root.appendChild(hist);
+});
+
+// 5) Shared severity legend (spans all columns, centered).
+const sevLegend = document.createElement('div');
+sevLegend.className = 'hist-legend hist-legend-shared';
+sevLegend.innerHTML = `
+  <span><i style="background:#3ddc84"></i>1 lane (no conflict)</span>
+  <span><i style="background:#ffb454"></i>2–4 lanes (mild)</span>
+  <span><i style="background:#ff5c7a"></i>&gt;4 lanes (heavy)</span>
+`;
+root.appendChild(sevLegend);
+
+// 6) Shared ladder title.
+const ladTitle = document.createElement('div');
+ladTitle.className = 'section-title';
+ladTitle.textContent = 'smem layout — bank per (row, col)';
+root.appendChild(ladTitle);
+
+// 7) Ladders — stacked vertically, each spanning all columns. Each
+// ladder gets its own sub-heading (the variant label) so the reader
+// can tell them apart without the side-by-side layout.
+PAYLOAD.columns.forEach((col, ci) => {
+  if (!col.panels.length) return;
+  const p = col.panels[0];
+  const sub = document.createElement('div');
+  sub.className = 'ladder-sub';
+  sub.innerHTML = `<span class="label">${col.label}</span>`;
+  root.appendChild(sub);
+  const ladder = document.createElement('div');
+  ladder.className = 'ladder';
+  ladder.id = `l_c${ci}_p0`;
+  // Stacked layout doubles the available real estate per ladder.
+  const lay = p.layout;
+  const axisW = 56, axisH = 32, maxH = 900, maxW = 960;
+  const cellH = Math.max(6, Math.min(10, Math.floor((maxH - axisH) / lay.rows)));
+  const cellW = Math.max(cellH, Math.min(3 * cellH, Math.floor((maxW - axisW) / lay.cols)));
+  ladder.style.width = `${lay.cols * cellW + axisW}px`;
+  ladder.style.height = `${lay.rows * cellH + axisH}px`;
+  root.appendChild(ladder);
+});
+
+// 8) Shared bank legend.
+const bankLegendEl = document.createElement('div');
+bankLegendEl.className = 'bank-legend bank-legend-shared';
+bankLegendEl.id = 'shared-bank-legend';
+root.appendChild(bankLegendEl);
+
+// Now render plots for each column's first panel.
+PAYLOAD.columns.forEach((col, ci) => {
+  if (!col.panels.length) return;
+  col.panels.forEach((p, pi) => {
+    if (pi > 0) return;  // one panel per column expected
+    const id = `c${ci}_p${pi}`;
 
     const m=echarts.init(document.getElementById(`m_${id}`),null,{renderer:'canvas'});
     const md=[];
@@ -300,39 +380,39 @@ PAYLOAD.columns.forEach((col,ci)=>{
     });
     m.setOption({
       backgroundColor:'transparent',
-      tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
+      tooltip:{backgroundColor:THEME.tooltipBg,borderColor:THEME.axisLine,textStyle:{color:THEME.tooltipText,fontSize:12},
         formatter:pt=>{const [b,l,c]=pt.value;
           if (c === 0) return `bank ${b}<br/><span style="color:#6b7280">no lane</span>`;
-          const ai = pt.data.addrIdx;
+          const addr = p.lane_addrs[l];
           const dist = p.distinct_addrs[b];
           const verdict = dist === 1 ? '<span style="color:#3ddc84">broadcast — 0 events</span>'
                        : dist <= 4 ? `<span style="color:#ffb454">${dist}-way conflict</span>`
                                    : `<span style="color:#ff5c7a">${dist}-way conflict</span>`;
-          return `lane <b>${l}</b> → bank <b>${b}</b>, addr-color <b>#${ai}</b><br/>${verdict}`;
+          return `lane <b>${l}</b> → bank <b>${b}</b>, addr <b>${addr}</b><br/>${verdict}`;
         }},
       grid:{left:38,right:8,top:8,bottom:42},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
-        nameTextStyle:{color:'#6b7280',fontSize:13},axisLine:{lineStyle:{color:'#2a2d33'}},
+        nameTextStyle:{color:'#6b7280',fontSize:13},axisLine:{lineStyle:{color:THEME.axisLine}},
         axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
         nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:13},
-        axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
+        axisLine:{lineStyle:{color:THEME.axisLine}},axisTick:{show:false},
         axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
       series:[{type:'heatmap',data:md,progressive:0,
-        itemStyle:{borderRadius:2,borderColor:'#161a21',borderWidth:1},
+        itemStyle:{borderRadius:2},
         emphasis:{itemStyle:{borderColor:'#fff',borderWidth:1.5}},
         animationDuration:500,animationEasing:'cubicOut'}]});
 
     const h=echarts.init(document.getElementById(`h_${id}`),null,{renderer:'canvas'});
     h.setOption({
       backgroundColor:'transparent',
-      tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
+      tooltip:{backgroundColor:THEME.tooltipBg,borderColor:THEME.axisLine,textStyle:{color:THEME.tooltipText,fontSize:12},
         formatter:pt=>`bank <b>${pt.name}</b><br/>${pt.value} lane(s)`},
       grid:{left:38,right:8,top:6,bottom:22},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],
-        axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
+        axisLine:{lineStyle:{color:THEME.axisLine}},axisTick:{show:false},
         axisLabel:{color:'#6b7280',fontSize:12,interval:3,showMaxLabel:true,showMinLabel:true}},
-      yAxis:{type:'value',min:0,max:8,splitLine:{lineStyle:{color:'#1c212b'}},
+      yAxis:{type:'value',min:0,max:8,splitLine:{lineStyle:{color:THEME.splitLine}},
         axisLabel:{color:'#6b7280',fontSize:12},axisLine:{show:false},axisTick:{show:false}},
       series:[{type:'bar',data:p.distinct_addrs.map(c=>({value:c,itemStyle:{
         color:{type:'linear',x:0,y:0,x2:0,y2:1,
@@ -347,34 +427,24 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const lEl = document.getElementById(`l_${id}`);
     const ldr = echarts.init(lEl, null, {renderer:'canvas'});
     const ldrData = [];
-    // touchedNow: cells the warp accessed AT THE CURRENT k_iter (white outline)
-    // sweep: cells the warp accessed across the full inner-loop sweep
-    //   (tooltip shows the full provenance per cell)
+    // touchedNow: cells the 32 lanes of the focused Load access AT THE
+    // CURRENT k_iter (32 cells, one per lane). These are the only cells
+    // fully opaque — making the conflict reading direct: two opaque
+    // cells sharing a bank color = same bank hit with different
+    // addresses = conflict for this LDS.
     const touchedNow = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes_now]));
     const sweep = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.sweep]));
     const substByLoad = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.subst_by_load]));
-    // Cells touched by the focused Load (the one this card represents)
-    // across the whole K sweep. Highlighted with a white outline so
-    // the reader can spot when two highlighted cells in the same bank
-    // column share a color = conflict for that LDS.
     const focusLoad = lay.load_name;
-    const focusCells = new Set(
-      lay.touched.filter(t => t.subst_by_load && t.subst_by_load[focusLoad]).map(t => `${t.r},${t.c}`)
-    );
     const conflictLoadsByCell = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.conflict_loads || []]));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
         const k = `${r},${c}`;
-        const reachable = sweep.has(k);
-        const isFocus = focusCells.has(k);
-        const color = isPad ? '#3a3f48' : BANK_PALETTE[bank % BANK_PALETTE.length];
-        // Three opacity levels: focused-Load cells (top), other
-        // reachable cells (middle), padding/unreachable (bottom).
-        // Reading rule: two cells with the high-opacity rows in the
-        // same column sharing a color → conflict for that LDS.
-        const op = isPad ? 0.18 : (isFocus ? 0.95 : (reachable ? 0.32 : 0.18));
+        const isNow = (touchedNow.get(k) || []).length > 0;
+        const color = isPad ? THEME.padCell : BANK_PALETTE[bank % BANK_PALETTE.length];
+        const op = isNow ? THEME.opFocus : THEME.opFaint;
         ldrData.push({
           value:[c, r, bank],
           itemStyle:{color: color, opacity: op},
@@ -423,14 +493,14 @@ PAYLOAD.columns.forEach((col,ci)=>{
       grid:{left:30, right:14, top:6, bottom:18},
       xAxis:{
         type:'category', data:[...Array(lay.cols).keys()],
-        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLine:{lineStyle:{color:THEME.axisLine}}, axisTick:{show:false},
         axisLabel:{color:'#6b7280', fontSize:11,
           interval: Math.max(0, Math.floor(lay.cols/8) - 1),
           showMaxLabel: true, showMinLabel: true},
       },
       yAxis:{
         type:'category', data:[...Array(lay.rows).keys()], inverse:true,
-        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLine:{lineStyle:{color:THEME.axisLine}}, axisTick:{show:false},
         axisLabel:{color:'#6b7280', fontSize:11,
           interval: Math.max(0, Math.floor(lay.rows/8) - 1),
           showMaxLabel: true, showMinLabel: true},
@@ -468,11 +538,37 @@ PAYLOAD.columns.forEach((col,ci)=>{
 """
 
 
-def emit_html(columns: list[dict], out_path: str) -> None:
+_THEMES = {
+    "dark": {
+        "empty": "#2a2d33",
+        "tooltipBg": "#0e1014",
+        "tooltipText": "#e8eaed",
+        "axisLine": "#2a2d33",
+        "splitLine": "#1c212b",
+        "padCell": "#3a3f48",
+        "opFocus": 1.0,
+        "opFaint": 0.18,
+    },
+    "light": {
+        "empty": "#b8bec7",
+        "tooltipBg": "#ffffff",
+        "tooltipText": "#0f172a",
+        "axisLine": "#6b7280",
+        "splitLine": "#9ca3af",
+        "padCell": "#64748b",
+        "opFocus": 1.0,
+        "opFaint": 0.18,
+    },
+}
+
+
+def emit_html(columns: list[dict], out_path: str, theme: str = "dark") -> None:
     n = max(1, len(columns))
     html = (
         HTML.replace("__MAXW__", str(min(2200, 480 * n + 80)))
         .replace("__NCOL__", str(n))
+        .replace("__THEME__", theme)
+        .replace("__THEME_JS__", json.dumps(_THEMES[theme]))
         .replace("__PAYLOAD__", json.dumps({"columns": columns}))
     )
     with open(out_path, "w") as f:
@@ -503,6 +599,7 @@ def main() -> None:
     p.add_argument("--k-iter", type=int, default=0)
     p.add_argument("--warp-id", type=int, default=0)
     p.add_argument("--out", default="/tmp/bank_conflicts.html")
+    p.add_argument("--theme", choices=("dark", "light"), default="dark")
     args = p.parse_args()
 
     stage_filter = set(args.stage) if args.stage else None
@@ -525,9 +622,6 @@ def main() -> None:
     for arg in args.ir:
         path, label = _parse_ir_arg(arg)
         g = graph_from_ir_path(path)
-        # Run twice when ``--load`` is set: once unfiltered (for the
-        # per-Stage union ladder) and once filtered (for the visible
-        # cards).
         panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, load_filter)
         union_panels = simulate_graph(g, stage_filter, args.k_iter, args.warp_id, None) if load_filter is not None else panels
         scalar_total = sum(p.conflict_events for p in panels)
@@ -540,7 +634,7 @@ def main() -> None:
             }
         )
 
-    emit_html(columns, args.out)
+    emit_html(columns, args.out, theme=args.theme)
     print(f"saved {args.out}")
 
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -210,8 +210,6 @@ PAYLOAD.columns.forEach((col,ci)=>{
     card.innerHTML=`
       <div class="card-title">${p.panel_title}</div>
       <div class="card-formula">${p.formula}</div>
-      <span class="card-verdict ${verdict(p.max_way)}"><span class="dot"></span>
-        max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -84,6 +84,7 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
                 "c": c,
                 "lanes_now": touched_now.get((r, c), []),
                 "sweep": full_sweep.get((r, c), []),
+                "subst": list(p.full_sweep_subst_idx.get((r, c), ())),
             }
             for (r, c) in all_cells
         ]
@@ -288,6 +289,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
     //   (tooltip shows the full provenance per cell)
     const touchedNow = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes_now]));
     const sweep = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.sweep]));
+    const substMap = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.subst]));
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
@@ -352,8 +354,13 @@ PAYLOAD.columns.forEach((col,ci)=>{
             return head + padTag + `<br/><span style="color:#6b7280">never read by warp ${0} (other warps own this row)</span>`;
           }
           const star = isNow ? `<br/><span style="color:#fff">★ accessed at the rendered k_iter</span>` : '';
+          // Show both the symbolic form and the substituted form (vars
+          // replaced with the concrete values that produce this cell).
+          const subst = substMap.get(k) || [];
+          const substExpr = subst.length ? subst.join(', ') : lay.index_expr;
           return head +
             `<br/>load <code style="color:#7dd3fc">${lay.load_name}[${lay.index_expr}]</code>` +
+            `<br/>     = <code style="color:#3ddc84">${lay.load_name}[${substExpr}]</code>` +
             star +
             `<br/>${formatSweep(sweepPairs)}` +
             padTag;

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -192,10 +192,10 @@ HTML = """<!doctype html>
   .ladder{width:100%;margin-top:8px;}
   .ladder-title{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);
     margin-top:14px;margin-bottom:6px;}
-  .bank-legend{display:flex;flex-wrap:wrap;gap:4px 10px;margin-top:8px;
-    font-family:'JetBrains Mono',ui-monospace,monospace;font-size:10px;color:var(--muted);}
-  .bank-legend span{display:inline-flex;align-items:center;gap:4px;}
-  .bank-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
+  .bank-legend{display:grid;grid-template-columns:repeat(8,1fr);gap:3px 6px;margin-top:8px;
+    font-family:'JetBrains Mono',ui-monospace,monospace;font-size:9px;color:var(--muted);}
+  .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}
+  .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -144,9 +144,7 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
                     "index_expr": ", ".join(p.index_repr),
                     "load_name": p.load_name,
                 },
-                "notes": [
-                    f"index = ({', '.join(p.index_repr)})",
-                ],
+                "notes": [],
             }
         )
     return out
@@ -233,8 +231,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
-      <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
-      <div class="card-notes">${p.notes.join('<br/>')}</div>`;
+      <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);
 
     const m=echarts.init(document.getElementById(`m_${id}`),null,{renderer:'canvas'});

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -192,6 +192,10 @@ HTML = """<!doctype html>
   .ladder{width:100%;margin-top:8px;}
   .ladder-title{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);
     margin-top:14px;margin-bottom:6px;}
+  .bank-legend{display:flex;flex-wrap:wrap;gap:4px 10px;margin-top:8px;
+    font-family:'JetBrains Mono',ui-monospace,monospace;font-size:10px;color:var(--muted);}
+  .bank-legend span{display:inline-flex;align-items:center;gap:4px;}
+  .bank-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
@@ -251,6 +255,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
       <div class="hist" id="h_${id}"></div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
+      <div class="bank-legend" id="bl_${id}"></div>
       ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);
 
@@ -412,6 +417,20 @@ PAYLOAD.columns.forEach((col,ci)=>{
         itemStyle:{borderRadius:1},
         animationDuration:400, animationEasing:'cubicOut',
       }],
+    });
+    // Bank-color legend below the ladder. Only shows banks that
+    // actually appear in the smem layout (typically 0..31, but the
+    // legend trims to the unique banks present). Compact horizontal
+    // chips with the BANK_PALETTE color + "bank N" label.
+    const banksUsed = new Set();
+    for (let r = 0; r < lay.rows; r++) {
+      for (let c = 0; c < lay.cols; c++) banksUsed.add(lay.banks[r][c]);
+    }
+    const legend = document.getElementById(`bl_${id}`);
+    [...banksUsed].sort((a,b)=>a-b).forEach(bank => {
+      const chip = document.createElement('span');
+      chip.innerHTML = `<i style="background:${BANK_PALETTE[bank % BANK_PALETTE.length]}"></i>bank ${bank}`;
+      legend.appendChild(chip);
     });
     window.addEventListener('resize',()=>{m.resize();h.resize();ldr.resize();});
   });

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -263,14 +263,17 @@ PAYLOAD.columns.forEach((col,ci)=>{
       </div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
       <div class="ladder" id="l_${id}" style="${(()=>{
-        // 3:1 wide rectangles for ladder cells (cell_w = 3 × cell_h).
-        // Container fills column; height = rows × cell_h + axis. Cell
-        // height is computed to keep total ≤ 360 px while ensuring the
-        // 3× wider cells don't exceed 100% column width.
-        const axisH = 24, maxH = 360;
-        const N = Math.max(2, Math.min(6, Math.floor((maxH - axisH) / p.layout.rows)));
+        // Natural-size square cells: pick the largest cell-size px
+        // that fits both maxW and maxH, then size the container to
+        // (cols*N + axisW) × (rows*N + axisH). Don't stretch — leave
+        // unused horizontal space for the iframe to be narrower.
+        const axisW = 38, axisH = 24, maxH = 360, maxW = 380;
+        const N = Math.max(2, Math.min(6,
+          Math.floor((maxH - axisH) / p.layout.rows),
+          Math.floor((maxW - axisW) / p.layout.cols)));
+        const w = p.layout.cols * N + axisW;
         const h = p.layout.rows * N + axisH;
-        return `width:100%; height:${h}px`;
+        return `width:${w}px; height:${h}px`;
       })()}"></div>
       ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -313,27 +313,34 @@ PAYLOAD.columns.forEach((col,ci)=>{
     const touchedNow = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.lanes_now]));
     const sweep = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.sweep]));
     const substByLoad = new Map(lay.touched.map(t => [`${t.r},${t.c}`, t.subst_by_load]));
-    const conflictCells = new Set(lay.touched.filter(t => t.conflict).map(t => `${t.r},${t.c}`));
+    // Cells touched by the focused Load (the one this card represents)
+    // across the whole K sweep. Highlighted with a white outline so
+    // the reader can spot when two highlighted cells in the same bank
+    // column share a color = conflict for that LDS.
+    const focusLoad = lay.load_name;
+    const focusCells = new Set(
+      lay.touched.filter(t => t.subst_by_load && t.subst_by_load[focusLoad]).map(t => `${t.r},${t.c}`)
+    );
     for (let r = 0; r < lay.rows; r++) {
       for (let c = 0; c < lay.cols; c++) {
         const bank = lay.banks[r][c];
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
         const k = `${r},${c}`;
         const reachable = sweep.has(k);
-        const isConflict = conflictCells.has(k);
+        const isFocus = focusCells.has(k);
         const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
         ldrData.push({
           value:[c, r, bank],
           itemStyle:{
             color: color,
-            // Reachable cells: medium-bright. Padding / unreachable: dim.
             opacity: (isPad || !reachable) ? 0.18 : 0.7,
-            // Real-conflict cells (touched by an LDS where their bank
-            // had > 1 distinct addr) get a red outline. Layout-only
-            // potential (single-color column the warp never multi-
-            // exercises) stays unmarked.
-            borderColor: isConflict ? '#ff5c7a' : 'transparent',
-            borderWidth: isConflict ? 2 : 0,
+            // White outline = "this Load (the focused one) touches the
+            // cell at some k_iter". Reading rule: when two outlined
+            // cells in the same column have the same color, the
+            // focused Load's LDS at that column produces a real
+            // conflict on that bank.
+            borderColor: isFocus ? '#ffffff' : 'transparent',
+            borderWidth: isFocus ? 1.5 : 0,
           },
         });
       }
@@ -360,10 +367,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
             ([ln, subst]) => `<code style="color:#3ddc84">${ln}[${subst.join(', ')}]</code>`
           );
           const loadSection = substLines.length ? `<br/>${substLines.join('<br/>')}` : '';
-          const conflictTag = conflictCells.has(k)
-            ? `<br/><span style="color:#ff5c7a">⚠ real conflict — this LDS has &gt; 1 distinct addr on bank ${bank}</span>`
-            : '';
-          return head + loadSection + conflictTag + padTag;
+          return head + loadSection + padTag;
         },
       },
       grid:{left:30, right:14, top:6, bottom:18},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -215,11 +215,21 @@ const WARP=32, BANKS=32;
 const palette={empty:'#2a2d33',ok:'#3ddc84',warn:'#ffb454',bad:'#ff5c7a'};
 const cellColor=c=>c===0?palette.empty:c===1?palette.ok:c<=4?palette.warn:palette.bad;
 const verdict=m=>m>4?'v-bad':m>1?'v-warn':'v-ok';
-// Categorical palette for "color = address". Picked for high contrast on
-// dark bg + reasonable distinguishability. Cycles modulo length when a
-// panel has more unique addresses than colors.
-const ADDR_PALETTE=['#7dd3fc','#3ddc84','#ffb454','#ff5c7a','#c084fc','#fcd34d','#67e8f9','#fb923c',
+// Two distinct palettes — keep "color = bank" (smem layout) and
+// "color = address" (punch card) visually independent so the reader
+// doesn't conflate them.
+//
+// BANK_PALETTE: 16-color rainbow used in the smem-layout ladder. Each
+// hue maps to a bank id (mod 16 — banks 0..15 use the first 16 hues,
+// banks 16..31 reuse them).
+const BANK_PALETTE=['#7dd3fc','#3ddc84','#ffb454','#ff5c7a','#c084fc','#fcd34d','#67e8f9','#fb923c',
                     '#a3e635','#f472b6','#60a5fa','#34d399','#fde047','#fb7185','#818cf8','#facc15'];
+// ADDR_PALETTE: warm-only palette (yellows, oranges, reds, browns) used
+// in the lane×bank punch card. A warp typically has 1-4 distinct
+// addresses per Load, so a short palette is fine. Warm-only avoids
+// overlap with the cool/rainbow BANK_PALETTE — the reader can tell at
+// a glance which plot a color belongs to.
+const ADDR_PALETTE=['#fde047','#fb923c','#ef4444','#a3a3a3','#facc15','#fdba74','#dc2626','#78350f'];
 
 const root=document.getElementById('columns');
 PAYLOAD.columns.forEach((col,ci)=>{
@@ -331,7 +341,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
         const k = `${r},${c}`;
         const reachable = sweep.has(k);
         const isFocus = focusCells.has(k);
-        const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
+        const color = isPad ? '#3a3f48' : BANK_PALETTE[bank % BANK_PALETTE.length];
         // Three opacity levels: focused-Load cells (top), other
         // reachable cells (middle), padding/unreachable (bottom).
         // Reading rule: two cells with the high-opacity rows in the

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -192,7 +192,7 @@ HTML = """<!doctype html>
   /* Histogram shares the bank axis with the punchcard above —
      match its max-width so banks line up vertically. */
   .hist{width:100%;max-width:320px;height:80px;margin:2px auto 0;}
-  .ladder{width:100%;margin-top:4px;}
+  .ladder{margin:4px auto 0;}
   .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
     margin-top:10px;margin-bottom:4px;}
   .bank-legend{display:grid;grid-template-columns:repeat(8,1fr);gap:3px 6px;margin-top:8px;
@@ -200,8 +200,8 @@ HTML = """<!doctype html>
   .bank-legend span{display:inline-flex;align-items:center;gap:4px;white-space:nowrap;}
   .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
   .bank-legend-shared{margin-top:14px;font-size:10px;}
-  .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:6px;
-    font-size:10px;color:var(--muted);}
+  .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin:6px auto 0;
+    width:100%;max-width:320px;font-size:10px;color:var(--muted);}
   .hist-legend span{display:inline-flex;align-items:center;gap:5px;}
   .hist-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
@@ -261,7 +261,17 @@ PAYLOAD.columns.forEach((col,ci)=>{
         <span><i style="background:#ff5c7a"></i>&gt;4 lanes (heavy)</span>
       </div>
       <div class="ladder-title">smem layout — bank per (row, col)</div>
-      <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
+      <div class="ladder" id="l_${id}" style="${(()=>{
+        // Square cells: pick one cell-size px, then size container to
+        // (cols*N + axis_w) × (rows*N + axis_h). Caps cell-size if the
+        // total height would otherwise blow past 360px.
+        const axisW = 38, axisH = 24;
+        const maxH = 360;
+        const N = Math.max(3, Math.min(6, Math.floor((maxH - axisH) / p.layout.rows)));
+        const w = p.layout.cols * N + axisW;
+        const h = p.layout.rows * N + axisH;
+        return `width:${w}px; height:${h}px`;
+      })()}"></div>
       ${p.notes.length ? `<div class="card-notes">${p.notes.join('<br/>')}</div>` : ''}`;
     colEl.appendChild(card);
 

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -332,43 +332,6 @@ PAYLOAD.columns.forEach((col,ci)=>{
         });
       }
     }
-    const compactRanges = arr => {
-      if (!arr.length) return '';
-      const parts = []; let s = arr[0], e = arr[0];
-      for (let i = 1; i < arr.length; i++) {
-        if (arr[i] === e + 1) { e = arr[i]; }
-        else { parts.push(s === e ? `${s}` : `${s}-${e}`); s = arr[i]; e = arr[i]; }
-      }
-      parts.push(s === e ? `${s}` : `${s}-${e}`);
-      return parts.join(', ');
-    };
-    // Group sweep entries by Load name, then by k_iter. Each entry is
-    // [load_name, k_iter, lane]. Renders one section per Load with up
-    // to ``cap`` k_iter lines below it.
-    const formatSweep = entries => {
-      if (!entries.length) return '';
-      const byLoad = new Map();
-      entries.forEach(([ln, k, l]) => {
-        if (!byLoad.has(ln)) byLoad.set(ln, new Map());
-        const byIter = byLoad.get(ln);
-        if (!byIter.has(k)) byIter.set(k, []);
-        byIter.get(k).push(l);
-      });
-      const cap = 4;
-      const sections = [];
-      for (const [ln, byIter] of [...byLoad.entries()].sort()) {
-        const ks = [...byIter.keys()].sort((a,b)=>a-b);
-        const lines = ks.map(k => {
-          const lanes = byIter.get(k).sort((a,b)=>a-b);
-          return `&nbsp;&nbsp;k_iter=<b>${k}</b>: lanes ${compactRanges(lanes)} (${lanes.length}×)`;
-        });
-        const tail = lines.length > cap
-          ? lines.slice(0, cap).concat([`&nbsp;&nbsp;<span style="color:#6b7280">… +${lines.length - cap} more iters</span>`])
-          : lines;
-        sections.push(`<span style="color:#7dd3fc">${ln}</span>:<br/>${tail.join('<br/>')}`);
-      }
-      return sections.join('<br/>');
-    };
     ldr.setOption({
       backgroundColor:'transparent',
       tooltip:{
@@ -386,19 +349,16 @@ PAYLOAD.columns.forEach((col,ci)=>{
             return head + padTag + `<br/><span style="color:#6b7280">never read by warp 0 (other warps own this row)</span>`;
           }
           const star = isNow ? `<br/><span style="color:#fff">★ accessed at the rendered k_iter</span>` : '';
-          // One substituted form per Load that hits this cell.
+          // One substituted form per Load that hits this cell. The
+          // substituted index already encodes the k_iter (it's the
+          // last component, e.g. in6[((0*8)+2), 5] → k=5), so we
+          // don't repeat it as a separate "k_iter=..." line.
           const substMap = substByLoad.get(k) || {};
           const substLines = Object.entries(substMap).sort().map(
             ([ln, subst]) => `<code style="color:#3ddc84">${ln}[${subst.join(', ')}]</code>`
           );
-          const loadSection = substLines.length
-            ? `<br/>${substLines.join('<br/>')}`
-            : '';
-          return head +
-            loadSection +
-            star +
-            `<br/>${formatSweep(sweepPairs)}` +
-            padTag;
+          const loadSection = substLines.length ? `<br/>${substLines.join('<br/>')}` : '';
+          return head + loadSection + star + padTag;
         },
       },
       grid:{left:30, right:14, top:6, bottom:18},

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -185,13 +185,14 @@ HTML = """<!doctype html>
   .v-ok{color:#3ddc84;} .v-ok .dot{background:#3ddc84;}
   .v-warn{color:#ffb454;} .v-warn .dot{background:#ffb454;}
   .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
-  /* Square punchcard: 32 banks × 32 lanes is intrinsically square
-     data. Capping width keeps cells visibly square instead of squashed
-     wide rectangles when the container is stretched. */
-  .matrix{width:100%;max-width:320px;aspect-ratio:1/1;height:auto;margin:0 auto 10px;}
+  /* Punchcard cells are 3:1 wide rectangles (96×32 nominal plot area
+     for a 32×32 bank×lane grid). The container fills available width
+     and scales height to maintain the aspect ratio, so cells stay
+     proportional regardless of column width. */
+  .matrix{width:100%;aspect-ratio:96/32;height:auto;margin:0 auto 10px;}
   /* Histogram shares the bank axis with the punchcard above —
-     match its max-width so banks line up vertically. */
-  .hist{width:100%;max-width:320px;height:80px;margin:2px auto 0;}
+     match its width so banks line up vertically. */
+  .hist{width:100%;height:80px;margin:2px auto 0;}
   .ladder{margin:4px auto 0;}
   .ladder-title{font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);
     margin-top:10px;margin-bottom:4px;}
@@ -201,7 +202,7 @@ HTML = """<!doctype html>
   .bank-legend i{width:8px;height:8px;border-radius:2px;display:inline-block;flex-shrink:0;}
   .bank-legend-shared{margin-top:14px;font-size:10px;}
   .hist-legend{display:flex;flex-wrap:wrap;gap:4px 12px;margin:6px auto 0;
-    width:100%;max-width:320px;font-size:10px;color:var(--muted);}
+    width:100%;font-size:10px;color:var(--muted);}
   .hist-legend span{display:inline-flex;align-items:center;gap:5px;}
   .hist-legend i{width:9px;height:9px;border-radius:2px;display:inline-block;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -49,6 +49,26 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
         unique_addrs = sorted(set(p.lane_addrs))
         addr_to_idx = {a: i for i, a in enumerate(unique_addrs)}
         lane_addr_idx = [addr_to_idx[a] for a in p.lane_addrs]
+        # Smem layout ladder: cell(r, c) → bank id under the padded row
+        # stride. Including the pad columns so the +1-shift is visible.
+        # Cap rows to keep the diagram readable (most ladders are clear in
+        # the first 16-32 rows).
+        pad_cols = p.pad[1] if len(p.pad) > 1 else 0
+        pad_rows = p.pad[0] if len(p.pad) > 0 else 0
+        layout_rows = min(p.rows + pad_rows, 64)
+        layout_cols = p.cols + pad_cols
+        row_stride = p.cols + pad_cols
+        smem_layout = [[(r * row_stride + c) % 32 for c in range(layout_cols)] for r in range(layout_rows)]
+        # Mark cells the warp actually touched in this LDS (row, col) pairs
+        # — drawn with a white outline overlay on top of the ladder.
+        # Reconstruct (row, col) per lane from the linear address.
+        touched: list[tuple[int, int]] = []
+        for addr in p.lane_addrs:
+            r, c = divmod(addr, row_stride)
+            if 0 <= r < layout_rows and 0 <= c < layout_cols:
+                touched.append((r, c))
+        # Dedupe touched (lanes broadcast the same cell — show once).
+        touched_uniq = sorted(set(touched))
         out.append(
             {
                 "panel_title": f"{p.stage_name} ← {p.buf}",
@@ -71,6 +91,15 @@ def _serialize(panels: list[BankConflictResult]) -> list[dict]:
                 "cols": p.cols,
                 "pad": list(p.pad),
                 "smem_bytes": p.smem_bytes,
+                "layout": {
+                    "rows": layout_rows,
+                    "cols": layout_cols,
+                    "data_rows": p.rows,
+                    "data_cols": p.cols,
+                    "row_stride": row_stride,
+                    "banks": smem_layout,
+                    "touched": [list(t) for t in touched_uniq],
+                },
                 "notes": [
                     f"index = ({', '.join(p.index_repr)})",
                     f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
@@ -117,6 +146,9 @@ HTML = """<!doctype html>
   .v-bad{color:#ff5c7a;} .v-bad .dot{background:#ff5c7a;}
   .matrix{width:100%;height:240px;}
   .hist{width:100%;height:100px;margin-top:4px;}
+  .ladder{width:100%;margin-top:8px;}
+  .ladder-title{font-size:10px;letter-spacing:.18em;text-transform:uppercase;color:var(--muted);
+    margin-top:14px;margin-bottom:6px;}
   .empty{color:var(--muted);font-size:12px;padding:32px 16px;text-align:center;
     background:rgba(255,255,255,.02);border-radius:10px;border:1px dashed rgba(255,255,255,.06);}
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
@@ -169,6 +201,8 @@ PAYLOAD.columns.forEach((col,ci)=>{
         max-way ${p.max_way} · avg ${p.avg_way.toFixed(1)} lane/bank</span>
       <div class="matrix" id="m_${id}"></div>
       <div class="hist" id="h_${id}"></div>
+      <div class="ladder-title">smem layout — bank per (row,col), accessed cells outlined</div>
+      <div class="ladder" id="l_${id}" style="height:${Math.min(360, 8 + p.layout.rows * 6)}px"></div>
       <div class="card-notes">${p.notes.join('<br/>')}</div>`;
     colEl.appendChild(card);
 
@@ -229,7 +263,67 @@ PAYLOAD.columns.forEach((col,ci)=>{
           colorStops:[{offset:0,color:cellColor(c)},{offset:1,color:cellColor(c)+'55'}]},
         borderRadius:[3,3,0,0]}})),barWidth:'70%',
         animationDuration:600,animationEasing:'cubicOut'}]});
-    window.addEventListener('resize',()=>{m.resize();h.resize();});
+    // Smem-layout ladder: each cell colored by its bank id (0..31)
+    // using the same address palette mod 32. Cells the warp actually
+    // touched at this k_iter get a white outline overlay so the
+    // connection between layout and access pattern is visible.
+    const lay = p.layout;
+    const lEl = document.getElementById(`l_${id}`);
+    const ldr = echarts.init(lEl, null, {renderer:'canvas'});
+    const ldrData = [];
+    const touchedSet = new Set(lay.touched.map(([r,c]) => `${r},${c}`));
+    for (let r = 0; r < lay.rows; r++) {
+      for (let c = 0; c < lay.cols; c++) {
+        const bank = lay.banks[r][c];
+        const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
+        const isTouched = touchedSet.has(`${r},${c}`);
+        const color = isPad ? '#3a3f48' : ADDR_PALETTE[bank % ADDR_PALETTE.length];
+        ldrData.push({
+          value:[c, r, bank],
+          itemStyle:{
+            color: color,
+            opacity: isPad ? 0.45 : 1.0,
+            borderColor: isTouched ? '#ffffff' : 'transparent',
+            borderWidth: isTouched ? 1.5 : 0,
+          },
+        });
+      }
+    }
+    ldr.setOption({
+      backgroundColor:'transparent',
+      tooltip:{
+        backgroundColor:'#0e1014', borderColor:'#2a2d33',
+        textStyle:{color:'#e8eaed', fontSize:12},
+        formatter: pt => {
+          const [c, r, bank] = pt.value;
+          const t = touchedSet.has(`${r},${c}`) ? '<br/><span style="color:#fff">★ accessed by warp</span>' : '';
+          const padTag = (c >= lay.data_cols || r >= lay.data_rows)
+            ? '<br/><span style="color:#6b7280">padding</span>' : '';
+          return `row=<b>${r}</b>, col=<b>${c}</b><br/>bank <b>${bank}</b>${t}${padTag}`;
+        },
+      },
+      grid:{left:38, right:8, top:6, bottom:24},
+      xAxis:{
+        type:'category', data:[...Array(lay.cols).keys()],
+        name:'col', nameLocation:'middle', nameGap:18,
+        nameTextStyle:{color:'#6b7280', fontSize:10},
+        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.cols/8) - 1)},
+      },
+      yAxis:{
+        type:'category', data:[...Array(lay.rows).keys()], inverse:true,
+        name:'row', nameLocation:'middle', nameGap:24,
+        nameTextStyle:{color:'#6b7280', fontSize:10},
+        axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
+        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.rows/8) - 1)},
+      },
+      series:[{
+        type:'heatmap', data: ldrData, progressive: 0,
+        itemStyle:{borderRadius:1},
+        animationDuration:400, animationEasing:'cubicOut',
+      }],
+    });
+    window.addEventListener('resize',()=>{m.resize();h.resize();ldr.resize();});
   });
 });
 </script>

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -250,11 +250,11 @@ PAYLOAD.columns.forEach((col,ci)=>{
       grid:{left:38,right:8,top:8,bottom:28},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
         nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},
-        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+        axisTick:{show:false},axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
       yAxis:{type:'category',data:[...Array(WARP).keys()],inverse:true,name:'lane',
         nameLocation:'middle',nameGap:28,nameTextStyle:{color:'#6b7280',fontSize:11},
         axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
-        axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+        axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
       series:[{type:'heatmap',data:md,progressive:0,
         itemStyle:{borderRadius:2,borderColor:'#161a21',borderWidth:1},
         emphasis:{itemStyle:{borderColor:'#fff',borderWidth:1.5}},
@@ -268,7 +268,7 @@ PAYLOAD.columns.forEach((col,ci)=>{
       grid:{left:38,right:8,top:6,bottom:22},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],
         axisLine:{lineStyle:{color:'#2a2d33'}},axisTick:{show:false},
-        axisLabel:{color:'#6b7280',fontSize:10,interval:3}},
+        axisLabel:{color:'#6b7280',fontSize:10,interval:3,showMaxLabel:true,showMinLabel:true}},
       yAxis:{type:'value',splitLine:{lineStyle:{color:'#1c212b'}},
         axisLabel:{color:'#6b7280',fontSize:10},axisLine:{show:false},axisTick:{show:false}},
       series:[{type:'bar',data:p.distinct_addrs.map(c=>({value:c,itemStyle:{
@@ -354,28 +354,29 @@ PAYLOAD.columns.forEach((col,ci)=>{
             return head + padTag + `<br/><span style="color:#6b7280">never read by warp ${0} (other warps own this row)</span>`;
           }
           const star = isNow ? `<br/><span style="color:#fff">★ accessed at the rendered k_iter</span>` : '';
-          // Show both the symbolic form and the substituted form (vars
-          // replaced with the concrete values that produce this cell).
           const subst = substMap.get(k) || [];
           const substExpr = subst.length ? subst.join(', ') : lay.index_expr;
           return head +
-            `<br/>load <code style="color:#7dd3fc">${lay.load_name}[${lay.index_expr}]</code>` +
-            `<br/>     = <code style="color:#3ddc84">${lay.load_name}[${substExpr}]</code>` +
+            `<br/>load <code style="color:#3ddc84">${lay.load_name}[${substExpr}]</code>` +
             star +
             `<br/>${formatSweep(sweepPairs)}` +
             padTag;
         },
       },
-      grid:{left:30, right:8, top:6, bottom:18},
+      grid:{left:30, right:14, top:6, bottom:18},
       xAxis:{
         type:'category', data:[...Array(lay.cols).keys()],
         axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.cols/8) - 1)},
+        axisLabel:{color:'#6b7280', fontSize:9,
+          interval: Math.max(0, Math.floor(lay.cols/8) - 1),
+          showMaxLabel: true, showMinLabel: true},
       },
       yAxis:{
         type:'category', data:[...Array(lay.rows).keys()], inverse:true,
         axisLine:{lineStyle:{color:'#2a2d33'}}, axisTick:{show:false},
-        axisLabel:{color:'#6b7280', fontSize:9, interval: Math.max(0, Math.floor(lay.rows/8) - 1)},
+        axisLabel:{color:'#6b7280', fontSize:9,
+          interval: Math.max(0, Math.floor(lay.rows/8) - 1),
+          showMaxLabel: true, showMinLabel: true},
       },
       series:[{
         type:'heatmap', data: ldrData, progressive: 0,

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -37,31 +37,51 @@ def graph_from_ir_path(path: str) -> Graph:
 
 
 def _serialize(panels: list[BankConflictResult]) -> list[dict]:
-    return [
-        {
-            "panel_title": f"{p.stage_name} ← {p.buf}",
-            "formula": (f"{p.stage_class}({p.rows}×{p.cols})  " + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")),
-            "lane_banks": p.lane_banks,
-            "counts": p.counts,
-            "distinct_addrs": p.distinct_addrs,
-            "max_way": p.max_way,
-            "raw_max_way": p.raw_max_way,
-            "conflict_events": p.conflict_events,
-            "lds128_events": p.lds128_events,
-            "vec_group_size": p.vec_group_size,
-            "avg_way": p.avg_way,
-            "rows": p.rows,
-            "cols": p.cols,
-            "pad": list(p.pad),
-            "smem_bytes": p.smem_bytes,
-            "notes": [
-                f"index = ({', '.join(p.index_repr)})",
-                f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
-                (f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}  (vec={p.vec_group_size})"),
-            ],
-        }
-        for p in panels
-    ]
+    out: list[dict] = []
+    for p in panels:
+        # Per-lane address-color index: same address → same color, regardless
+        # of bank. Cells of the SAME color stacked in one bank column are
+        # the actual conflict (different lanes serialized to one bank with
+        # different addresses); cells of DIFFERENT colors stacked = fine
+        # (each lane hit a different address, no within-warp serialization).
+        # Wait — corrected: same color = same addr = broadcast = fine.
+        # Different colors stacked in one column = different addrs → conflict.
+        unique_addrs = sorted(set(p.lane_addrs))
+        addr_to_idx = {a: i for i, a in enumerate(unique_addrs)}
+        lane_addr_idx = [addr_to_idx[a] for a in p.lane_addrs]
+        out.append(
+            {
+                "panel_title": f"{p.stage_name} ← {p.buf}",
+                "formula": (
+                    f"{p.stage_class}({p.rows}×{p.cols})  "
+                    + (f"pad={p.pad}" if p.pad and any(p.pad) else "no pad")
+                ),
+                "lane_banks": p.lane_banks,
+                "lane_addr_idx": lane_addr_idx,
+                "n_unique_addrs": len(unique_addrs),
+                "counts": p.counts,
+                "distinct_addrs": p.distinct_addrs,
+                "max_way": p.max_way,
+                "raw_max_way": p.raw_max_way,
+                "conflict_events": p.conflict_events,
+                "lds128_events": p.lds128_events,
+                "vec_group_size": p.vec_group_size,
+                "avg_way": p.avg_way,
+                "rows": p.rows,
+                "cols": p.cols,
+                "pad": list(p.pad),
+                "smem_bytes": p.smem_bytes,
+                "notes": [
+                    f"index = ({', '.join(p.index_repr)})",
+                    f"enclosing axes = {', '.join(p.enclosing_axes) or '(none)'}",
+                    (
+                        f"LDS.32 events: {p.conflict_events}  ·  LDS.128 events: {p.lds128_events}"
+                        f"  (vec={p.vec_group_size})"
+                    ),
+                ],
+            }
+        )
+    return out
 
 
 HTML = """<!doctype html>
@@ -123,6 +143,11 @@ const WARP=32, BANKS=32;
 const palette={empty:'#2a2d33',ok:'#3ddc84',warn:'#ffb454',bad:'#ff5c7a'};
 const cellColor=c=>c===0?palette.empty:c===1?palette.ok:c<=4?palette.warn:palette.bad;
 const verdict=m=>m>4?'v-bad':m>1?'v-warn':'v-ok';
+// Categorical palette for "color = address". Picked for high contrast on
+// dark bg + reasonable distinguishability. Cycles modulo length when a
+// panel has more unique addresses than colors.
+const ADDR_PALETTE=['#7dd3fc','#3ddc84','#ffb454','#ff5c7a','#c084fc','#fcd34d','#67e8f9','#fb923c',
+                    '#a3e635','#f472b6','#60a5fa','#34d399','#fde047','#fb7185','#818cf8','#facc15'];
 
 const root=document.getElementById('columns');
 PAYLOAD.columns.forEach((col,ci)=>{
@@ -152,17 +177,29 @@ PAYLOAD.columns.forEach((col,ci)=>{
     for(let l=0;l<WARP;l++) for(let b=0;b<BANKS;b++)
       md.push({value:[b,l,0],itemStyle:{color:palette.empty}});
     p.lane_banks.forEach((bank,lane)=>{
-      // Color cells by distinct_addrs at that bank — broadcasts (multiple
-      // lanes at same address) are NOT conflicts and stay green.
-      const c=p.distinct_addrs[bank];
-      md.push({value:[bank,lane,c],itemStyle:{color:cellColor(c),shadowBlur:6,shadowColor:cellColor(c)+'88'}});
+      // Color cells by ADDRESS index. Same color = same address (broadcast).
+      // Different colors stacked in one bank column = different addresses
+      // serialized = real bank conflict.
+      const addrIdx = p.lane_addr_idx[lane];
+      const color = ADDR_PALETTE[addrIdx % ADDR_PALETTE.length];
+      md.push({
+        value:[bank,lane,1],
+        itemStyle:{color: color, shadowBlur:6, shadowColor:color+'66'},
+        addrIdx: addrIdx,
+      });
     });
     m.setOption({
       backgroundColor:'transparent',
       tooltip:{backgroundColor:'#0e1014',borderColor:'#2a2d33',textStyle:{color:'#e8eaed',fontSize:12},
         formatter:pt=>{const [b,l,c]=pt.value;
-          return c===0?`bank ${b}<br/><span style="color:#6b7280">no lane</span>`
-                      :`lane <b>${l}</b> → bank <b>${b}</b><br/>contention: <b>${c}</b> lane(s)`;}},
+          if (c === 0) return `bank ${b}<br/><span style="color:#6b7280">no lane</span>`;
+          const ai = pt.data.addrIdx;
+          const dist = p.distinct_addrs[b];
+          const verdict = dist === 1 ? '<span style="color:#3ddc84">broadcast — 0 events</span>'
+                       : dist <= 4 ? `<span style="color:#ffb454">${dist}-way conflict</span>`
+                                   : `<span style="color:#ff5c7a">${dist}-way conflict</span>`;
+          return `lane <b>${l}</b> → bank <b>${b}</b>, addr-color <b>#${ai}</b><br/>${verdict}`;
+        }},
       grid:{left:38,right:8,top:8,bottom:28},
       xAxis:{type:'category',data:[...Array(BANKS).keys()],name:'bank',nameLocation:'middle',nameGap:22,
         nameTextStyle:{color:'#6b7280',fontSize:11},axisLine:{lineStyle:{color:'#2a2d33'}},

--- a/tests/compiler/diagnostics/test_bank_conflicts.py
+++ b/tests/compiler/diagnostics/test_bank_conflicts.py
@@ -281,6 +281,86 @@ def test_stage_filter_restricts_results():
     assert simulate_graph(g, stage_filter={"other"}) == []
 
 
+def _build_multi_load_tileop(thread_axes, stage_axes, indices, stage_cls=Stage, pad=()):
+    addressing = AffineAddressing(dims=tuple(range(len(stage_axes))))
+    stage = stage_cls(
+        name="smem",
+        buf="src",
+        origin=tuple(Literal(0) for _ in range(len(stage_axes))),
+        axes=stage_axes,
+        addressing=addressing,
+        pad=pad,
+    )
+    loads = tuple(Load(name=f"x{i}", input="smem", index=tuple(idx)) for i, idx in enumerate(indices))
+    tile = Tile(axes=thread_axes, body=(stage, *loads))
+    return TileOp(body=(tile,), name="multi")
+
+
+def test_lds128_chain_absorbs_4way_contiguous_columns():
+    """4 column-contiguous Loads in one TileOp form an LDS.128 chain;
+    each cycle's per-bank distinct count of 4 is absorbed → 0 events."""
+    a = Axis("a", 32)
+    indices = [(Literal(0), Var("a") * Literal(4) + Literal(i)) for i in range(4)]
+    tile_op = _build_multi_load_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        indices=indices,
+    )
+    g = Graph()
+    g.add_node(tile_op, [], None, node_id="k")
+    results = simulate_graph(g)
+    assert len(results) == 4
+    assert all(r.vec_group_size == 4 for r in results), [r.vec_group_size for r in results]
+    # Per cycle: 32 lanes × address (a*4+i) → 8 distinct banks, 4 lanes
+    # per bank → 4 distinct addrs each (no broadcasts here since lane*4
+    # mod 32 is bijective on lanes 0..7 then repeats with different addr).
+    # max(0, 4 - vec_width=4) = 0 absorbed.
+    assert all(r.lds128_events == 0 for r in results), [r.lds128_events for r in results]
+
+
+def test_lds128_chain_does_not_absorb_8way_unaligned():
+    """Same row but lane stride 8 — each cycle's per-bank distinct count
+    is 8 > vec_width=4 → 4 events absorbed, 4 events remain per bank.
+    Unaligned with the LDS.128 width, so absorption is partial."""
+    a = Axis("a", 32)
+    indices = [(Literal(0), Var("a") * Literal(8) + Literal(i)) for i in range(4)]
+    tile_op = _build_multi_load_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 64)),
+        indices=indices,
+    )
+    g = Graph()
+    g.add_node(tile_op, [], None, node_id="k")
+    results = simulate_graph(g)
+    assert len(results) == 4
+    assert all(r.vec_group_size == 4 for r in results)
+    # Per Load: 32 lanes × (a*8+i) hit 4 banks (since 8 mod 32 cycle
+    # length 4) with 8 distinct addrs each → 8-way per bank.
+    # absorbed = max(0, 8 - 4) = 4 events per bank × 4 active banks = 16.
+    assert all(r.lds128_events == 16 for r in results), [r.lds128_events for r in results]
+
+
+def test_lds128_non_vectorizable_row_strided_unchanged():
+    """Loads at the same column but consecutive rows — NOT vectorizable
+    (rows aren't contiguous). vec_group_size stays 1; lds128_events ==
+    conflict_events."""
+    a = Axis("a", 32)
+    # ``[a*4+i, 0]`` — 4 different rows, same col 0. Adjacent Loads
+    # differ by `+row_stride` per lane, not +1 → not vectorizable.
+    indices = [(Var("a") * Literal(4) + Literal(i), Literal(0)) for i in range(4)]
+    tile_op = _build_multi_load_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 128), Axis("c", 16)),
+        indices=indices,
+    )
+    g = Graph()
+    g.add_node(tile_op, [], None, node_id="k")
+    results = simulate_graph(g)
+    assert len(results) == 4
+    assert all(r.vec_group_size == 1 for r in results)
+    assert all(r.lds128_events == r.conflict_events for r in results)
+
+
 @pytest.mark.parametrize("rows", [16, 32, 64, 128])
 def test_avg_lane_per_bank_consistent(rows: int):
     """``avg_way`` equals 32/distinct_banks. Sanity: row-strided no-pad

--- a/tests/compiler/diagnostics/test_bank_conflicts.py
+++ b/tests/compiler/diagnostics/test_bank_conflicts.py
@@ -1,0 +1,297 @@
+"""Tests for the smem bank-conflict simulator.
+
+Each fixture builds a minimal ``TileOp`` with a known ``Stage`` + body
+``Load`` and asserts the predicted lane→bank distribution.
+
+Expected ``max_way`` values are derived from first principles. To
+verify on real hardware, dump the equivalent kernel and run::
+
+    ncu --metrics smsp__sass_l1tex_data_bank_conflicts_pipe_lsu_mem_shared_op_ld.sum
+
+A 32-way conflict in this simulator predicts 31 bank-conflict events
+per warp-LDS instruction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deplodock.compiler.diagnostics.bank_conflicts import (
+    BANKS,
+    WARP_SIZE,
+    StageBinding,
+    simulate,
+    simulate_graph,
+    thread_axis_env,
+)
+from deplodock.compiler.graph import Graph
+from deplodock.compiler.ir.axis import BIND_THREAD, Axis, BoundAxis
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.stmt import Load, Loop, Tile
+from deplodock.compiler.ir.tile.ir import AffineAddressing, Stage, TileOp
+
+# ---------------------------------------------------------------------------
+# Fixture builder — a 1-Stage, 1-Load TileOp wrapped in a Tile with a
+# single thread axis (so threadIdx.x maps directly to that axis).
+# ---------------------------------------------------------------------------
+
+
+def _build_tileop(
+    *,
+    thread_axes: tuple[BoundAxis, ...],
+    stage_axes: tuple[Axis, ...],
+    pad: tuple[int, ...] = (),
+    load_index,
+    inner_loop_axis: Axis | None = None,
+    stage_cls=Stage,
+) -> TileOp:
+    """Build ``TileOp(Tile(Stage; [Loop?](Load)))``.
+
+    ``load_index`` is a tuple of ``Expr`` matching the staged buffer's
+    expected access (rank == ``len(stage_axes)``).
+    ``inner_loop_axis`` wraps the Load in a serial Loop — used when the
+    test wants to bind a k-iter; pass ``None`` for a Load directly in
+    the Tile body.
+    """
+    addressing = AffineAddressing(dims=tuple(range(len(stage_axes))))
+    stage = stage_cls(
+        name="smem",
+        buf="src",
+        origin=tuple(Literal(0) for _ in range(len(stage_axes))),
+        axes=stage_axes,
+        addressing=addressing,
+        pad=pad,
+    )
+    load = Load(name="x", input="smem", index=tuple(load_index))
+    if inner_loop_axis is not None:
+        body = (stage, Loop(axis=inner_loop_axis, body=(load,)))
+    else:
+        body = (stage, load)
+    tile = Tile(axes=thread_axes, body=body)
+    return TileOp(body=(tile,), name="probe")
+
+
+def _binding_of(tile_op: TileOp) -> StageBinding:
+    from deplodock.compiler.diagnostics.bank_conflicts import find_stage_bindings
+
+    bindings = find_stage_bindings(tile_op)
+    assert len(bindings) == 1, f"expected exactly one binding, got {len(bindings)}"
+    return bindings[0]
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for thread_axis_env (mirrors the runtime decode).
+# ---------------------------------------------------------------------------
+
+
+def test_thread_axis_env_single_axis():
+    ax = (Axis("a", 32),)
+    assert thread_axis_env(ax, 0) == {"a": 0}
+    assert thread_axis_env(ax, 31) == {"a": 31}
+
+
+def test_thread_axis_env_two_axes_outer_first():
+    """``Tile.thread_axes = (outer:8, inner:4)`` flattens via tid =
+    outer*4 + inner. Lane 0 → (0,0); lane 4 → (1,0); lane 7 → (1,3)."""
+    ax = (Axis("o", 8), Axis("i", 4))
+    assert thread_axis_env(ax, 0) == {"o": 0, "i": 0}
+    assert thread_axis_env(ax, 4) == {"o": 1, "i": 0}
+    assert thread_axis_env(ax, 7) == {"o": 1, "i": 3}
+    assert thread_axis_env(ax, 31) == {"o": 7, "i": 3}
+
+
+# ---------------------------------------------------------------------------
+# Bank-conflict fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_row_strided_load_no_pad_is_32_way_conflict():
+    """All 32 lanes read different rows at fixed col=0 from a (32,32)
+    smem; row stride = 32 = #banks → every lane lands on bank 0."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        pad=(),
+        load_index=(Var("a"), Literal(0)),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    assert r.max_way == 32
+    assert r.lane_banks == [0] * WARP_SIZE
+    assert r.counts[0] == 32
+
+
+def test_row_strided_load_pad_one_clears_conflict():
+    """Same access, pad=(0,1) makes row stride 33; bank = (lane*33)%32 =
+    lane%32, all distinct → no conflict."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        pad=(0, 1),
+        load_index=(Var("a"), Literal(0)),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    assert r.max_way == 1
+    assert sorted(r.lane_banks) == list(range(32))
+
+
+def test_col_coalesced_load_no_conflict():
+    """All lanes read row 0 at column = lane → bank = lane → 1-way."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        pad=(),
+        load_index=(Literal(0), Var("a")),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    assert r.max_way == 1
+
+
+def test_register_tile_F4_row_stride_16_8way_conflict():
+    """Pattern matmul-A loads with F=4: lane reads row=lane*4 in a
+    (128,16) smem at fixed col=0. row_stride=16 → bank=(lane*4*16)%32 =
+    (lane*64)%32 = 0 → 32-way."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 128), Axis("c", 16)),
+        pad=(),
+        load_index=(Var("a") * Literal(4), Literal(0)),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    assert r.max_way == 32
+    assert r.counts[0] == 32
+
+
+def test_register_tile_F4_pad_one_partial_fix():
+    """Same F=4 pattern with pad=(0,1) → row stride 17.
+    addr = lane*4*17 = lane*68; bank = (lane*68)%32 = (lane*4)%32.
+    lane*4 mod 32 cycles through {0,4,8,...,28} (8 banks) with 4 lanes
+    each → max_way 4 (mild conflict — pad=1 is not enough for F=4)."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 128), Axis("c", 16)),
+        pad=(0, 1),
+        load_index=(Var("a") * Literal(4), Literal(0)),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    assert r.max_way == 4
+    nonzero = [c for c in r.counts if c > 0]
+    assert len(nonzero) == 8
+    assert all(c == 4 for c in nonzero)
+
+
+def test_two_thread_axes_decode_into_index():
+    """``Tile.thread_axes=(o:8, i:4)`` flattens via tid=o*4+i.
+    Stage(8,4); Load `[o,i]` → lane reads `[lane//4, lane%4]`.
+    addr = (lane//4)*4 + (lane%4) = lane → bank = lane → 1-way."""
+    o = Axis("o", 8)
+    i = Axis("i", 4)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(o, BIND_THREAD), BoundAxis(i, BIND_THREAD)),
+        stage_axes=(Axis("r", 8), Axis("c", 4)),
+        pad=(),
+        load_index=(Var("o"), Var("i")),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    assert r.max_way == 1
+    assert sorted(r.lane_banks) == list(range(32))
+
+
+def test_k_iter_changes_bank_for_col_coalesced():
+    """Load `[0, a + k_iter]`: shifting k_iter shifts the bank by k_iter
+    but the per-lane spread is unchanged (still 1-way). Confirms k_iter
+    propagates into the eval env."""
+    a = Axis("a", 32)
+    k = Axis("k", 4)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        pad=(),
+        load_index=(Literal(0), Var("a") + Var("k")),
+        inner_loop_axis=k,
+    )
+    binding = _binding_of(tile_op)
+    r0 = simulate(binding, k_iter=0)
+    r2 = simulate(binding, k_iter=2)
+    assert r0 is not None and r2 is not None
+    assert r0.max_way == 1 and r2.max_way == 1
+    # Each lane shifts by 2 banks when k_iter goes 0→2.
+    assert r2.lane_banks == [(b + 2) % BANKS for b in r0.lane_banks]
+
+
+def test_buffered_stage_slot_dim_dropped():
+    """When the Load index has a leading slot dim that exceeds Stage.axes
+    rank, simulator drops it (slot is CTA-uniform, doesn't change banks).
+    Verifies the slot=0 vs slot=1 case yields identical bank spread."""
+
+    a = Axis("a", 32)
+    base_kwargs = dict(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        pad=(),
+    )
+    tile_op_slot0 = _build_tileop(**base_kwargs, load_index=(Literal(0), Var("a"), Literal(0)))
+    tile_op_slot1 = _build_tileop(**base_kwargs, load_index=(Literal(1), Var("a"), Literal(0)))
+    r0 = simulate(_binding_of(tile_op_slot0))
+    r1 = simulate(_binding_of(tile_op_slot1))
+    assert r0 is not None and r1 is not None
+    assert r0.lane_banks == r1.lane_banks
+    assert r0.max_way == 32  # row-strided → 32-way as in fixture 1
+
+
+def test_simulate_graph_walks_multiple_tileops():
+    """``simulate_graph`` should walk every TileOp in a Graph."""
+    g = Graph()
+    a = Axis("a", 32)
+    for nid in ("k0", "k1"):
+        op = _build_tileop(
+            thread_axes=(BoundAxis(a, BIND_THREAD),),
+            stage_axes=(Axis("r", 32), Axis("c", 32)),
+            load_index=(Var("a"), Literal(0)),
+        )
+        op.name = nid
+        g.add_node(op, [], None, node_id=nid)
+    results = simulate_graph(g)
+    # Two TileOps × one (Stage, Load) each = 2 results.
+    assert len(results) == 2
+    assert all(r.max_way == 32 for r in results)
+
+
+def test_stage_filter_restricts_results():
+    """``stage_filter`` excludes non-matching stage names."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", 32), Axis("c", 32)),
+        load_index=(Var("a"), Literal(0)),
+    )
+    g = Graph()
+    g.add_node(tile_op, [], None, node_id="k0")
+    assert simulate_graph(g, stage_filter={"smem"}) != []
+    assert simulate_graph(g, stage_filter={"other"}) == []
+
+
+@pytest.mark.parametrize("rows", [16, 32, 64, 128])
+def test_avg_lane_per_bank_consistent(rows: int):
+    """``avg_way`` equals 32/distinct_banks. Sanity: row-strided no-pad
+    always lands on 1 bank → avg=32."""
+    a = Axis("a", 32)
+    tile_op = _build_tileop(
+        thread_axes=(BoundAxis(a, BIND_THREAD),),
+        stage_axes=(Axis("r", rows), Axis("c", 32)),
+        load_index=(Var("a"), Literal(0)),
+    )
+    r = simulate(_binding_of(tile_op))
+    assert r is not None
+    nonzero = [c for c in r.counts if c > 0]
+    assert r.avg_way == pytest.approx(WARP_SIZE / len(nonzero))


### PR DESCRIPTION
## Summary

- Add **\`deplodock.compiler.diagnostics.bank_conflicts\`**: a closed-form simulator that reads body \`Load\`s of staged buffers, decodes warp lanes onto thread-axis vars, and reports per-Stage / per-Load bank-conflict severity (max_way, distinct addrs, LDS.32 vs LDS.128 events with broadcast absorption). Used by the \`013_pad_smem\` pass (already on main) and now also by an interactive visualizer.
- Add **\`scripts/visualize_bank_conflicts.py\`**: takes one or more Tile-IR JSON dumps (e.g. \`05_lowering_tile.json\` from \`DEPLODOCK_DUMP_DIR\`) and emits a single-page ECharts report. Side-by-side punchcards (lane × bank, colored by address) + per-variant smem-layout ladders stacked vertically, with shared severity legend and 32-distinct-color bank legend. Reading rule: two opaque cells in the layout sharing a bank color = same bank, different addresses = conflict.
  - \`--theme {dark,light}\` for both site-embedded and republishable PNG variants.
  - Tooltip shows real smem addresses + index expressions substituted with the lane-decoded thread vars.
- Add three diagnostic env-var gates so the visualizer can render before/after pairs without recompiling: \`DEPLODOCK_DISABLE_PAD_SMEM\`, \`DEPLODOCK_DISABLE_CHUNK_REDUCE\`, \`DEPLODOCK_DISABLE_CHUNK_REGISTER_TILE\`.
- Add \`scripts/sweep_pass_gates.py\` and \`scripts/diff_perf_results.py\` for benchmarking pass-by-pass impact.

## Test plan

- [x] \`make lint\` passes
- [x] \`pytest tests/compiler/diagnostics/\` — 19 tests covering broadcast absorption, LDS.128 vectorization, multi-axis thread decoding, padded-stride bank distribution.
- [ ] Reviewer: pull the branch, run \`DEPLODOCK_DUMP_DIR=/tmp/d ./venv/bin/deplodock compile TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --seq-len 32\` then \`./venv/bin/python scripts/visualize_bank_conflicts.py -i /tmp/d/05_lowering_tile.json --out /tmp/r.html\` and verify the report renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)