### PR TITLE
Add H200 variants for Qwen3.6 27B/35B-A3B recipes

### DIFF
--- a/recipes/Qwen3.6-27B-FP8/recipe.yaml
+++ b/recipes/Qwen3.6-27B-FP8/recipe.yaml
@@ -20,5 +20,11 @@ benchmark:
   random_output_len: 2000
 
 matrices:
-  deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-  deploy.gpu_count: 1
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
+    deploy.gpu_count: 1
+
+  - deploy.gpu: "NVIDIA H200 141GB"
+    deploy.gpu_count: 1
+    engine.llm.max_concurrent_requests: 32
+    engine.llm.vllm.extra_args: "--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 --language-model-only --speculative-config '{\"method\":\"qwen3_next_mtp\",\"num_speculative_tokens\":2}'"
+    benchmark.max_concurrency: 32

--- a/recipes/Qwen3.6-35B-A3B-FP8/recipe.yaml
+++ b/recipes/Qwen3.6-35B-A3B-FP8/recipe.yaml
@@ -20,5 +20,12 @@ benchmark:
   random_output_len: 2000
 
 matrices:
-  deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-  deploy.gpu_count: 1
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
+    deploy.gpu_count: 1
+
+  - deploy.gpu: "NVIDIA H200 141GB"
+    deploy.gpu_count: 1
+    engine.llm.gpu_memory_utilization: 0.85
+    engine.llm.max_concurrent_requests: 32
+    engine.llm.vllm.extra_args: '--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 --language-model-only --default-chat-template-kwargs ''{"preserve_thinking": true}'' --speculative-config ''{"method":"qwen3_next_mtp","num_speculative_tokens":2}'''
+    benchmark.max_concurrency: 32

--- a/recipes/Qwen3.6-35B-A3B/recipe.yaml
+++ b/recipes/Qwen3.6-35B-A3B/recipe.yaml
@@ -21,5 +21,13 @@ benchmark:
   random_output_len: 2000
 
 matrices:
-  deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
-  deploy.gpu_count: 2
+  - deploy.gpu: "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"
+    deploy.gpu_count: 2
+
+  - deploy.gpu: "NVIDIA H200 141GB"
+    deploy.gpu_count: 2
+    engine.llm.gpu_memory_utilization: 0.85
+    engine.llm.context_length: 262144
+    engine.llm.max_concurrent_requests: 32
+    engine.llm.vllm.extra_args: '--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 --language-model-only --default-chat-template-kwargs ''{"preserve_thinking": true}'' --speculative-config ''{"method":"qwen3_next_mtp","num_speculative_tokens":2}'''
+    benchmark.max_concurrency: 32


### PR DESCRIPTION
Add 1xH200 entries for Qwen3.6-27B-FP8 and Qwen3.6-35B-A3B-FP8, and a 2xH200 entry for Qwen3.6-35B-A3B (BF16). H200 variants raise concurrency to 32 (leveraging extra memory vs Pro 6000), enable qwen3_next_mtp speculative decoding, and on the BF16 35B-A3B unlock the full 262K native context.