### PR TITLE
Centralize DEPLODOCK_* env handling in deplodock/config.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,14 @@ When the user asks about a CLI flag, recipe field, or matrix combinator, read th
 - `DEPLODOCK_DUMP_DIR` environment variable (optional) — when set, all compiler stages dump intermediate artifacts (graphs, CUDA kernels, execution plans) to this directory for debugging. Per kernel, the dump also writes a `<kname>.torch.json` reproducer — the original PyTorch ops that kernel implements (sliced by op provenance), with an `i/N` coverage header (full vs partial) — runnable via `deplodock run --ir <kname>.torch.json --bench` to reproduce accuracy / latency vs torch for that op. Kernels are named after the ops they realize (`k_rms_norm`, `k_sdpa_reduce`)
 - `DEPLODOCK_TUNE_DB` environment variable (optional) — overrides the default tuning SQLite cache path (`~/.cache/deplodock/autotune.db`). `deplodock compile` / `run` / `tune` all read from / write to this path so a tuned variant picked up by one command shows up in the next.
 
+All `DEPLODOCK_*` config env vars (the two above plus `DEPLODOCK_NVCC_FLAGS`, `DEPLODOCK_DEBUG`, `DEPLODOCK_KNOBS`,
+`DEPLODOCK_TUNE_PATIENCE`, `DEPLODOCK_BENCH_BACKENDS`, `DEPLODOCK_CUBIN_CACHE`, `DEPLODOCK_NO_NVCC`, `DEPLODOCK_GPU_LOCK`,
+…) are read and written through a single module, `deplodock/config.py` — the sole owner of `os.environ` for these vars.
+CLI `--flag` overrides (e.g. `--nvcc-flags`) resolve via `config.set_nvcc_flags` inside the library, not in the command
+layer, so programmatic callers and tests get the same precedence. The dynamic `DEPLODOCK_<KNOB>` namespace is owned by
+`compiler/pipeline/knob.py` (which borrows `config.knob_var` / `config.knob_raw`); provider/secret vars stay with
+`deplodock/redact.py`.
+
 ## Running Tests
 
 ```bash

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -16,6 +16,13 @@ commands/vm ────► provisioning (create/delete instances)
 - `deplodock/deploy/` — compose generation, deploy orchestration
 - `deplodock/provisioning/` — VM types, SSH polling, shell helpers, cloud providers
 - `deplodock/logging_setup.py` — CLI logging setup (`setup_cli_logging()`)
+- `deplodock/config.py` — the single owner of `os.environ` for all `DEPLODOCK_*` config vars. Typed getters
+  (`tune_db_path`, `nvcc_flags`, `debug_enabled`, `dump_dir`, `tune_patience`, `bench_backends_raw`, `cubin_cache_dir`,
+  …) read the env live; `set_nvcc_flags(cli_value, default)` holds the `--nvcc-flags` > env > command-default precedence
+  that used to live in this CLI layer, so every callsite (CLI, programmatic, tests) shares it. The thin
+  `compile.apply_nvcc_flags` / `compile.resolve_tune_db` wrappers just adapt argparse to it. (Provider/secret vars stay
+  with `redact.py`; the dynamic `DEPLODOCK_<KNOB>` namespace stays with `compiler/pipeline/knob.py`, which borrows
+  `config.knob_var` / `config.knob_raw`.)
 - `deplodock/redact.py` — `redact_secrets()`, `SecretRedactingFilter`, `install_redaction()` (attach the filter to a handler — must be a handler, not a logger, so child-logger records that propagate up are still redacted), `register_secret()` (call after resolving any secret from a CLI flag — `--hf-token`, `--api-key` — or env var so its value is added to the redaction set)
 - `deplodock/benchmark/` — config, logging, workload, tasks, execution, structured JSON results
 

--- a/deplodock/commands/bench/__init__.py
+++ b/deplodock/commands/bench/__init__.py
@@ -73,9 +73,11 @@ def handle_bench(args):
         sys.exit(1)
 
     # Inject DEPLODOCK_DUMP_DIR / DEPLODOCK_DEBUG into command tasks when
-    # --dump-dir / --debug are set. The env vars use $task_dir which is
-    # resolved at runtime by the command workload runner. Artifacts are
-    # pulled back via result_files glob.
+    # --dump-dir / --debug are set. These are keys in the *remote* command's
+    # env (resolved at runtime by the command workload runner via $task_dir),
+    # not local-process env access, so they stay literal (see deplodock/config.py
+    # for the local-process DEPLODOCK_* owner). Artifacts are pulled back via
+    # the result_files glob.
     if args.dump_dir or args.debug:
         for task in tasks:
             if task.recipe.command is not None:

--- a/deplodock/commands/compile.py
+++ b/deplodock/commands/compile.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from deplodock import config
 from deplodock.compiler.pipeline import (
     CUDA_PASSES,
     KERNEL_PASSES,
@@ -58,8 +58,7 @@ def resolve_tune_db() -> Path:
     Callers should treat the path as advisory — the engine only opens
     it when the file actually exists; otherwise the compile falls back
     to rule defaults (greedy option-0)."""
-    override = os.environ.get("DEPLODOCK_TUNE_DB")
-    return Path(override) if override else Path.home() / ".cache" / "deplodock" / "autotune.db"
+    return config.tune_db_path()
 
 
 def add_input_args(parser) -> None:
@@ -167,17 +166,13 @@ def add_nvcc_args(parser) -> None:
 
 
 def apply_nvcc_flags(args, default: str) -> str:
-    """Resolve and publish the effective extra nvcc flags via the
-    ``DEPLODOCK_NVCC_FLAGS`` env var (the carrier the cubin compiler + the
-    bench-worker subprocess + ``Context.structural_key`` all read). Precedence:
-    ``--nvcc-flags`` > a pre-set env var > the command ``default``. Must run
-    before any compile/bench. Returns the effective string."""
-    val = getattr(args, "nvcc_flags", None)
-    if val is not None:
-        os.environ["DEPLODOCK_NVCC_FLAGS"] = val
-    elif "DEPLODOCK_NVCC_FLAGS" not in os.environ:
-        os.environ["DEPLODOCK_NVCC_FLAGS"] = default
-    return os.environ.get("DEPLODOCK_NVCC_FLAGS", "")
+    """Resolve and publish the effective extra nvcc flags. Thin CLI adapter that
+    extracts ``--nvcc-flags`` from ``args`` and delegates the override/precedence
+    (``--nvcc-flags`` > pre-set env > command ``default``) to
+    :func:`deplodock.config.set_nvcc_flags`, so every callsite (CLI, programmatic,
+    tests) shares one implementation. Must run before any compile/bench. Returns
+    the effective string."""
+    return config.set_nvcc_flags(getattr(args, "nvcc_flags", None), default)
 
 
 def setup_pipeline_runtime(args) -> None:

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -13,6 +13,8 @@ import os
 import sys
 from pathlib import Path
 
+from deplodock import config
+
 logger = logging.getLogger(__name__)
 
 
@@ -156,7 +158,7 @@ def handle_run(args):
     # (b) pollutes the captured CSV with cutlass / cuBLAS kernel rows
     # the perf summary then has to filter out. The child only needs to
     # launch the deplodock kernels so ncu can sample our metrics.
-    skip_accuracy = os.environ.get(_NCU_RECURSE_GUARD) == "1"
+    skip_accuracy = config.ncu_child()
 
     try:
         if not skip_accuracy:
@@ -376,7 +378,7 @@ def _theoretical_occupancy(regs_per_thread: int, smem_per_block: int, threads_pe
     return min(100.0, 100.0 * active_warps / max_warps)
 
 
-_NCU_RECURSE_GUARD = "DEPLODOCK_NCU_CHILD"
+_NCU_RECURSE_GUARD = config.NCU_CHILD
 
 # Curated ncu metric set — verified to populate on RTX 5090 (sm_120) +
 # TMA kernels. ``--set detailed`` is broken there (``SpeedOfLight_Roofline``
@@ -420,7 +422,7 @@ def _run_ncu_profile(args, *, dump_dir=None):
     import sys
     from pathlib import Path as _Path
 
-    if os.environ.get(_NCU_RECURSE_GUARD):
+    if config.ncu_child():
         return
 
     ncu = shutil.which("ncu")
@@ -435,7 +437,7 @@ def _run_ncu_profile(args, *, dump_dir=None):
     # ``__post_init__``. Drop the env var for the child so the parent's
     # ``60_*.json`` (bench results) survive — ncu output is captured via
     # stdout and saved by the parent below.
-    env.pop("DEPLODOCK_DUMP_DIR", None)
+    env.pop(config.DUMP_DIR, None)
 
     cmd: list[str] = [
         ncu,
@@ -934,7 +936,7 @@ def _resolve_backends(cli_value: str | None) -> set[str]:
     test is the point of the bench). Returns the canonical backend
     keys ``{"eager", "tcompile", "deplodock"}``.
     """
-    raw = cli_value or os.environ.get("DEPLODOCK_BENCH_BACKENDS") or "eager,deplodock"
+    raw = config.bench_backends_raw(cli_value)
     selected: set[str] = {"deplodock"}
     for tok in raw.split(","):
         tok = tok.strip().lower()

--- a/deplodock/commands/tune.py
+++ b/deplodock/commands/tune.py
@@ -7,6 +7,7 @@ import os
 import sys
 from pathlib import Path
 
+from deplodock import config
 from deplodock.commands.compile import (
     add_diagnostics_args,
     add_input_args,
@@ -129,7 +130,7 @@ def handle_tune(args):
     db = SearchDB(path=db_path)
     logger.info("Tuning DB: %s", db_path)
 
-    patience = args.patience if args.patience is not None else int(os.environ.get("DEPLODOCK_TUNE_PATIENCE", 100))
+    patience = args.patience if args.patience is not None else config.tune_patience(100)
     ctx = Context.probe()
     t0 = time.monotonic()
     try:

--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -40,9 +40,12 @@ arg_order).
   Compile vs load is split (`compile_to_cubin` / `load_function`) so the
   GPU-free compile can run off-process; the loaded `Function` is launch- and
   smem-attr-compatible with `RawKernel`.
-- **Opt level** comes from `DEPLODOCK_NVCC_FLAGS` (`nvcc.effective_flags`): the
-  CLI sets it — `tune` → `-Xcicc -O1`, `compile`/`run` → nvcc default -O3,
-  `--nvcc-flags` overrides. -O1 dodges a cicc/LLVM front-end blowup on big
+- **Opt level** comes from `DEPLODOCK_NVCC_FLAGS` (`nvcc.effective_flags`, which
+  delegates to `config.nvcc_flags()` — `deplodock/config.py` is the single owner
+  of `os.environ` for `DEPLODOCK_*` vars, incl. `DEPLODOCK_NO_NVCC` /
+  `DEPLODOCK_CUBIN_CACHE`). The CLI sets the flags via `config.set_nvcc_flags`
+  (override logic, no longer in the command layer) — `tune` → `-Xcicc -O1`,
+  `compile`/`run` → nvcc default -O3, `--nvcc-flags` overrides. -O1 dodges a cicc/LLVM front-end blowup on big
   unrolled register-tile kernels (cicc, not ptxas, is the cost: a tall-thin
   register tile unrolls into a ~5K-instruction basic block → up to 21 s → 0.1 s
   at -O1) but is **NOT runtime-optimal** (reductions/attention ~1.5–3× slower),

--- a/deplodock/compiler/backend/cuda/backend.py
+++ b/deplodock/compiler/backend/cuda/backend.py
@@ -7,12 +7,12 @@ node carries a rendered CUDA kernel source plus its launch geometry.
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
 
+from deplodock import config
 from deplodock.compiler.backend import Backend, BenchmarkResult, RunResult
 from deplodock.compiler.backend.cuda.program import (
     benchmark_program,
@@ -39,25 +39,20 @@ if TYPE_CHECKING:
     from deplodock.compiler.pipeline.dump import CompilerDump
 
 
-_DEBUG_ENV = "DEPLODOCK_DEBUG"
-_TUNE_DB_ENV = "DEPLODOCK_TUNE_DB"
-_DEFAULT_TUNE_DB = Path.home() / ".cache" / "deplodock" / "autotune.db"
-
-
 def _resolve_tune_db(value: Path | str | None) -> Path | None:
     """Resolve the ``tune_db=`` constructor argument.
 
     - ``None`` → ``None`` (no DB; test-isolation default).
-    - ``"auto"`` → ``DEPLODOCK_TUNE_DB`` env → ``~/.cache/deplodock/autotune.db``.
-      The result is returned regardless of whether the file exists;
-      ``compile()`` skips opening it when missing.
+    - ``"auto"`` → ``DEPLODOCK_TUNE_DB`` env → ``~/.cache/deplodock/autotune.db``
+      (shared resolution in :func:`deplodock.config.tune_db_path`). The result
+      is returned regardless of whether the file exists; ``compile()`` skips
+      opening it when missing.
     - Explicit ``Path`` / ``str`` → that path (no env lookup).
     """
     if value is None:
         return None
     if value == "auto":
-        override = os.environ.get(_TUNE_DB_ENV)
-        return Path(override) if override else _DEFAULT_TUNE_DB
+        return config.tune_db_path()
     return Path(value)
 
 
@@ -83,7 +78,7 @@ class CudaBackend(Backend):
         tune_db: Path | str | None = None,
     ) -> None:
         if debug is None:
-            debug = os.environ.get(_DEBUG_ENV, "").strip().lower() in ("1", "true", "yes")
+            debug = config.debug_enabled()
         if dump is None:
             from deplodock.compiler.pipeline.dump import CompilerDump as _CD
 

--- a/deplodock/compiler/backend/cuda/nvcc.py
+++ b/deplodock/compiler/backend/cuda/nvcc.py
@@ -31,9 +31,9 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+from deplodock import config
 
-_CACHE_DIR = Path(os.environ.get("DEPLODOCK_CUBIN_CACHE", Path.home() / ".cache" / "deplodock" / "cubin"))
+logger = logging.getLogger(__name__)
 
 # Base nvcc flags deplodock always compiles with (matches ``program._nvrtc_options``).
 _BASE_FLAGS = ["--use_fast_math"]
@@ -47,25 +47,24 @@ def effective_flags() -> list[str]:
     Read fresh each call so a per-invocation override / the bench-worker
     subprocess (which inherits the env) both see the same value, and so the
     flags fold into the cache key."""
-    extra = os.environ.get("DEPLODOCK_NVCC_FLAGS", "").split()
-    return [*_BASE_FLAGS, *extra]
+    return [*_BASE_FLAGS, *config.nvcc_flags().split()]
 
 
 def cubin_cache_dir() -> Path:
-    """Directory holding the content-addressed cubin cache."""
-    return _CACHE_DIR
+    """Directory holding the content-addressed cubin cache (``DEPLODOCK_CUBIN_CACHE``)."""
+    return config.cubin_cache_dir()
 
 
 def clear_cubin_cache() -> None:
     """Delete the entire cubin cache (used by ``deplodock tune --clean``)."""
-    shutil.rmtree(_CACHE_DIR, ignore_errors=True)
+    shutil.rmtree(cubin_cache_dir(), ignore_errors=True)
 
 
 @functools.cache
 def nvcc_path() -> str | None:
     """Resolve the ``nvcc`` binary (PATH, then ``$CUDA_HOME``/``$CUDA_PATH``),
     or ``None`` when unavailable. Cached — looked up once per process."""
-    if os.environ.get("DEPLODOCK_NO_NVCC", "").strip().lower() in ("1", "true", "yes"):
+    if config.nvcc_disabled():
         return None
     found = shutil.which("nvcc")
     if found:
@@ -131,11 +130,12 @@ def compile_to_cubin(source: str, name: str, *, arch: str) -> Path:
     nvcc = nvcc_path()
     if nvcc is None:
         raise RuntimeError("nvcc unavailable")
-    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    out = _CACHE_DIR / f"{_cache_key(source, name, arch)}.cubin"
+    cache = cubin_cache_dir()
+    cache.mkdir(parents=True, exist_ok=True)
+    out = cache / f"{_cache_key(source, name, arch)}.cubin"
     if out.exists():
         return out
-    with tempfile.TemporaryDirectory(dir=_CACHE_DIR) as td:
+    with tempfile.TemporaryDirectory(dir=cache) as td:
         cu = Path(td) / "k.cu"
         cu.write_text(source)
         tmp_cubin = Path(td) / "k.cubin"

--- a/deplodock/compiler/backend/gpu_lock.py
+++ b/deplodock/compiler/backend/gpu_lock.py
@@ -22,16 +22,17 @@ nested calls inside the same process don't deadlock against themselves.
 from __future__ import annotations
 
 import contextlib
-import os
 from collections.abc import Iterator
 from pathlib import Path
+
+from deplodock import config
 
 _LOCK_CACHE: dict[str, object] = {}
 
 
 def _resolve_lock():
     """Return the cached ``FileLock`` instance, or ``None`` for no-op."""
-    path = os.environ.get("DEPLODOCK_GPU_LOCK")
+    path = config.gpu_lock_path()
     if not path:
         return None
     cached = _LOCK_CACHE.get(path)

--- a/deplodock/compiler/context.py
+++ b/deplodock/compiler/context.py
@@ -15,8 +15,9 @@ the signature alone.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
+
+from deplodock import config
 
 # Per-block static-smem cap. Hard hardware limit since Maxwell (sm_50);
 # anything declared as ``__shared__`` at compile time must fit.
@@ -41,9 +42,9 @@ _MAX_DYNAMIC_SMEM_BY_CC: dict[tuple[int, int], int] = {
 
 def _env_compile_flags() -> str:
     """Extra nvcc flags for this compile (``DEPLODOCK_NVCC_FLAGS``). Set by the
-    CLI commands; folded into :meth:`Context.structural_key` so the perf cache
-    is partitioned by opt level."""
-    return os.environ.get("DEPLODOCK_NVCC_FLAGS", "")
+    CLI commands (via :func:`deplodock.config.set_nvcc_flags`); folded into
+    :meth:`Context.structural_key` so the perf cache is partitioned by opt level."""
+    return config.nvcc_flags()
 
 
 def _max_dynamic_smem_for(cc: tuple[int, int]) -> int:

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -283,11 +283,15 @@ rule module — no manual registration.
 
 **Pinning knobs from the environment.** Two equivalent forms:
 
-- **Per-knob:** `DEPLODOCK_<NAME>=<value>` (e.g. `DEPLODOCK_BK=32`). Read directly by the rule that owns the knob.
+- **Per-knob:** `DEPLODOCK_<NAME>=<value>` (e.g. `DEPLODOCK_BK=32`). Read by the rule that owns the knob (via
+  `Knob.narrow`) or by `compiler/tuning.py`'s heuristics. The `DEPLODOCK_<NAME>` env-var key is built by
+  `config.knob_var` and the value read via `config.knob_raw` / `config.int_env` — `deplodock/config.py` is the single
+  owner of `os.environ` for all `DEPLODOCK_*` vars; `knob.py` keeps the `Knob` descriptor's per-type decode.
 - **Aggregate:** `DEPLODOCK_KNOBS="K1=V1,K2=V2,..."` (e.g. `DEPLODOCK_KNOBS="BK=2,BM=16,BN=128,FM=8,FN=8,STAGE=111"`).
   Parsed once at `knob.py` import via `apply_knobs_env()`, which splats each entry into the corresponding
-  `DEPLODOCK_<K>` env var so all the per-knob readers pick it up uniformly. An explicit per-knob var wins over the
-  aggregate (so `DEPLODOCK_BK=4 DEPLODOCK_KNOBS="BK=2,BM=16"` ends up with BK=4, BM=16).
+  `DEPLODOCK_<K>` env var (via `config.set_knob(..., overwrite=False)`) so all the per-knob readers pick it up
+  uniformly. An explicit per-knob var wins over the aggregate (so `DEPLODOCK_BK=4 DEPLODOCK_KNOBS="BK=2,BM=16"` ends up
+  with BK=4, BM=16).
 
 Pinning replaces tuner choice: the rule sees the env value and emits exactly that variant instead of forking. Useful for
 reproducing a tune-time variant from CI logs, A/B-comparing two configs, or pinning a known-good config in a Makefile

--- a/deplodock/compiler/pipeline/dump.py
+++ b/deplodock/compiler/pipeline/dump.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from deplodock import config
 
 if TYPE_CHECKING:
     from deplodock.compiler.backend.base import BenchmarkResult
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ENV_VAR = "DEPLODOCK_DUMP_DIR"
+ENV_VAR = config.DUMP_DIR
 
 
 @dataclass
@@ -59,10 +60,8 @@ class CompilerDump:
     @classmethod
     def from_env(cls) -> CompilerDump | None:
         """Create from DEPLODOCK_DUMP_DIR env var, or return None."""
-        dump_dir = os.environ.get(ENV_VAR)
-        if dump_dir:
-            return cls(dir=Path(dump_dir).expanduser())
-        return None
+        d = config.dump_dir()
+        return cls(dir=d) if d else None
 
     @classmethod
     def resolve(cls, cli_dir: str | Path | None = None) -> CompilerDump | None:

--- a/deplodock/compiler/pipeline/knob.py
+++ b/deplodock/compiler/pipeline/knob.py
@@ -16,13 +16,14 @@ instance — no ``register(...)`` wrapper, no manual bookkeeping.
 
 from __future__ import annotations
 
-import os
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from types import ModuleType
 from typing import Any
+
+from deplodock import config
 
 
 class KnobType(Enum):
@@ -50,7 +51,7 @@ class Knob:
 
     @property
     def env(self) -> str:
-        return f"DEPLODOCK_{self.name.upper()}"
+        return config.knob_var(self.name)
 
     def parse(self, raw: str, *, width: int | None = None) -> Any:
         """Decode an env-string value per ``type``. ``width`` is required
@@ -104,7 +105,7 @@ class Knob:
 
         ``BINMASK`` isn't supported — it would need ``width``, and no
         rule enumerates BINMASK candidates today."""
-        raw = os.environ.get(self.env)
+        raw = config.knob_raw(self.name)
         if raw is None:
             return tuple(candidates)
         if self.type is KnobType.BINMASK:
@@ -185,7 +186,7 @@ def apply_knobs_env(raw: str | None = None) -> dict[str, str]:
     ``DEPLODOCK_KNOBS`` (useful in tests).
     """
     if raw is None:
-        raw = os.environ.get("DEPLODOCK_KNOBS", "")
+        raw = config.knobs_aggregate()
     applied: dict[str, str] = {}
     if not raw:
         return applied
@@ -200,19 +201,16 @@ def apply_knobs_env(raw: str | None = None) -> dict[str, str]:
         value = value.strip()
         if not key:
             raise ValueError(f"DEPLODOCK_KNOBS entry {entry!r} has empty KEY")
-        env_name = f"DEPLODOCK_{key}"
         # Individual per-knob env vars win — don't clobber an explicit
         # ``DEPLODOCK_BK=4`` with whatever the aggregate says.
-        if env_name in os.environ:
-            continue
-        os.environ[env_name] = value
-        applied[env_name] = value
+        if config.set_knob(key, value, overwrite=False):
+            applied[config.knob_var(key)] = value
     return applied
 
 
-# Splat ``DEPLODOCK_KNOBS`` once at import so every later
-# ``os.environ.get("DEPLODOCK_<NAME>")`` reader (knob.py is imported
-# transitively by every pipeline pass) sees the per-knob keys.
+# Splat ``DEPLODOCK_KNOBS`` once at import so every later per-knob reader
+# (``config.knob_raw`` / ``config.int_env`` — knob.py is imported transitively
+# by every pipeline pass) sees the individual ``DEPLODOCK_<NAME>`` keys.
 apply_knobs_env()
 
 

--- a/deplodock/compiler/tuning.py
+++ b/deplodock/compiler/tuning.py
@@ -49,10 +49,11 @@ compute these inputs themselves and call the heuristics directly.
 
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from deplodock import config
 
 if TYPE_CHECKING:
     from deplodock.compiler.ir.stmt.body import Body
@@ -154,14 +155,12 @@ _SPLITK_NUM_SMS = 170  # RTX 5090; conservative upper bound for sm_120
 # --- Helpers ------------------------------------------------------------
 
 
-def _int_env(name: str, default: int) -> int:
-    raw = os.environ.get(name)
-    if not raw:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        return default
+def _knob_int(name: str, default: int) -> int:
+    """Read the matmul knob ``DEPLODOCK_<NAME>`` as an int (empty / invalid →
+    ``default``). Thin alias over :func:`deplodock.config.int_env` that builds the
+    env-var key via :func:`deplodock.config.knob_var` so the prefix lives in one
+    place; the ``Knob`` descriptor namespace is owned by ``pipeline/knob.py``."""
+    return config.int_env(config.knob_var(name), default)
 
 
 # --- BodyInfo -----------------------------------------------------------
@@ -350,7 +349,7 @@ def _tma_swizzle_enabled() -> bool:
     """TMA hardware-swizzle gate. Off by default — only fires when the
     inner box-dim byte size matches a swizzle width AND ``DEPLODOCK_TMA_SWIZZLE``
     opts in."""
-    return os.environ.get("DEPLODOCK_TMA_SWIZZLE", "0") in ("1", "true", "True")
+    return config.tma_swizzle_enabled()
 
 
 # --- Heuristics (pure numeric) -----------------------------------------
@@ -362,10 +361,10 @@ def thread_tile_shape(output_extents: tuple[int, ...], body_info: BodyInfo) -> t
     kernels (single THREAD axis; same env namespace as the matmul case)."""
     if body_info.has_matmul:
         (def_bn, def_bm), _ = _default_tile(output_extents, body_info)
-        bn = _int_env("DEPLODOCK_BN", def_bn)
-        bm = _int_env("DEPLODOCK_BM", def_bm)
+        bn = _knob_int("BN", def_bn)
+        bm = _knob_int("BM", def_bm)
         return (bn, bm)
-    return (_int_env("DEPLODOCK_BN", _NON_MATMUL_BN_DEFAULT),)
+    return (_knob_int("BN", _NON_MATMUL_BN_DEFAULT),)
 
 
 def register_tile_shape(
@@ -384,10 +383,10 @@ def register_tile_shape(
     if not body_info.has_matmul:
         return (1, 1)
     (def_bn, def_bm), (def_fm, def_fn) = _default_tile(output_extents, body_info)
-    f_m = _int_env("DEPLODOCK_FM", def_fm)
-    f_n = _int_env("DEPLODOCK_FN", def_fn)
-    bn = _int_env("DEPLODOCK_BN", def_bn)
-    bm = _int_env("DEPLODOCK_BM", def_bm)
+    f_m = _knob_int("FM", def_fm)
+    f_n = _knob_int("FN", def_fn)
+    bn = _knob_int("BN", def_bn)
+    bm = _knob_int("BM", def_bm)
     if not thread_extents:
         return (f_m, f_n)
     te_set = {int(e) for e in thread_extents}
@@ -415,12 +414,9 @@ def forced_bk(
     smem cap at the active tile shape.
 
     ``static_smem_cap`` defaults to ``Context.static_smem_cap`` (48 KB)."""
-    raw = os.environ.get("DEPLODOCK_BK")
-    if raw:
-        try:
-            return int(raw)
-        except ValueError:
-            return None
+    forced = _knob_int("BK", 0)
+    if forced > 0:
+        return forced
     if not body_info.has_matmul:
         return None
     m = output_extents[1] if len(output_extents) >= 2 else 0
@@ -444,8 +440,8 @@ def _bk_fits_smem(output_extents: tuple[int, ...], body_info: BodyInfo, bk: int,
     if len(output_extents) < 2:
         return bk
     (def_bn, def_bm), _ = _default_tile(output_extents, body_info)
-    bn_actual = min(output_extents[0], _int_env("DEPLODOCK_BN", def_bn))
-    bm_actual = min(output_extents[1], _int_env("DEPLODOCK_BM", def_bm))
+    bn_actual = min(output_extents[0], _knob_int("BN", def_bn))
+    bm_actual = min(output_extents[1], _knob_int("BM", def_bm))
     n_inputs = max(body_info.external_input_count, 2)
     stage_footprint = n_inputs * max(bn_actual, bm_actual) * _DTYPE_BYTES * 2
     while bk > 1 and stage_footprint * bk > budget:
@@ -465,14 +461,14 @@ def auto_splitk(
     ``waves_target * num_sms`` total CTAs, divide by the current
     M-N grid count, clamp to the largest divisor of ``k_o_extent``
     that is ≤ the target. Returns 1 when no useful split exists."""
-    forced = _int_env("DEPLODOCK_SPLITK", 0)
+    forced = _knob_int("SPLITK", 0)
     if forced > 0:
         return forced
     if not body_info.has_matmul:
         return 1
     (def_bn, def_bm), _ = _default_tile(output_extents, body_info)
-    bn = _int_env("DEPLODOCK_BN", def_bn)
-    bm = _int_env("DEPLODOCK_BM", def_bm)
+    bn = _knob_int("BN", def_bn)
+    bm = _knob_int("BM", def_bm)
     targets = (bn, bm)
     # Pre-blockify thread extents — same shape as ``tile.axes`` extents
     # in the legacy synthetic-Tile call. Sort descending; innermost-2
@@ -509,4 +505,4 @@ def _splitk_target_waves(output_extents: tuple[int, ...], body_info: BodyInfo) -
 def cooperative_block_size() -> int:
     """Threads/CTA for synthetic-thread axes in non-matmul paths.
     Shares the matmul ``DEPLODOCK_BN`` env namespace."""
-    return _int_env("DEPLODOCK_BN", _NON_MATMUL_BN_DEFAULT)
+    return _knob_int("BN", _NON_MATMUL_BN_DEFAULT)

--- a/deplodock/config.py
+++ b/deplodock/config.py
@@ -1,0 +1,198 @@
+"""Single source of truth for ``DEPLODOCK_*`` environment-variable handling.
+
+Every read or write of a ``DEPLODOCK_*`` config var goes through this module.
+It is intentionally stdlib-only (no ``deplodock`` imports) so that ``knob.py``
+— imported transitively by every pipeline pass — can depend on it without a
+cycle.
+
+Design contract:
+
+- ``os.environ`` stays the backing store. Bench-worker subprocesses
+  (``backend/cuda/program.py``) and the ncu child (``commands/run.py``) spawn
+  with ``env=dict(os.environ)``, so anything written here propagates to them;
+  tests monkeypatch ``os.environ`` directly, so getters must read it **live**.
+- Getters read ``os.environ`` on every call (never cache at import).
+- The one setter, :func:`set_nvcc_flags`, centralizes the ``--flag > env >
+  default`` override that used to live in the CLI layer, so every callsite
+  (CLI, programmatic, tests) shares it.
+
+Out of scope: provider/secret vars (``HF_TOKEN``, ``CLOUDRIFT_*``, ``GCP_*``,
+``NO_COLOR``) — those stay at their use sites, and ``deplodock/redact.py`` owns
+secret redaction. The dynamic ``DEPLODOCK_<KNOB>`` namespace is owned by
+``compiler/pipeline/knob.py``; it borrows :data:`PREFIX` / :func:`knob_var` and
+the parse primitives here but keeps its own descriptor logic.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# --- Var-name constants (the single source of truth for spellings) ---------
+
+PREFIX = "DEPLODOCK_"
+TUNE_DB = "DEPLODOCK_TUNE_DB"
+NVCC_FLAGS = "DEPLODOCK_NVCC_FLAGS"
+DEBUG = "DEPLODOCK_DEBUG"
+DUMP_DIR = "DEPLODOCK_DUMP_DIR"
+KNOBS = "DEPLODOCK_KNOBS"
+TUNE_PATIENCE = "DEPLODOCK_TUNE_PATIENCE"
+BENCH_BACKENDS = "DEPLODOCK_BENCH_BACKENDS"
+CUBIN_CACHE = "DEPLODOCK_CUBIN_CACHE"
+NO_NVCC = "DEPLODOCK_NO_NVCC"
+GPU_LOCK = "DEPLODOCK_GPU_LOCK"
+NCU_CHILD = "DEPLODOCK_NCU_CHILD"
+
+_CACHE_ROOT = Path.home() / ".cache" / "deplodock"
+
+
+def knob_var(name: str) -> str:
+    """The ``DEPLODOCK_<NAME>`` env-var key for a knob named ``name``.
+
+    Sole place the knob-name → env-var join lives. Used by
+    :class:`~deplodock.compiler.pipeline.knob.Knob` (via ``Knob.env``), the
+    ``DEPLODOCK_KNOBS`` splat, and ``compiler/tuning.py``'s literal knob reads."""
+    return f"{PREFIX}{name.upper()}"
+
+
+def knob_raw(name: str) -> str | None:
+    """Raw string value of the knob env var ``DEPLODOCK_<NAME>``, or ``None`` if
+    unset. The per-type decode (INT / BOOL / BINMASK) stays in the ``Knob``
+    descriptor (``compiler/pipeline/knob.py``); this is just the env read."""
+    return os.environ.get(knob_var(name))
+
+
+def knobs_aggregate() -> str:
+    """Raw ``DEPLODOCK_KNOBS`` aggregate string (``""`` if unset)."""
+    return _str(KNOBS)
+
+
+def set_knob(name: str, value: str, *, overwrite: bool = True) -> bool:
+    """Write ``DEPLODOCK_<NAME>=value`` into ``os.environ`` (so pipeline passes
+    and bench subprocesses see it). With ``overwrite=False`` only writes when the
+    key is absent. Returns ``True`` iff a write happened."""
+    key = knob_var(name)
+    if not overwrite and key in os.environ:
+        return False
+    os.environ[key] = value
+    return True
+
+
+# --- Shared parse primitives -----------------------------------------------
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _bool(name: str, default: bool = False) -> bool:
+    """Truthy env read. ``{"1","true","yes","on"}`` (case-insensitive) → True;
+    unset → ``default``; anything else → False."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in _TRUTHY
+
+
+def int_env(name: str, default: int) -> int:
+    """Int env read. Empty / unset / unparseable → ``default``."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _str(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+# --- Typed getters (read os.environ live) ----------------------------------
+
+
+def tune_db_path() -> Path:
+    """Autotune SQLite cache path: ``DEPLODOCK_TUNE_DB`` → ``~/.cache/deplodock/autotune.db``.
+
+    The shared resolution for ``compile`` / ``run`` / ``tune`` / ``knobs`` and
+    for :class:`CudaBackend` constructed with ``tune_db="auto"``. The path is
+    advisory — the engine only opens it when the file exists."""
+    override = os.environ.get(TUNE_DB)
+    return Path(override) if override else _CACHE_ROOT / "autotune.db"
+
+
+def nvcc_flags() -> str:
+    """Extra nvcc flags for this compile (``DEPLODOCK_NVCC_FLAGS``, ``""`` if unset).
+
+    Read fresh each call so a per-invocation override (set via
+    :func:`set_nvcc_flags`) and the bench-worker subprocess (which inherits the
+    env) see the same value, and so the flags fold into cache keys."""
+    return _str(NVCC_FLAGS)
+
+
+def debug_enabled() -> bool:
+    """``DEPLODOCK_DEBUG`` — per-launch debug dump path in the CUDA backend."""
+    return _bool(DEBUG)
+
+
+def dump_dir() -> Path | None:
+    """``DEPLODOCK_DUMP_DIR`` as an expanded ``Path``, or ``None`` when unset."""
+    raw = os.environ.get(DUMP_DIR)
+    return Path(raw).expanduser() if raw else None
+
+
+def tune_patience(default: int = 100) -> int:
+    """``DEPLODOCK_TUNE_PATIENCE`` — inner-MCTS patience fallback for ``tune``."""
+    return int_env(TUNE_PATIENCE, default)
+
+
+def bench_backends_raw(cli_value: str | None) -> str:
+    """Raw comma-separated bench-backend selection. Precedence: ``cli_value`` >
+    ``DEPLODOCK_BENCH_BACKENDS`` > ``"eager,deplodock"``. Backend-key
+    normalization stays at the call site (``run.py:_resolve_backends``)."""
+    return cli_value or os.environ.get(BENCH_BACKENDS) or "eager,deplodock"
+
+
+def cubin_cache_dir() -> Path:
+    """Content-addressed cubin cache dir: ``DEPLODOCK_CUBIN_CACHE`` → ``~/.cache/deplodock/cubin``."""
+    override = os.environ.get(CUBIN_CACHE)
+    return Path(override) if override else _CACHE_ROOT / "cubin"
+
+
+def nvcc_disabled() -> bool:
+    """``DEPLODOCK_NO_NVCC`` — force the cupy/NVRTC path instead of offline nvcc."""
+    return _bool(NO_NVCC)
+
+
+def gpu_lock_path() -> str | None:
+    """``DEPLODOCK_GPU_LOCK`` path, or ``None`` for the no-op (unset) case."""
+    return os.environ.get(GPU_LOCK)
+
+
+def ncu_child() -> bool:
+    """``DEPLODOCK_NCU_CHILD`` — set in the ncu-profiled child to prevent
+    recursive re-spawning of ncu."""
+    return _bool(NCU_CHILD)
+
+
+def tma_swizzle_enabled() -> bool:
+    """``DEPLODOCK_TMA_SWIZZLE`` — opt in to TMA hardware-swizzle modes."""
+    return _bool(knob_var("tma_swizzle"))
+
+
+# --- Setters (write os.environ so subprocesses inherit) --------------------
+
+
+def set_nvcc_flags(cli_value: str | None, default: str) -> str:
+    """Resolve and publish the effective extra nvcc flags via
+    ``DEPLODOCK_NVCC_FLAGS`` (the carrier the cubin compiler, the bench-worker
+    subprocess, and ``Context.structural_key`` all read).
+
+    Precedence: ``cli_value`` (a ``--nvcc-flags`` override, when not ``None``) >
+    a pre-set env var > ``default`` (per-command policy: ``""`` for compile/run,
+    ``"-Xcicc -O1"`` for tune). Must run before any compile/bench. Returns the
+    effective string."""
+    if cli_value is not None:
+        os.environ[NVCC_FLAGS] = cli_value
+    elif NVCC_FLAGS not in os.environ:
+        os.environ[NVCC_FLAGS] = default
+    return os.environ.get(NVCC_FLAGS, "")


### PR DESCRIPTION
## What

All `DEPLODOCK_*` config env vars are now read and written through one module,
`deplodock/config.py` — the sole owner of `os.environ` for these vars. Previously
env access was scattered across ~12 files with three different ad-hoc parsers, and
`DEPLODOCK_TUNE_DB` was resolved in three places.

## Why

Two goals:
1. **Single module** for all env work.
2. **Override resolution moves out of the CLI.** Before, `commands/compile.py`
   *wrote* `os.environ["DEPLODOCK_NVCC_FLAGS"]` so core readers could read it
   back, and the `--flag > env > default` precedence lived in the CLI — so
   programmatic callers (`run --code`, tests, `bench_model_kernels.py`) silently
   got empty defaults. Now `config.set_nvcc_flags(cli_value, default)` holds that
   precedence in the library; every callsite shares it.

`os.environ` stays the backing store (getters read live) because bench-worker
subprocesses and the ncu child inherit `env=dict(os.environ)`, and tests
monkeypatch the env directly.

## Changes

- **New `deplodock/config.py`** (stdlib-only, no `deplodock` imports so `knob.py`
  can use it without a cycle): var-name constants, parse primitives (`_bool`,
  `int_env`, `_path`, `_str`), typed live getters, the `set_nvcc_flags` setter,
  and knob-namespace helpers (`knob_var`, `knob_raw`, `knobs_aggregate`,
  `set_knob`).
- **Migrated** `nvcc.py`, `context.py`, `backend.py`, `tuning.py`, `knob.py`,
  `dump.py`, `gpu_lock.py`, and the `run`/`compile`/`tune` commands to delegate.
  `compile.apply_nvcc_flags` / `resolve_tune_db` are kept as thin argparse
  adapters (no import churn for callers/tests).
- `knob.py` keeps the `Knob` descriptor's per-type decode but sources the prefix
  and env access from `config`.
- Docs updated: `CLAUDE.md`, `commands/ARCHITECTURE.md`,
  `compiler/pipeline/ARCHITECTURE.md`, `compiler/backend/cuda/ARCHITECTURE.md`.

## Behavior changes (intentional, benign)

- `DEPLODOCK_CUBIN_CACHE` is now read **live** instead of frozen at `nvcc.py`
  import (no test sets it post-import; removes a latent surprise).
- The bool truthy-set is unified to `{1,true,yes,on}` (case-insensitive) — a safe
  widening of the three previous variants.
- `force_bk` aligns with the existing `SPLITK` `">0 wins"` convention (only
  affects invalid/zero/negative `DEPLODOCK_BK`, which was already undefined).

**Out of scope (unchanged):** provider/secret vars (`HF_TOKEN`, `CLOUDRIFT_*`,
`GCP_*`, `NO_COLOR`) stay with their use sites and `redact.py`.

## Test plan

- `make test`: **1317 passed, 27 skipped** (on sm_120 GPU)
- `make lint`: clean
- CLI smoke: `--nvcc-flags` override on/off, `DEPLODOCK_KNOBS`/`DEPLODOCK_BN` pinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)