### PR TITLE
Add --network flag to deploy cloud and bench

### DIFF
--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -254,7 +254,7 @@ deplodock vm create cloudrift --instance-type rtx4090.1 --ssh-key ~/.ssh/id_ed25
 deplodock vm delete cloudrift --instance-id <id>
 ```
 
-CloudRift attach to a specific network with `--network <name>` (on both `vm create cloudrift` and `vm create gpu`). The name must exist in the target datacenter; omit to let CloudRift pick a public network.
+CloudRift attach to a specific network with `--network <name>` (on `vm create cloudrift`, `vm create gpu`, `deploy cloud`, and `bench`). The name must exist in the target datacenter; omit to let CloudRift pick a public network.
 
 #### Allocation strategy (shared by `deploy cloud`, `bench`, `vm create gpu`)
 

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -38,8 +38,15 @@ def handle_bench(args):
     config = load_config(args.config)
     validate_config(config)
 
-    if args.billing_exempt:
-        config.setdefault("providers", {}).setdefault("cloudrift", {})["billing_exempt"] = True
+    if args.billing_exempt or args.network:
+        providers = config.setdefault("providers", {})
+        # `cloudrift:` in config.yaml can parse to None when it has only commented children.
+        if providers.get("cloudrift") is None:
+            providers["cloudrift"] = {}
+        if args.billing_exempt:
+            providers["cloudrift"]["billing_exempt"] = True
+        if args.network:
+            providers["cloudrift"]["network"] = args.network
 
     ssh_key = _expand_path(args.ssh_key)
     dry_run = args.dry_run
@@ -282,6 +289,11 @@ def register_bench_command(subparsers):
         "--billing-exempt",
         action="store_true",
         help="Skip billing for CloudRift instances (admin-only)",
+    )
+    parser.add_argument(
+        "--network",
+        default=None,
+        help="CloudRift network name (must exist in target datacenter; default: provider picks a public network)",
     )
     parser.add_argument(
         "--filter",

--- a/deplodock/commands/deploy/cloud.py
+++ b/deplodock/commands/deploy/cloud.py
@@ -36,8 +36,12 @@ async def _handle_cloud(args):
     register_secret(hf_token)
 
     providers_config = None
-    if args.billing_exempt:
-        providers_config = {"cloudrift": {"billing_exempt": True}}
+    if args.billing_exempt or args.network:
+        providers_config = {"cloudrift": {}}
+        if args.billing_exempt:
+            providers_config["cloudrift"]["billing_exempt"] = True
+        if args.network:
+            providers_config["cloudrift"]["network"] = args.network
 
     conn = await provision_cloud_vm(
         gpu_name=recipe.deploy.gpu,
@@ -83,6 +87,11 @@ def register_cloud_target(subparsers):
     parser.add_argument("--model-dir", default="/hf_models", help="Model cache directory")
     parser.add_argument("--dry-run", action="store_true", help="Print commands without executing")
     parser.add_argument("--billing-exempt", action="store_true", help="Skip billing for CloudRift (admin-only)")
+    parser.add_argument(
+        "--network",
+        default=None,
+        help="CloudRift network name (must exist in target datacenter; default: provider picks a public network)",
+    )
     parser.add_argument("--gpu", required=True, help="GPU name (selects matching matrix entry)")
     parser.add_argument("--gpu-count", type=int, required=True, help="GPU count (selects matching matrix entry)")
     parser.add_argument(

--- a/tests/benchmark/test_bench_dryrun.py
+++ b/tests/benchmark/test_bench_dryrun.py
@@ -64,6 +64,52 @@ def test_bench_multiple_recipes(run_cli, make_bench_config, recipes_dir, tmp_pat
     assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
 
 
+def test_bench_network_flag_dry_run(run_cli, make_bench_config, recipes_dir, tmp_path):
+    """--network propagates into the CloudRift rent payload."""
+    config_path = make_bench_config(tmp_path)
+    recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
+    rc, stdout, stderr = run_cli(
+        "bench",
+        recipe,
+        "--config",
+        config_path,
+        "--network",
+        "public",
+        "--dry-run",
+    )
+    assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
+    assert '"network": "public"' in stdout
+
+
+def test_bench_network_flag_with_null_cloudrift_config(run_cli, recipes_dir, tmp_path):
+    """`providers.cloudrift: null` (commented children only) must not crash with --network."""
+    import yaml
+
+    config = {
+        "benchmark": {
+            "local_results_dir": os.path.join(str(tmp_path), "results"),
+            "model_dir": "/hf_models",
+        },
+        "providers": {"cloudrift": None},
+    }
+    config_path = os.path.join(str(tmp_path), "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.dump(config, f)
+
+    recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")
+    rc, stdout, stderr = run_cli(
+        "bench",
+        recipe,
+        "--config",
+        config_path,
+        "--network",
+        "public",
+        "--dry-run",
+    )
+    assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
+    assert '"network": "public"' in stdout
+
+
 def test_bench_no_teardown_dry_run(run_cli, make_bench_config, recipes_dir, tmp_path):
     config_path = make_bench_config(tmp_path)
     recipe = os.path.join(recipes_dir, "Qwen3-Coder-30B-A3B-Instruct-AWQ")

--- a/tests/deploy/test_deploy_cloud_dryrun.py
+++ b/tests/deploy/test_deploy_cloud_dryrun.py
@@ -120,6 +120,43 @@ def test_deploy_cloud_provider_flag_override_dry_run(run_cli, tmp_path):
     assert "Trying candidate: cloudrift" not in stdout
 
 
+def test_deploy_cloud_network_flag_dry_run(run_cli, tmp_path):
+    """--network propagates into the CloudRift rent payload."""
+    recipe = {
+        "model": {"huggingface": "test-org/test-model"},
+        "engine": {
+            "llm": {
+                "tensor_parallel_size": 1,
+                "vllm": {"image": "vllm/vllm-openai:v0.17.0"},
+            }
+        },
+        "matrices": [
+            {
+                "deploy.gpu": "NVIDIA GeForce RTX 5090",
+                "deploy.gpu_count": 1,
+            },
+        ],
+    }
+    with open(tmp_path / "recipe.yaml", "w") as f:
+        yaml.dump(recipe, f)
+
+    rc, stdout, stderr = run_cli(
+        "deploy",
+        "cloud",
+        "--recipe",
+        str(tmp_path),
+        "--gpu",
+        "NVIDIA GeForce RTX 5090",
+        "--gpu-count",
+        "1",
+        "--network",
+        "public",
+        "--dry-run",
+    )
+    assert rc == 0, f"stderr: {stderr}\nstdout: {stdout}"
+    assert '"network": "public"' in stdout
+
+
 def test_deploy_cloud_provider_default_is_cloudrift_for_h200(run_cli, tmp_path):
     """Without --provider, H200 defaults to CloudRift (first entry in hardware table)."""
     recipe = {


### PR DESCRIPTION
Mirrors the --network flag already on `vm create cloudrift` / `vm create gpu` (merged in #129). With this all four user-facing entry points can pin a CloudRift instance to a specific network name, which is required on datacenters where the default public network isn't the right pick.

Also fixes the same latent crash for `bench` that gpu.py had: when config.yaml's `cloudrift:` section parses to None (all-commented children), the old `setdefault("cloudrift", {})` chain returned the existing None and crashed on item assignment.