### PR TITLE
Qwen3-Embedding perf suite + sibling-reduce merge in normalize_body

### DIFF
--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -138,8 +138,21 @@ canonicalized before validation:
 - `drop_size_one_free_axes` — inline extent-1 free Loops.
 - `canonicalize_free_axis_order` — sort outer free Loops by axis name.
 - `eliminate_copy_aliases` — drop `y = copy(x)` Assigns.
-- `unify_sibling_reduce_axes` — collapse sibling reduce Loops sharing
-  an input dim (softmax's max + sum sweeps become one reduce axis).
+- `unify_sibling_reduce_axes` — rename sibling reduce Loops whose
+  reduce-axis Load positions overlap on any `(source, dim)` pair so
+  they share one canonical axis name (softmax's max + sum sweeps; the
+  two matmul reductions in `silu(x@Wg) * (x@Wu)` that both index `x`
+  at the same K slot). Union-find groups all transitively-overlapping
+  Loops at one scope.
+- `merge_sibling_reduce_loops` — concatenate sibling reduce Loops that
+  share `axis.name` / `extent` into one Loop body. Gated on disjoint
+  SSA defs across the two halves, the second body not reading any name
+  the first body defines (blocks softmax-style sequential reduces
+  where sum-exp reads `acc_max`), and no between-stmt def consumed by
+  the second loop. Eliminates the duplicate K traversal in patterns
+  like `silu(x@Wg) * (x@Wu)`; downstream `dedup_loads` then collapses
+  the duplicate `x` loads, and the lowering passes stage both weight
+  tensors symmetrically.
 - `split_invariant_divides` — rewrite `divide(x, y)` into
   `reciprocal(y) + multiply(x, recip)` when `y` is loop-invariant
   w.r.t. some axis `x` depends on, so the rcp can hoist out of the

--- a/deplodock/compiler/ir/stmt/normalize.py
+++ b/deplodock/compiler/ir/stmt/normalize.py
@@ -72,6 +72,7 @@ def normalize_body(
     stmts = canonicalize_free_axis_order(stmts)
     stmts = eliminate_copy_aliases(stmts)
     stmts = unify_sibling_reduce_axes(stmts)
+    stmts = merge_sibling_reduce_loops(stmts)
     if hoist:
         stmts = split_invariant_divides(stmts)
         stmts = hoist_loop_invariants(stmts)
@@ -185,10 +186,11 @@ def eliminate_copy_aliases(stmts: Body) -> Body:
 
 
 def unify_sibling_reduce_axes(stmts: Body) -> Body:
-    """At every scope, find sibling reduce ``Loop``s whose reduce axes index
-    the same ``(Load.source, dim)`` position and rename them to a single
-    canonical axis name. Recurses through every block-structured Stmt
-    (Loop / StridedLoop / Tile / Cond) to find nested scopes."""
+    """At every scope, find sibling reduce ``Loop``s whose reduce axes
+    index overlapping ``(Load.source, dim)`` positions and rename them
+    to a single canonical axis name. Recurses through every block-
+    structured Stmt (Loop / StridedLoop / Tile / Cond) to find nested
+    scopes."""
     stmts = Body.coerce(stmts)
 
     def walk(body: Body) -> Body:
@@ -210,33 +212,63 @@ def unify_sibling_reduce_axes(stmts: Body) -> Body:
 
 def _unify_siblings(body: Body) -> Body:
     """Single-scope sibling grouping: rename reduce-axis vars across
-    sibling reduce Loops that index the same ``(source, dim)`` positions
-    so they share one canonical axis name."""
+    sibling reduce Loops whose bare-Var Load positions overlap on any
+    ``(source, dim)`` pair so they share one canonical axis name.
+
+    Two reduce Loops that bind different axis names but both index the
+    same input slot (e.g. ``x[..., a2]`` and ``x[..., a3]`` for the
+    same ``x``) are semantically the same reduction dimension. Union-
+    find on the overlap relation merges all transitively-connected
+    Loops into one group. Within a group, the first Loop's axis name
+    wins; later Loops are rewritten to use it.
+
+    Pairing on overlap rather than exact-set equality lets matmul-
+    siblings that bring in distinct weight tensors (e.g.
+    ``silu(x@Wg) * (x@Wu)`` — both reduce over K and index x, but only
+    one indexes Wg and the other Wu) unify on the shared x position;
+    the downstream :func:`merge_sibling_reduce_loops` pass then
+    concatenates their bodies.
+    """
     stmts = list(body)
-    groups: dict[frozenset[tuple[str, int]], list[int]] = {}
+
+    entries: list[tuple[int, str, int, frozenset[tuple[str, int]]]] = []
     for i, s in enumerate(stmts):
         if isinstance(s, Loop) and s.is_reduce:
             positions = _reduce_axis_source_positions(s.body, s.axis.name)
             if positions:
-                groups.setdefault(frozenset(positions), []).append(i)
+                entries.append((i, s.axis.name, int(s.axis.extent), frozenset(positions)))
 
-    for indices in groups.values():
-        if len(indices) < 2:
-            continue
-        first = stmts[indices[0]]
-        assert isinstance(first, Loop)
-        canonical = first.axis.name
-        canonical_extent = int(first.axis.extent)
-        for idx in indices[1:]:
-            loop = stmts[idx]
-            assert isinstance(loop, Loop)
-            if int(loop.axis.extent) != canonical_extent or loop.axis.name == canonical:
+    if len(entries) < 2:
+        return Body(stmts)
+
+    parent = list(range(len(entries)))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a in range(len(entries)):
+        for b in range(a + 1, len(entries)):
+            if entries[a][2] != entries[b][2]:
                 continue
-            new_axis = Axis(name=canonical, extent=canonical_extent)
-            sub = Sigma({loop.axis.name: Var(canonical)})
-            rename_axis = _make_axis_renamer(loop.axis.name, new_axis)
-            renamed = tuple(s.rewrite(_identity_rename, sub, rename_axis) for s in loop.body)
-            stmts[idx] = replace(loop, axis=new_axis, body=renamed)
+            if entries[a][3] & entries[b][3]:
+                ra, rb = find(a), find(b)
+                if ra != rb:
+                    parent[max(ra, rb)] = min(ra, rb)
+
+    for k, (idx, axis_name, extent, _) in enumerate(entries):
+        canonical = entries[find(k)][1]
+        if canonical == axis_name:
+            continue
+        loop = stmts[idx]
+        assert isinstance(loop, Loop)
+        new_axis = Axis(name=canonical, extent=extent)
+        sub = Sigma({loop.axis.name: Var(canonical)})
+        rename_axis = _make_axis_renamer(loop.axis.name, new_axis)
+        renamed = tuple(s.rewrite(_identity_rename, sub, rename_axis) for s in loop.body)
+        stmts[idx] = replace(loop, axis=new_axis, body=renamed)
 
     return Body(stmts)
 
@@ -252,6 +284,116 @@ def _reduce_axis_source_positions(body: Body, reduce_axis_name: str) -> set[tupl
         for dim, e in enumerate(s.index)
         if isinstance(e, Var) and e.name == reduce_axis_name
     }
+
+
+# ---------------------------------------------------------------------------
+# Pass 4b: merge sibling reduce Loops with matching axis into one Loop.
+# ---------------------------------------------------------------------------
+#
+# After :func:`unify_sibling_reduce_axes` renames sibling reduce axes
+# that index overlapping ``(source, dim)`` positions to one canonical
+# name, adjacent reduce Loops with the same axis name/extent become
+# structurally identical iteration scopes. Merging concatenates their
+# bodies into one Loop so the reduce axis is traversed once instead of
+# twice. Downstream ``dedup_loads`` then collapses the duplicate Loads
+# both halves share — e.g. ``load x[0, a0, k]`` in the gated-MLP
+# pattern ``silu(x@Wg) * (x@Wu)`` where both matmuls reduce over the
+# same K and share x as a Load source. Symmetric staging follows: once
+# wu lives in the same K-loop as wg, ``stage_inputs`` / ``tma_copy`` /
+# ``double_buffer`` apply uniformly.
+# ---------------------------------------------------------------------------
+
+
+def merge_sibling_reduce_loops(stmts: Body) -> Body:
+    """Merge sibling reduce ``Loop``s with matching ``axis.name`` and
+    ``axis.extent`` into one Loop whose body is the concatenation.
+
+    Gates a merge on three conditions:
+
+    1. The two bodies have disjoint SSA defs — no name collision and
+       no inner-scope shadowing once they share one Loop.
+    2. The second Loop's body does not read any SSA name the first
+       Loop's body defines (including ``Accum`` exports). When it
+       does, the two reductions are sequentially dependent — e.g.
+       softmax's sum-exp loop reads ``acc_max`` from the preceding
+       max loop. Merging would replace that read of the *finalized*
+       max with a read of the in-flight per-iter value, changing
+       semantics.
+    3. No statement that sits between the two Loops defines an SSA
+       name the second Loop's body reads — otherwise the merge would
+       move that read above its def.
+
+    Statements that sit between the two original Loops stay in their
+    original positions in the parent Body. References to the first
+    Loop's ``Accum`` remain valid (Accum names cross the Loop
+    boundary). References to the second Loop's ``Accum`` from
+    statements that originally followed it now resolve to the merged
+    Loop above them — still defs-before-uses.
+
+    Recurses through every block-structured Stmt to find nested scopes.
+    """
+    stmts = Body.coerce(stmts)
+
+    def walk(body: Body) -> Body:
+        recursed: list[Stmt] = []
+        for s in body:
+            nested = s.nested()
+            if nested:
+                recursed.append(s.with_bodies(tuple(walk(b) for b in nested)))
+            else:
+                recursed.append(s)
+        return _merge_sibling_reduce_loops(Body(recursed))
+
+    return walk(stmts)
+
+
+def _merge_sibling_reduce_loops(body: Body) -> Body:
+    items = list(body)
+    if len(items) < 2:
+        return body
+
+    out: list[Stmt] = []
+    consumed: set[int] = set()
+    for i, s in enumerate(items):
+        if i in consumed:
+            continue
+        if not (isinstance(s, Loop) and s.is_reduce):
+            out.append(s)
+            continue
+        merged = s
+        for j in range(i + 1, len(items)):
+            if j in consumed:
+                continue
+            t = items[j]
+            if not (
+                isinstance(t, Loop)
+                and t.is_reduce
+                and t.axis.name == merged.axis.name
+                and int(t.axis.extent) == int(merged.axis.extent)
+                and t.unroll == merged.unroll
+            ):
+                continue
+            merged_defs = _all_ssa_defs(merged.body)
+            if merged_defs & _all_ssa_defs(t.body):
+                continue
+            if merged_defs & _all_ssa_uses(t.body):
+                continue
+            between_defs: set[str] = set()
+            for k in range(i + 1, j):
+                if k in consumed:
+                    continue
+                between_defs |= _all_ssa_defs(Body((items[k],)))
+            if between_defs & _all_ssa_uses(t.body):
+                continue
+            merged = Loop(
+                axis=merged.axis,
+                body=Body(tuple(merged.body) + tuple(t.body)),
+                unroll=merged.unroll,
+            )
+            consumed.add(j)
+        out.append(merged)
+
+    return Body(out)
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -155,6 +155,82 @@ inventory + lowering edges + the `perf` row per kernel, and returns
 the aggregate `PerfStats` (summed across kernels) for the search to
 score.
 
+## Tuning workflow
+
+The autotune loop selects one tile-lowering variant per CudaOp by repeatedly running the full pipeline with different knob
+choices at each fork point, benching the produced kernels, and steering subsequent rollouts toward the configurations that
+produced the lowest measured latency.
+
+**Driving the loop.** `deplodock tune <model_or_ir | --code EXPR>` constructs a `TuningSearch(patience=N, ucb_c=C)`,
+hands it to `Pipeline.tune(graph, search=...)`, and iterates terminals until the search's `stop_reason` fires. Each
+terminal is one fully-lowered `Graph[CudaOp]` whose every kernel got `_bench_terminal`'d. The tuning database (default
+`~/.cache/deplodock/autotune.db`, overridable with `--tune-db PATH` or `DEPLODOCK_TUNE_DB`) accumulates rows across runs;
+calling `tune` again on the same expression resumes from the cached state instead of re-benching.
+
+**Search dynamics.** SP-MCTS over the fork DAG with max-Q normalized UCB1 (see `search/policy/mcts.py`):
+
+- **Selection** picks the child of the current node with the highest `Q_norm + ucb_c · sqrt(ln(parent_visits) / child_visits)`,
+  where `Q_norm = child.best_reward / global_best_reward` and `reward = 1 / median_us` (so lower latency = higher reward).
+  `child.score` is a rank-only structural prior the rule stamped via `TileOp.score` (no magnitude — only relative ordering).
+- **Expansion** is implicit: `Pipeline.search` pops a node and runs one rule batch; every fork pushes one new child per
+  alternative. The tree mirrors the graph's fork lineage.
+- **Simulation** is the actual `backend.benchmark(...)` call on the terminal — one real GPU run per leaf.
+- **Backprop** walks the popped candidate's `parent` chain up to the root, updating `visits` and `best_reward` so future
+  UCB1 calls see the new max-Q.
+- **Patience** counts terminals visited *since the last new global best*; when it exceeds `--patience N` (default 20),
+  `TuningSearch.stop_reason` is set and `Pipeline.tune` exits.
+
+**Reading the result.** `_bench_terminal` writes one `perf` row per CudaOp per `(context_key, backend)` keyed on
+`op_cache_key`, plus a `lowering` edge per rewrite hop carrying the knob delta the rule stamped. A subsequent
+`deplodock run --tune-db PATH ...` (or `make bench-kernels-tuned`) replays the cached forks via `GreedySearch`, which
+walks the parent op's `op_cache_key` in `lowering` and follows the best-known child at each step. No GPU bench is
+required on the replay path when every kernel already has a `perf` row.
+
+**Stub backend.** With `backend=None`, `_bench_terminal` short-circuits to `latency_us=1.0` and persists nothing — used by
+test fixtures so `Pipeline.run`'s greedy replay doesn't clobber tuned rows with a stub when no GPU is available.
+
+## Tunable knobs
+
+A **`Knob`** (`knob.py`) is the canonical schema for one tuning dimension: name, type (`INT` / `BOOL` / `BINMASK`),
+candidate `hints` (advisory — the rule still validates structural fit), and a short help string. Rules declare them as
+module-level constants and stamp values into `TileOp.knobs` dicts; the autotuner reads those dicts back as the per-hop
+knob delta in the `lowering` table. The registry (`knob.registry()`) auto-collects every `Knob` instance in every loaded
+rule module — no manual registration.
+
+**Pinning knobs from the environment.** Two equivalent forms:
+
+- **Per-knob:** `DEPLODOCK_<NAME>=<value>` (e.g. `DEPLODOCK_BK=32`). Read directly by the rule that owns the knob.
+- **Aggregate:** `DEPLODOCK_KNOBS="K1=V1,K2=V2,..."` (e.g. `DEPLODOCK_KNOBS="BK=2,BM=16,BN=128,FM=8,FN=8,STAGE=111"`).
+  Parsed once at `knob.py` import via `apply_knobs_env()`, which splats each entry into the corresponding
+  `DEPLODOCK_<K>` env var so all the per-knob readers pick it up uniformly. An explicit per-knob var wins over the
+  aggregate (so `DEPLODOCK_BK=4 DEPLODOCK_KNOBS="BK=2,BM=16"` ends up with BK=4, BM=16).
+
+Pinning replaces tuner choice: the rule sees the env value and emits exactly that variant instead of forking. Useful for
+reproducing a tune-time variant from CI logs, A/B-comparing two configs, or pinning a known-good config in a Makefile
+recipe.
+
+**Registered knobs.** All knobs in `passes/lowering/tile/*.py`:
+
+| Knob          | Type     | Owning rule                  | What it controls                                                                                  |
+|---------------|----------|------------------------------|---------------------------------------------------------------------------------------------------|
+| `BK`          | INT      | `002_chunk_matmul_k`         | Per-stage K-chunk size for matmul reductions; intra-CTA K-loop trip count = `K / BK`.             |
+| `SPLITK`      | INT      | `003_split_matmul_k`         | Cross-CTA K-split factor for matmul; `1` = no split. Multiplies CTA count, requires a final combine. |
+| `BN`          | INT      | `004_launch_geometry`        | CTA innermost THREAD-axis width (the column tile each warp covers).                               |
+| `BM`          | INT      | `004_launch_geometry`        | CTA outer THREAD-axis width (matmul only — the row tile each warp covers).                        |
+| `STAGE`       | BINMASK  | `007_stage_inputs`           | Bitmask over ranked candidate buffers — char `i` = stage buffer `i`. `"111"` stages all three.    |
+| `FM`          | INT      | `008_register_tile`          | Register-tile factor for the next-outer tilable nest level (per-thread row tile).                 |
+| `FN`          | INT      | `008_register_tile`          | Register-tile factor for the innermost tilable nest level (per-thread column tile).               |
+| `TMA`         | BOOL     | `011_tma_copy`               | Use `cp.async.bulk.tensor` staging (sm_90+ only); default tracks arch.                            |
+| `TMA_SWIZZLE` | BOOL     | `011_tma_copy`               | Enable TMA hardware-swizzle modes (B128 / B64 / B32); default off.                                |
+
+`BINMASK` parsing accepts a binary string (`"101"` = bits 0 and 2 set, char `i` = bit `i`), the keywords `"all"` / `"none"`,
+or a decimal / `0x`-hex int clamped to the candidate width. `format_tuning_knobs` drops `BOOL` knobs from the rendered
+`knobs=` line — they're treated as pass-presence markers, not values.
+
+Two non-`Knob` env toggles also affect tile lowering: `DEPLODOCK_FUSED_PIPELINE=1` (`007b_split_fused_for_pipeline`)
+and `DEPLODOCK_BUFFER_COMPUTE=1` (`010_double_buffer`). These don't participate in the autotune fork lattice — they're
+binary opt-ins for experimental features that don't yet have enough signal to be candidate-driven.
+
 ## Pass directories
 
 Pass files are numerically prefixed so `sorted()` pickup is

--- a/deplodock/compiler/pipeline/knob.py
+++ b/deplodock/compiler/pipeline/knob.py
@@ -16,6 +16,7 @@ instance — no ``register(...)`` wrapper, no manual bookkeeping.
 
 from __future__ import annotations
 
+import os
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -133,6 +134,60 @@ def reset_registry() -> None:
     monkeypatch ``sys.modules`` use this to force a rebuild."""
     global _REGISTRY
     _REGISTRY = None
+
+
+# --- Aggregate env var ------------------------------------------------------
+
+
+def apply_knobs_env(raw: str | None = None) -> dict[str, str]:
+    """Splat ``DEPLODOCK_KNOBS="K1=V1,K2=V2,..."`` into individual
+    ``DEPLODOCK_<K>=V`` env vars.
+
+    Convenience for setting many knobs from one place (CLI invocation,
+    Makefile recipe, pytest ``monkeypatch.setenv``). Individual
+    ``DEPLODOCK_<K>`` vars take precedence: this only writes a key when
+    the per-knob env var is unset, so callers can pin one knob from
+    the command line and supply the rest via ``DEPLODOCK_KNOBS``
+    without surprise.
+
+    Whitespace is tolerant; empty entries are skipped. A malformed
+    entry (no ``=``) raises ``ValueError``. Returns the dict of keys
+    actually applied (for tests / diagnostics).
+
+    Runs at module import time on the live process environment. Pass
+    ``raw`` explicitly to apply a different aggregate without touching
+    ``DEPLODOCK_KNOBS`` (useful in tests).
+    """
+    if raw is None:
+        raw = os.environ.get("DEPLODOCK_KNOBS", "")
+    applied: dict[str, str] = {}
+    if not raw:
+        return applied
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            raise ValueError(f"DEPLODOCK_KNOBS entry {entry!r} is missing '=' (expected KEY=VALUE)")
+        key, _, value = entry.partition("=")
+        key = key.strip().upper()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"DEPLODOCK_KNOBS entry {entry!r} has empty KEY")
+        env_name = f"DEPLODOCK_{key}"
+        # Individual per-knob env vars win — don't clobber an explicit
+        # ``DEPLODOCK_BK=4`` with whatever the aggregate says.
+        if env_name in os.environ:
+            continue
+        os.environ[env_name] = value
+        applied[env_name] = value
+    return applied
+
+
+# Splat ``DEPLODOCK_KNOBS`` once at import so every later
+# ``os.environ.get("DEPLODOCK_<NAME>")`` reader (knob.py is imported
+# transitively by every pipeline pass) sees the per-knob keys.
+apply_knobs_env()
 
 
 # --- Rendering -------------------------------------------------------------

--- a/deplodock/compiler/pipeline/passes/lowering/tile/015_pipeline_k_outer.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/015_pipeline_k_outer.py
@@ -132,6 +132,21 @@ def _eligible(loop: Loop, invariant_names: set[str]) -> bool:
             return False
         if len({s.buffer_count for s in stages}) != 1:
             return False
+        # Reject when a plain (sync) ``BufferedStage`` lives alongside
+        # async/TMA Stages. The pipelining schedule hoists async/TMA
+        # Stage decls + their first-iter loads to the prologue and peels
+        # the last iter to the epilogue — both outside the K-outer loop
+        # body. A sync ``BufferedStage`` left inside the loop declares
+        # its ``Smem`` at loop scope, and the epilogue's reduce body
+        # references that name from outside the scope ("identifier
+        # x_smem is undefined" at nvcc time). The cleanest fix is to
+        # skip pipelining here; ``async_copy`` either promotes every
+        # Stage to async (and this gate accepts), or some Stage stays
+        # sync and we keep the unpipelined-but-correct schedule.
+        async_kinds = (AsyncBufferedStage, TmaBufferedStage)
+        sync_stages = [s for s in k_outer.body if isinstance(s, BufferedStage) and not isinstance(s, async_kinds)]
+        if sync_stages:
+            return False
         # Cross-loop-deps gate, relaxed: reject only when an unresolved
         # dep is *not* in ``invariant_names``.
         for c in k_inner.body:

--- a/tests/compiler/ir/stmt/test_merge_sibling_reduce_loops.py
+++ b/tests/compiler/ir/stmt/test_merge_sibling_reduce_loops.py
@@ -1,0 +1,308 @@
+"""Tests for ``unify_sibling_reduce_axes`` (relaxed overlap matching) and
+``merge_sibling_reduce_loops`` in ``stmt/normalize.py``.
+
+Builds bodies by hand and asserts on the post-pass structure so failures
+point at the pass itself rather than upstream lowering. The motivating
+case is the gated-MLP pattern ``silu(x @ Wg) * (x @ Wu)`` where the two
+sibling reduce-loops index ``x`` at the same K position but bring in
+distinct weight tensors — unify must group them on the shared x slot,
+then merge must concatenate the bodies into one K-loop.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.stmt.blocks import Loop
+from deplodock.compiler.ir.stmt.body import Body
+from deplodock.compiler.ir.stmt.leaves import Accum, Assign, Load, Write
+from deplodock.compiler.ir.stmt.normalize import (
+    merge_sibling_reduce_loops,
+    unify_sibling_reduce_axes,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _matmul_reduce(axis: Axis, w_buffer: str, out_acc: str, k_load: str = "x") -> Loop:
+    """Build a single reduce-Loop body: ``acc += W[k, n] * x[k]``.
+
+    Used to assemble the gated-MLP / matmul-sibling patterns the new
+    passes target. Inner SSA names are namespaced by ``out_acc`` so two
+    instances composed in one parent body have disjoint defs.
+    """
+    return Loop(
+        axis=axis,
+        body=(
+            Load(name=f"w_{out_acc}", input=w_buffer, index=(Var(axis.name), Var("n"))),
+            Load(name=f"x_{out_acc}", input=k_load, index=(Var(axis.name),)),
+            Assign(name=f"m_{out_acc}", op="multiply", args=(f"w_{out_acc}", f"x_{out_acc}")),
+            Accum(name=out_acc, value=f"m_{out_acc}"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# unify_sibling_reduce_axes — overlap-based grouping
+# ---------------------------------------------------------------------------
+
+
+def test_unify_groups_loops_with_shared_load_position() -> None:
+    """Two reduce-loops over different axis names but both indexing ``x``
+    at the same dim must end up sharing one canonical axis name."""
+    a = Axis("a2", 16)
+    b = Axis("a3", 16)
+    body = Body(
+        (
+            _matmul_reduce(a, w_buffer="Wg", out_acc="acc0"),
+            _matmul_reduce(b, w_buffer="Wu", out_acc="acc1"),
+        )
+    )
+
+    out = unify_sibling_reduce_axes(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 2
+    assert loops[0].axis.name == loops[1].axis.name == "a2"
+
+
+def test_unify_skips_when_extents_differ() -> None:
+    """Overlap on (source, dim) is necessary but not sufficient: extents
+    must also match — different extents mean different iteration spaces
+    even if positions overlap."""
+    a = Axis("a2", 16)
+    b = Axis("a3", 32)
+    body = Body(
+        (
+            _matmul_reduce(a, w_buffer="Wg", out_acc="acc0"),
+            _matmul_reduce(b, w_buffer="Wu", out_acc="acc1"),
+        )
+    )
+
+    out = unify_sibling_reduce_axes(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert loops[0].axis.name == "a2"
+    assert loops[1].axis.name == "a3"
+
+
+def test_unify_skips_disjoint_load_positions() -> None:
+    """Two reduce-loops with no shared (source, dim) overlap stay in
+    distinct groups — they index unrelated tensors at the reduce axis."""
+    a = Axis("a2", 16)
+    b = Axis("a3", 16)
+    body = Body(
+        (
+            Loop(axis=a, body=(Load(name="p", input="A", index=(Var("a2"),)), Accum(name="acc0", value="p"))),
+            Loop(axis=b, body=(Load(name="q", input="B", index=(Var("a3"),)), Accum(name="acc1", value="q"))),
+        )
+    )
+
+    out = unify_sibling_reduce_axes(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert loops[0].axis.name == "a2"
+    assert loops[1].axis.name == "a3"
+
+
+def test_unify_transitively_groups_three_loops() -> None:
+    """Union-find on the overlap relation: A overlaps B on (x,0), B
+    overlaps C on (y,0), so all three unify to one canonical name."""
+    a = Axis("a", 8)
+    b = Axis("b", 8)
+    c = Axis("c", 8)
+    body = Body(
+        (
+            Loop(axis=a, body=(Load(name="p", input="x", index=(Var("a"),)), Accum(name="acc_a", value="p"))),
+            Loop(
+                axis=b,
+                body=(
+                    Load(name="q", input="x", index=(Var("b"),)),
+                    Load(name="r", input="y", index=(Var("b"),)),
+                    Assign(name="s", op="multiply", args=("q", "r")),
+                    Accum(name="acc_b", value="s"),
+                ),
+            ),
+            Loop(axis=c, body=(Load(name="t", input="y", index=(Var("c"),)), Accum(name="acc_c", value="t"))),
+        )
+    )
+
+    out = unify_sibling_reduce_axes(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert {loop.axis.name for loop in loops} == {"a"}
+
+
+# ---------------------------------------------------------------------------
+# merge_sibling_reduce_loops — concatenation under safety gates
+# ---------------------------------------------------------------------------
+
+
+def test_merge_concatenates_matching_reduce_bodies() -> None:
+    """The motivating case: after unify renames both axes to ``a2``,
+    merge concatenates the two bodies into one Loop, eliminating the
+    duplicate K traversal."""
+    a = Axis("k", 16)
+    body = Body(
+        (
+            _matmul_reduce(a, w_buffer="Wg", out_acc="acc0"),
+            _matmul_reduce(a, w_buffer="Wu", out_acc="acc1"),
+            Write(output="out", index=(Var("n"),), value="acc1"),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 1, f"expected one merged Loop, got {len(loops)}"
+    inner_accs = [s.name for s in loops[0].body if isinstance(s, Accum)]
+    assert inner_accs == ["acc0", "acc1"]
+
+
+def test_merge_skips_when_second_loop_reads_first_loops_accum() -> None:
+    """Softmax pattern: first reduce produces ``acc_max``, second reduce
+    body reads it inside the iteration. Merging would change the read
+    from finalized to in-flight — must be skipped."""
+    a = Axis("k", 16)
+    body = Body(
+        (
+            Loop(axis=a, body=(Load(name="x1", input="X", index=(Var("k"),)), Accum(name="acc_max", value="x1", op="maximum"))),
+            Loop(
+                axis=a,
+                body=(
+                    Load(name="x2", input="X", index=(Var("k"),)),
+                    Assign(name="d", op="subtract", args=("x2", "acc_max")),
+                    Assign(name="e", op="exp", args=("d",)),
+                    Accum(name="acc_sum", value="e"),
+                ),
+            ),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 2, "softmax-style sequential reduces must stay distinct"
+
+
+def test_merge_skips_on_ssa_name_collision() -> None:
+    """If both bodies define the same SSA name, merging would create
+    inner-scope shadowing — skip rather than guess a rename."""
+    a = Axis("k", 16)
+    body = Body(
+        (
+            Loop(axis=a, body=(Load(name="v", input="A", index=(Var("k"),)), Accum(name="acc0", value="v"))),
+            Loop(axis=a, body=(Load(name="v", input="B", index=(Var("k"),)), Accum(name="acc1", value="v"))),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 2, "name collision on 'v' must block the merge"
+
+
+def test_merge_skips_when_between_stmt_def_used_by_second_loop() -> None:
+    """A pure stmt between the two loops defines an SSA name the second
+    loop's body reads — merging would move the read above the def."""
+    a = Axis("k", 16)
+    body = Body(
+        (
+            Loop(axis=a, body=(Load(name="p", input="A", index=(Var("k"),)), Accum(name="acc0", value="p"))),
+            Assign(name="bias", op="exp", args=("acc0",)),
+            Loop(
+                axis=a,
+                body=(
+                    Load(name="q", input="B", index=(Var("k"),)),
+                    Assign(name="m", op="multiply", args=("q", "bias")),
+                    Accum(name="acc1", value="m"),
+                ),
+            ),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 2, "between-stmt def consumed by second loop must block the merge"
+
+
+def test_merge_keeps_intermediate_pure_stmts_in_place() -> None:
+    """Pure stmts between the two reduce-loops that only depend on the
+    first loop's Accum (not the second's body) remain valid post-merge
+    — first Accum is still in scope above them, and they don't feed the
+    second loop's body."""
+    a = Axis("k", 16)
+    body = Body(
+        (
+            _matmul_reduce(a, w_buffer="Wg", out_acc="acc0"),
+            Assign(name="silu_val", op="silu", args=("acc0",)),  # depends only on acc0
+            _matmul_reduce(a, w_buffer="Wu", out_acc="acc1"),
+            Assign(name="result", op="multiply", args=("silu_val", "acc1")),
+            Write(output="out", index=(Var("n"),), value="result"),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    loops = [s for s in out if isinstance(s, Loop)]
+    assert len(loops) == 1, "intermediate stmt depending only on first Accum must not block the merge"
+    inner_accs = [s.name for s in loops[0].body if isinstance(s, Accum)]
+    assert inner_accs == ["acc0", "acc1"]
+
+
+def test_merge_recurses_into_nested_loops() -> None:
+    """Outer free-loops over (n, m) wrap sibling reduce-loops over k —
+    the pass must descend through the outer Loops and merge the inner
+    siblings."""
+    k = Axis("k", 16)
+    n = Axis("n", 4)
+    body = Body(
+        (
+            Loop(
+                axis=n,
+                body=(
+                    _matmul_reduce(k, w_buffer="Wg", out_acc="acc0"),
+                    _matmul_reduce(k, w_buffer="Wu", out_acc="acc1"),
+                    Write(output="o", index=(Var("n"),), value="acc1"),
+                ),
+            ),
+        )
+    )
+
+    out = merge_sibling_reduce_loops(body)
+
+    outer = out[0]
+    assert isinstance(outer, Loop) and outer.axis.name == "n"
+    inner_loops = [s for s in outer.body if isinstance(s, Loop)]
+    assert len(inner_loops) == 1, "inner sibling reduces must merge inside the outer Loop body"
+
+
+def test_unify_then_merge_collapses_gated_mlp_pattern() -> None:
+    """End-to-end: the gated-MLP pattern ``silu(x@Wg) * (x@Wu)`` enters
+    with distinct axis names ``a2`` / ``a3`` indexing the same x slot.
+    After unify + merge, one K-loop carries both matmul reductions and
+    the post-loop multiply still references both Accums correctly."""
+    a = Axis("a2", 16)
+    b = Axis("a3", 16)
+    body = Body(
+        (
+            _matmul_reduce(a, w_buffer="Wg", out_acc="acc0"),
+            Assign(name="silu_val", op="silu", args=("acc0",)),
+            _matmul_reduce(b, w_buffer="Wu", out_acc="acc1"),
+            Assign(name="result", op="multiply", args=("silu_val", "acc1")),
+            Write(output="out", index=(Var("n"),), value="result"),
+        )
+    )
+
+    unified = unify_sibling_reduce_axes(body)
+    merged = merge_sibling_reduce_loops(unified)
+
+    loops = [s for s in merged if isinstance(s, Loop)]
+    assert len(loops) == 1
+    accs_inside = [s.name for s in loops[0].body if isinstance(s, Accum)]
+    assert accs_inside == ["acc0", "acc1"]
+    x_loads = [s for s in loops[0].body if isinstance(s, Load) and s.input == "x"]
+    assert len(x_loads) == 2, "dedup happens in a later pass — merge alone leaves both x loads"

--- a/tests/compiler/passes/test_pipeline_k_outer_sync_stage.py
+++ b/tests/compiler/passes/test_pipeline_k_outer_sync_stage.py
@@ -1,0 +1,118 @@
+"""Regression test for ``015_pipeline_k_outer`` skipping kernels with a
+plain (sync) ``BufferedStage`` alongside async/TMA Stages.
+
+Background: when ``stage_inputs`` produces a mix of async Stages (wg /
+wu) and a sync Stage (x — when ``async_copy`` can't promote it because
+of slab shape / alignment), the K-outer pipeline used to hoist only the
+async Stages' decls to the prologue while leaving the sync ``Smem``
+decl inside the K-loop body. The pipelined epilogue then peeled the
+last K iteration past the loop's closing brace, referencing
+``x_smem`` from a scope where it was no longer declared → nvcc error
+``identifier "x_smem" is undefined``.
+
+The gate added in ``015_pipeline_k_outer`` rejects the loop in this
+configuration so the unpipelined-but-correct schedule survives.
+
+This test pins the exact knob set that historically tripped the bug
+(``BK=2, BM=16, BN=128, FM=8, FN=8, STAGE=111``) on the gated-MLP
+pattern from Qwen3-Embedding-0.6B kernel 10 and asserts the full
+compile → CUDA-render pipeline succeeds end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+GATED_MLP_CODE = (
+    "import torch; import torch.nn.functional as F; "
+    "x=torch.randn((1, 32, 1024)); "
+    "wg=torch.randn((1024, 3072)); "
+    "wu=torch.randn((1024, 3072)); "
+    "F.silu(torch.matmul(x,wg))*torch.matmul(x,wu)"
+)
+
+# Knob set that historically tripped the x_smem-undefined nvcc error.
+BUGGY_KNOBS = {
+    "DEPLODOCK_BK": "2",
+    "DEPLODOCK_BM": "16",
+    "DEPLODOCK_BN": "128",
+    "DEPLODOCK_FM": "8",
+    "DEPLODOCK_FN": "8",
+    "DEPLODOCK_STAGE": "111",
+}
+
+
+@pytest.fixture
+def env_with_knobs(monkeypatch):
+    for k, v in BUGGY_KNOBS.items():
+        monkeypatch.setenv(k, v)
+    return os.environ.copy()
+
+
+def test_compile_gated_mlp_with_sync_x_stage_does_not_dangle_smem(env_with_knobs, tmp_path):
+    """End-to-end: compile the gated-MLP pattern at the historically-
+    buggy knob set and assert the rendered CUDA source declares every
+    ``*_smem`` buffer it references — i.e. no dangling identifier."""
+    out = tmp_path / "kernel.cu"
+    result = subprocess.run(
+        [sys.executable, "-m", "deplodock.deplodock", "compile", "--code", GATED_MLP_CODE, "--ir", "cuda", "--output", str(out)],
+        capture_output=True,
+        text=True,
+        env=env_with_knobs,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert out.exists(), "compile did not produce a .cu file"
+    src = out.read_text()
+
+    # Every smem buffer referenced must be declared at some scope. The
+    # historic failure mode: ``x_smem[...]`` referenced after the loop
+    # whose body declared it. Asserting on a balanced
+    # decl-count-per-name catches the scope mismatch without baking in
+    # exact line numbers.
+    for buffer in ("wg_smem", "x_smem", "wu_smem"):
+        assert "__shared__" in src and buffer in src, f"missing {buffer} or any __shared__ decl"
+        # Count uses (rough — any token occurrence) and decls (``__shared__ ... <buffer>[``).
+        decls = src.count(f"float {buffer}[")
+        uses = src.count(f"{buffer}[") + src.count(f"&{buffer}[")
+        assert decls >= 1, f"{buffer} never declared"
+        # Every use must be reachable from some declaration. With the
+        # gate active, all three buffers are declared at the kernel-body
+        # scope so every use is in scope. (Pre-fix: x_smem decl was
+        # nested inside a for-loop and uses after the loop dangled.)
+        assert uses > decls, f"{buffer} declared {decls}× but never used"
+
+
+def test_compile_gated_mlp_does_not_pipeline_when_sync_stage_present(env_with_knobs, tmp_path):
+    """Direct evidence the pipelining was skipped: the pipelined schedule
+    emits a *peeled tail* (a copy of the reduce body after the main
+    K-outer loop, reading from the last buffer slot). When the gate
+    rejects pipelining, only the unrolled-by-double-buffer main loop
+    remains and there is no post-loop tail."""
+    dump_dir = tmp_path / "dump"
+    dump_dir.mkdir()
+    env = env_with_knobs.copy()
+    env["DEPLODOCK_DUMP_DIR"] = str(dump_dir)
+    result = subprocess.run(
+        [sys.executable, "-m", "deplodock.deplodock", "compile", "--code", GATED_MLP_CODE, "--ir", "kernel"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    pipeline_dump = dump_dir / "05_lowering_tile__015_pipeline_k_outer.rules.txt"
+    if pipeline_dump.exists():
+        # If the file exists at all, the pass must have skipped (gate
+        # rejected this case). Skipped passes leave a "no rewrite"
+        # diagnostic; a successful firing would show ``BufferedStage``
+        # decls hoisted out of a Loop and a new Loop with smaller
+        # extent — neither should appear here when the sync-Stage gate
+        # is active.
+        text = pipeline_dump.read_text()
+        assert "no eligible" in text.lower() or "skipped" in text.lower() or text.strip() == "", (
+            "pipeline_k_outer should have skipped on sync-Stage presence, but produced a rewrite:\n" + text[:500]
+        )

--- a/tests/compiler/pipeline/test_knob.py
+++ b/tests/compiler/pipeline/test_knob.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from deplodock.compiler.pipeline.knob import Knob, KnobType
+from deplodock.compiler.pipeline.knob import Knob, KnobType, apply_knobs_env
 
 
 def test_int_parse():
@@ -78,3 +78,72 @@ def test_binmask_requires_width():
 def test_env_property():
     assert Knob("BN", KnobType.INT).env == "DEPLODOCK_BN"
     assert Knob("STAGE", KnobType.BINMASK).env == "DEPLODOCK_STAGE"
+
+
+# ---------------------------------------------------------------------------
+# DEPLODOCK_KNOBS aggregate env var
+# ---------------------------------------------------------------------------
+
+
+def test_apply_knobs_env_splats_into_individual_keys(monkeypatch):
+    """Aggregate env var sets ``DEPLODOCK_<K>`` per entry."""
+    monkeypatch.delenv("DEPLODOCK_BK", raising=False)
+    monkeypatch.delenv("DEPLODOCK_BM", raising=False)
+    monkeypatch.delenv("DEPLODOCK_BN", raising=False)
+    applied = apply_knobs_env("BK=2,BM=16,BN=128")
+    assert applied == {"DEPLODOCK_BK": "2", "DEPLODOCK_BM": "16", "DEPLODOCK_BN": "128"}
+
+
+def test_apply_knobs_env_individual_takes_precedence(monkeypatch):
+    """An explicit ``DEPLODOCK_<K>`` wins over the aggregate."""
+    monkeypatch.setenv("DEPLODOCK_BK", "4")
+    monkeypatch.delenv("DEPLODOCK_BM", raising=False)
+    applied = apply_knobs_env("BK=2,BM=16")
+    assert "DEPLODOCK_BK" not in applied  # not clobbered
+    assert applied == {"DEPLODOCK_BM": "16"}
+    import os
+
+    assert os.environ["DEPLODOCK_BK"] == "4"
+    assert os.environ["DEPLODOCK_BM"] == "16"
+
+
+def test_apply_knobs_env_tolerates_whitespace(monkeypatch):
+    """Whitespace around keys / values / separators is stripped."""
+    monkeypatch.delenv("DEPLODOCK_BK", raising=False)
+    monkeypatch.delenv("DEPLODOCK_BM", raising=False)
+    applied = apply_knobs_env(" BK = 2 ,  BM=16 ")
+    assert applied == {"DEPLODOCK_BK": "2", "DEPLODOCK_BM": "16"}
+
+
+def test_apply_knobs_env_skips_empty_entries(monkeypatch):
+    """Empty entries (trailing comma, double comma) are skipped."""
+    monkeypatch.delenv("DEPLODOCK_BK", raising=False)
+    applied = apply_knobs_env("BK=2,,")
+    assert applied == {"DEPLODOCK_BK": "2"}
+
+
+def test_apply_knobs_env_rejects_missing_equals():
+    """An entry without ``=`` is malformed and surfaces an error."""
+    with pytest.raises(ValueError, match="missing '='"):
+        apply_knobs_env("BK=2,BMnoequals")
+
+
+def test_apply_knobs_env_rejects_empty_key():
+    """An entry like ``=4`` has an empty KEY and is rejected."""
+    with pytest.raises(ValueError, match="empty KEY"):
+        apply_knobs_env("=4")
+
+
+def test_apply_knobs_env_uppercases_key(monkeypatch):
+    """Lowercased keys round-trip to the upper-case env-var convention."""
+    monkeypatch.delenv("DEPLODOCK_BK", raising=False)
+    applied = apply_knobs_env("bk=2")
+    assert applied == {"DEPLODOCK_BK": "2"}
+
+
+def test_apply_knobs_env_no_raw_falls_back_to_env(monkeypatch):
+    """With no ``raw`` argument, the function reads ``DEPLODOCK_KNOBS``."""
+    monkeypatch.delenv("DEPLODOCK_BK", raising=False)
+    monkeypatch.setenv("DEPLODOCK_KNOBS", "BK=8")
+    applied = apply_knobs_env()
+    assert applied == {"DEPLODOCK_BK": "8"}

--- a/tests/perf/ARCHITECTURE.md
+++ b/tests/perf/ARCHITECTURE.md
@@ -1,87 +1,76 @@
 # Perf Suite — `tests/perf/`
 
-Apples-to-apples kernel-level performance comparison between Deplodock and PyTorch
-eager. Gated by the `perf` pytest marker — **deselected by default** so `make test`
-stays fast. Run explicitly with `make bench-kernels` (or `pytest -m perf`).
+Apples-to-apples kernel-level performance comparison between Deplodock and PyTorch eager. Gated by the `perf` pytest
+marker — **deselected by default** so `make test` stays fast. Run explicitly with `make bench-kernels` (or
+`pytest -m perf`).
 
 ## What it measures
 
-Each case is one (op, shape) pair drawn from real transformer blocks (TinyLlama
-hidden=2048, intermediate=5632, heads=32, head_dim=64; Qwen2.5-7B hidden=3584,
-intermediate=18944, heads=28, head_dim=128) at `seq_len ∈ {32, 128, 512}`.
+The case list mirrors the 12 fused kernels Deplodock emits when compiling a single Qwen3-Embedding-0.6B decoder layer
+(`deplodock compile Qwen/Qwen3-Embedding-0.6B --layer 0 --ir loop`). Each case is a small Python expression that
+lowers to the same single fused launch, so the suite is a kernel-by-kernel view of what the compiler actually runs at
+the model level. Model dims: hidden=1024, intermediate=3072, num_heads=16, num_kv_heads=8, head_dim=128. Each case
+runs at `seq_len ∈ {32, 128, 512}`.
 
-| Op                | What runs (deplodock)                          | What runs (PyTorch)              |
-|-------------------|------------------------------------------------|----------------------------------|
-| `matmul`          | `MatmulOp(a, b)`                               | `torch.matmul`                   |
-| `rmsnorm`         | `RmsNormOp(x, w)`                              | `F.rms_norm`                     |
-| `softmax`         | `SoftmaxOp(x)`                                 | `F.softmax`                      |
-| `silu_mul`        | `ElementwiseOp("silu") → ElementwiseOp("mul")` | `F.silu(gate) * up`              |
-| `sdpa`            | `SdpaOp(q, k, v, is_causal=True)` (fused)      | `F.scaled_dot_product_attention` |
-| `matmul_add`      | `MatmulOp → ElementwiseOp("add")`              | `torch.matmul(x, w) + r`         |
-| `silu_mul_matmul` | `silu → mul → MatmulOp`                        | `torch.matmul(F.silu(g)*u, w)`   |
+| Op          | Maps to Qwen3 kernel(s)                                | What runs (deplodock)                              | What runs (PyTorch)                            |
+|-------------|--------------------------------------------------------|----------------------------------------------------|------------------------------------------------|
+| `rmsnorm`   | 0 / 9 (input + post-attn layernorm), 4 / 5 (q/k norm)  | `RmsNormOp(x, w)`                                  | `F.rms_norm`                                   |
+| `matmul`    | 1 / 2 / 3 (q_proj, kv_proj)                            | `MatmulOp(a, b)`                                   | `torch.matmul`                                 |
+| `sdpa`      | 6 + 7 (masked QK + softmax/AV)                         | `SdpaOp(q, k, v, is_causal=True)`                  | `F.scaled_dot_product_attention(..., GQA)`     |
+| `matmul_add`| 8 (o_proj+resid), 11 (down_proj+resid)                 | `MatmulOp → ElementwiseOp("add")`                  | `torch.matmul(x, w) + r`                       |
+| `gated_mlp` | 10 (gate·silu·up fused, sans down-proj)                | `MatmulOp ×2 → silu → multiply`                    | `F.silu(torch.matmul(x, wg)) * torch.matmul(x, wu)` |
 
-Primitive ops (`matmul`, `rmsnorm`, `softmax`, `silu_mul`) live in
-`test_primitives.py`. Fused signatures (`sdpa`, `matmul_add`,
-`silu_mul_matmul`) live in `test_fused.py`.
+Primitive ops (`rmsnorm`, `matmul`) live in `test_primitives.py`. Fused signatures (`sdpa`, `matmul_add`,
+`gated_mlp`) live in `test_fused.py`. `gated_mlp` is the gate+up fused launch (Qwen3 layer kernel 10); both matmuls
+share the same hidden-dim reduce and the silu·multiply is folded into the epilogue. The down_proj+residual that
+follows is a separate kernel (`matmul_add.down_proj`).
 
-`matmul_add` mirrors the `k_add_*_reduce` kernels Deplodock emits inside a
-block — the residual add gets fused into the matmul epilogue for o_proj /
-down_proj. `silu_mul_matmul` mirrors `k_mul_*_reduce` — the SiLU+up gating
-fuses into the down_proj reduction. Both should compile to a single launch;
-that's the kernel that actually dominates block latency, so measuring the
-fused chain is the apples-to-apples comparison.
-
-Deplodock currently emits FP32 only, so both sides run FP32. The `dtype` field
-on `Case` is kept for future FP16 support.
+Deplodock currently emits FP32 only, so both sides run FP32. The `dtype` field on `Case` is kept for future FP16
+support.
 
 ## How it's wired
 
-- `cases.py` — `Case` dataclass + curated `CASES` list + `build_torch_ref` /
-  `build_deplodock_graph`.
-- `conftest.py` — `bench_pair` fixture (CUDA-event timing on the torch side,
-  `CudaBackend.benchmark` on the deplodock side), session-end summary table,
-  JSON dump to `.results/`.
-- `test_primitives.py` / `test_fused.py` — one parametrized test each, ids =
-  `case.name`.
+- `cases.py` — `Case` dataclass + curated `CASES` list + `build_torch_ref` / `build_deplodock_graph`.
+- `conftest.py` — `bench_pair` fixture (CUDA-event timing on the torch side, `CudaBackend.benchmark` on the deplodock
+  side), session-end summary table, JSON dump to `.results/`.
+- `test_primitives.py` / `test_fused.py` — one parametrized test each, ids = `case.name`.
 
-The deplodock-side timing reuses `CudaBackend.benchmark` (per-kernel CUDA events
-via cupy, see `deplodock/compiler/backend/cuda/program.py:369`) so launch counts
-and per-kernel latency are available; the torch side uses `torch.cuda.Event`
-matching the pattern in `scripts/bench_block.py:194-202`.
+The deplodock-side timing reuses `CudaBackend.benchmark` (per-kernel CUDA events via cupy, see
+`deplodock/compiler/backend/cuda/program.py:369`) so launch counts and per-kernel latency are available; the torch
+side uses `torch.cuda.Event` matching the pattern in `scripts/bench_block.py:194-202`.
 
 ## Reading the output
 
-`pytest_terminal_summary` prints one table sorted by `ratio = torch_us /
-deplodock_us` ascending — losses (ratio < 1) first:
+`pytest_terminal_summary` prints one table sorted by `ratio = torch_us / deplodock_us` ascending — losses
+(ratio < 1) first:
 
 ```
-case                       shape                          torch_us  depl_us  ratio  launches
--------------------------  -----------------------------  --------  -------  -----  --------
-matmul.qwen.gate_proj.s512 (1,512,3584) x (3584,18944)      1230.0   2890.4  0.43x         1
-rmsnorm.tinyllama.s512     (1,512,2048) x (2048,)             12.1      9.8  1.23x         1
+case                          shape                          torch_us  depl_us  ratio  launches
+----------------------------  -----------------------------  --------  -------  -----  --------
+gated_mlp.qwen3emb.s512       (1,512,1024) x (1024,3072) ...   1230.0   2890.4  0.43x         1
+rmsnorm.qwen3emb.layer.s512   (1,512,1024) x (1024,)             12.1      9.8  1.23x         1
 ...
 ```
 
-The same data is dumped to `tests/perf/.results/<utc-timestamp>.json` for
-cross-run diffing. `DEPLODOCK_GIT_REV` is recorded if set. A self-contained
-ECharts plot of `ratio` per case (sorted ascending, bars colored by op,
-optional `torch.compile` overlay) is written next to the JSON as
-`<utc-timestamp>.html` — open it in a browser; no server needed (the chart
-loads ECharts from the jsDelivr CDN).
+The same data is dumped to `tests/perf/.results/<utc-timestamp>.json` for cross-run diffing. `DEPLODOCK_GIT_REV` is
+recorded if set. A self-contained ECharts plot of `ratio` per case (sorted ascending, bars colored by op, optional
+`torch.compile` overlay) is written next to the JSON as `<utc-timestamp>.html` — open it in a browser; no server
+needed (the chart loads ECharts from the jsDelivr CDN).
 
 ## Adding a case
 
-Append to the appropriate builder in `cases.py` (`_matmul_cases`,
-`_rmsnorm_cases`, …) — no test code changes required, parametrize picks it up
-by name.
+Append to the appropriate builder in `cases.py` (`_matmul_proj_cases`, `_rmsnorm_layer_cases`, …) — no test code
+changes required, parametrize picks it up by name. If a new fused launch appears in the Qwen3-Embedding layer dump
+that the current taxonomy doesn't cover, add a new op to `Case.op` along with matching branches in `code`,
+`build_torch_ref`, and `build_deplodock_graph`.
 
 ## Running
 
 ```bash
-make bench-kernels                                                # full suite
-./venv/bin/pytest tests/perf/ -m perf -v -k matmul                # one op
-./venv/bin/pytest tests/perf/ -m perf -v -k 'matmul.tinyllama'    # one model
-./venv/bin/pytest tests/perf/test_primitives.py -m perf -v -s     # primitives only
+make bench-kernels                                                  # full suite
+./venv/bin/pytest tests/perf/ -m perf -v -k matmul                  # one op
+./venv/bin/pytest tests/perf/ -m perf -v -k 'qwen3emb.layer'        # one kernel family
+./venv/bin/pytest tests/perf/test_primitives.py -m perf -v -s       # primitives only
 ```
 
 `make test` continues to skip everything in `tests/perf/`.

--- a/tests/perf/cases.py
+++ b/tests/perf/cases.py
@@ -1,30 +1,26 @@
 """Curated (op, shape) cases for the perf suite.
 
-Each ``Case`` describes a single sublayer that occurs inside a real
-transformer block at a real shape. The same Case drives both:
+Each ``Case`` describes one fused launch that Deplodock emits when
+compiling a single Qwen3-Embedding-0.6B decoder layer at seq_len 32 /
+128 / 512. The case list mirrors the 12 kernels produced by
+``deplodock compile Qwen/Qwen3-Embedding-0.6B --layer 0`` after the
+fusion pass, so the perf suite is an apples-to-apples view of what the
+compiler actually runs at the model level.
+
+For each Case both:
 
 - the PyTorch reference closure (``build_torch_ref``) — eager call into
-  ``torch.matmul`` / ``F.rms_norm`` / ``F.softmax`` / ``F.silu`` /
-  ``F.scaled_dot_product_attention`` etc.;
-- the Deplodock graph (``build_deplodock_graph``) — a tiny ``Graph``
-  built from the corresponding frontend op, then compiled by
-  ``CudaBackend``.
+  ``torch.matmul`` / ``F.rms_norm`` / ``F.scaled_dot_product_attention``
+  etc.;
+- the Deplodock graph (``build_deplodock_graph``) — a small ``Graph``
+  built from frontend ops that lowers to the same single fused
+  kernel that comes out of the Qwen3-Embedding layer.
 
-Shapes are pinned to what TinyLlama-1.1B and Qwen2.5-7B blocks actually
-see; we deliberately keep the list compact so the suite runs in seconds
-and the summary table fits on one screen. Add cases by appending to
-``CASES`` — no other surgery needed.
-
-Fused chains (``matmul_add``, ``silu_mul_matmul``) live alongside the
-primitives because the dominant kernels Deplodock emits inside a block
-are matmuls with elementwise epilogues fused in (e.g. down_proj+residual,
-silu·up·W_down). Measuring the fused chain end-to-end is the apples-to-
-apples comparison against the kernel that actually runs.
-
-Deplodock currently emits FP32 only, so all cases run FP32 on both
-sides for an apples-to-apples comparison. The ``dtype`` field is kept
-on ``Case`` so an FP16 column can be added later without touching
-callers.
+Shapes are pinned to Qwen3-Embedding-0.6B: hidden=1024, intermediate=
+3072, num_heads=16, num_kv_heads=8, head_dim=128. Deplodock currently
+emits FP32 only, so all cases run FP32 on both sides; the ``dtype``
+field is kept on ``Case`` so an FP16 column can be added later
+without touching callers.
 """
 
 from __future__ import annotations
@@ -39,8 +35,8 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True)
 class Case:
-    name: str  # e.g. "matmul.tinyllama.q_proj.s512"
-    op: str  # one of: matmul, rmsnorm, softmax, silu_mul, rope, sdpa
+    name: str  # e.g. "matmul.qwen3emb.q_proj.s128"
+    op: str  # one of: matmul, rmsnorm, sdpa, matmul_add, gated_mlp
     shapes: tuple[tuple[int, ...], ...]  # input shapes, in op order
     dtype: str = "fp32"
     tags: tuple[str, ...] = field(default_factory=tuple)
@@ -62,33 +58,19 @@ class Case:
             return f"{preamble}; a=torch.randn({s[0]}); b=torch.randn({s[1]}); torch.matmul(a,b)"
         if self.op == "rmsnorm":
             return f"{preamble}; x=torch.randn({s[0]}); w=torch.randn({s[1]}); F.rms_norm(x, {tuple(s[1])}, w, eps=1e-6)"
-        if self.op == "softmax":
-            return f"{preamble}; x=torch.randn({s[0]}); F.softmax(x, dim=-1)"
-        if self.op == "silu_mul":
-            return f"{preamble}; gate=torch.randn({s[0]}); up=torch.randn({s[1]}); F.silu(gate)*up"
         if self.op == "sdpa":
             gqa = "True" if s[0][-3] != s[1][-3] else "False"
             return (
                 f"{preamble}; q=torch.randn({s[0]}); k=torch.randn({s[1]}); v=torch.randn({s[2]}); "
                 f"F.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa={gqa})"
             )
-        if self.op == "naive_attn":
-            # Block-style decomposition matching HF's NaiveSDPA path:
-            # qk = q @ k.T * scale; attn = softmax(qk + causal_mask); out = attn @ v.
-            # ``-1e9`` mask term keeps the trace fp32-clean (``-inf`` would
-            # canonicalize through eager but trip later passes).
-            seq = s[0][-2]
-            dh = s[0][-1]
-            return (
-                f"import math; {preamble}; "
-                f"q=torch.randn({s[0]}); k=torch.randn({s[1]}); v=torch.randn({s[2]}); "
-                f"mask=torch.full(({seq},{seq}), -1e9).triu(1); "
-                f"F.softmax(q @ k.transpose(-2,-1) * (1.0/math.sqrt({dh})) + mask, dim=-1) @ v"
-            )
         if self.op == "matmul_add":
             return f"{preamble}; x=torch.randn({s[0]}); w=torch.randn({s[1]}); r=torch.randn({s[2]}); torch.matmul(x,w)+r"
-        if self.op == "silu_mul_matmul":
-            return f"{preamble}; gate=torch.randn({s[0]}); up=torch.randn({s[1]}); w=torch.randn({s[2]}); torch.matmul(F.silu(gate)*up, w)"
+        if self.op == "gated_mlp":
+            return (
+                f"{preamble}; x=torch.randn({s[0]}); wg=torch.randn({s[1]}); wu=torch.randn({s[2]}); "
+                f"F.silu(torch.matmul(x,wg))*torch.matmul(x,wu)"
+            )
         raise ValueError(f"unknown op: {self.op}")
 
     @property
@@ -96,11 +78,9 @@ class Case:
         """Number of measured iterations the bencher should run for this
         case. Heavy ops (~ms-scale per iter) drop to 20 to keep the suite
         fast; everything else stays at 100. ``heavy`` is detected by
-        total input element count — the dominant factor in matmul /
-        silu_mul_matmul cost. Threshold (50 M elements) covers the
-        fp32-suite cases that empirically run > 1 ms each (qwen
-        gate/up/down_proj.s512 and silu_mul_matmul.{tinyllama,qwen}
-        s512)."""
+        total input element count — the dominant factor in matmul cost.
+        Threshold (50 M elements) covers the fp32 cases that empirically
+        run > 1 ms each (e.g. gated_mlp at s=512)."""
         total_elements = sum(_prod(s) for s in self.shapes)
         return 20 if total_elements > 50_000_000 else 100
 
@@ -113,195 +93,143 @@ def _prod(shape: tuple[int, ...]) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Model dimensions
+# Model dimensions — Qwen3-Embedding-0.6B
 # ---------------------------------------------------------------------------
 
-# TinyLlama-1.1B-Chat-v1.0
-_TL_H = 2048  # hidden_size
-_TL_I = 5632  # intermediate_size
-_TL_HEADS = 32
-_TL_KV_HEADS = 4
-_TL_DH = _TL_H // _TL_HEADS  # 64
-
-# Qwen2.5-7B
-_Q_H = 3584
-_Q_I = 18944
-_Q_HEADS = 28
-_Q_KV_HEADS = 4
-_Q_DH = _Q_H // _Q_HEADS  # 128
+# Source: config.json from Qwen/Qwen3-Embedding-0.6B
+_H = 1024  # hidden_size
+_I = 3072  # intermediate_size
+_HEADS = 16  # num_attention_heads
+_KV_HEADS = 8  # num_key_value_heads
+_DH = 128  # head_dim
+_Q_DIM = _HEADS * _DH  # 2048 — fused Q-projection output width
+_KV_DIM = _KV_HEADS * _DH  # 1024 — fused K/V-projection output width
 
 _SEQ_LENS = (32, 128, 512)
+_TAG = "qwen3emb"
 
 
-def _matmul_cases() -> list[Case]:
+# ---------------------------------------------------------------------------
+# Per-kernel case builders
+#
+# The kernel ids below match the ``=== N: kernel_name ===`` blocks in
+# ``deplodock compile Qwen/Qwen3-Embedding-0.6B --layer 0 --dump-dir DIR``,
+# stage ``04_loop_fusion.kernels.txt``.
+# ---------------------------------------------------------------------------
+
+
+def _rmsnorm_layer_cases() -> list[Case]:
+    """Kernel 0 (input_layernorm) and 9 (post_attention_layernorm) —
+    identical shape, so just one case per seq_len."""
     cases: list[Case] = []
-    for tag, hidden, inter, _heads, kv_heads, dh in [
-        ("tinyllama", _TL_H, _TL_I, _TL_HEADS, _TL_KV_HEADS, _TL_DH),
-        ("qwen", _Q_H, _Q_I, _Q_HEADS, _Q_KV_HEADS, _Q_DH),
-    ]:
-        kv_out = kv_heads * dh
-        for s in _SEQ_LENS:
-            for proj, n_out in [
-                ("q_proj", hidden),
-                ("kv_proj", kv_out),
-                ("o_proj", hidden),
-                ("gate_proj", inter),
-                ("up_proj", inter),
-                ("down_proj", hidden),
-            ]:
-                k_in = inter if proj == "down_proj" else hidden
-                cases.append(
-                    Case(
-                        name=f"matmul.{tag}.{proj}.s{s}",
-                        op="matmul",
-                        shapes=((1, s, k_in), (k_in, n_out)),
-                        tags=(tag, "matmul", proj),
-                    )
-                )
+    for s in _SEQ_LENS:
+        cases.append(
+            Case(
+                name=f"rmsnorm.{_TAG}.layer.s{s}",
+                op="rmsnorm",
+                shapes=((1, s, _H), (_H,)),
+                tags=(_TAG, "rmsnorm", "layer_norm"),
+            )
+        )
     return cases
 
 
-def _rmsnorm_cases() -> list[Case]:
+def _rmsnorm_qknorm_cases() -> list[Case]:
+    """Kernels 4 / 5 — per-head RMSNorm on Q/K with the reduce over
+    head_dim. The kernel produced by Deplodock fuses the reshape +
+    transpose with the norm, but the perf-relevant arithmetic is the
+    rmsnorm with a head_dim-wide reduce; we test that shape directly."""
     cases: list[Case] = []
-    for tag, hidden in [("tinyllama", _TL_H), ("qwen", _Q_H)]:
-        for s in _SEQ_LENS:
+    for s in _SEQ_LENS:
+        for tag, heads in [("q_norm", _HEADS), ("k_norm", _KV_HEADS)]:
             cases.append(
                 Case(
-                    name=f"rmsnorm.{tag}.s{s}",
+                    name=f"rmsnorm.{_TAG}.{tag}.s{s}",
                     op="rmsnorm",
-                    shapes=((1, s, hidden), (hidden,)),
-                    tags=(tag, "rmsnorm"),
+                    shapes=((1, heads, s, _DH), (_DH,)),
+                    tags=(_TAG, "rmsnorm", tag, "attn"),
                 )
             )
     return cases
 
 
-def _softmax_cases() -> list[Case]:
+def _matmul_proj_cases() -> list[Case]:
+    """Kernels 1 / 2 / 3 — Q/K/V projections out of the input rmsnorm.
+    K and V share the same shape (KV_DIM), so we keep one ``kv_proj``
+    case rather than testing both."""
     cases: list[Case] = []
-    for tag, heads in [("tinyllama", _TL_HEADS), ("qwen", _Q_HEADS)]:
-        for s in _SEQ_LENS:
+    for s in _SEQ_LENS:
+        for proj, n_out in [("q_proj", _Q_DIM), ("kv_proj", _KV_DIM)]:
             cases.append(
                 Case(
-                    name=f"softmax.{tag}.s{s}",
-                    op="softmax",
-                    shapes=((1, heads, s, s),),
-                    tags=(tag, "softmax"),
-                )
-            )
-    return cases
-
-
-def _silu_mul_cases() -> list[Case]:
-    cases: list[Case] = []
-    for tag, inter in [("tinyllama", _TL_I), ("qwen", _Q_I)]:
-        for s in _SEQ_LENS:
-            cases.append(
-                Case(
-                    name=f"silu_mul.{tag}.s{s}",
-                    op="silu_mul",
-                    shapes=((1, s, inter), (1, s, inter)),
-                    tags=(tag, "silu_mul", "mlp"),
+                    name=f"matmul.{_TAG}.{proj}.s{s}",
+                    op="matmul",
+                    shapes=((1, s, _H), (_H, n_out)),
+                    tags=(_TAG, "matmul", proj),
                 )
             )
     return cases
 
 
 def _sdpa_cases() -> list[Case]:
+    """Kernels 6 + 7 — masked QK (with RoPE folded in) and softmax/AV.
+    ``F.scaled_dot_product_attention`` is the natural eager reference;
+    Deplodock's frontend ``SdpaOp`` decomposes and fuses into two
+    launches matching the Qwen3 layer."""
     cases: list[Case] = []
-    for tag, heads, kv_heads, dh in [
-        ("tinyllama", _TL_HEADS, _TL_KV_HEADS, _TL_DH),
-        ("qwen", _Q_HEADS, _Q_KV_HEADS, _Q_DH),
-    ]:
-        for s in _SEQ_LENS:
-            cases.append(
-                Case(
-                    name=f"sdpa.{tag}.s{s}",
-                    op="sdpa",
-                    shapes=((1, heads, s, dh), (1, kv_heads, s, dh), (1, kv_heads, s, dh)),
-                    tags=(tag, "sdpa", "attn"),
-                )
+    for s in _SEQ_LENS:
+        cases.append(
+            Case(
+                name=f"sdpa.{_TAG}.s{s}",
+                op="sdpa",
+                shapes=((1, _HEADS, s, _DH), (1, _KV_HEADS, s, _DH), (1, _KV_HEADS, s, _DH)),
+                tags=(_TAG, "sdpa", "attn"),
             )
+        )
     return cases
 
 
 def _matmul_add_cases() -> list[Case]:
-    """Matmul fused with a residual add: ``X @ W + R``.
-
-    Mirrors the ``k_add_*_reduce`` kernels Deplodock emits for o_proj
-    and down_proj where the residual add gets fused into the matmul
-    epilogue.
-    """
+    """Kernels 8 / 11 — o_proj+residual and down_proj+residual. Both
+    fuse the residual add into the matmul epilogue."""
     cases: list[Case] = []
-    for tag, hidden, inter in [("tinyllama", _TL_H, _TL_I), ("qwen", _Q_H, _Q_I)]:
-        for s in _SEQ_LENS:
-            for proj, k_in in [("o_proj", hidden), ("down_proj", inter)]:
-                cases.append(
-                    Case(
-                        name=f"matmul_add.{tag}.{proj}.s{s}",
-                        op="matmul_add",
-                        shapes=((1, s, k_in), (k_in, hidden), (1, s, hidden)),
-                        tags=(tag, "matmul_add", proj),
-                    )
-                )
-    return cases
-
-
-def _naive_attn_cases() -> list[Case]:
-    """Block-style naive attention (Q @ K.T scaled + mask → softmax →
-    @ V), separate from the ``F.scaled_dot_product_attention`` cases.
-
-    Distinct kernel path: HF's ``NaiveSDPA`` (used by ``bench_block``)
-    decomposes attention into the explicit qk-matmul + scale + mask +
-    softmax + av-matmul chain. Tracing this chain through deplodock
-    produces the ``k_scaled_dot_product_attention_qk_ew_pointwise``
-    kernel — a matmul-with-pointwise-epilogue. A previous iteration of
-    the loop-fusion guard made this kernel 13× slower in the block
-    bench (0.05× of eager); the standalone ``F.sdpa`` cases didn't
-    catch it because ``F.sdpa`` traces to ``SdpaOp`` and a different
-    decomposition. These cases pin the naive path so any regression
-    surfaces in ``make bench-kernels``.
-
-    Heads kept equal across Q/K/V (no GQA expansion via
-    ``repeat_interleave``, which doesn't trace cleanly through
-    deplodock today). The kernel shape and fusion pattern are the
-    same; only the multi-head broadcast differs.
-    """
-    cases: list[Case] = []
-    for tag, heads, dh in [("tinyllama", _TL_HEADS, _TL_DH), ("qwen", _Q_HEADS, _Q_DH)]:
-        for s in _SEQ_LENS:
+    for s in _SEQ_LENS:
+        for proj, k_in in [("o_proj", _Q_DIM), ("down_proj", _I)]:
             cases.append(
                 Case(
-                    name=f"naive_attn.{tag}.s{s}",
-                    op="naive_attn",
-                    shapes=((1, heads, s, dh), (1, heads, s, dh), (1, heads, s, dh)),
-                    tags=(tag, "naive_attn", "attn"),
+                    name=f"matmul_add.{_TAG}.{proj}.s{s}",
+                    op="matmul_add",
+                    shapes=((1, s, k_in), (k_in, _H), (1, s, _H)),
+                    tags=(_TAG, "matmul_add", proj),
                 )
             )
     return cases
 
 
-def _silu_mul_matmul_cases() -> list[Case]:
-    """SiLU-gated MLP fused with down_proj: ``(silu(gate) * up) @ W_down``.
-
-    Mirrors the dominant ``k_mul_*_reduce`` kernel — the elementwise
-    SiLU+multiply gets fused into the down_proj matmul reduction.
-    """
+def _gated_mlp_cases() -> list[Case]:
+    """Kernel 10 — ``silu(x @ Wgate) * (x @ Wup)`` collapses into a
+    single launch with two reductions over hidden_size sharing the same
+    free axes. This is the dominant MLP-side kernel; do not confuse it
+    with the older ``silu_mul_matmul`` variant (`(silu(g)*u) @ Wdown`)
+    that does not appear in the Qwen3 layer."""
     cases: list[Case] = []
-    for tag, hidden, inter in [("tinyllama", _TL_H, _TL_I), ("qwen", _Q_H, _Q_I)]:
-        for s in _SEQ_LENS:
-            cases.append(
-                Case(
-                    name=f"silu_mul_matmul.{tag}.s{s}",
-                    op="silu_mul_matmul",
-                    shapes=((1, s, inter), (1, s, inter), (inter, hidden)),
-                    tags=(tag, "silu_mul_matmul", "mlp", "down_proj"),
-                )
+    for s in _SEQ_LENS:
+        cases.append(
+            Case(
+                name=f"gated_mlp.{_TAG}.s{s}",
+                op="gated_mlp",
+                shapes=((1, s, _H), (_H, _I), (_H, _I)),
+                tags=(_TAG, "gated_mlp", "mlp"),
             )
+        )
     return cases
 
 
-PRIMITIVE_CASES: list[Case] = _matmul_cases() + _rmsnorm_cases() + _softmax_cases() + _silu_mul_cases()
-FUSED_CASES: list[Case] = _sdpa_cases() + _naive_attn_cases() + _matmul_add_cases() + _silu_mul_matmul_cases()
+# Primitive vs fused split: ``PRIMITIVE_CASES`` covers single-frontend-op
+# kernels (matmul, rmsnorm); ``FUSED_CASES`` covers kernels that fuse
+# multiple frontend ops into one launch (sdpa, matmul_add, gated_mlp).
+PRIMITIVE_CASES: list[Case] = _rmsnorm_layer_cases() + _rmsnorm_qknorm_cases() + _matmul_proj_cases()
+FUSED_CASES: list[Case] = _sdpa_cases() + _matmul_add_cases() + _gated_mlp_cases()
 CASES: list[Case] = PRIMITIVE_CASES + FUSED_CASES
 
 
@@ -333,15 +261,6 @@ def build_torch_ref(case: Case) -> Callable[[], None]:
         normalized_shape = case.shapes[1]
         return lambda: F.rms_norm(x, normalized_shape, w, eps=1e-6)
 
-    if case.op == "softmax":
-        x = _r(case.shapes[0])
-        return lambda: F.softmax(x, dim=-1)
-
-    if case.op == "silu_mul":
-        gate = _r(case.shapes[0])
-        up = _r(case.shapes[1])
-        return lambda: F.silu(gate) * up
-
     if case.op == "sdpa":
         q = _r(case.shapes[0])
         k = _r(case.shapes[1])
@@ -349,29 +268,17 @@ def build_torch_ref(case: Case) -> Callable[[], None]:
         # GQA expansion handled by SDPA when enable_gqa=True (PyTorch ≥ 2.5).
         return lambda: F.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa=q.shape[-3] != k.shape[-3])
 
-    if case.op == "naive_attn":
-        import math
-
-        q = _r(case.shapes[0])
-        k = _r(case.shapes[1])
-        v = _r(case.shapes[2])
-        seq = q.shape[-2]
-        dh = q.shape[-1]
-        mask = torch.full((seq, seq), -1e9, device=device, dtype=dtype).triu(1)
-        scale = 1.0 / math.sqrt(dh)
-        return lambda: F.softmax(q @ k.transpose(-2, -1) * scale + mask, dim=-1) @ v
-
     if case.op == "matmul_add":
         x = _r(case.shapes[0])
         w = _r(case.shapes[1])
         r = _r(case.shapes[2])
         return lambda: torch.matmul(x, w) + r
 
-    if case.op == "silu_mul_matmul":
-        gate = _r(case.shapes[0])
-        up = _r(case.shapes[1])
-        w = _r(case.shapes[2])
-        return lambda: torch.matmul(F.silu(gate) * up, w)
+    if case.op == "gated_mlp":
+        x = _r(case.shapes[0])
+        wg = _r(case.shapes[1])
+        wu = _r(case.shapes[2])
+        return lambda: F.silu(torch.matmul(x, wg)) * torch.matmul(x, wu)
 
     raise ValueError(f"unknown op: {case.op}")
 
@@ -386,7 +293,7 @@ def build_deplodock_graph(case: Case):
     compiler decomposes/fuses on its own."""
     from deplodock.compiler.graph import Graph, Tensor
     from deplodock.compiler.ir.base import InputOp
-    from deplodock.compiler.ir.frontend.ir import MatmulOp, RmsNormOp, SdpaOp, SoftmaxOp
+    from deplodock.compiler.ir.frontend.ir import MatmulOp, RmsNormOp, SdpaOp
     from deplodock.compiler.ir.tensor.ir import ElementwiseOp
 
     g = Graph()
@@ -407,24 +314,6 @@ def build_deplodock_graph(case: Case):
         g.add_node(InputOp(), [], Tensor("w", w_shape), node_id="w")
         g.add_node(RmsNormOp(eps=1e-6), ["x", "w"], Tensor("y", x_shape), node_id="y")
         g.inputs = ["x", "w"]
-        g.outputs = ["y"]
-        return g
-
-    if case.op == "softmax":
-        (x_shape,) = case.shapes
-        g.add_node(InputOp(), [], Tensor("x", x_shape), node_id="x")
-        g.add_node(SoftmaxOp(axis=-1), ["x"], Tensor("y", x_shape), node_id="y")
-        g.inputs = ["x"]
-        g.outputs = ["y"]
-        return g
-
-    if case.op == "silu_mul":
-        gate_shape, up_shape = case.shapes
-        g.add_node(InputOp(), [], Tensor("gate", gate_shape), node_id="gate")
-        g.add_node(InputOp(), [], Tensor("up", up_shape), node_id="up")
-        g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("s", gate_shape), node_id="s")
-        g.add_node(ElementwiseOp("multiply"), ["s", "up"], Tensor("y", gate_shape), node_id="y")
-        g.inputs = ["gate", "up"]
         g.outputs = ["y"]
         return g
 
@@ -451,16 +340,17 @@ def build_deplodock_graph(case: Case):
         g.outputs = ["y"]
         return g
 
-    if case.op == "silu_mul_matmul":
-        gate_shape, up_shape, w_shape = case.shapes
-        mm_shape = tuple(gate_shape[:-1]) + (w_shape[-1],)
-        g.add_node(InputOp(), [], Tensor("gate", gate_shape), node_id="gate")
-        g.add_node(InputOp(), [], Tensor("up", up_shape), node_id="up")
-        g.add_node(InputOp(), [], Tensor("w", w_shape), node_id="w")
-        g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("s", gate_shape), node_id="s")
-        g.add_node(ElementwiseOp("multiply"), ["s", "up"], Tensor("p", gate_shape), node_id="p")
-        g.add_node(MatmulOp(), ["p", "w"], Tensor("y", mm_shape), node_id="y")
-        g.inputs = ["gate", "up", "w"]
+    if case.op == "gated_mlp":
+        x_shape, wg_shape, wu_shape = case.shapes
+        mm_shape = tuple(x_shape[:-1]) + (wg_shape[-1],)
+        g.add_node(InputOp(), [], Tensor("x", x_shape), node_id="x")
+        g.add_node(InputOp(), [], Tensor("wg", wg_shape), node_id="wg")
+        g.add_node(InputOp(), [], Tensor("wu", wu_shape), node_id="wu")
+        g.add_node(MatmulOp(), ["x", "wg"], Tensor("mg", mm_shape), node_id="mg")
+        g.add_node(MatmulOp(), ["x", "wu"], Tensor("mu", mm_shape), node_id="mu")
+        g.add_node(ElementwiseOp("silu"), ["mg"], Tensor("sg", mm_shape), node_id="sg")
+        g.add_node(ElementwiseOp("multiply"), ["sg", "mu"], Tensor("y", mm_shape), node_id="y")
+        g.inputs = ["x", "wg", "wu"]
         g.outputs = ["y"]
         return g
 


### PR DESCRIPTION
## Summary

Two related changes on this branch:

**1. Replace the perf suite with kernels from Qwen3-Embedding-0.6B (commit 133c704e).**
The case list mirrors the 12 fused launches emitted by `deplodock compile Qwen/Qwen3-Embedding-0.6B --layer 0`, so the suite is a kernel-by-kernel view of what the compiler actually runs at the model level. Drops the TinyLlama/Qwen2.5-7B legacy cases and the ops that don't appear in a Qwen3 layer (`softmax`, `silu_mul`, `naive_attn`, `silu_mul_matmul`). Adds a `gated_mlp` op for kernel 10 (`silu(x@Wg) * (x@Wu)` fused into one launch).

**2. Merge sibling reduce-loops in `normalize_body` (commit 84d0cc89).**
The gated-MLP kernel emitted two separate K-loops — one for the gate matmul, one for the up matmul — even though both reduce over the same hidden dim and share `x` as a Load source. Two changes to `ir/stmt/normalize.py`:

- `unify_sibling_reduce_axes` now groups sibling reduce-loops by *any* shared `(Load.source, dim)` overlap (union-find), not exact-set equality. The two matmul siblings unify on the shared x position even though they bring in distinct weight tensors.
- New `merge_sibling_reduce_loops` concatenates sibling reduce-loops with matching `axis.name`/`extent` into one Loop. Gated on disjoint SSA defs, no read of the first body's defs from the second (preserves softmax-style sequential reduces where sum-exp reads `acc_max`), and no between-stmt def consumed by the second loop.

After merge, downstream `dedup_loads` collapses the duplicate `x` loads and the staging/TMA/double-buffer passes apply symmetrically to both weight tensors.

## Perf (gated_mlp.qwen3emb, default knobs, RTX 5090, FP32)

| case | before | after |
|---|---|---|
| s32  | 0.09× | **0.48×** |
| s128 | 0.36× | **0.98×** |
| s512 | 0.63× | **1.00×** (cuBLAS parity) |

## Test plan

- [x] `make lint`
- [x] `make test` (full compiler suite, 609 tests) — all pass
- [x] 11 new tests in `tests/compiler/ir/stmt/test_merge_sibling_reduce_loops.py` — all pass
- [x] `pytest tests/perf/ -m perf -k gated_mlp` — three seq lens pass, ratios as above
- [x] Loop-IR dump shows one K-loop with both Accums and one `x` Load

🤖 Generated with [Claude Code](https://claude.com/claude-code)