### PR TITLE
Dim carries an Expr — unify static and symbolic shape arithmetic

### DIFF
--- a/deplodock/compiler/ARCHITECTURE.md
+++ b/deplodock/compiler/ARCHITECTURE.md
@@ -54,7 +54,7 @@ autotuning cache doesn't bust on cosmetic edits.
 | Path                  | Role                                    | See                          |
 |-----------------------|-----------------------------------------|------------------------------|
 | `graph.py`            | `Graph`, `Node`, `Tensor`, `Hints`      | —                            |
-| `dim.py`              | `Dim` — static-or-symbolic axis extent  | —                            |
+| `dim.py`              | `Dim` — shape extent backed by an `Expr` (static or symbolic) | —    |
 | `ir/`                 | Op-type definitions per dialect         | `ir/ARCHITECTURE.md`         |
 | `trace/`              | PyTorch/HuggingFace → Graph IR          | `trace/ARCHITECTURE.md`      |
 | `pipeline/`           | Rewrite engine, passes, dump hooks      | `pipeline/ARCHITECTURE.md`   |
@@ -75,10 +75,17 @@ autotuning cache doesn't bust on cosmetic edits.
 ## Shared invariants
 
 - **Shape lives on the graph**, not on the op — `node.output.shape`. Each shape element is a `Dim`
-  (`compiler/dim.py`): static (`Dim(32)`) today, symbolic (`Dim("seq_len")`) once dynamic-shapes lands. Read sites use
-  `d.value` (always works) or `d.as_static()` (raises on symbolic); there is deliberately no `__int__` / `__index__`,
-  so `int(d)` and `range(d)` fail loudly when fed a symbolic dim. `Tensor.__post_init__` and `Axis.__post_init__`
-  coerce bare `int` / `str` to `Dim`, so producer call sites need no change.
+  (`compiler/dim.py`) that wraps an `Expr` from `ir/expr.py`: static (`Dim(32)` → `Literal(32)`), atomic
+  symbolic (`Dim("seq_len")` → `Var("seq_len")`), or composite from arithmetic (`Dim("S") * Dim(2)` →
+  `BinaryExpr("*", Var("S"), Literal(2))`). `Dim` overloads `+`/`-`/`*`/`//`/`%` and eager-folds via
+  `Expr.simplify` — static math matches plain int math byte-for-byte; symbolic stays as `BinaryExpr`.
+  Read sites use `d.expr` (always works), `d.as_static()` (raises on symbolic), `d.as_atom_name()` (raises
+  unless `Var`-backed), or `d.value` (back-compat shim: int for `Literal`, str for `Var`, raises on
+  composite). There is deliberately no `__int__` / `__index__`, so `int(d)` and `range(d)` fail loudly
+  on anything but a static-int `Dim`. Symbolic dims resolve at launch via `d.expr.eval(sym_env)` —
+  composite shapes (e.g. an `S * 2` concat output) resolve from input array axes without per-site
+  branching. `Tensor.__post_init__` and `Axis.__post_init__` coerce bare `int` / `str` to `Dim`, so
+  producer call sites need no change.
 - **`ElementwiseOp` inputs must already share the output shape.** The
   decomposition helper
   `pipeline/passes/frontend/decomposition/_broadcast.broadcast_to` wraps

--- a/deplodock/compiler/backend/cuda/backend.py
+++ b/deplodock/compiler/backend/cuda/backend.py
@@ -134,16 +134,24 @@ class CudaBackend(Backend):
             result, pre_result = run_program(compiled, input_data=input_data, pre_run=pre_run)
             result_outputs = result.outputs
             time_ms = result.time_ms
-        # Symbolic output shapes (Dim("seq_len")) bind from the supplied input
-        # array shapes via the same per-buffer mapping the launch resolver uses.
+        # Symbolic output shapes bind from the supplied input array shapes:
+        # walk each input dim's expr.free_vars() and record where each name
+        # came from. Output dims (possibly composite Dim exprs) then resolve
+        # via ``expr.eval(sym_env)`` — one path covers Literal / Var /
+        # BinaryExpr uniformly.
+        from deplodock.compiler.ir.expr import Var  # noqa: PLC0415
+
         sym_env: dict[str, int] = {}
-        for nid in compiled.inputs:
-            for d, dim in enumerate(compiled.nodes[nid].output.shape):
-                if not dim.is_static and input_data is not None and nid in input_data:
-                    sym_env.setdefault(dim.value, int(input_data[nid].shape[d]))
+        if input_data is not None:
+            for nid in compiled.inputs:
+                if nid not in input_data:
+                    continue
+                for d, dim in enumerate(compiled.nodes[nid].output.shape):
+                    if isinstance(dim.expr, Var):
+                        sym_env.setdefault(dim.expr.name, int(input_data[nid].shape[d]))
         outputs: dict[str, np.ndarray] = {}
         for name, vals in result_outputs.items():
-            shape = tuple(d.as_static() if d.is_static else sym_env[d.value] for d in compiled.nodes[name].output.shape)
+            shape = tuple(int(d.expr.eval(sym_env)) for d in compiled.nodes[name].output.shape)
             outputs[name] = np.asarray(vals, dtype=compiled.nodes[name].output.dtype.np).reshape(shape)
         return RunResult(outputs=outputs, time_ms=time_ms), pre_result
 

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -28,6 +28,7 @@ import numpy as np
 from deplodock.compiler.backend import BenchmarkResult, LaunchTime, RunResult
 from deplodock.compiler.backend.cuda import _tma
 from deplodock.compiler.backend.cuda.dtype import cupy_dtype
+from deplodock.compiler.dim import Dim
 from deplodock.compiler.dtype import DataType
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.base import ConstantOp, InputOp
@@ -65,19 +66,20 @@ def _ensure_dynamic_smem_attr(kernel: cp.RawKernel, smem_bytes: int) -> None:
 @dataclass
 class _Buffer:
     name: str
-    # Shape factors are ``int`` (static) or ``str`` (symbolic axis name).
-    # Static-only kernels collapse to ``tuple[int, ...]``; symbolic dims
-    # are resolved at ``_allocate`` time from input array shapes.
-    shape: tuple
+    # ``Dim``-valued shape. Static dims carry a ``Literal`` expr, atomic
+    # symbolic carry a ``Var``, composite (e.g. ``S * 2`` from a reshape
+    # or cat) carry a ``BinaryExpr``. ``resolve_shape`` calls ``expr.eval``
+    # to turn any of those into a runtime int.
+    shape: tuple[Dim, ...]
     dtype: DataType
     role: str  # "input" | "constant" | "output" | "scratch"
 
     @property
     def is_symbolic(self) -> bool:
-        return any(isinstance(d, str) for d in self.shape)
+        return any(not d.is_static for d in self.shape)
 
     def resolve_shape(self, sym_values: dict[str, int]) -> tuple[int, ...]:
-        return tuple(d if isinstance(d, int) else sym_values[d] for d in self.shape)
+        return tuple(int(d.expr.eval(sym_values)) for d in self.shape)
 
 
 def _buffers(graph: Graph) -> list[_Buffer]:
@@ -93,11 +95,7 @@ def _buffers(graph: Graph) -> list[_Buffer]:
             role = "output"
         else:
             role = "scratch"
-        # ``Dim.value`` is ``int`` for static, ``str`` for symbolic — keep
-        # symbolic as the bare name so ``_allocate`` can resolve at launch
-        # time. Fully-static graphs collapse to ``tuple[int, ...]``.
-        shape = tuple(d.value for d in node.output.shape)
-        bufs.append(_Buffer(name=nid, shape=shape, dtype=node.output.dtype, role=role))
+        bufs.append(_Buffer(name=nid, shape=tuple(node.output.shape), dtype=node.output.dtype, role=role))
     return bufs
 
 

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -204,12 +204,25 @@ def _symbolic_bindings(graph: Graph) -> dict[str, tuple[str, int]]:
     """Walk graph inputs to map every symbolic dim name to its source
     ``(input_buf, dim_index)`` — the launch resolver reads the runtime
     value from ``input_arrays[buf].shape[dim_index]``. First-seen position
-    wins on conflicts so each name resolves deterministically."""
+    wins on conflicts so each name resolves deterministically.
+
+    Input dims are atomic ``Var``-backed when symbolic (composite Dim exprs
+    appear only on derived tensors). We collect via ``expr.free_vars()`` so
+    each free name binds to the first input axis where it appears."""
+    from deplodock.compiler.ir.expr import Var  # noqa: PLC0415
+
     bindings: dict[str, tuple[str, int]] = {}
     for nid in graph.inputs:
         for d, dim in enumerate(graph.nodes[nid].output.shape):
-            if not dim.is_static:
-                bindings.setdefault(dim.value, (nid, d))
+            if dim.is_static:
+                continue
+            if not isinstance(dim.expr, Var):
+                raise ValueError(
+                    f"input {nid!r} axis {d} has a composite symbolic dim {dim!r}; "
+                    "inputs must carry atomic Var-backed symbolic dims so the launch "
+                    "resolver can recover each name from a single shape axis"
+                )
+            bindings.setdefault(dim.expr.name, (nid, d))
     return bindings
 
 

--- a/deplodock/compiler/dim.py
+++ b/deplodock/compiler/dim.py
@@ -1,73 +1,182 @@
-"""``Dim`` — one tensor / axis extent.
+"""``Dim`` — one tensor / axis extent, backed by an ``Expr``.
 
-Static (``Dim(32)``) or symbolic (``Dim("seq_len")``). Symbolic values
-resolve to an ``int`` only at runtime, from the actual input shapes.
+Every Dim carries a shape expression:
+
+- ``Dim(32)`` wraps ``Literal(32, "int")`` — a static extent.
+- ``Dim("seq_len")`` wraps ``Var("seq_len")`` — an atomic symbolic extent.
+- ``Dim(seq) * Dim(2)`` wraps ``BinaryExpr("*", Var("seq"), Literal(2))`` —
+  a composite symbolic extent. Operators on Dim dispatch to ``Expr`` and
+  eagerly fold via ``Expr.simplify``: ``Dim(32) * Dim(64) → Dim(Literal(2048))``,
+  ``Dim("s") * Dim(1) → Dim(Var("s"))``.
 
 Reads:
 
-- ``d.value`` always works — returns the underlying ``int | str``.
-- ``d.as_static()`` returns the int, or raises if the dim is symbolic.
-- ``d == 32`` / ``d == "seq_len"`` works for migration ergonomics.
+- ``d.expr`` always works — returns the underlying ``Expr``.
+- ``d.as_static()`` returns the int for ``Literal``-backed dims, raises otherwise.
+- ``d.value`` returns the int (``Literal``) or the name (``Var``); raises on
+  composite. Kept for back-compat with existing call sites that key on the
+  symbolic name string (e.g. launch-time ``sym_env`` dicts).
+- ``d == 32`` / ``d == "seq_len"`` / ``d == Dim(...)`` all work — the first
+  two unwrap to ``Literal.value`` / ``Var.name``; composite dims only compare
+  structurally to other Dims.
 
-No ``__int__`` / ``__index__``: ``int(d)`` and ``range(d)`` deliberately
-fail. Sites that need a static int must say so via ``.as_static()`` —
-that way introducing a symbolic dim later breaks loudly at the sites
-that can't yet handle it, rather than silently casting through.
+No ``__int__`` / ``__index__``: ``int(d)`` and ``range(d)`` deliberately fail.
+Sites that need a static int must say so via ``.as_static()`` — that way
+introducing a symbolic dim later breaks loudly at the sites that can't yet
+handle it, rather than silently casting through.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from deplodock.compiler.ir.expr import BinaryExpr, Expr, Literal, SimplifyCtx, Var
 
-@dataclass(frozen=True, eq=False)
+
+def _coerce_expr(value: int | str | Expr | Dim) -> Expr:
+    """Coerce a Dim constructor argument to an ``Expr``.
+
+    - bare ``int`` → ``Literal(value, "int")``
+    - bare ``str`` → ``Var(value)``
+    - ``Expr``     → passed through
+    - ``Dim``      → unwrapped to its ``expr``
+    """
+    if isinstance(value, Dim):
+        return value.expr
+    if isinstance(value, int):
+        return Literal(value, "int")
+    if isinstance(value, str):
+        return Var(value)
+    # Expr is a Union — check by membership in the known node classes
+    # via duck-typing on the AST API (``eval`` is on every concrete Expr).
+    if hasattr(value, "eval") and hasattr(value, "substitute"):
+        return value
+    raise TypeError(f"Dim: cannot wrap {type(value).__name__}: {value!r}")
+
+
+def _simplify(expr: Expr) -> Expr:
+    return expr.simplify(SimplifyCtx.empty())
+
+
+@dataclass(frozen=True, init=False, eq=False)
 class Dim:
-    value: int | str
+    expr: Expr
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.value, (int, str)):
-            raise TypeError(f"Dim.value must be int or str, got {type(self.value).__name__}: {self.value!r}")
+    def __init__(self, value: int | str | Expr | Dim) -> None:
+        # ``frozen=True`` blocks normal assignment; route through object.__setattr__.
+        object.__setattr__(self, "expr", _coerce_expr(value))
+
+    # ---- inspection ------------------------------------------------------
 
     @property
     def is_static(self) -> bool:
-        return isinstance(self.value, int)
+        return isinstance(self.expr, Literal) and isinstance(self.expr.value, int)
 
     def as_static(self) -> int:
-        if not isinstance(self.value, int):
-            raise TypeError(f"Dim({self.value!r}) is symbolic — cannot resolve to int statically")
-        return self.value
+        if not (isinstance(self.expr, Literal) and isinstance(self.expr.value, int)):
+            raise TypeError(f"Dim({self.expr!r}) is not a static int — cannot resolve to int statically")
+        return self.expr.value
+
+    @property
+    def value(self) -> int | str:
+        """Back-compat shim: ``Literal.value`` for static, ``Var.name`` for atomic
+        symbolic. Raises on composite. Prefer ``.expr`` at new call sites."""
+        if isinstance(self.expr, Literal) and isinstance(self.expr.value, int):
+            return self.expr.value
+        if isinstance(self.expr, Var):
+            return self.expr.name
+        raise TypeError(f"Dim({self.expr!r}).value: composite dim has no scalar value; use .expr")
+
+    # ---- arithmetic — eager-fold via Expr.simplify -----------------------
+
+    def __add__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("+", self.expr, _coerce_expr(other))))
+
+    def __radd__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("+", _coerce_expr(other), self.expr)))
+
+    def __sub__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("-", self.expr, _coerce_expr(other))))
+
+    def __rsub__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("-", _coerce_expr(other), self.expr)))
+
+    def __mul__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("*", self.expr, _coerce_expr(other))))
+
+    def __rmul__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("*", _coerce_expr(other), self.expr)))
+
+    def __floordiv__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("//", self.expr, _coerce_expr(other))))
+
+    def __rfloordiv__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("//", _coerce_expr(other), self.expr)))
+
+    def __mod__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("%", self.expr, _coerce_expr(other))))
+
+    def __rmod__(self, other: int | Dim) -> Dim:
+        return Dim(_simplify(BinaryExpr("%", _coerce_expr(other), self.expr)))
+
+    # ---- equality + hashing ---------------------------------------------
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Dim):
-            return self.value == other.value
-        if isinstance(other, (int, str)):
-            return self.value == other
+            return self.expr == other.expr
+        # Back-compat ergonomics: ``Dim(32) == 32`` and ``Dim("s") == "s"``
+        # keep working so test assertions and existing pass code don't churn.
+        # Composite dims (``BinaryExpr``-backed) never compare equal to bare
+        # int/str — they only compare structurally to other Dims.
+        if isinstance(other, bool):
+            return NotImplemented
+        if isinstance(other, int):
+            return isinstance(self.expr, Literal) and self.expr.value == other
+        if isinstance(other, str):
+            return isinstance(self.expr, Var) and self.expr.name == other
         return NotImplemented
 
+    def __ne__(self, other: object) -> bool:
+        eq = self.__eq__(other)
+        if eq is NotImplemented:
+            return NotImplemented
+        return not eq
+
     def __hash__(self) -> int:
-        return hash(self.value)
+        # Hash on the canonical Expr so Dim(32) and Dim(Literal(32, "int"))
+        # hash identically. Atomic Vars and Literals are themselves frozen
+        # and hashable; composite BinaryExpr is hashable post-M0.
+        return hash(self.expr)
 
     def __repr__(self) -> str:
-        return f"Dim({self.value!r})"
+        if isinstance(self.expr, Literal) and isinstance(self.expr.value, int):
+            return f"Dim({self.expr.value!r})"
+        if isinstance(self.expr, Var):
+            return f"Dim({self.expr.name!r})"
+        return f"Dim({self.expr!r})"
 
     def __str__(self) -> str:
         # Used by f-strings / ``str()`` — render transparently so pretty IR
         # output (``for i in 0..32``) and ``Body.structural_key`` digests
-        # don't change shape just because the type wrapper exists. Use
-        # ``repr(d)`` (→ ``Dim(32)``) when you need the type to be visible.
-        return str(self.value)
+        # don't change shape just because the type wrapper exists.
+        if isinstance(self.expr, Literal) and isinstance(self.expr.value, int):
+            return str(self.expr.value)
+        if isinstance(self.expr, Var):
+            return self.expr.name
+        return self.expr.pretty()
 
 
-def to_dim(value: int | str | Dim) -> Dim:
-    """Coerce ``int`` / ``str`` to ``Dim``; pass ``Dim`` through unchanged."""
+def to_dim(value: int | str | Dim | Expr) -> Dim:
+    """Coerce ``int`` / ``str`` / ``Expr`` to ``Dim``; pass ``Dim`` through unchanged."""
     return value if isinstance(value, Dim) else Dim(value)
 
 
 def as_static(d: object) -> int:
-    """Coerce a shape element (``Dim``, ``int``, or ``str``) to a static
-    int. Use at boundaries where the upstream type isn't yet uniformly
-    ``Dim`` — e.g. ``infer_output_shape`` returns that mix ints/strings
-    from constructor args with ``Dim`` from another Tensor's shape.
+    """Coerce a shape element (``Dim``, ``int``, or ``str``) to a static int.
+
+    Use at boundaries where the upstream type isn't yet uniformly ``Dim`` —
+    e.g. ``infer_output_shape`` returns that mix ints/strings from constructor
+    args with ``Dim`` from another Tensor's shape.
 
     Raises if ``d`` is symbolic (``Dim('seq_len')`` or ``str``)."""
     if isinstance(d, Dim):

--- a/deplodock/compiler/dim.py
+++ b/deplodock/compiler/dim.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from deplodock.compiler.ir.expr import BinaryExpr, Expr, Literal, SimplifyCtx, Var
+from deplodock.compiler.ir.expr import BinaryExpr, Expr, Interval, Literal, SimplifyCtx, Var
 
 
 def _coerce_expr(value: int | str | Expr | Dim) -> Expr:
@@ -55,7 +55,13 @@ def _coerce_expr(value: int | str | Expr | Dim) -> Expr:
 
 
 def _simplify(expr: Expr) -> Expr:
-    return expr.simplify(SimplifyCtx.empty())
+    # Shape vars (every free ``Var`` in a Dim expression) are positive by
+    # definition: a tensor extent can't be zero or negative. Expose that
+    # via ``SimplifyCtx.ranges`` so the simplifier's ``//`` cancellation
+    # path can safely cancel matching factors (otherwise ``(s*128) // (s*4)``
+    # has no way to reduce to ``32``).
+    ranges = {name: Interval(1, 1 << 30) for name in expr.free_vars()}
+    return expr.simplify(SimplifyCtx(ranges))
 
 
 @dataclass(frozen=True, init=False, eq=False)

--- a/deplodock/compiler/dim.py
+++ b/deplodock/compiler/dim.py
@@ -93,6 +93,15 @@ class Dim:
             return self.expr.name
         raise TypeError(f"Dim({self.expr!r}).value: composite dim has no scalar value; use .expr")
 
+    def as_atom_name(self) -> str:
+        """Return the symbolic name when this Dim is a single ``Var``; raise
+        otherwise. Use at sites that route by symbolic name — kernel signature
+        params, structural-key entries, runtime ``sym_env`` lookups — and
+        want to fail loud if a static or composite Dim slips in."""
+        if isinstance(self.expr, Var):
+            return self.expr.name
+        raise TypeError(f"Dim({self.expr!r}).as_atom_name: dim is not an atomic Var")
+
     # ---- arithmetic — eager-fold via Expr.simplify -----------------------
 
     def __add__(self, other: int | Dim) -> Dim:

--- a/deplodock/compiler/dim.py
+++ b/deplodock/compiler/dim.py
@@ -13,12 +13,21 @@ Reads:
 
 - ``d.expr`` always works — returns the underlying ``Expr``.
 - ``d.as_static()`` returns the int for ``Literal``-backed dims, raises otherwise.
+- ``d.as_atom_name()`` returns the str name for ``Var``-backed dims, raises otherwise.
+  Use at sites that route by symbolic name (kernel param signature, sym_env keys).
 - ``d.value`` returns the int (``Literal``) or the name (``Var``); raises on
-  composite. Kept for back-compat with existing call sites that key on the
-  symbolic name string (e.g. launch-time ``sym_env`` dicts).
+  composite. Back-compat shim — prefer ``.as_static()`` / ``.as_atom_name()`` / ``.expr``
+  at new call sites.
 - ``d == 32`` / ``d == "seq_len"`` / ``d == Dim(...)`` all work — the first
   two unwrap to ``Literal.value`` / ``Var.name``; composite dims only compare
   structurally to other Dims.
+
+Runtime resolution:
+
+- ``d.expr.eval(sym_env)`` gives the int extent at launch time, where
+  ``sym_env: dict[str, int]`` maps each symbolic name to its concrete value
+  (read from input array shapes). Composite Dims (e.g. ``S * 2`` from a cat
+  output) resolve uniformly with atomic ones — one path, no branch.
 
 No ``__int__`` / ``__index__``: ``int(d)`` and ``range(d)`` deliberately fail.
 Sites that need a static int must say so via ``.as_static()`` — that way

--- a/deplodock/compiler/graph.py
+++ b/deplodock/compiler/graph.py
@@ -786,6 +786,12 @@ class Graph:
                 "inputs": node.inputs,
                 "output": {
                     "name": node.output.name,
+                    # JSON dump preserves atomic Dims (int / Var name) so the
+                    # round-trip ``deplodock run --ir <json>`` flow reconstructs
+                    # them via ``Dim(value)``. Composite Dims (BinaryExpr-backed,
+                    # e.g. from a CatOp output) currently can't round-trip and
+                    # ``.value`` will raise — those graphs aren't yet a JSON
+                    # serialization target.
                     "shape": [d.value for d in node.output.shape],
                     "dtype": node.output.dtype.name,
                 },

--- a/deplodock/compiler/ir/expr.py
+++ b/deplodock/compiler/ir/expr.py
@@ -368,6 +368,9 @@ class BinaryExpr(_ExprOps):
                 decomp = _div_mod_decompose(left, right.value, ctx)
                 if decomp is not None:
                     return decomp[0]
+            cancelled = _cancel_common_factors(op, left, right, ctx)
+            if cancelled is not None:
+                return cancelled
         elif op == "%":
             if _is_one(right) or _is_zero(left):
                 return _make_int_literal(0)
@@ -375,6 +378,9 @@ class BinaryExpr(_ExprOps):
                 decomp = _div_mod_decompose(left, right.value, ctx)
                 if decomp is not None:
                     return decomp[1]
+            cancelled = _cancel_common_factors(op, left, right, ctx)
+            if cancelled is not None:
+                return cancelled
         elif op == "&&":
             if _is_truthy(left):
                 return right
@@ -687,6 +693,100 @@ def _fold_binop_literals(op: str, left: Literal, right: Literal) -> Literal:
     if isinstance(folded, int) and both_int:
         return _make_int_literal(folded)
     return Literal(float(folded), "float")
+
+
+def _multiplicative_factors(expr: Expr) -> tuple[list[Expr], int]:
+    """Flatten an ``Expr`` tree of ``*`` into ``([non-int factors], int coefficient)``.
+
+    ``(a * 4) * b`` → ``([Var('a'), Var('b')], 4)``. Used by
+    ``_cancel_common_factors`` to canonicalize both sides of ``//`` / ``%``
+    before checking for cancellation.
+    """
+    if isinstance(expr, Literal) and expr.dtype == "int" and isinstance(expr.value, int):
+        return [], expr.value
+    if isinstance(expr, BinaryExpr) and expr.op == "*":
+        lf, lk = _multiplicative_factors(expr.left)
+        rf, rk = _multiplicative_factors(expr.right)
+        return lf + rf, lk * rk
+    return [expr], 1
+
+
+def _is_positive(expr: Expr, ctx: SimplifyCtx) -> bool:
+    """Conservatively decide whether ``expr`` is provably ``>= 1``.
+
+    Used to gate factor cancellation in ``a // b → ...`` — cancelling a
+    shared factor is unsound if that factor could be zero. Shape vars are
+    flagged via ``SimplifyCtx.ranges`` by ``Dim._simplify``."""
+    if isinstance(expr, Literal) and isinstance(expr.value, int):
+        return expr.value >= 1
+    rng = expr.range(ctx)
+    return rng is not None and rng.lo >= 1
+
+
+def _rebuild_product(factors: list[Expr], k: int) -> Expr:
+    """Inverse of ``_multiplicative_factors``: reassemble into an ``Expr``."""
+    if k == 0:
+        return _make_int_literal(0)
+    if not factors:
+        return _make_int_literal(k)
+    out: Expr = factors[0]
+    for f in factors[1:]:
+        out = BinaryExpr("*", out, f)
+    if k != 1:
+        out = BinaryExpr("*", out, _make_int_literal(k))
+    return out
+
+
+def _cancel_common_factors(op: str, left: Expr, right: Expr, ctx: SimplifyCtx) -> Expr | None:
+    """Try to simplify ``left op right`` (``op in {"/", "//", "%"}``) by
+    cancelling positive multiplicative factors common to both sides.
+
+    For ``(s * 128) // (s * 4)`` with ``s >= 1`` (from ``ctx.ranges``):
+    cancels the ``s`` and gcds the integer parts → ``32``. Returns ``None``
+    when no cancellation applies, letting the caller fall through to the
+    default ``BinaryExpr(op, left, right)`` path.
+    """
+    import math  # noqa: PLC0415
+
+    L_factors, L_k = _multiplicative_factors(left)
+    R_factors, R_k = _multiplicative_factors(right)
+
+    cancelled = False
+    R_remaining = list(R_factors)
+    L_remaining: list[Expr] = []
+    for f in L_factors:
+        matched_idx = None
+        for i, rf in enumerate(R_remaining):
+            if f == rf and _is_positive(f, ctx):
+                matched_idx = i
+                break
+        if matched_idx is not None:
+            R_remaining.pop(matched_idx)
+            cancelled = True
+        else:
+            L_remaining.append(f)
+
+    if L_k > 0 and R_k > 0:
+        g = math.gcd(L_k, R_k)
+        if g > 1:
+            L_k //= g
+            R_k //= g
+            cancelled = True
+
+    if not cancelled:
+        return None
+
+    new_left = _rebuild_product(L_remaining, L_k)
+    new_right = _rebuild_product(R_remaining, R_k)
+    if op in ("/", "//"):
+        if _is_one(new_right):
+            return new_left
+        if _is_zero(new_left):
+            return _make_int_literal(0)
+    elif op == "%":
+        if _is_one(new_right) or _is_zero(new_left):
+            return _make_int_literal(0)
+    return BinaryExpr(op, new_left, new_right)
 
 
 def _div_mod_decompose(expr: Expr, n: int, ctx: SimplifyCtx) -> tuple[Expr, Expr] | None:

--- a/deplodock/compiler/ir/expr.py
+++ b/deplodock/compiler/ir/expr.py
@@ -178,7 +178,7 @@ def apply_binop(op: str, lv: object, rv: object) -> object:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class Var(_ExprOps):
     """Variable reference."""
 
@@ -213,7 +213,7 @@ class Var(_ExprOps):
         return ctx.ranges.get(self.name)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Literal(_ExprOps):
     """Numeric constant."""
 
@@ -259,7 +259,7 @@ class Literal(_ExprOps):
         return None
 
 
-@dataclass
+@dataclass(frozen=True)
 class BinaryExpr(_ExprOps):
     """Binary operation.
 
@@ -430,7 +430,7 @@ class BinaryExpr(_ExprOps):
         return None
 
 
-@dataclass
+@dataclass(frozen=True)
 class Builtin(_ExprOps):
     """GPU built-in variable (threadIdx.x, blockIdx.y, blockDim.x, etc.).
 
@@ -462,7 +462,7 @@ class Builtin(_ExprOps):
         return self
 
 
-@dataclass
+@dataclass(frozen=True)
 class FuncCallExpr(_ExprOps):
     """Intrinsic / math function call.
 
@@ -474,7 +474,7 @@ class FuncCallExpr(_ExprOps):
     """
 
     name: str
-    args: list[Expr]
+    args: tuple[Expr, ...]
 
     def eval(self, env: dict[str, object]) -> object:
         from deplodock.compiler.ir.elementwise import ElementwiseImpl
@@ -489,7 +489,7 @@ class FuncCallExpr(_ExprOps):
         return f"{self.name}({', '.join(a.pretty() for a in self.args)})"
 
     def substitute(self, mapping: dict[str, Expr]) -> Expr:
-        return FuncCallExpr(self.name, [a.substitute(mapping) for a in self.args])
+        return FuncCallExpr(self.name, tuple(a.substitute(mapping) for a in self.args))
 
     def free_vars(self) -> frozenset[str]:
         out: frozenset[str] = frozenset()
@@ -503,13 +503,13 @@ class FuncCallExpr(_ExprOps):
         return f"{spelling}({args})"
 
     def simplify(self, ctx: SimplifyCtx) -> Expr:
-        new_args = [a.simplify(ctx) for a in self.args]
+        new_args = tuple(a.simplify(ctx) for a in self.args)
         if all(x is y for x, y in zip(new_args, self.args, strict=True)):
             return self
         return FuncCallExpr(self.name, new_args)
 
 
-@dataclass
+@dataclass(frozen=True)
 class TernaryExpr(_ExprOps):
     """TernaryExpr expression: cond ? if_true : if_false.
 
@@ -555,7 +555,7 @@ class TernaryExpr(_ExprOps):
         return TernaryExpr(cond, a, b)
 
 
-@dataclass
+@dataclass(frozen=True)
 class CastExpr(_ExprOps):
     """Type cast of an inner expression to ``dtype`` (e.g. ``"int"``, ``"float"``)."""
 

--- a/deplodock/compiler/ir/frontend/ir.py
+++ b/deplodock/compiler/ir/frontend/ir.py
@@ -21,33 +21,17 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from deplodock.compiler.dim import Dim
+from deplodock.compiler.dim import Dim, to_dim
 from deplodock.compiler.ir.base import Op, _keepdim_axis
 
 
-def _static(d) -> int:
-    """Coerce a shape element (``Dim`` from Tensor.shape, or raw ``int``
-    from a numpy array) to a static int. Raises if the dim is symbolic."""
-    return d.as_static() if isinstance(d, Dim) else int(d)
-
-
-def _split_factors(shape) -> tuple[int, list[str]]:
-    """Split a shape into ``(static_product, [symbolic_names])`` — used by
-    ``ReshapeOp.infer_output_shape`` to handle ``-1`` inference in the
-    presence of symbolic dims."""
-    static = 1
-    symbolic: list[str] = []
+def _numel(shape: tuple[Dim, ...]) -> Dim:
+    """Product of a shape's extents as a single ``Dim``. Eager-fold makes the
+    all-static case match plain int arithmetic byte-for-byte."""
+    out = Dim(1)
     for d in shape:
-        if isinstance(d, Dim):
-            if d.is_static:
-                static *= d.as_static()
-            else:
-                symbolic.append(d.value)
-        elif isinstance(d, str):
-            symbolic.append(d)
-        else:
-            static *= int(d)
-    return static, symbolic
+        out = out * d
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -93,38 +77,18 @@ class ReshapeOp(Op):
 
     shape: tuple[int | str, ...]
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
         if -1 not in self.shape:
-            return tuple(self.shape)
-        # Split each side's product into static-int and symbolic-name parts so
-        # ``-1`` can be inferred even when symbolic dims appear on both sides.
-        in_static, in_sym = _split_factors(input_shapes[0])
-        known_static, known_sym = _split_factors([d for d in self.shape if d != -1])
-        # Cancel matching symbolic factors (a symbolic dim that appears on both
-        # sides drops out, e.g. ``(1, S, 2048).reshape(1, S, H, -1)`` collapses).
-        for name in list(known_sym):
-            if name in in_sym:
-                in_sym.remove(name)
-                known_sym.remove(name)
-        if known_sym:
-            raise ValueError(
-                f"reshape from {tuple(input_shapes[0])} to {self.shape} leaves unresolved symbolic "
-                f"factor(s) {known_sym} on the target side — cannot infer -1 dim"
-            )
-        if not in_sym:
-            inferred: int | str = in_static // known_static if known_static else 1
-        elif len(in_sym) == 1 and in_static == known_static:
-            inferred = in_sym[0]  # the lone symbolic factor flows straight through
-        elif len(in_sym) == 1 and known_static and in_static % known_static == 0:
-            # Symbolic times a static factor — can't represent without an Expr.
-            raise ValueError(
-                f"reshape from {tuple(input_shapes[0])} to {self.shape} would infer -1 as "
-                f"{in_sym[0]} * {in_static // known_static} — symbolic * static products aren't supported yet"
-            )
-        else:
-            raise ValueError(f"reshape from {tuple(input_shapes[0])} to {self.shape}: cannot infer -1 dim symbolically")
-        resolved = list(self.shape)
-        resolved[resolved.index(-1)] = inferred
+            return tuple(to_dim(d) for d in self.shape)
+        in_shape = tuple(to_dim(d) for d in input_shapes[0])
+        known = tuple(to_dim(d) for d in self.shape if d != -1)
+        # Inferred axis takes whatever the remaining product needs. ``Dim``
+        # arithmetic eager-folds the all-static case to a Literal int; mixed
+        # static/symbolic produces a ``BinaryExpr`` Dim that resolves at launch.
+        inferred = _numel(in_shape) // _numel(known) if known else _numel(in_shape)
+        resolved: list[Dim] = []
+        for d in self.shape:
+            resolved.append(inferred if d == -1 else to_dim(d))
         return tuple(resolved)
 
     def forward(self, *inputs):
@@ -163,25 +127,21 @@ class CatOp(Op):
     is a scalar ConstantOp indicating the concat axis.
     """
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
         # Tensor inputs are all but the trailing scalar dim-constant.
         # Find them by skipping shape-(1,) inputs at the tail.
         def _is_scalar_constant(s):
-            return len(s) == 1 and (s[0] == 1 if isinstance(s[0], (int, Dim)) else False)
+            return len(s) == 1 and s[0] == 1
 
-        tensor_shapes = [s for s in input_shapes if len(s) > 1 or (len(s) == 1 and not _is_scalar_constant(s))]
+        tensor_shapes = [tuple(to_dim(d) for d in s) for s in input_shapes if len(s) > 1 or (len(s) == 1 and not _is_scalar_constant(s))]
         if not tensor_shapes:
-            return tuple(input_shapes[0])
+            return tuple(to_dim(d) for d in input_shapes[0])
         # Cat along the last dim by default (matches CatOp tracer convention).
-        ndim = len(tensor_shapes[0])
+        last = len(tensor_shapes[0]) - 1
         out = list(tensor_shapes[0])
-        last = ndim - 1
-        total = 0
-        for s in tensor_shapes:
-            d = s[last]
-            if isinstance(d, Dim) and not d.is_static:
-                return tuple(out)  # symbolic; bail out
-            total += _static(d)
+        total = tensor_shapes[0][last]
+        for s in tensor_shapes[1:]:
+            total = total + s[last]
         out[last] = total
         return tuple(out)
 
@@ -225,10 +185,10 @@ class LinearOp(Op):
 
     has_bias: bool = False
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
-        x_shape = input_shapes[0]
-        w_shape = input_shapes[1]  # (out_features, in_features)
-        return tuple(x_shape[:-1]) + (w_shape[-2],)
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
+        x_shape = tuple(to_dim(d) for d in input_shapes[0])
+        w_shape = tuple(to_dim(d) for d in input_shapes[1])  # (out_features, in_features)
+        return x_shape[:-1] + (w_shape[-2],)
 
     def forward(self, *inputs):
         x, w = inputs[0], inputs[1]
@@ -244,11 +204,11 @@ class MatmulOp(Op):
 
     has_bias: bool = False
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
-        a_shape = input_shapes[0]
-        b_shape = input_shapes[1]
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
+        a_shape = tuple(to_dim(d) for d in input_shapes[0])
+        b_shape = tuple(to_dim(d) for d in input_shapes[1])
         # Standard matmul: A(..., M, K) @ B(..., K, N) → (..., M, N)
-        return tuple(a_shape[:-1]) + (b_shape[-1],)
+        return a_shape[:-1] + (b_shape[-1],)
 
     def forward(self, *inputs):
         a, b = inputs[0], inputs[1]

--- a/deplodock/compiler/ir/frontend/ir.py
+++ b/deplodock/compiler/ir/frontend/ir.py
@@ -21,13 +21,15 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from deplodock.compiler.dim import Dim, to_dim
+from deplodock.compiler.dim import Dim
 from deplodock.compiler.ir.base import Op, _keepdim_axis
 
 
-def _numel(shape: tuple[Dim, ...]) -> Dim:
-    """Product of a shape's extents as a single ``Dim``. Eager-fold makes the
-    all-static case match plain int arithmetic byte-for-byte."""
+def _numel(shape) -> Dim:
+    """Product of a shape's extents as a single ``Dim``. Accumulator starts
+    at ``Dim(1)`` so bare-int shape elements (from tests / loader scratch
+    shapes) are promoted to ``Dim`` on the first multiply; pure-Dim inputs
+    fold exactly via ``Expr.simplify``."""
     out = Dim(1)
     for d in shape:
         out = out * d
@@ -77,19 +79,17 @@ class ReshapeOp(Op):
 
     shape: tuple[int | str, ...]
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         if -1 not in self.shape:
-            return tuple(to_dim(d) for d in self.shape)
-        in_shape = tuple(to_dim(d) for d in input_shapes[0])
-        known = tuple(to_dim(d) for d in self.shape if d != -1)
+            return tuple(self.shape)
+        known = tuple(d for d in self.shape if d != -1)
         # Inferred axis takes whatever the remaining product needs. ``Dim``
         # arithmetic eager-folds the all-static case to a Literal int; mixed
         # static/symbolic produces a ``BinaryExpr`` Dim that resolves at launch.
-        inferred = _numel(in_shape) // _numel(known) if known else _numel(in_shape)
-        resolved: list[Dim] = []
-        for d in self.shape:
-            resolved.append(inferred if d == -1 else to_dim(d))
-        return tuple(resolved)
+        # ``_numel`` bootstraps the accumulator with ``Dim(1)``, so a raw-int
+        # input shape still yields a ``Dim`` result.
+        inferred = _numel(input_shapes[0]) // _numel(known) if known else _numel(input_shapes[0])
+        return tuple(inferred if d == -1 else d for d in self.shape)
 
     def forward(self, *inputs):
 
@@ -127,20 +127,24 @@ class CatOp(Op):
     is a scalar ConstantOp indicating the concat axis.
     """
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         # Tensor inputs are all but the trailing scalar dim-constant.
         # Find them by skipping shape-(1,) inputs at the tail.
         def _is_scalar_constant(s):
             return len(s) == 1 and s[0] == 1
 
-        tensor_shapes = [tuple(to_dim(d) for d in s) for s in input_shapes if len(s) > 1 or (len(s) == 1 and not _is_scalar_constant(s))]
+        tensor_shapes = [s for s in input_shapes if len(s) > 1 or (len(s) == 1 and not _is_scalar_constant(s))]
         if not tensor_shapes:
-            return tuple(to_dim(d) for d in input_shapes[0])
+            return tuple(input_shapes[0])
         # Cat along the last dim by default (matches CatOp tracer convention).
+        # Bootstrap ``total`` with ``Dim(0)`` so the cat-axis result is always
+        # a ``Dim`` (eager-fold collapses the static-input case to a Literal
+        # int-backed Dim). Other axes flow through as whatever the caller
+        # passed in; ``Tensor.__post_init__`` coerces on assignment.
         last = len(tensor_shapes[0]) - 1
         out = list(tensor_shapes[0])
-        total = tensor_shapes[0][last]
-        for s in tensor_shapes[1:]:
+        total: Dim = Dim(0)
+        for s in tensor_shapes:
             total = total + s[last]
         out[last] = total
         return tuple(out)
@@ -185,10 +189,10 @@ class LinearOp(Op):
 
     has_bias: bool = False
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
-        x_shape = tuple(to_dim(d) for d in input_shapes[0])
-        w_shape = tuple(to_dim(d) for d in input_shapes[1])  # (out_features, in_features)
-        return x_shape[:-1] + (w_shape[-2],)
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+        x_shape = input_shapes[0]
+        w_shape = input_shapes[1]  # (out_features, in_features)
+        return tuple(x_shape[:-1]) + (w_shape[-2],)
 
     def forward(self, *inputs):
         x, w = inputs[0], inputs[1]
@@ -204,11 +208,11 @@ class MatmulOp(Op):
 
     has_bias: bool = False
 
-    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple[Dim, ...]:
-        a_shape = tuple(to_dim(d) for d in input_shapes[0])
-        b_shape = tuple(to_dim(d) for d in input_shapes[1])
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+        a_shape = input_shapes[0]
+        b_shape = input_shapes[1]
         # Standard matmul: A(..., M, K) @ B(..., K, N) → (..., M, N)
-        return a_shape[:-1] + (b_shape[-1],)
+        return tuple(a_shape[:-1]) + (b_shape[-1],)
 
     def forward(self, *inputs):
         a, b = inputs[0], inputs[1]

--- a/deplodock/compiler/ir/stmt/base.py
+++ b/deplodock/compiler/ir/stmt/base.py
@@ -213,11 +213,11 @@ def op_to_expr(fn: str, inputs: list[Expr]) -> Expr:
     if fn in _BINARY_OP:
         return BinaryExpr(_BINARY_OP[fn], inputs[0], inputs[1])
     if fn == "maximum":
-        return FuncCallExpr("fmax", list(inputs))
+        return FuncCallExpr("fmax", tuple(inputs))
     if fn == "minimum":
-        return FuncCallExpr("fmin", list(inputs))
+        return FuncCallExpr("fmin", tuple(inputs))
     if fn == "pow":
-        return FuncCallExpr("pow", list(inputs))
+        return FuncCallExpr("pow", tuple(inputs))
     if fn == "negative":
         return BinaryExpr("-", Literal(0.0, "float"), inputs[0])
     if fn == "copy":
@@ -225,15 +225,15 @@ def op_to_expr(fn: str, inputs: list[Expr]) -> Expr:
     if fn == "reciprocal":
         return BinaryExpr("/", Literal(1.0, "float"), inputs[0])
     if fn == "relu":
-        return FuncCallExpr("fmax", [Literal(0.0, "float"), inputs[0]])
+        return FuncCallExpr("fmax", (Literal(0.0, "float"), inputs[0]))
     if fn == "sigmoid":
         neg_x = BinaryExpr("-", Literal(0.0, "float"), inputs[0])
-        exp_neg = FuncCallExpr("exp", [neg_x])
+        exp_neg = FuncCallExpr("exp", (neg_x,))
         return BinaryExpr("/", Literal(1.0, "float"), BinaryExpr("+", Literal(1.0, "float"), exp_neg))
     if fn in ("exp", "rsqrt", "tanh", "sqrt", "erf"):
-        return FuncCallExpr(fn, list(inputs))
+        return FuncCallExpr(fn, tuple(inputs))
     if fn == "abs":
-        return FuncCallExpr("fabs", list(inputs))
+        return FuncCallExpr("fabs", tuple(inputs))
     raise NotImplementedError(f"render: elementwise fn={fn!r} not supported")
 
 

--- a/deplodock/compiler/ir/stmt/base.py
+++ b/deplodock/compiler/ir/stmt/base.py
@@ -268,7 +268,7 @@ def render_index(buf: str, indices: tuple, ctx: RenderCtx) -> str:
     for d, idx in enumerate(indices):
         stride: Expr = Literal(1, "int")
         for k in range(d + 1, len(shape)):
-            stride = BinaryExpr("*", stride, _shape_dim_expr(shape[k]))
+            stride = BinaryExpr("*", stride, _to_expr(shape[k]))
         stride = stride.simplify(SimplifyCtx.empty())
         term: Expr = idx if _is_one(stride) else BinaryExpr("*", idx, stride)
         flat = term if flat is None else BinaryExpr("+", flat, term)
@@ -276,15 +276,16 @@ def render_index(buf: str, indices: tuple, ctx: RenderCtx) -> str:
     return flat.simplify(SimplifyCtx.empty()).render(ctx)
 
 
-def _shape_dim_expr(d) -> Expr:
-    """Wrap a shape element as an ``Expr``: ``Literal`` for static ``Dim`` /
-    ``int``, ``Var`` for symbolic ``Dim('name')``. The simplifier folds
-    arithmetic across the resulting tree before rendering."""
+def _to_expr(d) -> Expr:
+    """Pull the ``Expr`` out of a shape element: ``Dim`` exposes its expr
+    directly; bare ``int`` becomes ``Literal``. ``Tensor.shape`` is always
+    ``tuple[Dim, ...]``, so the ``int`` branch only catches the rare
+    bare-int shape that slipped past coercion."""
     if isinstance(d, Dim):
-        return Literal(d.value, "int") if d.is_static else Var(d.value)
+        return d.expr
     if isinstance(d, int):
         return Literal(d, "int")
-    raise TypeError(f"_shape_dim_expr: unexpected shape element {d!r}")
+    raise TypeError(f"_to_expr: unexpected shape element {d!r}")
 
 
 def _is_one(e: Expr) -> bool:

--- a/deplodock/compiler/ir/stmt/leaves.py
+++ b/deplodock/compiler/ir/stmt/leaves.py
@@ -62,7 +62,7 @@ def _promote_args_to_f32(target, args: tuple[str, ...], arg_dtypes: list[str]) -
             # returns ``"__half2float(x)"`` — we split on the open paren.
             paren = converted.index("(") if "(" in converted else -1
             if paren > 0 and converted.endswith(")"):
-                out.append(FuncCallExpr(converted[:paren], [Var(a)]))
+                out.append(FuncCallExpr(converted[:paren], (Var(a),)))
             else:
                 out.append(Var(a))
     return out

--- a/deplodock/compiler/ir/stmt/normalize.py
+++ b/deplodock/compiler/ir/stmt/normalize.py
@@ -240,15 +240,16 @@ def _unify_siblings(body: Body) -> Body:
     """
     stmts = list(body)
 
-    # Store the ``Dim.value`` (int | str) rather than ``as_static`` so symbolic
-    # sibling reduces compare cleanly: two ``Dim('seq_len')`` siblings still
-    # unify, two distinct symbolic names don't.
+    # Key on ``Dim.expr`` (the underlying ``Expr``) so structural equality on
+    # extents matches both static and symbolic siblings: two ``Dim('seq_len')``
+    # siblings unify (both back to ``Var('seq_len')``); two distinct symbolic
+    # names don't. ``Expr`` is frozen + hashable so it slots into the tuple key.
     entries: list[tuple[int, str, object, frozenset[tuple[str, int]]]] = []
     for i, s in enumerate(stmts):
         if isinstance(s, Loop) and s.is_reduce:
             positions = _reduce_axis_source_positions(s.body, s.axis.name)
             if positions:
-                entries.append((i, s.axis.name, s.axis.extent.value, frozenset(positions)))
+                entries.append((i, s.axis.name, s.axis.extent.expr, frozenset(positions)))
 
     if len(entries) < 2:
         return Body(stmts)

--- a/deplodock/compiler/pipeline/passes/frontend/decomposition/130_reshape.py
+++ b/deplodock/compiler/pipeline/passes/frontend/decomposition/130_reshape.py
@@ -41,7 +41,7 @@ def _reshape_coord_map(in_shape: tuple, out_shape: tuple):
         stride_simplified = out_stride.simplify(SimplifyCtx.empty())
         term = placeholder(d) if _is_one(stride_simplified) else BinaryExpr("*", placeholder(d), stride_simplified)
         flat = term if flat is None else BinaryExpr("+", term, flat)
-        out_stride = BinaryExpr("*", out_stride, _dim_expr(out_shape[d]))
+        out_stride = BinaryExpr("*", out_stride, _to_expr(out_shape[d]))
 
     if flat is None:
         flat = Literal(0, "int")
@@ -51,7 +51,7 @@ def _reshape_coord_map(in_shape: tuple, out_shape: tuple):
     for j in range(in_ndim - 1, -1, -1):
         stride_j = in_stride.simplify(SimplifyCtx.empty())
         coord = flat if _is_one(stride_j) else BinaryExpr("/", flat, stride_j)
-        dim_j = _dim_expr(in_shape[j])
+        dim_j = _to_expr(in_shape[j])
         if j > 0:
             coord = BinaryExpr("%", coord, dim_j)
         coords.insert(0, coord.simplify(SimplifyCtx.empty()))
@@ -60,17 +60,18 @@ def _reshape_coord_map(in_shape: tuple, out_shape: tuple):
     return tuple(coords)
 
 
-def _dim_expr(d) -> object:
-    """``Literal`` for static ``Dim`` / ``int``; ``Var`` for symbolic ``Dim('name')``
-    or bare ``str``. Mirrors ``ir/stmt/base.py:_shape_dim_expr`` for the reshape
-    coord-map's stride math."""
+def _to_expr(d) -> object:
+    """Pull the ``Expr`` out of a shape element. ``Tensor.shape`` is always
+    ``tuple[Dim, ...]`` so ``d.expr`` is the common path; bare ``int`` /
+    ``str`` only show up for the un-coerced literal-shape passed via
+    ``ReshapeOp.shape``."""
     if isinstance(d, Dim):
-        return Literal(d.value, "int") if d.is_static else Var(d.value)
+        return d.expr
     if isinstance(d, int):
         return Literal(d, "int")
     if isinstance(d, str):
         return Var(d)
-    raise TypeError(f"_dim_expr: unexpected shape element {d!r}")
+    raise TypeError(f"_to_expr: unexpected shape element {d!r}")
 
 
 def _is_one(e) -> bool:

--- a/deplodock/compiler/pipeline/passes/lowering/cuda/010_lower_kernelop.py
+++ b/deplodock/compiler/pipeline/passes/lowering/cuda/010_lower_kernelop.py
@@ -111,8 +111,9 @@ def _launch_geometry(
                 if v != 1:
                     factors.append(v)
             else:
-                seen.setdefault(a.extent.value, None)
-                factors.append(a.extent.value)
+                name = a.extent.as_atom_name()
+                seen.setdefault(name, None)
+                factors.append(name)
         return tuple(factors) if factors else (1,)
 
     for s in kernel_op.body:
@@ -136,10 +137,10 @@ def _launch_geometry(
 
 
 def _collect_symbolic_axis_names(kernel_op: KernelOp) -> dict[str, None]:
-    """Walk the entire body and collect every symbolic ``Axis.extent.value``
-    referenced by any tile or loop. Dict (not set) so insertion order
-    matches first-seen order — kernel param signature is stable across
-    runs of the same kernel."""
+    """Walk the entire body and collect every symbolic axis name (via
+    ``Axis.extent.as_atom_name()``) referenced by any tile or loop. Dict
+    (not set) so insertion order matches first-seen order — kernel param
+    signature is stable across runs of the same kernel."""
     from deplodock.compiler.ir.axis import Axis  # noqa: PLC0415
     from deplodock.compiler.ir.stmt.base import Stmt  # noqa: PLC0415
 
@@ -148,7 +149,7 @@ def _collect_symbolic_axis_names(kernel_op: KernelOp) -> dict[str, None]:
     def visit(stmt: Stmt) -> None:
         for ax in _stmt_axes(stmt):
             if isinstance(ax, Axis) and not ax.extent.is_static:
-                seen.setdefault(ax.extent.value, None)
+                seen.setdefault(ax.extent.as_atom_name(), None)
         for body in stmt.nested():
             for child in body:
                 visit(child)

--- a/deplodock/compiler/trace/torch.py
+++ b/deplodock/compiler/trace/torch.py
@@ -303,7 +303,9 @@ def _op_shape(raw_shape, sym_rename: dict[str, str] | None = None):
 def _dim_tuple_to_op_shape(shape):
     """Convert a ``tuple[Dim | int, ...]`` (from ``_wrap_shape`` output) back
     to the ``tuple[int | str, ...]`` form ``ReshapeOp.shape`` /
-    ``SliceOp.shape`` carry. ``Dim`` wrappers unwrap to ``.value``."""
+    ``SliceOp.shape`` carry. Atomic ``Dim`` wrappers unwrap via ``.value``
+    (Literal → int, Var → name); composite Dims aren't emitted by the
+    tracer here so the int|str form is sufficient."""
     from deplodock.compiler.dim import Dim
 
     return tuple(d.value if isinstance(d, Dim) else d for d in shape)

--- a/tests/compiler/ir/test_expr_frozen_equality.py
+++ b/tests/compiler/ir/test_expr_frozen_equality.py
@@ -1,0 +1,84 @@
+"""Lock in that ``Expr`` nodes are frozen + structurally hashable.
+
+Required so ``Dim`` (which will carry an ``Expr``) keeps a stable
+``__hash__`` across construction paths and survives use as a dict key /
+set member in ``Axis`` and graph structural keys.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from deplodock.compiler.ir.expr import (
+    BinaryExpr,
+    Builtin,
+    CastExpr,
+    FuncCallExpr,
+    Literal,
+    TernaryExpr,
+    Var,
+)
+
+
+def test_var_structural_equality():
+    assert Var("x") == Var("x")
+    assert Var("x") != Var("y")
+    assert hash(Var("x")) == hash(Var("x"))
+
+
+def test_literal_structural_equality():
+    assert Literal(1, "int") == Literal(1, "int")
+    assert Literal(1, "int") != Literal(1, "float")
+    assert hash(Literal(1, "int")) == hash(Literal(1, "int"))
+
+
+def test_binary_expr_structural_equality():
+    e1 = BinaryExpr("+", Var("a"), Literal(2, "int"))
+    e2 = BinaryExpr("+", Var("a"), Literal(2, "int"))
+    assert e1 == e2
+    assert hash(e1) == hash(e2)
+
+
+def test_funccallexpr_structural_equality():
+    f1 = FuncCallExpr("exp", (Var("x"),))
+    f2 = FuncCallExpr("exp", (Var("x"),))
+    assert f1 == f2
+    assert hash(f1) == hash(f2)
+
+
+def test_ternary_and_cast_hashable():
+    t = TernaryExpr(Var("c"), Var("a"), Var("b"))
+    assert hash(t) == hash(TernaryExpr(Var("c"), Var("a"), Var("b")))
+    c = CastExpr("int", Var("x"))
+    assert hash(c) == hash(CastExpr("int", Var("x")))
+
+
+def test_builtin_hashable():
+    assert Builtin("tid.x") == Builtin("tid.x")
+    assert hash(Builtin("tid.x")) == hash(Builtin("tid.x"))
+
+
+def test_var_is_frozen():
+    v = Var("x")
+    with pytest.raises(FrozenInstanceError):
+        v.name = "y"  # type: ignore[misc]
+
+
+def test_binary_expr_is_frozen():
+    e = BinaryExpr("+", Var("a"), Literal(1, "int"))
+    with pytest.raises(FrozenInstanceError):
+        e.op = "-"  # type: ignore[misc]
+
+
+def test_funccallexpr_args_is_tuple():
+    f = FuncCallExpr("exp", (Var("x"),))
+    assert isinstance(f.args, tuple)
+
+
+def test_expr_works_as_dict_key():
+    """Used to key ``SimplifyCtx.ranges``, hash-cache equivalent subexpressions, etc."""
+    d: dict[object, int] = {}
+    d[BinaryExpr("+", Var("a"), Literal(1, "int"))] = 7
+    assert d[BinaryExpr("+", Var("a"), Literal(1, "int"))] == 7

--- a/tests/compiler/test_shape_inference_symbolic.py
+++ b/tests/compiler/test_shape_inference_symbolic.py
@@ -1,0 +1,71 @@
+"""Symbolic-shape coverage for ``infer_output_shape`` on arithmetic ops.
+
+After the Dim-carries-Expr refactor, the arithmetic ops (Matmul, Linear, Cat,
+Reshape) compose shapes via ``Dim`` operators with no static/symbolic branch.
+These tests pin down the resulting shapes for the patterns that matter for
+whole-model HF compile: matmul-on-symbolic-M, cat-of-symbolic-axis,
+reshape that turns a symbolic dim into a composite (``S * H``).
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.dim import Dim
+from deplodock.compiler.ir.expr import BinaryExpr, Literal, Var
+from deplodock.compiler.ir.frontend.ir import CatOp, LinearOp, MatmulOp, ReshapeOp
+
+
+def test_matmul_symbolic_m():
+    # (1, S, K) @ (K, N) -> (1, S, N)
+    out = MatmulOp().infer_output_shape([(Dim(1), Dim("S"), Dim(64)), (Dim(64), Dim(128))])
+    assert out == (Dim(1), Dim("S"), Dim(128))
+
+
+def test_linear_symbolic_m_lm_head_pattern():
+    # (1, S, hidden=3584) @ (vocab=152064, hidden=3584).T -> (1, S, vocab)
+    out = LinearOp().infer_output_shape([(Dim(1), Dim("S"), Dim(3584)), (Dim(152064), Dim(3584))])
+    assert out == (Dim(1), Dim("S"), Dim(152064))
+
+
+def test_cat_two_symbolic_halves_doubles():
+    # RoPE half-rotation: concat two (1, H, S, D/2) tensors back to (1, H, S, D/2 + D/2)
+    out = CatOp().infer_output_shape([(Dim(1), Dim(8), Dim("S"), Dim(32)), (Dim(1), Dim(8), Dim("S"), Dim(32))])
+    assert out == (Dim(1), Dim(8), Dim("S"), Dim(64))
+
+
+def test_cat_symbolic_axis_stays_symbolic():
+    # cat along a symbolic axis produces 2*S as a composite Dim
+    out = CatOp().infer_output_shape([(Dim(1), Dim("S")), (Dim(1), Dim("S"))])
+    expected_last = Dim("S") + Dim("S")
+    assert out == (Dim(1), expected_last)
+    assert out[1].expr == BinaryExpr("+", Var("S"), Var("S"))
+
+
+def test_reshape_minus_one_inferred_static():
+    # Same as the legacy static case: -1 resolves to 3584 via numel arithmetic.
+    out = ReshapeOp(shape=(1, 8, -1)).infer_output_shape([(Dim(1), Dim(28), Dim(8), Dim(128))])
+    assert out == (Dim(1), Dim(8), Dim(3584))
+    assert out[2].expr == Literal(3584, "int")
+
+
+def test_reshape_minus_one_cancels_symbolic_factor():
+    # (1, S, 2048).reshape(1, S, H, -1) with H=8 -> last dim = (S*2048) // (S*8).
+    # The simplifier cancels the shared positive ``S`` factor (Dim arithmetic
+    # injects a >=1 range for shape vars) and folds the int gcd: 2048/8 = 256.
+    out = ReshapeOp(shape=(1, "S", 8, -1)).infer_output_shape([(Dim(1), Dim("S"), Dim(2048))])
+    assert out == (Dim(1), Dim("S"), Dim(8), Dim(256))
+
+
+def test_reshape_minus_one_drops_when_only_static_remains():
+    # (1, S, 2048).reshape(1, S, -1): the shared ``S`` factor cancels and
+    # 2048 / 1 = 2048 — the -1 resolves cleanly.
+    out = ReshapeOp(shape=(1, "S", -1)).infer_output_shape([(Dim(1), Dim("S"), Dim(2048))])
+    assert out == (Dim(1), Dim("S"), Dim(2048))
+
+
+def test_reshape_minus_one_keeps_symbolic_when_unmatched():
+    # (1, S, T).reshape(1, T, -1): the ``T`` factor cancels but ``S`` does not,
+    # so -1 = S. Composite Dim that resolves at launch.
+    out = ReshapeOp(shape=(1, "T", -1)).infer_output_shape([(Dim(1), Dim("S"), Dim("T"))])
+    assert out[0] == Dim(1)
+    assert out[1] == Dim("T")
+    assert out[2] == Dim("S")

--- a/tests/test_dim_arithmetic.py
+++ b/tests/test_dim_arithmetic.py
@@ -1,0 +1,101 @@
+"""``Dim`` arithmetic — eager-fold via ``Expr.simplify``.
+
+Covers:
+- static-static folds to a static Dim (matches today's int math byte-for-byte)
+- static-symbolic / symbolic-symbolic compose into BinaryExpr-backed Dims
+- algebraic identities (``*1``, ``+0``) collapse
+- ``Dim(32) == 32`` and ``Dim('s') == 's'`` ergonomics preserved
+- composite Dims compare structurally, never to bare int/str
+- Dim is hashable for use as dict key / set member / Axis(extent=...)
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.dim import Dim
+from deplodock.compiler.ir.expr import BinaryExpr, Literal, Var
+
+
+def test_static_static_arithmetic_folds():
+    assert Dim(32) * Dim(64) == Dim(2048)
+    assert (Dim(32) * Dim(64)).expr == Literal(2048, "int")
+    assert Dim(7) + Dim(5) == Dim(12)
+    assert Dim(20) - Dim(3) == Dim(17)
+    assert Dim(64) // Dim(2) == Dim(32)
+    assert Dim(10) % Dim(3) == Dim(1)
+
+
+def test_symbolic_compose_keeps_binary_expr():
+    assert (Dim("s") * Dim(2)).expr == BinaryExpr("*", Var("s"), Literal(2, "int"))
+    assert (Dim("s") + Dim("s")).expr == BinaryExpr("+", Var("s"), Var("s"))
+
+
+def test_algebraic_identities_collapse():
+    assert (Dim("s") * Dim(1)).expr == Var("s")
+    assert (Dim("s") + Dim(0)).expr == Var("s")
+    assert (Dim("s") * Dim(0)).expr == Literal(0, "int")
+    assert (Dim(1) * Dim("s")).expr == Var("s")
+
+
+def test_int_dim_arithmetic_ergonomic():
+    assert Dim("s") * 2 == Dim("s") * Dim(2)
+    assert 2 * Dim("s") == Dim(2) * Dim("s")
+    assert Dim("s") + 0 == Dim("s")
+
+
+def test_equality_with_bare_int_and_str():
+    assert Dim(32) == 32
+    assert Dim("s") == "s"
+    assert Dim(32) != 33
+    assert Dim("s") != "t"
+    assert Dim(32) != "32"  # int Dim never matches string
+    assert Dim("s") != 5  # symbolic Dim never matches int
+
+
+def test_composite_does_not_compare_to_bare():
+    composite = Dim("s") * Dim(2)
+    assert composite != 32
+    assert composite != "s*2"
+    # structural eq still works against another composite
+    assert composite == Dim("s") * Dim(2)
+
+
+def test_dim_hashable_and_dict_key():
+    d = {Dim(32): "a", Dim("s"): "b", Dim("s") * Dim(2): "c"}
+    assert d[Dim(32)] == "a"
+    assert d[Dim("s")] == "b"
+    assert d[Dim("s") * Dim(2)] == "c"
+
+
+def test_value_back_compat_atomic_only():
+    assert Dim(32).value == 32
+    assert Dim("s").value == "s"
+    import pytest
+
+    with pytest.raises(TypeError, match="composite"):
+        _ = (Dim("s") * Dim(2)).value
+
+
+def test_as_static_raises_on_symbolic():
+    import pytest
+
+    assert Dim(32).as_static() == 32
+    with pytest.raises(TypeError):
+        Dim("s").as_static()
+    with pytest.raises(TypeError):
+        (Dim("s") * Dim(2)).as_static()
+
+
+def test_str_renders_transparently():
+    # Pretty IR (``for i in 0..32``) and structural keys depend on this.
+    assert str(Dim(32)) == "32"
+    assert str(Dim("s")) == "s"
+
+
+def test_dim_from_expr():
+    assert Dim(Var("s")) == Dim("s")
+    assert Dim(Literal(32, "int")) == Dim(32)
+
+
+def test_dim_idempotent():
+    assert Dim(Dim(32)) == Dim(32)
+    assert Dim(Dim("s")) == Dim("s")


### PR DESCRIPTION
## Summary

- Unify the two shape languages (static `int`, symbolic `str`) into one: `Dim` now wraps an `Expr` from
  `ir/expr.py`. `Dim(32)` is `Literal(32)`-backed, `Dim("seq_len")` is `Var("seq_len")`-backed, and
  composite Dims (`Dim("S") * Dim(2)`) carry a `BinaryExpr`. Operators on `Dim` dispatch to `Expr` and
  eager-fold via `Expr.simplify` so static math matches plain int math byte-for-byte.
- `infer_output_shape` for `MatmulOp` / `LinearOp` / `CatOp` / `ReshapeOp` now composes shapes via `Dim`
  arithmetic with no `is_static` branching. Both `_dim_expr` / `_shape_dim_expr` helpers deleted.
- Launch-time `sym_env` resolution collapses to `dim.expr.eval(sym_env)` — composite shapes (e.g.
  `S * 2` from a cat output) resolve uniformly with atomic ones.
- `_Buffer.shape` is now `tuple[Dim, ...]`; `resolve_shape` goes through `expr.eval`.

Cleanup that fell out:

- Frozen `Var` / `Literal` / `BinaryExpr` / `Builtin` / `FuncCallExpr` / `TernaryExpr` / `CastExpr`
  so Dim keeps stable structural `__hash__` for `Axis(extent=Dim(...))` and graph keys.
- New simplifier rule `_cancel_common_factors` for `//` and `%` so `(s*128) // (s*4)` folds back to
  `32` when the shape-var is provably positive (Dim injects `Interval(1, ...)` ranges via SimplifyCtx).
- New `Dim.as_atom_name()` helper for sites that route by symbolic name; fail-loud if a composite
  slips in.

Back-compat:

- `Dim(32) == 32` and `Dim("s") == "s"` still hold. `Dim.value` is preserved as a back-compat shim
  (raises on composite). All 1222 pre-existing tests pass unchanged; +20 new tests added.

Motivates `plans/whole-model-hf-compile.md` M2 (RoPE `head_dim // 2`) and M5/M6 (reshape-heavy
whole-model decomposition). Plan file: `/home/dikobraz/.claude/plans/let-s-plan-this-refactor-gleaming-graham.md`.

## Milestones (one per commit)

| M  | Slice |
|----|-------|
| M0 | freeze Expr dataclasses + tuple-ify `FuncCallExpr.args` |
| M1 | `Dim` carries an `Expr` (eager-fold operators, preserve ergonomics) |
| M2+M3 | arithmetic `infer_output_shape` via Dim ops; drop both `_dim_expr` helpers; teach the simplifier to cancel common positive factors |
| M4 | sym_env resolution via `expr.eval` |
| M5 | sweep residual `Dim.value` access; `_Buffer.shape` carries `Dim` |
| M6 | doc updates |

## Test plan

- [x] `make test` — 1242 passed, 27 skipped (no regressions, no new skips)
- [x] `make lint` — clean
- [x] New: `tests/test_dim_arithmetic.py` — 12 tests covering eager fold, symbolic compose, algebraic
  identities, ergonomic equality, hashability, composite vs. atomic
- [x] New: `tests/compiler/test_shape_inference_symbolic.py` — 7 tests for matmul/linear/cat/reshape
  on symbolic shapes; reshape `-1` inference with shared positive factor cancellation
- [x] New: `tests/compiler/ir/test_expr_frozen_equality.py` — 10 tests pinning frozen + structural
  hashable behavior on every Expr node type
- [x] Existing `test_cuda_symbolic_linear_traced_and_run` (3 seq_lens, fp32 rtol≤1e-4) passes — covers
  the end-to-end dynamic-shape CUDA run path under the new sym_env resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)