### PR TITLE
Add restart: unless-stopped to compose template

### DIFF
--- a/deplodock/deploy/compose.py
+++ b/deplodock/deploy/compose.py
@@ -97,7 +97,8 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
     ports:
       - "{port}:8000"
     shm_size: '16gb'
-    ipc: host{docker_options_lines}
+    ipc: host
+    restart: unless-stopped{docker_options_lines}
     command: >
       {command_str}
     healthcheck:
@@ -118,6 +119,7 @@ def generate_compose(recipe: Recipe, model_dir, hf_token, num_instances=1, gpu_d
       - "8080:8080"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    restart: unless-stopped
     depends_on:
 {depends}
 """

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -228,7 +228,9 @@ engine:
 
 Each key-value pair is rendered as a top-level service key in the generated Docker Compose file, inserted after `ipc: host` and before `command:`. Values are serialized via `yaml.dump()` to handle nested structures (lists, dicts, scalars) correctly.
 
-Keys managed by the compose template (`image`, `container_name`, `entrypoint`, `deploy`, `devices`, `group_add`, `volumes`, `environment`, `ports`, `shm_size`, `ipc`, `command`, `healthcheck`) are rejected at validation time via `validate_docker_options()`, following the same pattern as `validate_extra_args()`.
+Keys managed by the compose template (`image`, `container_name`, `entrypoint`, `deploy`, `devices`, `group_add`, `volumes`, `environment`, `ports`, `shm_size`, `ipc`, `command`, `healthcheck`, `restart`) are rejected at validation time via `validate_docker_options()`, following the same pattern as `validate_extra_args()`.
+
+The compose template hard-codes `restart: unless-stopped` on every engine service (and the nginx load balancer in multi-instance deployments). Containers therefore come back automatically after a host reboot or after a process crash, but a manual `docker stop` / `docker compose down` is still honored — which is what the bench teardown path relies on.
 
 Matrix overrides work naturally via deep merge:
 ```yaml

--- a/deplodock/recipe/recipe.py
+++ b/deplodock/recipe/recipe.py
@@ -71,6 +71,7 @@ _MANAGED_COMPOSE_KEYS = frozenset(
         "ipc",
         "command",
         "healthcheck",
+        "restart",
     }
 )
 

--- a/tests/deploy/test_compose.py
+++ b/tests/deploy/test_compose.py
@@ -275,3 +275,20 @@ def test_compose_docker_options_nested_values(sample_config):
     parsed = yaml.safe_load(result)
     svc = parsed["services"]["vllm_0"]
     assert svc["ulimits"] == {"memlock": {"soft": -1, "hard": -1}}
+
+
+# ── restart policy ────────────────────────────────────────────────
+
+
+def test_compose_restart_policy_on_engine_service(sample_config):
+    recipe = Recipe.from_dict(sample_config)
+    result = generate_compose(recipe, "/mnt/models", "token", num_instances=1)
+    parsed = yaml.safe_load(result)
+    assert parsed["services"]["vllm_0"]["restart"] == "unless-stopped"
+
+
+def test_compose_restart_policy_on_nginx_service(sample_config_multi):
+    recipe = Recipe.from_dict(sample_config_multi)
+    result = generate_compose(recipe, "/mnt/models", "token", num_instances=2)
+    parsed = yaml.safe_load(result)
+    assert parsed["services"]["nginx"]["restart"] == "unless-stopped"


### PR DESCRIPTION
Containers now auto-recover after host reboots and process crashes while still honoring manual `docker compose down` (bench teardown). Adds `restart` to the managed-keys set so `docker_options` can't override it.