### PR TITLE
Lazy partition-planner variants + freeze IR Stmts

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -89,6 +89,27 @@ Group imports in this order, separated by blank lines:
 
 Style rules are enforced by [Ruff](https://docs.astral.sh/ruff/), configured in `pyproject.toml`. Run `make lint` to check and `make format` to auto-fix. Enabled rule sets: `E` (pycodestyle), `F` (pyflakes), `W` (warnings), `I` (isort), `UP` (pyupgrade), `B` (bugbear).
 
+### IR statements must be frozen dataclasses
+
+Every concrete `Stmt` subclass — Loop-IR (`Loop`, `StridedLoop`, `Cond`, leaves), Tile-IR (`GridTile`, `ThreadTile`,
+`RegisterTile`, `SerialTile`, `StridedTile`, `Stage`, `StageBundle`, `AsyncWait`), Kernel-IR (`Smem`, `Sync`,
+`CpAsyncCopy`, `TmaDescriptor`, `TmaLoad`, `MbarrierInit`, …) — must be declared `@dataclass(frozen=True)`. `Body` is
+already a `tuple[Stmt, ...]` subclass, so freezing every Stmt makes the entire body tree hashable end-to-end.
+
+Why: structural caches (`Body.structural_key()` and any future bodies-as-cache-keys work) traverse the body and hash
+every Stmt. A single mutable Stmt anywhere in the tree poisons every cache that keys on the surrounding Body — and
+the surrounding code can't degrade gracefully without losing the optimization.
+
+If you need to "edit" a frozen Stmt, return a new instance via `dataclasses.replace(stmt, field=value)`. If a
+`__post_init__` needs to coerce a field (e.g. `tuple → Body`), use `object.__setattr__(self, "field", coerced)` —
+that's the standard pattern for frozen dataclasses that still need light normalization at construction time. Don't
+add `try/except TypeError` fallbacks around structural caches to tolerate unhashable stmts; fix the unhashable stmt
+instead.
+
+Op subclasses don't have to be frozen (the engine mutates `op.source` / `op.knobs` / `op.inputs` / `op.outputs` post-
+construction). Just make sure no Op ends up as a *field value* of a Stmt — `Assign.op` / `Accum.op` / `Select.op` take
+an `ElementwiseImpl` (the lightweight value object, already hashable), never an `ElementwiseOp` wrapper.
+
 ### Dependency Injection for Testability
 
 Shared logic accepts callable parameters (`run_cmd`, `write_file`) so

--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -49,6 +49,20 @@ keep working unchanged. `source` is excluded from
 `Graph.structural_key` and from `op_cache_key` — kernels rendered
 along different lowering paths still dedup in the tuning cache.
 
+**Stmt subclasses are `@dataclass(frozen=True)`** — every concrete Loop-IR
+/ Tile-IR / Kernel-IR statement (`Loop`, `Cond`, leaves, `GridTile`,
+`ThreadTile`, `Stage`, `StageBundle`, `Smem`, `Sync`, `CpAsyncCopy`,
+`TmaDescriptor`, …) is immutable + hashable. `Body` is a `tuple[Stmt, ...]`
+subclass, so a full body tree hashes structurally end-to-end. This makes
+`Body.structural_key()` and any other bodies-as-cache-keys path work
+without a try/except fallback for unhashable stmts. To "edit" a frozen
+Stmt, return a fresh instance via `dataclasses.replace(stmt, field=value)`;
+`__post_init__` coercions use `object.__setattr__`. Ops, by contrast,
+are NOT frozen — the engine mutates `op.source` / `op.knobs` / `op.inputs` /
+`op.outputs` post-construction. Op fields stored inside Stmts (e.g.
+`Assign.op`) must be lightweight value objects (e.g. `ElementwiseImpl`,
+not `ElementwiseOp`) so the surrounding Stmt's hashability isn't poisoned.
+
 ## `base.py`
 
 Cross-cutting root. Imported by every dialect, imports nothing from

--- a/deplodock/compiler/ir/base.py
+++ b/deplodock/compiler/ir/base.py
@@ -105,6 +105,30 @@ class Op:
         """
         return None
 
+    @staticmethod
+    def lazy_score(ctx, *, knobs=None, shapes=None, params=None) -> float | None:  # noqa: ARG004
+        """Cheap pre-instantiation scorer. Lets a rule rank variants
+        without building each op just to read :meth:`score` — the
+        instantiation may be the bulk of the lowering cost (e.g.
+        ``TileOp.__post_init__`` runs full body normalization).
+
+        Subclasses override to implement when the score formula can be
+        evaluated from precomputed inputs:
+
+        - ``knobs`` — pinned knob dict for this variant
+        - ``shapes`` — op-defined shape descriptor (e.g. ``KernelShape``
+          for ``TileOp`` — the static per-LoopOp planning state)
+        - ``params`` — op-defined variant tuple (e.g. ``TileParams``)
+
+        Return ``None`` when the lazy path isn't implementable for
+        these inputs; callers (rules using deferred-materialization
+        forks) fall back to constructing the op and calling
+        :meth:`score`. The contract is "lazy = score-equivalent when
+        non-None": ``cls.lazy_score(...) == cls(...).score(ctx)`` for
+        any inputs both can score.
+        """
+        return None
+
 
 @dataclass
 class InputOp(Op):

--- a/deplodock/compiler/ir/kernel/ir.py
+++ b/deplodock/compiler/ir/kernel/ir.py
@@ -63,7 +63,7 @@ from deplodock.compiler.ir.tile.ir import GridTile, RegisterTile, SerialTile, St
 # ---------------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class Smem(Stmt):
     """Declare a per-block ``__shared__`` array.
 
@@ -122,7 +122,7 @@ class Smem(Stmt):
         return [f"{_pad(ctx.indent)}__shared__ {ali}{self.dtype} {self.name}[{total}];"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class Sync(Stmt):
     """``__syncthreads();`` — block-wide barrier."""
 
@@ -133,7 +133,7 @@ class Sync(Stmt):
         return [f"{_pad(ctx.indent)}__syncthreads();"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class CpAsyncCopy(Stmt):
     """Issue one ``cp.async.cg.shared.global`` instruction.
 
@@ -175,7 +175,7 @@ class CpAsyncCopy(Stmt):
         ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class CpAsyncCommit(Stmt):
     """``cp.async.commit_group;`` — finalize the preceding cp.async copies
     issued by this thread into a commit group. Pairs with
@@ -188,7 +188,7 @@ class CpAsyncCommit(Stmt):
         return [f'{_pad(ctx.indent)}asm volatile("cp.async.commit_group;\\n" ::: "memory");']
 
 
-@dataclass
+@dataclass(frozen=True)
 class CpAsyncWait(Stmt):
     """``cp.async.wait_group N;`` — block this thread until ≤ N cp.async
     groups remain in flight. ``group=0`` waits for everything (synchronous
@@ -203,7 +203,7 @@ class CpAsyncWait(Stmt):
         return [f'{_pad(ctx.indent)}asm volatile("cp.async.wait_group {self.group};\\n" ::: "memory");']
 
 
-@dataclass
+@dataclass(frozen=True)
 class TmaDescriptor(Stmt):
     """Host-built ``CUtensorMap`` descriptor for a TMA box copy.
 
@@ -237,7 +237,7 @@ class TmaDescriptor(Stmt):
         return []
 
 
-@dataclass
+@dataclass(frozen=True)
 class TmaLoad(Stmt):
     """``cp.async.bulk.tensor.<rank>d`` — single-thread box copy.
 
@@ -289,7 +289,7 @@ def _mbar_addr_expr(mbar: str, slot: Expr | None) -> str:
     return f"__cvta_generic_to_shared(&{mbar}[{{slot_expr}}])".replace("{slot_expr}", "%(slot)s")
 
 
-@dataclass
+@dataclass(frozen=True)
 class MbarrierInit(Stmt):
     """``mbarrier.init.shared.b64 [&mbar[slot]], count;`` — one-shot init.
 
@@ -313,7 +313,7 @@ class MbarrierInit(Stmt):
         return [f"{pad}mbarrier_init({addr}, {self.count});"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class MbarrierArriveExpectTx(Stmt):
     """``mbarrier.arrive.expect_tx.shared.b64`` — declare the expected
     transaction byte count for the in-flight TMA copy on this barrier.
@@ -333,7 +333,7 @@ class MbarrierArriveExpectTx(Stmt):
         return [f"{pad}mbarrier_arrive_expect_tx({addr}, {self.bytes_});"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class MbarrierWait(Stmt):
     """``mbarrier.try_wait.parity.shared.b64`` — block until the barrier's
     parity flips for ``phase``. Replaces ``CpAsyncWait + Sync`` for TMA
@@ -355,7 +355,7 @@ class MbarrierWait(Stmt):
         return [f"{pad}mbarrier_wait_parity({addr}, {phase_expr});"]
 
 
-@dataclass
+@dataclass(frozen=True)
 class TreeHalve(Stmt):
     """Cooperative power-of-two tree reduction over a 1D smem buffer.
 
@@ -395,7 +395,7 @@ class TreeHalve(Stmt):
         ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class WarpShuffle(Stmt):
     """Warp-shuffle reduction: combine ``value`` across ``length`` lanes
     via ``__shfl_xor_sync`` and bind the broadcast result to ``name``.

--- a/deplodock/compiler/ir/stmt/body.py
+++ b/deplodock/compiler/ir/stmt/body.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, field
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import TYPE_CHECKING
 
 from deplodock.compiler.ir.stmt.base import Stmt
@@ -458,11 +458,20 @@ class Body(tuple[Stmt, ...]):
 
     @cached_property
     def _cached_structural_key(self) -> str:
-        from deplodock.compiler.ir.stmt.base import pretty_body  # noqa: PLC0415
-        from deplodock.compiler.ir.stmt.normalize import normalize_body  # noqa: PLC0415
-
-        normalized = normalize_body(self, hoist=False, canonical_buffers=True, cluster_ops=True)
-        return "\n".join(pretty_body(normalized))
+        # Delegates to a module-level lru_cache keyed by Body content
+        # (Body is ``tuple[Stmt, ...]`` and every Stmt subclass is a
+        # frozen dataclass, so the cache key is structural). Two
+        # different Body instances with identical stmts now share the
+        # one ``normalize_body`` call — matters in tune mode where
+        # ``_record_op_inventory`` walks the source chain of every
+        # CudaOp in every terminal and hammers ``op_cache_key`` ->
+        # ``Body.structural_key()`` on bodies that frequently recur
+        # structurally across variants. The cache is safe because
+        # ``structural_key`` always normalizes with the same fixed flag
+        # combination (``hoist=False, canonical_buffers=True,
+        # cluster_ops=True``); generic ``normalize_body`` callers with
+        # other flags do not share this cache.
+        return _shared_structural_key(self)
 
     @cached_property
     def coordination(self) -> Coordination:
@@ -543,6 +552,34 @@ class Body(tuple[Stmt, ...]):
             _write_atomic_axes=atomic_by_id,
             _write_broadcast_axes=broadcast_by_id,
         )
+
+
+@lru_cache(maxsize=4096)
+def _shared_structural_key(body: Body) -> str:
+    """Module-level memoization for :meth:`Body.structural_key`.
+
+    The structural-key formula is fixed: ``normalize_body(body,
+    hoist=False, canonical_buffers=True, cluster_ops=True)`` joined as
+    pretty-printed text. With every concrete ``Stmt`` subclass a frozen
+    dataclass and ``Body`` a ``tuple[Stmt, ...]`` subclass, equal-content
+    bodies hash equal — so two structurally identical Body instances
+    share one normalize+pretty walk through this cache. Tune mode hits
+    this hard from ``_record_op_inventory`` (one ``op_cache_key`` call
+    per ancestor in every CudaOp's source chain, per terminal candidate).
+
+    The cache is sound because the flag combination is hard-coded here.
+    Generic :func:`normalize_body` callers with other flags don't share
+    this cache — ``cluster_ops=True`` collapses semantically distinct ops
+    to a single cluster representative (``add``↔``sub``, ``div``↔``mod``,
+    …), which is the right canonicalization for structural-equivalence
+    queries but would be a *correctness bug* for any callsite running
+    the normalized body.
+    """
+    from deplodock.compiler.ir.stmt.base import pretty_body  # noqa: PLC0415
+    from deplodock.compiler.ir.stmt.normalize import normalize_body  # noqa: PLC0415
+
+    normalized = normalize_body(body, hoist=False, canonical_buffers=True, cluster_ops=True)
+    return "\n".join(pretty_body(normalized))
 
 
 @dataclass(frozen=True)

--- a/deplodock/compiler/ir/stmt/normalize.py
+++ b/deplodock/compiler/ir/stmt/normalize.py
@@ -66,6 +66,7 @@ def normalize_body(
     :attr:`Body.structural_key()` so two bodies that differ only in the
     *kind* of FMA / compare / SFU op at the same position hash equal.
     """
+    stmts = Body.coerce(stmts)
     stmts = topo_sort_siblings(stmts)
     stmts = drop_size_one_free_axes(stmts)
     stmts = canonicalize_free_axis_order(stmts)

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass, field, replace
+from functools import cached_property
 from typing import Literal as _Lit
 
 from deplodock.compiler.dtype import DataType
@@ -1172,6 +1173,28 @@ class TileOp(BodyOp):
         return threads <= ctx.max_threads_per_cta
 
     def score(self, ctx) -> float:  # noqa: ARG002 — ctx reserved for cc-specific tuning
+        return self._cached_score
+
+    @cached_property
+    def _cached_score(self) -> float:
+        """Cached score — ``score(ctx)`` delegates here. ``ctx`` is unused
+        by the formula today (see :meth:`score`'s ARG002 noqa), so the
+        value is a pure function of ``self`` and is safe to memoize:
+        ``self.body`` is frozen after ``__post_init__`` (it's a ``Body``
+        which is a ``tuple[Stmt, ...]`` subclass, every Stmt is itself
+        a frozen dataclass), and ``self.knobs`` is set by
+        ``Candidate.apply`` BEFORE the op is installed on the graph
+        node — so by the time anyone reads ``score`` the inputs are
+        stable.
+
+        Why this matters: ``Candidate.score`` (the MCTS prior) walks
+        every node in the graph and calls ``op.score(ctx)``. Sibling
+        ``SearchNode``s share the same inner ``Candidate``, so the same
+        TileOp instance is scored from every sibling's ``inner.score()``
+        call. Without this cache each TileOp re-walked its body for
+        coalescing analysis on every visit; on Qwen3 0.6B with ~150
+        TileOps in the graph that was the dominant tune-mode cost.
+        """
         from deplodock.compiler.ir.tile.ir import Stage as _Stage  # noqa: PLC0415
 
         block_axes, thread_axes = self._launch_geometry()

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -104,7 +104,7 @@ SerialKind = _Lit["plain", "stage_inner", "serial_outer", "pipeline"]
 # for cp.async, or ``MbarrierWait(mbar, phase, slot)`` for TMA.
 
 
-@dataclass
+@dataclass(frozen=True)
 class AsyncWait(Stmt):
     """Explicit wait carrier for pipelined async / TMA schedules.
 
@@ -434,7 +434,7 @@ def _render_tile_bracket(
 #   semantics are derived: ``is_reduce`` iff the body contains ``Accum``.
 
 
-@dataclass
+@dataclass(frozen=True)
 class ParallelTile(Stmt):
     """Abstract base for tile flavors that bind a parallel axis tuple.
 
@@ -448,7 +448,7 @@ class ParallelTile(Stmt):
 
     def __post_init__(self) -> None:
         if not isinstance(self.body, Body):
-            self.body = Body(self.body)
+            object.__setattr__(self, "body", Body(self.body))
 
     def nested(self) -> tuple[Body, ...]:
         return (self.body,)
@@ -481,7 +481,7 @@ class ParallelTile(Stmt):
         return _render_tile_bracket(indent, for_lines, self._pretty_label(), self.body)
 
 
-@dataclass
+@dataclass(frozen=True)
 class GridTile(ParallelTile):
     """CTA-grid parallel tile. Axes lift to ``blockIdx`` (row-major).
 
@@ -507,7 +507,7 @@ class GridTile(ParallelTile):
         return out
 
 
-@dataclass
+@dataclass(frozen=True)
 class ThreadTile(ParallelTile):
     """Thread-parallel tile. Axes lift to ``threadIdx`` (row-major flatten).
 
@@ -557,7 +557,7 @@ class ThreadTile(ParallelTile):
         return out
 
 
-@dataclass
+@dataclass(frozen=True)
 class RegisterTile(ParallelTile):
     """Per-thread register-cell tile. Body replicated F× per axis by 006a.
 
@@ -576,7 +576,7 @@ class RegisterTile(ParallelTile):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class SerialTileBase(Stmt):
     """Abstract base for serial-iteration tile flavors. One axis, one body."""
 
@@ -585,7 +585,7 @@ class SerialTileBase(Stmt):
 
     def __post_init__(self) -> None:
         if not isinstance(self.body, Body):
-            self.body = Body(self.body)
+            object.__setattr__(self, "body", Body(self.body))
 
     def nested(self) -> tuple[Body, ...]:
         return (self.body,)
@@ -602,7 +602,7 @@ class SerialTileBase(Stmt):
         return any(isinstance(s, Accum) for s in self.body)
 
 
-@dataclass
+@dataclass(frozen=True)
 class SerialTile(SerialTileBase):
     """Sequential iteration over ``axis``. Replaces ``Loop``.
 
@@ -665,7 +665,7 @@ class SerialTile(SerialTileBase):
         return out
 
 
-@dataclass
+@dataclass(frozen=True)
 class StridedTile(SerialTileBase):
     """Strided serial iteration: ``for (axis = start; axis < extent; axis += step)``.
 
@@ -789,7 +789,7 @@ class SwizzleMode(enum.Enum):
     B128 = "B128"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Stage(Stmt):
     """Cooperative-staging unit: one or more ``Source`` entries plus an
     optional cooperative ``compute`` template.
@@ -821,7 +821,7 @@ class Stage(Stmt):
         if not self.sources:
             raise ValueError("Stage: requires at least one Source")
         if self.compute is not None and not isinstance(self.compute, Body):
-            self.compute = Body.coerce(self.compute)
+            object.__setattr__(self, "compute", Body.coerce(self.compute))
 
     def nested(self) -> tuple[Body, ...]:
         return (self.compute,) if self.compute is not None else ()
@@ -882,7 +882,7 @@ class Stage(Stmt):
         return out
 
 
-@dataclass
+@dataclass(frozen=True)
 class StageBundle(Stmt):
     """Single-policy group of cooperative ``Stage`` members sharing one
     consumer ``body``.
@@ -928,7 +928,7 @@ class StageBundle(Stmt):
 
     def __post_init__(self) -> None:
         if not isinstance(self.body, Body):
-            self.body = Body.coerce(self.body)
+            object.__setattr__(self, "body", Body.coerce(self.body))
         if not self.stages:
             raise ValueError("StageBundle: requires at least one Stage")
         for s in self.stages:
@@ -1024,6 +1024,78 @@ class StageBundle(Stmt):
 # ---------------------------------------------------------------------------
 
 
+def score_tile_geometry(
+    *,
+    thread_extents: list[int],
+    block_extents: list[int],
+    knobs: dict,
+    has_stages: bool,
+    coalescing_inner_extent: int,
+) -> float:
+    """Pure-formula scoring shared by :meth:`TileOp.score` and the partition
+    planner. Takes the launch-geometry summary the score depends on (already
+    resolved to static ints, symbolic axes substituted as 1) plus the knob
+    bundle, so the planner can score un-materialized ``TileParams`` against
+    the same yardstick a fully-built ``TileOp`` would use.
+
+    ``coalescing_inner_extent`` is the summed extent of thread axes that
+    appear in any Write's inner-stride dim (0 when none align)."""
+    from math import prod  # noqa: PLC0415
+
+    target_threads = 256
+    target_ctas = 256
+    score = 0.0
+    if not thread_extents:
+        return 0.0
+    threads = prod(thread_extents)
+    ctas = prod(block_extents) if block_extents else 1
+
+    if "FM" in knobs:
+        final_threads = threads
+        cells = max(1, int(knobs.get("FM", 1)) * int(knobs.get("FN", 1)))
+    elif threads >= 1024:
+        final_threads = target_threads
+        cells = max(1, threads // target_threads)
+    else:
+        final_threads = threads
+        cells = 1
+
+    if final_threads < 32:
+        score -= 2.0
+    elif final_threads > 1024:
+        score -= 2.0
+    else:
+        distance = abs(final_threads - target_threads)
+        multiplier = 2.0 if (cells < 16 and "FM" in knobs) else 1.0
+        score -= min(distance / target_threads * multiplier, 2.0)
+
+    if cells == 1:
+        score -= 1.0
+    elif cells > 64:
+        score -= min((cells - 64) / 64.0, 1.0)
+
+    if ctas < target_ctas:
+        score -= (target_ctas - ctas) / target_ctas
+    elif ctas <= 2048:
+        score += 0.5
+    else:
+        score -= min((ctas - 2048) / 4096.0, 2.5)
+
+    splitk = int(knobs.get("SPLITK", 1))
+    if splitk > 4:
+        score -= min((splitk - 4) / 4.0, 1.0)
+
+    if has_stages:
+        score += 1.0
+    if "FM" in knobs:
+        score += 1.0
+
+    if coalescing_inner_extent > 0:
+        score += min(coalescing_inner_extent / 32, 1.0)
+
+    return score
+
+
 @dataclass
 class TileOp(BodyOp):
     """One GPU kernel as a Tile IR program — pre-materialization.
@@ -1100,98 +1172,151 @@ class TileOp(BodyOp):
         return threads <= ctx.max_threads_per_cta
 
     def score(self, ctx) -> float:  # noqa: ARG002 — ctx reserved for cc-specific tuning
-        from math import prod  # noqa: PLC0415
-
         from deplodock.compiler.ir.tile.ir import Stage as _Stage  # noqa: PLC0415
 
-        target_threads = 256
-        target_ctas = 256
-        score = 0.0
         block_axes, thread_axes = self._launch_geometry()
         if not thread_axes and not block_axes:
             return 0.0
-
-        # Symbolic axes (Dim("seq_len")) substitute 1 for scoring — the value is
-        # the same across every variant of this LoopOp so it doesn't affect ranking.
         thread_extents = [ax.extent.as_static() if ax.extent.is_static else 1 for ax in thread_axes]
         block_extents = [ax.extent.as_static() if ax.extent.is_static else 1 for ax in block_axes]
         if not thread_extents:
             return 0.0
+        has_stages = any(isinstance(s, _Stage) for s in self.body.iter())
+        return score_tile_geometry(
+            thread_extents=thread_extents,
+            block_extents=block_extents,
+            knobs=self.knobs,
+            has_stages=has_stages,
+            coalescing_inner_extent=self._coalescing_inner_extent(thread_axes),
+        )
 
-        threads = prod(thread_extents)
-        ctas = prod(block_extents) if block_extents else 1
+    @staticmethod
+    def lazy_score(ctx, *, knobs=None, shapes=None, params=None) -> float | None:  # noqa: ARG004
+        """Lazy scorer (see :meth:`Op.lazy_score`). Returns ``None`` unless
+        called with both ``shapes`` (a :class:`KernelShape` from the
+        partition planner) and ``params`` (a :class:`TileParams` variant).
+        Computes the same value :meth:`score` would on the materialized
+        TileOp, but without running ``_build_split_body`` or
+        ``TileOp.__post_init__`` — lets the planner rank dozens of
+        variants per LoopOp in microseconds instead of milliseconds each.
 
-        if "FM" in self.knobs:
-            final_threads = threads
-            cells = max(1, int(self.knobs.get("FM", 1)) * int(self.knobs.get("FN", 1)))
-        elif threads >= 1024:
-            final_threads = target_threads
-            cells = max(1, threads // target_threads)
+        Launch geometry the planner will produce (mirrors ``_wrap_tower``):
+            - block axes: ``[K_s?, M_b?, N_b]`` with extents
+              ``[SPLITK, ceil(E_M/(BM·FM)), ceil(E_N/(BN·FN))]``
+            - thread axes: ``[K_c?, M_t?, N_t]`` with extents
+              ``[BR, BM, BN]``
+
+        Symbolic outer M/N axes contribute extent 1 to the block-extent
+        product (matches what :meth:`score` does with non-static
+        ``Axis.extent``).
+        """
+        if shapes is None or params is None:
+            return None
+        # Lazy-import to avoid circulars (KernelShape / TileParams live in
+        # the planner module, which depends on this IR module).
+        shape = shapes
+        p = params
+
+        m_symbolic = shape.outer_m is not None and not shape.outer_m.axis.extent.is_static
+        n_symbolic = not shape.outer_n.axis.extent.is_static
+
+        thread_extents: list[int] = []
+        if p.br > 1:
+            thread_extents.append(p.br)
+        if shape.outer_m is not None:
+            thread_extents.append(p.bm)
+        thread_extents.append(p.bn)
+
+        block_extents: list[int] = []
+        if p.splitk > 1:
+            block_extents.append(p.splitk)
+        if shape.outer_m is not None:
+            if m_symbolic:
+                block_extents.append(1)
+            else:
+                E_M = shape.outer_m.axis.extent.as_static()
+                block_extents.append(max(1, E_M // (p.bm * p.fm)))
+        if n_symbolic:
+            block_extents.append(1)
         else:
-            final_threads = threads
-            cells = 1
+            E_N = shape.outer_n.axis.extent.as_static()
+            block_extents.append(max(1, E_N // (p.bn * p.fn)))
 
-        if final_threads < 32:
-            score -= 2.0
-        elif final_threads > 1024:
-            score -= 2.0
-        else:
-            distance = abs(final_threads - target_threads)
-            multiplier = 2.0 if (cells < 16 and "FM" in self.knobs) else 1.0
-            score -= min(distance / target_threads * multiplier, 2.0)
+        # Planner always stamps FM/FN — score keys off ``"FM" in knobs``.
+        score_knobs = {"FM": p.fm, "FN": p.fn, "SPLITK": p.splitk}
 
-        if cells == 1:
-            score -= 1.0
-        elif cells > 64:
-            score -= min((cells - 64) / 64.0, 1.0)
+        # Stages are added by later passes (020_stage_inputs); the planner's
+        # output never contains them at this point.
+        has_stages = False
 
-        if ctas < target_ctas:
-            score -= (target_ctas - ctas) / target_ctas
-        elif ctas <= 2048:
-            score += 0.5
-        else:
-            score -= min((ctas - 2048) / 4096.0, 2.5)
+        coalescing = TileOp._coalescing_inner_extent_from_writes(shape, p)
 
-        splitk = int(self.knobs.get("SPLITK", 1))
-        # SPLITK > 4 pays a real atomicAdd contention cost on top of the
-        # cross-CTA reduction tax; SPLITK=2/4 is usually enough.
-        if splitk > 4:
-            score -= min((splitk - 4) / 4.0, 1.0)
+        return score_tile_geometry(
+            thread_extents=thread_extents,
+            block_extents=block_extents,
+            knobs=score_knobs,
+            has_stages=has_stages,
+            coalescing_inner_extent=coalescing,
+        )
 
-        if any(isinstance(s, _Stage) for s in self.body.iter()):
-            score += 1.0
-        if "FM" in self.knobs:
-            score += 1.0
+    @staticmethod
+    def _coalescing_inner_extent_from_writes(shape, params) -> int:
+        """Mirror of :meth:`_coalescing_inner_extent` computed against the
+        un-rewritten LoopOp body. σ_outer keeps the outer M/N axis names
+        on the eventual thread tiles (M_t inherits ``outer_m.axis.name``,
+        N_t inherits ``outer_n.axis.name``, K_c inherits ``k_loop.axis.name``),
+        so the inner-stride free-var match works the same way before and
+        after body construction.
 
-        score += self._coalescing_bonus(thread_axes)
+        Size-1 thread axes are skipped — ``normalize_body`` inlines them
+        out of the materialized body, so they don't appear in the post-
+        materialization ``thread_axes`` ``_coalescing_inner_extent``
+        iterates. Mirroring that here keeps the lazy score consistent
+        with ``TileOp.score`` on size-1 corners (e.g. BN=1 matmul rows).
+        """
+        from deplodock.compiler.ir.stmt.leaves import Write  # noqa: PLC0415
 
-        return score
+        thread_extent: dict[str, int] = {}
+        if params.br > 1 and shape.k_loop is not None:
+            thread_extent[shape.k_loop.axis.name] = params.br
+        if shape.outer_m is not None and params.bm > 1:
+            thread_extent[shape.outer_m.axis.name] = params.bm
+        if params.bn > 1:
+            thread_extent[shape.outer_n.axis.name] = params.bn
+        if not thread_extent:
+            return 0
 
-    def _coalescing_bonus(self, thread_axes) -> float:
-        """Reward tile shapes whose thread axes align with the innermost
-        output-write dimension (the coalesced-stride axis).
+        best = 0
+        for stmt in shape.outer_n.body.iter():
+            if not isinstance(stmt, Write) or not stmt.index:
+                continue
+            inner_vars = set(stmt.index[-1].free_vars())
+            matched = inner_vars & thread_extent.keys()
+            if not matched:
+                continue
+            extent = sum(thread_extent[name] for name in matched)
+            if extent > best:
+                best = extent
+        return best
 
-        For each top-level ``Write`` in the body, look at the **last**
-        index expression — that's the inner-stride dim of the output
-        buffer. Count how many thread-axis Vars appear free in it, sum
-        their extents, and turn that into a bonus capped at +1.0.
+    def _coalescing_inner_extent(self, thread_axes) -> int:
+        """Sum the extents of thread axes that appear in the inner-stride
+        dim of any top-level ``Write`` in the body. Feeds the coalescing
+        term in :func:`score_tile_geometry`.
 
-        Why this matters: empirically, two variants with identical
-        ``cells × threads × ctas`` can differ 2x in measured latency
-        purely because one parks its threads along the M (outer-stride)
-        output axis and the other parks them along N (inner-stride).
-        The N-major variant gets coalesced gmem loads on the matmul B
-        operand and coalesced store on the output; the M-major one
-        strides B by ``N`` per thread. The four base score terms
-        (threads, cells, ctas, splitk) can't distinguish them — this
-        bonus does.
+        Why this matters: two variants with identical ``cells × threads
+        × ctas`` can differ 2x in measured latency purely because one
+        parks its threads along the M (outer-stride) output axis and
+        the other along N (inner-stride). The N-major variant coalesces
+        gmem loads + the output store; the M-major one strides by N
+        per thread. The four base score terms can't distinguish them.
         """
         from deplodock.compiler.ir.stmt.leaves import Write  # noqa: PLC0415
 
         if not thread_axes:
-            return 0.0
+            return 0
         thread_names = {ax.name for ax in thread_axes}
-        best_inner_extent = 0
+        best = 0
         for stmt in self.body.iter():
             if not isinstance(stmt, Write) or not stmt.index:
                 continue
@@ -1199,17 +1324,10 @@ class TileOp(BodyOp):
             matched = inner_vars & thread_names
             if not matched:
                 continue
-            extent_in_inner = sum((ax.extent.as_static() if ax.extent.is_static else 1) for ax in thread_axes if ax.name in matched)
-            if extent_in_inner > best_inner_extent:
-                best_inner_extent = extent_in_inner
-        if best_inner_extent <= 0:
-            return 0.0
-        # Bonus saturates at warp-size alignment: an inner-dim thread
-        # extent of ≥ 32 already gives full coalescing; anything past
-        # that has no marginal coalescing gain. Cap the reward so the
-        # term doesn't dominate the threads/cells/ctas signals.
-        warp = 32
-        return min(best_inner_extent / warp, 1.0)
+            extent = sum((ax.extent.as_static() if ax.extent.is_static else 1) for ax in thread_axes if ax.name in matched)
+            if extent > best:
+                best = extent
+        return best
 
 
 # ---------------------------------------------------------------------------
@@ -1265,6 +1383,7 @@ __all__ = [
     "Stmt",
     # Top-level
     "TileOp",
+    "score_tile_geometry",
     # Scheduling constants
     "BLOCK_SIZE",
     # Re-exports

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -82,13 +82,29 @@ into get materialized. `Fork.knobs` is read by `_best_fork` (for
 DB-seeded greedy replay) without firing the thunk; `Fork.score` is the
 MCTS prior the producing rule attaches.
 
-No production rule currently emits branch Forks — an early experiment
-in the partition planner showed that a priority-rank-derived
-`Fork.score` is a coarser MCTS prior than the proper `TileOp.score`,
-so hierarchical exploration found best variants more slowly than the
-flat list. The infrastructure stays because it's straightforward to
-use once a richer per-level prior (or a search-space size that
-amortizes the structural overhead) justifies it.
+The partition planner (`lowering/tile/010_partition_loops`) emits a
+hierarchical Fork tree: `BR → (BM,BN) → (FM,FN) → (BK,SPLITK) → TileOp`
+leaf. Sibling sorting uses `TileOp.lazy_score(ctx, shapes=..., params=...)`
+— the static-method counterpart of `Op.score` that estimates the same
+formula from cheap inputs (knob bundle + planner shape) so siblings rank
+without anyone instantiating a TileOp. The branch tree's `Fork.score`
+propagates max from leaves, matching MCTS's max-Q semantics.
+
+Leaf Fork `expand` thunks call `_materialize(plan, params)` lazily —
+`_build_split_body` + `TileOp.__post_init__` (which runs the full
+12-pass `normalize_body`) only fire for the variant the search actually
+resolves. In greedy `deplodock compile`, that's one variant per
+LoopOp. Earlier behavior materialized every variant up front (dozens
+to ~200 per matmul-class kernel) just to score them; the lazy split
+cut whole-model Qwen3 0.6B compile from 10+ minutes to ~48 seconds.
+
+For rules that want a custom lazy scorer, override
+`Op.lazy_score(cls, ctx, *, knobs=None, shapes=None, params=None)` on
+the producing Op class. The base implementation returns `None` (no
+lazy estimate available); callers fall back to constructing the op
+and calling `score(ctx)`. `TileOp.lazy_score` is the reference
+implementation — it consumes `KernelShape` + `TileParams` from the
+partition planner and replicates `TileOp.score`'s formula byte-for-byte.
 
 **Idempotence requirement.** Every rule MUST be idempotent on its own
 output. The engine re-runs the entire pipeline on each popped candidate

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -166,7 +166,7 @@ class KernelShape:
     variant of a single kernel: the output axis Loops (innermost-N, optional
     M, extra outer chain), the K reduce Loop (None for pointwise), and the
     set of axis names ``_replace_k_loops`` should rewrite (collected once
-    upfront by ``_split_kernel_fully`` instead of re-classified per variant).
+    upfront by ``_plan_kernel`` instead of re-classified per variant).
     """
 
     outer_n: Loop
@@ -180,6 +180,27 @@ class KernelShape:
     prologue: tuple[Stmt, ...] = ()
 
 
+@dataclass(frozen=True)
+class _Plan:
+    """Cheap-to-build planning state shared across every variant of one
+    LoopOp. Holds the inputs ``_materialize`` needs to build any single
+    TileOp on demand: the per-LoopOp ``shape``, the leading non-Loop body
+    stmts, the LoopOp's carry-forward knobs, the rendered kernel name, and
+    the enumerated ``TileParams`` sorted by score. The planner runs every
+    classification + enumeration step once and stops short of body
+    construction — ``_materialize(plan, params)`` runs the expensive
+    ``_build_split_body`` + ``TileOp.__post_init__`` work for one
+    variant only, called lazily from the chosen Fork leaf's ``expand``.
+    """
+
+    shape: KernelShape
+    leading: tuple[Stmt, ...]
+    base_knobs: dict
+    kernel_name: str
+    loop_op: LoopOp
+    params: tuple[TileParams, ...]
+
+
 def rewrite(ctx: Context, root: Node) -> Graph | None | TileOp | Fork | list[Fork]:
     """Emit a hierarchical Fork tree over knob bundles:
     ``BR → (BM,BN) → (FM,FN) → (BK,SPLITK) → TileOp leaf``.
@@ -190,27 +211,42 @@ def rewrite(ctx: Context, root: Node) -> Graph | None | TileOp | Fork | list[For
     Fork wrappers — most matmul kernels have BR fixed at 1 so they
     actually emit a 3-level tree.
 
-    Each branch Fork's ``score`` is the max ``TileOp.score(ctx)`` of any
-    leaf reachable under it — the planner-side equivalent of the max-Q
-    propagation MCTS does on measured rewards. Siblings at each level
-    are sorted by score descending so the highest-scoring branch is
-    option-0 (the greedy primary, the +∞-tiebreak winner)."""
+    Variant *materialization* (``_build_split_body`` + ``TileOp(...)``
+    which runs the body-normalize pipeline) is deferred to the leaf
+    Fork's ``expand`` thunk, so greedy compile only builds the one
+    chosen variant per LoopOp. ``_plan_kernel`` runs the cheap up-front
+    classification + enumeration and produces a ``_Plan`` with bare
+    ``TileParams`` tuples; sibling sorting uses :meth:`TileOp.lazy_score`
+    (mirrors :meth:`TileOp.score`) so the ordering matches what the
+    fully-built TileOps would have produced."""
     loop_op: LoopOp = root.op
     kernel_name = _kernel_name_for(loop_op, root.id)
     # Idempotence is structural: once the planner has built a TileOp, the
     # rule pattern (LoopOp) no longer matches.
-    variants = _split_kernel_fully(loop_op, ctx, kernel_name=kernel_name)
-    if variants is None:
+    plan = _plan_kernel(loop_op, ctx, kernel_name=kernel_name)
+    if plan is None:
         raise RuleSkipped("kernel shape not handled by planner (or already planned)")
 
-    if len(variants) == 1:
-        return variants[0]
+    if len(plan.params) == 1:
+        return _materialize(plan, plan.params[0])
 
-    return _build_fork_tree(variants, ctx)
+    return _build_fork_tree_lazy(plan, ctx)
 
 
-def _build_fork_tree(variants: list[TileOp], ctx: Context) -> Fork | list[Fork]:
-    """Convert a flat ``list[TileOp]`` into the hierarchical Fork tree.
+def _score_variant(plan: _Plan, params: TileParams, ctx: Context) -> float:
+    """Score one variant from the plan + params. Prefers
+    :meth:`TileOp.lazy_score` (cheap, params/shape-only) and falls back to
+    materializing + :meth:`TileOp.score` if a future TileOp drops its lazy
+    implementation. Lets the planner rank siblings before paying the
+    body-construction cost."""
+    lazy = TileOp.lazy_score(ctx, shapes=plan.shape, params=params)
+    if lazy is not None:
+        return lazy
+    return _materialize(plan, params).score(ctx)
+
+
+def _build_fork_tree_lazy(plan: _Plan, ctx: Context) -> Fork | list[Fork]:
+    """Convert ``plan.params`` into the hierarchical Fork tree.
 
     Grouping order (outermost first): BR → (BM,BN) → (FM,FN) → (BK,SPLITK).
     A level is skipped (Fork wrapper omitted) when every variant in the
@@ -218,46 +254,50 @@ def _build_fork_tree(variants: list[TileOp], ctx: Context) -> Fork | list[Fork]:
     common case (all variants have BR=1) doesn't add a useless 1-child
     Fork layer.
 
-    **Sibling ordering** is by max-propagated ``TileOp.score`` descending:
-    option-0 at each level is the branch containing the best-scoring
-    reachable leaf. ``TileOp.score`` is the single source of truth for
-    both greedy primary selection AND the MCTS prior — keep them aligned
-    so a high-score variant the search will exploit later is also the
-    one greedy picks today.
+    **Sibling ordering** is by max-propagated :func:`_score_variant`
+    descending — same yardstick :meth:`TileOp.score` would use post-
+    materialization, routed through :meth:`TileOp.lazy_score` (the lazy
+    cousin of ``score`` exposed on the Op base) so we don't have to
+    build every TileOp just to rank them. Leaf Fork ``expand`` thunks
+    defer ``_materialize(plan, params)`` until the search actually
+    resolves that leaf — greedy compile only fires one per LoopOp.
 
     Returns a single ``Fork`` when the top-level group collapses to one
     branch (engine still routes through the fork-spawn path since
     ``isinstance(option, Fork)``), otherwise the ``list[Fork]`` of
     siblings.
     """
-    leaf_score: dict[int, float] = {id(v): float(v.score(ctx)) for v in variants}
+    leaf_score: dict[int, float] = {id(p): _score_variant(plan, p, ctx) for p in plan.params}
 
     def _sorted(forks: list[Fork]) -> list[Fork]:
         return sorted(forks, key=lambda f: -f.score)
 
-    def _leaf_forks(group: list[TileOp]) -> list[Fork]:
+    def _leaf_forks(group: list[TileParams]) -> list[Fork]:
         out = [
             Fork(
-                knobs={BK.name: v.knobs[BK.name], SPLITK.name: v.knobs[SPLITK.name]},
-                expand=(lambda op=v: [op]),
-                score=leaf_score[id(v)],
+                knobs={BK.name: p.bk, SPLITK.name: p.splitk},
+                expand=(lambda p=p: [_materialize(plan, p)]),
+                score=leaf_score[id(p)],
                 is_leaf=True,
             )
-            for v in group
+            for p in group
         ]
         return _sorted(out)
 
     def _group_level(
-        group: list[TileOp],
+        group: list[TileParams],
         knob_names: tuple[str, ...],
+        knob_getters: tuple,
         child_builder,
     ) -> list[Fork]:
         """Build sibling Forks for one level, keyed by ``knob_names``,
-        sorted by max-propagated score descending."""
-        keyed: dict[tuple, list[TileOp]] = {}
-        for v in group:
-            key = tuple(v.knobs[n] for n in knob_names)
-            keyed.setdefault(key, []).append(v)
+        sorted by max-propagated score descending. ``knob_getters`` reads
+        the matching field off ``TileParams`` (the planner's source of
+        truth pre-materialization)."""
+        keyed: dict[tuple, list[TileParams]] = {}
+        for p in group:
+            key = tuple(g(p) for g in knob_getters)
+            keyed.setdefault(key, []).append(p)
         if len(keyed) == 1:
             return child_builder(next(iter(keyed.values())))
         siblings: list[Fork] = []
@@ -275,16 +315,16 @@ def _build_fork_tree(variants: list[TileOp], ctx: Context) -> Fork | list[Fork]:
             )
         return _sorted(siblings)
 
-    def _fmfn_level(group: list[TileOp]) -> list[Fork]:
-        return _group_level(group, (FM.name, FN.name), _leaf_forks)
+    def _fmfn_level(group: list[TileParams]) -> list[Fork]:
+        return _group_level(group, (FM.name, FN.name), (lambda p: p.fm, lambda p: p.fn), _leaf_forks)
 
-    def _bmbn_level(group: list[TileOp]) -> list[Fork]:
-        return _group_level(group, (BM.name, BN.name), _fmfn_level)
+    def _bmbn_level(group: list[TileParams]) -> list[Fork]:
+        return _group_level(group, (BM.name, BN.name), (lambda p: p.bm, lambda p: p.bn), _fmfn_level)
 
-    def _br_level(group: list[TileOp]) -> list[Fork]:
-        return _group_level(group, (BR.name,), _bmbn_level)
+    def _br_level(group: list[TileParams]) -> list[Fork]:
+        return _group_level(group, (BR.name,), (lambda p: p.br,), _bmbn_level)
 
-    top = _br_level(variants)
+    top = _br_level(list(plan.params))
     if len(top) == 1:
         return top[0]
     return top
@@ -638,8 +678,13 @@ def _gate_linear_epilogue_on_k_s_zero(stmts: tuple[Stmt, ...], k_s_name: str) ->
     return reduce_part + (cond,)
 
 
-def _split_kernel_fully(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "") -> list[TileOp] | None:
-    """Unified σ-split for matmul, pointwise, and cooperative-reduce kernels.
+def _plan_kernel(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "") -> _Plan | None:
+    """Unified σ-split planning for matmul, pointwise, and cooperative-reduce
+    kernels. Returns a :class:`_Plan` whose ``params`` enumerates every
+    candidate ``TileParams`` but doesn't materialize any TileOp — the
+    expensive ``_build_split_body`` + ``TileOp.__post_init__`` work is
+    deferred to :func:`_materialize`, invoked from the chosen Fork leaf's
+    ``expand`` thunk in :func:`_build_fork_tree_lazy`.
 
     Detection is predicate-driven: ``is_matmul_reduce`` (≥ 2 K-indexed Loads +
     Accum) picks the matmul knob set; any other reduce with extent ≥ warp_size
@@ -807,25 +852,47 @@ def _split_kernel_fully(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "")
         prologue=prologue,
     )
     leading, _ = _split_leading_non_loops(loop_op.body)
-    variants: list[TileOp] = []
-    for params in param_combos:
-        try:
-            chain_body = _build_split_body(shape, params)
-        except _BuildSkipped:
-            continue
-        new_body = leading + chain_body
-        knobs = {
-            **loop_op.knobs,
-            BN.name: params.bn,
-            BM.name: params.bm,
-            FM.name: params.fm,
-            FN.name: params.fn,
-            BK.name: params.bk,
-            SPLITK.name: params.splitk,
-            BR.name: params.br,
-        }
-        variants.append(TileOp(body=new_body, name=kernel_name, knobs=knobs))
-    return variants or None
+    if not param_combos:
+        return None
+    return _Plan(
+        shape=shape,
+        leading=leading,
+        base_knobs=dict(loop_op.knobs),
+        kernel_name=kernel_name,
+        loop_op=loop_op,
+        params=tuple(param_combos),
+    )
+
+
+def _materialize(plan: _Plan, params: TileParams) -> TileOp:
+    """Build one ``TileOp`` for a single ``TileParams`` against the
+    planner's pre-computed shape. The expensive bits — ``_build_split_body``
+    and ``TileOp.__post_init__`` (which runs ``normalize_body`` over the
+    fresh body) — happen here, lazily, from the chosen Fork leaf's
+    ``expand`` thunk.
+
+    ``_BuildSkipped`` is shape-determined (raised only when
+    ``_replace_k_loops`` can't find any K-axis Loops in the body, which
+    depends on ``shape.target_names`` matching the body's axis names, not
+    on params). If it ever fires here, the shape was misclassified at
+    plan time — the assertion surfaces the bug instead of silently
+    dropping a leaf.
+    """
+    try:
+        chain_body = _build_split_body(plan.shape, params)
+    except _BuildSkipped as exc:
+        raise AssertionError(f"shape-level _BuildSkipped fired at materialize time for kernel {plan.kernel_name!r}: {exc}") from exc
+    knobs = {
+        **plan.base_knobs,
+        BN.name: params.bn,
+        BM.name: params.bm,
+        FM.name: params.fm,
+        FN.name: params.fn,
+        BK.name: params.bk,
+        SPLITK.name: params.splitk,
+        BR.name: params.br,
+    }
+    return TileOp(body=plan.leading + chain_body, name=plan.kernel_name, knobs=knobs)
 
 
 def _priority_matmul(p: TileParams) -> tuple[int, ...]:

--- a/deplodock/compiler/pipeline/search/candidate.py
+++ b/deplodock/compiler/pipeline/search/candidate.py
@@ -292,35 +292,30 @@ class LazyCandidate:
 
     def score(self) -> float:
         """Mean of every node's ``op.score(ctx)`` in the candidate's
-        graph. For a branch :class:`Fork`, return
-        ``inner.score() + fork.score`` — the fork's prior preserves the
-        priority signal MCTS would otherwise lose at intermediate
-        levels. For a leaf Fork, fire the (trivial) thunk to retrieve
-        the wrapped ``Op``/``Graph``, then score with that option
-        substituted at the match's root (Op case) or via full resolve
-        + score (Graph case)."""
-        from deplodock.compiler.ir.base import Op  # noqa: PLC0415
+        graph, with the pending Fork's planner prior added on top.
 
+        Branch and leaf Forks score identically: ``inner.score() +
+        fork.score``. ``fork.score`` is the planner-computed prior the
+        rule attached (for partition leaves, that's
+        ``TileOp.lazy_score(ctx, shapes=..., params=...)`` — the same
+        formula ``TileOp.score`` runs post-materialization, but cheap).
+
+        We deliberately do NOT fire ``fork.expand()`` here to recover
+        the option and re-score it: ``expand()`` for a partition leaf
+        runs ``_build_split_body`` + ``TileOp.__post_init__`` (full body
+        normalization), and MCTS's ``_ucb_key`` reads this score for
+        every unvisited sibling at every descent level. Materializing
+        every leaf just to rank them defeats the whole lazy-planner
+        design. The leaf's planner-side score is already an accurate
+        equivalent of what its post-materialization
+        ``TileOp.score(ctx)`` would return (the lazy/eager parity
+        check in ``test_lazy_score_matches_tile_op_score`` enforces
+        this), so the cheap signal is the right one to use.
+        """
         if self.pending is None:
             return self.inner.score()
-        match, fork = self.pending
-        if not fork.is_leaf:
-            return self.inner.score() + fork.score
-        # Leaf Fork — fire the trivial thunk to retrieve the wrapped option.
-        leaves = fork.expand()
-        if not leaves:
-            return self.inner.score()
-        option = leaves[0]
-        if not isinstance(option, Op):
-            return self.resolve().score()
-        ctx = self.inner.ctx
-        scores: list[float] = []
-        for n in self.inner.graph.nodes.values():
-            op = option if n.id == match.root_node_id else n.op
-            s = op.score(ctx)
-            if s is not None:
-                scores.append(s)
-        return sum(scores) / len(scores) if scores else 0.0
+        _, fork = self.pending
+        return self.inner.score() + fork.score
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/pipeline/search/policy/mcts.py
+++ b/deplodock/compiler/pipeline/search/policy/mcts.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from functools import cached_property
 
 from deplodock.compiler.pipeline.search.candidate import LazyCandidate
 from deplodock.compiler.pipeline.search.db import PerfStats
@@ -38,8 +39,18 @@ class SearchNode:
     best_reward: float = 0.0  # max reward over this subtree's measured leaves
     live: int = 0  # count of un-popped frontier leaves in this subtree
 
-    @property
+    @cached_property
     def score(self) -> float:
+        """Cached :meth:`LazyCandidate.score` — UCB descent reads this on
+        every unvisited sibling at every level per pop. Without the
+        cache, ``Candidate.score`` (which iterates every graph node and
+        calls ``op.score(ctx)``) re-runs ~O(siblings) per pop, with
+        leaf-Fork siblings additionally materializing their TileOps via
+        ``fork.expand()`` (full ``_build_split_body`` + body
+        normalization). The cache is sound because ``LazyCandidate.score``
+        is a pure function of ``inner.graph`` + ``pending``, both
+        frozen once the SearchNode is attached.
+        """
         return self.candidate.score() if self.candidate is not None else float("-inf")
 
 

--- a/tests/compiler/passes/test_partition_planner_forks.py
+++ b/tests/compiler/passes/test_partition_planner_forks.py
@@ -1,14 +1,17 @@
 """Tests for the hierarchical Fork tree emitted by ``010_partition_loops``.
 
-The planner converts its flat ``list[TileOp]`` variant set into a
-``BR → (BM,BN) → (FM,FN) → (BK,SPLITK) → TileOp leaf`` Fork tree. Levels
-with a single value collapse (no Fork wrapper). Branch scores propagate
-``max`` from leaves so the search picks high-Q subtrees first.
+The planner emits a ``BR → (BM,BN) → (FM,FN) → (BK,SPLITK) → TileOp leaf``
+Fork tree from a ``_Plan`` (cheap-to-build pre-materialization state).
+Levels with a single value collapse (no Fork wrapper). Branch scores
+propagate ``max`` from leaves so the search picks high-Q subtrees first.
+Leaf ``expand`` thunks materialize the chosen TileOp on demand —
+:func:`_materialize` runs ``_build_split_body`` + body normalization
+only when the leaf is actually resolved.
 
 We exercise the builder directly via importlib (the module name has a
 ``000_`` numeric prefix and isn't importable with normal syntax) on
-real planner-emitted ``TileOp`` lists rather than synthetic stubs —
-that way we catch knob-name drift and ``TileOp.score`` shape changes.
+real planner-emitted plans rather than synthetic stubs — that way we
+catch knob-name drift and score-formula shape changes.
 """
 
 from __future__ import annotations
@@ -26,8 +29,9 @@ from deplodock.compiler.ir.tile.ir import TileOp
 from deplodock.compiler.pipeline.pipeline import Fork
 
 _planner = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.tile.010_partition_loops")
-_build_fork_tree = _planner._build_fork_tree
-_split_kernel_fully = _planner._split_kernel_fully
+_build_fork_tree_lazy = _planner._build_fork_tree_lazy
+_plan_kernel = _planner._plan_kernel
+_materialize = _planner._materialize
 
 
 def _ctx() -> Context:
@@ -91,19 +95,19 @@ def _loop_op_pointwise(*, m: int = 4, n: int = 8) -> LoopOp:
     )
 
 
-def _matmul_variants() -> list[TileOp]:
-    """Return the planner's flat ``list[TileOp]`` for a plain matmul.
-    Multi-variant by construction (matmul gets the full BN×BM×FM×FN×BK×SPLITK grid)."""
-    variants = _split_kernel_fully(_loop_op_matmul(), _ctx(), kernel_name="k_matmul")
-    assert variants is not None and len(variants) > 1, "matmul should yield multiple variants"
-    return variants
+def _matmul_plan():
+    """Return the planner's ``_Plan`` for a plain matmul. Multi-variant by
+    construction (matmul gets the full BN×BM×FM×FN×BK×SPLITK grid)."""
+    plan = _plan_kernel(_loop_op_matmul(), _ctx(), kernel_name="k_matmul")
+    assert plan is not None and len(plan.params) > 1, "matmul should yield multiple variants"
+    return plan
 
 
-def _pointwise_variants() -> list[TileOp]:
-    """Planner's flat variant list for a pointwise kernel — all BR=1."""
-    variants = _split_kernel_fully(_loop_op_pointwise(), _ctx(), kernel_name="k_pointwise")
-    assert variants is not None and len(variants) > 1, "pointwise should yield multiple variants"
-    return variants
+def _pointwise_plan():
+    """Planner's ``_Plan`` for a pointwise kernel — all BR=1."""
+    plan = _plan_kernel(_loop_op_pointwise(), _ctx(), kernel_name="k_pointwise")
+    assert plan is not None and len(plan.params) > 1, "pointwise should yield multiple variants"
+    return plan
 
 
 def _walk_leaves(tree: Fork | list[Fork]) -> list[Fork]:
@@ -136,34 +140,41 @@ def test_single_variant_short_circuits_to_single_leaf():
     """With one variant in, the builder collapses every level and returns
     a single leaf Fork (not a list of siblings). The engine still routes
     it through the fork-spawn path since ``isinstance(option, Fork)``."""
-    variants = _matmul_variants()
-    one = variants[:1]
-    tree = _build_fork_tree(one, _ctx())
+    plan = _matmul_plan()
+    one_plan = _planner._Plan(
+        shape=plan.shape,
+        leading=plan.leading,
+        base_knobs=plan.base_knobs,
+        kernel_name=plan.kernel_name,
+        loop_op=plan.loop_op,
+        params=plan.params[:1],
+    )
+    tree = _build_fork_tree_lazy(one_plan, _ctx())
     assert isinstance(tree, Fork)
     assert tree.is_leaf
 
 
 def test_multi_variant_matmul_emits_branch_forks():
-    variants = _matmul_variants()
-    tree = _build_fork_tree(variants, _ctx())
+    plan = _matmul_plan()
+    tree = _build_fork_tree_lazy(plan, _ctx())
     branches = _walk_branches(tree)
     assert branches, "expected branch Forks for a multi-variant matmul"
 
 
 def test_leaves_preserve_every_variant():
-    """Tree's leaf set must equal the flat variant list (no dup/drop)."""
-    variants = _matmul_variants()
-    tree = _build_fork_tree(variants, _ctx())
+    """Tree's leaf set must equal the planner's enumerated params (no dup/drop)."""
+    plan = _matmul_plan()
+    tree = _build_fork_tree_lazy(plan, _ctx())
     leaves = _walk_leaves(tree)
-    assert len(leaves) == len(variants), f"leaf count {len(leaves)} doesn't match variant count {len(variants)}"
+    assert len(leaves) == len(plan.params), f"leaf count {len(leaves)} doesn't match variant count {len(plan.params)}"
 
 
 def test_leaf_knobs_are_bk_splitk_only():
     """Leaf Forks pin only (BK, SPLITK) — the rest is committed by ancestor
     branch Forks. The DB lookup at fork-replay time matches deltas
     per-level, so the partition must be tight."""
-    variants = _matmul_variants()
-    tree = _build_fork_tree(variants, _ctx())
+    plan = _matmul_plan()
+    tree = _build_fork_tree_lazy(plan, _ctx())
     for leaf in _walk_leaves(tree):
         assert set(leaf.knobs.keys()) <= {"BK", "SPLITK"}, f"leaf knobs leak into non-(BK,SPLITK): {leaf.knobs}"
 
@@ -171,8 +182,8 @@ def test_leaf_knobs_are_bk_splitk_only():
 def test_branch_score_is_max_of_children():
     """Max-propagated scores: each branch Fork's score equals the max
     score among its direct children (branches or leaves)."""
-    variants = _matmul_variants()
-    tree = _build_fork_tree(variants, _ctx())
+    plan = _matmul_plan()
+    tree = _build_fork_tree_lazy(plan, _ctx())
     for branch in _walk_branches(tree):
         children = branch.expand()
         assert children
@@ -181,30 +192,50 @@ def test_branch_score_is_max_of_children():
 
 
 def test_first_leaf_matches_best_score_variant():
-    """Sibling ordering is by max-propagated ``TileOp.score`` descending:
+    """Sibling ordering is by max-propagated ``TileOp.lazy_score`` descending:
     the leaf reachable by always taking option-0 must be the highest-
-    scoring variant in the planner's emission. Greedy primary = score
-    primary (single source of truth, also used as MCTS prior)."""
-    variants = _matmul_variants()
+    scoring TileParams in the planner's enumeration. Greedy primary =
+    score primary (single source of truth, also used as MCTS prior).
+
+    Asserted against ``TileOp.lazy_score`` (the cheap pre-materialization
+    scorer on the Op protocol) rather than instantiating every variant —
+    both compute the same number by ``lazy_score``'s contract."""
+    plan = _matmul_plan()
     ctx = _ctx()
-    tree = _build_fork_tree(variants, ctx)
+    tree = _build_fork_tree_lazy(plan, ctx)
 
     node = tree if isinstance(tree, Fork) else tree[0]
     while not node.is_leaf:
         node = node.expand()[0]
     leaf_op = node.expand()[0]
 
-    expected = max(variants, key=lambda v: v.score(ctx))
-    assert leaf_op.score(ctx) == pytest.approx(expected.score(ctx)), (
-        f"option-0 leaf score {leaf_op.score(ctx)} != max variant score {expected.score(ctx)}"
+    expected = max(plan.params, key=lambda p: TileOp.lazy_score(ctx, shapes=plan.shape, params=p))
+    assert leaf_op.score(ctx) == pytest.approx(TileOp.lazy_score(ctx, shapes=plan.shape, params=expected)), (
+        f"option-0 leaf TileOp.score {leaf_op.score(ctx)} != best lazy_score {TileOp.lazy_score(ctx, shapes=plan.shape, params=expected)}"
     )
+
+
+def test_lazy_score_matches_tile_op_score():
+    """``Op.lazy_score`` contract check: the lazy estimate must equal what
+    the materialized ``TileOp.score(ctx)`` returns. Run across every
+    variant of the matmul plan since it has the widest variant set + the
+    full FM/FN/SPLITK branching that exercises every score-formula branch."""
+    plan = _matmul_plan()
+    ctx = _ctx()
+    for p in plan.params:
+        materialized = _materialize(plan, p)
+        lazy = TileOp.lazy_score(ctx, shapes=plan.shape, params=p)
+        assert lazy is not None, f"TileOp.lazy_score returned None for {p}"
+        assert materialized.score(ctx) == pytest.approx(lazy), (
+            f"score mismatch for {p}: TileOp.score={materialized.score(ctx)} vs lazy_score={lazy}"
+        )
 
 
 def test_pointwise_collapses_br_layer():
     """Pointwise kernels have BR=1 fixed, so the BR Fork layer must
     collapse — no branch Fork should ever pin BR for them."""
-    variants = _pointwise_variants()
-    tree = _build_fork_tree(variants, _ctx())
+    plan = _pointwise_plan()
+    tree = _build_fork_tree_lazy(plan, _ctx())
     for branch in _walk_branches(tree):
         assert "BR" not in branch.knobs, f"BR leaked into branch for pointwise: {branch.knobs}"
 
@@ -213,8 +244,8 @@ def test_branch_knobs_partition_cleanly():
     """The union of (root-fork knobs, walked branch knobs, leaf knobs)
     along any root→leaf path must cover ``{BR, BM, BN, FM, FN, BK, SPLITK}``
     exactly once each — no knob duplicated across levels, none missing."""
-    variants = _matmul_variants()
-    tree = _build_fork_tree(variants, _ctx())
+    plan = _matmul_plan()
+    tree = _build_fork_tree_lazy(plan, _ctx())
     expected = {"BR", "BM", "BN", "FM", "FN", "BK", "SPLITK"}
 
     # Walk one root→leaf path and check.

--- a/tests/compiler/test_kernel_op.py
+++ b/tests/compiler/test_kernel_op.py
@@ -15,7 +15,6 @@ from deplodock.compiler.ir.loop import (
     SelectBranch,
     Write,
 )
-from deplodock.compiler.ir.tensor.ir import ElementwiseOp
 
 
 def Port(index=()):
@@ -178,7 +177,7 @@ def test_load_stmt_binding():
                 axis=Axis("a0", 4),
                 body=(
                     Load("x_val", input="src_0", index=(Var("a0"),)),
-                    Assign("y", ElementwiseOp("negative"), ("x_val",)),
+                    Assign("y", ElementwiseImpl("negative"), ("x_val",)),
                     Write(output="out_0", index=(Var("a0"),), value="y"),
                 ),
             ),
@@ -199,7 +198,7 @@ def test_load_stmt_multiple_sources():
                 body=(
                     Load("a", input="src_0", index=(Var("a0"),)),
                     Load("b", input="src_2", index=(Var("a0"),)),
-                    Assign("y", ElementwiseOp("add"), ("a", "b")),
+                    Assign("y", ElementwiseImpl("add"), ("a", "b")),
                     Write(output="out_0", index=(Var("a0"),), value="y"),
                 ),
             ),
@@ -242,7 +241,7 @@ def test_update_synthesizes_accum_decl():
 
 
 def test_assign_construction():
-    a = Assign("out", ElementwiseOp("add"), args=("a", "b"))
+    a = Assign("out", ElementwiseImpl("add"), args=("a", "b"))
     assert a.name == "out"
     assert a.op.name == "add"
     assert a.args == ("a", "b")
@@ -264,7 +263,7 @@ def test_kernel_pointwise():
         axes=axes,
         inputs=(p, p),
         body=(
-            Assign("z", ElementwiseOp("add"), args=("$0", "$1")),
+            Assign("z", ElementwiseImpl("add"), args=("$0", "$1")),
             Write(output="out_0", index=(Var("a0"),), value="z"),
         ),
     )
@@ -292,7 +291,7 @@ def test_kernel_matmul():
         axes=axes,
         inputs=(p, p),
         body=(
-            Assign("multiply", ElementwiseOp("multiply"), args=("$0", "$1")),
+            Assign("multiply", ElementwiseImpl("multiply"), args=("$0", "$1")),
             Accum(name="dot", value="multiply"),
             Write(output="out_0", index=(Var("a0"),), value="dot"),
         ),
@@ -309,9 +308,9 @@ def test_kernel_matmul_bias():
         axes=axes,
         inputs=(p_mk, p_mk, p_bias),
         body=(
-            Assign("multiply", ElementwiseOp("multiply"), args=("$0", "$1")),
+            Assign("multiply", ElementwiseImpl("multiply"), args=("$0", "$1")),
             Accum(name="dot", value="multiply"),
-            Assign("out", ElementwiseOp("add"), args=("dot", "$2")),
+            Assign("out", ElementwiseImpl("add"), args=("dot", "$2")),
             Write(output="out_0", index=(Var("a0"),), value="out"),
         ),
     )
@@ -346,8 +345,8 @@ def test_kernel_unary_chain():
         axes=axes,
         inputs=(p,),
         body=(
-            Assign("negative", ElementwiseOp("negative"), args=("$0",)),
-            Assign("exp", ElementwiseOp("exp"), args=("negative",)),
+            Assign("negative", ElementwiseImpl("negative"), args=("$0",)),
+            Assign("exp", ElementwiseImpl("exp"), args=("negative",)),
             Write(output="out_0", index=(Var("a0"),), value="exp"),
         ),
     )
@@ -363,7 +362,7 @@ def test_kernel_scatter_output_via_select():
         axes=axes,
         inputs=(p, p),
         body=(
-            Assign("z", ElementwiseOp("add"), args=("$0", "$1")),
+            Assign("z", ElementwiseImpl("add"), args=("$0", "$1")),
             Select(
                 name="v",
                 branches=(
@@ -389,7 +388,7 @@ def test_ssa_rejects_undefined_arg():
         _loop(
             axes=axes,
             inputs=(p,),
-            body=(Assign("y", ElementwiseOp("exp"), args=("z",)),),
+            body=(Assign("y", ElementwiseImpl("exp"), args=("z",)),),
         )
 
 
@@ -401,8 +400,8 @@ def test_ssa_rejects_duplicate_name():
             axes=axes,
             inputs=(p,),
             body=(
-                Assign("y", ElementwiseOp("exp"), args=("$0",)),
-                Assign("y", ElementwiseOp("negative"), args=("y",)),
+                Assign("y", ElementwiseImpl("exp"), args=("$0",)),
+                Assign("y", ElementwiseImpl("negative"), args=("y",)),
             ),
         )
 
@@ -417,8 +416,8 @@ def test_ssa_topo_sorts_forward_reference():
         axes=axes,
         inputs=(p,),
         body=(
-            Assign("a", ElementwiseOp("add"), args=("$0", "b")),
-            Assign("b", ElementwiseOp("exp"), args=("$0",)),
+            Assign("a", ElementwiseImpl("add"), args=("$0", "b")),
+            Assign("b", ElementwiseImpl("exp"), args=("$0",)),
             Write(output="out_0", index=(Var("a0"),), value="a"),
         ),
     )
@@ -435,9 +434,9 @@ def test_ssa_allows_input_name_reuse_in_multiple_args():
         axes=axes,
         inputs=(p,),
         body=(
-            Assign("a", ElementwiseOp("exp"), args=("$0",)),
-            Assign("b", ElementwiseOp("negative"), args=("$0",)),
-            Assign("c", ElementwiseOp("add"), args=("a", "b")),
+            Assign("a", ElementwiseImpl("exp"), args=("$0",)),
+            Assign("b", ElementwiseImpl("negative"), args=("$0",)),
+            Assign("c", ElementwiseImpl("add"), args=("a", "b")),
             Write(output="out_0", index=(Var("a0"),), value="c"),
         ),
     )
@@ -477,7 +476,7 @@ def test_loop_stmt_basic():
             Loop(
                 axis=Axis("a0", 8),
                 body=(
-                    Assign("v", ElementwiseOp("negative"), args=("$0",)),
+                    Assign("v", ElementwiseImpl("negative"), args=("$0",)),
                     Write(output="out_0", index=(Var("a0"),), value="v"),
                 ),
             ),
@@ -498,7 +497,7 @@ def test_loop_axis_sibling_same_name_allowed():
         body=(
             Loop(axis=Axis("k", 8), body=(Accum(name="mx", value="$0", op="maximum"),)),
             Loop(axis=Axis("k", 8), body=(Accum(name="sm", value="$1"),)),
-            Assign("v", ElementwiseOp("add"), args=("mx", "sm")),
+            Assign("v", ElementwiseImpl("add"), args=("mx", "sm")),
             Write(output="out_0", index=(Var("a0"),), value="v"),
         ),
     )
@@ -519,7 +518,7 @@ def test_loop_ssa_scoping():
             body=(
                 Loop(
                     axis=Axis("a0_inner", 4),
-                    body=(Assign("v", ElementwiseOp("negative"), args=("$0",)),),
+                    body=(Assign("v", ElementwiseImpl("negative"), args=("$0",)),),
                 ),
                 # Reference 'v' outside the inner Loop — should fail.
                 Write(output="out_0", index=(Var("a0"),), value="v"),


### PR DESCRIPTION
## Summary

- **Lazy variant materialization in `010_partition_loops`** — `deplodock compile Qwen/Qwen3-Embedding-0.6B --ir cuda` drops from **10+ minutes to ~48 seconds** (~13×). py-spy on the old build showed every sample inside `_split_kernel_fully` → `_build_split_body` → `TileOp.__post_init__` → `normalize_body`, since every variant was materialized just so `_build_fork_tree` could sort siblings by `TileOp.score`.
- Splits `_split_kernel_fully` into `_plan_kernel` (cheap shape + `TileParams` enumeration, no body construction) + `_materialize(plan, params)` (builds one TileOp). Leaf Fork `expand` thunks call `_materialize` only when the search resolves that leaf — greedy compile fires one per LoopOp instead of dozens.
- **New `Op.lazy_score(cls, ctx, *, knobs, shapes, params) -> float | None`** on the Op base class — generalizable pattern for any rule that wants to rank variants pre-instantiation. Default returns `None` (caller falls back to constructing the op and calling `score(ctx)`); `TileOp.lazy_score` is the reference implementation, replicating `TileOp.score`'s formula from `KernelShape` + `TileParams`. Parity asserted across every variant of a matmul plan in `test_lazy_score_matches_tile_op_score`.
- **Every concrete `Stmt` subclass is now `@dataclass(frozen=True)`** — Loop-IR, Tile-IR (`GridTile`, `ThreadTile`, `RegisterTile`, `SerialTile`, `StridedTile`, `Stage`, `StageBundle`, `AsyncWait`), Kernel-IR (`Smem`, `Sync`, `CpAsyncCopy`, `TmaDescriptor`, `TmaLoad`, `MbarrierInit`, …). `Body` is a `tuple[Stmt, ...]` subclass so the whole body tree hashes structurally end-to-end. Unblocks `Body.structural_key()` and any future bodies-as-cache-keys work without try/except fallbacks. `__post_init__` field coercions converted to `object.__setattr__`.
- **Misuse fix** — `Assign.op` / `Accum.op` / `Select.op` are typed `ElementwiseImpl` (already hashable). `tests/compiler/test_kernel_op.py` was passing `ElementwiseOp("name")` (an Op wrapper), violating the type annotation. Replaced with `ElementwiseImpl("name")` so the Stmt hash works without freezing the entire Op hierarchy.

## What I tried and dropped

Caching `normalize_body` directly with `functools.lru_cache` (the original ask). Measured **+4.3s overhead** on Qwen3 0.6B compile — the planner's variants produce unique bodies, so the cache never hits; hash-key construction is pure tax. Kept the freezing (still useful for structural keys), removed the wrapper.

## Test plan

- [x] `make test` — 1238 passed, 27 skipped (whole repo)
- [x] `make lint` — clean
- [x] Time `deplodock compile Qwen/Qwen3-Embedding-0.6B --ir cuda` — ~48s (previously 10+ min, killed at 11+ min)
- [ ] Sanity-run `deplodock tune` on a small kernel to confirm no MCTS regression (autotune materializes every leaf anyway, so the lazy split shouldn't hurt; worth a smoke check)

## Files

- `pipeline/passes/lowering/tile/010_partition_loops.py` — `_plan_kernel` / `_materialize` / `_score_variant` / `_build_fork_tree_lazy` + new `_Plan` dataclass
- `ir/base.py` — `Op.lazy_score` base method
- `ir/tile/ir.py` — `score_tile_geometry` formula extracted; `TileOp.lazy_score` override; freeze all Tile-IR Stmt subclasses
- `ir/kernel/ir.py` — freeze all Kernel-IR Stmt subclasses
- `STYLE.md`, `ir/ARCHITECTURE.md`, `pipeline/ARCHITECTURE.md` — document the Stmt-frozen invariant + lazy planner
- `tests/compiler/passes/test_partition_planner_forks.py` — updated to drive `_plan_kernel` / `_build_fork_tree_lazy`; added `test_lazy_score_matches_tile_op_score` parity check
- `tests/compiler/test_kernel_op.py` — `ElementwiseOp(...)` → `ElementwiseImpl(...)` in Stmt constructors

🤖 Generated with [Claude Code](https://claude.com/claude-code)