### PR TITLE
Add Gemma 4 31B-it recipes (BF16 + FP8-Dynamic) for 1xH200

### DIFF
--- a/recipes/gemma-4-31B-it-FP8-Dynamic/recipe.yaml
+++ b/recipes/gemma-4-31B-it-FP8-Dynamic/recipe.yaml
@@ -1,0 +1,26 @@
+model:
+  huggingface: "RedHatAI/gemma-4-31B-it-FP8-Dynamic"
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    # Native max; FP8 weights ~31 GB leave ~110 GB on 1xH200 (141 GB) for KV cache.
+    context_length: 262144
+    max_concurrent_requests: 32
+    vllm:
+      # Pinned Hopper (CUDA 12.9) tag from vLLM's official Gemma 4 recipe; FP8 dynamic
+      # variant requires the gemma4 build, not the stable v0.20.x line.
+      image: "vllm/vllm-openai:gemma4-0505-cu129"
+      extra_args: "--enable-auto-tool-choice --tool-call-parser gemma4 --reasoning-parser gemma4 --chat-template examples/tool_chat_template_gemma4.jinja --limit-mm-per-prompt '{\"image\": 0, \"audio\": 0}' --kv-cache-dtype fp8"
+
+benchmark:
+  max_concurrency: 32
+  num_prompts: 64
+  random_input_len: 2000
+  random_output_len: 2000
+
+matrices:
+  deploy.gpu: "NVIDIA H200 141GB"
+  deploy.gpu_count: 1

--- a/recipes/gemma-4-31B-it/recipe.yaml
+++ b/recipes/gemma-4-31B-it/recipe.yaml
@@ -1,0 +1,24 @@
+model:
+  huggingface: "google/gemma-4-31B-it"
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.9
+    # Native max is 262144; BF16 weights ~62 GB leave ~73 GB on 1xH200 (141 GB) for KV cache.
+    context_length: 131072
+    max_concurrent_requests: 16
+    vllm:
+      image: "vllm/vllm-openai:gemma4-0505-cu129"
+      extra_args: "--enable-auto-tool-choice --tool-call-parser gemma4 --reasoning-parser gemma4 --chat-template examples/tool_chat_template_gemma4.jinja --limit-mm-per-prompt '{\"image\": 0, \"audio\": 0}'"
+
+benchmark:
+  max_concurrency: 16
+  num_prompts: 64
+  random_input_len: 2000
+  random_output_len: 2000
+
+matrices:
+  deploy.gpu: "NVIDIA H200 141GB"
+  deploy.gpu_count: 1


### PR DESCRIPTION
Adds two new recipes targeting 1xH200:
- google/gemma-4-31B-it (BF16): TP=1, 131K context, ~62 GB weights
- RedHatAI/gemma-4-31B-it-FP8-Dynamic: TP=1, full 262K context, concurrency 32, --kv-cache-dtype fp8

Both use the official vLLM Gemma 4 Hopper image (gemma4-0505-cu129), gemma4 tool/reasoning parsers, the bundled tool_chat_template_gemma4.jinja chat template, and disable image/audio MM profiling for text-only serving.