### PR TITLE
Unify ECharts plotting under deplodock/visualize/

### DIFF
--- a/deplodock/visualize/ARCHITECTURE.md
+++ b/deplodock/visualize/ARCHITECTURE.md
@@ -1,0 +1,107 @@
+# `deplodock/visualize/`
+
+Shared ECharts visualization stack. Owns theme tokens, fonts, qualitative
+palettes, the HTML page shell, a generic bar-chart emitter, and HTML→image
+rendering.
+
+```
+visualize/
+  theme.py       THEMES (dark/light), FONTS, STATUS, PALETTE_1, PALETTE_2
+  page.py        render_html — page shell, ECharts <script>, JS globals
+  bar_chart.py   Bar / BarChart / render_bar_chart — auto orientation
+  image.py       render — PNG/JPEG/WebP/PDF/SVG via Playwright
+```
+
+## Theme tokens
+
+`THEMES["dark" | "light"]` is the single source of truth for foreground
+text, axis lines, tooltip surface, etc. `page.render_html` lifts every
+token into `:root[data-theme=…]` CSS variables (`--fg`, `--muted`,
+`--axis-line`, `--split-line`, `--tooltip-bg`, `--tooltip-text`, `--rule`,
+`--label-accent`, `--surface`) and exposes the same dict to JS as
+`window.THEME`.
+
+`FONTS["ui" | "mono"]` ship as JS globals too — use `FONTS.mono` for any
+monospace label so axis ticks line up across charts.
+
+`STATUS = {ok, warn, bad}` is the universal pass/borderline/fail palette
+(green/orange/red).
+
+## Palettes
+
+Two 32-color qualitative palettes live in `theme.py`:
+
+- `PALETTE_1` — cool/rainbow hues (cyans, greens, blues, purples).
+- `PALETTE_2` — warm hues (yellows, oranges, reds, browns).
+
+They're designed to stay visually disjoint, so a chart that has two
+independent color dimensions (e.g. `color = bank` and `color = address` on
+the same page) can pick one palette per dimension without confusion. Don't
+introduce chart-specific aliases — reference the generic palettes directly
+and document the mapping at the call site.
+
+## Page shell
+
+`render_html(*, body_html, scripts_js, theme="dark", title="",
+extra_css="", transparent=True)` builds a self-contained page:
+
+- Includes ECharts from a CDN.
+- Sets `data-theme` on `<html>` and emits CSS variables.
+- Injects `THEME`, `PALETTE_1`, `PALETTE_2`, `STATUS`, `FONTS` as JS
+  globals.
+- Sets `window.echartsReady = true` after the caller's `scripts_js`
+  finishes — used by `image.render` to know when the canvas is paintable.
+
+Pass `transparent=False` for standalone images that need an opaque
+backdrop; the default suits embedding in dark pages and READMEs.
+
+## Bar chart
+
+`BarChart` carries `categories`, parallel `bars` (each a `Bar(name,
+values, color?)`), an optional `baseline` reference line, and optional
+pre-formatted `tooltip_rows` (HTML strings indexed by category).
+
+Orientation policy:
+
+- `len(categories) <= AUTO_HORIZONTAL_THRESHOLD` (12) → vertical.
+- otherwise → horizontal.
+- Override via `orientation = "horizontal" | "vertical"`.
+
+Vertical = bars grow upward, categories on x-axis; horizontal = bars grow
+rightward, categories on y-axis (long lists, monospace labels). Same
+option scaffolding either way — only axis assignments differ.
+
+## Image rendering
+
+`render(html, out_path, *, width, height, selector, transparent)` detects
+format from `out_path.suffix`:
+
+| suffix | backend | transparent? |
+|---|---|---|
+| `.png`, `.webp` | Playwright `element.screenshot` | ✓ |
+| `.jpg`/`.jpeg`  | Playwright `element.screenshot(type="jpeg")` | always opaque |
+| `.pdf`          | Playwright `page.pdf` | via `print_background` |
+| `.svg`          | concatenated `chart.renderToSVGString()` | ECharts only — no surrounding HTML |
+
+Playwright is an optional dep:
+
+```
+pip install -e '.[visualize]'
+playwright install chromium
+```
+
+Without it `image.render` raises `ImportError` with the install command.
+HTML emission has zero deps beyond stdlib.
+
+## Adding a new chart
+
+1. Build an option dict that pulls colors from `THEMES[theme]` and
+   typography from `FONTS`. Don't hardcode hex literals — every shared
+   token belongs in `theme.py`.
+2. If the chart shape is general (bars, lines, scatter), extend the
+   relevant module. If it's bespoke layout (e.g. the smem punchcard with
+   ladders + legends), keep the layout at the call site and pass the
+   bespoke CSS/HTML/JS into `render_html` via `extra_css` / `body_html` /
+   `scripts_js`.
+3. Pick palettes by name (`PALETTE_1`, `PALETTE_2`) — never inline an
+   ad-hoc list.

--- a/deplodock/visualize/__init__.py
+++ b/deplodock/visualize/__init__.py
@@ -1,0 +1,24 @@
+"""Shared ECharts theming, page shell, generic bar chart, and HTML→image
+rendering. See ``ARCHITECTURE.md``."""
+
+from deplodock.visualize.bar_chart import AUTO_HORIZONTAL_THRESHOLD, Bar, BarChart, render_bar_chart
+from deplodock.visualize.image import SUPPORTED as IMAGE_SUPPORTED
+from deplodock.visualize.image import render as render_image
+from deplodock.visualize.page import render_html
+from deplodock.visualize.theme import FONTS, PALETTE_1, PALETTE_2, PALETTES, STATUS, THEMES
+
+__all__ = [
+    "AUTO_HORIZONTAL_THRESHOLD",
+    "Bar",
+    "BarChart",
+    "FONTS",
+    "IMAGE_SUPPORTED",
+    "PALETTES",
+    "PALETTE_1",
+    "PALETTE_2",
+    "STATUS",
+    "THEMES",
+    "render_bar_chart",
+    "render_html",
+    "render_image",
+]

--- a/deplodock/visualize/bar_chart.py
+++ b/deplodock/visualize/bar_chart.py
@@ -1,0 +1,194 @@
+"""Generic grouped bar chart. One series per ``Bar``; orientation auto-picks
+horizontal vs vertical based on category count (override with
+``orientation``). Produces a self-contained HTML page via
+``deplodock.visualize.page.render_html``."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from deplodock.visualize.page import render_html
+from deplodock.visualize.theme import THEMES
+
+AUTO_HORIZONTAL_THRESHOLD = 12
+
+# Default colors used when a Bar doesn't pin one. Picked from PALETTE_1 to
+# stay categorical and high-contrast on dark/light themes.
+DEFAULT_SERIES_COLORS = ["#4dabf7", "#ffd166", "#3ddc84", "#c084fc", "#fb7185", "#67e8f9"]
+
+
+@dataclass
+class Bar:
+    name: str
+    values: list[float | None]
+    color: str | None = None
+
+
+@dataclass
+class BarChart:
+    categories: list[str]
+    bars: list[Bar]
+    value_name: str = ""
+    title: str = ""
+    subtitle: str = ""
+    baseline: float | None = None
+    baseline_label: str | None = None
+    tooltip_rows: list[str] | None = None
+    orientation: Literal["auto", "horizontal", "vertical"] = "auto"
+    row_height: int = 22
+    margin: dict[str, int] = field(default_factory=dict)
+
+    def resolved_orientation(self) -> Literal["horizontal", "vertical"]:
+        if self.orientation != "auto":
+            return self.orientation
+        return "horizontal" if len(self.categories) > AUTO_HORIZONTAL_THRESHOLD else "vertical"
+
+
+def _series_for(bar: Bar, idx: int, *, baseline: float | None, baseline_label: str | None, theme: dict[str, Any]) -> dict:
+    color = bar.color or DEFAULT_SERIES_COLORS[idx % len(DEFAULT_SERIES_COLORS)]
+    series: dict = {
+        "name": bar.name,
+        "type": "bar",
+        "data": [v if v is not None else "-" for v in bar.values],
+        "itemStyle": {"color": color},
+        "barCategoryGap": "30%",
+    }
+    if idx == 0 and baseline is not None:
+        series["markLine"] = {
+            "silent": True,
+            "symbol": "none",
+            "lineStyle": {"type": "dashed", "color": theme["muted"]},
+            "data": [
+                {
+                    "label": {
+                        "formatter": baseline_label or f"{baseline}",
+                        "color": theme["muted"],
+                    },
+                }
+            ],
+        }
+    return series
+
+
+def _option(chart: BarChart, *, theme_name: str) -> dict:
+    t = THEMES[theme_name]
+    orient = chart.resolved_orientation()
+    is_horizontal = orient == "horizontal"
+
+    cat_axis = {
+        "type": "category",
+        "data": chart.categories,
+        "inverse": is_horizontal,  # horizontal: top-down ordering of caller-supplied list
+        "axisLabel": {
+            "fontSize": 11,
+            "fontFamily": "monospace" if is_horizontal else "inherit",
+            "color": t["fg"],
+            "interval": 0,
+            "rotate": 0 if is_horizontal else 30,
+        },
+        "axisLine": {"lineStyle": {"color": t["axisLine"]}},
+        "axisTick": {"show": False},
+    }
+    val_axis = {
+        "type": "value",
+        "name": chart.value_name,
+        "nameLocation": "middle",
+        "nameGap": 30 if is_horizontal else 40,
+        "nameTextStyle": {"color": t["muted"]},
+        "axisLine": {"lineStyle": {"color": t["axisLine"]}},
+        "axisLabel": {"color": t["fg"]},
+        "splitLine": {"lineStyle": {"color": t["splitLine"]}},
+    }
+
+    series = []
+    for i, bar in enumerate(chart.bars):
+        s = _series_for(bar, i, baseline=chart.baseline, baseline_label=chart.baseline_label, theme=t)
+        # markLine x/y axis depends on orientation — fix it now.
+        if "markLine" in s:
+            data0 = s["markLine"]["data"][0]
+            data0[("xAxis" if is_horizontal else "yAxis")] = chart.baseline
+        series.append(s)
+
+    default_margin = (
+        {"left": 200, "right": 50, "top": 70, "bottom": 60} if is_horizontal else {"left": 70, "right": 40, "top": 70, "bottom": 90}
+    )
+    margin = {**default_margin, **chart.margin}
+
+    return {
+        "backgroundColor": "transparent",
+        "textStyle": {"color": t["fg"]},
+        "title": {
+            "text": chart.title,
+            "subtext": chart.subtitle,
+            "left": 0,
+            "top": 0,
+            "textStyle": {"color": t["fg"], "fontSize": 14, "fontWeight": "normal"},
+            "subtextStyle": {"color": t["muted"], "fontSize": 12},
+        },
+        "grid": {**margin, "containLabel": False},
+        "legend": {
+            "top": 36,
+            "textStyle": {"color": t["fg"]},
+            "data": [b.name for b in chart.bars],
+            "icon": "rect",
+            "itemWidth": 12,
+            "itemHeight": 10,
+        },
+        "tooltip": {
+            "trigger": "axis",
+            "axisPointer": {"type": "shadow", "shadowStyle": {"color": t["rule"]}},
+            "backgroundColor": t["tooltipBg"],
+            "borderColor": t["axisLine"],
+            "textStyle": {"color": t["tooltipText"]},
+        },
+        "xAxis": cat_axis if not is_horizontal else val_axis,
+        "yAxis": val_axis if not is_horizontal else cat_axis,
+        "series": series,
+    }
+
+
+def render_bar_chart(chart: BarChart, *, theme: str = "dark", transparent: bool = True) -> str:
+    """Return a self-contained HTML page rendering ``chart``."""
+    orient = chart.resolved_orientation()
+    is_horizontal = orient == "horizontal"
+    option = _option(chart, theme_name=theme)
+    payload = {
+        "option": option,
+        "tooltipRows": chart.tooltip_rows,
+        "orientation": orient,
+        "rowHeight": chart.row_height,
+        "n": len(chart.categories),
+        "padTop": option["grid"]["top"],
+        "padBot": option["grid"]["bottom"],
+    }
+    body_html = '<div id="chart" style="width:100%;"></div>\n'
+    scripts_js = f"""
+const PAYLOAD = {json.dumps(payload)};
+const el = document.getElementById('chart');
+if (PAYLOAD.orientation === 'horizontal') {{
+  el.style.height = (PAYLOAD.n * PAYLOAD.rowHeight + PAYLOAD.padTop + PAYLOAD.padBot) + 'px';
+}} else {{
+  el.style.height = '520px';
+}}
+const chart = echarts.init(el, null, {{ renderer: 'canvas' }});
+const opt = PAYLOAD.option;
+if (PAYLOAD.tooltipRows) {{
+  opt.tooltip.formatter = (params) => {{
+    const i = params[0].dataIndex;
+    return PAYLOAD.tooltipRows[i];
+  }};
+}}
+chart.setOption(opt);
+window.addEventListener('resize', () => chart.resize());
+"""
+    title = chart.title or "deplodock chart"
+    return render_html(
+        body_html=body_html,
+        scripts_js=scripts_js,
+        theme=theme,
+        title=title,
+        transparent=transparent,
+        extra_css=("#chart { width: 100%; }\n" if not is_horizontal else ""),
+    )

--- a/deplodock/visualize/image.py
+++ b/deplodock/visualize/image.py
@@ -1,0 +1,96 @@
+"""Render an HTML page (typically one produced by ``deplodock.visualize``)
+to an image file. Format is auto-detected from the output path's suffix.
+Backed by Playwright headless Chromium — installed via the optional
+``[visualize]`` extra (``pip install -e '.[visualize]' && playwright install
+chromium``)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+SUPPORTED = {".png", ".jpg", ".jpeg", ".webp", ".pdf", ".svg"}
+
+_PLAYWRIGHT_HINT = (
+    "playwright is required for image rendering. Install with:\n    pip install -e '.[visualize]' && playwright install chromium"
+)
+
+
+def _import_playwright():
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as e:
+        raise ImportError(_PLAYWRIGHT_HINT) from e
+    return sync_playwright
+
+
+def render(
+    html: str,
+    out_path: Path | str,
+    *,
+    width: int = 1400,
+    height: int = 900,
+    selector: str = "body",
+    transparent: bool = True,
+) -> None:
+    """Render ``html`` to ``out_path``. Format is detected from the suffix
+    (case-insensitive). Supported: ``.png``, ``.jpg``/``.jpeg``, ``.webp``,
+    ``.pdf``, ``.svg``.
+
+    PNG and WebP honor ``transparent``. JPEG always renders on white.
+    PDF uses ``page.pdf`` (``print_background = not transparent``). SVG
+    extracts each ECharts instance via ``chart.renderToSVGString()`` and
+    concatenates them; this requires charts to use the SVG renderer or
+    the page to be re-rendered, so the function temporarily swaps the
+    renderer at runtime.
+    """
+    out = Path(out_path)
+    suffix = out.suffix.lower()
+    if suffix not in SUPPORTED:
+        raise ValueError(f"unsupported image suffix {suffix!r}; expected one of {sorted(SUPPORTED)}")
+
+    sync_playwright = _import_playwright()
+    with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False) as tmp:
+        tmp.write(html)
+        tmp_path = tmp.name
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        try:
+            context = browser.new_context(viewport={"width": width, "height": height})
+            page = context.new_page()
+            page.goto(f"file://{tmp_path}")
+            page.wait_for_function("window.echartsReady === true", timeout=10_000)
+
+            if suffix == ".pdf":
+                page.pdf(path=str(out), print_background=not transparent)
+            elif suffix == ".svg":
+                svg = page.evaluate(
+                    """() => {
+                        const insts = [];
+                        document.querySelectorAll('div').forEach(el => {
+                            const inst = echarts.getInstanceByDom(el);
+                            if (inst) insts.push(inst);
+                        });
+                        return insts.map(i => i.renderToSVGString()).join('\\n');
+                    }"""
+                )
+                if not svg.strip():
+                    raise RuntimeError(
+                        "no ECharts instances found on page — cannot render SVG. "
+                        "Note: SVG export only captures ECharts canvases, not surrounding HTML."
+                    )
+                Path(out).write_text(svg)
+            else:
+                el = page.locator(selector).first
+                kwargs: dict = {"path": str(out)}
+                if suffix in (".jpg", ".jpeg"):
+                    kwargs["type"] = "jpeg"
+                    kwargs["quality"] = 92
+                else:
+                    kwargs["type"] = "png" if suffix == ".png" else "webp"
+                    kwargs["omit_background"] = transparent
+                el.screenshot(**kwargs)
+        finally:
+            browser.close()
+            Path(tmp_path).unlink(missing_ok=True)

--- a/deplodock/visualize/page.py
+++ b/deplodock/visualize/page.py
@@ -1,0 +1,79 @@
+"""Shared HTML page shell for ECharts-based visualizations. Emits the
+ECharts script include, exposes ``THEME``/``PALETTE_1``/``PALETTE_2``/
+``STATUS``/``FONTS`` as JS globals, and sets ``window.echartsReady`` after
+the caller's scripts run so external image renderers know when the canvas
+is ready to screenshot."""
+
+from __future__ import annotations
+
+import json
+
+from deplodock.visualize.theme import FONTS, PALETTE_1, PALETTE_2, STATUS, THEMES
+
+ECHARTS_CDN = "https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"
+
+
+def _root_css(theme: str, *, transparent: bool) -> str:
+    t = THEMES[theme]
+    bg = "transparent" if transparent else t["surface"]
+    return f""":root[data-theme="{theme}"] {{
+  --fg: {t["fg"]};
+  --muted: {t["muted"]};
+  --axis-line: {t["axisLine"]};
+  --split-line: {t["splitLine"]};
+  --tooltip-bg: {t["tooltipBg"]};
+  --tooltip-text: {t["tooltipText"]};
+  --rule: {t["rule"]};
+  --label-accent: {t["labelAccent"]};
+  --surface: {t["surface"]};
+}}
+html, body {{ margin: 0; background: {bg}; color: var(--fg);
+  font-family: {FONTS["ui"]}; }}
+"""
+
+
+def render_html(
+    *,
+    body_html: str,
+    scripts_js: str,
+    theme: str = "dark",
+    title: str = "",
+    extra_css: str = "",
+    transparent: bool = True,
+) -> str:
+    """Wrap ``body_html`` and ``scripts_js`` in the shared page shell.
+
+    Injected JS globals: ``THEME`` (theme dict), ``PALETTE_1`` / ``PALETTE_2``
+    (32-color qualitative palettes), ``STATUS`` (ok/warn/bad), ``FONTS``
+    (ui/mono CSS strings).
+    """
+    if theme not in THEMES:
+        raise ValueError(f"unknown theme {theme!r}; expected one of {sorted(THEMES)}")
+    globals_js = (
+        f"const THEME = {json.dumps(THEMES[theme])};\n"
+        f"const PALETTE_1 = {json.dumps(PALETTE_1)};\n"
+        f"const PALETTE_2 = {json.dumps(PALETTE_2)};\n"
+        f"const STATUS = {json.dumps(STATUS)};\n"
+        f"const FONTS = {json.dumps(FONTS)};\n"
+    )
+    return f"""<!doctype html>
+<html lang="en" data-theme="{theme}">
+<head>
+<meta charset="utf-8" />
+<title>{title}</title>
+<script src="{ECHARTS_CDN}"></script>
+<style>
+{_root_css(theme, transparent=transparent)}
+{extra_css}
+</style>
+</head>
+<body>
+{body_html}
+<script>
+{globals_js}
+{scripts_js}
+window.echartsReady = true;
+</script>
+</body>
+</html>
+"""

--- a/deplodock/visualize/theme.py
+++ b/deplodock/visualize/theme.py
@@ -1,0 +1,127 @@
+"""Theme tokens, fonts, and qualitative palettes shared by every chart in
+``deplodock.visualize``. Generic by design — palettes are named by hue
+character (not by use site) so any chart can pick whichever fits."""
+
+from __future__ import annotations
+
+from typing import Any
+
+THEMES: dict[str, dict[str, Any]] = {
+    "dark": {
+        "fg": "#e8eaed",
+        "muted": "#6b7280",
+        "axisLine": "#2a2d33",
+        "splitLine": "#1c212b",
+        "tooltipBg": "#0e1014",
+        "tooltipText": "#e8eaed",
+        "empty": "#2a2d33",
+        "padCell": "#3a3f48",
+        "focusBorder": "#ffffff",
+        "labelAccent": "#7dd3fc",
+        "rule": "rgba(255,255,255,.06)",
+        "surface": "#0b0d11",
+        "opFocus": 1.0,
+        "opFaint": 0.45,
+    },
+    "light": {
+        "fg": "#1f2937",
+        "muted": "#4b5563",
+        "axisLine": "#9ca3af",
+        "splitLine": "#d1d5db",
+        "tooltipBg": "#ffffff",
+        "tooltipText": "#0f172a",
+        "empty": "#b8bec7",
+        "padCell": "#64748b",
+        "focusBorder": "#0f172a",
+        "labelAccent": "#0369a1",
+        "rule": "rgba(0,0,0,.08)",
+        "surface": "#ffffff",
+        "opFocus": 1.0,
+        "opFaint": 0.45,
+    },
+}
+
+FONTS = {
+    "ui": "'Inter',system-ui,-apple-system,'Segoe UI',sans-serif",
+    "mono": "'JetBrains Mono',ui-monospace,monospace",
+}
+
+STATUS = {"ok": "#3ddc84", "warn": "#ffb454", "bad": "#ff5c7a"}
+
+# 32 distinct cool/rainbow hues. Use when each color stands for a discrete
+# category (e.g. one bank id per color). Saturated and well-spaced so two
+# adjacent entries are visually distinguishable.
+PALETTE_1 = [
+    "#7dd3fc",
+    "#3ddc84",
+    "#ffb454",
+    "#ff5c7a",
+    "#c084fc",
+    "#fcd34d",
+    "#67e8f9",
+    "#fb923c",
+    "#a3e635",
+    "#f472b6",
+    "#60a5fa",
+    "#34d399",
+    "#fde047",
+    "#fb7185",
+    "#818cf8",
+    "#facc15",
+    "#0ea5e9",
+    "#16a34a",
+    "#d97706",
+    "#dc2626",
+    "#9333ea",
+    "#ca8a04",
+    "#0891b2",
+    "#ea580c",
+    "#65a30d",
+    "#db2777",
+    "#1d4ed8",
+    "#059669",
+    "#a16207",
+    "#be123c",
+    "#4338ca",
+    "#b45309",
+]
+
+# 32 warm hues (yellows → oranges → reds → browns). Designed to stay visually
+# disjoint from PALETTE_1 so a reader can tell at a glance which dimension a
+# color belongs to when both palettes appear on the same page.
+PALETTE_2 = [
+    "#fef08a",
+    "#fed7aa",
+    "#fca5a5",
+    "#fbbf24",
+    "#f59e0b",
+    "#fdba74",
+    "#f97316",
+    "#ef4444",
+    "#fef9c3",
+    "#fde68a",
+    "#fee2e2",
+    "#eab308",
+    "#c2410c",
+    "#b91c1c",
+    "#7f1d1d",
+    "#92400e",
+    "#fef3c7",
+    "#ffedd5",
+    "#ffe4e6",
+    "#9a3412",
+    "#991b1b",
+    "#78350f",
+    "#7c2d12",
+    "#881337",
+    "#fbcfe8",
+    "#fff7ed",
+    "#fef2f2",
+    "#713f12",
+    "#44403c",
+    "#f43f5e",
+    "#f87171",
+    "#ea661a",
+]
+
+PALETTES = (PALETTE_1, PALETTE_2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,10 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff"]
 compile = ["torch", "transformers", "cppyy==3.5.0", "safetensors"]
+visualize = ["playwright>=1.40"]
 # flash-attn requires torch at build time, install separately:
 #   pip install flash-attn --no-build-isolation
-dev = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff", "matplotlib", "graphviz", "torch", "transformers", "cupy-cuda12x; sys_platform == 'linux'", "cppyy==3.5.0", "safetensors"]
+dev = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff", "matplotlib", "graphviz", "torch", "transformers", "cupy-cuda12x; sys_platform == 'linux'", "cppyy==3.5.0", "safetensors", "playwright>=1.40"]
 
 [tool.setuptools.packages.find]
 include = ["deplodock*"]

--- a/scripts/visualize_bank_conflicts.py
+++ b/scripts/visualize_bank_conflicts.py
@@ -29,6 +29,7 @@ import os
 
 from deplodock.compiler.diagnostics.bank_conflicts import BankConflictResult, simulate_graph
 from deplodock.compiler.graph import Graph
+from deplodock.visualize.page import render_html
 
 
 def graph_from_ir_path(path: str) -> Graph:
@@ -151,24 +152,8 @@ def _serialize(panels: list[BankConflictResult], all_panels_for_union: list[Bank
     return out
 
 
-HTML = """<!doctype html>
-<html lang="en" data-theme="__THEME__">
-<head>
-<meta charset="utf-8" />
-<title>smem bank conflicts (IR-driven)</title>
-<script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
-<style>
-  :root[data-theme="dark"] {
-    --bg:transparent; --fg:#e8eaed; --muted:#6b7280;
-    --rule:rgba(255,255,255,.06); --label-accent:#7dd3fc;
-  }
-  :root[data-theme="light"] {
-    --bg:transparent; --fg:#1f2937; --muted:#4b5563;
-    --rule:rgba(0,0,0,.08); --label-accent:#0369a1;
-  }
+EXTRA_CSS = """
   *{box-sizing:border-box;}
-  html,body{margin:0;background:transparent;color:var(--fg);
-    font-family:'Inter',system-ui,-apple-system,'Segoe UI',sans-serif;}
   /* Center the column grid + shared legend horizontally; shrink to
      content width so unused horizontal space sits outside the page. */
   .page{display:flex;flex-direction:column;align-items:center;margin:0;padding:0;}
@@ -227,36 +212,23 @@ HTML = """<!doctype html>
   .legend{display:flex;gap:18px;margin-top:28px;color:var(--muted);font-size:12px;}
   .legend span{display:inline-flex;align-items:center;gap:8px;}
   .legend i{width:10px;height:10px;border-radius:3px;display:inline-block;}
-</style>
-</head>
-<body>
+"""
+
+BODY_HTML = """
   <div class="page">
     <div class="page-grid" id="page-grid"></div>
   </div>
-<script>
-const PAYLOAD = __PAYLOAD__;
-const THEME = __THEME_JS__;
+"""
+
+# PALETTE_1 — used for the smem-layout ladder ("color = bank id").
+# PALETTE_2 — used for the lane×bank punch card ("color = address index").
+# Both are 32-color qualitative palettes from deplodock.visualize.theme;
+# kept visually disjoint so a reader never confuses one plot for the other.
+SCRIPTS_JS = r"""
 const WARP=32, BANKS=32;
-const palette={empty:THEME.empty,ok:'#3ddc84',warn:'#ffb454',bad:'#ff5c7a'};
+const palette={empty:THEME.empty,ok:STATUS.ok,warn:STATUS.warn,bad:STATUS.bad};
 const cellColor=c=>c===0?palette.empty:c===1?palette.ok:c<=4?palette.warn:palette.bad;
 const verdict=m=>m>4?'v-bad':m>1?'v-warn':'v-ok';
-// Two distinct palettes — keep "color = bank" (smem layout) and
-// "color = address" (punch card) visually independent so the reader
-// doesn't conflate them.
-//
-// BANK_PALETTE: 32 distinct hues (one per smem bank). Same color =
-// same bank, so two highlighted cells sharing a color in the layout
-// land on the same bank — direct visual cue for a bank conflict.
-const BANK_PALETTE=['#7dd3fc','#3ddc84','#ffb454','#ff5c7a','#c084fc','#fcd34d','#67e8f9','#fb923c',
-                    '#a3e635','#f472b6','#60a5fa','#34d399','#fde047','#fb7185','#818cf8','#facc15',
-                    '#0ea5e9','#16a34a','#d97706','#dc2626','#9333ea','#ca8a04','#0891b2','#ea580c',
-                    '#65a30d','#db2777','#1d4ed8','#059669','#a16207','#be123c','#4338ca','#b45309'];
-// ADDR_PALETTE: warm-only palette (yellows, oranges, reds, browns) used
-// in the lane×bank punch card. A warp typically has 1-4 distinct
-// addresses per Load, so a short palette is fine. Warm-only avoids
-// overlap with the cool/rainbow BANK_PALETTE — the reader can tell at
-// a glance which plot a color belongs to.
-const ADDR_PALETTE=['#fde047','#fb923c','#ef4444','#a3a3a3','#facc15','#fdba74','#dc2626','#78350f'];
 
 // Layout: one page-grid with N columns (one per IR variant). Rows
 // alternate between shared titles (spanning all columns, left-justified)
@@ -369,7 +341,7 @@ PAYLOAD.columns.forEach((col, ci) => {
       // Different colors stacked in one bank column = different addresses
       // serialized = real bank conflict.
       const addrIdx = p.lane_addr_idx[lane];
-      const color = ADDR_PALETTE[addrIdx % ADDR_PALETTE.length];
+      const color = PALETTE_2[addrIdx % PALETTE_2.length];
       md.push({
         value:[bank,lane,1],
         itemStyle:{color: color, shadowBlur:6, shadowColor:color+'66'},
@@ -440,7 +412,7 @@ PAYLOAD.columns.forEach((col, ci) => {
         const isPad = (c >= lay.data_cols) || (r >= lay.data_rows);
         const k = `${r},${c}`;
         const isNow = (touchedNow.get(k) || []).length > 0;
-        const color = isPad ? THEME.padCell : BANK_PALETTE[bank % BANK_PALETTE.length];
+        const color = isPad ? THEME.padCell : PALETTE_1[bank % PALETTE_1.length];
         const op = isNow ? THEME.opFocus : THEME.opFaint;
         const style = {color: color, opacity: op};
         if (isNow) {
@@ -527,53 +499,26 @@ PAYLOAD.columns.forEach((col, ci) => {
   if (!host) return;
   [...banksUsed].sort((a,b)=>a-b).forEach(bank => {
     const chip = document.createElement('span');
-    chip.innerHTML = `<i style="background:${BANK_PALETTE[bank % BANK_PALETTE.length]}"></i>bank ${bank}`;
+    chip.innerHTML = `<i style="background:${PALETTE_1[bank % PALETTE_1.length]}"></i>bank ${bank}`;
     host.appendChild(chip);
   });
 })();
-</script>
-</body>
-</html>
 """
 
 
-_THEMES = {
-    "dark": {
-        "empty": "#2a2d33",
-        "tooltipBg": "#0e1014",
-        "tooltipText": "#e8eaed",
-        "axisLine": "#2a2d33",
-        "splitLine": "#1c212b",
-        "padCell": "#3a3f48",
-        "opFocus": 1.0,
-        "opFaint": 0.45,
-        "focusBorder": "#ffffff",
-    },
-    "light": {
-        "empty": "#b8bec7",
-        "tooltipBg": "#ffffff",
-        "tooltipText": "#0f172a",
-        "axisLine": "#6b7280",
-        "splitLine": "#9ca3af",
-        "padCell": "#64748b",
-        "opFocus": 1.0,
-        "opFaint": 0.45,
-        "focusBorder": "#0f172a",
-    },
-}
-
-
-def emit_html(columns: list[dict], out_path: str, theme: str = "dark") -> None:
-    n = max(1, len(columns))
-    html = (
-        HTML.replace("__MAXW__", str(min(2200, 480 * n + 80)))
-        .replace("__NCOL__", str(n))
-        .replace("__THEME__", theme)
-        .replace("__THEME_JS__", json.dumps(_THEMES[theme]))
-        .replace("__PAYLOAD__", json.dumps({"columns": columns}))
+def emit_html(columns: list[dict], out_path: str, theme: str = "dark", *, transparent: bool = True) -> str:
+    payload_js = f"const PAYLOAD = {json.dumps({'columns': columns})};\n"
+    html = render_html(
+        body_html=BODY_HTML,
+        scripts_js=payload_js + SCRIPTS_JS,
+        theme=theme,
+        title="smem bank conflicts (IR-driven)",
+        extra_css=EXTRA_CSS,
+        transparent=transparent,
     )
     with open(out_path, "w") as f:
         f.write(html)
+    return html
 
 
 def _parse_ir_arg(arg: str) -> tuple[str, str]:
@@ -601,6 +546,15 @@ def main() -> None:
     p.add_argument("--warp-id", type=int, default=0)
     p.add_argument("--out", default="/tmp/bank_conflicts.html")
     p.add_argument("--theme", choices=("dark", "light"), default="dark")
+    p.add_argument(
+        "--image",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Also render to image (format from suffix: .png/.jpg/.webp/.pdf/.svg). Repeatable. Requires '.[visualize]' extra.",
+    )
+    p.add_argument("--transparent", dest="transparent", action="store_true", default=True)
+    p.add_argument("--no-transparent", dest="transparent", action="store_false")
     args = p.parse_args()
 
     stage_filter = set(args.stage) if args.stage else None
@@ -635,8 +589,14 @@ def main() -> None:
             }
         )
 
-    emit_html(columns, args.out, theme=args.theme)
+    html = emit_html(columns, args.out, theme=args.theme, transparent=args.transparent)
     print(f"saved {args.out}")
+
+    for image_path in args.image:
+        from deplodock.visualize.image import render as render_image
+
+        render_image(html, image_path, transparent=args.transparent)
+        print(f"saved {image_path}")
 
 
 if __name__ == "__main__":

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -367,8 +367,20 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     tw.write_line(f"perf results saved to {out}")
 
     plot = _RESULTS_DIR / f"{stamp}.html"
-    plot.write_text(_render_plot(rows, stamp))
+    html = _render_plot(rows, stamp)
+    plot.write_text(html)
     tw.write_line(f"perf plot saved to {plot}")
+
+    png = plot.with_suffix(".png")
+    try:
+        from deplodock.visualize.image import render as render_image
+
+        render_image(html, png, transparent=True)
+        tw.write_line(f"perf plot image saved to {png}")
+    except ImportError:
+        tw.write_line("perf plot PNG skipped (install '.[visualize]' + 'playwright install chromium')")
+    except Exception as e:  # noqa: BLE001
+        tw.write_line(f"perf plot PNG skipped: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -377,15 +389,13 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
 
 def _render_plot(rows: list[PerfRow], stamp: str) -> str:
-    """Render a self-contained HTML page with an Apache ECharts grouped
-    horizontal bar chart of speedup ratio (vs PyTorch eager) per case.
-    Two series: ``torch.compile`` and Deplodock. Eager is the implicit
-    baseline at ratio=1.0 (parity line). Cases sorted by Deplodock
-    ratio ascending so losses cluster at the top.
+    """Render a self-contained HTML page comparing per-case speedup of
+    Deplodock and ``torch.compile`` against the PyTorch-eager baseline.
+    Cases are sorted by Deplodock ratio (wins at top). The shared
+    ``deplodock.visualize.bar_chart`` picks orientation based on case
+    count — typical perf runs land in horizontal mode."""
+    from deplodock.visualize.bar_chart import Bar, BarChart, render_bar_chart
 
-    Styled for embedding on a dark-themed page: transparent body
-    background and chart canvas; light foreground colors. The chart
-    auto-sizes its height to fit ``len(rows)`` rows."""
     rows_sorted = sorted(rows, key=lambda r: r.ratio, reverse=True)
 
     def _tcomp_ratio(r: PerfRow) -> float | None:
@@ -393,136 +403,50 @@ def _render_plot(rows: list[PerfRow], stamp: str) -> str:
             return None
         return round(r.torch_us / r.torch_compile_us, 3)
 
-    data = {
-        "names": [r.name for r in rows_sorted],
-        "shapes": [r.shape for r in rows_sorted],
-        "ops": [r.op for r in rows_sorted],
-        "eager_us": [round(r.torch_us, 1) for r in rows_sorted],
-        "tcomp_us": [(round(r.torch_compile_us, 1) if r.torch_compile_us is not None else None) for r in rows_sorted],
-        "depl_us": [round(r.deplodock_us, 1) for r in rows_sorted],
-        "depl_ratio": [round(r.ratio, 3) for r in rows_sorted],
-        "tcomp_ratio": [_tcomp_ratio(r) for r in rows_sorted],
-        "stamp": stamp,
-        "n": len(rows_sorted),
-    }
-    data_json = json.dumps(data)
+    tcomp_color = "#ffd166"
+    depl_color = "#4dabf7"
 
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>deplodock perf — {stamp}</title>
-<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
-<style>
-  html, body {{ background: transparent; }}
-  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-         margin: 0; padding: 12px; color: #e6e6e6; }}
-  h1 {{ font-size: 15px; margin: 0 0 4px 0; color: #f0f0f0; font-weight: 500; }}
-  .sub {{ font-size: 12px; color: #a0a0a0; margin-bottom: 10px; }}
-  #chart {{ width: 100%; background: transparent; }}
-</style>
-</head>
-<body>
-  <h1>Per-kernel speedup vs PyTorch eager</h1>
-  <div class="sub">FP32 on RTX 5090. Ratio = eager_us / backend_us (higher is faster).
-    Eager is the baseline at 1.0 (dashed line). Sorted by deplodock ratio:
-    wins at top, losses at bottom.</div>
-  <div id="chart"></div>
-<script>
-const D = {data_json};
-const chart = echarts.init(document.getElementById('chart'),
-                           null, {{ renderer: 'canvas' }});
-const rowH = 22, padTop = 60, padBot = 60;
-document.getElementById('chart').style.height =
-  (D.n * rowH + padTop + padBot) + 'px';
-chart.resize();
+    tooltip_rows: list[str] = []
+    for r in rows_sorted:
+        tr = _tcomp_ratio(r)
+        t_us = round(r.torch_compile_us, 1) if r.torch_compile_us is not None else None
+        tooltip_rows.append(
+            "<br>".join(
+                [
+                    f"<b>{r.name}</b>",
+                    f'<span style="color:#888">{r.shape}</span>',
+                    "",
+                    f'<span style="color:#999">■</span> eager: {round(r.torch_us, 1)} µs (1.00×)',
+                    (f'<span style="color:{tcomp_color}">■</span> torch.compile: ' + ("—" if t_us is None else f"{t_us} µs ({tr:.2f}×)")),
+                    (f'<span style="color:{depl_color}">■</span> deplodock: {round(r.deplodock_us, 1)} µs ({round(r.ratio, 2):.2f}×)'),
+                ]
+            )
+        )
 
-const COLORS = {{
-  tcomp:   '#ffd166',
-  depl:    '#4dabf7',
-}};
-
-const series = [
-  {{
-    name: 'deplodock / eager',
-    type: 'bar',
-    data: D.depl_ratio,
-    itemStyle: {{ color: COLORS.depl }},
-    barGap: '15%',
-    barCategoryGap: '30%',
-    markLine: {{
-      silent: true,
-      symbol: 'none',
-      lineStyle: {{ type: 'dashed', color: 'rgba(255,255,255,0.35)' }},
-      data: [{{ xAxis: 1, label: {{ formatter: '1.0× (eager)', color: '#a0a0a0' }} }}],
-    }},
-  }},
-  {{
-    name: 'torch.compile / eager',
-    type: 'bar',
-    data: D.tcomp_ratio.map(v => v == null ? '-' : v),
-    itemStyle: {{ color: COLORS.tcomp }},
-  }},
-];
-
-chart.setOption({{
-  backgroundColor: 'transparent',
-  textStyle: {{ color: '#d0d0d0' }},
-  grid: {{ left: 260, right: 50, top: padTop, bottom: padBot, containLabel: false }},
-  legend: {{
-    top: 28,
-    textStyle: {{ color: '#d0d0d0' }},
-    data: series.map(s => s.name),
-    icon: 'rect',
-    itemWidth: 12,
-    itemHeight: 10,
-  }},
-  tooltip: {{
-    trigger: 'axis',
-    axisPointer: {{ type: 'shadow', shadowStyle: {{ color: 'rgba(255,255,255,0.06)' }} }},
-    backgroundColor: 'rgba(20,20,20,0.95)',
-    borderColor: '#444',
-    textStyle: {{ color: '#e0e0e0' }},
-    formatter: (params) => {{
-      const i = params[0].dataIndex;
-      const tr = D.tcomp_ratio[i];
-      const dr = D.depl_ratio[i];
-      const e = D.eager_us[i];
-      const t = D.tcomp_us[i];
-      const d = D.depl_us[i];
-      return [
-        '<b>' + D.names[i] + '</b>',
-        '<span style="color:#888">' + D.shapes[i] + '</span>',
-        '',
-        '<span style="color:#999">■</span> eager: ' + e + ' µs (1.00×)',
-        '<span style="color:' + COLORS.tcomp + '">■</span> torch.compile: ' + (t == null ? '—' : t + ' µs (' + tr.toFixed(2) + '×)'),
-        '<span style="color:' + COLORS.depl  + '">■</span> deplodock: ' + d + ' µs (' + dr.toFixed(2) + '×)',
-      ].join('<br>');
-    }},
-  }},
-  xAxis: {{
-    type: 'value',
-    name: 'speedup vs eager (×)',
-    nameLocation: 'middle',
-    nameGap: 30,
-    nameTextStyle: {{ color: '#a0a0a0' }},
-    axisLine: {{ lineStyle: {{ color: '#555' }} }},
-    axisLabel: {{ color: '#b0b0b0' }},
-    splitLine: {{ lineStyle: {{ color: 'rgba(255,255,255,0.06)' }} }},
-  }},
-  yAxis: {{
-    type: 'category',
-    data: D.names,
-    inverse: true,
-    axisLabel: {{ fontSize: 10, fontFamily: 'monospace', color: '#c0c0c0' }},
-    axisLine: {{ lineStyle: {{ color: '#555' }} }},
-    axisTick: {{ show: false }},
-  }},
-  series: series,
-}});
-
-window.addEventListener('resize', () => chart.resize());
-</script>
-</body>
-</html>
-"""
+    chart = BarChart(
+        categories=[r.name for r in rows_sorted],
+        bars=[
+            Bar(
+                name="deplodock / eager",
+                values=[round(r.ratio, 3) for r in rows_sorted],
+                color=depl_color,
+            ),
+            Bar(
+                name="torch.compile / eager",
+                values=[_tcomp_ratio(r) for r in rows_sorted],
+                color=tcomp_color,
+            ),
+        ],
+        value_name="speedup vs eager (×)",
+        title=f"Per-kernel speedup vs PyTorch eager — {stamp}",
+        subtitle=(
+            "FP32 on RTX 5090. Ratio = eager_us / backend_us (higher is faster). "
+            "Eager is the baseline at 1.0 (dashed line). Sorted by deplodock ratio: "
+            "wins at top, losses at bottom."
+        ),
+        baseline=1.0,
+        baseline_label="1.0× (eager)",
+        tooltip_rows=tooltip_rows,
+        orientation="horizontal",
+    )
+    return render_bar_chart(chart, theme="dark", transparent=True)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,122 @@
+"""Smoke tests for ``deplodock.visualize``. Asserts that the shared theme
+exposes the expected token surface, that ``BarChart`` renders self-contained
+HTML for both orientations, and that the page shell injects the JS globals
+that downstream charts rely on."""
+
+from __future__ import annotations
+
+import pytest
+
+from deplodock.visualize import Bar, BarChart, render_bar_chart, render_html
+from deplodock.visualize.bar_chart import AUTO_HORIZONTAL_THRESHOLD
+from deplodock.visualize.theme import FONTS, PALETTE_1, PALETTE_2, STATUS, THEMES
+
+_REQUIRED_TOKENS = {
+    "fg",
+    "muted",
+    "axisLine",
+    "splitLine",
+    "tooltipBg",
+    "tooltipText",
+    "empty",
+    "padCell",
+    "focusBorder",
+    "labelAccent",
+    "rule",
+    "surface",
+    "opFocus",
+    "opFaint",
+}
+
+
+@pytest.mark.parametrize("name", ["dark", "light"])
+def test_themes_complete(name: str) -> None:
+    assert _REQUIRED_TOKENS <= set(THEMES[name])
+
+
+def test_palettes_have_32_entries() -> None:
+    assert len(PALETTE_1) == 32
+    assert len(PALETTE_2) == 32
+    # Disjoint by construction so a chart can use both at once.
+    assert not (set(PALETTE_1) & set(PALETTE_2))
+
+
+def test_fonts_and_status() -> None:
+    assert "Inter" in FONTS["ui"]
+    assert "JetBrains" in FONTS["mono"]
+    assert set(STATUS) == {"ok", "warn", "bad"}
+
+
+def test_render_html_injects_globals() -> None:
+    html = render_html(body_html="<div></div>", scripts_js="// noop", title="t")
+    assert 'data-theme="dark"' in html
+    assert "echarts.min.js" in html
+    assert "const THEME =" in html
+    assert "const PALETTE_1 =" in html
+    assert "const PALETTE_2 =" in html
+    assert "const STATUS =" in html
+    assert "window.echartsReady = true" in html
+
+
+def test_render_html_unknown_theme_raises() -> None:
+    with pytest.raises(ValueError):
+        render_html(body_html="", scripts_js="", theme="solarized")
+
+
+def test_bar_chart_auto_orientation_vertical() -> None:
+    chart = BarChart(
+        categories=["a", "b", "c"],
+        bars=[Bar("s", [1.0, 2.0, 3.0])],
+    )
+    assert chart.resolved_orientation() == "vertical"
+    html = render_bar_chart(chart)
+    assert "echarts" in html and "data-theme" in html
+
+
+def test_bar_chart_auto_orientation_horizontal() -> None:
+    n = AUTO_HORIZONTAL_THRESHOLD + 5
+    chart = BarChart(
+        categories=[f"c{i}" for i in range(n)],
+        bars=[Bar("s", [float(i) for i in range(n)])],
+    )
+    assert chart.resolved_orientation() == "horizontal"
+
+
+def test_bar_chart_baseline_emitted() -> None:
+    chart = BarChart(
+        categories=["a", "b"],
+        bars=[Bar("s", [1.0, 2.0])],
+        baseline=1.0,
+        baseline_label="1×",
+    )
+    html = render_bar_chart(chart)
+    assert "markLine" in html
+    assert "1\\u00d7" in html or "1×" in html
+
+
+def test_bar_chart_tooltip_rows_referenced() -> None:
+    chart = BarChart(
+        categories=["a", "b"],
+        bars=[Bar("s", [1.0, 2.0])],
+        tooltip_rows=["<b>row a</b>", "<b>row b</b>"],
+    )
+    html = render_bar_chart(chart)
+    assert "tooltipRows" in html
+    assert "row a" in html
+
+
+def test_image_render_missing_playwright_raises_importerror(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("playwright"):
+            raise ImportError("simulated absence")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    from deplodock.visualize.image import render
+
+    with pytest.raises(ImportError, match="playwright is required"):
+        render("<html></html>", tmp_path / "x.png")


### PR DESCRIPTION
## Summary

- New `deplodock/visualize/` package owning theme tokens, fonts, qualitative palettes, the page shell, a generic bar chart, and HTML→image rendering.
- `scripts/visualize_bank_conflicts.py` and `tests/perf/conftest.py::_render_plot` migrated onto the shared stack — no more divergent theme literals or duplicated ECharts page boilerplate.
- Optional `[visualize]` extra (`playwright>=1.40`) gates image export; HTML emission has zero deps beyond stdlib.

### Modules

- `theme.py` — `THEMES` (dark/light), `FONTS`, `STATUS`, `PALETTE_1` (32 cool hues), `PALETTE_2` (32 warm hues, disjoint from PALETTE_1).
- `page.py` — `render_html(...)`: CSS variables from theme, ECharts CDN, JS globals (`THEME`/`PALETTE_1`/`PALETTE_2`/`STATUS`/`FONTS`), `window.echartsReady` flag, `transparent=True` default.
- `bar_chart.py` — generic `Bar` / `BarChart`; auto orientation (vertical ≤12 categories, horizontal otherwise), baseline line, optional pre-formatted tooltip rows.
- `image.py` — `render(html, out_path, ...)` autodetects format from suffix (`.png` / `.jpg` / `.webp` / `.pdf` / `.svg`); Playwright lazy-imported with an actionable `ImportError` if missing.
- `ARCHITECTURE.md` — tokens, palettes, orientation policy, image backend, "how to add a new chart".

### Migrations

- `tests/perf/conftest.py::_render_plot` — ~150 lines of inline HTML/JS → ~50-line `BarChart` builder. Sibling PNG written next to the HTML; absence of Playwright degrades gracefully (HTML still saved, one-line note).
- `scripts/visualize_bank_conflicts.py` — local `_THEMES` / `BANK_PALETTE` / `ADDR_PALETTE` deleted; smem layout uses `PALETTE_1` and the punchcard uses `PALETTE_2`. Bespoke smem CSS still lives at the call site, threaded through `page.render_html` via `extra_css`/`body_html`/`scripts_js`. New `--image PATH` (repeatable) and `--transparent` / `--no-transparent` flags.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 915 passed / 84 skipped
- [x] `tests/test_visualize.py` — 11 smoke tests (theme completeness, palette size + disjointness, page-shell global injection, orientation policy, baseline emission, tooltip rows, Playwright-missing error path)
- [ ] Manual: `python scripts/visualize_bank_conflicts.py -i <dump>:label --out x.html --theme {dark,light}` — visually identical to pre-change
- [ ] Manual: `pip install -e '.[visualize]' && playwright install chromium`, then `--image x.png --image x.svg` — image matches HTML; `--no-transparent` yields opaque background
- [ ] Manual: perf run produces both `<stamp>.html` and `<stamp>.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)