### PR TITLE
Fix flaky loop-runner cache + double-buffer/pad-smem CUDA accuracy tests

### DIFF
--- a/deplodock/compiler/ir/loop/runner.py
+++ b/deplodock/compiler/ir/loop/runner.py
@@ -11,8 +11,11 @@ Module-level state:
 - ``_PRELUDE_INSTALLED``: ``cppyy.cppdef(PRELUDE)`` is idempotent in
   effect but emits warnings on redefinition; we install the prelude
   once.
-- ``_FN_CACHE``: keyed by ``(loop id, input_shapes, output_shape)`` so
-  repeated calls with the same shapes don't re-JIT.
+- ``_FN_CACHE``: keyed by the rendered C++ source string (which folds in
+  the loop body + input/output shapes) so repeated calls with an identical
+  kernel don't re-JIT. NOT keyed on ``id(loop)`` — object addresses are
+  recycled by CPython, so a GC'd LoopOp's id can alias a later same-shape
+  one and serve the wrong cached kernel.
 - ``_FN_COUNTER``: monotonic id used to give every kernel a unique C
   symbol name; cppyy / Cling can't redefine a function once it's been
   compiled in the same process.
@@ -113,7 +116,14 @@ def execute_loop_op_cpp(
 
     bufs = tuple(loop.inputs)
     input_shapes = {name: tuple(int(d) for d in input_arrays[name].shape) for name in bufs}
-    cache_key = (id(loop), tuple(input_shapes.items()), tuple(out_shape))
+    # Key on the rendered source, NOT ``id(loop)``: a LoopOp plus its runtime
+    # shapes uniquely determine the C++ string (see module docstring), and the
+    # object address is unsafe — CPython reuses the id of a GC'd LoopOp, so a
+    # later same-shape LoopOp (e.g. tanh after a freed negate) could collide on
+    # ``id`` and be served the stale kernel. Render with a fixed placeholder
+    # name so the key is stable across calls; the JIT'd symbol gets its unique
+    # ``_FN_COUNTER`` name only on a miss.
+    cache_key = render_loopop_cpp(loop, "loopop_kern", input_shapes, out_shape)
 
     fn = _FN_CACHE.get(cache_key)
     if fn is None:

--- a/tests/compiler/ir/loop/test_runner_cache.py
+++ b/tests/compiler/ir/loop/test_runner_cache.py
@@ -1,0 +1,62 @@
+"""Regression: the loop-runner JIT cache must key on kernel content, not
+object identity.
+
+``execute_loop_op_cpp`` memoizes JIT-compiled kernels so repeated calls with
+the same kernel don't re-invoke Cling. The key used to include ``id(loop)``,
+which is a use-after-free hazard: CPython recycles the address of a GC'd
+``LoopOp``, so a later same-shape LoopOp (e.g. ``tanh`` after a freed
+``negative``) could alias the old id and be handed the stale cached kernel —
+silently returning ``-x`` for ``tanh``. This surfaced only under randomized /
+parallel test ordering (the GC timing that triggers id reuse), never in
+isolation.
+
+We force the collision deterministically by pinning every ``id`` the runner
+sees to a constant, then check two structurally-different same-shape kernels
+each compute their own result. Under the old id-keyed cache this fails (the
+second kernel is served the first's compiled function); under content-keying
+it passes. cppyy-only — no CUDA required.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp
+
+cppyy = pytest.importorskip("cppyy")
+
+
+def _build(fn: str) -> Graph:
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (4, 8)), node_id="x")
+    g.add_node(op=ElementwiseOp(fn), inputs=["x"], output=Tensor("y", (4, 8)), node_id="y")
+    g.inputs, g.outputs = ["x"], ["y"]
+    return g
+
+
+def _run_loop(graph: Graph, x: np.ndarray) -> np.ndarray:
+    from deplodock.compiler.backend.loop import LoopBackend
+
+    be = LoopBackend()
+    return be.run(be.compile(graph), input_data={"x": x})[0].outputs["y"]
+
+
+def test_cache_not_keyed_on_object_identity(monkeypatch):
+    from deplodock.compiler.ir.loop import runner
+
+    # Pin every id() the runner module evaluates to one constant, forcing the
+    # exact id-collision the old cache key was vulnerable to.
+    monkeypatch.setattr(runner, "id", lambda _obj: 0xC0FFEE, raising=False)
+    monkeypatch.setattr(runner, "_FN_CACHE", {})
+
+    x = np.random.default_rng(0).uniform(0.1, 5.0, size=(4, 8)).astype(np.float32)
+
+    neg = _run_loop(_build("negative"), x)
+    np.testing.assert_allclose(neg, -x, rtol=2e-5, atol=1e-5)
+
+    # Same shape, different body — must NOT be served the cached negate kernel.
+    tanh = _run_loop(_build("tanh"), x)
+    np.testing.assert_allclose(tanh, np.tanh(x), rtol=2e-5, atol=1e-5)

--- a/tests/compiler/test_double_buffer_accuracy.py
+++ b/tests/compiler/test_double_buffer_accuracy.py
@@ -1,17 +1,20 @@
 """CUDA accuracy regression for the wrap-body double-buffer path.
 
-040_use_ring_buffers promotes a wrap-body ``Stage`` inside a
-``SerialTile(serial_outer)`` to ``BufferedStage(buffer_count=2,
-phase=K_o%2)``. The materializer doubles the smem allocation, prepends
+040_use_ring_buffers promotes a SYNC ``StageBundle`` inside a
+``SerialTile(serial_outer)`` to ``policy=BUFFERED, buffer_count=2,
+phase=K_o%2``. The materializer doubles the smem allocation, prepends
 the phase to the cooperative-load Write and to every body Load that
 reads from staged smem, and drops the leading ``__syncthreads`` because
-consecutive iterations write distinct physical slabs.
+consecutive iterations write distinct physical slabs. On sm_80+
+``060_use_async_copy`` then swaps that bundle's policy in-place to ASYNC
+(cp.async transport) — the ``buffer_count=2`` ring is unchanged.
 
 Each parametrized config pins planner knobs that force K_o >= 2 (so the
 double-buffer eligibility check passes). The test compiles the matmul
 through the full CUDA pipeline, asserts the resulting TileOp actually
-contains a ``BufferedStage`` (so a regression that silently turns off
-the promotion would surface), and then runs the compiled kernel and
+contains a double-buffered ring (``buffer_count >= 2``, regardless of
+the realized transport — so a regression that silently turns off the
+promotion would surface), and then runs the compiled kernel and
 compares against a NumpyBackend reference.
 
 Skipped without CUDA.
@@ -25,7 +28,7 @@ import pytest
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.frontend.ir import MatmulOp
-from deplodock.compiler.ir.tile.ir import StageBundle, StagePolicy, TileOp
+from deplodock.compiler.ir.tile.ir import StageBundle, TileOp
 
 from .conftest import requires_cuda
 
@@ -61,9 +64,17 @@ def _build_matmul(m: int, k: int, n: int) -> tuple[Graph, dict[str, tuple[int, .
 
 
 def _has_buffered_stage(compiled: Graph) -> bool:
-    """The CUDA pipeline lowers TileOp → KernelOp → CudaOp; the BufferedStage
-    only lives at the TileOp / KernelOp boundary. We re-compile through
-    TILE_PASSES to inspect that intermediate IR."""
+    """The CUDA pipeline lowers TileOp → KernelOp → CudaOp; the double-buffer
+    ring only lives at the TileOp / KernelOp boundary. We re-compile through
+    TILE_PASSES to inspect that intermediate IR.
+
+    040_use_ring_buffers promotes the SYNC bundle to ``buffer_count = 2``;
+    on sm_80+ 060_use_async_copy then swaps that bundle's policy in-place to
+    ASYNC (cp.async transport) — the ring is unchanged, only the transport.
+    So we detect "double-buffering fired" by ``buffer_count >= 2`` rather
+    than a specific policy: a SYNC bundle always has ``buffer_count == 1``,
+    so any bundle with ``>= 2`` proves 040 ran (and we're not on the plain
+    single-slab path)."""
     from deplodock.compiler.pipeline import TILE_PASSES, Pipeline
 
     # Build a fresh graph (same shape/dims) and run only through TILE_PASSES.
@@ -74,8 +85,8 @@ def _has_buffered_stage(compiled: Graph) -> bool:
         node = compiled.nodes[nid]
         g.add_node(op=InputOp(), inputs=[], output=node.output, node_id=nid)
     o_node = compiled.nodes["o"]
-    # Skip — we just want to know if BufferedStage shows up for the same
-    # shape under the same pinned knobs (env vars are already set by the
+    # Skip — we just want to know if a double-buffered ring shows up for the
+    # same shape under the same pinned knobs (env vars are already set by the
     # caller's monkeypatch).
     g.add_node(op=MatmulOp(), inputs=["a", "b"], output=o_node.output, node_id="o")
     g.inputs = list(compiled.inputs)
@@ -84,7 +95,7 @@ def _has_buffered_stage(compiled: Graph) -> bool:
     op = g2.nodes["o"].op
     if not isinstance(op, TileOp):
         return False
-    return any((isinstance(s, StageBundle) and s.policy == StagePolicy.BUFFERED) for s in op.body.iter())
+    return any((isinstance(s, StageBundle) and s.buffer_count >= 2) for s in op.body.iter())
 
 
 def _random_inputs(input_shapes: dict[str, tuple[int, ...]], seed: int = 0) -> dict[str, np.ndarray]:
@@ -123,14 +134,16 @@ def test_double_buffer_matmul_accuracy(case, monkeypatch):
     graph, input_shapes = _build_matmul(m, k, n)
     inputs = _random_inputs(input_shapes)
 
-    # First: confirm the pass actually fires under these knobs. If 010 stopped
-    # firing for whatever reason (eligibility tightened, planner shape
-    # changed), the accuracy check below would still pass — but on the
-    # plain-Stage path, not BufferedStage — which would silently regress
-    # double-buffer coverage. Assert explicitly.
+    # First: confirm the pass actually fires under these knobs. If
+    # 040_use_ring_buffers stopped firing for whatever reason (eligibility
+    # tightened, planner shape changed), the accuracy check below would still
+    # pass — but on the plain single-slab SYNC path, not a double-buffered
+    # ring — which would silently regress double-buffer coverage. Assert
+    # explicitly (buffer_count >= 2 holds whether the ring is realized as
+    # BUFFERED or, on sm_80+, promoted to ASYNC cp.async transport).
     graph_for_inspection, _ = _build_matmul(m, k, n)
     assert _has_buffered_stage(graph_for_inspection), (
-        f"040_use_ring_buffers did not produce a BufferedStage for M={m}, K={k}, N={n} under knobs={knobs}"
+        f"040_use_ring_buffers did not produce a double-buffered ring (buffer_count >= 2) for M={m}, K={k}, N={n} under knobs={knobs}"
     )
 
     ref = _reference(graph, inputs)

--- a/tests/compiler/test_pad_smem_accuracy.py
+++ b/tests/compiler/test_pad_smem_accuracy.py
@@ -55,9 +55,14 @@ def _tile_op_pad_summary(m: int, k: int, n: int) -> dict[str, tuple[int, ...]]:
         return {}
     out: dict[str, tuple[int, ...]] = {}
     for s in op.body.iter():
-        if isinstance(s, StageBundle) and s.policy == StagePolicy.BUFFERED:
-            for src in s.sources:
-                out[src.name] = src.pad
+        # 070_pad_smem pads BUFFERED / ASYNC bundles (SYNC needs no
+        # rotation break, TMA forbids pad). On sm_80+ the double-buffer
+        # ring is realized as ASYNC, so read the pad off whichever of the
+        # two the pipeline produced. Sources live on the member Stages.
+        if isinstance(s, StageBundle) and s.policy in (StagePolicy.BUFFERED, StagePolicy.ASYNC):
+            for stage in s.stages:
+                for src in stage.sources:
+                    out[src.name] = src.pad
     return out
 
 


### PR DESCRIPTION
Two independent test fixes surfaced while rebasing `feature/stage-bundle` onto latest `main`.

## 1. Loop-runner JIT cache keyed on `id(loop)` (the CI failure)

`execute_loop_op_cpp` (`deplodock/compiler/ir/loop/runner.py`) memoized JIT-compiled kernels under a key
containing `id(loop)`. CPython recycles the address of a GC'd object, so a freed `LoopOp`'s id can be reused by
a later **same-shape** `LoopOp` — e.g. a `tanh` kernel allocated where a `negative` kernel used to live —
yielding an identical cache key and serving the stale negate kernel. `tanh(x)` then returns `-x`.

The collision only fires under the GC timing that randomized/parallel test ordering produces
(`pytest-randomly` + xdist), so it passed locally and in isolation but failed intermittently on CI:
`test_torch_ops.py::test_unary[loop-tanh]`.

**Fix:** key the cache on the rendered C++ source string (a `LoopOp` + runtime shapes uniquely determine it,
per the module docstring) instead of object identity. Adds a regression test that forces the id-collision
deterministically — it fails on the old key with the exact `-x` symptom and passes with content-keying.

## 2. double-buffer / pad-smem CUDA accuracy tests (sm_80+)

On sm_80+ (dev/CI GPU is sm_120), `060_use_async_copy` *unconditionally* promotes the double-buffer
`StageBundle` from `policy=BUFFERED` to `ASYNC` (cp.async) in place, so the final tile IR never carries
`policy == BUFFERED`. `test_double_buffer_accuracy` and `test_pad_smem_accuracy` asserted on that policy and
failed once run on a GPU host (they are `@requires_cuda`, which CI skips — the #150 Stage->StageBundle refactor
was merged without GPU validation).

`040_use_ring_buffers` still fires (`buffer_count=2`, `phase`); only the transport is swapped, and
`070_pad_smem` still pads the realized BUFFERED/ASYNC bundle.

**Fix (test-only):**
- double-buffer: detect the ring via `buffer_count >= 2` (transport-agnostic; SYNC is always `1`).
- pad-smem: read pads off the member `Stage`s of the realized BUFFERED/ASYNC bundle (`StageBundle` has
  `.stages`, each `Stage` has `.sources`; there is no `StageBundle.sources`).

Accuracy assertions are unchanged and pass — the realized kernel is the same ASYNC kernel the already-passing
`test_async_copy_accuracy` exercises.

## Test plan

- `make test` -> **1231 passed, 27 skipped** (was 5 CUDA failures + 1 flaky `loop-tanh`).
- `make lint` -> clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)