### PR TITLE
Stage body refactor + epilogue fusion (2.1-2.4x on silu·gate·matmul)

### DIFF
--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -250,6 +250,50 @@ class Stage(Stmt):
     # 32-way bank conflicts that arise when adjacent threads stride through
     # power-of-2 multiples of bank width.
     pad: tuple[int, ...] = ()
+    # Cooperative-load program: the per-CTA logical compute that produces
+    # the staged slab. Trivial form (auto-synthesized when not provided) is
+    # ``Load(input=buf, index=origin+cache_vars); Write(output=name,
+    # index=cache_vars, value=loaded)`` — equivalent to today's
+    # synthesized-from-(buf, origin, axes, addressing) materializer path.
+    # Non-trivial bodies (fused producer compute) are reserved for the
+    # follow-up stage-epilogue fusion pass; the materializer trip-wire
+    # rejects them until phase 2.
+    body: Body = field(default_factory=Body)
+
+    def __post_init__(self) -> None:
+        # Coerce tuple inputs (e.g. from rewrite/with_bodies that build a
+        # plain tuple comprehension) into the Body subclass so downstream
+        # walkers can call ``.map`` / ``.iter`` on Stage's nested body.
+        if not isinstance(self.body, Body):
+            self.body = Body.coerce(self.body)
+        if not self.body:
+            self.body = self._synthesize_trivial_body()
+
+    def _synthesize_trivial_body(self) -> Body:
+        cache_index = tuple(Var(ax.name) for ax in self.axes)
+        if isinstance(self.addressing, AffineAddressing):
+            decoded: dict[int, Expr] = dict(zip(self.addressing.dims, cache_index, strict=True))
+            src_index = tuple(o if d not in decoded else o + decoded[d] for d, o in enumerate(self.origin))
+        else:
+            src_index = self.addressing.exprs
+        load_name = f"{self.name}__src"
+        return Body(
+            (
+                Load(name=load_name, input=self.buf, index=src_index),
+                Write(output=self.name, index=cache_index, value=load_name),
+            )
+        )
+
+    # Phase 1: ``body`` is auxiliary metadata. The materializer still reads
+    # legacy ``(buf, origin, addressing)`` fields, and several tile passes
+    # (notably ``008_register_tile``) rely on ``Stage`` being opaque to
+    # generic body walkers — exposing the body via ``nested()`` would let
+    # F-axis replication descend into the cooperative-load Loads and
+    # corrupt their semantics. So we keep the leaf-stmt protocol here;
+    # σ-substitution through the body is handled explicitly by the
+    # Stage-specific ``rewrite`` / ``simplify`` handlers in
+    # ``deplodock/compiler/ir/tile/passes.py``. Phase 2 (when materializer
+    # walks ``body`` directly) revisits this.
 
     def deps(self) -> tuple[str, ...]:
         return ()
@@ -316,6 +360,7 @@ class BufferedStage(Stage):
     phase: Expr = field(kw_only=True)
 
     def __post_init__(self) -> None:
+        super().__post_init__()
         if self.buffer_count < 2:
             raise ValueError(f"BufferedStage {self.name!r}: buffer_count must be >= 2, got {self.buffer_count}")
 

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -197,9 +197,40 @@ class TemplateAddressing:
     exprs: tuple[Expr, ...]
 
 
+def trivial_stage_body(
+    name: str,
+    buf: str,
+    origin: tuple[Expr, ...],
+    axes: tuple[Axis, ...],
+    addressing: AffineAddressing | TemplateAddressing,
+) -> Body:
+    """Build the canonical ``Load + Write`` body for a cooperative-load
+    Stage. Source-side index is reconstructed from ``origin + cache_var``
+    pairs (affine) or kept verbatim (template); the Write target is the
+    Stage's smem name with cache-local Var coords.
+
+    Single source of truth for body synthesis: ``Stage`` callers that don't
+    fuse anything into the producer use this helper directly; the
+    ``primary_load`` / ``origin`` / ``addressing`` properties round-trip
+    through it."""
+    cache_index = tuple(Var(ax.name) for ax in axes)
+    if isinstance(addressing, AffineAddressing):
+        decoded: dict[int, Expr] = dict(zip(addressing.dims, cache_index, strict=True))
+        src_index = tuple(o if d not in decoded else o + decoded[d] for d, o in enumerate(origin))
+    else:
+        src_index = addressing.exprs
+    load_name = f"{name}__src"
+    return Body(
+        (
+            Load(name=load_name, input=buf, index=src_index),
+            Write(output=name, index=cache_index, value=load_name),
+        )
+    )
+
+
 @dataclass
 class Stage(Stmt):
-    """Operand-cache declaration — stage a contiguous slab of ``buf``
+    """Operand-cache declaration — stage a contiguous slab of a gmem buffer
     into a named local buffer for reuse across the surrounding ``Tile``
     body.
 
@@ -209,25 +240,25 @@ class Stage(Stmt):
     trailing ``Sync`` so the freshly-loaded smem is visible to all
     threads in the CTA.
 
-    Slab geometry:
+    Carried state:
 
-    - ``origin`` — per-source-dim CTA-uniform anchor (length == source
-      buffer rank). Each entry is an Expr that's constant across the
-      threads of a CTA — typically ``BIND_BLOCK`` Vars and Literals.
+    - ``name`` — staged buffer's SSA-like identifier. Subsequent
+      ``Load(input=name, index=cache-local)`` reads in the surrounding
+      Tile body refer to it directly.
     - ``axes`` — cache axes (smem layout, in this order).
-    - ``addressing`` — discriminated union of ``AffineAddressing``
-      (fast path, ``origin + decoded``) and ``TemplateAddressing``
-      (escape hatch carrying the original symbolic Load index).
+    - ``body`` — cooperative-load program. Today this is the trivial
+      ``Load(input=src_buf, index=...); Write(output=name, ...)`` pair
+      built by :func:`trivial_stage_body`; future producer-side fusion
+      will inline elementwise compute between the Load and Write.
+    - ``pad`` — bank-conflict-breaking padding (per cache axis).
 
-    SSA-like: ``name`` is the staged buffer's identifier; subsequent
-    ``Load(input=name, index=cache-local)`` reads in the body refer to
-    it directly. The strategy that inserts the Stage is also responsible
-    for rewriting body Loads to target ``name`` with cache-local Vars
-    (matching ``axes`` in order).
+    The legacy slab-geometry fields (``buf``, ``origin``, ``addressing``)
+    are now derived from ``body``'s primary Load via properties:
 
-    The slab form maps directly to TMA / ``cp.async.bulk`` tensor-
-    descriptor copies: ``origin`` is the box-origin and ``axes``
-    extents are the box-extents.
+    - ``buf = body[0].input``
+    - ``origin = body[0].index`` with cache-axis Vars substituted to 0
+    - ``addressing`` = ``AffineAddressing`` iff every cache axis appears
+      coef-1 in exactly one source dim, else ``TemplateAddressing``
 
     Transport is encoded structurally via subclass:
 
@@ -239,10 +270,8 @@ class Stage(Stmt):
     """
 
     name: str
-    buf: str
-    origin: tuple[Expr, ...]
     axes: tuple[Axis, ...]
-    addressing: AffineAddressing | TemplateAddressing
+    body: Body
     # Per-cache-axis extra extent added to the smem allocation (not to the
     # cooperative-load extent). Empty tuple = no padding. Used by the bank-
     # conflict pass to break stride-aliased smem layouts: padding dim ``d``
@@ -250,15 +279,6 @@ class Stage(Stmt):
     # 32-way bank conflicts that arise when adjacent threads stride through
     # power-of-2 multiples of bank width.
     pad: tuple[int, ...] = ()
-    # Cooperative-load program: the per-CTA logical compute that produces
-    # the staged slab. Trivial form (auto-synthesized when not provided) is
-    # ``Load(input=buf, index=origin+cache_vars); Write(output=name,
-    # index=cache_vars, value=loaded)`` — equivalent to today's
-    # synthesized-from-(buf, origin, axes, addressing) materializer path.
-    # Non-trivial bodies (fused producer compute) are reserved for the
-    # follow-up stage-epilogue fusion pass; the materializer trip-wire
-    # rejects them until phase 2.
-    body: Body = field(default_factory=Body)
 
     def __post_init__(self) -> None:
         # Coerce tuple inputs (e.g. from rewrite/with_bodies that build a
@@ -266,37 +286,92 @@ class Stage(Stmt):
         # walkers can call ``.map`` / ``.iter`` on Stage's nested body.
         if not isinstance(self.body, Body):
             self.body = Body.coerce(self.body)
-        if not self.body:
-            self.body = self._synthesize_trivial_body()
+        if len(self.body) < 2:
+            raise ValueError(f"Stage {self.name!r}: body must contain at least one Load and one Write, got {len(self.body)} stmts")
 
-    def _synthesize_trivial_body(self) -> Body:
-        cache_index = tuple(Var(ax.name) for ax in self.axes)
-        if isinstance(self.addressing, AffineAddressing):
-            decoded: dict[int, Expr] = dict(zip(self.addressing.dims, cache_index, strict=True))
-            src_index = tuple(o if d not in decoded else o + decoded[d] for d, o in enumerate(self.origin))
-        else:
-            src_index = self.addressing.exprs
-        load_name = f"{self.name}__src"
-        return Body(
-            (
-                Load(name=load_name, input=self.buf, index=src_index),
-                Write(output=self.name, index=cache_index, value=load_name),
-            )
-        )
-
-    # Phase 1: ``body`` is auxiliary metadata. The materializer still reads
-    # legacy ``(buf, origin, addressing)`` fields, and several tile passes
-    # (notably ``008_register_tile``) rely on ``Stage`` being opaque to
-    # generic body walkers — exposing the body via ``nested()`` would let
-    # F-axis replication descend into the cooperative-load Loads and
-    # corrupt their semantics. So we keep the leaf-stmt protocol here;
+    # Stage stays opaque to generic body walkers (no ``nested()`` /
+    # ``with_bodies()`` override). Exposing the cooperative-load Loads to
+    # ``008_register_tile``'s ``Body.map``-based F-axis replication would
+    # corrupt their semantics — cache-axis Vars in the body are
+    # smem-local, not values that participate in F-axis register tiling.
     # σ-substitution through the body is handled explicitly by the
     # Stage-specific ``rewrite`` / ``simplify`` handlers in
-    # ``deplodock/compiler/ir/tile/passes.py``. Phase 2 (when materializer
-    # walks ``body`` directly) revisits this.
+    # ``deplodock/compiler/ir/tile/passes.py``.
 
     def deps(self) -> tuple[str, ...]:
         return ()
+
+    # ------------------------------------------------------------------
+    # Derived slab-geometry views (legacy ``buf`` / ``origin`` /
+    # ``addressing`` field accessors, re-expressed as body-driven
+    # properties so the body is the single source of truth).
+    # ------------------------------------------------------------------
+
+    @property
+    def primary_load(self) -> Load:
+        """The producer-side Load that anchors this Stage's slab.
+
+        Today every Stage body has exactly one Load (trivial cooperative
+        load); raises if a future fused body has more than one source
+        Load. Callers needing all source Loads should use
+        :attr:`source_loads`."""
+        loads = tuple(s for s in self.body if isinstance(s, Load))
+        if len(loads) != 1:
+            raise ValueError(
+                f"Stage {self.name!r}: primary_load undefined — body has {len(loads)} Loads "
+                "(multi-source fused stages must use ``source_loads``)."
+            )
+        return loads[0]
+
+    @property
+    def source_loads(self) -> tuple[Load, ...]:
+        """Every Load in ``body``, in body order. Trivial body returns a
+        1-tuple; fused bodies (future) may return more."""
+        return tuple(s for s in self.body if isinstance(s, Load))
+
+    @property
+    def buf(self) -> str:
+        """Source gmem buffer name. ``body[0].input`` for the trivial /
+        single-source case."""
+        return self.primary_load.input
+
+    @property
+    def origin(self) -> tuple[Expr, ...]:
+        """Per-source-dim CTA-uniform anchor: ``primary_load.index`` with
+        every cache-axis Var substituted to 0 and simplified."""
+        from deplodock.compiler.ir.expr import SimplifyCtx  # noqa: PLC0415
+        from deplodock.compiler.ir.sigma import Sigma  # noqa: PLC0415
+
+        sigma = Sigma({ax.name: Literal(0, "int") for ax in self.axes})
+        ctx = SimplifyCtx.empty()
+        return tuple(sigma.reduce(e, ctx) for e in self.primary_load.index)
+
+    @property
+    def addressing(self) -> AffineAddressing | TemplateAddressing:
+        """Affine if every cache axis appears coef-1 in exactly one source
+        dim of ``primary_load.index``, else template (verbatim index)."""
+        from deplodock.compiler.ir.expr import SimplifyCtx  # noqa: PLC0415
+        from deplodock.compiler.ir.sigma import Sigma  # noqa: PLC0415
+
+        index = self.primary_load.index
+        var_to_dim: dict[str, int] = {}
+        for ax in self.axes:
+            dims = [d for d, e in enumerate(index) if ax.name in e.free_vars()]
+            if len(dims) != 1:
+                return TemplateAddressing(exprs=index)
+            var_to_dim[ax.name] = dims[0]
+
+        ctx = SimplifyCtx.empty()
+        origin = self.origin
+        for ax in self.axes:
+            d = var_to_dim[ax.name]
+            one_sigma = Sigma({a.name: (Literal(1, "int") if a.name == ax.name else Literal(0, "int")) for a in self.axes})
+            actual = one_sigma.reduce(index[d], ctx)
+            expected = (origin[d] + Literal(1, "int")).simplify(ctx)
+            if actual.pretty() != expected.pretty():
+                return TemplateAddressing(exprs=index)
+
+        return AffineAddressing(dims=tuple(var_to_dim[ax.name] for ax in self.axes))
 
     @property
     def alloc_extents(self) -> tuple[int, ...]:

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -401,10 +401,21 @@ class Stage(Stmt):
         return n
 
     def exprs(self) -> tuple[Expr, ...]:
-        template = self.addressing.exprs if isinstance(self.addressing, TemplateAddressing) else ()
-        return (*self.origin, *template)
+        # Exprs visible to generic Expr walkers (axis-dep analysis in 008,
+        # σ-substitution targets in 015). Iterate every source Load's index
+        # so fused stages expose all gmem references; trivial stages
+        # reduce to ``(*origin,)`` (one Load, AffineAddressing).
+        out: tuple[Expr, ...] = ()
+        for src in self.source_loads:
+            out = (*out, *src.index)
+        return out
 
     def pretty(self, indent: str = "") -> list[str]:
+        if len(self.source_loads) > 1:
+            srcs = ", ".join(src.input for src in self.source_loads)
+            cache = ", ".join(f"{ax.name}:{ax.extent}" for ax in self.axes)
+            pad = f" pad=({', '.join(str(p) for p in self.pad)})" if self.pad and any(self.pad) else ""
+            return [f"{indent}{self.name} = {type(self).__name__}(fuse[{srcs}], cache=({cache})){pad}{self._pretty_extra()}"]
         origin = ", ".join(e.pretty() for e in self.origin)
         if isinstance(self.addressing, AffineAddressing):
             slab = ", ".join(f"{ax.name}:{ax.extent}@{d}" for ax, d in zip(self.axes, self.addressing.dims, strict=True))
@@ -738,7 +749,8 @@ class TileOp(Op):
         bufs: dict[str, None] = {}
         for s in self:
             if isinstance(s, Stage):
-                bufs.setdefault(s.buf, None)
+                for src in s.source_loads:
+                    bufs.setdefault(src.input, None)
             elif isinstance(s, Load) and s.input not in stage_names:
                 bufs.setdefault(s.input, None)
         return tuple(bufs)

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -55,6 +55,7 @@ from deplodock.compiler.ir.expr import (
     Var,
 )
 from deplodock.compiler.ir.stmt import (
+    INDENT,
     Accum,
     Assign,
     Body,
@@ -415,7 +416,8 @@ class Stage(Stmt):
             srcs = ", ".join(src.input for src in self.source_loads)
             cache = ", ".join(f"{ax.name}:{ax.extent}" for ax in self.axes)
             pad = f" pad=({', '.join(str(p) for p in self.pad)})" if self.pad and any(self.pad) else ""
-            return [f"{indent}{self.name} = {type(self).__name__}(fuse[{srcs}], cache=({cache})){pad}{self._pretty_extra()}"]
+            head = f"{indent}{self.name} = {type(self).__name__}(fuse[{srcs}], cache=({cache})){pad}{self._pretty_extra()}:"
+            return [head, *pretty_body(self.body, indent + INDENT)]
         origin = ", ".join(e.pretty() for e in self.origin)
         if isinstance(self.addressing, AffineAddressing):
             slab = ", ".join(f"{ax.name}:{ax.extent}@{d}" for ax, d in zip(self.axes, self.addressing.dims, strict=True))

--- a/deplodock/compiler/ir/tile/passes.py
+++ b/deplodock/compiler/ir/tile/passes.py
@@ -22,12 +22,18 @@ from deplodock.compiler.ir.tile.ir import AsyncWait, Combine, Stage
 
 @rewrite.register
 def _(s: Stage, rename: Rename, sigma: Sigma, axis_fn: AxisFn) -> Stmt:
-    return type(s)(**_stage_kwargs(s, on_expr=sigma.apply, on_axis=axis_fn))
+    # _stage_kwargs walks Expr/Axis fields but stops at Stmt boundaries — body
+    # stmts need explicit recursion (parallel to Loop / StridedLoop handlers).
+    kwargs = _stage_kwargs(s, on_expr=sigma.apply, on_axis=axis_fn)
+    kwargs["body"] = tuple(rewrite(c, rename, sigma, axis_fn) for c in s.body)
+    return type(s)(**kwargs)
 
 
 @simplify.register
 def _(s: Stage, ctx: SimplifyCtx) -> Stmt:
-    return type(s)(**_stage_kwargs(s, on_expr=lambda e: e.simplify(ctx), on_axis=lambda a: a))
+    kwargs = _stage_kwargs(s, on_expr=lambda e: e.simplify(ctx), on_axis=lambda a: a)
+    kwargs["body"] = tuple(simplify(c, ctx) for c in s.body)
+    return type(s)(**kwargs)
 
 
 @rewrite.register

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
@@ -195,6 +195,7 @@ def _materialize(blk: Tile) -> Stmt:
         return [CpAsyncWait(group=stmt.keep), Sync()]
 
     def emit_tma_stage(stage: TmaBufferedStage) -> list[Stmt]:
+        _assert_trivial_stage_body(stage)
         desc_name = f"{stage.name}_desc"
         gid = stage_group[id(stage)]
         mbar_name = _mbar_name(gid)
@@ -645,6 +646,25 @@ def _emit_combine(accum: Accum, t: str, n_threads: int) -> list[Stmt]:
 # ---------------------------------------------------------------------------
 
 
+def _assert_trivial_stage_body(stage: Stage) -> None:
+    """Phase-1 trip-wire: materializer still reads legacy (buf, origin,
+    addressing) fields, so the Stage body must be the auto-synthesized
+    trivial pair ``Load(input=buf, ...) ; Write(output=name, ...)``.
+    Anything richer (fused producer compute) requires phase 2.
+    """
+    if len(stage.body) != 2:
+        raise AssertionError(
+            f"Stage {stage.name!r}: expected trivial 2-stmt body (Load, Write), "
+            f"got {len(stage.body)} stmts — fused stage bodies are not yet supported "
+            f"by the materializer (phase 2 required)."
+        )
+    load, write = stage.body
+    if not isinstance(load, Load) or load.input != stage.buf:
+        raise AssertionError(f"Stage {stage.name!r}: body[0] must be Load(input={stage.buf!r}), got {load!r}")
+    if not isinstance(write, Write) or write.output != stage.name:
+        raise AssertionError(f"Stage {stage.name!r}: body[1] must be Write(output={stage.name!r}), got {write!r}")
+
+
 def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
     """Expand a ``Stage`` Stmt into ``Smem`` decl + cooperative load + sync.
 
@@ -669,6 +689,7 @@ def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
     1's leading Sync is harmless (no prior state)."""
     if not stage.axes:
         raise ValueError(f"Stage {stage.name!r} has no cache axes")
+    _assert_trivial_stage_body(stage)
     extents = tuple(int(ax.extent) for ax in stage.axes)
     padded_extents = stage.alloc_extents
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
@@ -162,7 +162,11 @@ def _materialize(blk: Tile) -> Stmt:
         if isinstance(stmt, Stage) and len(stmt.source_loads) > 1:
             if stmt.name in declared_smem:
                 continue
-            extents = stmt.alloc_extents  # padded cache extents (no buffer_count — compute Stage isn't buffered)
+            # When the compute Stage was promoted to BufferedStage (DEPLODOCK_BUFFER_COMPUTE),
+            # include buffer_count in the leading dim of the smem alloc.
+            extents = stmt.alloc_extents
+            if isinstance(stmt, BufferedStage):
+                extents = (stmt.buffer_count, *extents)
             compute_stage_prologue.append(Smem(name=stmt.name, extents=extents))
             declared_smem.add(stmt.name)
 
@@ -808,6 +812,16 @@ def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
         return name
 
     walked_body = tuple(s.rewrite(_identity, cache_sigma) for s in stage.body)
+    # Buffered fused stages: the trivial-path prepends ``stage.phase`` to
+    # ``smem_index`` so the cooperative Write lands in the current ring
+    # slot. The fused path's terminal Write comes from the body's own
+    # Write stmt (with cache-local index) — apply the same prepend.
+    if isinstance(stage, BufferedStage):
+        *prefix, final = walked_body
+        assert isinstance(final, Write) and final.output == stage.name, (
+            f"Stage {stage.name!r}: buffered fused body must end with Write(output={stage.name!r}), got {final!r}"
+        )
+        walked_body = (*prefix, Write(output=final.output, index=(stage.phase, *final.index), value=final.value, reduce_op=final.reduce_op))
     cooperative_load = StridedLoop(
         axis=iter_axis,
         start=tid_expr,

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
@@ -52,7 +52,7 @@ from deplodock.compiler.ir.kernel.ir import (
     TreeHalve,
     WarpShuffle,
 )
-from deplodock.compiler.ir.stmt import Accum, Cond, Load, Loop, Stmt, StridedLoop, Tile, Write
+from deplodock.compiler.ir.stmt import Accum, Assign, Cond, Load, Loop, Stmt, StridedLoop, Tile, Write
 from deplodock.compiler.ir.tile.ir import (
     BYTES_PER_ELEM,
     AffineAddressing,
@@ -195,7 +195,7 @@ def _materialize(blk: Tile) -> Stmt:
         return [CpAsyncWait(group=stmt.keep), Sync()]
 
     def emit_tma_stage(stage: TmaBufferedStage) -> list[Stmt]:
-        _assert_trivial_stage_body(stage)
+        _assert_stage_body_shape(stage)
         desc_name = f"{stage.name}_desc"
         gid = stage_group[id(stage)]
         mbar_name = _mbar_name(gid)
@@ -646,23 +646,24 @@ def _emit_combine(accum: Accum, t: str, n_threads: int) -> list[Stmt]:
 # ---------------------------------------------------------------------------
 
 
-def _assert_trivial_stage_body(stage: Stage) -> None:
-    """Phase-1 trip-wire: materializer still reads legacy (buf, origin,
-    addressing) fields, so the Stage body must be the auto-synthesized
-    trivial pair ``Load(input=buf, ...) ; Write(output=name, ...)``.
-    Anything richer (fused producer compute) requires phase 2.
+def _assert_stage_body_shape(stage: Stage) -> None:
+    """Materializer body precondition. Accepted bodies are a linear chain
+    of ``Load`` / ``Assign`` followed by exactly one terminal ``Write``
+    whose output is ``stage.name``. Single-source (trivial) and
+    multi-source (post-fusion) bodies both pass; anything richer (nested
+    Loops / Conds / extra Writes) is rejected so the materializer's flat
+    cooperative-load template stays meaningful.
     """
-    if len(stage.body) != 2:
-        raise AssertionError(
-            f"Stage {stage.name!r}: expected trivial 2-stmt body (Load, Write), "
-            f"got {len(stage.body)} stmts — fused stage bodies are not yet supported "
-            f"by the materializer (phase 2 required)."
-        )
-    load, write = stage.body
-    if not isinstance(load, Load) or load.input != stage.buf:
-        raise AssertionError(f"Stage {stage.name!r}: body[0] must be Load(input={stage.buf!r}), got {load!r}")
-    if not isinstance(write, Write) or write.output != stage.name:
-        raise AssertionError(f"Stage {stage.name!r}: body[1] must be Write(output={stage.name!r}), got {write!r}")
+    if len(stage.body) < 2:
+        raise AssertionError(f"Stage {stage.name!r}: body must contain ≥ 1 Load and a trailing Write, got {len(stage.body)} stmts")
+    if not any(isinstance(s, Load) for s in stage.body):
+        raise AssertionError(f"Stage {stage.name!r}: body must contain at least one Load")
+    last = stage.body[-1]
+    if not isinstance(last, Write) or last.output != stage.name:
+        raise AssertionError(f"Stage {stage.name!r}: body must end with Write(output={stage.name!r}), got {last!r}")
+    for s in stage.body[:-1]:
+        if not isinstance(s, (Load, Assign)):
+            raise AssertionError(f"Stage {stage.name!r}: body may only contain Load / Assign / final Write, got {type(s).__name__}")
 
 
 def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
@@ -689,7 +690,7 @@ def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
     1's leading Sync is harmless (no prior state)."""
     if not stage.axes:
         raise ValueError(f"Stage {stage.name!r} has no cache axes")
-    _assert_trivial_stage_body(stage)
+    _assert_stage_body_shape(stage)
     extents = tuple(int(ax.extent) for ax in stage.axes)
     padded_extents = stage.alloc_extents
 
@@ -710,23 +711,32 @@ def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
         coord_for = _flat_decode(stage.axes, iter_axis.name)
 
     smem_index = tuple(coord_for[ax.name] for ax in stage.axes)
-    if isinstance(stage.addressing, TemplateAddressing):
-        # Non-affine path (``/``, ``%`` from collapsed-reshape views).
-        # Cache extent equals the raw axis extent (no F-scale baked in),
-        # so substituting cache-axis Vars with their iter coords into
-        # the original Load index gives the right source address per
-        # cache position. Affine cases stay on the additive
-        # ``origin + decoded`` path because their cache extent IS scaled
-        # by F, so iter coord directly equals the cache-relative source
-        # position — no need to re-multiply via F.
-        from deplodock.compiler.ir.sigma import Sigma as _Sigma
+    # Source-index reconstruction is only used by the trivial-body /
+    # cp.async paths below. For fused (multi-source) bodies we walk the
+    # body's Loads directly and σ-rewrite their indices, so ``stage.addressing``
+    # is never consulted (it raises on multi-Load bodies). Single-Load
+    # bodies always have a well-defined addressing.
+    trivial = len(stage.source_loads) == 1 and len(stage.body) == 2
+    if trivial:
+        if isinstance(stage.addressing, TemplateAddressing):
+            # Non-affine path (``/``, ``%`` from collapsed-reshape views).
+            # Cache extent equals the raw axis extent (no F-scale baked in),
+            # so substituting cache-axis Vars with their iter coords into
+            # the original Load index gives the right source address per
+            # cache position. Affine cases stay on the additive
+            # ``origin + decoded`` path because their cache extent IS scaled
+            # by F, so iter coord directly equals the cache-relative source
+            # position — no need to re-multiply via F.
+            from deplodock.compiler.ir.sigma import Sigma as _Sigma
 
-        cache_sigma = _Sigma({ax.name: coord_for[ax.name] for ax in stage.axes})
-        source_index = tuple(cache_sigma.apply(e) for e in stage.addressing.exprs)
+            cache_sigma = _Sigma({ax.name: coord_for[ax.name] for ax in stage.axes})
+            source_index = tuple(cache_sigma.apply(e) for e in stage.addressing.exprs)
+        else:
+            assert isinstance(stage.addressing, AffineAddressing)
+            decoded_per_dim = {dim: coord_for[ax.name] for dim, ax in zip(stage.addressing.dims, stage.axes, strict=True)}
+            source_index = tuple(o if d not in decoded_per_dim else o + decoded_per_dim[d] for d, o in enumerate(stage.origin))
     else:
-        assert isinstance(stage.addressing, AffineAddressing)
-        decoded_per_dim = {dim: coord_for[ax.name] for dim, ax in zip(stage.addressing.dims, stage.axes, strict=True)}
-        source_index = tuple(o if d not in decoded_per_dim else o + decoded_per_dim[d] for d, o in enumerate(stage.origin))
+        source_index = ()  # unused on the fused path
 
     # Buffered stages prepend a phase dim to the smem allocation and to
     # both the cooperative-load write index and (downstream) every body
@@ -752,15 +762,39 @@ def _emit_stage(stage: Stage, tid_expr, n_threads: int) -> list[Stmt]:
         )
         return [Smem(name=stage.name, extents=full_extents), cooperative_load, CpAsyncCommit()]
 
-    load_name = f"{stage.name}_v"
+    if trivial:
+        # Trivial body fast path — preserves byte-identical Kernel IR for
+        # every non-fused stage (matches the legacy ``Load + Write`` shape
+        # the rest of the compiler / golden tests expect).
+        load_name = f"{stage.name}_v"
+        cooperative_load = StridedLoop(
+            axis=iter_axis,
+            start=tid_expr,
+            step=Literal(n_threads, "int"),
+            body=(
+                Load(name=load_name, input=stage.buf, index=source_index),
+                Write(output=stage.name, index=smem_index, value=load_name),
+            ),
+        )
+        return [*prelude, Smem(name=stage.name, extents=full_extents), cooperative_load, Sync()]
+
+    # Fused-body path: the Stage body carries the full producer program
+    # (Loads from multiple gmem buffers + elementwise compute + final
+    # Write to smem). σ-rewrite cache-axis Vars to per-thread flat-iter
+    # coords and emit the whole body inside the cooperative StridedLoop.
+    from deplodock.compiler.ir.sigma import Sigma as _Sigma  # noqa: PLC0415
+
+    cache_sigma = _Sigma({ax.name: coord_for[ax.name] for ax in stage.axes})
+
+    def _identity(name: str) -> str:
+        return name
+
+    walked_body = tuple(s.rewrite(_identity, cache_sigma) for s in stage.body)
     cooperative_load = StridedLoop(
         axis=iter_axis,
         start=tid_expr,
         step=Literal(n_threads, "int"),
-        body=(
-            Load(name=load_name, input=stage.buf, index=source_index),
-            Write(output=stage.name, index=smem_index, value=load_name),
-        ),
+        body=walked_body,
     )
     return [*prelude, Smem(name=stage.name, extents=full_extents), cooperative_load, Sync()]
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/001_materialize_tile.py
@@ -150,6 +150,22 @@ def _materialize(blk: Tile) -> Stmt:
     mbar_prologue: list[Stmt] = []
     declared_mbar: set[str] = set()
 
+    # Compute-Stage Smem hoist: a multi-source Stage (produced by 007b
+    # split) emits its body inside the K-outer loop body — Smem decls
+    # inside a loop don't reach kernel scope in CUDA. Walk the body once,
+    # pre-emit Smem decls for every multi-source Stage at kernel scope,
+    # and mark them ``declared_smem`` so ``_emit_stage``'s in-loop emit
+    # is dedup'd. Single-source stages are hoisted to prologue naturally
+    # by 015 (their first emission is σ_first above the K-outer loop).
+    compute_stage_prologue: list[Stmt] = []
+    for stmt in body.iter():
+        if isinstance(stmt, Stage) and len(stmt.source_loads) > 1:
+            if stmt.name in declared_smem:
+                continue
+            extents = stmt.alloc_extents  # padded cache extents (no buffer_count — compute Stage isn't buffered)
+            compute_stage_prologue.append(Smem(name=stmt.name, extents=extents))
+            declared_smem.add(stmt.name)
+
     stage_group, wait_group, group_stage_names, group_buffer_count = _partition_tma_groups(body)
     has_tma = bool(group_stage_names)
     # Per-stage issuer thread = position of stage name within its group
@@ -394,6 +410,8 @@ def _materialize(blk: Tile) -> Stmt:
             prologue.append(Cond(cond=BinaryExpr("==", Builtin("thread_idx.x"), Literal(0, "int")), body=tuple(mbar_inits)))
             prologue.append(Sync())
         new_body = prologue + new_body
+    if compute_stage_prologue:
+        new_body = compute_stage_prologue + new_body
     return Tile(axes=axes, body=_drop_redundant_syncs(new_body))
 
 

--- a/deplodock/compiler/pipeline/passes/lowering/tile/007_stage_inputs.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/007_stage_inputs.py
@@ -52,7 +52,7 @@ from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import BinaryExpr, Expr, Interval, Literal, SimplifyCtx, Var
 from deplodock.compiler.ir.sigma import Sigma
 from deplodock.compiler.ir.stmt import Body, Load, Loop, Stmt, StridedLoop, Tile
-from deplodock.compiler.ir.tile.ir import BYTES_PER_ELEM, AffineAddressing, Stage, TemplateAddressing, TileOp
+from deplodock.compiler.ir.tile.ir import BYTES_PER_ELEM, AffineAddressing, Stage, TemplateAddressing, TileOp, trivial_stage_body
 from deplodock.compiler.pipeline import Pattern, RuleSkipped
 from deplodock.compiler.pipeline.passes.lowering.tile._helpers import single_tile
 
@@ -378,10 +378,8 @@ def _build_stages(
             stages.append(
                 Stage(
                     name=smem_name,
-                    buf=buf,
-                    origin=slab.origin,
                     axes=slab.cache_axes,
-                    addressing=addressing,
+                    body=trivial_stage_body(smem_name, buf, slab.origin, slab.cache_axes, addressing),
                 )
             )
             used_bytes += slab.n_bytes

--- a/deplodock/compiler/pipeline/passes/lowering/tile/007a_fuse_stage_epilogue.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/007a_fuse_stage_epilogue.py
@@ -1,0 +1,334 @@
+"""Fuse loop-invariant producer chains into the upstream Stage body.
+
+After ``007_stage_inputs`` runs, the Tile body has shape::
+
+    Tile(axes=...):
+        for K_outer:                                 # free
+            stage_A = Stage(A, axes=(M,K))
+            stage_B = Stage(B, axes=(M,K))
+            stage_W = Stage(W, axes=(K,N))
+            for K_inner:                             # reduce
+                a = load stage_A[M, K_inner]
+                ... silu/elementwise chain on a ...
+                b = load stage_B[M, K_inner]
+                v = multiply(b, sig*a)               # final silu(a)*b
+                w = load stage_W[K_inner, N]
+                acc += multiply(w, v)
+
+In the silu-gated MLP shape (``F.silu(gate)*up @ W``), the chain
+``v0..v_silu`` depends only on ``stage_A`` + ``stage_B`` (cache axes
+``{M, K_inner}``); it has no dependency on ``N`` (the consumer thread
+axis). Today that chain re-runs every ``N``-thread, every ``N``-tile —
+~896× redundancy on Qwen-MLP shapes.
+
+This pass detects such cones and folds them into the producer Stage.
+The fused Stage's body becomes a multi-source program::
+
+    fused = Stage(name=…, axes=(M, K_inner), body=(
+        Load(input=A, index=…),
+        Load(input=B, index=…),
+        Assign(silu chain over A's load),
+        Assign(multiply with B's load),                 # the cone's frontier
+        Write(output=fused, index=(M, K_inner), value=<frontier>),
+    ))
+
+``stage_A`` and ``stage_B`` are removed; the consumer reduce body's cone
+collapses to a single Load from ``fused``.
+
+Scope (conservative for the first cut):
+
+- Single Tile.
+- Single reduce Loop inside the Tile body (or inside a free outer Loop).
+- Cone is identified per stage-cache-axes group: a group of ≥ 2 Stages
+  with identical ``axes`` whose dependent SSAs in the reduce body form
+  a coherent dataflow region (only ``Load`` / ``Assign``, no ``Cond`` /
+  nested loops) and whose ``free_vars`` are a subset of the cache axes.
+- Cone must have exactly one boundary SSA (the value consumed by the
+  reduce-body region outside the cone). Multi-output cones are skipped.
+
+Runs once per TileOp (the rewriter returns ``RuleSkipped`` if no cone
+was found). Must run **before** ``008_register_tile`` — that pass
+introduces F-axis split and would tangle cones across register tiles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace as dc_replace
+
+from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.expr import Expr, Var
+from deplodock.compiler.ir.stmt import Assign, Body, Load, Loop, Stmt, Write
+from deplodock.compiler.ir.tile.ir import Stage, TileOp
+from deplodock.compiler.pipeline import Pattern, RuleSkipped
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import single_tile
+
+PATTERN = [Pattern("root", TileOp)]
+
+
+def rewrite(root: Node) -> Graph | None:
+    new_body = _maybe_rewrite(root.op.body)
+    if new_body is None:
+        raise RuleSkipped("no fusable epilogue cone found")
+    return TileOp(body=new_body, name=root.op.name)
+
+
+def _maybe_rewrite(body: Body) -> Body | None:
+    idx, tile = single_tile(body)
+    new_tile_body = _process_scope(tile.body)
+    if new_tile_body is None:
+        return None
+    new_tile = dc_replace(tile, body=new_tile_body)
+    return body[:idx] + (new_tile,) + body[idx + 1 :]
+
+
+def _process_scope(scope_body: Body) -> Body | None:
+    """Find a reduce-Loop scope that has Stages preceding it (the
+    typical 007 layout) and try to fuse. If none found at this level,
+    recurse into free outer Loops."""
+    # Pattern: a sequence of Stages immediately followed by a reduce Loop.
+    stages: list[Stage] = []
+    reduce_loop: Loop | None = None
+    reduce_loop_idx: int | None = None
+    for i, s in enumerate(scope_body):
+        if isinstance(s, Stage):
+            stages.append(s)
+        elif isinstance(s, Loop) and s.is_reduce and stages:
+            reduce_loop = s
+            reduce_loop_idx = i
+            break
+        elif isinstance(s, Loop) and not s.is_reduce:
+            # Free outer loop — recurse into its body.
+            inner = _process_scope(s.body)
+            if inner is not None:
+                new_outer = dc_replace(s, body=inner)
+                return Body(scope_body[:i] + (new_outer,) + scope_body[i + 1 :])
+        else:
+            # Anything else (Combine, AsyncWait, etc.) resets the staged
+            # group — we only fuse stages that are immediate prefix of a
+            # reduce Loop.
+            stages = []
+
+    if reduce_loop is None or reduce_loop_idx is None:
+        return None
+
+    # Try to identify a fusable cone within this reduce body.
+    fused = _try_fuse(stages, reduce_loop)
+    if fused is None:
+        return None
+    new_stages, new_reduce_body, fused_stage = fused
+    new_loop = dc_replace(reduce_loop, body=new_reduce_body)
+    # Reassemble: stages before the fused stage's slot, fused stage, then
+    # the remaining (non-source) stages, then the rewritten reduce loop.
+    pre = scope_body[: reduce_loop_idx - len(stages)]
+    return Body(pre + tuple(new_stages) + (new_loop,) + scope_body[reduce_loop_idx + 1 :])
+
+
+def _try_fuse(stages: list[Stage], reduce_loop: Loop) -> tuple[list[Stage], Body, Stage] | None:
+    """Identify the largest fusable cone in ``reduce_loop.body`` whose
+    producer set is a group of Stages with identical cache axes.
+    Returns the rewritten ``(stages_list, reduce_body, fused_stage)`` or
+    ``None`` if no fusion is possible."""
+    # Group stages by their cache-axis tuple. Only groups with ≥ 2 stages
+    # benefit from fusion — one stage means there's already a single
+    # cooperative load.
+    groups: dict[tuple[str, ...], list[Stage]] = {}
+    for st in stages:
+        key = tuple(ax.name for ax in st.axes)
+        groups.setdefault(key, []).append(st)
+
+    candidates = [(key, grp) for key, grp in groups.items() if len(grp) >= 2]
+    if not candidates:
+        return None
+
+    # SSA dataflow on the reduce body.
+    ssa_stage_deps, ssa_free_vars, ssa_def = _ssa_dataflow(reduce_loop.body)
+
+    for cache_axes_tuple, group in candidates:
+        group_names = frozenset(st.name for st in group)
+        cache_axes_set = frozenset(cache_axes_tuple)
+
+        # The cone: SSAs whose Loads (transitive) all come from this group
+        # AND whose free vars are within the cache-axis set. A name with
+        # no stage deps (e.g. an SSA computed entirely from cache-axis
+        # Vars without a Load) is not part of any cone.
+        cone: set[str] = set()
+        for name, deps in ssa_stage_deps.items():
+            if not deps:
+                continue
+            if deps <= group_names and ssa_free_vars[name] <= cache_axes_set:
+                cone.add(name)
+
+        if not cone:
+            continue
+
+        # Boundary: cone SSAs consumed by any stmt outside the cone.
+        boundary = _find_boundary(reduce_loop.body, cone)
+        if len(boundary) != 1:
+            # Multi-output cones (e.g. two independent silu chains feeding
+            # different consumers) need more bookkeeping — skip for now.
+            continue
+        boundary_name = next(iter(boundary))
+
+        # The cone's *boundary* must be an Assign output, not a raw
+        # smem Load. A Load boundary means no compute happens between
+        # the gmem source and the consumer — fusion would just write
+        # the gmem value into a new smem buffer with no benefit. Defer
+        # to the existing single-stage staging path.
+        boundary_def = ssa_def[boundary_name]
+        if not isinstance(boundary_def, Assign):
+            continue
+
+        # Build the fused stage and rewrite the reduce body.
+        fused_stage, new_reduce_body = _build_fusion(group, group_names, reduce_loop.body, cone, boundary_name, ssa_def)
+        # Replace the source stages in the outer list with the fused
+        # stage; keep any other stages (from other groups) as-is.
+        new_stages: list[Stage] = []
+        emitted_fused = False
+        for st in stages:
+            if st.name in group_names:
+                if not emitted_fused:
+                    new_stages.append(fused_stage)
+                    emitted_fused = True
+            else:
+                new_stages.append(st)
+        return new_stages, new_reduce_body, fused_stage
+
+    return None
+
+
+def _ssa_dataflow(
+    body: Body,
+) -> tuple[dict[str, frozenset[str]], dict[str, frozenset[str]], dict[str, Stmt]]:
+    """Per-SSA-name: (transitive set of source-stage names it depends on,
+    free-axis Vars it references, the defining stmt). Operates over a
+    linear reduce body (no nested control flow, which is asserted by the
+    cone shape check)."""
+    stage_deps: dict[str, frozenset[str]] = {}
+    free_vars: dict[str, frozenset[str]] = {}
+    defs: dict[str, Stmt] = {}
+    for s in body:
+        if isinstance(s, Load):
+            defs[s.name] = s
+            stage_deps[s.name] = frozenset({s.input})
+            fv: frozenset[str] = frozenset()
+            for e in s.index:
+                fv = fv | frozenset(e.free_vars())
+            free_vars[s.name] = fv
+        elif isinstance(s, Assign):
+            defs[s.name] = s
+            d: frozenset[str] = frozenset()
+            fv = frozenset()
+            for arg in s.args:
+                d = d | stage_deps.get(arg, frozenset())
+                fv = fv | free_vars.get(arg, frozenset())
+            stage_deps[s.name] = d
+            free_vars[s.name] = fv
+    return stage_deps, free_vars, defs
+
+
+def _find_boundary(body: Body, cone: set[str]) -> set[str]:
+    """Boundary = cone-internal SSAs consumed by a stmt that isn't in
+    the cone. Uses ``Stmt.deps()`` so every consumer type (Assign /
+    Accum / Write / Select / Cond / …) is covered uniformly — easy to
+    miss one if we enumerate by hand."""
+    boundary: set[str] = set()
+    for s in body:
+        producer = isinstance(s, (Load, Assign)) and getattr(s, "name", None) in cone
+        if producer:
+            continue
+        for d in s.deps():
+            if d in cone:
+                boundary.add(d)
+    return boundary
+
+
+def _build_fusion(
+    group: list[Stage],
+    group_names: frozenset[str],
+    reduce_body: Body,
+    cone: set[str],
+    boundary_name: str,
+    ssa_def: dict[str, Stmt],
+) -> tuple[Stage, Body]:
+    """Construct the fused Stage and the rewritten reduce body.
+
+    Cone SSAs come from the reduce body; their backward closure includes
+    Loads on stage smem buffers. In the fused stage's body we replace
+    those smem Loads with the corresponding gmem Loads (lifted from
+    each source stage's own body).
+    """
+    # Map smem_name → its source stage's body Load (the gmem load that
+    # filled it). Lift the source stage's Load(stage.name=…) verbatim;
+    # σ-rewrite its index from per-stage cache vars to the fused stage's
+    # cache vars (here the names match since the group shares ``axes``,
+    # so no rewrite needed beyond unique SSA names).
+    fused_name = "_".join(st.name for st in group) + "_fused"
+    fused_axes = group[0].axes  # identical across the group
+
+    # Body: gmem Loads from each source stage's primary Load, then the
+    # cone's Assigns in original order, then a terminal Write from the
+    # boundary SSA into the fused smem buffer.
+    fused_body_stmts: list[Stmt] = []
+
+    # SSA rename map: smem-Load name in reduce body → fresh name we use
+    # in the fused body (to avoid colliding with cone Assigns we'll copy
+    # over).
+    smem_to_fused_load: dict[str, str] = {}
+
+    # For each source Stage, the body has shape Load(gmem)→Write(smem).
+    # We pull the Load verbatim, renaming its SSA to <stage.name>__gmem.
+    for st in group:
+        primary = st.primary_load
+        gmem_load = Load(name=f"{st.name}__gmem", input=primary.input, index=primary.index)
+        fused_body_stmts.append(gmem_load)
+
+    # Map: each reduce-body Load(input=stage.name) → the gmem-load name
+    # we just emitted. Multiple smem Loads on the same stage map to the
+    # same gmem name (the gmem value is what they all read).
+    for s in reduce_body:
+        if isinstance(s, Load) and s.input in group_names:
+            stage = next(st for st in group if st.name == s.input)
+            smem_to_fused_load[s.name] = f"{stage.name}__gmem"
+
+    # Copy cone Assigns in body order, σ-rewriting any arg names that
+    # refer to smem Loads → the gmem-Load SSA names.
+    for s in reduce_body:
+        if isinstance(s, Assign) and s.name in cone:
+            new_args = tuple(smem_to_fused_load.get(a, a) for a in s.args)
+            fused_body_stmts.append(Assign(name=s.name, op=s.op, args=new_args))
+
+    # Terminal Write: cache-local index, value = boundary SSA. The
+    # boundary SSA is a cone Assign already in the body above.
+    cache_index: tuple[Expr, ...] = tuple(Var(ax.name) for ax in fused_axes)
+    fused_body_stmts.append(Write(output=fused_name, index=cache_index, value=boundary_name))
+    fused_body = Body(tuple(fused_body_stmts))
+
+    fused_stage = Stage(name=fused_name, axes=fused_axes, body=fused_body)
+
+    # Rewrite the reduce body: drop cone stmts (their compute now lives
+    # in the fused stage), drop reduce-body Loads whose input is a source
+    # stage (they're folded into the fused stage too), and replace the
+    # boundary name's value with a fresh Load from the fused stage's
+    # smem buffer.
+    new_reduce_stmts: list[Stmt] = []
+    boundary_emitted = False
+    boundary_load_name = boundary_name  # reuse the SSA name for callers
+    for s in reduce_body:
+        if isinstance(s, Load) and s.input in group_names:
+            # All smem Loads from source stages are absorbed; the
+            # boundary load (a single fused-stage smem Load) replaces
+            # them. Emit it the first time we'd have emitted any source
+            # smem Load — keeps original ordering of downstream stmts.
+            if not boundary_emitted:
+                new_reduce_stmts.append(Load(name=boundary_load_name, input=fused_name, index=cache_index))
+                boundary_emitted = True
+            continue
+        if isinstance(s, Assign) and s.name in cone:
+            # Cone Assign moved into fused stage; drop here.
+            continue
+        new_reduce_stmts.append(s)
+
+    if not boundary_emitted:
+        new_reduce_stmts.insert(0, Load(name=boundary_load_name, input=fused_name, index=cache_index))
+
+    return fused_stage, Body(tuple(new_reduce_stmts))

--- a/deplodock/compiler/pipeline/passes/lowering/tile/007b_split_fused_for_pipeline.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/007b_split_fused_for_pipeline.py
@@ -1,0 +1,211 @@
+"""Split fused multi-source Stages into transport + compute stages so 015 can pipeline.
+
+After ``007a_fuse_stage_epilogue`` runs, multi-source fused stages carry
+both the gmem source Loads AND the producer compute (silu chain etc.) in
+a single ``Stage.body``. ``015_pipeline_k_outer`` software-pipelines by
+σ-shifting Stages and placing cloned-with-K_outer→K_outer+1 issues
+ahead of the K_inner reduce — but it only operates on
+``BufferedStage`` / ``TmaBufferedStage`` (single-source, transport-only)
+because the σ-shift on a fused body would also shift the silu compute,
+which has to stay at the original K_outer position.
+
+This pass exposes the transport / compute boundary as separate Tile-IR
+Stmts so the existing pipelining pass can do its job unchanged. For each
+fused Stage in a free outer Loop's body::
+
+    fused = Stage(fuse[A, B], axes=(M, K), body=[
+        a_v = Load A[…]              # gmem Load
+        b_v = Load B[…]              # gmem Load
+        … silu / mul …               # Assigns
+        Write fused[M,K] = result    # Write to fused smem
+    ])
+
+is rewritten to::
+
+    A_xport = Stage(A, axes=(M, K))                       # transport
+    B_xport = Stage(B, axes=(M, K))                       # transport
+    fused   = Stage(fuse[A_xport, B_xport], axes=(M, K), body=[
+        a_v = Load A_xport[M, K]      # smem Load (cache-local index)
+        b_v = Load B_xport[M, K]
+        … silu / mul …                # unchanged
+        Write fused[M, K] = result
+    ])
+
+Now ``A_xport`` / ``B_xport`` are single-source Stages eligible for the
+existing ``010 → 011 / 013 → 015`` chain (BufferedStage / TmaBufferedStage
+promotion + K-outer pipelining). The compute Stage stays as a plain
+multi-source ``Stage`` — its body reads from the transport stages' smem
+buffers, runs the elementwise chain, writes to the original fused-smem
+buffer. Because the compute Stage is multi-source it bypasses 010/011/013
+(those guards already check ``len(s.source_loads) == 1``) and falls
+naturally into 015's ``others`` list, where it's placed *between* the
+wait and the K_inner reduce in the steady-state body — exactly the slot
+the silu chain needs to land in.
+
+Conditional firing: the split is only profitable when 015 will actually
+pipeline, which requires the fused Stage to live inside a free outer
+Loop with extent ≥ 2. Otherwise the split adds a smem round-trip
+(scratch → fused) for no overlap benefit, so we leave the fused Stage
+intact.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace as dc_replace
+
+from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.stmt import Assign, Body, Load, Loop, Stmt, Tile, Write
+from deplodock.compiler.ir.tile.ir import Stage, TileOp, trivial_stage_body
+from deplodock.compiler.pipeline import Pattern, RuleSkipped
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import single_tile
+
+PATTERN = [Pattern("root", TileOp)]
+
+
+def _enabled() -> bool:
+    """Opt-in via ``DEPLODOCK_FUSED_PIPELINE``.
+
+    On Hopper (sm_90+) with TMA, splitting the fused stage into per-source
+    transport stages lets ``015_pipeline_k_outer`` overlap K+1 TMAs with K
+    compute — meaningful win. On sm_120 (which uses cp.async instead),
+    the split adds register pressure (more live SSA across the new
+    compute slot) and bumps smem by the per-source scratch buffers,
+    typically dropping occupancy enough to wash out the latency hide.
+    Default off until per-hardware autotuning picks per-recipe."""
+    return os.environ.get("DEPLODOCK_FUSED_PIPELINE", "0") in ("1", "true", "True")
+
+
+def rewrite(root: Node) -> Graph | None:
+    if not _enabled():
+        raise RuleSkipped("DEPLODOCK_FUSED_PIPELINE not set")
+    new_body = _maybe_rewrite(root.op.body)
+    if new_body is None:
+        raise RuleSkipped("no fused Stage to split for pipelining")
+    return TileOp(body=new_body, name=root.op.name)
+
+
+def _maybe_rewrite(body: Body) -> Body | None:
+    idx, tile = single_tile(body)
+    new_tile_body = _split_in_scope(tile.body)
+    if new_tile_body is None:
+        return None
+    return body[:idx] + (Tile(axes=tile.axes, body=new_tile_body),) + body[idx + 1 :]
+
+
+def _split_in_scope(scope_body: Body) -> Body | None:
+    """Walk the scope; for each free outer Loop containing fused Stages
+    immediately followed by a reduce Loop, split each fused Stage."""
+    out: list[Stmt] = []
+    changed = False
+    for s in scope_body:
+        if isinstance(s, Loop) and not s.is_reduce and int(s.axis.extent) >= 2:
+            new_inner = _split_loop_body(s.body)
+            if new_inner is not None:
+                out.append(dc_replace(s, body=new_inner))
+                changed = True
+                continue
+        out.append(s)
+    return Body(out) if changed else None
+
+
+def _split_loop_body(loop_body: Body) -> Body | None:
+    """Inside a free K_outer Loop body, split each fused Stage into
+    transport + compute. Leave non-fused stages and other stmts alone."""
+    # Collect sibling stage names first so we can skip compute Stages
+    # whose sources are already-split transport stages (their body Loads
+    # read from sibling stage smem, not gmem — splitting again would
+    # recurse on our own output).
+    sibling_stage_names = {s.name for s in loop_body if isinstance(s, Stage)}
+
+    out: list[Stmt] = []
+    changed = False
+    for s in loop_body:
+        if isinstance(s, Stage) and len(s.source_loads) > 1 and _has_compute(s.body) and not _sources_are_siblings(s, sibling_stage_names):
+            transports, compute = _split_fused_stage(s)
+            out.extend(transports)
+            out.append(compute)
+            changed = True
+        else:
+            out.append(s)
+    return Body(out) if changed else None
+
+
+def _sources_are_siblings(stage: Stage, sibling_names: set[str]) -> bool:
+    """True iff every source Load reads from a sibling Stage's smem
+    (i.e. the stage is already a compute-side stage produced by a prior
+    split). Such stages don't need further splitting — their inputs are
+    not gmem latency to overlap."""
+    return all(src.input in sibling_names for src in stage.source_loads)
+
+
+def _has_compute(body: Body) -> bool:
+    """A fused Stage with no Assigns is nominally multi-source but its
+    body is just (Load A; Load B; Write fused = ?). Splitting wouldn't
+    move any compute — skip."""
+    return any(isinstance(stmt, Assign) for stmt in body)
+
+
+def _split_fused_stage(fused: Stage) -> tuple[list[Stage], Stage]:
+    """Decompose ``fused`` into per-source transport Stages + a compute
+    Stage. The compute Stage keeps the original ``fused.name`` so
+    consumers (the reduce body's Loads on ``fused.name``) don't need
+    rewriting."""
+    cache_axes = fused.axes
+    cache_index = tuple(Var(ax.name) for ax in cache_axes)
+
+    # Per-source transport Stages — one per body Load. Each is single-
+    # source with a trivial Load→Write body, eligible for the standard
+    # 010 / 011 / 013 promotion chain.
+    transports: list[Stage] = []
+    src_load_to_xport: dict[str, str] = {}  # body-Load SSA name → xport stage smem name
+    for src_load in fused.source_loads:
+        xport_name = f"{fused.name}__{src_load.input}_xport"
+        # Reuse trivial_stage_body so the addressing classification works.
+        # Origin/addressing are derived from the existing source Load's
+        # index against the cache axes.
+        transport = Stage(
+            name=xport_name,
+            axes=cache_axes,
+            body=Body(
+                (
+                    Load(name=f"{xport_name}__src", input=src_load.input, index=src_load.index),
+                    Write(output=xport_name, index=cache_index, value=f"{xport_name}__src"),
+                )
+            ),
+            pad=fused.pad,
+        )
+        transports.append(transport)
+        src_load_to_xport[src_load.name] = xport_name
+
+    # Compute Stage. Its body re-reads from the per-source scratch smems
+    # (cache-local index) and runs the original Assigns + final Write.
+    compute_body_stmts: list[Stmt] = []
+    # Replace each gmem source Load with a smem Load on the corresponding
+    # transport stage's output; index becomes cache-local (the body's
+    # later Assigns reference the same SSA name, so we keep the name).
+    for s in fused.body:
+        if isinstance(s, Load) and s.name in src_load_to_xport:
+            xport_name = src_load_to_xport[s.name]
+            compute_body_stmts.append(Load(name=s.name, input=xport_name, index=cache_index))
+        elif isinstance(s, Load):
+            # Body Load on something else (rare; keep verbatim).
+            compute_body_stmts.append(s)
+        else:
+            # Assign / Write — copied verbatim, SSA names already resolved.
+            compute_body_stmts.append(s)
+
+    compute = Stage(
+        name=fused.name,
+        axes=cache_axes,
+        body=Body(tuple(compute_body_stmts)),
+        pad=fused.pad,
+    )
+    return transports, compute
+
+
+# Keep the import alive (unused below but useful in tests / future
+# helper additions); ``trivial_stage_body`` is the canonical builder
+# the 007a fuser uses, so referencing it documents the relationship.
+_ = trivial_stage_body

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
@@ -157,12 +157,9 @@ def _double_buffer(loop: Loop) -> Loop | None:
             new_body.append(
                 BufferedStage(
                     name=s.name,
-                    buf=s.buf,
-                    origin=s.origin,
                     axes=s.axes,
-                    addressing=s.addressing,
-                    pad=s.pad,
                     body=s.body,
+                    pad=s.pad,
                     buffer_count=_BUFFER_COUNT,
                     phase=phase,
                 )

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
@@ -162,6 +162,7 @@ def _double_buffer(loop: Loop) -> Loop | None:
                     axes=s.axes,
                     addressing=s.addressing,
                     pad=s.pad,
+                    body=s.body,
                     buffer_count=_BUFFER_COUNT,
                     phase=phase,
                 )

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
@@ -170,6 +170,13 @@ def _double_buffer(loop: Loop) -> Loop | None:
             )
         elif isinstance(s, Loop) and s.is_reduce:
             new_body.append(dc_replace(s, body=s.body.map(_make_load_rewriter(staged_names, phase))))
+        elif isinstance(s, Stage) and len(s.source_loads) > 1:
+            # Multi-source compute Stage (produced by 007b_split). Its
+            # body reads from sibling transport stages' smem buffers,
+            # which we just promoted to BufferedStage. Prepend the same
+            # phase index to those body Loads so the compute consumes
+            # the slot the producer just wrote.
+            new_body.append(dc_replace(s, body=s.body.map(_make_load_rewriter(staged_names, phase))))
         else:
             new_body.append(s)
     return dc_replace(loop, body=new_body)

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
@@ -152,7 +152,11 @@ def _double_buffer(loop: Loop) -> Loop | None:
     staged_names: set[str] = set()
     new_body: list[Stmt] = []
     for s in loop.body:
-        if isinstance(s, Stage):
+        # Fused stages (multi-source body) keep sync transport — the
+        # double-buffer pass only handles single-source slabs because
+        # the body-Load-rewrite below (phase prefix on smem reads) assumes
+        # one cooperative load per stage.
+        if isinstance(s, Stage) and len(s.source_loads) == 1:
             staged_names.add(s.name)
             new_body.append(
                 BufferedStage(

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_double_buffer.py
@@ -148,14 +148,21 @@ def _double_buffer(loop: Loop) -> Loop | None:
     ``buffer_count=2`` and a shared phase expression, and rewrite each
     body Load that reads from a staged buffer to prepend the phase
     index."""
+    import os  # noqa: PLC0415
+
+    buffer_compute = os.environ.get("DEPLODOCK_BUFFER_COMPUTE", "0") in ("1", "true", "True")
+
     phase = Var(loop.axis.name) % Literal(_BUFFER_COUNT, "int")
     staged_names: set[str] = set()
+    # Collect existing stage names so we can identify compute stages
+    # (multi-source bodies whose sources are sibling stages, not gmem).
+    sibling_stage_names = {s.name for s in loop.body if isinstance(s, Stage)}
+
     new_body: list[Stmt] = []
     for s in loop.body:
-        # Fused stages (multi-source body) keep sync transport — the
-        # double-buffer pass only handles single-source slabs because
-        # the body-Load-rewrite below (phase prefix on smem reads) assumes
-        # one cooperative load per stage.
+        # Single-source transport stages — the standard double-buffer
+        # promotion (ring smem + phase prefix on body Load + reduce-body
+        # Load rewrite).
         if isinstance(s, Stage) and len(s.source_loads) == 1:
             staged_names.add(s.name)
             new_body.append(
@@ -172,11 +179,29 @@ def _double_buffer(loop: Loop) -> Loop | None:
             new_body.append(dc_replace(s, body=s.body.map(_make_load_rewriter(staged_names, phase))))
         elif isinstance(s, Stage) and len(s.source_loads) > 1:
             # Multi-source compute Stage (produced by 007b_split). Its
-            # body reads from sibling transport stages' smem buffers,
-            # which we just promoted to BufferedStage. Prepend the same
-            # phase index to those body Loads so the compute consumes
-            # the slot the producer just wrote.
-            new_body.append(dc_replace(s, body=s.body.map(_make_load_rewriter(staged_names, phase))))
+            # body reads from sibling transport stages' smem buffers.
+            # Always prepend phase to those body Loads so the compute
+            # consumes the slot the producer just wrote. Additionally,
+            # when DEPLODOCK_BUFFER_COMPUTE is set, promote the compute
+            # stage itself to BufferedStage so its output (fused_smem) is
+            # ring-buffered — experimental, lets a downstream pass try to
+            # overlap compute and reduce across K_outer iterations.
+            sources_are_siblings = all(src.input in sibling_stage_names for src in s.source_loads)
+            new_inner_body = s.body.map(_make_load_rewriter(staged_names, phase))
+            if buffer_compute and sources_are_siblings:
+                staged_names.add(s.name)
+                new_body.append(
+                    BufferedStage(
+                        name=s.name,
+                        axes=s.axes,
+                        body=new_inner_body,
+                        pad=s.pad,
+                        buffer_count=_BUFFER_COUNT,
+                        phase=phase,
+                    )
+                )
+            else:
+                new_body.append(dc_replace(s, body=new_inner_body))
         else:
             new_body.append(s)
     return dc_replace(loop, body=new_body)

--- a/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
@@ -117,7 +117,7 @@ def _maybe_rewrite(
     for s in tile.body.iter():
         if isinstance(s, (AsyncBufferedStage, TmaBufferedStage)):
             continue
-        if isinstance(s, BufferedStage) and not _eligible(s, src_ranks, src_shapes):
+        if isinstance(s, BufferedStage) and len(s.source_loads) == 1 and not _eligible(s, src_ranks, src_shapes):
             raise RuleSkipped(
                 f"stage {s.name!r} (buf={s.buf!r}) not TMA-eligible; "
                 "leaving every stage in this tile to cp.async (avoids mixed-mode pipeline deadlock)"

--- a/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
@@ -164,6 +164,7 @@ def _process(
                     axes=s.axes,
                     addressing=s.addressing,
                     pad=s.pad,
+                    body=s.body,
                     buffer_count=s.buffer_count,
                     phase=s.phase,
                     swizzle=SwizzleMode.NONE,

--- a/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
@@ -154,6 +154,7 @@ def _process(
         if (
             isinstance(s, BufferedStage)
             and not isinstance(s, (AsyncBufferedStage, TmaBufferedStage))
+            and len(s.source_loads) == 1
             and _eligible(s, src_ranks, src_shapes)
         ):
             new_body.append(

--- a/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/011_tma_copy.py
@@ -159,12 +159,9 @@ def _process(
             new_body.append(
                 TmaBufferedStage(
                     name=s.name,
-                    buf=s.buf,
-                    origin=s.origin,
                     axes=s.axes,
-                    addressing=s.addressing,
-                    pad=s.pad,
                     body=s.body,
+                    pad=s.pad,
                     buffer_count=s.buffer_count,
                     phase=s.phase,
                     swizzle=SwizzleMode.NONE,

--- a/deplodock/compiler/pipeline/passes/lowering/tile/012_split_inner_for_swizzle.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/012_split_inner_for_swizzle.py
@@ -48,6 +48,7 @@ from deplodock.compiler.ir.tile.ir import (
     SwizzleMode,
     TileOp,
     TmaBufferedStage,
+    trivial_stage_body,
 )
 from deplodock.compiler.pipeline import Pattern, RuleSkipped
 from deplodock.compiler.pipeline.passes.lowering.tile._helpers import single_tile
@@ -180,12 +181,13 @@ def _split_stage(stage: TmaBufferedStage, mode: SwizzleMode, ips: int) -> TmaBuf
         mode.value,
     )
     # Body's Load index references the pre-split axis Var(orig.name); axes
-    # rewrite breaks that. Clear the body so Stage.__post_init__ re-synthesizes
-    # the trivial form from the new (axes, addressing). Phase-1 invariant:
+    # rewrite breaks that. Rebuild the trivial body from the new (axes,
+    # addressing) — origin doesn't change under the split. Precondition:
     # 012 only runs on trivial-body TMA stages.
     if len(stage.body) != 2:
         raise RuleSkipped(f"stage {stage.name!r}: split requires trivial body, got {len(stage.body)} stmts")
-    return dc_replace(stage, axes=new_axes, addressing=new_addressing, swizzle=mode, body=Body())
+    new_body = trivial_stage_body(stage.name, stage.buf, stage.origin, new_axes, new_addressing)
+    return dc_replace(stage, axes=new_axes, body=new_body, swizzle=mode)
 
 
 def _swizzle_decode_load(load: Load, mode: SwizzleMode, ips: int, factor: int) -> Load:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/012_split_inner_for_swizzle.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/012_split_inner_for_swizzle.py
@@ -179,7 +179,13 @@ def _split_stage(stage: TmaBufferedStage, mode: SwizzleMode, ips: int) -> TmaBuf
         inner_axis.extent,
         mode.value,
     )
-    return dc_replace(stage, axes=new_axes, addressing=new_addressing, swizzle=mode)
+    # Body's Load index references the pre-split axis Var(orig.name); axes
+    # rewrite breaks that. Clear the body so Stage.__post_init__ re-synthesizes
+    # the trivial form from the new (axes, addressing). Phase-1 invariant:
+    # 012 only runs on trivial-body TMA stages.
+    if len(stage.body) != 2:
+        raise RuleSkipped(f"stage {stage.name!r}: split requires trivial body, got {len(stage.body)} stmts")
+    return dc_replace(stage, axes=new_axes, addressing=new_addressing, swizzle=mode, body=Body())
 
 
 def _swizzle_decode_load(load: Load, mode: SwizzleMode, ips: int, factor: int) -> Load:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/013_async_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/013_async_copy.py
@@ -74,7 +74,12 @@ def _process(body: Body, n_threads: int) -> Body:
     new_body: list[Stmt] = []
     changed = False
     for s in body:
-        if isinstance(s, BufferedStage) and not isinstance(s, (AsyncBufferedStage, TmaBufferedStage)) and _eligible(s, n_threads):
+        if (
+            isinstance(s, BufferedStage)
+            and not isinstance(s, (AsyncBufferedStage, TmaBufferedStage))
+            and len(s.source_loads) == 1
+            and _eligible(s, n_threads)
+        ):
             new_body.append(
                 AsyncBufferedStage(
                     name=s.name,

--- a/deplodock/compiler/pipeline/passes/lowering/tile/013_async_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/013_async_copy.py
@@ -78,12 +78,9 @@ def _process(body: Body, n_threads: int) -> Body:
             new_body.append(
                 AsyncBufferedStage(
                     name=s.name,
-                    buf=s.buf,
-                    origin=s.origin,
                     axes=s.axes,
-                    addressing=s.addressing,
-                    pad=s.pad,
                     body=s.body,
+                    pad=s.pad,
                     buffer_count=s.buffer_count,
                     phase=s.phase,
                 )

--- a/deplodock/compiler/pipeline/passes/lowering/tile/013_async_copy.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/013_async_copy.py
@@ -83,6 +83,7 @@ def _process(body: Body, n_threads: int) -> Body:
                     axes=s.axes,
                     addressing=s.addressing,
                     pad=s.pad,
+                    body=s.body,
                     buffer_count=s.buffer_count,
                     phase=s.phase,
                 )

--- a/deplodock/compiler/tuning.py
+++ b/deplodock/compiler/tuning.py
@@ -209,7 +209,10 @@ def _external_input_count(stmts) -> int:
     bufs: set[str] = set()
     for s in body.iter():
         if isinstance(s, Stage):
-            bufs.add(s.buf)
+            # Fused stages load from multiple gmem buffers (silu-mul → gate, up);
+            # count each unique source so the heuristic sees the right input count.
+            for src_load in s.source_loads:
+                bufs.add(src_load.input)
         elif isinstance(s, Load) and s.input not in stage_names:
             bufs.add(s.input)
     return len(bufs)

--- a/plans/stage-body-refactor.md
+++ b/plans/stage-body-refactor.md
@@ -83,6 +83,19 @@ indistinguishable from today's behavior.
   `stage.rewrite(σ)`. Make sure `Stage.rewrite` threads σ through `body`
   so K-outer Vars inside body Loads get substituted along with `origin`.
 
+### Stage rewrite/simplify handlers (must change)
+
+Stage's handlers in `deplodock/compiler/ir/tile/passes.py:23-30` lean on
+`_stage_kwargs` → `_walk`, which recurses through tuples and dataclasses
+but **stops at `Stmt`** (`stmt/passes.py:42` — `not isinstance(value, Stmt)`).
+Body is a tuple of Stmts, so the introspection path would leave body stmts
+untouched. Update both handlers to mirror the `Loop` / `StridedLoop`
+pattern: build kwargs via `_stage_kwargs` for the non-body fields, then
+override `body=tuple(rewrite(c, rename, sigma, axis_fn) for c in s.body)`
+(and analogously `simplify(c, ctx)` in the simplify handler). Without this
+change, σ-substitution inside body Loads silently no-ops and phase-1's
+trivial-body invariant breaks under `015_pipeline_k_outer`.
+
 ### Materializer change (`pipeline/passes/lowering/kernel/001_materialize_tile.py`)
 
 - `_emit_stage` (line 648) and `emit_tma_stage` (line 197) keep their
@@ -151,7 +164,13 @@ text-level change at most call sites is zero. Exceptions:
   positionally: `Load`s become per-thread gmem reads, elementwise
   `Assign`s become per-thread compute, the terminal `Write` becomes
   the smem store. Cooperative-loop scaffolding (the `StridedLoop` over
-  cache axes) stays identical.
+  cache axes) stays identical. Note: `_emit_stage` and surrounding code
+  also reads `stage.origin` at lines 228, 245, 249, 252, 266, 708 (box-size
+  derivation, literal-origin detection, split-dim coord, σ-substitution in
+  index reconstruction), and `stage.addressing` at lines 201, 215, 692,
+  704, 706-707. All become property accesses, no source change required.
+  CpAsync/Load emissions at 001:287, 730, 740 also read `stage.buf` —
+  same story.
 - `pipeline/passes/lowering/kernel/001_materialize_tile.py:197`
   (`emit_tma_stage`) — TMA materialization requires a single `Load` with
   `AffineAddressing` and no compute between Load and Write. Add an
@@ -173,6 +192,13 @@ text-level change at most call sites is zero. Exceptions:
 - `compiler/diagnostics/bank_conflicts.py:118` — reads `Stage` + `Load`
   pairs from the tile body; uses `stage.name`, `stage.axes`, `stage.pad`.
   No legacy field used. No change.
+- `deplodock/compiler/tuning.py:212` (`bufs.add(s.buf)`) and
+  `deplodock/compiler/ir/tile/ir.py:621` (`bufs.setdefault(s.buf, None)` in
+  the external-inputs property) read `stage.buf`. After phase 2 these
+  continue to work as property accesses; for multi-source bodies, the
+  `buf` property raises (single-source only), which is correct — these
+  call sites assume a single source slab and should fail loudly if that
+  invariant breaks. Audit only, no edit.
 
 ### Tests
 

--- a/tests/compiler/ir/tile/test_stage_body.py
+++ b/tests/compiler/ir/tile/test_stage_body.py
@@ -1,0 +1,103 @@
+"""Phase-1 tests for ``Stage.body``: auto-synthesis from legacy
+``(buf, origin, axes, addressing)`` fields and σ-substitution through
+the explicit ``rewrite`` handler.
+
+Phase 1 keeps ``Stage`` as a *leaf* stmt (no ``nested()`` / ``with_bodies``
+override) so generic body walkers don't descend into the cooperative-load
+program — that breaks ``008_register_tile``'s F-axis replication. The body
+field exists, is populated, and is threaded by ``Stage.rewrite`` /
+``Stage.simplify``; everything else routes through legacy fields until
+phase 2.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.sigma import Sigma
+from deplodock.compiler.ir.stmt import Body, Load, Write
+from deplodock.compiler.ir.tile.ir import AffineAddressing, Stage, TemplateAddressing
+
+
+def _make_stage(addressing) -> Stage:
+    return Stage(
+        name="x_smem",
+        buf="x",
+        origin=(Var("k_outer") * Literal(16, "int"), Literal(0, "int")),
+        axes=(Axis("c0", 16), Axis("c1", 8)),
+        addressing=addressing,
+    )
+
+
+def test_trivial_body_synthesized_for_affine_addressing():
+    stage = _make_stage(AffineAddressing(dims=(0, 1)))
+
+    assert isinstance(stage.body, Body)
+    assert len(stage.body) == 2
+
+    load, write = stage.body
+    assert isinstance(load, Load)
+    assert load.input == "x"
+    # source index = origin[d] + cache_var (per affine dim mapping)
+    assert load.index[0] == stage.origin[0] + Var("c0")
+    assert load.index[1] == stage.origin[1] + Var("c1")
+
+    assert isinstance(write, Write)
+    assert write.output == "x_smem"
+    assert write.index == (Var("c0"), Var("c1"))
+    assert write.value == load.name
+
+
+def test_trivial_body_synthesized_for_template_addressing():
+    # Template carries the original symbolic Load index verbatim.
+    template = (Var("c0") * Literal(8, "int") + Var("c1"), Var("c1"))
+    stage = _make_stage(TemplateAddressing(exprs=template))
+
+    load, write = stage.body
+    assert load.index == template
+    assert write.index == (Var("c0"), Var("c1"))
+
+
+def test_explicit_body_passed_through():
+    custom_load = Load(name="raw", input="x", index=(Var("c0"), Var("c1")))
+    custom_write = Write(output="x_smem", index=(Var("c0"), Var("c1")), value="raw")
+    explicit_body = Body((custom_load, custom_write))
+    stage = Stage(
+        name="x_smem",
+        buf="x",
+        origin=(Literal(0, "int"), Literal(0, "int")),
+        axes=(Axis("c0", 16), Axis("c1", 8)),
+        addressing=AffineAddressing(dims=(0, 1)),
+        body=explicit_body,
+    )
+
+    assert stage.body is explicit_body or tuple(stage.body) == tuple(explicit_body)
+
+
+def test_rewrite_threads_sigma_through_body():
+    stage = _make_stage(AffineAddressing(dims=(0, 1)))
+    # Substitute k_outer → k_outer + 1 — touches both origin and the body
+    # Load's index, since both reference k_outer.
+    new_k = Var("k_outer") + Literal(1, "int")
+    sigma = Sigma({"k_outer": new_k})
+
+    rewritten = stage.rewrite(lambda n: n, sigma=sigma)
+    assert isinstance(rewritten, Stage)
+
+    # Legacy origin is σ-substituted.
+    assert rewritten.origin[0] == new_k * Literal(16, "int")
+
+    # Body's Load index is σ-substituted consistently.
+    body_load = rewritten.body[0]
+    assert isinstance(body_load, Load)
+    assert body_load.index[0] == new_k * Literal(16, "int") + Var("c0")
+
+
+def test_body_is_body_subclass_after_rewrite():
+    # rewrite handler builds body as a plain tuple comprehension; Stage's
+    # __post_init__ must coerce it back to Body so downstream walkers
+    # (Body.map / Body.iter) keep working.
+    stage = _make_stage(AffineAddressing(dims=(0, 1)))
+    sigma = Sigma({"k_outer": Literal(7, "int")})
+    rewritten = stage.rewrite(lambda n: n, sigma=sigma)
+    assert isinstance(rewritten.body, Body)

--- a/tests/compiler/ir/tile/test_stage_body.py
+++ b/tests/compiler/ir/tile/test_stage_body.py
@@ -1,103 +1,113 @@
-"""Phase-1 tests for ``Stage.body``: auto-synthesis from legacy
-``(buf, origin, axes, addressing)`` fields and σ-substitution through
-the explicit ``rewrite`` handler.
+"""Phase-2 tests for ``Stage.body``: body is the single source of truth;
+``buf`` / ``origin`` / ``addressing`` are derived properties.
 
-Phase 1 keeps ``Stage`` as a *leaf* stmt (no ``nested()`` / ``with_bodies``
-override) so generic body walkers don't descend into the cooperative-load
-program — that breaks ``008_register_tile``'s F-axis replication. The body
-field exists, is populated, and is threaded by ``Stage.rewrite`` /
-``Stage.simplify``; everything else routes through legacy fields until
-phase 2.
+Stage stays opaque to generic body walkers (no ``nested()`` /
+``with_bodies()`` override) because exposing the cooperative-load Loads
+to ``008_register_tile``'s F-axis replication corrupts their semantics.
+σ-substitution through the body is handled by the Stage-specific
+``rewrite`` / ``simplify`` handlers in ``deplodock/compiler/ir/tile/passes.py``.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import Literal, Var
 from deplodock.compiler.ir.sigma import Sigma
 from deplodock.compiler.ir.stmt import Body, Load, Write
-from deplodock.compiler.ir.tile.ir import AffineAddressing, Stage, TemplateAddressing
+from deplodock.compiler.ir.tile.ir import AffineAddressing, Stage, TemplateAddressing, trivial_stage_body
 
 
-def _make_stage(addressing) -> Stage:
-    return Stage(
-        name="x_smem",
-        buf="x",
-        origin=(Var("k_outer") * Literal(16, "int"), Literal(0, "int")),
-        axes=(Axis("c0", 16), Axis("c1", 8)),
-        addressing=addressing,
-    )
+def _affine_stage() -> Stage:
+    name = "x_smem"
+    axes = (Axis("c0", 16), Axis("c1", 8))
+    origin = (Var("k_outer") * Literal(16, "int"), Literal(0, "int"))
+    body = trivial_stage_body(name, "x", origin, axes, AffineAddressing(dims=(0, 1)))
+    return Stage(name=name, axes=axes, body=body)
 
 
-def test_trivial_body_synthesized_for_affine_addressing():
-    stage = _make_stage(AffineAddressing(dims=(0, 1)))
+def test_trivial_body_builder_matches_documented_shape():
+    name = "x_smem"
+    axes = (Axis("c0", 16), Axis("c1", 8))
+    origin = (Var("k_outer") * Literal(16, "int"), Literal(0, "int"))
+    body = trivial_stage_body(name, "x", origin, axes, AffineAddressing(dims=(0, 1)))
 
-    assert isinstance(stage.body, Body)
-    assert len(stage.body) == 2
-
-    load, write = stage.body
+    assert len(body) == 2
+    load, write = body
     assert isinstance(load, Load)
     assert load.input == "x"
-    # source index = origin[d] + cache_var (per affine dim mapping)
-    assert load.index[0] == stage.origin[0] + Var("c0")
-    assert load.index[1] == stage.origin[1] + Var("c1")
-
+    assert load.index[0] == origin[0] + Var("c0")
+    assert load.index[1] == origin[1] + Var("c1")
     assert isinstance(write, Write)
     assert write.output == "x_smem"
     assert write.index == (Var("c0"), Var("c1"))
     assert write.value == load.name
 
 
-def test_trivial_body_synthesized_for_template_addressing():
-    # Template carries the original symbolic Load index verbatim.
-    template = (Var("c0") * Literal(8, "int") + Var("c1"), Var("c1"))
-    stage = _make_stage(TemplateAddressing(exprs=template))
+def test_derived_buf_origin_addressing_affine():
+    stage = _affine_stage()
+    assert stage.buf == "x"
+    # origin: cache-axis Vars substituted to 0 + simplified
+    assert stage.origin[0].pretty() == (Var("k_outer") * Literal(16, "int")).pretty()
+    assert stage.origin[1].pretty() == Literal(0, "int").pretty()
+    addr = stage.addressing
+    assert isinstance(addr, AffineAddressing)
+    assert addr.dims == (0, 1)
 
-    load, write = stage.body
-    assert load.index == template
-    assert write.index == (Var("c0"), Var("c1"))
 
-
-def test_explicit_body_passed_through():
-    custom_load = Load(name="raw", input="x", index=(Var("c0"), Var("c1")))
-    custom_write = Write(output="x_smem", index=(Var("c0"), Var("c1")), value="raw")
-    explicit_body = Body((custom_load, custom_write))
-    stage = Stage(
-        name="x_smem",
-        buf="x",
-        origin=(Literal(0, "int"), Literal(0, "int")),
-        axes=(Axis("c0", 16), Axis("c1", 8)),
-        addressing=AffineAddressing(dims=(0, 1)),
-        body=explicit_body,
+def test_derived_addressing_template_for_nonaffine_index():
+    # Build a body whose Load index is non-affine in the cache axes —
+    # property derivation should fall back to TemplateAddressing.
+    name = "x_smem"
+    axes = (Axis("c0", 8),)
+    nonlinear_index = (Var("c0") * Literal(2, "int"),)  # 2·c0 — coef-1 probe rejects
+    body = Body(
+        (
+            Load(name=f"{name}__src", input="x", index=nonlinear_index),
+            Write(output=name, index=(Var("c0"),), value=f"{name}__src"),
+        )
     )
+    stage = Stage(name=name, axes=axes, body=body)
+    addr = stage.addressing
+    assert isinstance(addr, TemplateAddressing)
+    assert addr.exprs == nonlinear_index
 
-    assert stage.body is explicit_body or tuple(stage.body) == tuple(explicit_body)
+
+def test_primary_load_raises_for_multi_load_body():
+    name = "x_smem"
+    axes = (Axis("c0", 4),)
+    body = Body(
+        (
+            Load(name="l0", input="a", index=(Var("c0"),)),
+            Load(name="l1", input="b", index=(Var("c0"),)),
+            Write(output=name, index=(Var("c0"),), value="l0"),
+        )
+    )
+    stage = Stage(name=name, axes=axes, body=body)
+    with pytest.raises(ValueError, match="primary_load undefined"):
+        _ = stage.primary_load
+    # source_loads still works
+    assert len(stage.source_loads) == 2
 
 
 def test_rewrite_threads_sigma_through_body():
-    stage = _make_stage(AffineAddressing(dims=(0, 1)))
-    # Substitute k_outer → k_outer + 1 — touches both origin and the body
-    # Load's index, since both reference k_outer.
+    stage = _affine_stage()
+    # k_outer → k_outer + 1 — touches body Load's index. ``origin`` is
+    # derived, so it picks up the σ-substitution transparently.
     new_k = Var("k_outer") + Literal(1, "int")
     sigma = Sigma({"k_outer": new_k})
-
     rewritten = stage.rewrite(lambda n: n, sigma=sigma)
     assert isinstance(rewritten, Stage)
-
-    # Legacy origin is σ-substituted.
-    assert rewritten.origin[0] == new_k * Literal(16, "int")
-
-    # Body's Load index is σ-substituted consistently.
-    body_load = rewritten.body[0]
-    assert isinstance(body_load, Load)
-    assert body_load.index[0] == new_k * Literal(16, "int") + Var("c0")
+    # body Load index reflects the substitution
+    assert rewritten.body[0].index[0] == new_k * Literal(16, "int") + Var("c0")
+    # derived origin also reflects it (no double-substitution because
+    # cache-axis Var → 0 happens at property access on the post-σ body).
+    assert rewritten.origin[0].pretty() == (new_k * Literal(16, "int")).pretty()
 
 
-def test_body_is_body_subclass_after_rewrite():
-    # rewrite handler builds body as a plain tuple comprehension; Stage's
-    # __post_init__ must coerce it back to Body so downstream walkers
-    # (Body.map / Body.iter) keep working.
-    stage = _make_stage(AffineAddressing(dims=(0, 1)))
+def test_body_coerced_to_body_subclass_after_rewrite():
+    stage = _affine_stage()
     sigma = Sigma({"k_outer": Literal(7, "int")})
     rewritten = stage.rewrite(lambda n: n, sigma=sigma)
     assert isinstance(rewritten.body, Body)

--- a/tests/compiler/passes/test_fuse_stage_epilogue.py
+++ b/tests/compiler/passes/test_fuse_stage_epilogue.py
@@ -1,0 +1,118 @@
+"""Tests for ``007a_fuse_stage_epilogue`` — the silu·gate·matmul fuser.
+
+The pass walks each Tile body produced by ``007_stage_inputs``, finds
+groups of Stages with identical cache axes whose epilogue cone in the
+reduce loop body has free axes contained in those cache axes, and
+folds the cone into a single multi-source ``Stage`` with a non-trivial
+body. The materializer's body-walk path then emits the fused compute
+inside the cooperative load.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from deplodock.compiler.ir.axis import BIND_BLOCK, BIND_THREAD, Axis, BoundAxis
+from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.stmt import Accum, Assign, Body, Init, Load, Loop, Tile, Write
+from deplodock.compiler.ir.tile.ir import AffineAddressing, Stage, TileOp, trivial_stage_body
+
+_pass = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.tile.007a_fuse_stage_epilogue")
+
+
+def _silu_mul_matmul_tile() -> TileOp:
+    """Hand-build the Tile-IR shape that ``007_stage_inputs`` would
+    emit for ``F.silu(gate) * up @ W``: two same-axes Stages on
+    ``gate`` / ``up``, a third single-source Stage on ``w``, then a
+    reduce Loop containing the silu chain + matmul accumulate."""
+    m = Axis("m", 16)
+    n = Axis("n", 16)
+    k = Axis("k", 8)
+
+    gate_smem = Stage(
+        name="gate_smem",
+        axes=(m, k),
+        body=trivial_stage_body("gate_smem", "gate", (Literal(0, "int"), Literal(0, "int")), (m, k), AffineAddressing(dims=(0, 1))),
+    )
+    up_smem = Stage(
+        name="up_smem",
+        axes=(m, k),
+        body=trivial_stage_body("up_smem", "up", (Literal(0, "int"), Literal(0, "int")), (m, k), AffineAddressing(dims=(0, 1))),
+    )
+    w_smem = Stage(
+        name="w_smem",
+        axes=(k, n),
+        body=trivial_stage_body("w_smem", "w", (Literal(0, "int"), Literal(0, "int")), (k, n), AffineAddressing(dims=(0, 1))),
+    )
+
+    reduce_body = Body(
+        (
+            Load(name="g", input="gate_smem", index=(Var("m"), Var("k"))),
+            Assign(name="s0", op=ElementwiseImpl("negative"), args=("g",)),
+            Assign(name="s1", op=ElementwiseImpl("exp"), args=("s0",)),
+            Assign(name="s2", op=ElementwiseImpl("add"), args=("one", "s1")),
+            Assign(name="s3", op=ElementwiseImpl("reciprocal"), args=("s2",)),
+            Assign(name="sig", op=ElementwiseImpl("multiply"), args=("g", "s3")),
+            Load(name="u", input="up_smem", index=(Var("m"), Var("k"))),
+            Assign(name="silu_up", op=ElementwiseImpl("multiply"), args=("u", "sig")),
+            Load(name="ww", input="w_smem", index=(Var("k"), Var("n"))),
+            Assign(name="prod", op=ElementwiseImpl("multiply"), args=("ww", "silu_up")),
+            Accum(name="acc", value="prod", op=ElementwiseImpl("add")),
+        )
+    )
+    reduce_loop = Loop(axis=k, body=reduce_body)  # is_reduce=True implied by Accum in body
+
+    tile = Tile(
+        axes=(BoundAxis(axis=m, bind=BIND_THREAD), BoundAxis(axis=n, bind=BIND_THREAD), BoundAxis(axis=Axis("blk", 1), bind=BIND_BLOCK)),
+        body=(
+            Init(name="acc", op=ElementwiseImpl("add")),
+            Init(name="one", op=ElementwiseImpl("add")),  # placeholder; tracer puts a real const here
+            gate_smem,
+            up_smem,
+            w_smem,
+            reduce_loop,
+            Write(output="out", index=(Var("m"), Var("n")), value="acc"),
+        ),
+    )
+    return TileOp(body=(tile,), name="silu_mul_matmul")
+
+
+def test_fusion_collapses_silu_cone_into_producer_stage():
+    op = _silu_mul_matmul_tile()
+    # Drive the pass via its internal helper so we don't have to wire a
+    # full Graph + Node — the Graph wrapper only adds bookkeeping that
+    # this test doesn't care about.
+    new_body = _pass._maybe_rewrite(op.body)
+    assert new_body is not None, "fusion should fire on silu·gate·matmul shape"
+    new_op = TileOp(body=new_body, name=op.name)
+
+    # Locate the (now sole) M·K cache-axis Stage — gate_smem and up_smem
+    # should have collapsed into one fused stage; w_smem stays standalone.
+    tile = new_op.body[0]
+    stages_after = [s for s in tile.body if isinstance(s, Stage)]
+    assert len(stages_after) == 2, [s.name for s in stages_after]
+
+    fused = next(s for s in stages_after if "fused" in s.name)
+    standalone = next(s for s in stages_after if "fused" not in s.name)
+    assert standalone.name == "w_smem"
+
+    # Fused stage carries both gmem source loads + the silu compute.
+    fused_inputs = {ld.input for ld in fused.source_loads}
+    assert fused_inputs == {"gate", "up"}, fused_inputs
+    body_assigns = [s for s in fused.body if isinstance(s, Assign)]
+    op_names = [a.op.name for a in body_assigns]
+    # silu chain (negative, exp, add, reciprocal, multiply) + the
+    # final multiply with up's value.
+    assert "negative" in op_names and "exp" in op_names and "reciprocal" in op_names
+    # Final stmt is a Write into the fused stage's smem buffer.
+    last = fused.body[-1]
+    assert isinstance(last, Write) and last.output == fused.name
+
+    # Reduce body: silu chain is gone; only one Load from the fused
+    # stage remains (plus the w_smem Load and the accum chain).
+    reduce_loop = next(s for s in tile.body if isinstance(s, Loop) and s.is_reduce)
+    smem_loads = [s for s in reduce_loop.body if isinstance(s, Load)]
+    sources = {ld.input for ld in smem_loads}
+    assert sources == {fused.name, "w_smem"}, sources
+    assert not any(isinstance(s, Assign) and s.op.name in {"negative", "exp", "reciprocal"} for s in reduce_loop.body)

--- a/tests/compiler/passes/test_split_fused_for_pipeline.py
+++ b/tests/compiler/passes/test_split_fused_for_pipeline.py
@@ -1,0 +1,132 @@
+"""Tests for ``007b_split_fused_for_pipeline`` — splits fused multi-source
+Stages into per-source transport stages + a compute stage so 015 can
+software-pipeline the transport without dragging the compute along."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from contextlib import contextmanager
+
+from deplodock.compiler.ir.axis import BIND_BLOCK, BIND_THREAD, Axis, BoundAxis
+from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.stmt import Accum, Assign, Body, Init, Load, Loop, Tile, Write
+from deplodock.compiler.ir.tile.ir import Stage, TileOp
+
+_split = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.tile.007b_split_fused_for_pipeline")
+_fuse = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.tile.007a_fuse_stage_epilogue")
+
+
+@contextmanager
+def _enable_split():
+    prev = os.environ.get("DEPLODOCK_FUSED_PIPELINE")
+    os.environ["DEPLODOCK_FUSED_PIPELINE"] = "1"
+    try:
+        yield
+    finally:
+        if prev is None:
+            del os.environ["DEPLODOCK_FUSED_PIPELINE"]
+        else:
+            os.environ["DEPLODOCK_FUSED_PIPELINE"] = prev
+
+
+def _silu_tile_with_k_outer() -> TileOp:
+    """Build the post-007a shape: a free K_outer free-Loop containing a
+    fused gate+up Stage + the K_inner reduce."""
+    m = Axis("m", 16)
+    n = Axis("n", 16)
+    k = Axis("k", 8)
+    k_outer = Axis("k_outer", 4)  # free, extent >= 2
+
+    fused = Stage(
+        name="fused",
+        axes=(m, k),
+        body=Body(
+            (
+                Load(name="g_v", input="gate", index=(Literal(0, "int"), Var("k_outer") * Literal(8, "int") + Var("k"))),
+                Load(name="u_v", input="up", index=(Literal(0, "int"), Var("k_outer") * Literal(8, "int") + Var("k"))),
+                Assign(name="s0", op=ElementwiseImpl("negative"), args=("g_v",)),
+                Assign(name="s1", op=ElementwiseImpl("exp"), args=("s0",)),
+                Assign(name="sig", op=ElementwiseImpl("multiply"), args=("g_v", "s1")),
+                Assign(name="out", op=ElementwiseImpl("multiply"), args=("u_v", "sig")),
+                Write(output="fused", index=(Var("m"), Var("k")), value="out"),
+            )
+        ),
+    )
+
+    reduce_loop = Loop(
+        axis=k,
+        body=Body(
+            (
+                Load(name="f", input="fused", index=(Var("m"), Var("k"))),
+                Accum(name="acc", value="f", op=ElementwiseImpl("add")),
+            )
+        ),
+    )
+
+    outer = Loop(axis=k_outer, body=Body((fused, reduce_loop)))
+
+    tile = Tile(
+        axes=(BoundAxis(axis=m, bind=BIND_THREAD), BoundAxis(axis=n, bind=BIND_THREAD), BoundAxis(axis=Axis("blk", 1), bind=BIND_BLOCK)),
+        body=(Init(name="acc", op=ElementwiseImpl("add")), outer, Write(output="out", index=(Var("m"),), value="acc")),
+    )
+    return TileOp(body=(tile,), name="silu_pipeline")
+
+
+def test_split_decomposes_fused_into_transport_plus_compute():
+    op = _silu_tile_with_k_outer()
+    new_body = _split._maybe_rewrite(op.body)
+    assert new_body is not None
+
+    tile = new_body[0]
+    outer = next(s for s in tile.body if isinstance(s, Loop))
+    stages = [s for s in outer.body if isinstance(s, Stage)]
+
+    # Expect 2 single-source transport stages + 1 multi-source compute stage.
+    transports = [s for s in stages if len(s.source_loads) == 1]
+    computes = [s for s in stages if len(s.source_loads) > 1]
+    assert len(transports) == 2, [s.name for s in transports]
+    assert len(computes) == 1
+    compute = computes[0]
+    # The compute stage keeps the original fused name (so K_inner reduce
+    # Loads still resolve).
+    assert compute.name == "fused"
+
+    # Transport stage names mention the original source bufs.
+    xport_srcs = {t.source_loads[0].input for t in transports}
+    assert xport_srcs == {"gate", "up"}
+
+    # Compute stage's body Loads now target the transport stages' smem,
+    # not gmem (gate/up).
+    compute_load_srcs = {ld.input for ld in compute.source_loads}
+    transport_names = {t.name for t in transports}
+    assert compute_load_srcs == transport_names
+
+    # Compute body still carries the silu chain + final multiply.
+    assert any(isinstance(s, Assign) and s.op.name == "negative" for s in compute.body)
+    assert any(isinstance(s, Assign) and s.op.name == "multiply" for s in compute.body)
+
+
+def test_split_is_gated_off_by_default():
+    """Without the env var the rewriter should refuse to fire — keeps the
+    perf trade-off (extra smem + registers vs cp.async overlap) opt-in
+    until per-hardware autotuning decides per-recipe."""
+    op = _silu_tile_with_k_outer()
+    # Pass instance bypasses env var by calling _maybe_rewrite directly.
+    # The env-gated entry point ``rewrite`` is the one we test here, but
+    # exercising it cleanly requires a Graph/Node. Spot-check via the
+    # private helper that the unconditional logic doesn't fail.
+    assert _split._maybe_rewrite(op.body) is not None  # logic works
+    # Default state: env var unset → split disabled.
+    assert os.environ.get("DEPLODOCK_FUSED_PIPELINE") is None
+
+
+def test_split_with_env_var_runs_end_to_end():
+    with _enable_split():
+        op = _silu_tile_with_k_outer()
+        result = _split._maybe_rewrite(op.body)
+        assert result is not None
+        # Idempotent on already-split bodies (no fused multi-source stage left).
+        idempotent = _split._maybe_rewrite(result)
+        assert idempotent is None

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -166,7 +166,7 @@ def _tune_via_subprocess(case: Case) -> None:
         case.code,
         "-v",
     ]
-    if (patience := os.environ.get("DEPLODOCK_TUNE_PATIENCE")):
+    if patience := os.environ.get("DEPLODOCK_TUNE_PATIENCE"):
         cmd += ["--patience", patience]
     env = dict(os.environ)
     sys.stderr.write(f"[tune {case.name}] launching: {' '.join(cmd)}\n")

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -166,6 +166,8 @@ def _tune_via_subprocess(case: Case) -> None:
         case.code,
         "-v",
     ]
+    if (patience := os.environ.get("DEPLODOCK_TUNE_PATIENCE")):
+        cmd += ["--patience", patience]
     env = dict(os.environ)
     sys.stderr.write(f"[tune {case.name}] launching: {' '.join(cmd)}\n")
     sys.stderr.flush()


### PR DESCRIPTION
## Summary

Refactors `Stage` so its cooperative-load program lives in a `body: Body` field (single source of truth) and lands the consumer pass that exploits this — folds the silu/elementwise chain in `F.silu(gate)*up @ W` out of the per-thread reduce loop into the producer Stage's body. The chain runs once per CTA in the cooperative load instead of being recomputed per N-thread × per N-tile (~896× redundancy on Qwen MLP shapes).

## Commits

1. **Phase 1** ([`839ccbc7`](../../commit/839ccbc7)) — add `body: Body` to `Stage`, auto-synthesized from `(buf, origin, axes, addressing)`. Trip-wire in materializer for non-trivial bodies. No behavior change.
2. **Phase 2** ([`ac724eb3`](../../commit/ac724eb3)) — delete legacy `buf`/`origin`/`addressing` fields, derive them from `body[0]` via properties. Body becomes the single source of truth. Lifted `trivial_stage_body` helper.
3. **Fusion** ([`45f88cb2`](../../commit/45f88cb2)) — new `007a_fuse_stage_epilogue` pass + materializer body-walking + multi-source plumbing in `tuning.py` / `Stage.exprs` / `TileOp.inputs`.

## Perf (sm_120, fp32)

| Case | Before | After | Speedup |
|---|---|---|---|
| `silu_mul_matmul.tinyllama.s512` | 910 µs | 388 µs | **2.35×** |
| `silu_mul_matmul.qwen.s512` | 4786 µs | 2289 µs | **2.09×** |

Ratio vs eager PyTorch: 0.23–0.27× → 0.47–0.63×.

## Design highlights

- **Stage stays opaque to generic body walkers** (no `nested()` / `with_bodies()` override). Exposing the cooperative-load Loads to `008_register_tile`'s `Body.map`-based F-axis replication corrupts their semantics — cache-axis Vars are smem-local. σ-substitution through the body is handled explicitly by the Stage-specific `rewrite` / `simplify` handlers.
- **Materializer trivial-body fast path preserved byte-for-byte** — every non-fused stage produces identical Kernel IR. Multi-source bodies take a new path that σ-rewrites cache-axis Vars to per-thread flat-iter coords and emits the body inline.
- **010/011/013 (double-buffer / TMA / cp.async) skip multi-source stages** — those promotions assume a single-source slab. Fused stages keep sync transport.
- **Fusion is conservative**: groups with ≥ 2 stages sharing identical cache axes; cone must have exactly one Assign-typed boundary; no Select/Cond/nested-loop consumers.

## Test plan

- [x] `make test` — 1035 pass / 84 skip
- [x] `make lint` — clean
- [x] New unit test `test_fuse_stage_epilogue.py` constructs the silu·gate·matmul Tile-IR shape and asserts: gate_smem + up_smem collapse into a fused stage with both gmem inputs and the silu chain; reduce body has the chain removed and reads from the fused stage.
- [x] Phase-2 properties unit-tested: affine/template addressing derivation, `primary_load` raises for multi-source bodies, σ-threading.
- [x] End-to-end accuracy validated by `deplodock run --bench` on tinyllama + qwen silu_mul_matmul shapes (s=128, s=512).

🤖 Generated with [Claude Code](https://claude.com/claude-code)