### PR TITLE
Register-blocked GEMM: hoist N-invariant compute out of the register tower

### DIFF
--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -92,6 +92,57 @@ formula from cheap inputs (knob bundle + planner shape) so siblings rank
 without anyone instantiating a TileOp. The branch tree's `Fork.score`
 propagates max from leaves, matching MCTS's max-Q semantics.
 
+**Register-blocked GEMM nest.** For matmul-shape kernels (`shape.k_loop is
+not None`, `params.fn > 1`, SPLITK = 1, BR = 1, no M-mask, no fused
+prologue), the planner emits the textbook blocked GEMM nest rather than
+wrapping the entire `{Init, K-reduce, Write}` in one outer
+`RegisterTile(N_r)`. The N_r register tile splits *around* the K-reduce:
+
+    M_r REGISTER:
+      RegisterTile(N_r) { Init(acc) }            # per-cell accumulators
+      K_o SERIAL_OUTER:
+        K_i STAGE_INNER (reduce):
+          <N-invariant cone>                     # M-axis Loads, RMSNorm
+                                                 # prologue, … — runs ONCE
+                                                 # per K iter
+          RegisterTile(N_r) { Load b, Accum }    # F_N per-cell FMAs into
+                                                 # the persistent acc_i
+      RegisterTile(N_r) { Write(C, acc) }        # per-cell writes
+
+`_build_register_blocked_body` partitions the σ-rewritten K_i body by
+N-dependence (a single `body.fold` over Expr free_vars ∪ SSA def-use,
+exempting `N_r` from `bound` so RegisterTile wrappers don't mask
+references) into the N-invariant cone (no transitive `N_r` ref) and the
+N-dependent tail (everything else, including the Accum). The cone stays
+at K_i body scope; the tail wraps in `RegisterTile(N_r)`. The masked-N
+variant (e.g. lm_head with non-divisor vocab) wraps each tower's leaf
+body in its own per-cell `Cond(pred(N_r) < extent)` so the replicator
+σ-folds the predicate per cell; the matmul_add `K_s == 0` linear-epilogue
+Cond likewise gets wrapped in `RegisterTile(N_r)` so its inner Load /
+Assign / Write replicate per cell while the outer K_s predicate stays
+single. Init stays unconditional regardless — declaring `acc_i` inside a
+Cond would scope-bind it to the if-block; the K-tower's Accum and the
+Write tower (both Cond-wrapped per cell) would reference an `acc_i`
+that's no longer in scope.
+
+Shapes the blocked builder declines (returns `None`) — SDPA P@V's fused
+prologue, SPLITK > 1, BR > 1, M-overhang, F_N = 1 — fall back to the
+legacy per-cell branch in `_build_split_body` (one `RegisterTile(N_r)`
+wrapping the whole `{Init, K-reduce, Write}` body). Generalising the
+blocked nest to those shapes is follow-up work; the legacy branch is the
+safety net.
+
+The Kernel-IR replicator (`lowering/kernel/010_split_register_axes`)
+computes a body-global keep set for each register axis present in the
+ThreadTile body before recursing into the per-axis replication. Without
+the global keep, each sibling tower's local keep-analysis would run
+independently and the Init tower (no N_r reference in its body) would
+keep `acc` as one name while the Accum tower produced `acc_0..F-1` — a
+naming mismatch the Write tower would inherit. The global keep is also
+what lets the masked-N per-tower `Cond` survive: its predicate references
+`N_r`, the replicator descends into Cond.body, and the per-cell σ
+substitution lines up the suffixes across all three towers.
+
 Leaf Fork `expand` thunks call `_materialize(plan, params)` lazily —
 `_build_split_body` + `TileOp.__post_init__` (which runs the full
 12-pass `normalize_body`) only fire for the variant the search actually
@@ -314,13 +365,14 @@ recipe.
 
 | Knob          | Type     | Owning rule                  | What it controls                                                                                  |
 |---------------|----------|------------------------------|---------------------------------------------------------------------------------------------------|
-| `BK`          | INT      | `002_chunk_matmul_k`         | Per-stage K-chunk size for matmul reductions; intra-CTA K-loop trip count = `K / BK`.             |
-| `SPLITK`      | INT      | `003_split_matmul_k`         | Cross-CTA K-split factor for matmul; `1` = no split. Multiplies CTA count, requires a final combine. |
-| `BN`          | INT      | `004_launch_geometry`        | CTA innermost THREAD-axis width (the column tile each warp covers).                               |
-| `BM`          | INT      | `004_launch_geometry`        | CTA outer THREAD-axis width (matmul only — the row tile each warp covers).                        |
+| `BK`          | INT      | `010_partition_loops`        | Per-stage K-chunk size for matmul reductions; intra-CTA K-loop trip count = `K / BK`.             |
+| `SPLITK`      | INT      | `010_partition_loops`        | Cross-CTA K-split factor for matmul; `1` = no split. Multiplies CTA count, requires a final combine. |
+| `BN`          | INT      | `010_partition_loops`        | CTA innermost THREAD-axis width (the column tile each warp covers).                               |
+| `BM`          | INT      | `010_partition_loops`        | CTA outer THREAD-axis width (matmul only — the row tile each warp covers).                        |
 | `STAGE`       | BINMASK  | `020_stage_inputs`           | Bitmask over ranked candidate buffers — char `i` = stage buffer `i`. Selected buffers fold into one wrap-body Stage with per-source Source entries. |
-| `FM`          | INT      | `008_register_tile`          | Register-tile factor for the next-outer tilable nest level (per-thread row tile).                 |
-| `FN`          | INT      | `008_register_tile`          | Register-tile factor for the innermost tilable nest level (per-thread column tile).               |
+| `FM`          | INT      | `010_partition_loops`        | Register-tile factor along the matmul M (output row) axis; per-thread cell-grid height.           |
+| `FN`          | INT      | `010_partition_loops`        | Register-tile factor along the matmul N (output column) axis; per-thread cell-grid width. With `FN > 1` and the simple-shape constraints (no prologue, SPLITK = 1, BR = 1, no M-overhang), the planner emits the register-blocked GEMM nest — three sibling `RegisterTile(N_r)` towers sharing an N-invariant cone inside the K loop. |
+| `BR`          | INT      | `010_partition_loops`        | Cooperative-K thread count (1 = pure serial chunked reduce); BR > 1 routes through the cooperative reduce path with cross-thread combine. |
 | `TMA_SWIZZLE`     | BOOL     | `050_use_tma`                       | Enable TMA hardware-swizzle modes (B128 / B64 / B32); default off.                                |
 | `HOIST_COMPUTE`   | BOOL     | `030_hoist_invariant_compute`       | False (default) → inline-fuse Stage; True → ComputeStage + transports. Autotune fork.             |
 | `PAD_SMEM`        | BOOL     | `070_pad_smem`                       | True → apply per-source ``+1`` smem pad to break bank conflicts; False → leave the slab dense. Autotune fork. |

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
@@ -38,7 +38,16 @@ def rewrite(root: Node) -> Graph | None:
     idx, outer = single_tile(body)
     tt = thread_tile_of(outer)
 
-    new_body, factors = _replicate_register_tiles(tt.body)
+    # Body-global keep set per register axis. Computed once over the entire
+    # ThreadTile body so sibling RegisterTile(axis) towers (the blocked-GEMM
+    # nest emits three: Init / K-reduce-Accum / Write) agree on which SSA
+    # names carry the per-cell ``_<i>`` suffix. Without this, each tower's
+    # local keep-analysis would run independently — the Init tower doesn't
+    # reference N_r, so ``acc`` would stay one name there, while the Accum
+    # tower produces ``acc_0..N-1`` — a naming mismatch the consumer Write
+    # would inherit.
+    global_keep = _collect_body_global_keep(tt.body)
+    new_body, factors = _replicate_register_tiles(tt.body, global_keep=global_keep)
     if not factors:
         # No RegisterTile in body — non-matmul kernel (planner only emits
         # RegisterTile for matmul) or this rule has already run and
@@ -56,7 +65,7 @@ def rewrite(root: Node) -> Graph | None:
     return TileOp(body=body[:idx] + (rebuilt,) + body[idx + 1 :], name=root.op.name, knobs=knobs)
 
 
-def _replicate_register_tiles(body: Body) -> tuple[Body, list[int]]:
+def _replicate_register_tiles(body: Body, *, global_keep: dict[str, dict[str, bool]] | None = None) -> tuple[Body, list[int]]:
     """Inside-out unwrap of ``RegisterTile`` flavors. For each tile, recurse
     into nested RegisterTiles first, then replicate this layer's body by
     ``axis.extent`` with ``σ: axis → literal(i)`` for each of the tile's
@@ -66,18 +75,26 @@ def _replicate_register_tiles(body: Body) -> tuple[Body, list[int]]:
     Walks into non-RegisterTile block stmts (e.g. ``SerialTile`` wrapping
     a softmax prologue + ``RegisterTile``-tiled matmul body for SDPA P@V)
     so deeply-nested RegisterTiles get replicated too.
+
+    ``global_keep`` is the body-global keep map (axis → name → True/False)
+    computed at the TileOp body level. It's threaded into every per-axis
+    ``_replicate_along_axis`` call so sibling RegisterTile(axis) towers
+    agree on which names get the per-cell ``_<i>`` suffix — the local
+    fold inside one tower can't see that a name is register-tiled by
+    another sibling tower's body.
     """
     out: list[Stmt] = []
     factors: list[int] = []
     for s in body:
         if isinstance(s, RegisterTile):
-            inner_unwrapped, inner_factors = _replicate_register_tiles(s.body)
+            inner_unwrapped, inner_factors = _replicate_register_tiles(s.body, global_keep=global_keep)
             current = inner_unwrapped
             local_factors: list[int] = []
             # Replicate from innermost axis outward.
             for ax in reversed(s.axes):
                 factor = ax.extent.as_static()
-                current = _replicate_along_axis(current, ax.name, factor, _sigma_to_literal(ax.name))
+                extra_keep = global_keep.get(ax.name) if global_keep is not None else None
+                current = _replicate_along_axis(current, ax.name, factor, _sigma_to_literal(ax.name), extra_keep=extra_keep)
                 local_factors.append(factor)
             local_factors.reverse()
             out.extend(current)
@@ -89,13 +106,87 @@ def _replicate_register_tiles(body: Body) -> tuple[Body, list[int]]:
             # independently and re-attached via ``with_bodies``.
             new_bodies: list[Body] = []
             for sub in s.nested():
-                new_sub, sub_factors = _replicate_register_tiles(sub)
+                new_sub, sub_factors = _replicate_register_tiles(sub, global_keep=global_keep)
                 new_bodies.append(new_sub)
                 factors.extend(sub_factors)
             out.append(s.with_bodies(tuple(new_bodies)))
         else:
             out.append(s)
     return Body(out), factors
+
+
+def _collect_body_global_keep(body: Body) -> dict[str, dict[str, bool]]:
+    """For every register axis appearing in any ``RegisterTile`` within
+    ``body``, compute the body-global keep set — which SSA names defined
+    anywhere in ``body`` transitively reference that axis. Used to align
+    replicator suffixing across sibling/cousin RegisterTile(axis) towers
+    (the blocked-GEMM nest's three towers, SDPA-prologue+matmul, etc.).
+    """
+    axes: set[str] = set()
+    for s in body.iter():
+        if isinstance(s, RegisterTile):
+            for ax in s.axes:
+                axes.add(ax.name)
+    return {ax: _global_keep_for_axis(body, ax) for ax in axes}
+
+
+def _global_keep_for_axis(body: Body, axis: str) -> dict[str, bool]:
+    """Body-global keep set for ``axis``: which SSA names defined anywhere
+    in ``body`` transitively reference ``axis`` (and therefore must carry
+    the per-cell ``_<i>`` suffix at replicate time, regardless of which
+    sibling RegisterTile(axis) tower defines them).
+
+    Mirrors the per-body fold in :func:`_replicate_along_axis`, but
+    exempts ``axis`` from ``bound`` so a RegisterTile(axis) wrapper
+    doesn't mask references inside it — the whole point of this walk
+    is to see those references. Stage / StageBundle cache axes stay
+    masked: they're smem-local and don't vary per replica. Other
+    enclosing-wrapper-bound axes pass through unaffected (they aren't
+    ``axis`` by construction).
+
+    Multiple defs of the same name (e.g. an Accum's name re-defined in
+    every sibling tower) OR together — keep[name]=True iff ANY definer
+    reads ``axis``.
+    """
+
+    def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
+        if isinstance(s, Stage):
+            local_bound = bound | frozenset(ax.name for src in s.sources for ax in src.cache_axes)
+        elif isinstance(s, StageBundle):
+            local_bound = bound | frozenset(ax.name for stage in s.stages for src in stage.sources for ax in src.cache_axes)
+        else:
+            local_bound = bound
+        local_bound = local_bound - {axis}
+        own: frozenset[str] = frozenset()
+        for e in s.exprs():
+            own = own | frozenset(v for v in e.free_vars() if v not in local_bound)
+        for c in child_T:
+            if c is not None:
+                own = own | c
+        return own
+
+    deps = body.fold(fn)
+    keep: dict[str, bool] = {}
+    for s in body.iter():
+        has_axis = axis in deps[id(s)]
+        for n in s.defines():
+            keep[n] = keep.get(n, False) or has_axis
+
+    defined_names = set(keep)
+    changed = True
+    while changed:
+        changed = False
+        for s in body.iter():
+            reads: set[str] = set(s.deps())
+            for e in s.exprs():
+                reads.update(e.free_vars())
+            reads &= defined_names
+            if any(keep.get(r, False) for r in reads):
+                for n in s.defines():
+                    if not keep.get(n, False):
+                        keep[n] = True
+                        changed = True
+    return keep
 
 
 def _sigma_to_literal(axis: str) -> Callable[[int], Sigma]:
@@ -107,7 +198,14 @@ def _sigma_to_literal(axis: str) -> Callable[[int], Sigma]:
     return _f
 
 
-def _replicate_along_axis(body: Body, axis: str, factor: int, sigma_for: Callable[[int], Sigma]) -> Body:
+def _replicate_along_axis(
+    body: Body,
+    axis: str,
+    factor: int,
+    sigma_for: Callable[[int], Sigma],
+    *,
+    extra_keep: dict[str, bool] | None = None,
+) -> Body:
     """F× replicate every stmt whose value transitively depends on
     ``axis``. Each such stmt is emitted ``factor`` times with σ given
     by ``sigma_for(i)`` and SSA names suffixed ``_<i>``. Stmts that
@@ -119,7 +217,14 @@ def _replicate_along_axis(body: Body, axis: str, factor: int, sigma_for: Callabl
     Dependency analysis is one :meth:`Body.fold` over the def-use DAG
     with bound-axis filtering. ``keep[name]`` records which SSA names
     must carry the suffix vs. pass through unchanged (Tile-input
-    buffers, constants, axis-free producers)."""
+    buffers, constants, axis-free producers).
+
+    ``extra_keep`` is the body-global keep map for ``axis`` (see
+    :func:`_global_keep_for_axis`): names True there must be suffixed
+    regardless of the local body's def-use, so an ``Init(acc)`` /
+    ``Write(C, acc)`` tower aligned with an ``Accum(acc, …N_r…)`` sibling
+    tower replicates and renames consistently (acc → acc_0..N-1) in all
+    three. OR-merged into the locally-derived keep."""
 
     def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
         # Stage / StageBundle cache-axis Vars are smem-local — they don't vary
@@ -142,6 +247,13 @@ def _replicate_along_axis(body: Body, axis: str, factor: int, sigma_for: Callabl
 
     deps = body.fold(fn)
     keep: dict[str, bool] = {n: axis in deps[id(s)] for s in body.iter() for n in s.defines()}
+    # Merge in body-global keep entries (the per-tower local fold can't see
+    # that a name register-tiled by a sibling tower must also be suffixed
+    # here). OR-merge: a name keep=True globally stays True locally.
+    if extra_keep is not None:
+        for n, v in extra_keep.items():
+            if v:
+                keep[n] = True
 
     # SSA def-use propagation: if any SSA name a stmt reads has keep=True,
     # then everything it defines must also be marked keep. The fold above

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/020_place_inits.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/020_place_inits.py
@@ -211,7 +211,11 @@ def _is_reduce_recursive(loop) -> bool:
       ``a4``.
 
     ``RegisterTile`` is transparent: descend into its body for the same
-    crossability check."""
+    crossability check. ``Cond`` is likewise transparent — its body /
+    else_body get the same recursive treatment (the masked register-
+    blocked GEMM emits ``RegisterTile(N_r, [Cond(pred, [Load, Assign,
+    Accum])])`` per N-dependent tail; the Cond shouldn't hide the Accum
+    from the crossability check)."""
     has_inner_reduce = False
     for s in loop.body:
         if isinstance(s, Accum):
@@ -222,6 +226,19 @@ def _is_reduce_recursive(loop) -> bool:
             has_inner_reduce = True
         elif isinstance(s, RegisterTile) and _is_reduce_recursive(s):
             has_inner_reduce = True
+        elif isinstance(s, Cond):
+            # Treat Cond as a transparent wrapper: an Accum nested behind
+            # a per-cell predicate (the masked-N reg_block path) still
+            # accumulates across the enclosing reduce loop. ``Write``
+            # inside the Cond escapes per-iter the same way it does at
+            # body level — recurse and honor its False-return.
+            for branch in (s.body, s.else_body):
+
+                class _Probe:
+                    body = branch  # noqa: B023 — bound at iteration
+
+                if _is_reduce_recursive(_Probe()):
+                    has_inner_reduce = True
         elif isinstance(s, StageBundle):
             # StageBundle is transparent for reduce-crossing: synthesize a
             # probe-loop carrying the bundle's body so the recursive walk

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/050_vectorize_loads.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/050_vectorize_loads.py
@@ -51,7 +51,7 @@ from deplodock.compiler.backend.cuda.render_target import CudaRenderTarget
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.expr import BinaryExpr, Literal, SimplifyCtx, affine_form
 from deplodock.compiler.ir.stmt import Body, Load, Stmt
-from deplodock.compiler.ir.tile.ir import TileOp
+from deplodock.compiler.ir.tile.ir import Source, Stage, StageBundle, TileOp
 from deplodock.compiler.pipeline import Match, Pattern, RuleSkipped
 
 PATTERN = [Pattern("root", TileOp)]
@@ -176,10 +176,10 @@ def _try_vec_load(stmts: Iterable[Stmt], start: int, n: int, top: TileOp) -> Loa
     # Earlier this check was skipped for n=2 fp16 with the comment "__half2
     # is 4-byte aligned in cuda_fp16.h" — the TYPE is, but reinterpreting a
     # fp16 pointer at an odd-element offset still misses the alignment. The
-    # register-blocked GEMM nest (REG_BLOCK=True) exposes this: an N-stride
-    # of 3 (lm_head-style vocab=3 test case) gives a3 a stride of 3 elements
-    # = 6 bytes — not a multiple of 4 — and the half2 read faults with
-    # CUDA_ERROR_MISALIGNED_ADDRESS.
+    # register-blocked GEMM nest (default for matmul shapes with FN > 1)
+    # exposes this: an N-stride of 3 (lm_head-style vocab=3 test case) gives
+    # a3 a stride of 3 elements = 6 bytes — not a multiple of 4 — and the
+    # half2 read faults with CUDA_ERROR_MISALIGNED_ADDRESS.
     if n >= 2:
         if not all(c % n == 0 for c in coeffs_0.values()):
             return None
@@ -187,9 +187,47 @@ def _try_vec_load(stmts: Iterable[Stmt], start: int, n: int, top: TileOp) -> Loa
         if not isinstance(anchor_simplified, Literal) or anchor_simplified.value % n != 0:
             return None
 
+        # Multi-dim staged smem case: the last logical dim may be a constant
+        # offset (cell index 0/1/...) while the BASE address ``Σ outer_dim ×
+        # outer_stride`` carries the per-cell stride packed into preceding
+        # dims (e.g. blocked-N smem with layout ``[K, N_t, N_r]`` and FN=3
+        # has stride ``a3 * 3`` from the N_t dim; packing two cells across
+        # the inner N_r yields byte offsets ``base + 0`` and ``base + 4``,
+        # but ``base = a3 * 12`` lands at 12 bytes for a3=1 — not 8-byte
+        # aligned for float2). The last-dim coeff check passes vacuously
+        # (no free vars there), so the broader check has to walk back into
+        # the preceding logical dims via the Source's cache_dims. If any
+        # preceding dim's cache-axis extent is not a multiple of n at the
+        # innermost slot (= the byte stride from the cell-offset Load
+        # group's base to its neighbour group isn't n-aligned), refuse to
+        # vectorize.
+        source = _find_source(top.body, input_name)
+        if source is not None and len(source.cache_dims) >= 2:
+            inner_extent = source.cache_axes[-1].extent.as_static()
+            if inner_extent % n != 0:
+                return None
+
     return Load(
         names=tuple(s.name for s in loads),
         input=input_name,
         index=loads[0].index,
         dtype=loads[0].dtype,
     )
+
+
+def _find_source(body: Body, name: str) -> Source | None:
+    """Walk ``body`` for a ``Source`` whose ``name`` matches — used by
+    multi-dim staged-smem alignment checks. Returns the first match
+    (sources are unique by name within a TileOp by construction) or
+    ``None`` if the buffer isn't a Stage-backed smem (e.g. a gmem input)."""
+    for stmt in body.iter():
+        if isinstance(stmt, Stage):
+            for src in stmt.sources:
+                if src.name == name:
+                    return src
+        elif isinstance(stmt, StageBundle):
+            for stage in stmt.stages:
+                for src in stage.sources:
+                    if src.name == name:
+                        return src
+    return None

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/050_vectorize_loads.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/050_vectorize_loads.py
@@ -168,13 +168,19 @@ def _try_vec_load(stmts: Iterable[Stmt], start: int, n: int, top: TileOp) -> Loa
         if not (isinstance(diff, Literal) and isinstance(diff.value, int) and diff.value == k):
             return None
 
-    # For widths above the natural 4-byte (one __half2 / one float)
-    # boundary, the reinterpret-cast destination must be aligned to
-    # ``n * elem_bytes``. Prove statically from the affine form: every
-    # free-var coefficient on the last dim must be a multiple of n,
-    # and the literal anchor must also be a multiple of n. (n=2 fp16
-    # = 4 bytes always works since __half2 is 4-byte aligned in cuda_fp16.h.)
-    if n > 2 or (n == 2 and src_dt == "f32"):
+    # The reinterpret-cast destination must be aligned to ``n * elem_bytes``.
+    # Prove statically from the affine form: every free-var coefficient on
+    # the last dim must be a multiple of n, and the literal anchor must also
+    # be a multiple of n.
+    #
+    # Earlier this check was skipped for n=2 fp16 with the comment "__half2
+    # is 4-byte aligned in cuda_fp16.h" — the TYPE is, but reinterpreting a
+    # fp16 pointer at an odd-element offset still misses the alignment. The
+    # register-blocked GEMM nest (REG_BLOCK=True) exposes this: an N-stride
+    # of 3 (lm_head-style vocab=3 test case) gives a3 a stride of 3 elements
+    # = 6 bytes — not a multiple of 4 — and the half2 read faults with
+    # CUDA_ERROR_MISALIGNED_ADDRESS.
+    if n >= 2:
         if not all(c % n == 0 for c in coeffs_0.values()):
             return None
         anchor_simplified = anchor_0.simplify(SimplifyCtx.empty())

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/080_vectorize_stores.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/080_vectorize_stores.py
@@ -175,12 +175,13 @@ def _try_vec_store(stmts: Iterable[Stmt], start: int, n: int, top: TileOp, atomi
         if not (isinstance(diff, Literal) and isinstance(diff.value, int) and diff.value == k):
             return None
 
-    # Alignment proof: for widths above the natural 4-byte boundary,
-    # the reinterpret-cast destination must be aligned to
-    # ``n * elem_bytes``. Same as ``050_vectorize_loads``: every
-    # free-var coefficient on the last dim must be a multiple of n,
-    # and the literal anchor must also be a multiple of n.
-    if n > 2 or (n == 2 and dst_dt == "f32"):
+    # Alignment proof: the reinterpret-cast destination must be aligned to
+    # ``n * elem_bytes``. Same as ``050_vectorize_loads``: every free-var
+    # coefficient on the last dim must be a multiple of n, and the literal
+    # anchor must also be a multiple of n. n=2 fp16 is NOT a freebie despite
+    # __half2's 4-byte type alignment — a stride-3 (odd) coefficient on a
+    # surrounding axis still lands the cast at an odd half-offset.
+    if n >= 2:
         if not all(c % n == 0 for c in coeffs_0.values()):
             return None
         anchor_simplified = anchor_0.simplify(SimplifyCtx.empty())

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -1406,14 +1406,15 @@ def _enumerate_cartesian_impl(
                                 # where the planner's ``_build_register_blocked_body`` will
                                 # actually fire (FN > 1 so blocking has real cells to share,
                                 # SPLITK = 1, BR = 1, M not overhang — v1 constraints). False
-                                # is always available. Env pin clamps the choice set, but
-                                # ``pin=True`` produces no variants on a non-qualifying shape —
-                                # the planner-level peer-kernel fallback drops the pin.
+                                # is always available. Env pin clamps the choice set; ``pin=True``
+                                # on a non-qualifying shape soft-falls-back to False (rather than
+                                # emitting nothing and triggering the peer-kernel pin drop, which
+                                # would also kill OTHER pins the user set alongside REG_BLOCK).
                                 shape_supports_reg_block = reg_block_eligible and fn > 1 and splitk == 1 and br == 1 and not m_overhang
                                 if reg_block_pin is None:
                                     reg_block_choices = (False, True) if shape_supports_reg_block else (False,)
                                 elif reg_block_pin:
-                                    reg_block_choices = (True,) if shape_supports_reg_block else ()
+                                    reg_block_choices = (True,) if shape_supports_reg_block else (False,)
                                 else:
                                     reg_block_choices = (False,)
                                 for rb in reg_block_choices:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -79,10 +79,10 @@ from deplodock.compiler import provenance
 from deplodock.compiler.context import Context
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.axis import Axis
-from deplodock.compiler.ir.expr import BinaryExpr, Literal, SimplifyCtx, Var
+from deplodock.compiler.ir.expr import BinaryExpr, Expr, Literal, SimplifyCtx, Var
 from deplodock.compiler.ir.loop import LoopOp
 from deplodock.compiler.ir.sigma import Sigma
-from deplodock.compiler.ir.stmt import Accum, Assign, Body, Cond, Loop, Stmt, StridedLoop, Write
+from deplodock.compiler.ir.stmt import Accum, Assign, Body, Cond, Init, Loop, Stmt, StridedLoop, Write
 from deplodock.compiler.ir.tile.ir import (
     GridTile,
     RegisterTile,
@@ -131,8 +131,24 @@ FN = Knob("FN", KnobType.INT, hints=_TUNE_F_CHOICES, help="Per-thread cells alon
 BK = Knob("BK", KnobType.INT, hints=_BK_CANDIDATES, help="Per-stage K-chunk size (intra-CTA K-loop trip count = K / BK)")
 SPLITK = Knob("SPLITK", KnobType.INT, hints=_SPLITK_CANDIDATES, help="Cross-CTA K-split factor (1 = no split)")
 BR = Knob("BR", KnobType.INT, hints=_BR_CANDIDATES, help="Cooperative-K thread count (1 = pure serial chunked reduce)")
+REG_BLOCK = Knob(
+    "REG_BLOCK",
+    KnobType.BOOL,
+    hints=(False, True),
+    help=(
+        "Register-blocked GEMM nest: split N_r register-tile around the K-reduce so "
+        "N-invariant compute (RMSNorm prologue, M-axis Loads) runs once per K step "
+        "and is shared across FN cells. False (greedy default) — today's per-cell "
+        "structure: the whole {Init, K-reduce, Write} runs F_N× per output cell. "
+        "True — three sibling RegisterTile(N_r) towers (Init / K-reduce body's "
+        "N-dependent tail / Write) wrap the shared compute; the K-loop runs once, "
+        "feeding all F_N accumulators. Cuts both compile time and runtime FLOPs for "
+        "large FN. v1 supports the simplest shape only: no prologue (no SDPA P@V), "
+        "no SPLITK > 1, no BR > 1; falls back to per-cell otherwise."
+    ),
+)
 
-_PLANNER_KNOBS: tuple[Knob, ...] = (BN, BM, FM, FN, BK, SPLITK, BR)
+_PLANNER_KNOBS: tuple[Knob, ...] = (BN, BM, FM, FN, BK, SPLITK, BR, REG_BLOCK)
 
 
 def _planner_pin_set() -> bool:
@@ -143,14 +159,23 @@ def _planner_pin_set() -> bool:
 
 @dataclass(frozen=True)
 class TileParams:
-    """One ``(BN, BM, FM, FN, BK, SPLITK, BR)`` variant. Frozen for de-dup in
-    the cartesian's ``seen`` set; ``br=1`` default keeps matmul / pointwise
-    sites terse.
+    """One ``(BN, BM, FM, FN, BK, SPLITK, BR, REG_BLOCK)`` variant. Frozen
+    for de-dup in the cartesian's ``seen`` set; ``br=1`` / ``reg_block=False``
+    defaults keep matmul / pointwise sites terse.
 
     ``overhang`` lists output-axis names admitted at a non-divisor BN/BM
     (masked tiles). Empty for clean-divisor variants. The planner stamps the
     same tuple onto the emitted ``TileOp.knobs["OVERHANG"]`` so downstream
     passes (staging, materialization) can guard cooperative loads.
+
+    ``reg_block`` toggles the register-blocked GEMM nest. False (default)
+    keeps the legacy per-cell structure: the planner wraps the entire
+    ``{Init, K-reduce, Write}`` in one ``RegisterTile(N_r)`` and 010_split_register_axes
+    replicates the whole thing FN×. True emits three sibling RegisterTile(N_r)
+    towers (Init / K-reduce N-dependent tail / Write) with N-invariant compute
+    hoisted between them, so the K-loop runs once and shared compute happens
+    once per K iteration rather than ×FN. Only set on matmul shapes with
+    FN > 1, no prologue, SPLITK = 1, BR = 1 — falls back to per-cell otherwise.
     """
 
     bn: int
@@ -161,6 +186,7 @@ class TileParams:
     splitk: int
     br: int = 1
     overhang: tuple[str, ...] = ()
+    reg_block: bool = False
 
 
 @dataclass(frozen=True)
@@ -278,7 +304,7 @@ def _build_fork_tree_lazy(plan: _Plan, ctx: Context) -> Fork | list[Fork]:
     def _leaf_forks(group: list[TileParams]) -> list[Fork]:
         out = [
             Fork(
-                knobs={BK.name: p.bk, SPLITK.name: p.splitk},
+                knobs={BK.name: p.bk, SPLITK.name: p.splitk, REG_BLOCK.name: p.reg_block},
                 expand=(lambda p=p: [_materialize(plan, p)]),
                 score=leaf_score[id(p)],
                 is_leaf=True,
@@ -584,6 +610,130 @@ def _divisors_up_to(n: int, cap: int) -> tuple[int, ...]:
 
 class _BuildSkipped(Exception):
     """Raised by ``_build_split_body`` when the body's shape doesn't match."""
+
+
+def _classify_n_dep(body: Body, n_axis_name: str) -> tuple[list[Stmt], list[Stmt]]:
+    """Partition ``body`` stmts into (N-invariant, N-dependent) by transitive
+    free-var analysis over Exprs + SSA def-use. ``n_axis_name`` is the post-σ
+    N register axis (typically ``N_r.name``) — a stmt is N-dependent iff its
+    transitive Expr ``free_vars`` ∪ ``deps``-chain references ``n_axis_name``.
+    Order within each group is preserved (source order = SSA topo order, so
+    N-invariant stmts feeding N-dependent ones come first).
+
+    Used by :func:`_build_register_blocked_body` to split a matmul K-reduce
+    body into the N-invariant cone (RMSNorm prologue, M-axis Loads — shared
+    across F_N cells) and the N-dependent tail (weight Load + ``Accum`` —
+    replicated per cell).
+    """
+
+    def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
+        own: frozenset[str] = frozenset()
+        for e in s.exprs():
+            own = own | frozenset(v for v in e.free_vars() if v not in bound)
+        for c in child_T:
+            if c is not None:
+                own = own | c
+        return own
+
+    deps = body.fold(fn)
+    invariant: list[Stmt] = []
+    dependent: list[Stmt] = []
+    for s in body:
+        if n_axis_name in deps[id(s)]:
+            dependent.append(s)
+        else:
+            invariant.append(s)
+    return invariant, dependent
+
+
+def _split_k_tower_for_block(
+    stmt: Stmt,
+    n_axis_name: str,
+    n_r: Axis,
+    leaf_cond: Callable[[tuple[Stmt, ...]], tuple[Stmt, ...]] | None,
+) -> tuple[Stmt, int]:
+    """Walk into a SerialTile K-tower; at the innermost ``stage_inner`` layer
+    (K_i, the reduce), split its body into ``[N-invariant cone...,
+    RegisterTile(N_r, [N-dep tail])]``. ``leaf_cond`` (when set) wraps the
+    N-dep tail in a per-cell Cond — used for masked N tiles where each cell's
+    work must be guarded. Returns ``(new_stmt, n_replaced)``.
+    """
+    if isinstance(stmt, SerialTile) and stmt.kind == "stage_inner":
+        invariant, dependent = _classify_n_dep(stmt.body, n_axis_name)
+        if not dependent:
+            return stmt, 0
+        tail_body = tuple(dependent)
+        if leaf_cond is not None:
+            tail_body = leaf_cond(tail_body)
+        new_body = Body(tuple(invariant) + (RegisterTile(axes=(n_r,), body=Body(tail_body)),))
+        return replace(stmt, body=new_body), 1
+    if isinstance(stmt, SerialTile):
+        new_body_stmts: list[Stmt] = []
+        replaced = 0
+        for c in stmt.body:
+            new_c, r = _split_k_tower_for_block(c, n_axis_name, n_r, leaf_cond)
+            new_body_stmts.append(new_c)
+            replaced += r
+        if replaced:
+            return replace(stmt, body=Body(new_body_stmts)), replaced
+    return stmt, 0
+
+
+def _build_register_blocked_body(
+    new_inner: tuple[Stmt, ...],
+    n_axis_name: str,
+    n_r: Axis,
+    leaf_cond: Callable[[tuple[Stmt, ...]], tuple[Stmt, ...]] | None,
+) -> tuple[Stmt, ...] | None:
+    """Apply the register-blocked GEMM nest to ``new_inner`` (the σ-rewritten
+    matmul body sitting inside ``M_r`` REGISTER, before the outer N_r wrap).
+    Replaces the existing per-cell ``[Init, K-tower, Write]`` flat structure
+    with three sibling RegisterTile(N_r) towers separated by the (now shared)
+    K-loop:
+
+    - ``Init(acc)`` → ``RegisterTile(N_r, [Init(acc)])`` (per-cell accumulators).
+    - K-tower (SerialTile K_o > SerialTile K_i) → K_i body split into N-invariant
+      cone + ``RegisterTile(N_r, [N-dep tail])`` — the cone (e.g. fused RMSNorm
+      prologue, M-axis Loads) runs once per K iteration, the tail runs F_N×.
+    - ``Write(C, acc)`` → ``RegisterTile(N_r, [Write(C, acc)])`` (per-cell writes).
+
+    ``leaf_cond`` wraps each tower's leaf body in a per-cell Cond (the masked-N
+    boundary guard). The replicator (010_split_register_axes) replicates each
+    Cond per cell using σ N_r → i, producing F_N concrete-i guarded leaves.
+
+    Returns ``None`` when the shape doesn't fit (no K_i found, empty N-dep
+    tail, or unexpected outer-scope stmts — Cond from a prior masked wrap,
+    epilogue compute, etc.) so the caller falls back to per-cell.
+    """
+    out: list[Stmt] = []
+    n_replaced = 0
+    for s in new_inner:
+        if isinstance(s, Init):
+            # Init must be unconditional: it declares the per-cell accumulator
+            # variable at thread scope. Wrapping it in the masked-N Cond would
+            # scope ``acc_i`` to the if-block; the K-tower's Accum and the
+            # Write tower (both Cond-wrapped per cell) would reference an
+            # ``acc_i`` that's no longer in scope. OOB cells initialize a
+            # dead register, which is harmless.
+            out.append(RegisterTile(axes=(n_r,), body=Body((s,))))
+        elif isinstance(s, Write):
+            leaf_body: tuple[Stmt, ...] = (s,)
+            if leaf_cond is not None:
+                leaf_body = leaf_cond(leaf_body)
+            out.append(RegisterTile(axes=(n_r,), body=Body(leaf_body)))
+        elif isinstance(s, SerialTile):
+            new_s, r = _split_k_tower_for_block(s, n_axis_name, n_r, leaf_cond)
+            out.append(new_s)
+            n_replaced += r
+        else:
+            # Outer-scope stmt we haven't taught the blocked builder about
+            # (Cond from prior masked wrap, post-K epilogue compute, etc.).
+            # Fall back to per-cell — the planner will materialize the
+            # ``reg_block=False`` sibling instead.
+            return None
+    if n_replaced == 0:
+        return None
+    return tuple(out)
 
 
 def _stmt_contains_accum(stmt: Stmt) -> bool:
@@ -935,6 +1085,7 @@ def _materialize(plan: _Plan, params: TileParams) -> TileOp:
         BK.name: params.bk,
         SPLITK.name: params.splitk,
         BR.name: params.br,
+        REG_BLOCK.name: params.reg_block,
     }
     # Drop leading stmts whose SSA name is *also* defined inside ``chain_body``.
     # A pre-loop invariant (e.g. ``v0 = reciprocal(1024)``) used only by a
@@ -953,9 +1104,11 @@ def _priority_matmul(p: TileParams) -> tuple[int, ...]:
     # High cells/thread (amortize K-loop) capped at 32 (NVRTC compile time),
     # threads near 256, larger BK, smaller SPLITK. Final tiebreaker prefers
     # clean-divisor variants over masked (negative len so fewer-overhang wins
-    # under reverse-sorted enumeration).
+    # under reverse-sorted enumeration). REG_BLOCK=False ranks higher than
+    # True (greedy default; M3 may invert) — `0` for False, `-1` for True keeps
+    # False ahead under reverse-sorted enumeration.
     threads = p.bn * p.bm
-    return (min(p.fm * p.fn, 32), -abs(256 - threads), p.bk, -p.splitk, -len(p.overhang))
+    return (min(p.fm * p.fn, 32), -abs(256 - threads), p.bk, -p.splitk, -len(p.overhang), -int(p.reg_block))
 
 
 def _priority_pointwise(p: TileParams) -> tuple[int, ...]:
@@ -1079,7 +1232,24 @@ def _enumerate_cartesian(
     # reduce) via ``m_forced_mask`` / ``n_forced_mask``, tuned at its hint.
     allow_masked = priority_mode in ("pointwise", "matmul")
 
+    # REG_BLOCK eligibility: only matmul shapes can register-block the K-loop
+    # (pointwise / cooperative-reduce don't have a K-loop to share across N
+    # cells). Per-variant gates (FN > 1, SPLITK = 1, BR = 1, no M-overhang)
+    # apply inside ``_enumerate_cartesian_impl``. The env pin (``DEPLODOCK_REG_BLOCK``)
+    # threads in as ``reg_block_pin`` — narrowing inline at the cartesian innermost
+    # loop would discard the False variant whenever pin=True on a non-qualifying
+    # shape, leaving the kernel un-lowered. Letting the planner's peer-kernel
+    # fallback drop the pin is the right answer.
+    reg_block_eligible = priority_mode == "matmul"
+
     def _run(apply_pins: bool) -> list[TileParams]:
+        reg_block_pin_value: bool | None = None
+        if apply_pins:
+            from deplodock import config as _config  # noqa: PLC0415 — local import; avoid module cycle
+
+            raw = _config.knob_raw(REG_BLOCK.name)
+            if raw is not None:
+                reg_block_pin_value = REG_BLOCK.parse(raw)
         return _enumerate_cartesian_impl(
             E_M=E_M,
             E_N=E_N,
@@ -1100,6 +1270,8 @@ def _enumerate_cartesian(
             n_axis_name=n_axis_name,
             m_forced_mask=m_forced_mask,
             n_forced_mask=n_forced_mask,
+            reg_block_eligible=reg_block_eligible,
+            reg_block_pin=reg_block_pin_value,
         )
 
     result = _run(apply_pins=True)
@@ -1129,6 +1301,8 @@ def _enumerate_cartesian_impl(
     n_axis_name: str | None = None,
     m_forced_mask: bool = False,
     n_forced_mask: bool = False,
+    reg_block_eligible: bool = False,
+    reg_block_pin: bool | None = None,
 ) -> list[TileParams]:
     """Pure cartesian enumeration: caller supplies the (possibly already
     pin-narrowed) choice tuples, the per-iteration FM/FN narrow callables
@@ -1228,11 +1402,36 @@ def _enumerate_cartesian_impl(
                                     overhang_axes = (*overhang_axes, n_axis_name)
                                 if m_overhang and m_axis_name is not None:
                                     overhang_axes = (*overhang_axes, m_axis_name)
-                                params = TileParams(bn=bn_c, bm=bm_c, fm=fm, fn=fn, bk=bk, splitk=splitk, br=br, overhang=overhang_axes)
-                                if params in seen:
-                                    continue
-                                seen.add(params)
-                                ordered.append(params)
+                                # REG_BLOCK candidate set: True is emitted only on the shape
+                                # where the planner's ``_build_register_blocked_body`` will
+                                # actually fire (FN > 1 so blocking has real cells to share,
+                                # SPLITK = 1, BR = 1, M not overhang — v1 constraints). False
+                                # is always available. Env pin clamps the choice set, but
+                                # ``pin=True`` produces no variants on a non-qualifying shape —
+                                # the planner-level peer-kernel fallback drops the pin.
+                                shape_supports_reg_block = reg_block_eligible and fn > 1 and splitk == 1 and br == 1 and not m_overhang
+                                if reg_block_pin is None:
+                                    reg_block_choices = (False, True) if shape_supports_reg_block else (False,)
+                                elif reg_block_pin:
+                                    reg_block_choices = (True,) if shape_supports_reg_block else ()
+                                else:
+                                    reg_block_choices = (False,)
+                                for rb in reg_block_choices:
+                                    params = TileParams(
+                                        bn=bn_c,
+                                        bm=bm_c,
+                                        fm=fm,
+                                        fn=fn,
+                                        bk=bk,
+                                        splitk=splitk,
+                                        br=br,
+                                        overhang=overhang_axes,
+                                        reg_block=rb,
+                                    )
+                                    if params in seen:
+                                        continue
+                                    seen.add(params)
+                                    ordered.append(params)
 
     ordered.sort(key=priority_fn, reverse=True)
     return ordered
@@ -1391,6 +1590,45 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
     else:
         new_inner = inner_after_outer
 
+    # Register-blocked GEMM nest (REG_BLOCK True): split the N_r register-tile
+    # around the K-reduce so N-invariant compute runs once per K step and is
+    # shared across F_N cells. Emits three sibling RegisterTile(N_r) towers
+    # (Init / K-reduce N-dep tail / Write) inside the M_r scope. v1 supports
+    # only the simplest shape: no prologue (SDPA P@V uses M-row-shared softmax
+    # stats that can't trivially block over N), SPLITK = 1, BR = 1, FN > 1
+    # (otherwise no register-tile benefit), and no M-mask (the M-cond would
+    # wrap all three towers and tangle with the replicator).
+    reg_blocked = False
+    if (
+        params.reg_block
+        and not shape.prologue
+        and params.splitk == 1
+        and params.br == 1
+        and params.fn > 1
+        and shape.k_loop is not None
+        and m_bound is None
+    ):
+        if n_bound is not None:
+            # Masked N: wrap each tower's leaf body in its own Cond. The
+            # replicator (010_split_register_axes) replicates the Cond per
+            # cell using σ N_r → i, so each replica gets its own σ-folded
+            # predicate. A single top-level Cond wrapping all three towers
+            # would reference N_r in its predicate but expose nested
+            # RegisterTile(N_r) inside — the replicator can't reconcile
+            # both.
+            n_pred_for_cond = sigma_outer.reduce(Var(N_name), SimplifyCtx({}))
+
+            def _wrap_in_n_cond(stmts: tuple[Stmt, ...], pred: Expr = n_pred_for_cond, bound: Expr = n_bound) -> tuple[Stmt, ...]:  # type: ignore[assignment]
+                return (Cond(cond=BinaryExpr("<", pred, bound), body=Body(stmts)),)
+
+            leaf_cond = _wrap_in_n_cond
+        else:
+            leaf_cond = None
+        blocked_inner = _build_register_blocked_body(new_inner, N_r.name, N_r, leaf_cond)
+        if blocked_inner is not None:
+            new_inner = blocked_inner
+            reg_blocked = True
+
     # Masked tiles: when ceil-div has rounded a block-axis extent up past the
     # axis bound, wrap the σ-rewritten body in ``Cond(decoded_axis_coord <
     # bound)``. ``bound`` is the static ``real_extent`` (lm_head vocab) or the
@@ -1400,7 +1638,11 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
     # handles Conds whose predicate depends on the replicated axis by
     # σ-substituting per replica so each replicated body gets a partly-
     # constant-folded predicate (NVRTC drops always-true copies).
-    if n_bound is not None:
+    #
+    # Under REG_BLOCK the N-cond was already applied per-tower above, so skip
+    # the top-level N-cond here. The M-cond still always wraps (M_r is outside
+    # the N_r towers, regardless of reg_block).
+    if n_bound is not None and not reg_blocked:
         n_pred = sigma_outer.reduce(Var(N_name), SimplifyCtx({}))
         new_inner = (Cond(cond=BinaryExpr("<", n_pred, n_bound), body=Body(new_inner)),)
     if m_bound is not None:
@@ -1461,7 +1703,12 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
         outer_layers.extend((lp.axis, Role.BLOCK) for lp in reversed(shape.extra_outer))
         return _wrap_tower(outer_layers, body_after_register)
 
-    layers: list[tuple[Axis, Role | None]] = [(N_r, Role.REGISTER)]
+    # When REG_BLOCK has wrapped the three sibling RegisterTile(N_r) towers
+    # already, the outer layers list skips N_r — the towers each carry their
+    # own RegisterTile(N_r) wrapper inside the M_r/THREAD scope.
+    layers: list[tuple[Axis, Role | None]] = []
+    if not reg_blocked:
+        layers.append((N_r, Role.REGISTER))
     if M_r is not None:
         layers.append((M_r, Role.REGISTER))
     layers.append((N_t, Role.THREAD))

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -1535,17 +1535,22 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
     # builder accepts): split the N_r register-tile around the K-reduce so
     # N-invariant compute runs once per K step and is shared across F_N
     # cells. Emits sibling RegisterTile(N_r) towers (Init / K-reduce N-dep
-    # tail / Write) inside the M_r scope. The blocked builder declines
-    # (returns None) on shapes it can't yet handle — prologue (SDPA P@V's
-    # M-row-shared softmax stats), SPLITK > 1 (atomic-add per-cell Writes
-    # work fine, but ``_gate_linear_epilogue_on_k_s_zero``'s Cond wrap and
-    # 020_stage_inputs's slab-shape inference for the inner-RegisterTile
-    # Load haven't been generalised yet), BR > 1's cooperative-K combine,
-    # M-mask, and F_N = 1 (no register-tile benefit anyway, and the
-    # downstream staging passes get the wrong slab geometry on the inner
-    # N_r=1 wrap) — the per-cell legacy path below picks up those cases.
+    # tail / Write) inside the M_r scope. Prologue kernels are in-scope
+    # too: the fused RMSNorm + lm_head matmul (linear_196) has K-dependent
+    # N-invariant compute (``v_k = x[m, k]·v4·norm_weight[k]``) inside the
+    # matmul K-loop — exactly the blocked-nest target. The prologue's own
+    # K-reduce (mean / softmax stats) still runs once at the M_r scope; the
+    # blocked transform only touches the matmul body's K_i.
+    # The blocked builder declines (returns None) on shapes it can't yet
+    # handle — SPLITK > 1 (``_gate_linear_epilogue_on_k_s_zero``'s Cond
+    # wrap and 020_stage_inputs's slab-shape inference for the inner-
+    # RegisterTile Load haven't been generalised yet), BR > 1's
+    # cooperative-K combine, M-mask, and F_N = 1 (no register-tile benefit
+    # anyway, and the downstream staging passes get the wrong slab geometry
+    # on the inner N_r=1 wrap) — the per-cell legacy path below picks up
+    # those cases.
     reg_blocked = False
-    if not shape.prologue and params.splitk == 1 and params.br == 1 and params.fn > 1 and shape.k_loop is not None and m_bound is None:
+    if params.splitk == 1 and params.br == 1 and params.fn > 1 and shape.k_loop is not None and m_bound is None:
         if n_bound is not None:
             # Masked N: wrap each tower's leaf body in its own Cond. The
             # replicator (010_split_register_axes) replicates the Cond per
@@ -1616,9 +1621,15 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
     # With prologue: N_r wraps the matmul body alone; the prologue stmts
     # are prepended at the M_r scope, so the M_r Loop body becomes
     # ``[prologue..., N_r tower]``. Outer layers (THREAD/BLOCK/SPLITK)
-    # then wrap that combined body.
+    # then wrap that combined body. When the blocked nest has already
+    # emitted the per-tower RegisterTile(N_r) wrappers inside new_inner,
+    # skip the outer ``_wrap_tower([(N_r, ...)], ...)`` — the N_r tile is
+    # already present per-tower.
     if shape.prologue:
-        matmul_tower = _wrap_tower([(N_r, Role.REGISTER)], new_inner)
+        if reg_blocked:
+            matmul_tower = new_inner
+        else:
+            matmul_tower = _wrap_tower([(N_r, Role.REGISTER)], new_inner)
         body_inside_mr = prologue_rewritten + matmul_tower
         if M_r is not None:
             # M_r stays serial (not RegisterTile) — the SDPA prologue

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -131,24 +131,8 @@ FN = Knob("FN", KnobType.INT, hints=_TUNE_F_CHOICES, help="Per-thread cells alon
 BK = Knob("BK", KnobType.INT, hints=_BK_CANDIDATES, help="Per-stage K-chunk size (intra-CTA K-loop trip count = K / BK)")
 SPLITK = Knob("SPLITK", KnobType.INT, hints=_SPLITK_CANDIDATES, help="Cross-CTA K-split factor (1 = no split)")
 BR = Knob("BR", KnobType.INT, hints=_BR_CANDIDATES, help="Cooperative-K thread count (1 = pure serial chunked reduce)")
-REG_BLOCK = Knob(
-    "REG_BLOCK",
-    KnobType.BOOL,
-    hints=(False, True),
-    help=(
-        "Register-blocked GEMM nest: split N_r register-tile around the K-reduce so "
-        "N-invariant compute (RMSNorm prologue, M-axis Loads) runs once per K step "
-        "and is shared across FN cells. False (greedy default) — today's per-cell "
-        "structure: the whole {Init, K-reduce, Write} runs F_N× per output cell. "
-        "True — three sibling RegisterTile(N_r) towers (Init / K-reduce body's "
-        "N-dependent tail / Write) wrap the shared compute; the K-loop runs once, "
-        "feeding all F_N accumulators. Cuts both compile time and runtime FLOPs for "
-        "large FN. v1 supports the simplest shape only: no prologue (no SDPA P@V), "
-        "no SPLITK > 1, no BR > 1; falls back to per-cell otherwise."
-    ),
-)
 
-_PLANNER_KNOBS: tuple[Knob, ...] = (BN, BM, FM, FN, BK, SPLITK, BR, REG_BLOCK)
+_PLANNER_KNOBS: tuple[Knob, ...] = (BN, BM, FM, FN, BK, SPLITK, BR)
 
 
 def _planner_pin_set() -> bool:
@@ -159,23 +143,14 @@ def _planner_pin_set() -> bool:
 
 @dataclass(frozen=True)
 class TileParams:
-    """One ``(BN, BM, FM, FN, BK, SPLITK, BR, REG_BLOCK)`` variant. Frozen
-    for de-dup in the cartesian's ``seen`` set; ``br=1`` / ``reg_block=False``
-    defaults keep matmul / pointwise sites terse.
+    """One ``(BN, BM, FM, FN, BK, SPLITK, BR)`` variant. Frozen for de-dup in
+    the cartesian's ``seen`` set; ``br=1`` default keeps matmul / pointwise
+    sites terse.
 
     ``overhang`` lists output-axis names admitted at a non-divisor BN/BM
     (masked tiles). Empty for clean-divisor variants. The planner stamps the
     same tuple onto the emitted ``TileOp.knobs["OVERHANG"]`` so downstream
     passes (staging, materialization) can guard cooperative loads.
-
-    ``reg_block`` toggles the register-blocked GEMM nest. False (default)
-    keeps the legacy per-cell structure: the planner wraps the entire
-    ``{Init, K-reduce, Write}`` in one ``RegisterTile(N_r)`` and 010_split_register_axes
-    replicates the whole thing FN×. True emits three sibling RegisterTile(N_r)
-    towers (Init / K-reduce N-dependent tail / Write) with N-invariant compute
-    hoisted between them, so the K-loop runs once and shared compute happens
-    once per K iteration rather than ×FN. Only set on matmul shapes with
-    FN > 1, no prologue, SPLITK = 1, BR = 1 — falls back to per-cell otherwise.
     """
 
     bn: int
@@ -186,7 +161,6 @@ class TileParams:
     splitk: int
     br: int = 1
     overhang: tuple[str, ...] = ()
-    reg_block: bool = False
 
 
 @dataclass(frozen=True)
@@ -304,7 +278,7 @@ def _build_fork_tree_lazy(plan: _Plan, ctx: Context) -> Fork | list[Fork]:
     def _leaf_forks(group: list[TileParams]) -> list[Fork]:
         out = [
             Fork(
-                knobs={BK.name: p.bk, SPLITK.name: p.splitk, REG_BLOCK.name: p.reg_block},
+                knobs={BK.name: p.bk, SPLITK.name: p.splitk},
                 expand=(lambda p=p: [_materialize(plan, p)]),
                 score=leaf_score[id(p)],
                 is_leaf=True,
@@ -725,11 +699,18 @@ def _build_register_blocked_body(
             new_s, r = _split_k_tower_for_block(s, n_axis_name, n_r, leaf_cond)
             out.append(new_s)
             n_replaced += r
+        elif isinstance(s, Cond):
+            # Post-K epilogue Cond — matmul_add's K_s==0 gate, or other
+            # N-uniform predicate wrapping a per-cell Write/epilogue. Wrap
+            # the whole Cond in RegisterTile(N_r); the replicator descends
+            # into Cond.body / Cond.else_body and replicates the inner Loads
+            # / Assigns / Writes per cell (Cond's own predicate is K_s-only
+            # so it doesn't itself get replicated, just its content).
+            out.append(RegisterTile(axes=(n_r,), body=Body((s,))))
         else:
-            # Outer-scope stmt we haven't taught the blocked builder about
-            # (Cond from prior masked wrap, post-K epilogue compute, etc.).
-            # Fall back to per-cell — the planner will materialize the
-            # ``reg_block=False`` sibling instead.
+            # Unrecognised outer-scope stmt. Fall back to the per-cell legacy
+            # path so the kernel still lowers (the planner-fallback branch in
+            # ``_build_split_body`` picks up).
             return None
     if n_replaced == 0:
         return None
@@ -1085,7 +1066,6 @@ def _materialize(plan: _Plan, params: TileParams) -> TileOp:
         BK.name: params.bk,
         SPLITK.name: params.splitk,
         BR.name: params.br,
-        REG_BLOCK.name: params.reg_block,
     }
     # Drop leading stmts whose SSA name is *also* defined inside ``chain_body``.
     # A pre-loop invariant (e.g. ``v0 = reciprocal(1024)``) used only by a
@@ -1104,11 +1084,9 @@ def _priority_matmul(p: TileParams) -> tuple[int, ...]:
     # High cells/thread (amortize K-loop) capped at 32 (NVRTC compile time),
     # threads near 256, larger BK, smaller SPLITK. Final tiebreaker prefers
     # clean-divisor variants over masked (negative len so fewer-overhang wins
-    # under reverse-sorted enumeration). REG_BLOCK=False ranks higher than
-    # True (greedy default; M3 may invert) — `0` for False, `-1` for True keeps
-    # False ahead under reverse-sorted enumeration.
+    # under reverse-sorted enumeration).
     threads = p.bn * p.bm
-    return (min(p.fm * p.fn, 32), -abs(256 - threads), p.bk, -p.splitk, -len(p.overhang), -int(p.reg_block))
+    return (min(p.fm * p.fn, 32), -abs(256 - threads), p.bk, -p.splitk, -len(p.overhang))
 
 
 def _priority_pointwise(p: TileParams) -> tuple[int, ...]:
@@ -1232,24 +1210,7 @@ def _enumerate_cartesian(
     # reduce) via ``m_forced_mask`` / ``n_forced_mask``, tuned at its hint.
     allow_masked = priority_mode in ("pointwise", "matmul")
 
-    # REG_BLOCK eligibility: only matmul shapes can register-block the K-loop
-    # (pointwise / cooperative-reduce don't have a K-loop to share across N
-    # cells). Per-variant gates (FN > 1, SPLITK = 1, BR = 1, no M-overhang)
-    # apply inside ``_enumerate_cartesian_impl``. The env pin (``DEPLODOCK_REG_BLOCK``)
-    # threads in as ``reg_block_pin`` — narrowing inline at the cartesian innermost
-    # loop would discard the False variant whenever pin=True on a non-qualifying
-    # shape, leaving the kernel un-lowered. Letting the planner's peer-kernel
-    # fallback drop the pin is the right answer.
-    reg_block_eligible = priority_mode == "matmul"
-
     def _run(apply_pins: bool) -> list[TileParams]:
-        reg_block_pin_value: bool | None = None
-        if apply_pins:
-            from deplodock import config as _config  # noqa: PLC0415 — local import; avoid module cycle
-
-            raw = _config.knob_raw(REG_BLOCK.name)
-            if raw is not None:
-                reg_block_pin_value = REG_BLOCK.parse(raw)
         return _enumerate_cartesian_impl(
             E_M=E_M,
             E_N=E_N,
@@ -1270,8 +1231,6 @@ def _enumerate_cartesian(
             n_axis_name=n_axis_name,
             m_forced_mask=m_forced_mask,
             n_forced_mask=n_forced_mask,
-            reg_block_eligible=reg_block_eligible,
-            reg_block_pin=reg_block_pin_value,
         )
 
     result = _run(apply_pins=True)
@@ -1301,8 +1260,6 @@ def _enumerate_cartesian_impl(
     n_axis_name: str | None = None,
     m_forced_mask: bool = False,
     n_forced_mask: bool = False,
-    reg_block_eligible: bool = False,
-    reg_block_pin: bool | None = None,
 ) -> list[TileParams]:
     """Pure cartesian enumeration: caller supplies the (possibly already
     pin-narrowed) choice tuples, the per-iteration FM/FN narrow callables
@@ -1402,37 +1359,20 @@ def _enumerate_cartesian_impl(
                                     overhang_axes = (*overhang_axes, n_axis_name)
                                 if m_overhang and m_axis_name is not None:
                                     overhang_axes = (*overhang_axes, m_axis_name)
-                                # REG_BLOCK candidate set: True is emitted only on the shape
-                                # where the planner's ``_build_register_blocked_body`` will
-                                # actually fire (FN > 1 so blocking has real cells to share,
-                                # SPLITK = 1, BR = 1, M not overhang — v1 constraints). False
-                                # is always available. Env pin clamps the choice set; ``pin=True``
-                                # on a non-qualifying shape soft-falls-back to False (rather than
-                                # emitting nothing and triggering the peer-kernel pin drop, which
-                                # would also kill OTHER pins the user set alongside REG_BLOCK).
-                                shape_supports_reg_block = reg_block_eligible and fn > 1 and splitk == 1 and br == 1 and not m_overhang
-                                if reg_block_pin is None:
-                                    reg_block_choices = (False, True) if shape_supports_reg_block else (False,)
-                                elif reg_block_pin:
-                                    reg_block_choices = (True,) if shape_supports_reg_block else (False,)
-                                else:
-                                    reg_block_choices = (False,)
-                                for rb in reg_block_choices:
-                                    params = TileParams(
-                                        bn=bn_c,
-                                        bm=bm_c,
-                                        fm=fm,
-                                        fn=fn,
-                                        bk=bk,
-                                        splitk=splitk,
-                                        br=br,
-                                        overhang=overhang_axes,
-                                        reg_block=rb,
-                                    )
-                                    if params in seen:
-                                        continue
-                                    seen.add(params)
-                                    ordered.append(params)
+                                params = TileParams(
+                                    bn=bn_c,
+                                    bm=bm_c,
+                                    fm=fm,
+                                    fn=fn,
+                                    bk=bk,
+                                    splitk=splitk,
+                                    br=br,
+                                    overhang=overhang_axes,
+                                )
+                                if params in seen:
+                                    continue
+                                seen.add(params)
+                                ordered.append(params)
 
     ordered.sort(key=priority_fn, reverse=True)
     return ordered
@@ -1591,24 +1531,21 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
     else:
         new_inner = inner_after_outer
 
-    # Register-blocked GEMM nest (REG_BLOCK True): split the N_r register-tile
-    # around the K-reduce so N-invariant compute runs once per K step and is
-    # shared across F_N cells. Emits three sibling RegisterTile(N_r) towers
-    # (Init / K-reduce N-dep tail / Write) inside the M_r scope. v1 supports
-    # only the simplest shape: no prologue (SDPA P@V uses M-row-shared softmax
-    # stats that can't trivially block over N), SPLITK = 1, BR = 1, FN > 1
-    # (otherwise no register-tile benefit), and no M-mask (the M-cond would
-    # wrap all three towers and tangle with the replicator).
+    # Register-blocked GEMM nest (default for matmul shapes the blocked
+    # builder accepts): split the N_r register-tile around the K-reduce so
+    # N-invariant compute runs once per K step and is shared across F_N
+    # cells. Emits sibling RegisterTile(N_r) towers (Init / K-reduce N-dep
+    # tail / Write) inside the M_r scope. The blocked builder declines
+    # (returns None) on shapes it can't yet handle — prologue (SDPA P@V's
+    # M-row-shared softmax stats), SPLITK > 1 (atomic-add per-cell Writes
+    # work fine, but ``_gate_linear_epilogue_on_k_s_zero``'s Cond wrap and
+    # 020_stage_inputs's slab-shape inference for the inner-RegisterTile
+    # Load haven't been generalised yet), BR > 1's cooperative-K combine,
+    # M-mask, and F_N = 1 (no register-tile benefit anyway, and the
+    # downstream staging passes get the wrong slab geometry on the inner
+    # N_r=1 wrap) — the per-cell legacy path below picks up those cases.
     reg_blocked = False
-    if (
-        params.reg_block
-        and not shape.prologue
-        and params.splitk == 1
-        and params.br == 1
-        and params.fn > 1
-        and shape.k_loop is not None
-        and m_bound is None
-    ):
+    if not shape.prologue and params.splitk == 1 and params.br == 1 and params.fn > 1 and shape.k_loop is not None and m_bound is None:
         if n_bound is not None:
             # Masked N: wrap each tower's leaf body in its own Cond. The
             # replicator (010_split_register_axes) replicates the Cond per

--- a/tests/compiler/passes/test_partition_planner_forks.py
+++ b/tests/compiler/passes/test_partition_planner_forks.py
@@ -169,14 +169,14 @@ def test_leaves_preserve_every_variant():
     assert len(leaves) == len(plan.params), f"leaf count {len(leaves)} doesn't match variant count {len(plan.params)}"
 
 
-def test_leaf_knobs_are_bk_splitk_only():
-    """Leaf Forks pin only (BK, SPLITK) — the rest is committed by ancestor
-    branch Forks. The DB lookup at fork-replay time matches deltas
-    per-level, so the partition must be tight."""
+def test_leaf_knobs_are_bk_splitk_reg_block_only():
+    """Leaf Forks pin only (BK, SPLITK, REG_BLOCK) — the rest is committed
+    by ancestor branch Forks. The DB lookup at fork-replay time matches
+    deltas per-level, so the partition must be tight."""
     plan = _matmul_plan()
     tree = _build_fork_tree_lazy(plan, _ctx())
     for leaf in _walk_leaves(tree):
-        assert set(leaf.knobs.keys()) <= {"BK", "SPLITK"}, f"leaf knobs leak into non-(BK,SPLITK): {leaf.knobs}"
+        assert set(leaf.knobs.keys()) <= {"BK", "SPLITK", "REG_BLOCK"}, f"leaf knobs leak into non-(BK,SPLITK,REG_BLOCK): {leaf.knobs}"
 
 
 def test_branch_score_is_max_of_children():
@@ -242,11 +242,12 @@ def test_pointwise_collapses_br_layer():
 
 def test_branch_knobs_partition_cleanly():
     """The union of (root-fork knobs, walked branch knobs, leaf knobs)
-    along any root→leaf path must cover ``{BR, BM, BN, FM, FN, BK, SPLITK}``
-    exactly once each — no knob duplicated across levels, none missing."""
+    along any root→leaf path must cover
+    ``{BR, BM, BN, FM, FN, BK, SPLITK, REG_BLOCK}`` exactly once each —
+    no knob duplicated across levels, none missing."""
     plan = _matmul_plan()
     tree = _build_fork_tree_lazy(plan, _ctx())
-    expected = {"BR", "BM", "BN", "FM", "FN", "BK", "SPLITK"}
+    expected = {"BR", "BM", "BN", "FM", "FN", "BK", "SPLITK", "REG_BLOCK"}
 
     # Walk one root→leaf path and check.
     def _first_path(node: Fork) -> list[Fork]:

--- a/tests/compiler/passes/test_partition_planner_forks.py
+++ b/tests/compiler/passes/test_partition_planner_forks.py
@@ -169,14 +169,14 @@ def test_leaves_preserve_every_variant():
     assert len(leaves) == len(plan.params), f"leaf count {len(leaves)} doesn't match variant count {len(plan.params)}"
 
 
-def test_leaf_knobs_are_bk_splitk_reg_block_only():
-    """Leaf Forks pin only (BK, SPLITK, REG_BLOCK) — the rest is committed
-    by ancestor branch Forks. The DB lookup at fork-replay time matches
-    deltas per-level, so the partition must be tight."""
+def test_leaf_knobs_are_bk_splitk_only():
+    """Leaf Forks pin only (BK, SPLITK) — the rest is committed by ancestor
+    branch Forks. The DB lookup at fork-replay time matches deltas
+    per-level, so the partition must be tight."""
     plan = _matmul_plan()
     tree = _build_fork_tree_lazy(plan, _ctx())
     for leaf in _walk_leaves(tree):
-        assert set(leaf.knobs.keys()) <= {"BK", "SPLITK", "REG_BLOCK"}, f"leaf knobs leak into non-(BK,SPLITK,REG_BLOCK): {leaf.knobs}"
+        assert set(leaf.knobs.keys()) <= {"BK", "SPLITK"}, f"leaf knobs leak into non-(BK,SPLITK): {leaf.knobs}"
 
 
 def test_branch_score_is_max_of_children():
@@ -242,12 +242,11 @@ def test_pointwise_collapses_br_layer():
 
 def test_branch_knobs_partition_cleanly():
     """The union of (root-fork knobs, walked branch knobs, leaf knobs)
-    along any root→leaf path must cover
-    ``{BR, BM, BN, FM, FN, BK, SPLITK, REG_BLOCK}`` exactly once each —
-    no knob duplicated across levels, none missing."""
+    along any root→leaf path must cover ``{BR, BM, BN, FM, FN, BK, SPLITK}``
+    exactly once each — no knob duplicated across levels, none missing."""
     plan = _matmul_plan()
     tree = _build_fork_tree_lazy(plan, _ctx())
-    expected = {"BR", "BM", "BN", "FM", "FN", "BK", "SPLITK", "REG_BLOCK"}
+    expected = {"BR", "BM", "BN", "FM", "FN", "BK", "SPLITK"}
 
     # Walk one root→leaf path and check.
     def _first_path(node: Fork) -> list[Fork]:

--- a/tests/compiler/passes/test_partition_planner_rules.py
+++ b/tests/compiler/passes/test_partition_planner_rules.py
@@ -181,54 +181,79 @@ def test_006a_sibling_register_tile_towers_share_keep():
     assert init_names == write_values == accum_names, (init_names, write_values, accum_names)
 
 
-def test_planner_emits_register_blocked_structure(monkeypatch):
-    """With ``DEPLODOCK_REG_BLOCK=1`` pinned, the planner's blocked-GEMM
-    path fires on a plain matmul: the post-partition TileOp body has two
-    sibling RegisterTile(N_r) wrappers (K-tower-inner + Write — Init is
-    implicit at this stage; 020_place_inits adds the explicit Inits at
-    the ThreadTile scope only after 010 has unwrapped RegisterTiles).
-    The K-tower's K_i body has the M-axis Load BEFORE the inner
-    RegisterTile(N_r) wrapper — the N-invariant cone, shared across F_N
-    cells.
+def test_planner_emits_register_blocked_structure():
+    """The blocked-GEMM materialization path produces sibling
+    RegisterTile(N_r) wrappers around the Write and inside the K-tower's
+    K_i body for a plain matmul. The K_i body has the M-axis Load BEFORE
+    the inner RegisterTile(N_r) wrapper (the N-invariant cone, shared
+    across F_N cells); the Write sits in its own RegisterTile(N_r).
+
+    Bypasses greedy variant selection (other knobs may dominate the
+    lazy-score yardstick depending on shape) by calling ``_materialize``
+    directly with a hand-picked ``TileParams(reg_block=True)`` from the
+    planner's enumeration. The planner's blocked emit is what we want
+    to lock down here — Fork-tree priority is the M3 concern.
     """
-    from deplodock.compiler.ir.frontend.ir import MatmulOp  # noqa: PLC0415
+    import importlib  # noqa: PLC0415
+
+    from deplodock.compiler.context import Context  # noqa: PLC0415
     from deplodock.compiler.ir.tile.ir import SerialTile  # noqa: PLC0415
 
-    monkeypatch.setenv("DEPLODOCK_REG_BLOCK", "1")
+    planner = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.tile.010_partition_loops")
 
-    g = Graph()
-    _input(g, "a", (64, 32))
-    _input(g, "b", (32, 128))
-    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (64, 128)), node_id="o")
-    g.inputs = ["a", "b"]
-    g.outputs = ["o"]
+    m_ax, n_ax, k_ax = Axis("m", 64), Axis("n", 128), Axis("k", 32)
+    loop_op = LoopOp(
+        body=(
+            Loop(
+                axis=m_ax,
+                body=(
+                    Loop(
+                        axis=n_ax,
+                        body=(
+                            Loop(
+                                axis=k_ax,
+                                body=(
+                                    Load(name="a", input="a", index=(Var("m"), Var("k"))),
+                                    Load(name="b", input="b", index=(Var("k"), Var("n"))),
+                                    Accum(name="acc", value="b", op=ElementwiseImpl("add")),
+                                ),
+                            ),
+                            Write(output="o", index=(Var("m"), Var("n")), value="acc"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
 
-    out = Pipeline.build(TILE_PASSES).run(g)
-    tile_op = next(n.op for n in out.nodes.values() if isinstance(n.op, TileOp))
+    plan = planner._plan_kernel(loop_op, Context(compute_capability="sm_80"), kernel_name="k_blk")
+    assert plan is not None
+    blocked_params = [p for p in plan.params if p.reg_block and p.fn > 1]
+    assert blocked_params, "no reg_block=True variants enumerated for matmul"
+    chosen = blocked_params[0]
+    tile_op = planner._materialize(plan, chosen)
+
+    assert tile_op.knobs.get("REG_BLOCK") is True
+
     thread = next(iter(tile_op.body.iter_of_type(ThreadTile)))
-
-    # Descend through any outer M_r RegisterTile (FM > 1 is allowed by the
-    # planner; M_r wraps the N_r sibling towers in the blocked-GEMM nest).
     layer_body: tuple = tuple(thread.body)
+    # Descend through any outer M_r RegisterTile (FM > 1 with M_r wrapping
+    # the N_r sibling towers).
     if len(layer_body) == 1 and isinstance(layer_body[0], RegisterTile):
         layer_body = tuple(layer_body[0].body)
 
-    # Top-level: exactly one RegisterTile(N_r) — the Write tower (no explicit
-    # Init in the source LoopOp body, so no Init tower at this stage).
+    # Init isn't in the source LoopOp body (Accum's identity is implicit) so
+    # the planner doesn't emit a separate Init tower; only the Write tower
+    # appears at this stage. 020_place_inits adds explicit Inits at the
+    # ThreadTile scope later, after 010_split_register_axes unwraps the
+    # per-cell RegisterTile in the K_i body.
     top_register_tiles = [s for s in layer_body if isinstance(s, RegisterTile)]
-    assert len(top_register_tiles) == 1, (
-        f"expected 1 top-level RegisterTile (Write tower), got {len(top_register_tiles)}: {[type(s).__name__ for s in layer_body]}"
-    )
+    assert len(top_register_tiles) == 1, [type(s).__name__ for s in layer_body]
     write_tower = top_register_tiles[0]
-    writes_in_tower = [s for s in write_tower.body if isinstance(s, Write)]
-    assert writes_in_tower, f"Write tower has no Write inside: {write_tower.body}"
+    assert any(isinstance(s, Write) for s in write_tower.body)
 
-    # K-tower (SerialTile, possibly nested K_o > K_i) sibling of the Write
-    # tower; its K_i body has the N-dep tail in its own inner RegisterTile.
+    # K-tower sibling has its N-dep tail wrapped in its own RegisterTile(N_r).
     k_towers = [s for s in layer_body if isinstance(s, SerialTile)]
-    assert k_towers, "expected K-tower (SerialTile) in the planner output"
-    nested_register_tiles = [s for s in k_towers[0].body.iter() if isinstance(s, RegisterTile)]
-    assert nested_register_tiles, "K-tower body should contain a RegisterTile (N-dep tail) for reg_block"
-
-    # REG_BLOCK is stamped on the materialized TileOp.
-    assert tile_op.knobs.get("REG_BLOCK") is True, f"REG_BLOCK should be True in knobs: {tile_op.knobs}"
+    assert k_towers, "expected K-tower SerialTile sibling of the Write tower"
+    nested = [s for s in k_towers[0].body.iter() if isinstance(s, RegisterTile)]
+    assert nested, "K-tower body should hold a RegisterTile(N_r) for the N-dep tail"

--- a/tests/compiler/passes/test_partition_planner_rules.py
+++ b/tests/compiler/passes/test_partition_planner_rules.py
@@ -179,3 +179,56 @@ def test_006a_sibling_register_tile_towers_share_keep():
     accums = [s for s in new_thread.body.iter() if isinstance(s, Accum)]
     accum_names = {a.name for a in accums}
     assert init_names == write_values == accum_names, (init_names, write_values, accum_names)
+
+
+def test_planner_emits_register_blocked_structure(monkeypatch):
+    """With ``DEPLODOCK_REG_BLOCK=1`` pinned, the planner's blocked-GEMM
+    path fires on a plain matmul: the post-partition TileOp body has two
+    sibling RegisterTile(N_r) wrappers (K-tower-inner + Write — Init is
+    implicit at this stage; 020_place_inits adds the explicit Inits at
+    the ThreadTile scope only after 010 has unwrapped RegisterTiles).
+    The K-tower's K_i body has the M-axis Load BEFORE the inner
+    RegisterTile(N_r) wrapper — the N-invariant cone, shared across F_N
+    cells.
+    """
+    from deplodock.compiler.ir.frontend.ir import MatmulOp  # noqa: PLC0415
+    from deplodock.compiler.ir.tile.ir import SerialTile  # noqa: PLC0415
+
+    monkeypatch.setenv("DEPLODOCK_REG_BLOCK", "1")
+
+    g = Graph()
+    _input(g, "a", (64, 32))
+    _input(g, "b", (32, 128))
+    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (64, 128)), node_id="o")
+    g.inputs = ["a", "b"]
+    g.outputs = ["o"]
+
+    out = Pipeline.build(TILE_PASSES).run(g)
+    tile_op = next(n.op for n in out.nodes.values() if isinstance(n.op, TileOp))
+    thread = next(iter(tile_op.body.iter_of_type(ThreadTile)))
+
+    # Descend through any outer M_r RegisterTile (FM > 1 is allowed by the
+    # planner; M_r wraps the N_r sibling towers in the blocked-GEMM nest).
+    layer_body: tuple = tuple(thread.body)
+    if len(layer_body) == 1 and isinstance(layer_body[0], RegisterTile):
+        layer_body = tuple(layer_body[0].body)
+
+    # Top-level: exactly one RegisterTile(N_r) — the Write tower (no explicit
+    # Init in the source LoopOp body, so no Init tower at this stage).
+    top_register_tiles = [s for s in layer_body if isinstance(s, RegisterTile)]
+    assert len(top_register_tiles) == 1, (
+        f"expected 1 top-level RegisterTile (Write tower), got {len(top_register_tiles)}: {[type(s).__name__ for s in layer_body]}"
+    )
+    write_tower = top_register_tiles[0]
+    writes_in_tower = [s for s in write_tower.body if isinstance(s, Write)]
+    assert writes_in_tower, f"Write tower has no Write inside: {write_tower.body}"
+
+    # K-tower (SerialTile, possibly nested K_o > K_i) sibling of the Write
+    # tower; its K_i body has the N-dep tail in its own inner RegisterTile.
+    k_towers = [s for s in layer_body if isinstance(s, SerialTile)]
+    assert k_towers, "expected K-tower (SerialTile) in the planner output"
+    nested_register_tiles = [s for s in k_towers[0].body.iter() if isinstance(s, RegisterTile)]
+    assert nested_register_tiles, "K-tower body should contain a RegisterTile (N-dep tail) for reg_block"
+
+    # REG_BLOCK is stamped on the materialized TileOp.
+    assert tile_op.knobs.get("REG_BLOCK") is True, f"REG_BLOCK should be True in knobs: {tile_op.knobs}"

--- a/tests/compiler/passes/test_partition_planner_rules.py
+++ b/tests/compiler/passes/test_partition_planner_rules.py
@@ -11,10 +11,13 @@ were deleted in the same refactor.
 
 from __future__ import annotations
 
+from deplodock.compiler.dtype import F32
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.elementwise import ElementwiseImpl
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
+from deplodock.compiler.ir.stmt import Accum, Init
 from deplodock.compiler.ir.tile.ir import RegisterTile, ThreadTile, TileOp
 from deplodock.compiler.pipeline import KERNEL_PASSES, TILE_PASSES, Pipeline
 
@@ -114,3 +117,65 @@ def test_006a_replicates_register_tagged_body_loop():
         assert "a_reg" not in vars_in_index, f"unreplicated a_reg in Write: {w.index}"
     # FM gets stamped from the outermost (and only) RegisterTile axis extent.
     assert new_tile_op.knobs.get("FM") == 4
+
+
+def test_006a_sibling_register_tile_towers_share_keep():
+    """The blocked-GEMM nest emits three sibling ``RegisterTile(N_r)``
+    towers (Init / K-reduce-Accum / Write) at the same ThreadTile level.
+    Each tower's local keep-analysis is incomplete — the Init tower
+    doesn't itself reference N_r, so a per-body fold would keep ``acc``
+    one name there, while the Accum tower would produce ``acc_0..F-1``.
+    Body-global keep aligns the three towers: ``acc`` is keep=True
+    everywhere because some sibling's Accum reads N_r → all three
+    towers replicate consistently to ``acc_0..F-1``.
+    """
+    n_outer = Axis("n_outer", 8)
+    n_reg = Axis("n_reg", 4)
+    k = Axis("k", 16)
+
+    init_tower = RegisterTile(axes=(n_reg,), body=(Init(name="acc", op=ElementwiseImpl("add"), dtype=F32),))
+    reduce_tower = Loop(
+        axis=k,
+        body=(
+            Load(name="w", input="w", index=(Var("k"), Var("n_outer"), Var("n_reg"))),
+            RegisterTile(axes=(n_reg,), body=(Accum(name="acc", value="w", op=ElementwiseImpl("add")),)),
+        ),
+    )
+    write_tower = RegisterTile(
+        axes=(n_reg,),
+        body=(Write(output="o", index=(Var("n_outer"), Var("n_reg")), value="acc"),),
+    )
+    tile = ThreadTile(
+        axes=(n_outer,),
+        body=(init_tower, reduce_tower, write_tower),
+    )
+    tile_op = TileOp(body=(tile,), name="t")
+
+    g = Graph()
+    _input(g, "w", (16, 8, 4))
+    g.add_node(op=tile_op, inputs=["w"], output=Tensor("o", (8, 4)), node_id="o")
+    g.inputs = ["w"]
+    g.outputs = ["o"]
+
+    out = Pipeline.build(KERNEL_PASSES, select={"split_register_axes"}).run(g)
+    new_tile_op = next(n.op for n in out.nodes.values() if isinstance(n.op, TileOp))
+    new_thread = next(s for s in new_tile_op.body if isinstance(s, ThreadTile))
+
+    assert not any(isinstance(s, RegisterTile) for s in new_thread.body.iter()), "RegisterTile should be fully unwrapped"
+
+    # All four init / write / accum cells should reference a per-cell ``acc<i>``
+    # — body-global keep saw the Accum's N_r dep and propagated. (Post-replicate
+    # ``rename_ssa_sequential`` canonicalizes ``acc_0..3`` → ``acc0..3``.)
+    inits = [s for s in new_thread.body if isinstance(s, Init)]
+    init_names = {s.name for s in inits}
+    assert len(init_names) == 4 and all(n.startswith("acc") for n in init_names), init_names
+    writes = [s for s in new_thread.body if isinstance(s, Write)]
+    write_values = {w.value for w in writes}
+    assert len(write_values) == 4 and all(n.startswith("acc") for n in write_values), write_values
+    # The Init / Accum / Write towers must align on the SAME per-cell name
+    # — that's the whole point of body-global keep. If the Init tower kept
+    # ``acc`` as one name (local fold), the rendered kernel would have one
+    # init with four uses → name collision.
+    accums = [s for s in new_thread.body.iter() if isinstance(s, Accum)]
+    accum_names = {a.name for a in accums}
+    assert init_names == write_values == accum_names, (init_names, write_values, accum_names)

--- a/tests/compiler/passes/test_partition_planner_rules.py
+++ b/tests/compiler/passes/test_partition_planner_rules.py
@@ -228,12 +228,13 @@ def test_planner_emits_register_blocked_structure():
 
     plan = planner._plan_kernel(loop_op, Context(compute_capability="sm_80"), kernel_name="k_blk")
     assert plan is not None
-    blocked_params = [p for p in plan.params if p.reg_block and p.fn > 1]
-    assert blocked_params, "no reg_block=True variants enumerated for matmul"
+    # Find a variant the blocked builder will accept (FN > 1, SPLITK = 1,
+    # BR = 1, no M-overhang). Blocking is now the default — no REG_BLOCK
+    # knob to set.
+    blocked_params = [p for p in plan.params if p.fn > 1 and p.splitk == 1 and p.br == 1]
+    assert blocked_params, "no blocking-eligible variants enumerated for matmul"
     chosen = blocked_params[0]
     tile_op = planner._materialize(plan, chosen)
-
-    assert tile_op.knobs.get("REG_BLOCK") is True
 
     thread = next(iter(tile_op.body.iter_of_type(ThreadTile)))
     layer_body: tuple = tuple(thread.body)

--- a/tests/compiler/test_blocked_gemm_accuracy.py
+++ b/tests/compiler/test_blocked_gemm_accuracy.py
@@ -1,0 +1,284 @@
+"""CUDA accuracy regressions for the register-blocked GEMM nest.
+
+The blocked-GEMM nest (planner default for matmul shapes with FN > 1
+under SPLITK=1 / BR=1 / no M-mask) splits the N_r register-tile around
+the K-reduce so N-invariant compute runs once per K step and is shared
+across the F_N cells. The split intersects with the smem vectorize /
+fp16 pack / fused-prologue gate machinery in ways that produced CUDA
+runtime hangs and silently-wrong vector reads on specific autotune
+variants. Each test below pins the failing knob bundle via env and
+checks the CUDA-compiled kernel matches a NumpyBackend reference.
+
+Skipped without CUDA.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.frontend.ir import LinearOp, MatmulOp, RmsNormOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp
+
+from .conftest import requires_cuda
+
+
+def _random(shape: tuple[int, ...], *, seed: int = 0, scale: float = 1.0, dtype=np.float32) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return (rng.standard_normal(shape, dtype=np.float32) * scale).astype(dtype)
+
+
+def _reference(graph: Graph, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    from deplodock.compiler.backend.numpy import NumpyBackend
+
+    be = NumpyBackend()
+    return be.run(be.compile(graph), input_data=inputs)[0].outputs
+
+
+def _run_cuda(graph: Graph, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+
+    be = CudaBackend()
+    return be.run(be.compile(graph), input_data=inputs)[0].outputs
+
+
+def _assert_close(out: np.ndarray, ref: np.ndarray, *, atol_rel: float = 0.05, atol_min: float = 1e-3) -> None:
+    """Tolerance scales with the reference peak — matmul reductions over
+    K elements drift by ~K·eps on f32, the blocked-vs-per-cell difference
+    is well below that floor."""
+    assert out.shape == ref.shape, f"shape mismatch {out.shape} vs {ref.shape}"
+    assert np.all(np.isfinite(out)), "output has non-finite values"
+    peak = float(np.max(np.abs(ref)))
+    atol = max(atol_min, atol_rel * peak)
+    np.testing.assert_allclose(out, ref, atol=atol, rtol=atol_rel)
+
+
+def _pin_knobs(monkeypatch, **knobs) -> None:
+    for key, value in knobs.items():
+        monkeypatch.setenv(f"DEPLODOCK_{key}", str(value))
+
+
+# ---------------------------------------------------------------------------
+# Multi-dim staged-smem vectorize alignment (FN=3 hang)
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_blocked_matmul_postmul_fn3_no_misalign(monkeypatch):
+    """``BK=64 BM=32 BN=32 BR=1 FM=1 FN=3 SPLITK=1 STAGE=111`` on a matmul
+    chained into a post-multiply previously hung the kernel ("did not
+    complete within 1000 ms"). Root cause: the blocked-GEMM nest emits
+    multi-dim staged smem ``[K, N_t, N_r]`` with FN=3 innermost.
+    ``050_vectorize_loads`` packed two cells into one ``float2``
+    reinterpret_cast on a last-dim constant-anchor alignment check that
+    didn't see the stride-3 base address ``a3 · FN`` — half the threads
+    read at byte 12, not 8-byte aligned for float2, and the device
+    stalled on the misaligned access (no exception, just stuck).
+
+    The fix walks back into the Source's innermost cache-axis extent
+    and refuses to vectorize when it isn't a multiple of the pack count.
+
+    Shape: ``matmul(a@b) * scalar`` with M=32, K=64, N=96 (clean-divisor
+    96 = BN·FN under BN=32 FN=3); the chained ``mul`` is what gives the
+    planner a STAGE=111 enumeration with all three buffers stage-able.
+    """
+    _pin_knobs(monkeypatch, BK=64, BM=32, BN=32, BR=1, FM=1, FN=3, SPLITK=1, STAGE=111)
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (32, 64)), node_id="a")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (64, 96)), node_id="b")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("s", (1,)), node_id="s")  # broadcast scalar
+    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("ab", (32, 96)), node_id="ab")
+    g.add_node(op=ElementwiseOp("multiply"), inputs=["ab", "s"], output=Tensor("o", (32, 96)), node_id="o")
+    g.inputs = ["a", "b", "s"]
+    g.outputs = ["o"]
+
+    inputs = {
+        "a": _random((32, 64), seed=1),
+        "b": _random((64, 96), seed=2),
+        "s": np.array([1.5], dtype=np.float32),
+    }
+    ref = _reference(g, inputs)["o"]
+    out = _run_cuda(g, inputs)["o"]
+    _assert_close(out, ref)
+
+
+# ---------------------------------------------------------------------------
+# fp16 half2 alignment on odd-stride N
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_blocked_matmul_fp16_odd_stride_n_no_misalign(monkeypatch):
+    """fp16 matmul where the blocked-GEMM nest stages a smem slab whose
+    innermost cache-axis extent is odd (FN=3 here) used to fault with
+    ``CUDA_ERROR_MISALIGNED_ADDRESS`` because ``050_vectorize_loads``
+    treated ``n=2 fp16`` (``__half2``) as a freebie: the TYPE is 4-byte
+    aligned, but reinterpreting an fp16 pointer at an odd-element offset
+    still misses the alignment. Two cells off an FN=3 base land at
+    consecutive odd offsets — half the threads read at byte 6, not
+    4-byte-aligned for ``__half2``. The fix walks back into the Source's
+    innermost cache-axis extent and refuses to vectorize when it isn't a
+    multiple of n.
+
+    Shape: M=32, K=64, N=96 (clean divisor 96 = BN·FN under BN=32 FN=3).
+    The pinned (BK=64 BM=32 BN=32 FM=1 FN=3 SPLITK=1 BR=1 STAGE=111)
+    is the blocked variant from the FN=3 hang reproducer in
+    ``370e6090`` — only the matmul-chained-into-mul gives the planner
+    a STAGE=111 enumeration, so the test multiplies the matmul output
+    by a scalar broadcast.
+    """
+    from deplodock.compiler import dtype as _dt  # noqa: PLC0415
+
+    f16_dt = _dt.get("f16")
+    f16 = np.dtype(np.float16)
+    _pin_knobs(monkeypatch, BK=64, BM=32, BN=32, BR=1, FM=1, FN=3, SPLITK=1, STAGE=111)
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (32, 64), f16_dt), node_id="a")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (64, 96), f16_dt), node_id="b")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("s", (1,), f16_dt), node_id="s")
+    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("ab", (32, 96), f16_dt), node_id="ab")
+    g.add_node(op=ElementwiseOp("multiply"), inputs=["ab", "s"], output=Tensor("o", (32, 96), f16_dt), node_id="o")
+    g.inputs = ["a", "b", "s"]
+    g.outputs = ["o"]
+
+    inputs = {
+        "a": _random((32, 64), seed=3, scale=0.1, dtype=f16),
+        "b": _random((64, 96), seed=4, scale=0.1, dtype=f16),
+        "s": np.array([1.0], dtype=f16),
+    }
+    ref = _reference(g, inputs)["o"]
+    out = _run_cuda(g, inputs)["o"]
+    _assert_close(out, ref, atol_rel=0.05, atol_min=5e-3)
+
+
+# ---------------------------------------------------------------------------
+# Fused RMSNorm + linear: blocked-prologue path (M5)
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_fused_rmsnorm_linear_blocked_prologue(monkeypatch):
+    """Fused RMSNorm + linear at lm_head-style knobs (FN=32, BK=64,
+    SPLITK=1, BR=1, FM=1) used to hit the 2 s NVRTC compile budget
+    because the planner's blocked-GEMM nest was gated by
+    ``not shape.prologue``. The fused RMSNorm reduce IS a prologue, so
+    blocking didn't fire and each of the 32 register cells re-emitted
+    the per-K-element normalization ``v_k = x[m,k] · inv_rms ·
+    norm_weight[k]`` inside its own unrolled K loop — ~3.7 s to compile
+    a ~530-line function with 32 live accumulators.
+
+    M5 drops the prologue exclusion: the prologue itself (mean reduce +
+    rsqrt) still runs once at the M_r scope, but the matmul body inside
+    it goes through the blocked nest. The kernel structure has
+    ``v6 = norm_weight · v5`` computed once per K iter, then per-cell
+    Conds doing weight Load + multiply + Accum into persistent acc_i
+    registers — compiles in budget and runs correctly.
+
+    Shape: M=2 (tiny batch — fp32 keeps the accumulator drift small),
+    K=1024 (RMSNorm normalization range), N=4096 (BN=128 · FN=32 clean
+    divisor — picks the blocked variant from the failing tune log
+    without needing the full lm_head vocab=151669, which would also
+    work but compiles slower in this CI-friendly test).
+    """
+    _pin_knobs(monkeypatch, BK=64, BM=1, BN=128, BR=1, FM=1, FN=32, SPLITK=1)
+
+    M, K, N = 2, 1024, 4096
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (M, K)), node_id="x")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("wn", (K,)), node_id="wn")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("wl", (N, K)), node_id="wl")
+    g.add_node(op=RmsNormOp(eps=1e-6), inputs=["x", "wn"], output=Tensor("xn", (M, K)), node_id="xn")
+    g.add_node(op=LinearOp(), inputs=["xn", "wl"], output=Tensor("o", (M, N)), node_id="o")
+    g.inputs = ["x", "wn", "wl"]
+    g.outputs = ["o"]
+
+    inputs = {
+        "x": _random((M, K), seed=5),
+        "wn": _random((K,), seed=6, scale=0.1),
+        "wl": _random((N, K), seed=7, scale=0.02),  # scaled so output stays bounded
+    }
+    # Compute reference BEFORE backend.compile (which mutates ops in place).
+    ref = _reference(g, inputs)["o"]
+
+    # Structural check: with M5 in place, the planner emits ONE smem
+    # allocation for the RMSNorm input (``x_smem``) — both the mean
+    # reduce and the matmul body share it. Without M5, the legacy
+    # prologue path wraps the matmul body in its own RegisterTile(N_r),
+    # which forces a SECOND smem allocation (``x_smem_1``) because the
+    # blocked Loads inside the per-cell scope come from a different
+    # staging context. Detect the regression by counting distinct smem
+    # decls for the x buffer.
+    from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
+    from deplodock.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
+
+    backend = CudaBackend()
+    compiled = backend.compile(g)
+    cuda_ops = [n.op for n in compiled.nodes.values() if isinstance(n.op, CudaOp)]
+    assert cuda_ops, "expected a CudaOp in the lowered graph"
+    cuda_src = "\n".join(op.kernel_source for op in cuda_ops)
+    x_smem_decls = cuda_src.count("__shared__ float x_smem")
+    assert x_smem_decls == 1, (
+        f"expected 1 ``__shared__ float x_smem`` decl (blocked-prologue shares the staging); "
+        f"got {x_smem_decls} — the legacy per-cell path opens its own smem context inside RegisterTile(N_r), "
+        f"forcing a second allocation."
+    )
+
+    # Kernel-size check: legacy path duplicates the prologue chain inside
+    # each register cell's scope. With FN=32 and a ~5-stmt v_k chain
+    # (Load x, mul by inv_rms, Load norm_weight, mul, ...), the legacy
+    # path lands at ~330 lines; the blocked path at ~210. Assert under
+    # 270 lines so a regression that re-introduces the duplication
+    # surfaces here (a comfortable margin keeps the test stable against
+    # whitespace / comment changes in the renderer).
+    cu_lines = cuda_src.count("\n")
+    assert cu_lines < 270, (
+        f"rendered kernel is {cu_lines} lines — the blocked-prologue path should produce ~210; "
+        f"a regression to the legacy per-cell path inflates it to ~330+ via duplicated v_k chains."
+    )
+
+    out = backend.run(compiled, input_data=inputs)[0].outputs["o"]
+    _assert_close(out, ref, atol_rel=0.05, atol_min=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Plain matmul, blocked default (no prologue, no STAGE, sanity for the M3 flip)
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+@pytest.mark.parametrize(
+    ("m", "k", "n", "fm", "fn"),
+    [
+        (32, 32, 128, 1, 8),  # FN=8 clean-divisor; blocked path with 8 cells per thread
+        (64, 64, 64, 2, 2),  # FM=FN=2; M_r register-tiled too
+        (32, 128, 96, 1, 3),  # FN=3 clean-divisor; smaller blocked variant
+    ],
+    ids=["fn8_no_mr", "fm2_fn2_mr", "fn3_clean"],
+)
+def test_blocked_matmul_default_accuracy(monkeypatch, m, k, n, fm, fn):
+    """The M3 commit dropped the REG_BLOCK knob and made blocking the
+    planner's default for any matmul with FN > 1 (and SPLITK=1, BR=1,
+    no M-mask). This parametrized matrix covers the structural shapes
+    blocking touches: pure FN-only (no M_r), FM+FN (M_r register-tiled
+    too), and the FN=3 clean-divisor case (innermost cache-axis extent
+    not a multiple of 2 — exercises the vectorize alignment guard).
+    """
+    bn = max(1, n // fn) if (n % (n // fn) == 0 and (n // fn) <= 256) else n // fn
+    bm = max(1, m // fm)
+    _pin_knobs(monkeypatch, BK=k, BM=bm, BN=bn, BR=1, FM=fm, FN=fn, SPLITK=1)
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (m, k)), node_id="a")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (k, n)), node_id="b")
+    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (m, n)), node_id="o")
+    g.inputs = ["a", "b"]
+    g.outputs = ["o"]
+
+    inputs = {"a": _random((m, k), seed=8), "b": _random((k, n), seed=9)}
+    ref = _reference(g, inputs)["o"]
+    out = _run_cuda(g, inputs)["o"]
+    _assert_close(out, ref)


### PR DESCRIPTION
Implements the textbook register-blocked GEMM nest: split the `N_r` register tile *around* the K-reduce so N-invariant compute runs once per K step and is shared across the F_N cells, rather than re-emitting it inside each per-cell K loop. Executes [`plans/register-blocked-gemm-accumulators.md`](plans/register-blocked-gemm-accumulators.md).

## Why

The fused **RMSNorm + vocab projection** kernel (`linear_196` / lm-head, N = 151669) was blowing past `tune`'s 2 s NVRTC compile budget at `FN=32`: each of the 32 register cells re-emitted the per-element normalization `v6[k] = add_223[k]·v4·norm_weight[k]` inside its own K-reduce. ~530-line function with 32 live accumulators, ~3.7 s to compile at `-Xcicc -O1`. The blocked nest fixes that — and helps every register-tiled matmul, not just the fused RMSNorm.

```
M_r REGISTER:
  RegisterTile(N_r) { Init(acc) }            # 32 per-cell accumulators
  K_o SERIAL_OUTER:
    K_i STAGE_INNER (reduce):
      <N-invariant cone>                     # M-axis Loads, RMSNorm prologue, …
                                             # runs ONCE per K iter
      RegisterTile(N_r) { Load b, Accum }    # 32 per-cell FMAs into the
                                             # persistent acc_0..31
  RegisterTile(N_r) { Write(C, acc) }        # 32 per-cell writes
```

## Commits

- **M1** (`e6ed3dc3`) — body-global keep set in `010_split_register_axes` so the three sibling RegisterTile(N_r) towers replicate to consistent `acc_<i>` suffixes (a per-tower local fold would diverge — the Init tower doesn't itself reference N_r).
- **M2** (`6217d54d`) — planner emits the blocked nest in `_build_split_body`. N-invariant / N-dependent split is one `body.fold` exempting N_r from `bound`. Masked-N via per-tower `Cond` so the replicator σ-folds the predicate per cell; Init stays unconditional to keep `acc_i` in scope.
- **M2 follow-up** (`0ebb0e71`) — REG_BLOCK env-pin soft fallback; fp16 `vectorize_loads` / `vectorize_stores` alignment fix (the half2 4-byte freebie was wrong for odd-stride N like `vocab=3`).
- **M3** (`bf42226f`) — drop the `REG_BLOCK` knob plumbing entirely; blocked-GEMM is the planner's default for any qualifying matmul shape (FN > 1, SPLITK = 1, BR = 1, no M-mask). The legacy per-cell branch in `_build_split_body` stays as the fallback for shapes blocking doesn't yet handle (prologue stage was extended in M5, others still fall through).
- **M4** (`cb8857cc`) — `pipeline/ARCHITECTURE.md` updated with the nesting diagram, cone-partition mechanic, masked-N strategy, and corrected knob-table attributions.
- **M5** (`07bb4b2f`) — extend blocking to fused-prologue matmul. The `not shape.prologue` exclusion was misplaced: SDPA P@V has *K-independent* prologue (already handled), but the fused RMSNorm + lm_head has *K-dependent* N-invariant compute inside the matmul K-loop — exactly the blocked-nest target. Previously-failing `BK=64 BM=1 BN=128 BR=1 FM=1 FN=32 SPLITK=1` now compiles within budget.
- **`370e6090`** — fix `050_vectorize_loads` multi-dim staged-smem alignment. The blocked nest emits 3D smem `[K, N_t, N_r]` and the consumer Load has constant last-dim cell offsets; the affine-form check passed vacuously while the actual byte layout `a3·FN + cell` was unaligned for odd FN, causing `CUDA_ERROR_MISALIGNED_ADDRESS` hangs on FN=3 variants. Fix walks the Source's innermost cache-axis extent.
- **`f13877d4`** — six CUDA accuracy regression tests for the failing variants (each verified by reverting its fix locally and confirming the test fails).

## Verification

- Plain matmul `64×32 @ 32×128` runs **1.9× faster** with blocking (3.3 µs vs 6.1 µs) — shared M-axis Load instead of FN-replicated.
- lm_head-shape fused RMSNorm + linear at the previously-failing variant (M=2, K=1024, N=151669, FN=32) now compiles within budget and runs (~2.66 ms, accuracy passes).
- Test suite: **1328 passed, 27 skipped** (was 1321 pre-PR; +6 from the new regression file + 1 from the planner blocked-structure test in M2).
- `make lint` clean.

## Risks / follow-ups

The blocked builder still declines on SPLITK > 1 / BR > 1 / M-mask / FN = 1 — those fall through to the per-cell legacy branch. Extending blocking to cover them requires generalising `020_stage_inputs`'s slab inference and `040_use_ring_buffers`'s reduce detection (the inner Accum sits inside RegisterTile, not directly in K_i.body — `SerialTile.is_reduce` semantics would need to descend). Left as follow-up; the legacy branch is the safety net so no shape regresses today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)