### PR TITLE
Op provenance: per-kernel Torch reproducers, meaningful kernel names, vs-torch run --ir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ recipes/*/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*/
 
 # Claude Code per-user local settings (skills/agents under .claude/ are tracked)
 .claude/settings.local.json
+*-dump/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ When the user asks about a CLI flag, recipe field, or matrix combinator, read th
 - `make setup` to create the virtual environment and install dependencies
 - Docker and Docker Compose for local deployments
 - `HF_TOKEN` environment variable for HuggingFace model downloads
-- `DEPLODOCK_DUMP_DIR` environment variable (optional) — when set, all compiler stages dump intermediate artifacts (graphs, CUDA kernels, execution plans) to this directory for debugging
+- `DEPLODOCK_DUMP_DIR` environment variable (optional) — when set, all compiler stages dump intermediate artifacts (graphs, CUDA kernels, execution plans) to this directory for debugging. Per kernel, the dump also writes a `<kname>.torch.json` reproducer — the original PyTorch ops that kernel implements (sliced by op provenance), with an `i/N` coverage header (full vs partial) — runnable via `deplodock run --ir <kname>.torch.json --bench` to reproduce accuracy / latency vs torch for that op. Kernels are named after the ops they realize (`k_rms_norm`, `k_sdpa_reduce`)
 - `DEPLODOCK_TUNE_DB` environment variable (optional) — overrides the default tuning SQLite cache path (`~/.cache/deplodock/autotune.db`). `deplodock compile` / `run` / `tune` all read from / write to this path so a tuned variant picked up by one command shows up in the next.
 
 ## Running Tests
@@ -70,6 +70,7 @@ same worker.
   `lowering` / inventory rows to the SQLite cache (path from `DEPLODOCK_TUNE_DB` or `~/.cache/deplodock/autotune.db`),
   and stops on patience (N consecutive measured terminals without a new best).
 - `deplodock run --code "EXPR" [--bench] [--warmup N] [--iters N]` — compile + execute an inline `nn.Module`/torch expression on the CUDA backend, check accuracy vs eager, and (with `--bench`) print a latency table comparing eager PyTorch / `torch.compile` / Deplodock. Same `--code` grammar as `compile --code`.
+- `deplodock run --ir <file.json> [--bench]` — load a JSON IR dump (any stage), finish lowering, execute on random seeded inputs. For a **frontend-dialect** graph (e.g. a dumped `<kname>.torch.json` reproducer) it also builds a real-torch reference (`compiler/backend/torch_ref.py`) and prints the same accuracy check + eager / `torch.compile` / Deplodock table as `--code`; non-frontend IR (loop/tile/…) benches deplodock-only.
 - `deplodock inspect <ir_file>` — display graph IR summary (op counts, inputs, outputs)
 - `deplodock knobs [--db PATH] [--min-variants N] [--kernel SUBSTR]` — knob-impact analysis from the autotune DB.
   Joins `perf` with `cuda_op` and prints per-knob regret + a knob-interaction matrix sorted by geomean impact —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ same worker.
 - Quick test model (ungated, Llama arch): `TinyLlama/TinyLlama-1.1B-Chat-v1.0`
 - GPU benchmark model (ungated, 0.6B): `Qwen/Qwen3-Embedding-0.6B`
 - Block benchmark script: `python scripts/bench_block.py --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --seq-len 32`
+- Per-kernel chart: `python scripts/bench_model_kernels.py --model Qwen/Qwen3-Embedding-0.6B --layer 0` — compiles with a dump, benches each prov-named kernel from its `.torch.json` reproducer (eager / `torch.compile` overlaid where the kernel is torch-comparable; const-transforming ops like linear are deplodock-only), and renders a per-kernel latency bar chart via `deplodock.visualize`. `--tune` autotunes each kernel first.
 
 ## Key Make Targets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ same worker.
 - Quick test model (ungated, Llama arch): `TinyLlama/TinyLlama-1.1B-Chat-v1.0`
 - GPU benchmark model (ungated, 0.6B): `Qwen/Qwen3-Embedding-0.6B`
 - Block benchmark script: `python scripts/bench_block.py --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --seq-len 32`
-- Per-kernel chart: `python scripts/bench_model_kernels.py --model Qwen/Qwen3-Embedding-0.6B --layer 0` — compiles with a dump, benches each prov-named kernel from its `.torch.json` reproducer (eager / `torch.compile` overlaid where the kernel is torch-comparable; const-transforming ops like linear are deplodock-only), and renders a per-kernel latency bar chart via `deplodock.visualize`. `--tune` autotunes each kernel first.
+- Per-kernel chart: `python scripts/bench_model_kernels.py --model Qwen/Qwen3-Embedding-0.6B --layer 0` — compiles with a dump, benches each prov-named kernel from its `.torch.json` reproducer (eager / `torch.compile` overlaid where the kernel is torch-runnable — including linear/attention, whose transposed weights are matched via `load_ops`-replayed constants), and renders a per-kernel latency bar chart via `deplodock.visualize`. `--tune` autotunes each kernel first.
 
 ## Key Make Targets
 

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -633,8 +633,18 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     # Non-frontend IR (loop/tile/…) has no torch twin → deplodock-only bench.
     frontend = graph.copy() if torch_ref.is_runnable(graph) else None
 
+    backend = CudaBackend(debug=args.debug or None, dump=dump, tune_db="auto")
+    db = None
+    if backend.tune_db is not None and backend.tune_db.exists():
+        from deplodock.compiler.pipeline.search.db import SearchDB
+
+        db = SearchDB(path=backend.tune_db)
+        logger.info("Using tuning DB: %s", backend.tune_db)
     if tail:
-        graph = Pipeline.build(tail, dump=dump).run(graph)
+        # Thread the tune DB through the tail lowering so greedy fork selection
+        # (``_best_fork``) picks tuned variants. Without ``db=`` run --ir lowered
+        # at rule defaults and tuned results never showed up here.
+        graph = Pipeline.build(tail, dump=dump).run(graph, db=db)
     from deplodock.compiler.loader.binder import bind_constants
 
     rng = np.random.default_rng(args.seed)
@@ -680,9 +690,6 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
             arr = rng.standard_normal(_static(node.output.shape), dtype=np.float32) * 0.02
             input_data[nid] = arr.flatten().tolist()
 
-    backend = CudaBackend(debug=args.debug or None, dump=dump, tune_db="auto")
-    if backend.tune_db is not None and backend.tune_db.exists():
-        logger.info("Using tuning DB: %s", backend.tune_db)
     result, _ = backend.run(graph, input_data=input_data)
     for nid, arr in result.outputs.items():
         finite = np.isfinite(arr).all()

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -635,23 +635,50 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
 
     if tail:
         graph = Pipeline.build(tail, dump=dump).run(graph)
+    from deplodock.compiler.loader.binder import bind_constants
+
     rng = np.random.default_rng(args.seed)
-    input_data: dict[str, list[float]] = {}
+
+    def _static(shape):
+        return tuple(d.as_static() if hasattr(d, "as_static") else int(d) for d in shape)
+
+    # One random source array per distinct constant ``source_path`` — shared by
+    # deplodock (lowered graph) and the torch ref (frontend graph). The loader's
+    # ``bind_constants`` replays each constant's ``load_ops`` on it, so a weight
+    # that lowering transposed + renamed (linear: out×in → in×out) stays the same
+    # underlying tensor on both sides instead of two unrelated random draws.
+    sources: dict[str, np.ndarray] = {}
+    for gph in ([frontend] if frontend is not None else []) + [graph]:
+        for node in gph.nodes.values():
+            op = node.op
+            if isinstance(op, ConstantOp) and op.value is None and op.source_path and op.source_path not in sources:
+                shp = _static(op.source_shape or node.output.shape)
+                sources[op.source_path] = rng.standard_normal(shp, dtype=np.float32) * 0.02
+
+    input_data: dict[str, object] = {}
     input_tensors: dict[str, object] = {}
+    # Runtime inputs (activations): random, keyed by node id (preserved through
+    # lowering, so both sides see the same arrays). Scalar constants pass their
+    # literal value.
     for nid, node in graph.nodes.items():
         if isinstance(node.op, InputOp):
-            shape = tuple(d.as_static() for d in node.output.shape)
-            arr = rng.standard_normal(shape, dtype=np.float32)
+            arr = rng.standard_normal(_static(node.output.shape), dtype=np.float32)
             input_data[nid] = arr.flatten().tolist()
             input_tensors[nid] = _to_cuda_tensor(arr, node.output.dtype)
-        elif isinstance(node.op, ConstantOp):
-            if node.op.value is not None:
-                input_data[nid] = [float(node.op.value)]
-            else:
-                shape = tuple(d.as_static() for d in node.output.shape)
-                arr = rng.standard_normal(shape, dtype=np.float32) * 0.02
-                input_data[nid] = arr.flatten().tolist()
-                input_tensors[nid] = _to_cuda_tensor(arr, node.output.dtype)
+        elif isinstance(node.op, ConstantOp) and node.op.value is not None:
+            input_data[nid] = [float(node.op.value)]
+
+    # Parameter constants: bind the shared sources through each graph's load_ops.
+    input_data.update(bind_constants(graph, sources))
+    if frontend is not None:
+        for fid, arr in bind_constants(frontend, sources).items():
+            input_tensors[fid] = _to_cuda_tensor(arr, frontend.nodes[fid].output.dtype)
+
+    # Fallback for any value-None constant with no source_path (synthetic).
+    for nid, node in graph.nodes.items():
+        if isinstance(node.op, ConstantOp) and node.op.value is None and nid not in input_data:
+            arr = rng.standard_normal(_static(node.output.shape), dtype=np.float32) * 0.02
+            input_data[nid] = arr.flatten().tolist()
 
     backend = CudaBackend(debug=args.debug or None, dump=dump, tune_db="auto")
     if backend.tune_db is not None and backend.tune_db.exists():

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -702,7 +702,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
             torch_fn, torch_inputs = torch_ref.build_callable(frontend, input_tensors)
             with torch.no_grad():
                 eager_out = torch_fn(*torch_inputs)
-            _check_accuracy(result.outputs, eager_out)
+            _check_accuracy(result.outputs, eager_out, fatal=False)
         except Exception as exc:  # noqa: BLE001 — torch ref is best-effort
             logger.warning("torch reference unavailable (%s) — skipping vs-torch comparison", exc)
             torch_fn = None
@@ -826,16 +826,34 @@ def _to_cuda_kwargs(kwargs):
     return cuda_kwargs
 
 
-def _check_accuracy(outputs, eager_out):
+def _check_accuracy(outputs, eager_out, *, fatal=True):
+    """Compare backend ``outputs`` against the eager reference.
+
+    ``fatal`` (the ``--code`` path) aborts on mismatch / NaN. ``run --ir``
+    passes ``fatal=False``: a sliced reproducer is fed random *boundary* inputs
+    that can be out-of-domain for the op (e.g. a kernel expecting a
+    mean-of-squares gets random signed data → NaN from a downstream rsqrt), so
+    a failure there is informational, not a correctness gate — bench anyway."""
     import numpy as np  # noqa: PLC0415
 
+    def _fail(msg: str) -> None:
+        if fatal:
+            logger.error(msg)
+            sys.exit(1)
+        logger.warning("%s — non-fatal (random-input reproducer); skipping accuracy", msg)
+
     eager_flat = eager_out.detach().cpu().flatten().tolist()
+    if any(e != e for e in eager_flat):
+        _fail("eager reference contains NaN (reproducer inputs out of domain)")
+        if not fatal:
+            return
     failed = False
     for buf_name, arr in outputs.items():
         values = arr.flatten().tolist()
         if any(v != v for v in values):
-            logger.error("CORRECTNESS FAIL: output %s contains NaN", buf_name)
-            sys.exit(1)
+            _fail(f"CORRECTNESS FAIL: output {buf_name} contains NaN")
+            if not fatal:
+                return
         if len(values) == len(eager_flat):
             max_diff = max(abs(a - e) for a, e in zip(values, eager_flat, strict=True))
             mean_diff = sum(abs(a - e) for a, e in zip(values, eager_flat, strict=True)) / len(values)
@@ -885,7 +903,7 @@ def _check_accuracy(outputs, eager_out):
         else:
             logger.warning("Output size %d does not match eager %d; skipping accuracy", len(values), len(eager_flat))
     if failed:
-        sys.exit(1)
+        _fail("accuracy check failed vs eager")
 
 
 _BACKEND_ALIASES = {

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -677,9 +677,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         if torch_fn is not None:
             backends = _resolve_backends(args.bench_backends)
             torch_fns = _build_torch_fns(torch_fn, torch_inputs, {}, args.warmup, backends=backends)
-            results, bench = _bench_interleaved(
-                torch_fn, torch_inputs, {}, backend, graph, args.warmup, args.iters, torch_fns=torch_fns
-            )
+            results, bench = _bench_interleaved(torch_fn, torch_inputs, {}, backend, graph, args.warmup, args.iters, torch_fns=torch_fns)
             if dump:
                 dump.dump_benchmark(bench)
             _print_table(results)

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -619,24 +619,39 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     tail = _passes_after_stage(stage)
     logger.info("Loaded %s IR; running tail passes: %s", stage, tail or "(none)")
 
+    import torch
+
+    from deplodock.compiler.backend import torch_ref
+
     dump = CompilerDump.resolve(args.dump_dir)
     if dump:
         dump.dump_input_graph(graph)
+
+    # Snapshot the pre-lowering frontend graph so we can build a torch
+    # reference (eager + torch.compile) and compare accuracy/latency vs torch —
+    # the same table the --code path produces, now for a dumped .torch.json.
+    # Non-frontend IR (loop/tile/…) has no torch twin → deplodock-only bench.
+    frontend = graph.copy() if torch_ref.is_runnable(graph) else None
 
     if tail:
         graph = Pipeline.build(tail, dump=dump).run(graph)
     rng = np.random.default_rng(args.seed)
     input_data: dict[str, list[float]] = {}
+    input_tensors: dict[str, object] = {}
     for nid, node in graph.nodes.items():
         if isinstance(node.op, InputOp):
             shape = tuple(d.as_static() for d in node.output.shape)
-            input_data[nid] = rng.standard_normal(shape, dtype=np.float32).flatten().tolist()
+            arr = rng.standard_normal(shape, dtype=np.float32)
+            input_data[nid] = arr.flatten().tolist()
+            input_tensors[nid] = _to_cuda_tensor(arr, node.output.dtype)
         elif isinstance(node.op, ConstantOp):
             if node.op.value is not None:
                 input_data[nid] = [float(node.op.value)]
             else:
                 shape = tuple(d.as_static() for d in node.output.shape)
-                input_data[nid] = (rng.standard_normal(shape, dtype=np.float32) * 0.02).flatten().tolist()
+                arr = rng.standard_normal(shape, dtype=np.float32) * 0.02
+                input_data[nid] = arr.flatten().tolist()
+                input_tensors[nid] = _to_cuda_tensor(arr, node.output.dtype)
 
     backend = CudaBackend(debug=args.debug or None, dump=dump, tune_db="auto")
     if backend.tune_db is not None and backend.tune_db.exists():
@@ -646,14 +661,36 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         finite = np.isfinite(arr).all()
         logger.info("Output %s: shape=%s finite=%s mean=%.4f", nid, arr.shape, bool(finite), float(arr.mean()))
 
+    # Build the torch reference from the frontend snapshot, fed the same inputs.
+    torch_fn = torch_inputs = None
+    if frontend is not None:
+        try:
+            torch_fn, torch_inputs = torch_ref.build_callable(frontend, input_tensors)
+            with torch.no_grad():
+                eager_out = torch_fn(*torch_inputs)
+            _check_accuracy(result.outputs, eager_out)
+        except Exception as exc:  # noqa: BLE001 — torch ref is best-effort
+            logger.warning("torch reference unavailable (%s) — skipping vs-torch comparison", exc)
+            torch_fn = None
+
     if args.bench:
-        bench = backend.benchmark(graph, warmup=max(3, args.warmup // 5), num_iters=max(10, args.iters // 5))
-        print()
-        print(f"{'Backend':<24s} {'Latency (us)':>12s}")
-        print("-" * 38)
-        print(f"{'Deplodock':<24s} {bench.time_ms * 1000:>12.0f}")
-        if dump:
-            dump.dump_benchmark(bench)
+        if torch_fn is not None:
+            backends = _resolve_backends(args.bench_backends)
+            torch_fns = _build_torch_fns(torch_fn, torch_inputs, {}, args.warmup, backends=backends)
+            results, bench = _bench_interleaved(
+                torch_fn, torch_inputs, {}, backend, graph, args.warmup, args.iters, torch_fns=torch_fns
+            )
+            if dump:
+                dump.dump_benchmark(bench)
+            _print_table(results)
+        else:
+            bench = backend.benchmark(graph, warmup=max(3, args.warmup // 5), num_iters=max(10, args.iters // 5))
+            print()
+            print(f"{'Backend':<24s} {'Latency (us)':>12s}")
+            print("-" * 38)
+            print(f"{'Deplodock':<24s} {bench.time_ms * 1000:>12.0f}")
+            if dump:
+                dump.dump_benchmark(bench)
         _print_kernel_stats(graph, bench)
     if args.profile:
         _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
@@ -733,6 +770,14 @@ def _eager_output(module, args, kwargs):
     if isinstance(out, tuple):
         out = out[0]
     return out
+
+
+def _to_cuda_tensor(arr, dtype):
+    """numpy array → CUDA torch tensor in the node's dtype (default fp32)."""
+    import torch
+
+    td = getattr(torch, str(dtype), torch.float32)
+    return torch.from_numpy(arr).to("cuda").to(td)
 
 
 def _to_cuda_kwargs(kwargs):

--- a/deplodock/commands/tune.py
+++ b/deplodock/commands/tune.py
@@ -49,6 +49,18 @@ def register_tune_command(subparsers):
             f"shift the walk toward exploration. Default: {TuningSearch.DEFAULT_UCB_C:.4f}."
         ),
     )
+    parser.add_argument(
+        "--bench-timeout",
+        type=float,
+        default=20.0,
+        help=(
+            "Per-variant GPU-time budget (seconds) for the run stage of each bench; exceeding it marks the "
+            "variant bench_fail. The default 20s suits single-kernel sweeps but is too tight for whole-model "
+            "graphs: the first variant pays a one-time cold-start (hundreds of first-launch kernel loads) that "
+            "can exceed 20s even though steady-state is milliseconds, so every variant fails. Bump to ~90 for "
+            "full-model tuning. Default: 20."
+        ),
+    )
     add_diagnostics_args(parser)
     parser.set_defaults(func=handle_tune)
 
@@ -83,9 +95,9 @@ def handle_tune(args):
     # lets a slow-but-progressing 394-kernel bench finish rather than
     # getting pinned for cumulative GPU time alone.
     backend = CudaBackend(
-        bench_wall_timeout_s=60.0,
+        bench_wall_timeout_s=max(60.0, args.bench_timeout * 3),
         bench_compile_timeout_s=10.0,
-        bench_run_timeout_s=20.0,
+        bench_run_timeout_s=args.bench_timeout,
     )
     # ``DEPLODOCK_TUNE_DB`` env overrides the default cache path.
     db_path = resolve_tune_db()

--- a/deplodock/compiler/ARCHITECTURE.md
+++ b/deplodock/compiler/ARCHITECTURE.md
@@ -62,6 +62,7 @@ autotuning cache doesn't bust on cosmetic edits.
 | `loader/`             | Bind constants (safetensors / `nn.Module` → `input_data`) | —              |
 | `pipeline/search/`    | Autotune DB + MCTS tree (see below)     | `pipeline/ARCHITECTURE.md`   |
 | `structural.py`       | `Structural` protocol + `digest()` fold | —                            |
+| `provenance.py`       | Op provenance — map fused kernels back to original frontend ops | — (see below) |
 
 ## Per-layer rules
 
@@ -111,3 +112,24 @@ autotuning cache doesn't bust on cosmetic edits.
   `ir/loop/interpret.py` lets the default `Backend.run` topo-walk
   (`backend/base.py`) run post-fusion graphs on CPU — fusion
   correctness can be checked without a GPU.
+
+## Op provenance
+
+`provenance.py` threads a single `Node.hints["prov"]` map —
+`{origin_id: {"kind": <op-class>, "pieces": [piece_id, …]}}` — from the traced frontend graph all the way to each
+`CudaOp`, so a fused kernel knows which original PyTorch ops it implements. `origin_id` is the trace-time node id of an
+original op (`rms_norm_0`); `pieces` are the primitives it decomposed into and that this node embodies. Coverage of an
+origin is `len(pieces)` over the union of that origin's pieces across the whole graph (`totals` / `coverage`) — so the
+`i/N` fraction stays correct under CSE and recursive decomposition instead of freezing `N` at the first split.
+
+It rides on one chokepoint: `Graph.splice` calls `provenance.propagate` with a `mint_pieces` flag (set by
+`Candidate.apply` from the pass namespace — `True` only for `frontend/decomposition`). Decomposition *mints* each new
+fragment node as a fresh piece of the consumed origins; fusion / lifting / optimization folds *aggregate* the consumed
+piece sets onto the merged node (unioning the dissolved producers so a multi-output splice drops nothing). Lowering is
+in-place `Op` rebinds, so prov rides through `LoopOp → TileOp → KernelOp → CudaOp` untouched. Seeded once at
+`Pipeline.tune` entry (idempotent); pure metadata, excluded from structural / cache keys.
+
+Consumers: `pipeline/passes/lowering/tile/010_partition_loops._kernel_name_for` names kernels after the ops they realize
+(`k_rms_norm` when full, `k_rms_norm_reduce` when partial); `pipeline/dump._dump_torch_repro` slices the pristine
+frontend graph by a kernel's origins into a runnable `<kname>.torch.json`; `backend/torch_ref` runs that slice through
+real torch for the `run --ir` vs-torch comparison.

--- a/deplodock/compiler/backend/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/ARCHITECTURE.md
@@ -23,6 +23,18 @@ What differs is `compile()` — how far the backend lowers the graph:
 distinction is whether the graph has been fused yet. See
 `backend/cuda/ARCHITECTURE.md` for the CUDA-specific dispatch.
 
+## Torch reference (`torch_ref.py`)
+
+Not a `Backend` — a small Graph→torch evaluator that runs a frontend-dialect graph through **real PyTorch**, the eager /
+`torch.compile` baseline for `deplodock run --ir`. Each frontend / tensor op is mapped to its torch twin
+(`RmsNormOp`→`F.rms_norm`, `SdpaOp`→`F.scaled_dot_product_attention`, `LinearOp`→`F.linear`, `ElementwiseOp`/`ReduceOp`→
+the torch elementwise/reduce, layout ops→view/transpose/cat). `is_runnable(graph)` is `True` only when every compute op
+has a mapping — layout/data-dependent ops that appear post-decomposition (`IndexMapOp` / `GatherOp` / `ScatterOp`) are
+unsupported, so `run --ir` falls back to deplodock-only benchmarking for non-frontend IR. `build_callable(graph,
+input_tensors)` returns a pure `fn(*tensors)` (scalar constants read inline) so `torch.compile` can trace it. Used to
+turn a dumped `<kname>.torch.json` reproducer into an accuracy + latency comparison vs torch — see `../provenance.py`
+and `commands/run.py:_handle_run_ir`.
+
 ## Backend ABC (`base.py`)
 
 `Backend` is an abstract base class with `compile`, `run`, `benchmark`.

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -271,27 +271,35 @@ def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> 
     input_data = input_data or {}
     sym_values = _resolve_symbolic(compiled, input_data)
     arrays: dict[str, cp.ndarray] = {}
-    for buf in compiled.bufs:
-        resolved = buf.resolve_shape(sym_values)
-        shape = resolved or (1,)
-        cp_dtype = cupy_dtype(buf.dtype)
-        np_dtype = buf.dtype.np
-        src = input_data.get(buf.name)
-        if src is not None:
-            arr = cp.asarray(np.ascontiguousarray(src, dtype=np_dtype).reshape(shape))
-        elif buf.role == "constant" and buf.name in compiled.constants:
-            arr = cp.full(shape, float(compiled.constants[buf.name]), dtype=cp_dtype)
-        elif buf.role == "input":
-            # Pseudo-random fill for un-supplied inputs (matches old generated program).
-            n = 1
-            for d in shape:
-                n *= int(d)
-            idx = np.arange(n, dtype=np_dtype)
-            vals = (0.01 * ((idx.astype(np.float32) * 7 + 13) % 101 - 50)).astype(np_dtype)
-            arr = cp.asarray(vals.reshape(shape))
-        else:
-            arr = cp.zeros(shape, dtype=cp_dtype)
-        arrays[buf.name] = arr
+    # Saturating casts here are intended, not bugs: e.g. an SDPA mask-fill
+    # constant (``-1e9``) is meant to become ``-inf`` in fp16 (masked → 0 after
+    # softmax). Ignore the over/invalid warnings so genuine output stays clean.
+    with np.errstate(over="ignore", invalid="ignore"):
+        for buf in compiled.bufs:
+            resolved = buf.resolve_shape(sym_values)
+            shape = resolved or (1,)
+            cp_dtype = cupy_dtype(buf.dtype)
+            np_dtype = buf.dtype.np
+            src = input_data.get(buf.name)
+            if src is not None:
+                arr = cp.asarray(np.ascontiguousarray(src, dtype=np_dtype).reshape(shape))
+            elif buf.role == "constant" and buf.name in compiled.constants:
+                arr = cp.full(shape, float(compiled.constants[buf.name]), dtype=cp_dtype)
+            elif buf.role == "input":
+                # Pseudo-random fill for un-supplied inputs (matches old generated program).
+                n = 1
+                for d in shape:
+                    n *= int(d)
+                # Build the index ramp in int64, not ``np_dtype``: a float16 buffer
+                # past 65504 elements would overflow to ``inf`` (then ``inf % 101``
+                # → ``nan``). Compute in fp32 and cast the final values — always in
+                # ``[-0.5, 0.5]``, so fp16-safe.
+                idx = np.arange(n, dtype=np.int64)
+                vals = (0.01 * ((idx.astype(np.float32) * 7 + 13) % 101 - 50)).astype(np_dtype)
+                arr = cp.asarray(vals.reshape(shape))
+            else:
+                arr = cp.zeros(shape, dtype=cp_dtype)
+            arrays[buf.name] = arr
     return arrays
 
 

--- a/deplodock/compiler/backend/torch_ref.py
+++ b/deplodock/compiler/backend/torch_ref.py
@@ -4,10 +4,13 @@ reference for ``deplodock run --ir``.
 Each frontend / tensor-IR op is mapped to the equivalent torch op (the numpy
 ``forward()`` has a torch twin), so a dumped ``.torch.json`` reproducer can be
 accuracy-checked and timed against torch — including torch.compile fusion — not
-just numpy. Layout/data-dependent ops that only appear post-decomposition
-(``IndexMapOp`` / ``GatherOp`` / ``ScatterOp``) are deliberately unsupported:
-:func:`is_runnable` returns ``False`` for such graphs and the caller falls back
-to deplodock-only benchmarking.
+just numpy. ``IndexMapOp`` (the post-decomposition layout primitive — broadcast,
+transpose/reshape/slice/cat, RoPE rotate) is supported as a vectorized
+gather over coordinate grids, so HF norms/RoPE (which trace to primitive
+sequences, not fused aten ops) are torch-comparable. Only the data-dependent
+``GatherOp`` / ``ScatterOp`` (indices come from a runtime tensor, not from the
+output coordinates) stay unsupported: :func:`is_runnable` returns ``False`` and
+the caller falls back to deplodock-only benchmarking.
 """
 
 from __future__ import annotations
@@ -37,6 +40,7 @@ SUPPORTED = frozenset(
         "SoftmaxOp",
         "ElementwiseOp",
         "ReduceOp",
+        "IndexMapOp",
     }
 )
 
@@ -154,7 +158,101 @@ def _eval(node, ins: list):
         tensors = [i for i in ins if isinstance(i, torch.Tensor)]
         dim = next((int(i) for i in ins if not isinstance(i, torch.Tensor)), -1)
         return torch.cat(tensors, dim=dim)
+    if name == "IndexMapOp":
+        return _index_map(op, ins)
     raise NotImplementedError(f"torch_ref: op {name!r} unmapped")
+
+
+def _idx_expr(e, env: dict):
+    """Evaluate a coord/select ``Expr`` over the output-coordinate grids.
+
+    Mirrors ``Expr.eval`` but with torch-/CUDA-safe boolean ops (``Expr.eval``
+    routes ``&&``/``||`` through ``np.logical_and``, which can't take a CUDA
+    tensor). Falls back to ``Expr.eval`` for leaf node types that don't appear
+    in coord maps."""
+    cls = type(e).__name__
+    if cls == "Var":
+        return env[e.name]
+    if cls == "Literal":
+        return e.value
+    if cls == "BinaryExpr":
+        lo, ro = _idx_expr(e.left, env), _idx_expr(e.right, env)
+        op = e.op
+        ops = {
+            "+": lambda a, b: a + b,
+            "-": lambda a, b: a - b,
+            "*": lambda a, b: a * b,
+            "/": lambda a, b: a // b,
+            "//": lambda a, b: a // b,
+            "%": lambda a, b: a % b,
+            "<": lambda a, b: a < b,
+            "<=": lambda a, b: a <= b,
+            ">": lambda a, b: a > b,
+            ">=": lambda a, b: a >= b,
+            "==": lambda a, b: a == b,
+            "!=": lambda a, b: a != b,
+            "&&": lambda a, b: a & b,
+            "&": lambda a, b: a & b,
+            "||": lambda a, b: a | b,
+            "|": lambda a, b: a | b,
+            "^": lambda a, b: a ^ b,
+        }
+        if op in ops:
+            return ops[op](lo, ro)
+    return e.eval(env)
+
+
+def _index_map(op, ins: list):
+    """Run an ``IndexMapOp`` as a vectorized gather over output coordinates.
+
+    For every output cell, the first source whose ``select`` predicate holds
+    supplies the value, read from that source at ``coord_map`` (each entry an
+    affine ``Expr`` over the output coords). Single-source / ``select=None`` is
+    the common case (broadcast, transpose, reshape, slice)."""
+    import torch  # noqa: PLC0415
+
+    from deplodock.compiler.ir.expr import PLACEHOLDER_PREFIX  # noqa: PLC0415
+
+    out_shape = tuple(d.as_static() for d in op.out_shape)
+    # device / dtype from the first tensor-valued source (a source can be a
+    # scalar constant — stored as a python float).
+    base = next((ins[s.input_idx] for s in op.sources if torch.is_tensor(ins[s.input_idx])), None)
+    dev = base.device if base is not None else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dtype = base.dtype if base is not None else torch.float32
+    env = {}
+    for i, d in enumerate(out_shape):
+        shp = [1] * len(out_shape)
+        shp[i] = d
+        env[f"{PLACEHOLDER_PREFIX}{i}"] = torch.arange(d, device=dev, dtype=torch.long).reshape(shp).expand(out_shape)
+
+    result = torch.zeros(out_shape, dtype=dtype, device=dev)
+    filled = torch.zeros(out_shape, dtype=torch.bool, device=dev)
+    for src in op.sources:
+        s = ins[src.input_idx]
+        if not torch.is_tensor(s):  # scalar constant source → broadcast it
+            gathered = torch.full(out_shape, float(s), dtype=dtype, device=dev)
+        else:
+            idx = []
+            for i, c in enumerate(src.coord_map):
+                if i < s.dim() and s.shape[i] == 1:  # size-1 source dim → index 0 (mirror lift)
+                    idx.append(torch.zeros(out_shape, dtype=torch.long, device=dev))
+                else:
+                    v = _idx_expr(c, env)
+                    v = v if torch.is_tensor(v) else torch.full(out_shape, int(v), dtype=torch.long, device=dev)
+                    # Clamp: the gather runs on every cell, but a source's coord_map
+                    # may go out of range where its select is false (those values are
+                    # discarded by ``take`` below). Clamp so the gather never OOBs.
+                    idx.append(v.expand(out_shape).long().clamp(0, s.shape[i] - 1))
+            gathered = s[tuple(idx)]
+        if src.select is None:
+            sel = torch.ones(out_shape, dtype=torch.bool, device=dev)
+        else:
+            sv = _idx_expr(src.select, env)
+            sel = (sv if torch.is_tensor(sv) else torch.full(out_shape, bool(sv), device=dev)).expand(out_shape).bool()
+        take = sel & ~filled
+        result = torch.where(take, gathered, result)
+        filled = filled | take
+    return result
 
 
 def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tuple[Callable, list]:

--- a/deplodock/compiler/backend/torch_ref.py
+++ b/deplodock/compiler/backend/torch_ref.py
@@ -12,7 +12,8 @@ to deplodock-only benchmarking.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import torch
@@ -23,9 +24,19 @@ if TYPE_CHECKING:
 # GatherOp, ScatterOp, ScanOp, …) makes a graph non-runnable as a torch ref.
 SUPPORTED = frozenset(
     {
-        "TransposeOp", "ReshapeOp", "SliceOp", "CatOp", "UnsqueezeOp",
-        "LinearOp", "MatmulOp", "SdpaOp", "MeanOp", "RmsNormOp", "SoftmaxOp",
-        "ElementwiseOp", "ReduceOp",
+        "TransposeOp",
+        "ReshapeOp",
+        "SliceOp",
+        "CatOp",
+        "UnsqueezeOp",
+        "LinearOp",
+        "MatmulOp",
+        "SdpaOp",
+        "MeanOp",
+        "RmsNormOp",
+        "SoftmaxOp",
+        "ElementwiseOp",
+        "ReduceOp",
     }
 )
 
@@ -158,8 +169,11 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
 
     order = graph.topological_order()
     tensor_ids = [nid for nid in order if is_boundary(graph.nodes[nid].op) and getattr(graph.nodes[nid].op, "value", None) is None]
-    scalars = {nid: float(graph.nodes[nid].op.value) for nid in order
-               if is_boundary(graph.nodes[nid].op) and getattr(graph.nodes[nid].op, "value", None) is not None}
+    scalars = {
+        nid: float(graph.nodes[nid].op.value)
+        for nid in order
+        if is_boundary(graph.nodes[nid].op) and getattr(graph.nodes[nid].op, "value", None) is not None
+    }
     compute = [nid for nid in order if not is_boundary(graph.nodes[nid].op)]
     out_id = graph.outputs[0]
 

--- a/deplodock/compiler/backend/torch_ref.py
+++ b/deplodock/compiler/backend/torch_ref.py
@@ -1,0 +1,174 @@
+"""Execute a frontend Graph with real PyTorch — the eager / torch.compile
+reference for ``deplodock run --ir``.
+
+Each frontend / tensor-IR op is mapped to the equivalent torch op (the numpy
+``forward()`` has a torch twin), so a dumped ``.torch.json`` reproducer can be
+accuracy-checked and timed against torch — including torch.compile fusion — not
+just numpy. Layout/data-dependent ops that only appear post-decomposition
+(``IndexMapOp`` / ``GatherOp`` / ``ScatterOp``) are deliberately unsupported:
+:func:`is_runnable` returns ``False`` for such graphs and the caller falls back
+to deplodock-only benchmarking.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    import torch
+
+    from deplodock.compiler.graph import Graph
+
+# Frontend / tensor ops with a torch twin. Everything else (IndexMapOp,
+# GatherOp, ScatterOp, ScanOp, …) makes a graph non-runnable as a torch ref.
+SUPPORTED = frozenset(
+    {
+        "TransposeOp", "ReshapeOp", "SliceOp", "CatOp", "UnsqueezeOp",
+        "LinearOp", "MatmulOp", "SdpaOp", "MeanOp", "RmsNormOp", "SoftmaxOp",
+        "ElementwiseOp", "ReduceOp",
+    }
+)
+
+_TORCH_DTYPE = {"float32": "float32", "float16": "float16", "bfloat16": "bfloat16", "float64": "float64"}
+
+
+def is_runnable(graph: Graph) -> bool:
+    """True if every compute op in ``graph`` has a torch mapping."""
+    from deplodock.compiler.provenance import is_boundary  # noqa: PLC0415
+
+    return all(is_boundary(n.op) or type(n.op).__name__ in SUPPORTED for n in graph.nodes.values())
+
+
+def _elementwise(fn: str, ins: list):
+    import torch  # noqa: PLC0415
+    import torch.nn.functional as F  # noqa: PLC0415
+
+    table: dict[str, Callable] = {
+        "add": lambda a: a[0] + a[1],
+        "sum": lambda a: a[0] + a[1],
+        "subtract": lambda a: a[0] - a[1],
+        "sub": lambda a: a[0] - a[1],
+        "multiply": lambda a: a[0] * a[1],
+        "prod": lambda a: a[0] * a[1],
+        "divide": lambda a: a[0] / a[1],
+        "true_divide": lambda a: a[0] / a[1],
+        "pow": lambda a: a[0] ** a[1],
+        "maximum": lambda a: torch.maximum(a[0], a[1]),
+        "minimum": lambda a: torch.minimum(a[0], a[1]),
+        "negative": lambda a: -a[0],
+        "abs": lambda a: torch.abs(a[0]),
+        "reciprocal": lambda a: torch.reciprocal(a[0]),
+        "sqrt": lambda a: torch.sqrt(a[0]),
+        "rsqrt": lambda a: torch.rsqrt(a[0]),
+        "exp": lambda a: torch.exp(a[0]),
+        "log": lambda a: torch.log(a[0]),
+        "sin": lambda a: torch.sin(a[0]),
+        "cos": lambda a: torch.cos(a[0]),
+        "tanh": lambda a: torch.tanh(a[0]),
+        "sigmoid": lambda a: torch.sigmoid(a[0]),
+        "silu": lambda a: F.silu(a[0]),
+        "relu": lambda a: F.relu(a[0]),
+        "erf": lambda a: torch.erf(a[0]),
+        "gelu": lambda a: F.gelu(a[0]),
+        "gelu_tanh": lambda a: F.gelu(a[0], approximate="tanh"),
+        "copy": lambda a: a[0],
+    }
+    if fn not in table:
+        raise NotImplementedError(f"torch_ref: elementwise {fn!r} unmapped")
+    return table[fn](ins)
+
+
+def _eval(node, ins: list):
+    import torch  # noqa: PLC0415
+    import torch.nn.functional as F  # noqa: PLC0415
+
+    op = node.op
+    name = type(op).__name__
+    if name == "ElementwiseOp":
+        return _elementwise(op.op.name, ins)
+    if name == "ReduceOp":
+        x, ax, fn = ins[0], op.axis, op.op.name
+        if fn in ("sum", "add"):
+            return x.sum(dim=ax, keepdim=True)
+        if fn in ("prod", "multiply"):
+            return x.prod(dim=ax, keepdim=True)
+        if fn in ("maximum", "amax", "max"):
+            return x.amax(dim=ax, keepdim=True)
+        if fn in ("minimum", "amin", "min"):
+            return x.amin(dim=ax, keepdim=True)
+        raise NotImplementedError(f"torch_ref: reduce {fn!r} unmapped")
+    if name == "LinearOp":
+        return F.linear(ins[0], ins[1], ins[2] if op.has_bias else None)
+    if name == "MatmulOp":
+        out = ins[0] @ ins[1]
+        return out + ins[2] if op.has_bias else out
+    if name == "SdpaOp":
+        q, k, v = ins[0], ins[1], ins[2]
+        gqa = q.dim() >= 3 and q.shape[-3] != k.shape[-3]
+        try:
+            return F.scaled_dot_product_attention(q, k, v, is_causal=op.is_causal, enable_gqa=gqa)
+        except TypeError:  # older torch without enable_gqa
+            if gqa:
+                rep = q.shape[-3] // k.shape[-3]
+                k, v = k.repeat_interleave(rep, dim=-3), v.repeat_interleave(rep, dim=-3)
+            return F.scaled_dot_product_attention(q, k, v, is_causal=op.is_causal)
+    if name == "MeanOp":
+        return ins[0].mean(dim=op.axis, keepdim=True)
+    if name == "RmsNormOp":
+        x, w = ins[0], ins[1]
+        try:
+            return F.rms_norm(x, (x.shape[-1],), w, op.eps)
+        except (AttributeError, RuntimeError):
+            return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + op.eps) * w
+    if name == "SoftmaxOp":
+        return torch.softmax(ins[0], dim=op.axis)
+    if name == "TransposeOp":
+        ndim = ins[0].dim()
+        if len(op.axes) == ndim:
+            return ins[0].permute(*op.axes)
+        return ins[0].transpose(op.axes[0], op.axes[1])
+    if name == "ReshapeOp":
+        return ins[0].reshape(tuple(d.as_static() for d in node.output.shape))
+    if name == "UnsqueezeOp":
+        return ins[0].unsqueeze(op.dim)
+    if name == "SliceOp":
+        t = ins[0]
+        dim = int(ins[1]) if len(ins) > 1 else 0
+        start = int(ins[2]) if len(ins) > 2 else 0
+        end = int(ins[3]) if len(ins) > 3 else t.shape[dim]
+        idx = [slice(None)] * t.dim()
+        idx[dim] = slice(start, end)
+        return t[tuple(idx)]
+    if name == "CatOp":
+        tensors = [i for i in ins if isinstance(i, torch.Tensor)]
+        dim = next((int(i) for i in ins if not isinstance(i, torch.Tensor)), -1)
+        return torch.cat(tensors, dim=dim)
+    raise NotImplementedError(f"torch_ref: op {name!r} unmapped")
+
+
+def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tuple[Callable, list]:
+    """Build a torch callable for ``graph`` plus its positional input list.
+
+    The returned ``fn(*tensors)`` runs the frontend ops in topological order and
+    returns the graph's first output; the input list is the ``tensors`` to call
+    it with (drawn from ``input_tensors`` in boundary topo order). Scalar
+    constants are read inline from the graph (so ``fn`` is a pure function of
+    its tensor inputs and ``torch.compile`` can trace it)."""
+    from deplodock.compiler.provenance import is_boundary  # noqa: PLC0415
+
+    order = graph.topological_order()
+    tensor_ids = [nid for nid in order if is_boundary(graph.nodes[nid].op) and getattr(graph.nodes[nid].op, "value", None) is None]
+    scalars = {nid: float(graph.nodes[nid].op.value) for nid in order
+               if is_boundary(graph.nodes[nid].op) and getattr(graph.nodes[nid].op, "value", None) is not None}
+    compute = [nid for nid in order if not is_boundary(graph.nodes[nid].op)]
+    out_id = graph.outputs[0]
+
+    def fn(*tensors):
+        env = dict(scalars)
+        env.update(zip(tensor_ids, tensors, strict=True))
+        for nid in compute:
+            node = graph.nodes[nid]
+            env[nid] = _eval(node, [env[i] for i in node.inputs])
+        return env[out_id]
+
+    return fn, [input_tensors[i] for i in tensor_ids]

--- a/deplodock/compiler/graph.py
+++ b/deplodock/compiler/graph.py
@@ -465,7 +465,14 @@ class Graph:
         self.inputs = [new_id if i == old_id else i for i in self.inputs]
         self.outputs = [new_id if o == old_id else o for o in self.outputs]
 
-    def splice(self, fragment: Graph, *, consumed: Iterable[str], output: str | dict[str, str]) -> str | dict[str, str]:
+    def splice(
+        self,
+        fragment: Graph,
+        *,
+        consumed: Iterable[str],
+        output: str | dict[str, str],
+        mint_pieces: bool = False,
+    ) -> str | dict[str, str]:
         """Splice ``fragment`` into this graph in place of ``consumed``.
 
         Fragment ``InputOp`` nodes alias existing graph nodes by id (no
@@ -487,7 +494,18 @@ class Graph:
           each consumer is replaced by its own fused fragment node. Returns
           ``{old_id: new_id}`` (post-rename). Each redirected node's hints
           merge onto its own new output; other consumed nodes' hints (e.g.
-          the dissolved shared producer) are dropped."""
+          the dissolved shared producer) are dropped.
+
+        ``mint_pieces`` selects how op provenance threads through (see
+        :mod:`deplodock.compiler.provenance`): ``True`` for decomposition (each
+        new fragment node is a fresh piece of the consumed origins), ``False``
+        for fusion / lifting / folds (fragment outputs aggregate the consumed
+        pieces). The prov hint is overwritten after the generic hint merge so
+        union semantics win over last-writer."""
+        from deplodock.compiler import provenance  # noqa: PLC0415
+
+        consumed = list(consumed)
+        consumed_prov = {nid: provenance.get(self.nodes[nid]) for nid in consumed if nid in self.nodes}
         id_map: dict[str, str] = {}
         for frag_id in fragment.topological_order():
             frag_node = fragment.nodes[frag_id]
@@ -539,6 +557,19 @@ class Graph:
         for old_id in output_map:
             if old_id in self.nodes:
                 self.remove_node(old_id)
+
+        # Thread op provenance onto the new fragment nodes (mint fresh pieces
+        # for decomposition, aggregate consumed pieces otherwise). Runs after
+        # the generic hint merge so its union semantics win for the prov key.
+        new_compute_ids = [id_map[fid] for fid, fn in fragment.nodes.items() if not provenance.is_boundary(fn.op)]
+        provenance.propagate(
+            self,
+            consumed_prov=consumed_prov,
+            new_compute_ids=new_compute_ids,
+            new_by_old=new_by_old,
+            output_map=output_map,
+            mint_pieces=mint_pieces,
+        )
 
         # Promote each new node's id to its friendly output.name once consumed
         # nodes are gone — keeps kernel buf names (which embed the node id)

--- a/deplodock/compiler/graph.py
+++ b/deplodock/compiler/graph.py
@@ -161,7 +161,16 @@ def _serialize_field(v):
     from deplodock.compiler.dim import Dim
     from deplodock.compiler.ir.elementwise import ElementwiseImpl
     from deplodock.compiler.ir.stmt import Body
+    from deplodock.compiler.ir.tensor.ir import IndexSource
 
+    # ``IndexSource`` (IndexMapOp.sources) is a plain dataclass holding ``Expr``
+    # objects — serialize as eval-able repr strings, the same round-trip the
+    # body-Stmt path uses, so it survives JSON instead of being stringified by
+    # ``json.dumps(default=str)`` (which ``_deserialize_field`` couldn't reverse).
+    if isinstance(v, IndexSource):
+        return repr(v)
+    if isinstance(v, (list, tuple)) and v and all(isinstance(x, IndexSource) for x in v):
+        return [repr(x) for x in v]
     if isinstance(v, ElementwiseImpl):
         return v.name
     if isinstance(v, Dim):
@@ -195,6 +204,8 @@ def _deserialize_field(k, v):
     if k == "op" and isinstance(v, str):
         return ElementwiseImpl(v)
     if k == "body" and isinstance(v, list) and v and all(isinstance(e, str) for e in v):
+        return tuple(_eval_stmt(e) for e in v)
+    if k == "sources" and isinstance(v, list) and v and all(isinstance(e, str) and e.startswith("IndexSource(") for e in v):
         return tuple(_eval_stmt(e) for e in v)
     if isinstance(v, dict) and "__op__" in v:
         op_cls = _lookup_op_class(v["__op__"])
@@ -258,6 +269,7 @@ def _stmt_eval_scope() -> dict:
         Unpack,
         Write,
     )
+    from deplodock.compiler.ir.tensor.ir import IndexSource
     from deplodock.compiler.ir.tile.ir import (
         AffineAddressing,
         AsyncWait,
@@ -312,6 +324,7 @@ def _stmt_eval_scope() -> dict:
         "TreeHalve": TreeHalve,
         "WarpShuffle": WarpShuffle,
         "ElementwiseImpl": ElementwiseImpl,
+        "IndexSource": IndexSource,
         "DataType": DataType,
         # ``repr(np.dtype('float32'))`` is ``dtype('float32')`` — eval needs
         # ``dtype`` in scope to round-trip ``DataType.np``.

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -307,6 +307,14 @@ fusion step and a leading `lift_` from lifting; `_canonical_node_id`
 collapses both for display, and the rendered body is rewritten with
 the same map so `Load`/`Write` references match.
 
+Per compute kernel, `_dump_per_kernel` also writes `<prefix>.kernels/<kname>.json` — a standalone sub-graph (kernel +
+its `InputOp`/`ConstantOp` producers) loadable via `deplodock run --ir`. When op provenance is present (see
+`compiler/provenance.py`), it additionally writes `<kname>.torch.json` + `<kname>.torch.txt`: the **original Torch ops**
+that kernel implements, sliced from the pristine pre-decomposition graph stashed in `dump_input_graph`, with an `i/N`
+coverage header per origin (full vs partial). Because the slice is taken from the original graph by origin id, it is
+always made of whole Torch ops — runnable via `deplodock run --ir <kname>.torch.json --bench` to reproduce accuracy /
+latency vs torch for exactly those ops.
+
 ## Per-rule diff output (`rule_diff.py`)
 
 At `compile -vv` (DEBUG log level) the engine emits one block per rule application: a unified diff between the

--- a/deplodock/compiler/pipeline/dump.py
+++ b/deplodock/compiler/pipeline/dump.py
@@ -51,6 +51,10 @@ class CompilerDump:
         # files once instead of N times for N rule applications.
         self._rule_records: dict[tuple[int, str, str], list[dict]] = {}
         self._rule_texts: dict[tuple[int, str, str], list[str]] = {}
+        # Pristine, pre-decomposition Torch-dialect snapshot — the source for
+        # the per-kernel ``.torch.json`` reproducers. Stashed by
+        # ``dump_input_graph`` before any pass mutates the graph in place.
+        self._input_graph: Graph | None = None
 
     @classmethod
     def from_env(cls) -> CompilerDump | None:
@@ -111,7 +115,13 @@ class CompilerDump:
             del self._rule_records[(pass_idx, pname, rule_name)]
 
     def dump_input_graph(self, graph: Graph) -> None:
-        """Graph as captured by the tracer, before any rewriter pass runs."""
+        """Graph as captured by the tracer, before any rewriter pass runs.
+
+        Stashes a *copy* — the pipeline mutates the passed graph in place, and
+        the per-kernel reproducers (``_dump_torch_repro``) need the pristine
+        frontend ops, keyed by the trace-time node ids that prov uses as
+        origins."""
+        self._input_graph = graph.copy()
         self._dump_graph("00_input", graph)
 
     def _dump_graph(self, prefix: str, graph: Graph) -> None:
@@ -175,6 +185,7 @@ class CompilerDump:
             sub.outputs.append(nid)
             safe = self._safe_filename(kname)
             self._write_json(f"{prefix}.kernels/{safe}.json", sub.to_dict())
+            self._dump_torch_repro(prefix, safe, node, graph)
             # Co-locate the pretty body. Skip duplicate CUDA kernel
             # names (same body across reuse sites).
             if isinstance(node.op, CudaOp):
@@ -184,6 +195,70 @@ class CompilerDump:
             body = node.op.pretty_body()
             if body is not None:
                 self._write_text(f"{prefix}.kernels/{safe}.txt", body)
+
+    def _dump_torch_repro(self, prefix: str, safe: str, node, graph: Graph) -> None:
+        """Write the original Torch ops a kernel implements as a standalone
+        sub-graph (``<safe>.torch.json``) + a readable summary with per-origin
+        ``i/N`` coverage (``<safe>.torch.txt``).
+
+        Sliced from the pristine ``_input_graph`` by the kernel's prov origins,
+        so it is always whole Torch ops — runnable via
+        ``deplodock run --ir <f>.torch.json --bench`` to reproduce accuracy /
+        latency vs torch for exactly those ops."""
+        from deplodock.compiler import provenance  # noqa: PLC0415
+
+        if self._input_graph is None:
+            return
+        node_prov = provenance.get(node)
+        origins = {oid for oid in node_prov if oid in self._input_graph.nodes}
+        if not origins:
+            return
+        sub = self._torch_repro_subgraph(origins)
+        self._write_json(f"{prefix}.kernels/{safe}.torch.json", sub.to_dict())
+        cov = provenance.coverage(node_prov, provenance.totals(graph))
+        header = [f"# matching torch ops for kernel '{safe}'"]
+        for oid in sorted(origins):
+            have, total, full = cov[oid]
+            header.append(f"#   {oid} ({node_prov[oid]['kind']}): {have}/{total} — {'full' if full else 'partial'}")
+        self._write_text(f"{prefix}.kernels/{safe}.torch.txt", "\n".join(header) + "\n\n" + sub.pretty_print())
+
+    def _torch_repro_subgraph(self, origins: set[str]) -> Graph:
+        """Slice ``_input_graph`` to ``origins`` + their input closure.
+
+        A frontend op feeding an origin but not itself an origin becomes a
+        synthetic ``InputOp`` boundary (so the slice is standalone); constants
+        and real graph inputs are kept. Outputs are the sink origins — those no
+        other kept node consumes."""
+        from deplodock.compiler.graph import Graph as _Graph  # noqa: PLC0415
+        from deplodock.compiler.ir.base import ConstantOp, InputOp  # noqa: PLC0415
+
+        src = self._input_graph
+        keep: set[str] = set(origins)
+        synthetic: set[str] = set()
+        stack = [inp for oid in origins for inp in src.nodes[oid].inputs]
+        while stack:
+            cur = stack.pop()
+            if cur in keep or cur not in src.nodes:
+                continue
+            keep.add(cur)
+            if isinstance(src.nodes[cur].op, (ConstantOp, InputOp)):
+                stack.extend(src.nodes[cur].inputs)
+            else:
+                synthetic.add(cur)  # frontend op feeding an origin → boundary
+
+        consumed = {inp for nid in keep for inp in src.nodes[nid].inputs if inp in keep}
+        sub = _Graph()
+        for kid in self._topo_order(src, keep):
+            s = src.nodes[kid]
+            if kid in synthetic:
+                sub.add_node(InputOp(), [], s.output, node_id=s.id)
+                sub.inputs.append(kid)
+            else:
+                sub.add_node(s.op, list(s.inputs), s.output, node_id=s.id)
+                if isinstance(s.op, InputOp):
+                    sub.inputs.append(kid)
+        sub.outputs = [oid for oid in origins if oid not in consumed]
+        return sub
 
     def _collect_kernel_ancestors(self, graph: Graph, root_id: str, compute_types: tuple) -> tuple[set[str], set[str]]:
         """Collect ``root_id`` + transitive ConstantOp / InputOp ancestors.

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -70,9 +70,11 @@ from __future__ import annotations
 
 import enum
 import os
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 
+from deplodock.compiler import provenance
 from deplodock.compiler.context import Context
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.axis import Axis
@@ -201,7 +203,7 @@ class _Plan:
     params: tuple[TileParams, ...]
 
 
-def rewrite(ctx: Context, root: Node) -> Graph | None | TileOp | Fork | list[Fork]:
+def rewrite(ctx: Context, root: Node, match) -> Graph | None | TileOp | Fork | list[Fork]:
     """Emit a hierarchical Fork tree over knob bundles:
     ``BR → (BM,BN) → (FM,FN) → (BK,SPLITK) → TileOp leaf``.
 
@@ -220,7 +222,7 @@ def rewrite(ctx: Context, root: Node) -> Graph | None | TileOp | Fork | list[For
     (mirrors :meth:`TileOp.score`) so the ordering matches what the
     fully-built TileOps would have produced."""
     loop_op: LoopOp = root.op
-    kernel_name = _kernel_name_for(loop_op, root.id)
+    kernel_name = _kernel_name_for(loop_op, root.id, provenance.get(root), provenance.totals(match.graph))
     # Idempotence is structural: once the planner has built a TileOp, the
     # rule pattern (LoopOp) no longer matches.
     plan = _plan_kernel(loop_op, ctx, kernel_name=kernel_name)
@@ -330,11 +332,41 @@ def _build_fork_tree_lazy(plan: _Plan, ctx: Context) -> Fork | list[Fork]:
     return top
 
 
-def _kernel_name_for(loop: LoopOp, base_name: str) -> str:
-    """Build the rendered kernel-function name from the LoopOp shape and
-    the graph node id. ``k_<dedup_base>_<reduce|pointwise>``."""
+# Generic glue ops carry no descriptive name — a kernel made only of these
+# falls back to the node-id name. When a meaningful op (rms_norm / linear /
+# sdpa / …) is also present, the glue is dropped from the label.
+_GENERIC_KINDS = frozenset({"ElementwiseOp", "ReduceOp", "ScanOp", "IndexMapOp", "GatherOp", "ScatterOp"})
+
+
+def _humanize_kind(kind: str) -> str:
+    """``RmsNormOp`` → ``rms_norm``, ``SdpaOp`` → ``sdpa`` (CamelCase→snake, drop ``Op``)."""
+    stem = kind[:-2] if kind.endswith("Op") else kind
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", stem).lower()
+
+
+def _kernel_name_for(loop: LoopOp, base_name: str, node_prov: dict, totals: dict[str, set[str]]) -> str:
+    """Name the kernel after the original ops it implements (op provenance).
+
+    A kernel that fully realizes exactly one meaningful op gets the bare
+    ``k_<op>`` (e.g. ``k_rms_norm``); a partial one keeps the
+    ``_<reduce|pointwise>`` qualifier so the reduce half is told apart from the
+    pointwise tail. Multiple meaningful ops join (``k_linear_sdpa_...``). With
+    no provenance (or only glue ops) it falls back to the node-id name."""
     suffix = "reduce" if any(isinstance(s, Accum) for s in loop) else "pointwise"
-    return f"k_{_dedup_tokens(base_name)}_{suffix}"
+    meaningful = [oid for oid, e in node_prov.items() if e["kind"] not in _GENERIC_KINDS]
+    if not meaningful:
+        return f"k_{_dedup_tokens(base_name)}_{suffix}"
+
+    labels: list[str] = []
+    for oid in meaningful:
+        lbl = _humanize_kind(node_prov[oid]["kind"])
+        if lbl not in labels:
+            labels.append(lbl)
+    joined = _dedup_tokens("_".join(labels))
+    cov = provenance.coverage(node_prov, totals)
+    if len(meaningful) == 1 and cov[meaningful[0]][2]:  # single op, fully covered
+        return f"k_{joined}"
+    return f"k_{joined}_{suffix}"
 
 
 def _dedup_tokens(name: str) -> str:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -69,6 +69,7 @@ reduce prefers warp-sized-or-larger BR. All target ~256 threads/CTA.
 from __future__ import annotations
 
 import enum
+import hashlib
 import os
 import re
 from collections.abc import Callable
@@ -347,11 +348,19 @@ def _humanize_kind(kind: str) -> str:
 def _kernel_name_for(loop: LoopOp, base_name: str, node_prov: dict, totals: dict[str, set[str]]) -> str:
     """Name the kernel after the original ops it implements (op provenance).
 
-    A kernel that fully realizes exactly one meaningful op gets the bare
-    ``k_<op>`` (e.g. ``k_rms_norm``); a partial one keeps the
-    ``_<reduce|pointwise>`` qualifier so the reduce half is told apart from the
-    pointwise tail. Multiple meaningful ops join (``k_linear_sdpa_...``). With
-    no provenance (or only glue ops) it falls back to the node-id name."""
+    A kernel that fully realizes exactly one meaningful op gets ``k_<op>_<h>``
+    (e.g. ``k_rms_norm_3f2a1b``); a partial one keeps the ``_<reduce|pointwise>``
+    qualifier so the reduce half is told apart from the pointwise tail. Multiple
+    meaningful ops join (``k_linear_sdpa_...``). With no provenance (or only glue
+    ops) it falls back to the node-id name.
+
+    ``<h>`` is a short structural-body hash: prov labels are *not* unique (two
+    rms_norms, or SDPA's two distinct reduce kernels, share a label), but the
+    backend dispatches kernels by name and the launch dict holds one source per
+    name. The hash makes structurally-identical kernels share a name (so they
+    dedup to one compilation) and distinct kernels differ (so a duplicate label
+    never makes one launch reuse another's code). The node-id fallback is
+    already unique, so it needs no hash."""
     suffix = "reduce" if any(isinstance(s, Accum) for s in loop) else "pointwise"
     meaningful = [oid for oid, e in node_prov.items() if e["kind"] not in _GENERIC_KINDS]
     if not meaningful:
@@ -363,10 +372,13 @@ def _kernel_name_for(loop: LoopOp, base_name: str, node_prov: dict, totals: dict
         if lbl not in labels:
             labels.append(lbl)
     joined = _dedup_tokens("_".join(labels))
+    # ``structural_key`` is a pretty-printed body string; hash it to a short
+    # alphanumeric token (valid in a C identifier; identical bodies → same token).
+    h = hashlib.sha1(loop.body.structural_key().encode()).hexdigest()[:6]
     cov = provenance.coverage(node_prov, totals)
     if len(meaningful) == 1 and cov[meaningful[0]][2]:  # single op, fully covered
-        return f"k_{joined}"
-    return f"k_{joined}_{suffix}"
+        return f"k_{joined}_{h}"
+    return f"k_{joined}_{suffix}_{h}"
 
 
 def _dedup_tokens(name: str) -> str:

--- a/deplodock/compiler/pipeline/pipeline.py
+++ b/deplodock/compiler/pipeline/pipeline.py
@@ -541,9 +541,15 @@ class Pipeline:
 
         ``ctx`` is built once (probing the live device if not provided)
         and shared by every candidate."""
+        from deplodock.compiler import provenance  # noqa: PLC0415
         from deplodock.compiler.context import Context as _Context  # noqa: PLC0415
         from deplodock.compiler.pipeline.search.candidate import Candidate as _Candidate  # noqa: PLC0415
         from deplodock.compiler.pipeline.search.db import SearchDB as _SearchDB  # noqa: PLC0415
+
+        # Seed op provenance on the input graph before any pass runs — the one
+        # universal entry both ``run`` and ``tune`` funnel through. Idempotent,
+        # so a graph reloaded mid-pipeline keeps whatever prov it carried.
+        provenance.seed(graph)
 
         if ctx is None:
             ctx = _Context.probe()

--- a/deplodock/compiler/pipeline/search/candidate.py
+++ b/deplodock/compiler/pipeline/search/candidate.py
@@ -149,7 +149,16 @@ class Candidate:
             self.graph.nodes[match.root_node_id].op = option
         else:
             assert isinstance(option, Graph), f"expected Graph or Op; got {type(option).__name__}"
-            self.graph.splice(option, consumed=match.consumed, output=match.output or match.root_node_id)
+            # Decomposition expands one op into many distinct pieces (mint);
+            # every other fragment splice aggregates the consumed pieces.
+            pass_ = match.rule.pass_
+            mint_pieces = pass_ is not None and pass_.name.startswith("frontend/decomposition")
+            self.graph.splice(
+                option,
+                consumed=match.consumed,
+                output=match.output or match.root_node_id,
+                mint_pieces=mint_pieces,
+            )
             self.cursor.n_applied += 1
         self._advance_if_last(match)
 

--- a/deplodock/compiler/pipeline/search/keys.py
+++ b/deplodock/compiler/pipeline/search/keys.py
@@ -36,7 +36,13 @@ def op_cache_key(op: object) -> str | None:
     from deplodock.compiler.ir.tile.ir import TileOp  # noqa: PLC0415
 
     if isinstance(op, CudaOp):
-        return digest("CudaOp", op.kernel_source, op.arg_order, op.grid, op.block, op.smem_bytes)
+        # Name-invariant: the kernel function name is rendered into the source
+        # (``void <name>(...)``) but doesn't change runtime behavior. Normalize
+        # it out so renaming a kernel (e.g. via op provenance) neither busts the
+        # perf cache nor blocks an isolated-kernel tune from transferring to a
+        # whole-model compile.
+        src = op.kernel_source.replace(op.kernel_name, "_K_") if op.kernel_name else op.kernel_source
+        return digest("CudaOp", src, op.arg_order, op.grid, op.block, op.smem_bytes)
     if isinstance(op, (LoopOp, TileOp, KernelOp)):
         # Knobs are part of the key: same-body / different-knobs variants
         # (e.g. ``020_stage_inputs`` emits a no-op TileOp with a

--- a/deplodock/compiler/provenance.py
+++ b/deplodock/compiler/provenance.py
@@ -1,0 +1,155 @@
+"""Op provenance — map fused kernels back to the original frontend (PyTorch) ops.
+
+A node carries one hint, ``prov`` (key :data:`PROV`), a JSON-safe map::
+
+    {origin_id: {"kind": <op-class-name>, "pieces": [piece_id, ...]}}
+
+``origin_id`` is the trace-time node id of an original frontend op (e.g.
+``rms_norm_0``); ``pieces`` are the node ids of the primitives that op
+decomposed into and that this node embodies. The piece set grows as
+decomposition expands an op into many primitives (mint, :func:`mint`) and as
+fusion merges primitives from one origin into a single kernel (aggregate,
+:func:`union`). A kernel's coverage of an origin is ``len(its pieces)`` over the
+union of that origin's pieces across the whole graph (:func:`totals` /
+:func:`coverage`) — so ``i/N`` stays correct under CSE and recursive
+decomposition instead of freezing ``N`` at the first split.
+
+Pure attribution metadata: it rides on ``Node.hints``, which structural and
+autotune-cache keys already skip, so it never affects codegen identity. Stored
+with ``list`` (never ``set``) piece collections so it round-trips through
+``Graph.to_dict`` / JSON unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deplodock.compiler.graph import Graph, Node
+
+PROV = "prov"
+
+# Boundary sentinels compute nothing, so no kernel ever "implements" them —
+# they never carry provenance and never count toward coverage.
+_SKIP = ("InputOp", "ConstantOp")
+
+
+def is_boundary(op: object) -> bool:
+    """Whether ``op`` is a boundary sentinel that never carries provenance."""
+    return type(op).__name__ in _SKIP
+
+
+def get(node: Node) -> dict:
+    """Return ``node``'s prov map (an empty dict if unset).
+
+    May return the live hint dict — treat as read-only; mutate via :func:`put`.
+    """
+    return node.hints.get(PROV) or {}
+
+
+def put(node: Node, prov: dict) -> None:
+    """Store ``prov`` on ``node``, dropping the hint entirely when empty."""
+    if prov:
+        node.hints.set(PROV, prov)
+    else:
+        node.hints.remove(PROV)
+
+
+def origins(prov: dict) -> dict[str, str]:
+    """``{origin_id: kind}`` for every origin in ``prov``."""
+    return {oid: entry["kind"] for oid, entry in prov.items()}
+
+
+def union(*provs: dict) -> dict:
+    """Per-origin merge of several prov maps: union the piece lists, keep the
+    kind. The aggregate path (fusion / lifting / optimization folds) uses this
+    so a merged kernel accumulates every piece its inputs carried."""
+    out: dict = {}
+    for prov in provs:
+        for oid, entry in prov.items():
+            if oid in out:
+                out[oid]["pieces"] = sorted(set(out[oid]["pieces"]) | set(entry["pieces"]))
+            else:
+                out[oid] = {"kind": entry["kind"], "pieces": sorted(set(entry["pieces"]))}
+    return out
+
+
+def mint(origins_kind: dict[str, str], piece_id: str) -> dict:
+    """Build a prov where ``piece_id`` is a fresh single piece of each origin in
+    ``origins_kind`` (``{origin_id: kind}``). The mint path (decomposition) uses
+    this so each new fragment node becomes a distinct piece of the op it
+    expands."""
+    return {oid: {"kind": kind, "pieces": [piece_id]} for oid, kind in origins_kind.items()}
+
+
+def seed(graph: Graph) -> None:
+    """Idempotently stamp every compute node lacking prov with itself as a
+    single-piece origin: ``{node.id: {"kind": <op>, "pieces": [node.id]}}``.
+
+    Run once at pipeline entry. Nodes that already carry prov (a graph reloaded
+    mid-pipeline) keep it; boundary sentinels are skipped (see :data:`_SKIP`)."""
+    for nid, node in graph.nodes.items():
+        if is_boundary(node.op) or node.hints.has(PROV):
+            continue
+        node.hints.set(PROV, {nid: {"kind": type(node.op).__name__, "pieces": [nid]}})
+
+
+def totals(graph: Graph) -> dict[str, set[str]]:
+    """``{origin_id: all piece ids}`` unioned across every live node — the
+    denominator for ``i/N`` coverage."""
+    out: dict[str, set[str]] = {}
+    for node in graph.nodes.values():
+        for oid, entry in get(node).items():
+            out.setdefault(oid, set()).update(entry["pieces"])
+    return out
+
+
+def propagate(
+    graph: Graph,
+    *,
+    consumed_prov: dict[str, dict],
+    new_compute_ids: list[str],
+    new_by_old: dict[str, str],
+    output_map: dict[str, str],
+    mint_pieces: bool,
+) -> None:
+    """Thread provenance across one ``Graph.splice``.
+
+    ``consumed_prov`` is ``{consumed_node_id: prov}`` snapshotted before the
+    consumed nodes were removed; ``new_compute_ids`` are the graph ids of the
+    freshly-added non-boundary fragment nodes; ``new_by_old`` maps each
+    redirected consumed node to its fragment output.
+
+    - **mint** (``mint_pieces=True``, decomposition): each new fragment node
+      becomes a fresh piece of the consumed origins — one op expanding into
+      many distinct primitives.
+    - **aggregate** (otherwise — fusion / lifting / optimization folds): each
+      fragment output inherits its own consumed node's pieces unioned with the
+      ``shared`` pieces of every *dissolved* consumed node (those not in
+      ``output_map`` — e.g. a producer inlined into all its consumers), so no
+      origin is dropped at a multi-output splice."""
+    if mint_pieces:
+        origins_kind = origins(union(*consumed_prov.values())) if consumed_prov else {}
+        for nid in new_compute_ids:
+            put(graph.nodes[nid], mint(origins_kind, nid))
+        return
+
+    shared = union(*[p for cid, p in consumed_prov.items() if cid not in output_map])
+    for old_id, new_out in new_by_old.items():
+        put(graph.nodes[new_out], union(consumed_prov.get(old_id, {}), shared))
+    outputs = set(new_by_old.values())
+    for nid in new_compute_ids:
+        if nid not in outputs:
+            put(graph.nodes[nid], union(shared))
+
+
+def coverage(node_prov: dict, all_totals: dict[str, set[str]]) -> dict[str, tuple[int, int, bool]]:
+    """Per-origin ``(have, total, full)`` for one node given graph-wide
+    :func:`totals`. ``full`` means every piece of that origin lives in this
+    node — i.e. the kernel realizes the whole original op."""
+    out: dict[str, tuple[int, int, bool]] = {}
+    for oid, entry in node_prov.items():
+        have = len(set(entry["pieces"]))
+        total = len(all_totals.get(oid, set(entry["pieces"])))
+        out[oid] = (have, total, have >= total)
+    return out

--- a/plans/per-op-fork-drill-tuning.md
+++ b/plans/per-op-fork-drill-tuning.md
@@ -1,0 +1,132 @@
+# Per-op autotuning by isolated single-op subgraphs
+
+## Context
+
+`deplodock tune` runs one SP-MCTS tree over the whole graph (`search/policy/mcts.py`). Because the pipeline applies
+rules to the evolving candidate sequentially, fork points **nest**: every multi-option decision is re-explored under
+every choice of the earlier ones — a search space that is the **product** `∏_k n_k` of the per-op variant counts,
+scored by a single aggregate reward `1/total_us` with one global patience counter. This causes the documented
+starvation ([[project_mcts_exploration_limit]]): the bottleneck op dominates the aggregate and global patience
+expires before deep ops (sdpa.s512 P@V) reach good tiles.
+
+**Verified key fact** ([[autotune_no_graph_forks]]): every multi-option fork in the pipeline today is an **op
+fork** — an in-place `Op` rebind (`list[TileOp]` from pad_smem / stage_inputs / hoist; the `partition_loops` `Fork`
+tree → TileOps). No rule emits a multi-option `Graph` fork. An op rebind leaves the graph (data flow, shapes, every
+other op) unchanged, so each op's cost is **separable**: `T = Σ_k t_k` with `t_k` depending only on op `k`'s own
+variant.
+
+**Goal:** tune each op independently in its **own single-node graph** instead of cross-producting them in one tree.
+Total bench cost drops from `∏_k n_k` to `Σ_k n_k`, and each op gets its own patience.
+
+## Design
+
+### Tune each op as an isolated single-node graph
+
+Separability means an op can be compiled + benched on its own. So:
+
+1. Run the **deterministic structural passes** (`frontend/*` + `loop/*`; no multi-option forks there) on the full
+   graph once → the fused `LoopOp` kernels. These are the "ops".
+2. For each LoopOp node, slice a **single-node graph** (the op + `InputOp` stubs for its inputs, its output marked)
+   — the same op-provenance slicing already behind the per-kernel `.torch.json` reproducers
+   (`compile --dump-dir`, consumed by `scripts/bench_model_kernels.py --tune`).
+3. Run a **plain, unmodified `TuningSearch`** on that single-node graph. The subgraph holds exactly one op, so the
+   existing MCTS explores only that op's forks (partition × pad × stage), with `patience` as the op's budget.
+4. Persist results to the shared DB and mark the op terminated.
+
+The standalone results transfer to the full graph for free because the DB is keyed **structurally**: `op_cache_key`
+is name-invariant and a pure digest of body + knobs (`search/keys.py`). The sliced LoopOp's body is identical to its
+in-graph form, so its forks produce identical `TileOp`/`CudaOp` keys and `lowering` edges. The final full-graph
+`Pipeline.run` resolves every kernel to its tuned best via `_best_fork` (`pipeline.py:623`) — the same path
+`deplodock run` already uses to consume tuning results ([[project_tune_run_integration]]).
+
+### "Terminated" = tuned-to-requested-patience (skip already-tuned ops)
+
+Per op, persist the tuning effort and gate on it — this is the "skip already-tuned ops" feature, needed regardless:
+
+```
+terminated(op) ⟺ recorded_effort(ctx, op.key) >= requested_patience
+recorded_effort = ∞                  if the op's search EXHAUSTED its variants
+                = requested_patience if it stopped on patience      (kept as max over runs)
+```
+
+So re-running at the same patience drills nothing (idempotent); a higher patience re-tunes only under-tuned ops
+(incremental deepening); a shared DB across sessions skips already-tuned ops (resumable). "Is the whole graph
+tuned?" is a pure DB query: `all(terminated(op) for op in ops)` — no runtime flag.
+
+### The meta-loop (driver, in `commands/tune.py`)
+
+```
+fused = run frontend + loop passes on the full graph          # deterministic → LoopOp kernels
+for op in fused.loop_op_nodes:
+    if db.terminated(ctx, op.key, requested_patience):        # pure DB check — skip already-tuned
+        continue
+    sub = single_node_graph(op)                                # op + InputOp stubs (provenance slice)
+    search = TuningSearch(patience=requested_patience)         # plain, unmodified
+    drain Pipeline.tune(sub, search=search, db=db, backend=...)
+    db.record_effort(ctx, op.key, ∞ if search.stop_reason != "patience" else requested_patience)
+final = Pipeline.run(graph, db=db)                             # each kernel resolves to DB-best via _best_fork
+```
+
+Order is irrelevant (separable) — one search per op, no iteration. Benching is per-kernel (one launch), and an
+already-tuned op is skipped by the DB check before any work.
+
+## What this does NOT need (dropped from earlier drafts)
+
+No changes to `TuningSearch`, `push`, `Fork`, or `Candidate`. No second policy, no `Fork.kernel` tag, no
+`kernel_name` attribution, no per-kernel `observe` widening, no `focus`/`_drill_match`/`is_op_fork`/`drilled_this_pass`.
+`TuningSearch` runs unmodified on a one-op graph; the aggregate reward is already per-op there since the graph has
+one op. The greedy / DB / `_best_fork` / `_bench_terminal` machinery is reused as-is.
+
+## Milestones (single branch, commit after `make test` — [[feedback_single_branch_milestones]])
+
+- **M1 — Tuning-effort record in the DB** + unit tests: `record_effort(ctx, op_key, effort)` /
+  `effort_for(ctx, op_key)` (max-kept, `∞` sentinel for exhausted, context-keyed). The "skip already-tuned"
+  primitive; independently testable.
+- **M2 — Single-node graph slice** for a LoopOp node + unit test (round-trips through lowering to the same
+  `op_cache_key`s as in the full graph). Reuse the existing provenance slicer if it factors cleanly.
+- **M3 — Meta-loop driver** in `commands/tune.py`: structural prefix → per-op slice → standalone `TuningSearch` →
+  `record_effort` → final greedy emit. `--patience` documents "per op". Per-op `[tune]` progress logging.
+- **M4 — Docs** (`search/ARCHITECTURE.md` + compiler ARCHITECTURE): per-op isolated tuning, separability rationale,
+  effort-gated skip, structural DB handoff to greedy.
+
+## Files to modify
+
+- `deplodock/compiler/pipeline/search/db.py` — `record_effort` / `effort_for` + schema (`tuning_effort` keyed by
+  `(context_key, op_key)`).
+- `deplodock/commands/tune.py` — meta-loop: structural prefix, per-op slice, standalone tune, effort record, final
+  emit; `--patience` help.
+- Single-node slice helper — reuse / factor the existing op-provenance slicer (the one behind `.torch.json`); locate
+  during M2 (likely in the dump / trace slicing path).
+- Docs as in M4.
+- No changes to `mcts.py` / `pipeline.py` fork handling / `Fork` / `candidate.py`.
+
+## Tests
+
+- `test_db.py`: `record_effort` max-keeps, `∞` for exhausted, context-keyed (seq=32 effort ≠ seq=512).
+- Single-node slice test: a sliced LoopOp lowers to the same `op_cache_key`s / `lowering` edges as the full graph.
+- Meta-loop test on a 2-kernel synthetic: tunes to `Σ_k n_k` benches (no product), both bests in `db.lowering`,
+  `Pipeline.run` picks them up; **idempotency** (re-run same patience → no work) and **deepening** (higher patience
+  re-tunes only under-tuned ops).
+- Keep `test_greedy_db_lookup.py`, `test_tune_accuracy.py`, `test_thunk_forks.py` green (`TuningSearch` unchanged).
+
+## Verification (end-to-end)
+
+- `./venv/bin/pytest tests/compiler/pipeline/search/ tests/compiler/test_tune_accuracy.py -p no:randomly`.
+- Real tune of the Qwen layer / sdpa.s512: each kernel tuned standalone, deep kernels (P@V) reach good tiles, total
+  benches ≈ `Σ_k n_k`, per-kernel DB medians improve vs the old aggregate run; re-run is a no-op; then
+  `deplodock run --ir … --bench` / `Pipeline.run` picks up the tuned variants.
+- `make test` + `make lint` before each milestone commit.
+
+## Risks / assumptions
+
+- **Isolation bench vs in-context.** Tuning a sliced one-op graph uses synthetic seeded inputs and a cold-ish L2
+  with no neighbor launches. Sound under separability (`t_k` is shape-driven, neighbor-independent) and identical to
+  the tradeoff the existing per-kernel reproducer tuning already makes. The final full-graph `Pipeline.run` still
+  measures the real assembled latency.
+- **Structural DB handoff** relies on the sliced op producing the same `op_cache_key` / `lowering` `child_key` as in
+  the full graph (true: `op_cache_key` is a name-invariant body+knobs digest, and the sliced body is identical) and
+  on `_best_fork` re-matching it — the proven tune→run path ([[project_tune_run_integration]]).
+- **Effort keying** is per `(context_key, op_key)`; confirm the slice preserves input shapes so the partition
+  enumeration (and thus the keys) matches the full graph. "Exhausted vs patience-stopped" reads `search.stop_reason`.
+- **Structural prefix enumeration**: fusion decides kernel boundaries, so the LoopOp set must come from running the
+  (deterministic) frontend + loop passes on the full graph first, not from the raw input graph.

--- a/scripts/bench_model_kernels.py
+++ b/scripts/bench_model_kernels.py
@@ -1,0 +1,156 @@
+"""Per-kernel vs-torch benchmark + chart for a whole model (or one layer).
+
+End-to-end exercise of op provenance: compile the model with a dump (so every
+kernel gets a prov name + a ``<kname>.torch.json`` reproducer of the original
+Torch ops it implements), then for each kernel run ``deplodock run --ir
+<repro> --bench`` to time it against eager PyTorch and ``torch.compile``, and
+render a per-kernel speedup bar chart with the shared ``deplodock.visualize``
+plotting (same path the perf tests use).
+
+    python scripts/bench_model_kernels.py --model Qwen/Qwen3-Embedding-0.6B --layer 0
+    python scripts/bench_model_kernels.py --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --tune
+
+``--tune`` first autotunes each dumped kernel in isolation (the tuned variant
+flows back to a whole-model compile via the shared autotune DB), then benches.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_BIN = Path(sys.executable).parent
+_ROW = re.compile(r"^(Eager PyTorch|torch\.compile|Deplodock)\s+([\d.]+)")
+
+
+def _run(args: list[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run([str(_BIN / "deplodock"), *args], capture_output=True, text=True, **kw)
+
+
+def _final_kernels(dump_dir: Path) -> list[Path]:
+    """The ``.torch.json`` reproducers from the last (CUDA) stage dump."""
+    kernel_dirs = sorted(dump_dir.glob("*.kernels"))
+    if not kernel_dirs:
+        return []
+    return sorted(kernel_dirs[-1].glob("*.torch.json"))
+
+
+def _bench_one(repro: Path, backends: str, *, tune: bool, patience: int) -> dict[str, float] | None:
+    """Tune (optional) then bench one reproducer; parse the latency table.
+
+    Returns ``{backend: us}`` (always has ``Deplodock``; ``Eager PyTorch`` /
+    ``torch.compile`` only when the reproducer is torch-runnable — pure-compute
+    kernels), or ``None`` if the kernel failed to run at all."""
+    if tune:
+        _run(["tune", "--ir", str(repro), "--patience", str(patience)], timeout=900)
+    proc = _run(["run", "--ir", str(repro), "--bench", "--bench-backends", backends], timeout=600)
+    out: dict[str, float] = {}
+    for line in proc.stdout.splitlines():
+        m = _ROW.match(line)
+        if m:
+            out[m.group(1)] = float(m.group(2))
+    return out if "Deplodock" in out else None
+
+
+def _short(name: str) -> str:
+    """Drop the ``.torch`` + trailing structural hash for a readable label."""
+    stem = name.removesuffix(".torch")
+    return re.sub(r"_[0-9a-f]{6}$", "", stem)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--model", required=True, help="HF model id")
+    ap.add_argument("--layer", type=int, default=None, help="trace one layer (omit for whole model)")
+    ap.add_argument("--seq-len", type=int, default=128)
+    ap.add_argument("--tune", action="store_true", help="autotune each kernel before benching")
+    ap.add_argument("--patience", type=int, default=8)
+    ap.add_argument("--backends", default="eager,tcompile,deplodock")
+    ap.add_argument("--dump-dir", default="/tmp/deplodock-model-kernels")
+    ap.add_argument("--out", default=None, help="chart path (.html); a .png is written alongside")
+    args = ap.parse_args()
+
+    dump_dir = Path(args.dump_dir)
+    compile_args = ["compile", args.model, "--seq-len", str(args.seq_len)]
+    if args.layer is not None:
+        compile_args += ["--layer", str(args.layer)]
+    print(f"[1/3] compiling {args.model} (dump → {dump_dir}) …")
+    env_note = f"DEPLODOCK_DUMP_DIR={dump_dir}"
+    proc = _run(compile_args, env={**os.environ, "DEPLODOCK_DUMP_DIR": str(dump_dir)}, timeout=1800)
+    if proc.returncode != 0:
+        print(f"compile failed ({env_note}):\n{proc.stderr[-2000:]}", file=sys.stderr)
+        sys.exit(1)
+
+    repros = _final_kernels(dump_dir)
+    if not repros:
+        print("no per-kernel reproducers found — did the compile produce CUDA kernels?", file=sys.stderr)
+        sys.exit(1)
+    print(f"[2/3] benching {len(repros)} kernels vs torch{' (with tuning)' if args.tune else ''} …")
+
+    rows: list[tuple[str, dict[str, float]]] = []
+    for r in repros:
+        res = _bench_one(r, args.backends, tune=args.tune, patience=args.patience)
+        label = _short(r.name)
+        if res is None:
+            print(f"  - {label}: skipped (kernel failed to run)")
+            continue
+        vs = f" eager={res['Eager PyTorch']:.0f}us" if "Eager PyTorch" in res else " (deplodock-only)"
+        print(f"  - {label}: deplodock={res['Deplodock']:.0f}us{vs}")
+        rows.append((label, res))
+
+    if not rows:
+        print("no kernels produced a benchmark", file=sys.stderr)
+        sys.exit(1)
+
+    _render(rows, args)
+
+
+def _render(rows: list[tuple[str, dict[str, float]]], args) -> None:
+    from deplodock.visualize.bar_chart import Bar, BarChart, render_bar_chart
+
+    # Per-kernel latency (µs), slowest first. Eager / torch.compile overlaid
+    # where the reproducer is torch-runnable (pure-compute kernels); deplodock
+    # is always present.
+    rows.sort(key=lambda kv: kv[1]["Deplodock"], reverse=True)
+    n_vs = sum("Eager PyTorch" in res for _, res in rows)
+
+    def series(key):
+        return [res.get(key) for _, res in rows]
+
+    chart = BarChart(
+        categories=[label for label, _ in rows],
+        bars=[
+            Bar("Deplodock", series("Deplodock"), color="#4dabf7"),
+            Bar("Eager PyTorch", series("Eager PyTorch"), color="#999999"),
+            Bar("torch.compile", series("torch.compile"), color="#ffd166"),
+        ],
+        value_name="latency (µs) — lower is faster",
+        title=f"{args.model} — per-kernel latency",
+        subtitle=(
+            f"Each kernel benched from its dumped .torch.json ({len(rows)} kernels; "
+            f"{n_vs} torch-comparable, rest deplodock-only — const-transforming ops like linear "
+            "have no standalone torch reference)."
+        ),
+        orientation="horizontal",
+    )
+    html = render_bar_chart(chart, theme="dark", transparent=True)
+    out = Path(args.out) if args.out else Path(args.dump_dir) / "kernels.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html)
+    print(f"[3/3] chart → {out}")
+    png = out.with_suffix(".png")
+    try:
+        from deplodock.visualize.image import render as render_image
+
+        render_image(html, png, height=max(300, 40 * len(rows)))
+        print(f"        png → {png}")
+    except Exception as e:  # noqa: BLE001 — PNG is best-effort (needs the [visualize] extra)
+        print(f"        png skipped: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_model_kernels.py
+++ b/scripts/bench_model_kernels.py
@@ -132,8 +132,8 @@ def _render(rows: list[tuple[str, dict[str, float]]], args) -> None:
         title=f"{args.model} — per-kernel latency",
         subtitle=(
             f"Each kernel benched from its dumped .torch.json ({len(rows)} kernels; "
-            f"{n_vs} torch-comparable, rest deplodock-only — const-transforming ops like linear "
-            "have no standalone torch reference)."
+            f"{n_vs} torch-comparable, rest deplodock-only — kernels that don't recompile "
+            "standalone or contain ops without a torch twin)."
         ),
         orientation="horizontal",
     )

--- a/scripts/bench_model_kernels.py
+++ b/scripts/bench_model_kernels.py
@@ -156,8 +156,7 @@ def _compare_tuning(repros: list[Path], args) -> None:
 
     labels = [k for k in before if k in after]
     rows = [
-        (k, before[k]["Deplodock"], after[k]["Deplodock"], before[k].get("Eager PyTorch"), before[k].get("torch.compile"))
-        for k in labels
+        (k, before[k]["Deplodock"], after[k]["Deplodock"], before[k].get("Eager PyTorch"), before[k].get("torch.compile")) for k in labels
     ]
     rows.sort(key=lambda t: t[1], reverse=True)
     _render_comparison(rows, args)
@@ -228,10 +227,7 @@ def _render_latency(rows: list[tuple[str, dict[str, float]]], args) -> None:
         ],
         value_name="latency (µs) — lower is faster",
         title=f"{args.model} — per-kernel latency",
-        subtitle=(
-            f"Each kernel benched from its dumped .torch.json ({len(rows)} kernels; "
-            f"{n_vs} torch-comparable, rest deplodock-only)."
-        ),
+        subtitle=(f"Each kernel benched from its dumped .torch.json ({len(rows)} kernels; {n_vs} torch-comparable, rest deplodock-only)."),
         orientation="horizontal",
     )
     html = render_bar_chart(chart, theme="dark", transparent=True)

--- a/scripts/bench_model_kernels.py
+++ b/scripts/bench_model_kernels.py
@@ -4,14 +4,19 @@ End-to-end exercise of op provenance: compile the model with a dump (so every
 kernel gets a prov name + a ``<kname>.torch.json`` reproducer of the original
 Torch ops it implements), then for each kernel run ``deplodock run --ir
 <repro> --bench`` to time it against eager PyTorch and ``torch.compile``, and
-render a per-kernel speedup bar chart with the shared ``deplodock.visualize``
-plotting (same path the perf tests use).
+render a per-kernel bar chart with the shared ``deplodock.visualize`` plotting
+(same path the perf tests use).
 
+    # one-shot latency chart (uses whatever's in the autotune DB):
     python scripts/bench_model_kernels.py --model Qwen/Qwen3-Embedding-0.6B --layer 0
-    python scripts/bench_model_kernels.py --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --layer 0 --tune
 
-``--tune`` first autotunes each dumped kernel in isolation (the tuned variant
-flows back to a whole-model compile via the shared autotune DB), then benches.
+    # before/after-tuning comparison (clean isolated DB): bench → tune each
+    # kernel → bench again → comparison table + plot:
+    python scripts/bench_model_kernels.py --model Qwen/Qwen3-Embedding-0.6B --compare-tuning
+
+``--compare-tuning`` points every step at a fresh per-run autotune DB
+(``<dump-dir>/tune.db``) so the "before" numbers are untuned rule defaults and
+the "after" numbers reflect this run's tuning only.
 """
 
 from __future__ import annotations
@@ -27,27 +32,26 @@ _BIN = Path(sys.executable).parent
 _ROW = re.compile(r"^(Eager PyTorch|torch\.compile|Deplodock)\s+([\d.]+)")
 
 
-def _run(args: list[str], **kw) -> subprocess.CompletedProcess:
-    return subprocess.run([str(_BIN / "deplodock"), *args], capture_output=True, text=True, **kw)
+def _run(args: list[str], timeout: int | None = None, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    # Inherits os.environ (where main sets DEPLODOCK_TUNE_DB). DEPLODOCK_DUMP_DIR
+    # is passed only to compile — never to bench/tune, whose run --ir would
+    # otherwise create a CompilerDump that rmtree's the reproducer dir.
+    env = {**os.environ, **extra_env} if extra_env else None
+    return subprocess.run([str(_BIN / "deplodock"), *args], capture_output=True, text=True, timeout=timeout, env=env)
 
 
 def _final_kernels(dump_dir: Path) -> list[Path]:
     """The ``.torch.json`` reproducers from the last (CUDA) stage dump."""
     kernel_dirs = sorted(dump_dir.glob("*.kernels"))
-    if not kernel_dirs:
-        return []
-    return sorted(kernel_dirs[-1].glob("*.torch.json"))
+    return sorted(kernel_dirs[-1].glob("*.torch.json")) if kernel_dirs else []
 
 
-def _bench_one(repro: Path, backends: str, *, tune: bool, patience: int) -> dict[str, float] | None:
-    """Tune (optional) then bench one reproducer; parse the latency table.
+def _bench(repro: Path, backends: str, timeout: int = 600) -> dict[str, float] | None:
+    """Bench one reproducer; parse the latency table to ``{backend: us}``.
 
-    Returns ``{backend: us}`` (always has ``Deplodock``; ``Eager PyTorch`` /
-    ``torch.compile`` only when the reproducer is torch-runnable — pure-compute
-    kernels), or ``None`` if the kernel failed to run at all."""
-    if tune:
-        _run(["tune", "--ir", str(repro), "--patience", str(patience)], timeout=900)
-    proc = _run(["run", "--ir", str(repro), "--bench", "--bench-backends", backends], timeout=600)
+    Always has ``Deplodock``; ``Eager PyTorch`` / ``torch.compile`` only when the
+    reproducer is torch-runnable. ``None`` if the kernel failed to run."""
+    proc = _run(["run", "--ir", str(repro), "--bench", "--bench-backends", backends], timeout=timeout)
     out: dict[str, float] = {}
     for line in proc.stdout.splitlines():
         m = _ROW.match(line)
@@ -56,10 +60,13 @@ def _bench_one(repro: Path, backends: str, *, tune: bool, patience: int) -> dict
     return out if "Deplodock" in out else None
 
 
+def _tune(repro: Path, patience: int, timeout: int = 1200) -> None:
+    _run(["tune", str(repro), "--patience", str(patience)], timeout=timeout)
+
+
 def _short(name: str) -> str:
-    """Drop the ``.torch`` + trailing structural hash for a readable label."""
-    stem = name.removesuffix(".torch")
-    return re.sub(r"_[0-9a-f]{6}$", "", stem)
+    """Drop the ``.torch`` suffix + trailing structural hash for a readable label."""
+    return re.sub(r"_[0-9a-f]{6}$", "", name.removesuffix(".torch"))
 
 
 def main() -> None:
@@ -67,33 +74,50 @@ def main() -> None:
     ap.add_argument("--model", required=True, help="HF model id")
     ap.add_argument("--layer", type=int, default=None, help="trace one layer (omit for whole model)")
     ap.add_argument("--seq-len", type=int, default=128)
-    ap.add_argument("--tune", action="store_true", help="autotune each kernel before benching")
+    ap.add_argument("--tune", action="store_true", help="autotune each kernel before benching (one-shot mode)")
+    ap.add_argument("--compare-tuning", action="store_true", help="bench → tune each → bench again, with a comparison table")
     ap.add_argument("--patience", type=int, default=8)
     ap.add_argument("--backends", default="eager,tcompile,deplodock")
     ap.add_argument("--dump-dir", default="/tmp/deplodock-model-kernels")
-    ap.add_argument("--out", default=None, help="chart path (.html); a .png is written alongside")
+    ap.add_argument("--out", default=None, help="chart path (.html); a .png + .md table are written alongside")
     args = ap.parse_args()
 
     dump_dir = Path(args.dump_dir)
+    if args.compare_tuning:
+        # Isolate the experiment in a fresh DB so "before" is truly untuned.
+        # Sibling of the dump dir — not inside it (compile rmtree's the dump dir).
+        tune_db = dump_dir.parent / f"{dump_dir.name}-tune.db"
+        tune_db.unlink(missing_ok=True)
+        os.environ["DEPLODOCK_TUNE_DB"] = str(tune_db)
+
     compile_args = ["compile", args.model, "--seq-len", str(args.seq_len)]
     if args.layer is not None:
         compile_args += ["--layer", str(args.layer)]
-    print(f"[1/3] compiling {args.model} (dump → {dump_dir}) …")
-    env_note = f"DEPLODOCK_DUMP_DIR={dump_dir}"
-    proc = _run(compile_args, env={**os.environ, "DEPLODOCK_DUMP_DIR": str(dump_dir)}, timeout=1800)
+    print(f"[1/4] compiling {args.model} (dump → {dump_dir}) …", flush=True)
+    # DEPLODOCK_DUMP_DIR only here — bench/tune must not dump (they'd rmtree it).
+    proc = _run(compile_args, timeout=3600, extra_env={"DEPLODOCK_DUMP_DIR": str(dump_dir)})
     if proc.returncode != 0:
-        print(f"compile failed ({env_note}):\n{proc.stderr[-2000:]}", file=sys.stderr)
+        print(f"compile failed:\n{proc.stderr[-2000:]}", file=sys.stderr)
         sys.exit(1)
 
     repros = _final_kernels(dump_dir)
     if not repros:
         print("no per-kernel reproducers found — did the compile produce CUDA kernels?", file=sys.stderr)
         sys.exit(1)
-    print(f"[2/3] benching {len(repros)} kernels vs torch{' (with tuning)' if args.tune else ''} …")
 
+    if args.compare_tuning:
+        _compare_tuning(repros, args)
+    else:
+        _one_shot(repros, args)
+
+
+def _one_shot(repros: list[Path], args) -> None:
+    print(f"[2/4] benching {len(repros)} kernels vs torch{' (with tuning)' if args.tune else ''} …", flush=True)
     rows: list[tuple[str, dict[str, float]]] = []
     for r in repros:
-        res = _bench_one(r, args.backends, tune=args.tune, patience=args.patience)
+        if args.tune:
+            _tune(r, args.patience)
+        res = _bench(r, args.backends)
         label = _short(r.name)
         if res is None:
             print(f"  - {label}: skipped (kernel failed to run)")
@@ -101,20 +125,94 @@ def main() -> None:
         vs = f" eager={res['Eager PyTorch']:.0f}us" if "Eager PyTorch" in res else " (deplodock-only)"
         print(f"  - {label}: deplodock={res['Deplodock']:.0f}us{vs}")
         rows.append((label, res))
-
     if not rows:
         print("no kernels produced a benchmark", file=sys.stderr)
         sys.exit(1)
+    _render_latency(rows, args)
 
-    _render(rows, args)
+
+def _compare_tuning(repros: list[Path], args) -> None:
+    # before (untuned rule defaults)
+    print(f"[2/4] benching {len(repros)} kernels (before tuning) …", flush=True)
+    before: dict[str, dict[str, float]] = {}
+    for r in repros:
+        res = _bench(r, args.backends)
+        if res is not None:
+            before[_short(r.name)] = res
+            print(f"  - {_short(r.name)}: deplodock={res['Deplodock']:.0f}us", flush=True)
+
+    print(f"[3/4] tuning {len(repros)} kernels (patience={args.patience}) …", flush=True)
+    for i, r in enumerate(repros, 1):
+        print(f"  - [{i}/{len(repros)}] tuning {_short(r.name)} …", flush=True)
+        _tune(r, args.patience)
+
+    print(f"[4/4] benching {len(repros)} kernels (after tuning) …", flush=True)
+    after: dict[str, dict[str, float]] = {}
+    for r in repros:
+        res = _bench(r, args.backends)
+        if res is not None:
+            after[_short(r.name)] = res
+            print(f"  - {_short(r.name)}: deplodock={res['Deplodock']:.0f}us", flush=True)
+
+    labels = [k for k in before if k in after]
+    rows = [
+        (k, before[k]["Deplodock"], after[k]["Deplodock"], before[k].get("Eager PyTorch"), before[k].get("torch.compile"))
+        for k in labels
+    ]
+    rows.sort(key=lambda t: t[1], reverse=True)
+    _render_comparison(rows, args)
 
 
-def _render(rows: list[tuple[str, dict[str, float]]], args) -> None:
+def _fmt(v: float | None) -> str:
+    return f"{v:.0f}" if v is not None else "—"
+
+
+def _render_comparison(rows, args) -> None:
     from deplodock.visualize.bar_chart import Bar, BarChart, render_bar_chart
 
-    # Per-kernel latency (µs), slowest first. Eager / torch.compile overlaid
-    # where the reproducer is torch-runnable (pure-compute kernels); deplodock
-    # is always present.
+    out = Path(args.out) if args.out else Path(args.dump_dir) / "kernels.html"
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    # --- comparison table (markdown + stdout) ---
+    head = f"# {args.model} — per-kernel tuning comparison\n\n"
+    head += "| kernel | before µs | after µs | tune speedup | eager µs | torch.compile µs |\n"
+    head += "|---|--:|--:|--:|--:|--:|\n"
+    tb, ta = 0.0, 0.0
+    lines = []
+    for k, b, a, eager, tc in rows:
+        sp = b / a if a else 0.0
+        tb += b
+        ta += a
+        lines.append(f"| {k} | {b:.0f} | {a:.0f} | {sp:.2f}× | {_fmt(eager)} | {_fmt(tc)} |")
+    total = f"| **TOTAL** | **{tb:.0f}** | **{ta:.0f}** | **{(tb / ta if ta else 0):.2f}×** | | |"
+    table = head + "\n".join(lines) + "\n" + total + "\n"
+    print("\n" + table)
+    md = out.with_suffix(".md")
+    md.write_text(table)
+    print(f"comparison table → {md}")
+
+    # --- plot: per-kernel before/after/eager latency ---
+    chart = BarChart(
+        categories=[k for k, *_ in rows],
+        bars=[
+            Bar("Deplodock (before)", [b for _, b, *_ in rows], color="#868e96"),
+            Bar("Deplodock (tuned)", [a for _, _, a, *_ in rows], color="#4dabf7"),
+            Bar("Eager PyTorch", [eager for *_, eager, _ in rows], color="#51cf66"),
+        ],
+        value_name="latency (µs) — lower is faster",
+        title=f"{args.model} — per-kernel latency: before vs after tuning",
+        subtitle=f"{len(rows)} kernels, benched from their dumped .torch.json reproducers. Tuned with patience={args.patience}.",
+        orientation="horizontal",
+    )
+    html = render_bar_chart(chart, theme="dark", transparent=True)
+    out.write_text(html)
+    print(f"chart → {out}")
+    _write_png(html, out, len(rows))
+
+
+def _render_latency(rows: list[tuple[str, dict[str, float]]], args) -> None:
+    from deplodock.visualize.bar_chart import Bar, BarChart, render_bar_chart
+
     rows.sort(key=lambda kv: kv[1]["Deplodock"], reverse=True)
     n_vs = sum("Eager PyTorch" in res for _, res in rows)
 
@@ -132,8 +230,7 @@ def _render(rows: list[tuple[str, dict[str, float]]], args) -> None:
         title=f"{args.model} — per-kernel latency",
         subtitle=(
             f"Each kernel benched from its dumped .torch.json ({len(rows)} kernels; "
-            f"{n_vs} torch-comparable, rest deplodock-only — kernels that don't recompile "
-            "standalone or contain ops without a torch twin)."
+            f"{n_vs} torch-comparable, rest deplodock-only)."
         ),
         orientation="horizontal",
     )
@@ -141,12 +238,16 @@ def _render(rows: list[tuple[str, dict[str, float]]], args) -> None:
     out = Path(args.out) if args.out else Path(args.dump_dir) / "kernels.html"
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(html)
-    print(f"[3/3] chart → {out}")
+    print(f"[3/4] chart → {out}")
+    _write_png(html, out, len(rows))
+
+
+def _write_png(html: str, out: Path, n: int) -> None:
     png = out.with_suffix(".png")
     try:
         from deplodock.visualize.image import render as render_image
 
-        render_image(html, png, height=max(300, 40 * len(rows)))
+        render_image(html, png, height=max(300, 40 * n))
         print(f"        png → {png}")
     except Exception as e:  # noqa: BLE001 — PNG is best-effort (needs the [visualize] extra)
         print(f"        png skipped: {e}")

--- a/tests/compiler/test_indexmap.py
+++ b/tests/compiler/test_indexmap.py
@@ -125,3 +125,31 @@ def test_indexmap_infer_output_shape_returns_out_shape():
         sources=(IndexSource(input_idx=0, coord_map=(placeholder(0), placeholder(1), placeholder(2))),),
     )
     assert op.infer_output_shape([(99, 99, 99)]) == (4, 5, 6)
+
+
+def test_indexmap_sources_round_trip_through_json():
+    """``IndexMapOp.sources`` (IndexSource dataclasses holding Exprs) survive
+    ``Graph.to_dict`` → ``from_dict``. Regression: they used to be stringified
+    by ``json.dumps(default=str)`` and reloaded as ``str``, crashing
+    ``030_lift_indexmap`` (``'str' has no attribute 'input_idx'``) on
+    ``run --ir`` recompiles."""
+    from deplodock.compiler.graph import Graph, Tensor
+    from deplodock.compiler.ir.base import InputOp
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("a", (4, 8)), node_id="a")
+    g.add_node(InputOp(), [], Tensor("b", (4, 8)), node_id="b")
+    src0 = IndexSource(
+        input_idx=0,
+        coord_map=(placeholder(0), placeholder(1) + Literal(2, "int")),
+        select=placeholder(1).lt(Literal(8, "int")),
+    )
+    src1 = IndexSource(input_idx=1, coord_map=(placeholder(0), placeholder(1)))
+    g.add_node(IndexMapOp(out_shape=(4, 16), sources=(src0, src1)), ["a", "b"], Tensor("c", (4, 16)), node_id="c")
+    g.inputs, g.outputs = ["a", "b"], ["c"]
+
+    sources = Graph.from_dict(g.to_dict()).nodes["c"].op.sources
+    assert all(isinstance(s, IndexSource) for s in sources)
+    assert [s.input_idx for s in sources] == [0, 1]
+    assert sources[0].coord_map == src0.coord_map and sources[1].coord_map == src1.coord_map
+    assert sources[0].select == src0.select and sources[1].select is None

--- a/tests/compiler/test_loader.py
+++ b/tests/compiler/test_loader.py
@@ -35,6 +35,28 @@ def test_apply_load_ops_chain_transpose_then_reshape():
     np.testing.assert_array_equal(out, np.transpose(src, (0, 2, 1)).reshape(2, 12))
 
 
+def test_shared_source_across_lowering_transpose():
+    """The ``run --ir`` vs-torch path keys constant data by ``source_path``, so a
+    weight that lowering transposed + renamed (linear: out×in → in×out) draws
+    from the *same* source on both sides — the frontend reproducer gets ``W``,
+    the lowered graph gets ``Wᵀ`` — instead of two unrelated random draws."""
+    w = np.random.default_rng(0).standard_normal((4, 6)).astype(np.float32)
+    sources = {"m.w": w}
+
+    frontend = Graph()
+    frontend.add_node(ConstantOp(name="w", source_path="m.w", source_shape=(4, 6)), [], Tensor("w", (4, 6)), node_id="w")
+    lowered = Graph()
+    lowered.add_node(
+        ConstantOp(name="w", source_path="m.w", source_shape=(4, 6), load_ops=(TransposeOp(axes=(-2, -1)),)),
+        [],
+        Tensor("linear_wt", (6, 4)),
+        node_id="linear_wt",
+    )
+
+    np.testing.assert_array_equal(bind_constants(frontend, sources)["w"], w)
+    np.testing.assert_array_equal(bind_constants(lowered, sources)["linear_wt"], w.T)
+
+
 def test_bind_constants_resolves_by_source_path():
     g = Graph()
     g.add_node(

--- a/tests/compiler/test_provenance.py
+++ b/tests/compiler/test_provenance.py
@@ -1,0 +1,94 @@
+"""Tests for op provenance (deplodock.compiler.provenance).
+
+M1 covers the data model + seeding; the splice-propagation behavior
+(mint / aggregate through decomposition + fusion) is exercised in
+``test_provenance_splice.py``.
+"""
+
+from deplodock.compiler import provenance as prov
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
+
+
+def _graph() -> tuple[Graph, str, str, str, str]:
+    """C = Reduce{sum}(Elementwise{mul}(A, B)) — two compute nodes, two inputs."""
+    g = Graph()
+    a = g.add_node(InputOp(), [], Tensor("A", (4, 8, 4)))
+    b = g.add_node(InputOp(), [], Tensor("B", (4, 8, 4)))
+    g.inputs = [a, b]
+    ew = g.add_node(ElementwiseOp(op="multiply"), [a, b], Tensor("AB", (4, 8, 4)))
+    c = g.add_node(ReduceOp(op="sum", axis=1), [ew], Tensor("C", (4, 1, 4)))
+    g.outputs = [c]
+    return g, a, b, ew, c
+
+
+# --- seed ---
+
+
+def test_seed_stamps_compute_skips_boundary():
+    g, a, b, ew, c = _graph()
+    prov.seed(g)
+    assert prov.get(g.nodes[ew]) == {ew: {"kind": "ElementwiseOp", "pieces": [ew]}}
+    assert prov.get(g.nodes[c]) == {c: {"kind": "ReduceOp", "pieces": [c]}}
+    # InputOp sentinels compute nothing — never seeded.
+    assert prov.get(g.nodes[a]) == {}
+    assert prov.get(g.nodes[b]) == {}
+
+
+def test_seed_idempotent():
+    g, _, _, ew, _ = _graph()
+    prov.seed(g)
+    prov.put(g.nodes[ew], {"custom": {"kind": "X", "pieces": ["p"]}})
+    prov.seed(g)  # must not overwrite an already-seeded node
+    assert prov.get(g.nodes[ew]) == {"custom": {"kind": "X", "pieces": ["p"]}}
+
+
+# --- helpers ---
+
+
+def test_union_merges_pieces_keeps_kind():
+    a = {"o": {"kind": "RmsNormOp", "pieces": ["p1", "p2"]}}
+    b = {"o": {"kind": "RmsNormOp", "pieces": ["p2", "p3"]}, "q": {"kind": "LinearOp", "pieces": ["x"]}}
+    u = prov.union(a, b)
+    assert u["o"] == {"kind": "RmsNormOp", "pieces": ["p1", "p2", "p3"]}
+    assert u["q"] == {"kind": "LinearOp", "pieces": ["x"]}
+
+
+def test_mint_fresh_piece_per_origin():
+    m = prov.mint({"o": "RmsNormOp", "q": "LinearOp"}, "newnode")
+    assert m == {
+        "o": {"kind": "RmsNormOp", "pieces": ["newnode"]},
+        "q": {"kind": "LinearOp", "pieces": ["newnode"]},
+    }
+
+
+def test_origins():
+    p = {"o": {"kind": "RmsNormOp", "pieces": ["p1"]}, "q": {"kind": "LinearOp", "pieces": ["x"]}}
+    assert prov.origins(p) == {"o": "RmsNormOp", "q": "LinearOp"}
+
+
+def test_totals_and_coverage():
+    g, _, _, ew, c = _graph()
+    prov.put(g.nodes[ew], {"o": {"kind": "RmsNormOp", "pieces": ["p1", "p2"]}})
+    prov.put(g.nodes[c], {"o": {"kind": "RmsNormOp", "pieces": ["p3"]}})
+    t = prov.totals(g)
+    assert t["o"] == {"p1", "p2", "p3"}
+    assert prov.coverage(prov.get(g.nodes[ew]), t)["o"] == (2, 3, False)
+
+    # A node holding every piece is "full".
+    prov.put(g.nodes[c], {"o": {"kind": "RmsNormOp", "pieces": ["p1", "p2", "p3"]}})
+    t = prov.totals(g)
+    assert prov.coverage(prov.get(g.nodes[c]), t)["o"] == (3, 3, True)
+
+
+# --- serialization ---
+
+
+def test_prov_roundtrips_through_serialization():
+    g, _, _, ew, _ = _graph()
+    prov.put(g.nodes[ew], {"rms_0": {"kind": "RmsNormOp", "pieces": ["sq", "mean"]}})
+    g2 = Graph.from_dict(g.to_dict())
+    got = prov.get(g2.nodes[ew])
+    assert got == {"rms_0": {"kind": "RmsNormOp", "pieces": ["sq", "mean"]}}
+    assert isinstance(got["rms_0"]["pieces"], list)  # stays a list, not stringified

--- a/tests/compiler/test_provenance_dump.py
+++ b/tests/compiler/test_provenance_dump.py
@@ -1,0 +1,63 @@
+"""Per-kernel Torch reproducer dump (M4).
+
+The dump slices the pristine pre-decomposition graph by each kernel's prov
+origins → ``<kname>.torch.json`` (a standalone, runnable sub-graph of whole
+Torch ops) + ``<kname>.torch.txt`` (an ``i/N`` coverage summary).
+"""
+
+import json
+
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.frontend.ir import RmsNormOp
+from deplodock.compiler.pipeline import TILE_PASSES, Pipeline
+from deplodock.compiler.pipeline.dump import CompilerDump
+
+
+def _rms_graph() -> Graph:
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, 4, 8)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("w", (8,)), node_id="w")
+    g.add_node(RmsNormOp(), ["x", "w"], Tensor("rms_norm_0", (1, 4, 8)), node_id="rms_norm_0")
+    g.inputs, g.outputs = ["x", "w"], ["rms_norm_0"]
+    return g
+
+
+def test_torch_repro_is_whole_op_and_loadable(tmp_path):
+    g = _rms_graph()
+    dump = CompilerDump(dir=tmp_path)
+    dump.dump_input_graph(g)
+    Pipeline.build(TILE_PASSES, dump=dump).run(g)
+
+    repros = sorted(tmp_path.glob("*.kernels/*.torch.json"))
+    assert repros, "expected a per-kernel .torch.json reproducer"
+
+    # Sliced from the pristine graph → contains the whole original RmsNormOp,
+    # not its decomposed primitives.
+    sub = Graph.from_dict(json.loads(repros[-1].read_text()))
+    kinds = {type(n.op).__name__ for n in sub.nodes.values()}
+    assert "RmsNormOp" in kinds
+    assert sub.outputs == ["rms_norm_0"]
+    assert set(sub.inputs) == {"x", "w"}  # the rms_norm's own inputs become boundaries
+
+
+def test_torch_repro_coverage_header(tmp_path):
+    g = _rms_graph()
+    dump = CompilerDump(dir=tmp_path)
+    dump.dump_input_graph(g)
+    Pipeline.build(TILE_PASSES, dump=dump).run(g)
+
+    txts = sorted(tmp_path.glob("*.kernels/*.torch.txt"))
+    assert txts
+    body = txts[-1].read_text()
+    assert "rms_norm_0 (RmsNormOp):" in body
+    # rms_norm fully fuses at this shape → full coverage.
+    assert "— full" in body
+
+
+def test_no_repro_without_input_graph(tmp_path):
+    """A dump that never captured the input graph writes no reproducers."""
+    g = _rms_graph()
+    dump = CompilerDump(dir=tmp_path)  # no dump_input_graph call
+    Pipeline.build(TILE_PASSES, dump=dump).run(g)
+    assert not list(tmp_path.glob("*.kernels/*.torch.json"))

--- a/tests/compiler/test_provenance_naming.py
+++ b/tests/compiler/test_provenance_naming.py
@@ -1,0 +1,80 @@
+"""Provenance-driven kernel naming + name-invariant CudaOp cache key (M3)."""
+
+from deplodock.compiler import provenance as prov
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.cuda.ir import CudaOp
+from deplodock.compiler.ir.frontend.ir import RmsNormOp
+from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.tile.ir import TileOp
+from deplodock.compiler.pipeline import TILE_PASSES, Pipeline
+from deplodock.compiler.pipeline.search.keys import op_cache_key
+
+
+def _pointwise_loop() -> LoopOp:
+    i, j = Axis("i", 4), Axis("j", 8)
+    return LoopOp(
+        body=(
+            Loop(
+                axis=i,
+                body=(Loop(axis=j, body=(Load(name="x_v", input="x", index=(Var("i"), Var("j"))),
+                                              Write(output="o", index=(Var("i"), Var("j")), value="x_v"))),),
+            ),
+        )
+    )
+
+
+def _tile_names(g: Graph) -> list[str]:
+    out = Pipeline.build(TILE_PASSES).run(g)
+    return [n.op.name for n in out.nodes.values() if isinstance(n.op, TileOp)]
+
+
+def test_full_single_op_gets_bare_name():
+    """A kernel that fully realizes one meaningful op is named after it."""
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
+    g.add_node(_pointwise_loop(), ["x"], Tensor("o", (4, 8)), node_id="o")
+    g.inputs, g.outputs = ["x"], ["o"]
+    prov.put(g.nodes["o"], {"rms_norm_0": {"kind": "RmsNormOp", "pieces": ["o"]}})
+
+    assert "k_rms_norm" in _tile_names(g)
+
+
+def test_glue_only_kernel_falls_back_to_node_id():
+    """A kernel covering only generic glue ops keeps the node-id name."""
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
+    g.add_node(_pointwise_loop(), ["x"], Tensor("o", (4, 8)), node_id="o")
+    g.inputs, g.outputs = ["x"], ["o"]
+    prov.put(g.nodes["o"], {"mul_0": {"kind": "ElementwiseOp", "pieces": ["o"]}})
+
+    assert "k_o_pointwise" in _tile_names(g)
+
+
+def test_real_rms_norm_kernels_named_by_op():
+    """A real (decomposed + fused) rms_norm names every kernel that carries
+    it after the op — fully covered -> ``k_rms_norm``, split halves ->
+    ``k_rms_norm_reduce`` / ``k_rms_norm_pointwise``."""
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, 4, 8)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("w", (8,)), node_id="w")
+    g.add_node(RmsNormOp(), ["x", "w"], Tensor("rms_norm_0", (1, 4, 8)), node_id="rms_norm_0")
+    g.inputs, g.outputs = ["x", "w"], ["rms_norm_0"]
+
+    names = _tile_names(g)
+    assert names, "rms_norm should lower to at least one kernel"
+    assert all("rms_norm" in nm for nm in names), names
+
+
+def test_cuda_op_cache_key_is_name_invariant():
+    """Renaming a kernel must not change its CudaOp cache key (so renames
+    don't bust the tune DB and isolated-kernel tuning transfers)."""
+    src = 'extern "C" __global__ void {name}(float* x, float* o) {{ o[0] = x[0]; }}'
+    a = CudaOp(kernel_source=src.format(name="k_rms_norm"), kernel_name="k_rms_norm", arg_order=("x", "o"))
+    b = CudaOp(kernel_source=src.format(name="k_merged_lift_n5"), kernel_name="k_merged_lift_n5", arg_order=("x", "o"))
+    assert op_cache_key(a) == op_cache_key(b)
+
+    # A genuine structural difference still changes the key.
+    c = CudaOp(kernel_source=src.format(name="k_rms_norm"), kernel_name="k_rms_norm", arg_order=("x", "o"), smem_bytes=128)
+    assert op_cache_key(a) != op_cache_key(c)

--- a/tests/compiler/test_provenance_naming.py
+++ b/tests/compiler/test_provenance_naming.py
@@ -4,9 +4,9 @@ from deplodock.compiler import provenance as prov
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.cuda.ir import CudaOp
+from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.frontend.ir import RmsNormOp
 from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
-from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.tile.ir import TileOp
 from deplodock.compiler.pipeline import TILE_PASSES, Pipeline
 from deplodock.compiler.pipeline.search.keys import op_cache_key
@@ -18,8 +18,15 @@ def _pointwise_loop() -> LoopOp:
         body=(
             Loop(
                 axis=i,
-                body=(Loop(axis=j, body=(Load(name="x_v", input="x", index=(Var("i"), Var("j"))),
-                                              Write(output="o", index=(Var("i"), Var("j")), value="x_v"))),),
+                body=(
+                    Loop(
+                        axis=j,
+                        body=(
+                            Load(name="x_v", input="x", index=(Var("i"), Var("j"))),
+                            Write(output="o", index=(Var("i"), Var("j")), value="x_v"),
+                        ),
+                    ),
+                ),
             ),
         )
     )
@@ -38,7 +45,10 @@ def test_full_single_op_gets_bare_name():
     g.inputs, g.outputs = ["x"], ["o"]
     prov.put(g.nodes["o"], {"rms_norm_0": {"kind": "RmsNormOp", "pieces": ["o"]}})
 
-    assert "k_rms_norm" in _tile_names(g)
+    # Bare op name + a short structural-uniqueness hash (``k_rms_norm_<h>``),
+    # no reduce/pointwise qualifier since it's fully covered.
+    names = _tile_names(g)
+    assert any(n.startswith("k_rms_norm_") and "pointwise" not in n for n in names), names
 
 
 def test_glue_only_kernel_falls_back_to_node_id():

--- a/tests/compiler/test_provenance_splice.py
+++ b/tests/compiler/test_provenance_splice.py
@@ -1,0 +1,89 @@
+"""Provenance propagation through real passes (decompose / lift / fuse).
+
+Exercises the ``Graph.splice`` hook end to end: decomposition mints fresh
+pieces under one origin, fusion aggregates pieces across origins, and the
+piece count survives recursive decomposition.
+"""
+
+from deplodock.compiler import provenance as prov
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.frontend.ir import RmsNormOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
+
+
+def _rms_graph() -> Graph:
+    g = Graph()
+    x = g.add_node(InputOp(), [], Tensor("x", (1, 4, 8)))
+    w = g.add_node(InputOp(), [], Tensor("w", (8,)))
+    g.inputs = [x, w]
+    rms = g.add_node(RmsNormOp(), [x, w], Tensor("rms_norm_0", (1, 4, 8)))
+    g.outputs = [rms]
+    return g
+
+
+def _matmul_graph() -> tuple[Graph, str, str]:
+    g = Graph()
+    a = g.add_node(InputOp(), [], Tensor("A", (4, 8, 4)))
+    b = g.add_node(InputOp(), [], Tensor("B", (4, 8, 4)))
+    g.inputs = [a, b]
+    ew = g.add_node(ElementwiseOp(op="multiply"), [a, b], Tensor("AB", (4, 8, 4)))
+    c = g.add_node(ReduceOp(op="sum", axis=1), [ew], Tensor("C", (4, 1, 4)))
+    g.outputs = [c]
+    return g, ew, c
+
+
+def test_decomposition_mints_pieces_under_one_origin():
+    """RmsNormOp decomposes (recursively, incl. its inner mean) into many
+    primitives, all distinct pieces of the single ``rms_norm_0`` origin."""
+    from deplodock.compiler.pipeline import Pipeline
+
+    out = Pipeline.build(["frontend/decomposition"]).run(_rms_graph())
+
+    pieces: set[str] = set()
+    for node in out.nodes.values():
+        p = prov.get(node)
+        if not p:
+            continue  # InputOp / ConstantOp boundary
+        assert set(p) == {"rms_norm_0"}
+        assert p["rms_norm_0"]["kind"] == "RmsNormOp"
+        pieces.update(p["rms_norm_0"]["pieces"])
+    # rms_norm fans out into well more than one primitive (mul, mean→sum/div,
+    # add-eps, rsqrt, two scales, broadcasts).
+    assert len(pieces) >= 5
+
+
+def test_fusion_aggregates_origins():
+    """mul + sum fuse into one LoopOp whose prov covers both source origins."""
+    from deplodock.compiler.ir.loop import LoopOp
+    from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline
+
+    g, ew, c = _matmul_graph()
+    fused = Pipeline.build(LOOP_PASSES).run(g)
+
+    loops = [n for n in fused.nodes.values() if isinstance(n.op, LoopOp)]
+    assert len(loops) == 1
+    merged = prov.get(loops[0])
+    # both the elementwise and the reduce origins survive the fusion
+    assert set(merged) == {ew, c}
+    assert merged[ew]["kind"] == "ElementwiseOp"
+    assert merged[c]["kind"] == "ReduceOp"
+
+
+def test_rms_norm_fully_covered_after_full_pipeline():
+    """Through decompose→lift→fuse, the rms_norm origin's pieces survive; the
+    kernels that carry it collectively realize every piece (full coverage)."""
+    from deplodock.compiler.ir.loop import LoopOp
+    from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline
+
+    fused = Pipeline.build(LOOP_PASSES).run(_rms_graph())
+
+    totals = prov.totals(fused)
+    assert "rms_norm_0" in totals
+    # Union of pieces across all LoopOp kernels == the origin's total pieces:
+    # nothing was dropped crossing the fusion boundaries.
+    covered: set[str] = set()
+    for n in fused.nodes.values():
+        if isinstance(n.op, LoopOp):
+            covered.update(prov.get(n).get("rms_norm_0", {}).get("pieces", []))
+    assert covered == totals["rms_norm_0"]

--- a/tests/compiler/test_torch_ref.py
+++ b/tests/compiler/test_torch_ref.py
@@ -5,14 +5,16 @@ CPU (no GPU needed)."""
 import numpy as np
 import pytest
 
-torch = pytest.importorskip("torch")
-
 from deplodock.compiler.backend import torch_ref
 from deplodock.compiler.backend.numpy import NumpyBackend
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.frontend.ir import LinearOp, MatmulOp, RmsNormOp, SoftmaxOp
 from deplodock.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, ReduceOp
+
+# torch is only needed to build reference tensors / call the evaluator; the
+# deplodock imports above are torch-free, so gate after them.
+torch = pytest.importorskip("torch")
 
 
 def _assert_matches_numpy(g: Graph, arrays: dict[str, np.ndarray]):

--- a/tests/compiler/test_torch_ref.py
+++ b/tests/compiler/test_torch_ref.py
@@ -1,0 +1,90 @@
+"""torch_ref: the Graph→torch evaluator used as the eager reference for
+``deplodock run --ir``. Validated against each op's numpy ``forward()`` on
+CPU (no GPU needed)."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from deplodock.compiler.backend import torch_ref
+from deplodock.compiler.backend.numpy import NumpyBackend
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.frontend.ir import LinearOp, MatmulOp, RmsNormOp, SoftmaxOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, ReduceOp
+
+
+def _assert_matches_numpy(g: Graph, arrays: dict[str, np.ndarray]):
+    """torch_ref output == numpy forward() output for graph ``g``."""
+    be = NumpyBackend()
+    npy = be.run(be.compile(g), input_data=arrays)[0].outputs[g.outputs[0]]
+
+    tin = {k: torch.from_numpy(v.astype(np.float32)) for k, v in arrays.items()}
+    fn, inputs = torch_ref.build_callable(g, tin)
+    with torch.no_grad():
+        tout = fn(*inputs).cpu().numpy()
+
+    np.testing.assert_allclose(tout, npy, rtol=1e-4, atol=1e-4)
+
+
+def _rng():
+    return np.random.default_rng(0)
+
+
+def test_rms_norm():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, 4, 8)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("w", (8,)), node_id="w")
+    g.add_node(RmsNormOp(), ["x", "w"], Tensor("o", (1, 4, 8)), node_id="o")
+    g.inputs, g.outputs = ["x", "w"], ["o"]
+    r = _rng()
+    _assert_matches_numpy(g, {"x": r.standard_normal((1, 4, 8)), "w": r.standard_normal((8,))})
+
+
+def test_linear_and_elementwise():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("w", (16, 8)), node_id="w")
+    g.add_node(LinearOp(), ["x", "w"], Tensor("h", (4, 16)), node_id="h")
+    g.add_node(ElementwiseOp(op="silu"), ["h"], Tensor("o", (4, 16)), node_id="o")
+    g.inputs, g.outputs = ["x", "w"], ["o"]
+    r = _rng()
+    _assert_matches_numpy(g, {"x": r.standard_normal((4, 8)), "w": r.standard_normal((16, 8))})
+
+
+def test_matmul_softmax():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("a", (4, 8)), node_id="a")
+    g.add_node(InputOp(), [], Tensor("b", (8, 4)), node_id="b")
+    g.add_node(MatmulOp(), ["a", "b"], Tensor("s", (4, 4)), node_id="s")
+    g.add_node(SoftmaxOp(axis=-1), ["s"], Tensor("o", (4, 4)), node_id="o")
+    g.inputs, g.outputs = ["a", "b"], ["o"]
+    r = _rng()
+    _assert_matches_numpy(g, {"a": r.standard_normal((4, 8)), "b": r.standard_normal((8, 4))})
+
+
+def test_reduce_sum_keepdim():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
+    g.add_node(ReduceOp(op="sum", axis=-1), ["x"], Tensor("o", (4, 1)), node_id="o")
+    g.inputs, g.outputs = ["x"], ["o"]
+    _assert_matches_numpy(g, {"x": _rng().standard_normal((4, 8))})
+
+
+def test_is_runnable_rejects_gather():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("idx", (4, 8)), node_id="idx")
+    g.add_node(GatherOp(axis=0), ["x", "idx"], Tensor("o", (4, 8)), node_id="o")
+    g.inputs, g.outputs = ["x", "idx"], ["o"]
+    assert not torch_ref.is_runnable(g)
+
+
+def test_is_runnable_accepts_frontend():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, 4, 8)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("w", (8,)), node_id="w")
+    g.add_node(RmsNormOp(), ["x", "w"], Tensor("o", (1, 4, 8)), node_id="o")
+    g.inputs, g.outputs = ["x", "w"], ["o"]
+    assert torch_ref.is_runnable(g)

--- a/tests/compiler/test_torch_ref.py
+++ b/tests/compiler/test_torch_ref.py
@@ -9,8 +9,9 @@ from deplodock.compiler.backend import torch_ref
 from deplodock.compiler.backend.numpy import NumpyBackend
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.expr import BinaryExpr, Literal, placeholder
 from deplodock.compiler.ir.frontend.ir import LinearOp, MatmulOp, RmsNormOp, SoftmaxOp
-from deplodock.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, ReduceOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, IndexMapOp, IndexSource, ReduceOp
 
 # torch is only needed to build reference tensors / call the evaluator; the
 # deplodock imports above are torch-free, so gate after them.
@@ -72,6 +73,45 @@ def test_reduce_sum_keepdim():
     g.add_node(ReduceOp(op="sum", axis=-1), ["x"], Tensor("o", (4, 1)), node_id="o")
     g.inputs, g.outputs = ["x"], ["o"]
     _assert_matches_numpy(g, {"x": _rng().standard_normal((4, 8))})
+
+
+def _imap_graph(in_shapes, out_shape, sources) -> Graph:
+    g = Graph()
+    names = [f"in{i}" for i in range(len(in_shapes))]
+    for n, shp in zip(names, in_shapes, strict=True):
+        g.add_node(InputOp(), [], Tensor(n, shp), node_id=n)
+    g.add_node(IndexMapOp(out_shape=out_shape, sources=sources), names, Tensor("o", out_shape), node_id="o")
+    g.inputs, g.outputs = names, ["o"]
+    return g
+
+
+def test_indexmap_transpose():
+    # output (4,3)[a0,a1] = in0[a1,a0]
+    g = _imap_graph([(3, 4)], (4, 3), (IndexSource(input_idx=0, coord_map=(placeholder(1), placeholder(0))),))
+    _assert_matches_numpy(g, {"in0": _rng().standard_normal((3, 4))})
+
+
+def test_indexmap_broadcast():
+    # (8,) → (4,8): every row reads in0[a1]
+    g = _imap_graph([(8,)], (4, 8), (IndexSource(input_idx=0, coord_map=(placeholder(1),)),))
+    _assert_matches_numpy(g, {"in0": _rng().standard_normal((8,))})
+
+
+def test_indexmap_cat_with_select():
+    # output (4,4): a1<2 → in0[a0,a1]; a1>=2 → in1[a0,a1-2]
+    s0 = IndexSource(input_idx=0, coord_map=(placeholder(0), placeholder(1)), select=placeholder(1).lt(Literal(2, "int")))
+    s1 = IndexSource(
+        input_idx=1,
+        coord_map=(placeholder(0), placeholder(1) - Literal(2, "int")),
+        select=BinaryExpr(">=", placeholder(1), Literal(2, "int")),
+    )
+    g = _imap_graph([(4, 2), (4, 2)], (4, 4), (s0, s1))
+    _assert_matches_numpy(g, {"in0": _rng().standard_normal((4, 2)), "in1": _rng().standard_normal((4, 2))})
+
+
+def test_is_runnable_accepts_indexmap():
+    g = _imap_graph([(8,)], (4, 8), (IndexSource(input_idx=0, coord_map=(placeholder(1),)),))
+    assert torch_ref.is_runnable(g)
 
 
 def test_is_runnable_rejects_gather():


### PR DESCRIPTION
## What

Tracks which original PyTorch ops each fused CUDA kernel implements, and uses that to (1) dump per-kernel **Torch reproducers**, (2) name kernels after the ops they realize, and (3) compare any kernel **against torch** via `run --ir`.

## Why

Given a slow or wrong fused kernel there was no way back to the source op(s). Decomposition shatters one op into primitives and fusion merges primitives from several ops into one kernel, so by `CudaOp` time the origin is gone — making correctness/perf debugging and per-kernel tuning hard.

## How

- **Provenance** (`compiler/provenance.py`): each node carries `prov = {origin_id: {kind, pieces}}`, seeded at `Pipeline.tune` entry and threaded through the single `Graph.splice` chokepoint — decomposition *mints* fresh pieces, fusion/lifting *aggregate* them (flag set from the pass namespace in `Candidate.apply`). Lowering is in-place rebinds, so it rides to `CudaOp` untouched. Coverage is `len(pieces)/total` (union across the graph), robust to CSE/recursive decomposition.
- **Naming** (`010_partition_loops`): `k_rms_norm` (full) / `k_rms_norm_reduce` (partial), with a short structural-body hash for uniqueness (distinct kernels sharing a label must get distinct names — the backend dispatches by name). `CudaOp.op_cache_key` made **name-invariant** so renames don't bust the tune DB and isolated-kernel tuning transfers.
- **Reproducer dump** (`pipeline/dump.py`): `<kname>.torch.json` — the original Torch ops sliced by prov, with an `i/N` coverage header; runnable via `run --ir`.
- **torch_ref backend** + **`run --ir` vs-torch**: a `Graph→torch` evaluator builds eager + `torch.compile` references; `run --ir <frontend.json> --bench` prints the Eager / torch.compile / Deplodock table + accuracy check. Constant data is keyed by `source_path` and replayed through `load_ops` (`bind_constants`), so a transposed/renamed linear weight is the *same* tensor on both sides.
- **`run --ir` now threads the tune DB** into lowering, so tuned variants actually apply (e.g. tuning a Qwen attention reproducer drops the sdpa-reduce 83µs → 10µs).
- Fix: fp16 synthetic-input fill overflowed (`np.arange` in fp16) → garbage/NaN inputs; build the ramp in int64.
- `scripts/bench_model_kernels.py`: compile a model → bench each prov-named kernel from its reproducer → per-kernel latency chart via `deplodock.visualize`.

## Testing

- New: `test_provenance{,_splice,_naming,_dump}.py`, `test_torch_ref.py`, a `bind_constants` consistency test. Full `tests/compiler/` suite green (835 passed); `make lint` clean.
- Validated end-to-end on `Qwen/Qwen3-Embedding-0.6B` layer 0: prov names (`k_linear_reduce`, `k_sdpa_transpose_reshape_linear_reduce`, …), per-kernel vs-torch, and tune→run transfer.

## Notes

- Some reproducers (containing `mean`) hit a **pre-existing** `030_lift_indexmap` bug on standalone recompile — unrelated; those fall back to deplodock-only.
- Docs updated: `compiler/`, `backend/`, `pipeline/` ARCHITECTURE + `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)