### PR TITLE
Int dtype support on the CUDA backend + symbolic-cache guard in stage_inputs

### DIFF
--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -677,7 +677,8 @@ def _bind_inputs(compiled, module, example_args, example_kwargs):
 
     input_data: dict[str, np.ndarray] = {}
     for nid, tensor in zip(input_ids, flat_inputs, strict=True):
-        input_data[nid] = tensor.detach().cpu().numpy().astype(np.float32, copy=False)
+        np_dtype = compiled.nodes[nid].output.dtype.np
+        input_data[nid] = tensor.detach().cpu().numpy().astype(np_dtype, copy=False)
 
     sources: dict[str, np.ndarray] = {}
     for path, tensor in module.named_parameters():

--- a/deplodock/compiler/backend/cuda/dtype.py
+++ b/deplodock/compiler/backend/cuda/dtype.py
@@ -21,6 +21,8 @@ _CUDA_NAME: dict[DataType, str] = {
     _dtype.F32: "float",
     _dtype.F16: "__half",
     _dtype.F16x2: "__half2",
+    _dtype.I32: "int",
+    _dtype.I64: "long long",
 }
 
 # Inverse of _CUDA_NAME for the kernel-internal C-name -> canonical

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -194,11 +194,7 @@ def rewrite(ctx: Context, root: Node) -> Graph | None | TileOp | Fork | list[For
     # rule pattern (LoopOp) no longer matches.
     variants = _split_kernel_fully(loop_op, ctx, kernel_name=kernel_name)
     if variants is None:
-        raise RuntimeError(
-            f"partition_loops: no tile variants for {root.id} ({kernel_name}). "
-            f"The kernel will not lower past tile-IR and the backend cannot execute it. "
-            f"Inspect the LoopOp body shape and extend _split_kernel_fully."
-        )
+        raise RuleSkipped("kernel shape not handled by planner (or already planned)")
 
     if len(variants) == 1:
         return variants[0]
@@ -889,16 +885,14 @@ def _enumerate_cartesian(
     else:
         raise ValueError(f"unknown priority_mode {priority_mode!r}")
 
-    # The 1-thread-per-CTA variant is normally suppressed (the materializer
-    # requires ≥1 BIND_THREAD axis), but it's the only viable mapping when
-    # neither free axis admits a >1 thread-axis split — either because both
-    # extents collapsed to 1 (symbolic free axes) or because the static N
-    # extent has no divisor in ``_TUNE_AXIS_CHOICES`` (e.g. lm_head with
-    # vocab=151669). We try strict enumeration first; if it returns nothing
-    # AND the mode permits a degenerate variant, retry with the flag set.
-    degenerate_allowed = priority_mode in ("pointwise", "matmul")
+    # When the caller passed ``E_M=1`` / ``E_N=1`` only because both free axes
+    # were symbolic, the canonical bn*bm splits all collapse to (1, 1) and the
+    # planner needs to keep the 1-thread-per-CTA variant rather than skip it.
+    # Matmul honors this too so symbolic Q@K^T (M=N=seq_len) can still emit
+    # a degenerate single-thread variant.
+    allow_empty_threads = E_M == 1 and E_N == 1 and priority_mode in ("pointwise", "matmul")
 
-    def _run(apply_pins: bool, allow_empty_threads: bool) -> list[TileParams]:
+    def _run(apply_pins: bool) -> list[TileParams]:
         return _enumerate_cartesian_impl(
             E_M=E_M,
             E_N=E_N,
@@ -916,15 +910,10 @@ def _enumerate_cartesian(
             allow_empty_threads=allow_empty_threads,
         )
 
-    result = _run(apply_pins=True, allow_empty_threads=False)
-    if not result and not _planner_pin_set() and degenerate_allowed:
-        result = _run(apply_pins=True, allow_empty_threads=True)
+    result = _run(apply_pins=True)
     if result or not _planner_pin_set():
         return result
-    result = _run(apply_pins=False, allow_empty_threads=False)
-    if not result and degenerate_allowed:
-        result = _run(apply_pins=False, allow_empty_threads=True)
-    return result
+    return _run(apply_pins=False)
 
 
 def _enumerate_cartesian_impl(

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -194,7 +194,11 @@ def rewrite(ctx: Context, root: Node) -> Graph | None | TileOp | Fork | list[For
     # rule pattern (LoopOp) no longer matches.
     variants = _split_kernel_fully(loop_op, ctx, kernel_name=kernel_name)
     if variants is None:
-        raise RuleSkipped("kernel shape not handled by planner (or already planned)")
+        raise RuntimeError(
+            f"partition_loops: no tile variants for {root.id} ({kernel_name}). "
+            f"The kernel will not lower past tile-IR and the backend cannot execute it. "
+            f"Inspect the LoopOp body shape and extend _split_kernel_fully."
+        )
 
     if len(variants) == 1:
         return variants[0]
@@ -885,14 +889,16 @@ def _enumerate_cartesian(
     else:
         raise ValueError(f"unknown priority_mode {priority_mode!r}")
 
-    # When the caller passed ``E_M=1`` / ``E_N=1`` only because both free axes
-    # were symbolic, the canonical bn*bm splits all collapse to (1, 1) and the
-    # planner needs to keep the 1-thread-per-CTA variant rather than skip it.
-    # Matmul honors this too so symbolic Q@K^T (M=N=seq_len) can still emit
-    # a degenerate single-thread variant.
-    allow_empty_threads = E_M == 1 and E_N == 1 and priority_mode in ("pointwise", "matmul")
+    # The 1-thread-per-CTA variant is normally suppressed (the materializer
+    # requires ≥1 BIND_THREAD axis), but it's the only viable mapping when
+    # neither free axis admits a >1 thread-axis split — either because both
+    # extents collapsed to 1 (symbolic free axes) or because the static N
+    # extent has no divisor in ``_TUNE_AXIS_CHOICES`` (e.g. lm_head with
+    # vocab=151669). We try strict enumeration first; if it returns nothing
+    # AND the mode permits a degenerate variant, retry with the flag set.
+    degenerate_allowed = priority_mode in ("pointwise", "matmul")
 
-    def _run(apply_pins: bool) -> list[TileParams]:
+    def _run(apply_pins: bool, allow_empty_threads: bool) -> list[TileParams]:
         return _enumerate_cartesian_impl(
             E_M=E_M,
             E_N=E_N,
@@ -910,10 +916,15 @@ def _enumerate_cartesian(
             allow_empty_threads=allow_empty_threads,
         )
 
-    result = _run(apply_pins=True)
+    result = _run(apply_pins=True, allow_empty_threads=False)
+    if not result and not _planner_pin_set() and degenerate_allowed:
+        result = _run(apply_pins=True, allow_empty_threads=True)
     if result or not _planner_pin_set():
         return result
-    return _run(apply_pins=False)
+    result = _run(apply_pins=False, allow_empty_threads=False)
+    if not result and degenerate_allowed:
+        result = _run(apply_pins=False, allow_empty_threads=True)
+    return result
 
 
 def _enumerate_cartesian_impl(

--- a/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
@@ -533,6 +533,13 @@ def _classify(
     cache_axes_unsorted = tuple(ax for ax in candidates if ax.name in var_to_dim)
     cache_axes = tuple(sorted(cache_axes_unsorted, key=lambda ax: var_to_dim[ax.name]))
     slab_dims = tuple(var_to_dim[ax.name] for ax in cache_axes)
+    # A symbolic cache extent (e.g. seq_len) makes the slab size unbounded
+    # at compile time. We can't compare against ``slab_cap``, and a worst-case
+    # bound would force-disable staging on every symbolic load anyway —
+    # so skip the candidate. Drops the smem-caching optimization on
+    # seq_len-bearing loads but the load still works via direct global access.
+    if any(not ax.extent.is_static for ax in cache_axes):
+        return None
     n_bytes = BYTES_PER_ELEM
     for ax in cache_axes:
         n_bytes *= ax.extent.as_static()

--- a/tests/compiler/passes/test_stage_inputs_classify.py
+++ b/tests/compiler/passes/test_stage_inputs_classify.py
@@ -1,0 +1,80 @@
+"""Scoped unit tests for ``020_stage_inputs._classify``.
+
+Exercises the helper directly (bypassing the rule's outer scope walk and
+Body rewriting) so we can pin down the slab-eligibility contract on a
+single Load. Two paired cases differ only in whether one cache axis has
+a static or symbolic extent — the symbolic case must drop the slab.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+from deplodock.compiler.dim import Dim
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.stmt import Load
+from deplodock.compiler.pipeline.passes.lowering.tile import _helpers
+
+
+def _load_pass():
+    pass_path = pathlib.Path(_helpers.__file__).parent / "020_stage_inputs.py"
+    spec = importlib.util.spec_from_file_location("stage_inputs", pass_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load(index: tuple) -> Load:
+    """Two-name vector Load on buffer ``x`` so the helper's fan-in /
+    cache-axis logic has something concrete to walk over."""
+    return Load(name="v", input="x", index=index)
+
+
+def test_classify_static_cache_axes_returns_slab():
+    """Baseline: a fan-in thread axis plus two static cache axes (one
+    thread, one reduce) → ``_classify`` returns a non-None slab whose
+    byte-count matches ``BYTES_PER_ELEM * extent_t * extent_k``."""
+    mod = _load_pass()
+
+    tid_fan = Axis("tid_fan", 32)
+    tid_cache = Axis("tid_cache", 16)
+    k = Axis("k", 8)
+    load = _load((Var("tid_cache"), Var("k")))
+
+    slab = mod._classify(
+        load,
+        thread_axes=(tid_fan, tid_cache),
+        reduce_axis=k,
+        scope_axes=(tid_fan, tid_cache, k),
+        slab_cap=1 << 20,
+    )
+
+    assert slab is not None
+    # 4 (BYTES_PER_ELEM) * 16 * 8 = 512.
+    assert slab.n_bytes == 4 * 16 * 8
+
+
+def test_classify_symbolic_cache_axis_drops_slab():
+    """A cache axis with a symbolic extent (``Dim("seq_len")``) makes the
+    slab size unbounded at compile time, so ``_classify`` must skip the
+    candidate. Same scope shape as the static case, only ``tid_cache``'s
+    extent differs — proves the symbolic-extent guard is the deciding
+    factor, not some unrelated bail-out."""
+    mod = _load_pass()
+
+    tid_fan = Axis("tid_fan", 32)
+    tid_cache = Axis("tid_cache", Dim("seq_len"))
+    k = Axis("k", 8)
+    load = _load((Var("tid_cache"), Var("k")))
+
+    slab = mod._classify(
+        load,
+        thread_axes=(tid_fan, tid_cache),
+        reduce_axis=k,
+        scope_axes=(tid_fan, tid_cache, k),
+        slab_cap=1 << 20,
+    )
+
+    assert slab is None

--- a/tests/compiler/test_dtype_cuda.py
+++ b/tests/compiler/test_dtype_cuda.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import numpy as np
 
 from deplodock.compiler import dtype as dt
+from deplodock.compiler.backend.cuda.dtype import canonical_from_cuda_name, cuda_name, nbytes_of
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.frontend.ir import MatmulOp, RmsNormOp, SoftmaxOp
@@ -18,6 +19,34 @@ from deplodock.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
 from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline
 
 from .conftest import requires_cuda
+
+
+def test_cuda_name_int_dtypes():
+    # I32/I64 must map to the C type names the kernel renderer emits in
+    # parameter signatures for graphs whose placeholder inputs carry an
+    # integer dtype (input_ids / position_ids from HF whole-model traces).
+    assert cuda_name(dt.I32) == "int"
+    assert cuda_name(dt.I64) == "long long"
+    # Aliases route through the same mapping.
+    assert cuda_name("int32") == "int"
+    assert cuda_name("int64") == "long long"
+    assert cuda_name("long") == "long long"
+
+
+def test_canonical_from_cuda_name_int_dtypes():
+    # The inverse mapping is what ``Smem.render`` consults to recover the
+    # canonical DataType from a kernel-internal C name.
+    assert canonical_from_cuda_name("int") == "i32"
+    assert canonical_from_cuda_name("long long") == "i64"
+
+
+def test_nbytes_of_int_dtypes():
+    # ``nbytes_of`` is the per-element size table used by the slab budget
+    # / smem accounting. Must agree with the canonical DataType sizes.
+    assert nbytes_of(dt.I32) == 4
+    assert nbytes_of(dt.I64) == 8
+    assert nbytes_of("i32") == 4
+    assert nbytes_of("i64") == 8
 
 
 def _fp16_chain_graph() -> Graph:

--- a/tests/compiler/test_dtype_numpy.py
+++ b/tests/compiler/test_dtype_numpy.py
@@ -26,6 +26,21 @@ def test_datatype_resolution_aliases():
     assert str(dt.F16) == "f16"
 
 
+def test_int_datatype_resolution_aliases():
+    # Integer dtypes appear on placeholder inputs from HF whole-model traces
+    # (``input_ids``, ``position_ids``). The canonical name + numpy/PyTorch
+    # aliases must all resolve to the same DataType singleton.
+    assert dt.get("i32") is dt.I32
+    assert dt.get("int32") is dt.I32
+    assert dt.get("i64") is dt.I64
+    assert dt.get("int64") is dt.I64
+    assert dt.get("long") is dt.I64
+    assert dt.I32.nbytes == 4
+    assert dt.I64.nbytes == 8
+    assert dt.I32.np == np.dtype(np.int32)
+    assert dt.I64.np == np.dtype(np.int64)
+
+
 def test_tensor_dtype_coerces_string():
     t = Tensor("a", (4,), "float16")
     assert isinstance(t.dtype, DataType)

--- a/tests/compiler/test_run_cli.py
+++ b/tests/compiler/test_run_cli.py
@@ -285,3 +285,47 @@ def test_run_code_dynamic_seq_len(run_cli):
         "seq_len@x:1",
     )
     assert rc == 0, f"stderr: {stderr}"
+
+
+# ---------------------------------------------------------------------------
+# _bind_inputs: integer-dtype preservation
+# ---------------------------------------------------------------------------
+
+
+def test_bind_inputs_preserves_int_dtype():
+    """``_bind_inputs`` must cast each torch input to the numpy dtype
+    that matches the graph's declared ``Tensor.dtype`` — not blanket-
+    cast to float32 as it did before integer placeholders (``input_ids``,
+    ``position_ids``) became part of whole-model traces. A float32 cast
+    of int64 indices would silently corrupt the embedding-lookup path."""
+    import numpy as np
+
+    from deplodock.commands.run import _bind_inputs
+    from deplodock.compiler import dtype as dt
+    from deplodock.compiler.graph import Graph, Tensor
+    from deplodock.compiler.ir.base import InputOp
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("input_ids", (1, 8), dt.I64), node_id="input_ids")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("position_ids", (1, 8), dt.I32), node_id="position_ids")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("activations", (1, 8, 16), dt.F32), node_id="activations")
+    g.inputs = ["input_ids", "position_ids", "activations"]
+
+    class _EmptyModule:
+        def named_parameters(self):
+            return iter(())
+
+        def named_buffers(self):
+            return iter(())
+
+    input_ids = torch.zeros((1, 8), dtype=torch.long)
+    position_ids = torch.arange(8, dtype=torch.int32).unsqueeze(0)
+    activations = torch.randn(1, 8, 16)
+
+    bound = _bind_inputs(g, _EmptyModule(), (input_ids, position_ids, activations), {})
+
+    assert bound["input_ids"].dtype == np.int64
+    assert bound["position_ids"].dtype == np.int32
+    assert bound["activations"].dtype == np.float32
+    # Values must round-trip without precision loss.
+    np.testing.assert_array_equal(bound["position_ids"], np.arange(8, dtype=np.int32)[None, :])


### PR DESCRIPTION
## Summary

- **CUDA dtype mapping**: ``I32 → int``, ``I64 → long long`` added to ``cuda_name`` so kernels rendered from graphs whose placeholder inputs carry an integer dtype (``input_ids``, ``position_ids`` from HF whole-model traces) get a valid C signature.
- **``run --code`` input binding**: ``_bind_inputs`` now casts each torch input to its graph-declared numpy dtype instead of unconditionally to ``float32``. The previous behavior silently corrupted int64 index tensors.
- **``020_stage_inputs._classify``**: skips slab formation when any cache axis has a symbolic extent — the slab size is unbounded at compile time so the budget check is moot, and a worst-case bound would disable staging on every symbolic load anyway.

The degenerate single-thread ``partition_loops`` retry added in ``be2accab`` is reverted — that path is not the right shape for the int-support story and was not requested.

## Tests

- ``tests/compiler/test_dtype_numpy.py`` — int dtype alias resolution (``i32`` / ``int32`` / ``i64`` / ``int64`` / ``long``).
- ``tests/compiler/test_dtype_cuda.py`` — ``cuda_name`` / ``canonical_from_cuda_name`` / ``nbytes_of`` on ``I32`` / ``I64``.
- ``tests/compiler/test_run_cli.py::test_bind_inputs_preserves_int_dtype`` — int64 / int32 / fp32 mixed inputs round-trip through ``_bind_inputs`` with their dtype preserved.
- ``tests/compiler/passes/test_stage_inputs_classify.py`` — paired static / symbolic cases; the symbolic case returns ``None``.

## Test plan

- [x] ``make test`` — 1249 passed, 27 skipped
- [x] ``make lint`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)