### PR TITLE
Restore Tile-IR / Kernel-IR layering for warp specialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ recipes/*/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*/
 # Claude Code per-user local settings (skills/agents under .claude/ are tracked)
 .claude/settings.local.json
 *-dump/
+.claude/scheduled_tasks.lock

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -158,6 +158,100 @@ class AsyncWait(Stmt):
 
 
 # ---------------------------------------------------------------------------
+# WarpSpecialize — producer/consumer split for TMA-pipelined kernels
+# ---------------------------------------------------------------------------
+#
+# Tile-IR marker that the materializer (``100_materialize_tile``) lowers
+# into the full mbarrier handshake: empty-mbarrier ring (``Smem`` +
+# per-slot ``MbarrierInit``), per-K_o ``MbarrierWait`` / ``MbarrierArrive``
+# pairs, named ``bar.sync`` consumer fences, ``SetMaxNReg`` register
+# budget redistribution, and the producer/consumer ``Cond`` wrapper.
+#
+# The pass that emits this (``085_warp_specialize``) keeps all Tile-IR
+# vocabulary — no ``from deplodock.compiler.ir.kernel.ir import …``.
+# Companion to 080's ``AsyncWait``: where ``AsyncWait`` lets the pass
+# declare "wait for an async chunk, materializer picks the primitive",
+# ``WarpSpecialize`` lets the pass declare "split this ThreadTile body
+# into producer and consumer roles, materializer wires the rest".
+
+
+@dataclass(frozen=True)
+class WarpSpecialize(Stmt):
+    """Producer/consumer warp split inside a TMA-pipelined ThreadTile.
+
+    Fields:
+
+    - ``producer_body`` — stmts run by producer threads (TMA-issue
+      ``StageBundle`` scaffolding inside ``SerialTile(serial_outer)``).
+    - ``consumer_body`` — stmts run by consumer threads (``AsyncWait`` +
+      reduce loop + output ``Write``). Already σ-shifted by the pass so
+      every reference to the extended thread axis sees the original
+      ``[0, n_consumer_threads)`` range.
+    - ``ring_depth`` — empty-mbarrier slot count (== TMA buffer_count).
+    - ``n_producer_threads`` — for SetMaxNReg accounting (producers get
+      a small budget so consumers can claim the rest) and for deriving
+      the producer/consumer ``Cond`` predicate from the enclosing
+      ThreadTile.
+
+    The K_o axis the WS pass aligned scheduling against is identified by
+    the materializer structurally — the (single) ``SerialTile(serial_outer)``
+    in each branch. Carrying the axis *name* would break under
+    ``normalize_body``'s canonical rename pass (which renames Axis but
+    can't see a plain string field).
+
+    Other quantities (``predicate``, ``n_consumer_threads``, slot/phase
+    exprs, mbar name) are derivable from these fields plus the enclosing
+    ThreadTile.axes and are reconstructed at materialize time.
+
+    Nested ``WarpSpecialize`` is rejected at construction.
+    """
+
+    producer_body: Body
+    consumer_body: Body
+    ring_depth: int
+    n_producer_threads: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.producer_body, Body):
+            object.__setattr__(self, "producer_body", Body.coerce(self.producer_body))
+        if not isinstance(self.consumer_body, Body):
+            object.__setattr__(self, "consumer_body", Body.coerce(self.consumer_body))
+        if self.ring_depth < 1:
+            raise ValueError(f"WarpSpecialize: ring_depth must be >= 1, got {self.ring_depth}")
+        if self.n_producer_threads < 1:
+            raise ValueError(f"WarpSpecialize: n_producer_threads must be >= 1, got {self.n_producer_threads}")
+        # Nesting check — a WS inside another WS would require the
+        # materializer to track a stack of ws_consumer contexts; today
+        # 085 guards via the WS knob on the parent TileOp, but assert at
+        # the IR level so other rules can't sneak one in.
+        for body in (self.producer_body, self.consumer_body):
+            for s in body.iter():
+                if isinstance(s, WarpSpecialize):
+                    raise ValueError("WarpSpecialize cannot nest")
+
+    def nested(self) -> tuple[Body, ...]:
+        return (self.producer_body, self.consumer_body)
+
+    def with_bodies(self, bodies: tuple[Body, ...]) -> Stmt:
+        if len(bodies) != 2:
+            raise ValueError(f"WarpSpecialize.with_bodies: expected 2 bodies, got {len(bodies)}")
+        producer_body, consumer_body = bodies
+        return replace(self, producer_body=producer_body, consumer_body=consumer_body)
+
+    def deps(self) -> tuple[str, ...]:
+        return ()
+
+    def exprs(self) -> tuple[Expr, ...]:
+        return ()
+
+    def pretty(self, indent: str = "") -> list[str]:
+        head = f"{indent}warp_specialize(ring={self.ring_depth}, n_prod={self.n_producer_threads}):"
+        producer_lines = [f"{indent}{INDENT}producer:", *pretty_body(self.producer_body, indent + INDENT * 2)]
+        consumer_lines = [f"{indent}{INDENT}consumer:", *pretty_body(self.consumer_body, indent + INDENT * 2)]
+        return [head, *producer_lines, *consumer_lines]
+
+
+# ---------------------------------------------------------------------------
 # Stage primitives: Source + CacheDim + AffineAddressing/TemplateAddressing
 # ---------------------------------------------------------------------------
 

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -123,20 +123,19 @@ class AsyncWait(Stmt):
       the consumer-side ``MbarrierWait``. ``phase = (K_o / bc) % 2``
       tracks how many times the slot has been reused; ``slot = K_o % bc``
       picks the ring slot to wait on.
-    - ``barrier_id`` / ``barrier_count`` — named-barrier params for the
-      trailing CTA-fence ``Sync`` that the materializer emits after the
-      ``MbarrierWait``. Default 0 → ``__syncthreads()``. Set by
-      ``085_warp_specialize`` on consumer-side AsyncWaits (with a
-      non-zero ``barrier_id`` and ``barrier_count == n_consumer_threads``)
-      because ``__syncthreads()`` inside the WS consumer's ``Cond``
-      branch is CUDA UB on the warp-divergent condition.
+
+    The trailing CTA-fence ``Sync`` after the materializer's
+    ``MbarrierWait`` / ``CpAsyncWait`` defaults to ``__syncthreads()``.
+    Inside a WS consumer subtree it routes to a named ``bar.sync N, M``
+    instead — the materializer derives the named-barrier params from
+    the enclosing ``WarpSpecialize`` context, not from fields on this
+    Stmt. (``__syncthreads()`` is CUDA UB on the warp-divergent
+    producer/consumer branch.)
     """
 
     keep: int = 0
     phase: Expr | None = None
     slot: Expr | None = None
-    barrier_id: int = 0
-    barrier_count: int | None = None
 
     def exprs(self) -> tuple[Expr, ...]:
         out: tuple[Expr, ...] = ()
@@ -152,8 +151,6 @@ class AsyncWait(Stmt):
             extra += f", phase={self.phase.pretty()}"
         if self.slot is not None:
             extra += f", slot={self.slot.pretty()}"
-        if self.barrier_id != 0:
-            extra += f", bar={self.barrier_id}/{self.barrier_count}"
         return [f"{indent}AsyncWait(keep={self.keep}{extra})"]
 
 

--- a/deplodock/compiler/ir/tile/passes.py
+++ b/deplodock/compiler/ir/tile/passes.py
@@ -75,8 +75,6 @@ def _(s: AsyncWait, rename: Rename, sigma: Sigma, axis_fn: AxisFn) -> Stmt:
         keep=s.keep,
         phase=sigma.apply(s.phase) if s.phase is not None else None,
         slot=sigma.apply(s.slot) if s.slot is not None else None,
-        barrier_id=s.barrier_id,
-        barrier_count=s.barrier_count,
     )
 
 
@@ -86,8 +84,6 @@ def _(s: AsyncWait, ctx: SimplifyCtx) -> Stmt:
         keep=s.keep,
         phase=s.phase.simplify(ctx) if s.phase is not None else None,
         slot=s.slot.simplify(ctx) if s.slot is not None else None,
-        barrier_id=s.barrier_id,
-        barrier_count=s.barrier_count,
     )
 
 

--- a/deplodock/compiler/ir/tile/passes.py
+++ b/deplodock/compiler/ir/tile/passes.py
@@ -33,6 +33,7 @@ from deplodock.compiler.ir.tile.ir import (
     StageBundle,
     StridedTile,
     ThreadTile,
+    WarpSpecialize,
 )
 
 
@@ -87,6 +88,26 @@ def _(s: AsyncWait, ctx: SimplifyCtx) -> Stmt:
         slot=s.slot.simplify(ctx) if s.slot is not None else None,
         barrier_id=s.barrier_id,
         barrier_count=s.barrier_count,
+    )
+
+
+@rewrite.register
+def _(s: WarpSpecialize, rename: Rename, sigma: Sigma, axis_fn: AxisFn) -> Stmt:
+    return WarpSpecialize(
+        producer_body=tuple(rewrite(c, rename, sigma, axis_fn) for c in s.producer_body),
+        consumer_body=tuple(rewrite(c, rename, sigma, axis_fn) for c in s.consumer_body),
+        ring_depth=s.ring_depth,
+        n_producer_threads=s.n_producer_threads,
+    )
+
+
+@simplify.register
+def _(s: WarpSpecialize, ctx: SimplifyCtx) -> Stmt:
+    return WarpSpecialize(
+        producer_body=tuple(simplify(c, ctx) for c in s.producer_body),
+        consumer_body=tuple(simplify(c, ctx) for c in s.consumer_body),
+        ring_depth=s.ring_depth,
+        n_producer_threads=s.n_producer_threads,
     )
 
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/100_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/100_materialize_tile.py
@@ -232,13 +232,9 @@ def _materialize(blk: ThreadTile, *, warp_size: int, escape=None) -> Stmt:
         # The trailing fence routes to a named ``bar.sync`` when we're
         # inside a WarpSpecialize consumer subtree (``__syncthreads()``
         # is CUDA UB on the warp-divergent producer/consumer branch).
-        # Two channels supply the params, in priority order:
-        #
-        #   1. ``ws_consumer`` (preferred) — derive participants from
-        #      the WS context the materializer threads into the consumer
-        #      subtree walk. Used by ``emit_warp_specialize``.
-        #   2. ``stmt.barrier_id`` / ``stmt.barrier_count`` (legacy) —
-        #      085 stamps these for backward compat; deleted in C4.
+        # ``ws_consumer`` is threaded in by ``emit_warp_specialize`` and
+        # carries the producer thread count, from which the materializer
+        # derives the consumer participant count for ``bar.sync N, M``.
         if ws_consumer is not None:
             outer_ext = thread_axes[0].extent.as_static()
             inner_prod = 1
@@ -248,7 +244,7 @@ def _materialize(blk: ThreadTile, *, warp_size: int, escape=None) -> Stmt:
             n_cons = (outer_ext - extension) * inner_prod
             trailing_sync = Sync(barrier_id=1, count=n_cons)
         else:
-            trailing_sync = Sync(barrier_id=stmt.barrier_id, count=stmt.barrier_count)
+            trailing_sync = Sync()
         if stmt.phase is not None and tma.has_tma:
             gid = tma.wait_group.get(id(stmt))
             if gid is not None:

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/100_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/100_materialize_tile.py
@@ -440,9 +440,7 @@ def _materialize(blk: ThreadTile, *, warp_size: int, escape=None) -> Stmt:
         # matched SerialTile.axis (post-normalize canonical names like
         # ``a2`` rather than the WS-pass-time ``k_outer``).
         wired_producer = _wire_producer_wait(ws.producer_body, empty_mbar, bc)
-        wired_consumer = _wire_consumer_arrive(
-            ws.consumer_body, empty_mbar, bc, first_consumer_tid, n_consumer_threads
-        )
+        wired_consumer = _wire_consumer_arrive(ws.consumer_body, empty_mbar, bc, first_consumer_tid, n_consumer_threads)
 
         # Materialize each branch. Consumer-side AsyncWaits route their
         # trailing fence through the named ``bar.sync 1, n_consumer``

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/100_materialize_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/100_materialize_tile.py
@@ -42,9 +42,11 @@ from deplodock.compiler.ir.expr import BinaryExpr, Builtin, Literal, Var
 from deplodock.compiler.ir.kernel.ir import (
     CpAsyncWait,
     KernelOp,
+    MbarrierArrive,
     MbarrierArriveExpectTx,
     MbarrierInit,
     MbarrierWait,
+    SetMaxNReg,
     Smem,
     Sync,
     TmaDescriptor,
@@ -64,6 +66,7 @@ from deplodock.compiler.ir.tile.ir import (
     StridedTile,
     ThreadTile,
     TileOp,
+    WarpSpecialize,
 )
 from deplodock.compiler.pipeline import Pattern
 from deplodock.compiler.pipeline.passes.lowering.kernel._combine import emit_combine, find_nested_reduce_accums, single_thread_var
@@ -213,7 +216,7 @@ def _materialize(blk: ThreadTile, *, warp_size: int, escape=None) -> Stmt:
             out.append(s)
         return out
 
-    def emit_async_wait(stmt: AsyncWait) -> list[Stmt]:
+    def emit_async_wait(stmt: AsyncWait, *, ws_consumer: WarpSpecialize | None = None) -> list[Stmt]:
         # TMA path: wait carries the explicit consumer-side phase + slot
         # set by 015_pipeline_k_outer. The wait targets its pipeline-unit
         # group's mbar (each group has its own mbar with arrive count
@@ -226,11 +229,26 @@ def _materialize(blk: ThreadTile, *, warp_size: int, escape=None) -> Stmt:
         # (BM=16, BN=16 + stage) where the inner-loop schedule makes
         # the reorder profitable; on larger tiles the schedule is
         # dense enough that no useful hoist is possible.
-        # AsyncWait.barrier_id / barrier_count let the caller (085 for WS
-        # kernels) route the trailing CTA fence to a named barrier
-        # (``bar.sync N, count``) instead of ``__syncthreads()``. Default
-        # 0 keeps every legacy emission on ``__syncthreads()``.
-        trailing_sync = Sync(barrier_id=stmt.barrier_id, count=stmt.barrier_count)
+        # The trailing fence routes to a named ``bar.sync`` when we're
+        # inside a WarpSpecialize consumer subtree (``__syncthreads()``
+        # is CUDA UB on the warp-divergent producer/consumer branch).
+        # Two channels supply the params, in priority order:
+        #
+        #   1. ``ws_consumer`` (preferred) — derive participants from
+        #      the WS context the materializer threads into the consumer
+        #      subtree walk. Used by ``emit_warp_specialize``.
+        #   2. ``stmt.barrier_id`` / ``stmt.barrier_count`` (legacy) —
+        #      085 stamps these for backward compat; deleted in C4.
+        if ws_consumer is not None:
+            outer_ext = thread_axes[0].extent.as_static()
+            inner_prod = 1
+            for ax in thread_axes[1:]:
+                inner_prod *= ax.extent.as_static()
+            extension = ws_consumer.n_producer_threads // inner_prod
+            n_cons = (outer_ext - extension) * inner_prod
+            trailing_sync = Sync(barrier_id=1, count=n_cons)
+        else:
+            trailing_sync = Sync(barrier_id=stmt.barrier_id, count=stmt.barrier_count)
         if stmt.phase is not None and tma.has_tma:
             gid = tma.wait_group.get(id(stmt))
             if gid is not None:
@@ -382,32 +400,164 @@ def _materialize(blk: ThreadTile, *, warp_size: int, escape=None) -> Stmt:
                 )
         return out
 
-    def _process_stmt(stmt: Stmt) -> list[Stmt]:
+    def emit_warp_specialize(ws: WarpSpecialize) -> list[Stmt]:
+        """Lower a Tile-IR ``WarpSpecialize`` into the full mbarrier
+        handshake: empty-mbarrier ring + per-K_o ``MbarrierWait`` /
+        ``MbarrierArrive`` pairs + named ``bar.sync`` consumer fences +
+        ``SetMaxNReg`` register-budget redistribution + producer /
+        consumer ``Cond`` wrapper.
+
+        Geometry (predicate, consumer thread count, first-consumer tid)
+        is derived from the enclosing ``ThreadTile.axes`` and
+        ``ws.n_producer_threads`` — the WS pass doesn't carry them.
+        """
+        from deplodock.compiler.ir.stmt.body import Body  # noqa: PLC0415
+
+        outer = thread_axes[0]
+        outer_extent = outer.extent.as_static()
+        inner_product = 1
+        for ax in thread_axes[1:]:
+            inner_product *= ax.extent.as_static()
+        if ws.n_producer_threads % inner_product != 0:
+            raise ValueError(
+                f"WarpSpecialize: n_producer_threads ({ws.n_producer_threads}) "
+                f"must be divisible by inner thread-axes product ({inner_product})"
+            )
+        extension = ws.n_producer_threads // inner_product
+        n_consumer_threads = (outer_extent - extension) * inner_product
+        first_consumer_tid = ws.n_producer_threads
+        bc = ws.ring_depth
+        empty_mbar = "tma_mbar_empty"
+
+        # Empty-mbarrier prologue: Smem + per-slot MbarrierInit (single-
+        # thread gated) + Sync. Init count = 1 — exactly one consumer
+        # thread arrives per slot release.
+        empty_decl = Smem(name=empty_mbar, extents=(bc,), dtype="unsigned long long")
+        empty_inits = tuple(MbarrierInit(mbar=empty_mbar, count=1, slot=Literal(s, "int")) for s in range(bc))
+        init_cond = Cond(
+            cond=BinaryExpr("==", Builtin("thread_idx.x"), Literal(0, "int")),
+            body=empty_inits,
+        )
+
+        # Wire producer-side wait + consumer-side arrive into each
+        # branch's serial_outer K_o body. Each helper reads k_var off the
+        # matched SerialTile.axis (post-normalize canonical names like
+        # ``a2`` rather than the WS-pass-time ``k_outer``).
+        wired_producer = _wire_producer_wait(ws.producer_body, empty_mbar, bc)
+        wired_consumer = _wire_consumer_arrive(
+            ws.consumer_body, empty_mbar, bc, first_consumer_tid, n_consumer_threads
+        )
+
+        # Materialize each branch. Consumer-side AsyncWaits route their
+        # trailing fence through the named ``bar.sync 1, n_consumer``
+        # path — pass ws_consumer=ws into emit_async_wait via the ews
+        # plumbing.
+        def cons_ews(stmt: AsyncWait) -> list[Stmt]:
+            return emit_async_wait(stmt, ws_consumer=ws)
+
+        prod_out: list[Stmt] = []
+        for s in wired_producer:
+            prod_out.extend(_process_stmt(s))
+        cons_out: list[Stmt] = []
+        for s in wired_consumer:
+            cons_out.extend(_process_stmt(s, ews=cons_ews))
+
+        ws_cond = Cond(
+            cond=BinaryExpr("<", Var(outer.name), Literal(extension, "int")),
+            body=Body((SetMaxNReg(24, "dec"), *prod_out)),
+            else_body=Body((SetMaxNReg(240, "inc"), *cons_out)),
+        )
+        return [empty_decl, init_cond, Sync(), ws_cond]
+
+    def _wire_producer_wait(stmts, empty_mbar: str, bc: int):
+        """Prepend a ``MbarrierWait(empty[slot], phase)`` inside each
+        top-level ``SerialTile(serial_outer)``, gated by ``Cond(K_o >=
+        bc-1)`` so the first ``bc-1`` iters skip (those slots were
+        unfilled by the prologue). The K_o axis name is read off the
+        matched ``SerialTile.axis`` (canonical post-normalize)."""
+        from deplodock.compiler.ir.stmt.body import Body  # noqa: PLC0415
+
+        out: list[Stmt] = []
+        for s in stmts:
+            if isinstance(s, SerialTile) and s.kind == "serial_outer":
+                k_var = s.axis.name
+                k_plus_1 = Var(k_var) + Literal(1, "int")
+                slot_expr = k_plus_1 % Literal(bc, "int")
+                phase_expr = (k_plus_1 / Literal(bc, "int") - Literal(1, "int")) % Literal(2, "int")
+                wait_cond = Cond(
+                    cond=BinaryExpr(">=", Var(k_var), Literal(bc - 1, "int")),
+                    body=(MbarrierWait(mbar=empty_mbar, phase=phase_expr, slot=slot_expr),),
+                )
+                new_inner = Body((wait_cond, *s.body))
+                out.append(s.with_bodies((new_inner,)))
+            else:
+                out.append(s)
+        return out
+
+    def _wire_consumer_arrive(stmts, empty_mbar: str, bc: int, first_cons_tid: int, n_cons: int):
+        """Recursively descend stmts; inside every
+        ``SerialTile(serial_outer)``, append a named
+        ``Sync(barrier_id=1, count=n_cons)`` + a single-thread
+        ``MbarrierArrive``. The Sync is critical: without it the chosen
+        arriving thread (``threadIdx.x == first_cons_tid``) can race
+        ahead of slower consumers still reading the slot's smem; the
+        arrive then flips the empty mbarrier and the producer is free
+        to overwrite the slot mid-read."""
+        from deplodock.compiler.ir.stmt.body import Body  # noqa: PLC0415
+
+        def _augment(stmt: Stmt) -> Stmt:
+            if isinstance(stmt, SerialTile) and stmt.kind == "serial_outer":
+                k_var = stmt.axis.name
+                slot_expr = Var(k_var) % Literal(bc, "int")
+                barrier_sync = Sync(barrier_id=1, count=n_cons)
+                arrive_cond = Cond(
+                    cond=BinaryExpr("==", Builtin("thread_idx.x"), Literal(first_cons_tid, "int")),
+                    body=(MbarrierArrive(mbar=empty_mbar, slot=slot_expr),),
+                )
+                return stmt.with_bodies((Body((*stmt.body, barrier_sync, arrive_cond)),))
+            nested = stmt.nested()
+            if nested:
+                return stmt.with_bodies(tuple(Body(tuple(_augment(c) for c in b)) for b in nested))
+            return stmt
+
+        return [_augment(s) for s in stmts]
+
+    def _process_stmt(stmt: Stmt, *, ews=None) -> list[Stmt]:
         """Materialize one body Stmt — bundles inline their producer code
-        then recursively process their consumer body."""
+        then recursively process their consumer body.
+
+        ``ews`` overrides the per-walk ``emit_async_wait`` flavor — used
+        by ``emit_warp_specialize`` to thread a ``ws_consumer`` context
+        through the consumer subtree so AsyncWaits route their trailing
+        fence to the named ``bar.sync``."""
+        if ews is None:
+            ews = emit_async_wait
+        if isinstance(stmt, WarpSpecialize):
+            return list(emit_warp_specialize(stmt))
         if isinstance(stmt, StageBundle):
             out_local: list[Stmt] = list(filter_emit(emit_bundle_producer(stmt)))
             for inner in stmt.body:
-                out_local.extend(_process_stmt(inner))
+                out_local.extend(_process_stmt(inner, ews=ews))
             return out_local
         if isinstance(stmt, AsyncWait):
-            return list(emit_async_wait(stmt))
+            return list(ews(stmt))
         if isinstance(stmt, Cond):
-            # 085_warp_specialize wraps producer + consumer subtrees in
-            # a top-level ``Cond(warp_role_check, prod, cons)`` — both
-            # branches may contain StageBundles / AsyncWaits / SerialTiles
-            # that need recursive processing.
+            # Top-level Cond wrapping StageBundles / AsyncWaits — both
+            # branches may contain stmts that need recursive processing.
+            # (Pre-WarpSpecialize 085 emitted bare role-split Conds here;
+            # left in place because user-emitted Conds and other rules
+            # may still reach this point.)
             from deplodock.compiler.ir.stmt.body import Body  # noqa: PLC0415
 
             body_out: list[Stmt] = []
             for inner in stmt.body:
-                body_out.extend(_process_stmt(inner))
+                body_out.extend(_process_stmt(inner, ews=ews))
             else_out: list[Stmt] = []
             for inner in stmt.else_body:
-                else_out.extend(_process_stmt(inner))
+                else_out.extend(_process_stmt(inner, ews=ews))
             return [Cond(cond=stmt.cond, body=Body(tuple(body_out)), else_body=Body(tuple(else_out)))]
         if isinstance(stmt, (SerialTile, StridedTile, RegisterTile)):
-            single = _emit_loop(stmt, tid_expr, n_threads, transform, filter_emit, emit_bundle_producer, emit_async_wait)
+            single = _emit_loop(stmt, tid_expr, n_threads, transform, filter_emit, emit_bundle_producer, ews)
             extra: list[Stmt] = []
             if isinstance(stmt, (SerialTile, StridedTile)) and stmt.is_reduce:
                 accums_in_scope = {a.name: a for a in stmt.body if isinstance(a, Accum)}

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/_tma_groups.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/_tma_groups.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from deplodock.compiler.ir.stmt import Cond, Stmt
-from deplodock.compiler.ir.tile.ir import AsyncWait, SerialTile, StageBundle, StagePolicy
+from deplodock.compiler.ir.tile.ir import AsyncWait, SerialTile, StageBundle, StagePolicy, WarpSpecialize
 
 
 def _is_tma_bundle(s) -> bool:
@@ -153,12 +153,19 @@ def partition_tma_groups(body: tuple[Stmt, ...]) -> TmaGroups:
                 # its body so inner K_o loops still get discovered.
                 _walk(tuple(stmt.body))
                 continue
+            if isinstance(stmt, WarpSpecialize):
+                # 085_warp_specialize packs producer (TMA bundles) and
+                # consumer (AsyncWaits, reduce) into the two branches of
+                # a WarpSpecialize marker. Recurse with shared state so
+                # the bundles in producer_body and the AsyncWaits in
+                # consumer_body join the same pipeline-unit group.
+                _walk(tuple(stmt.producer_body))
+                _walk(tuple(stmt.consumer_body))
+                continue
             if isinstance(stmt, Cond):
-                # Warp-specialized output from 085_warp_specialize wraps
-                # producer + consumer subtrees in a Cond. Treat both
-                # branches as transparent: recurse with shared state so
-                # bundles in the producer branch + AsyncWaits in the
-                # consumer branch all join the same logical group.
+                # Pre-WarpSpecialize 085 emitted producer/consumer as a
+                # bare Cond; left in place for any other rule that may
+                # emit a Cond around StageBundles / AsyncWaits.
                 _walk(tuple(stmt.body))
                 _walk(tuple(stmt.else_body))
                 continue

--- a/deplodock/compiler/pipeline/passes/lowering/tile/085_warp_specialize.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/085_warp_specialize.py
@@ -20,31 +20,22 @@ The structural rewrite (WS=1 only):
    new_extent)`` which the σ shifts back to ``[0, original_extent)``
    inside the consumer body — every Load/Write index, every Loop bound,
    every cooperative-thread reference stays correct.
-3. **Allocate the empty mbarrier ring** (``Smem`` +
-   per-slot ``MbarrierInit`` inside a single-thread ``Cond``,
-   followed by ``Sync``) at the top of the new ThreadTile body. Init
-   count = 1 — exactly one consumer thread arrives per slot release.
-4. **Split the body by role** into producer / consumer subtrees:
-   - Producer subtree keeps ``StageBundle``s; inside each
-     ``SerialTile(serial_outer)`` it inserts ``MbarrierWait(empty[..],
-     phase=..)`` before the issue, gated by ``Cond(K_o >= bc-1, ...)``
-     so the first ``bc-1`` iters skip (those slots were unfilled by
-     prologue).
+3. **Split the body by role** into producer / consumer subtrees:
+   - Producer subtree keeps ``StageBundle``s.
    - Consumer subtree keeps ``AsyncWait`` + reduce ``SerialTile`` +
-     output ``Write``s; inside each ``SerialTile(serial_outer)`` it
-     appends ``MbarrierArrive(empty[slot])`` after the reduce, gated
-     by ``Cond(thread_idx == n_producer_threads, ...)`` so exactly one
-     consumer thread arrives. Consumer-side ``AsyncWait``s carry
-     ``barrier_id=1, barrier_count=n_consumer_threads`` so the
-     materializer's lowered trailing ``Sync`` is a named ``bar.sync``
-     (``__syncthreads`` is CUDA UB on the warp-divergent ``Cond``).
-5. **Wrap producer + consumer in ``Cond(inner_axis < extension, ...,
-   ...)``** with ``SetMaxNReg(24, "dec")`` and ``SetMaxNReg(240,
-   "inc")`` at the top of each branch.
+     output ``Write``s.
+4. **Package as a single Tile-IR ``WarpSpecialize`` Stmt** carrying the
+   role bodies, ring depth (= TMA buffer_count), and producer thread
+   count. The materializer (``100_materialize_tile.emit_warp_specialize``)
+   expands this into the empty-mbarrier ring, per-K_o handshake,
+   producer/consumer ``Cond`` wrapper, and ``SetMaxNReg`` register-
+   budget framing — none of which appear at Tile level.
 
-The materializer (``100_materialize_tile``) sees standard tile IR plus
-the new Cond / Smem / MbarrierInit / MbarrierArrive / SetMaxNReg
-primitives in the body and lowers each 1:1 without any WS-awareness.
+This pass stays inside the Tile-IR dialect — no ``from
+deplodock.compiler.ir.kernel.ir import …``. The boundary mirrors what
+``080_pipeline_stages`` already does for ``AsyncWait``: declare
+scheduling intent at Tile level, materializer fills in the hardware
+primitives.
 
 Eligibility:
 
@@ -63,17 +54,13 @@ Eligibility:
 
 from __future__ import annotations
 
-from dataclasses import replace
-
 from deplodock.compiler.context import Context
 from deplodock.compiler.graph import Node
 from deplodock.compiler.ir.axis import Axis
-from deplodock.compiler.ir.expr import BinaryExpr, Builtin, Literal, Var
-from deplodock.compiler.ir.kernel.ir import MbarrierArrive, MbarrierInit, MbarrierWait, SetMaxNReg, Smem, Sync
+from deplodock.compiler.ir.expr import Literal, Var
 from deplodock.compiler.ir.sigma import Sigma
-from deplodock.compiler.ir.stmt import Body, Cond, Stmt
+from deplodock.compiler.ir.stmt import Body, Stmt
 from deplodock.compiler.ir.tile.ir import (
-    AsyncWait,
     GridTile,
     RegisterTile,
     SerialTile,
@@ -81,6 +68,7 @@ from deplodock.compiler.ir.tile.ir import (
     StagePolicy,
     ThreadTile,
     TileOp,
+    WarpSpecialize,
 )
 from deplodock.compiler.pipeline import Pattern, RuleSkipped
 from deplodock.compiler.pipeline.knob import Knob, KnobType
@@ -218,78 +206,6 @@ def _split_by_role(stmts: tuple[Stmt, ...]) -> tuple[list[Stmt], list[Stmt]]:
     return producer, consumer
 
 
-def _wire_producer_wait(stmts: list[Stmt], empty_mbar: str, bc: int) -> list[Stmt]:
-    """Inside each producer K_o body, prepend a ``MbarrierWait`` on the
-    empty mbarrier slot, gated by ``Cond(K_o >= bc-1)`` (first ``bc-1``
-    iters fill slots that weren't touched by the prologue)."""
-    out: list[Stmt] = []
-    for s in stmts:
-        if isinstance(s, SerialTile) and s.kind == "serial_outer":
-            k_var = s.axis.name
-            k_plus_1 = Var(k_var) + Literal(1, "int")
-            slot_expr = k_plus_1 % Literal(bc, "int")
-            phase_expr = (k_plus_1 / Literal(bc, "int") - Literal(1, "int")) % Literal(2, "int")
-            wait_cond = Cond(
-                cond=BinaryExpr(">=", Var(k_var), Literal(bc - 1, "int")),
-                body=(MbarrierWait(mbar=empty_mbar, phase=phase_expr, slot=slot_expr),),
-            )
-            new_inner = Body((wait_cond, *s.body))
-            out.append(s.with_bodies((new_inner,)))
-        else:
-            out.append(s)
-    return out
-
-
-def _wire_consumer_arrive(stmts: list[Stmt], empty_mbar: str, bc: int, first_consumer_tid: int, n_consumer_threads: int) -> list[Stmt]:
-    """Recursively walk the consumer subtree; inside each
-    ``SerialTile(serial_outer)`` body, append a named-barrier ``Sync``
-    + a single-thread ``MbarrierArrive`` on the empty-mbar slot.
-
-    The Sync is critical: without it, the chosen arriving thread
-    (``threadIdx.x == first_consumer_tid``) can race ahead of slower
-    consumer threads still reading the slot's smem. The arrive flips
-    the empty mbarrier → producer can refill the slot → racing reads
-    see corrupted data. The named ``bar.sync barrier_id=1,
-    n_consumer_threads`` blocks all consumer threads at the loop's
-    tail before the arrive, so the slot's reads are all finished by
-    the time the producer is free to refill.
-
-    Recursion descends into any wrapper (e.g. ``RegisterTile`` around
-    the K_o loop in blocked matmul); the K_o loop itself isn't
-    recursed into."""
-
-    def _augment(stmt: Stmt) -> Stmt:
-        if isinstance(stmt, SerialTile) and stmt.kind == "serial_outer":
-            k_var = stmt.axis.name
-            slot_expr = Var(k_var) % Literal(bc, "int")
-            barrier_sync = Sync(barrier_id=1, count=n_consumer_threads)
-            arrive_cond = Cond(
-                cond=BinaryExpr("==", Builtin("thread_idx.x"), Literal(first_consumer_tid, "int")),
-                body=(MbarrierArrive(mbar=empty_mbar, slot=slot_expr),),
-            )
-            return stmt.with_bodies((Body((*stmt.body, barrier_sync, arrive_cond)),))
-        nested = stmt.nested()
-        if nested:
-            return stmt.with_bodies(tuple(Body(tuple(_augment(c) for c in b)) for b in nested))
-        return stmt
-
-    return [_augment(s) for s in stmts]
-
-
-def _stamp_async_wait_barrier(body: Body, count: int) -> Body:
-    """Recursively stamp ``barrier_id=1, barrier_count=count`` onto every
-    ``AsyncWait`` in the body. The materializer's lowered trailing
-    ``Sync`` then becomes a named ``bar.sync`` instead of the default
-    ``__syncthreads()`` (UB on the warp-divergent consumer Cond)."""
-
-    def _xform(s: Stmt) -> Stmt:
-        if isinstance(s, AsyncWait):
-            return replace(s, barrier_id=1, barrier_count=count)
-        return s
-
-    return body.map(_xform)
-
-
 def _apply_sigma(body: Body, sigma: Sigma) -> Body:
     """Apply ``sigma`` to every Stmt in ``body`` — substitutes the
     extended-axis Var with its shifted form throughout. ``Stmt.rewrite``
@@ -300,23 +216,22 @@ def _apply_sigma(body: Body, sigma: Sigma) -> Body:
 
 
 def _ws_transform(op: TileOp) -> TileOp:
-    """Build the WS=1 TileOp by structurally rewriting ``op``'s body."""
+    """Build the WS=1 TileOp by structurally rewriting ``op``'s body.
+
+    Output shape: the extended ThreadTile holds a single
+    ``WarpSpecialize`` carrying the two role bodies. The materializer
+    fabricates the mbarrier ring, handshake, register-budget framing,
+    and producer/consumer Cond wrapper from this marker."""
     tt = _find_thread_tile(op.body)
     assert tt is not None  # _eligible enforces
 
     outer = tt.axes[0]
-    outer_extent = outer.extent.as_static()
     inner_product = 1
     for ax in tt.axes[1:]:
         inner_product *= ax.extent.as_static()
     extension = _N_PRODUCER_THREADS // inner_product
     extended_outer = Axis(name=outer.name, extent=outer.extent + Literal(extension, "int"))
     new_axes = (extended_outer, *tt.axes[1:])
-
-    # Consumer threads = original total (we extended by exactly the
-    # producer count, so the consumer range still spans the original
-    # axis product). Used for the named-barrier participant count.
-    n_consumer_threads = outer_extent * inner_product
 
     # Sigma to shift the extended outer axis back into [0, outer_extent)
     # inside the consumer body. Producer threads have outer-axis values
@@ -325,42 +240,24 @@ def _ws_transform(op: TileOp) -> TileOp:
     sigma = Sigma({outer.name: Var(outer.name) - Literal(extension, "int")})
 
     bc = _first_buffer_count(op.body)
-    empty_mbar = "tma_mbar_empty"
-
-    # Empty mbarrier prologue: Smem + per-slot MbarrierInit (single-thread
-    # gated) + Sync. Placed at the top of the new ThreadTile body so the
-    # materializer's regular flow picks up the Smem decl and the
-    # MbarrierInit Conds + Sync render as-is.
-    empty_decl = Smem(name=empty_mbar, extents=(bc,), dtype="unsigned long long")
-    empty_inits = tuple(MbarrierInit(mbar=empty_mbar, count=1, slot=Literal(s, "int")) for s in range(bc))
-    init_cond = Cond(cond=BinaryExpr("==", Builtin("thread_idx.x"), Literal(0, "int")), body=empty_inits)
 
     # Split the original ThreadTile body into producer / consumer halves.
     prod_stmts, cons_stmts = _split_by_role(tuple(tt.body))
 
-    # Wire empty-mbarrier wait/arrive into the role-specific K_o bodies.
-    prod_stmts = _wire_producer_wait(prod_stmts, empty_mbar, bc)
-    # First consumer thread = extension * inner_product = _N_PRODUCER_THREADS.
-    cons_stmts = _wire_consumer_arrive(cons_stmts, empty_mbar, bc, _N_PRODUCER_THREADS, n_consumer_threads)
-
     # Apply the σ-shift to the consumer subtree (every Load/Write index,
-    # Loop bound, Accum ref), then stamp consumer-side AsyncWaits with
-    # the named-barrier params.
+    # Loop bound, Accum ref). Producer stays unshifted because producer
+    # threads have outer ∈ [0, extension) — exactly the pre-extension
+    # zero-based range.
     cons_body = _apply_sigma(Body(tuple(cons_stmts)), sigma)
-    cons_body = _stamp_async_wait_barrier(cons_body, count=n_consumer_threads)
 
-    # Wrap producer + consumer in Cond(outer < extension, prod, σ(cons))
-    # with SetMaxNReg framing each branch. The outermost axis controls
-    # producer/consumer membership; row-major decode places producer
-    # threads (outer ∈ [0, extension)) at contiguous tid [0, n_producer).
-    ws_cond = Cond(
-        cond=BinaryExpr("<", Var(outer.name), Literal(extension, "int")),
-        body=Body((SetMaxNReg(24, "dec"), *prod_stmts)),
-        else_body=Body((SetMaxNReg(240, "inc"), *cons_body)),
+    ws = WarpSpecialize(
+        producer_body=Body(tuple(prod_stmts)),
+        consumer_body=cons_body,
+        ring_depth=bc,
+        n_producer_threads=_N_PRODUCER_THREADS,
     )
 
-    new_tt_body = Body((empty_decl, init_cond, Sync(), ws_cond))
-    new_tt = ThreadTile(axes=new_axes, body=new_tt_body)
+    new_tt = ThreadTile(axes=new_axes, body=Body((ws,)))
 
     # Rewrap in GridTile if needed.
     new_outer: list[Stmt] = []

--- a/tests/architecture/test_layering.py
+++ b/tests/architecture/test_layering.py
@@ -1,0 +1,46 @@
+"""Layering guards — static import checks that lock in dialect boundaries.
+
+These tests don't exercise behavior. They scan source files for forbidden
+import patterns that would silently undo earlier refactors. Fast, no
+GPU, no test fixtures — they just open files and grep.
+
+Update / extend when adding a new layered subsystem; add a new test in
+this file rather than scattering one-off greps elsewhere.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+# Repo root: tests/architecture/ → tests/ → repo
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def test_lowering_tile_does_not_import_kernel_ir() -> None:
+    """``lowering/tile/*.py`` may not import from ``ir.kernel.ir``.
+
+    The Tile-IR / Kernel-IR boundary is: Tile passes encode scheduling
+    *decisions* (``StagePolicy``, ``AsyncWait``, ``WarpSpecialize``);
+    Kernel-IR carries hardware *primitives* (``Sync``, ``Smem``,
+    ``Mbarrier*``, ``SetMaxNReg``, …) that the materializer
+    (``100_materialize_tile``) emits. A Tile pass that imports
+    Kernel-IR types is fabricating Kernel stmts inside a Tile body —
+    exactly what PR #166 did to ``085_warp_specialize`` and what the
+    WarpSpecialize Stmt refactor undid.
+
+    If this test fires, either:
+    1. you genuinely need a new Tile-level abstraction (add a Stmt to
+       ``ir/tile/ir.py``, lower it in ``100_materialize_tile``), or
+    2. you're in the wrong directory — Kernel-IR-emitting passes live
+       under ``lowering/kernel/``.
+    """
+    tile_dir = _REPO_ROOT / "deplodock" / "compiler" / "pipeline" / "passes" / "lowering" / "tile"
+    assert tile_dir.is_dir(), f"lowering/tile/ not found at {tile_dir}"
+    forbidden = "from deplodock.compiler.ir.kernel"
+    offenders: list[str] = []
+    for py in sorted(tile_dir.glob("*.py")):
+        text = py.read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if forbidden in line:
+                offenders.append(f"{py.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()}")
+    assert not offenders, "lowering/tile/*.py must not import from ir.kernel — layering violation.\n" + "\n".join(offenders)

--- a/tests/compiler/ir/tile/test_warp_specialize_stmt.py
+++ b/tests/compiler/ir/tile/test_warp_specialize_stmt.py
@@ -1,0 +1,192 @@
+"""Stmt-protocol tests for ``WarpSpecialize`` (the Tile-IR carrier for the
+warp-specialization producer/consumer split).
+
+The materializer's lowering of ``WarpSpecialize`` into mbarrier
+primitives lives in ``tests/compiler/passes/test_materialize_warp_specialize.py``;
+this file only checks that the dataclass plays nicely with the generic
+body-walker protocol (``nested()`` / ``with_bodies()``) and the
+rewrite/simplify dispatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.sigma import Sigma
+from deplodock.compiler.ir.stmt import Body, Cond
+from deplodock.compiler.ir.tile.ir import AsyncWait, WarpSpecialize
+
+
+def _ws(**overrides):
+    """Build a minimal WarpSpecialize for protocol tests."""
+    kwargs = dict(
+        producer_body=Body((AsyncWait(keep=0),)),
+        consumer_body=Body((AsyncWait(keep=1),)),
+        ring_depth=2,
+        n_producer_threads=32,
+    )
+    kwargs.update(overrides)
+    return WarpSpecialize(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Construction + validation
+# ---------------------------------------------------------------------------
+
+
+def test_construct_basic():
+    ws = _ws()
+    assert ws.ring_depth == 2
+    assert ws.n_producer_threads == 32
+
+
+def test_body_coercion_from_tuple():
+    """tuple → Body coercion mirrors StageBundle / Cond."""
+    ws = WarpSpecialize(
+        producer_body=(AsyncWait(keep=0),),  # type: ignore[arg-type]
+        consumer_body=(AsyncWait(keep=1),),  # type: ignore[arg-type]
+        ring_depth=2,
+        n_producer_threads=32,
+    )
+    assert isinstance(ws.producer_body, Body)
+    assert isinstance(ws.consumer_body, Body)
+
+
+def test_rejects_zero_ring_depth():
+    with pytest.raises(ValueError, match="ring_depth"):
+        _ws(ring_depth=0)
+
+
+def test_rejects_zero_n_producer_threads():
+    with pytest.raises(ValueError, match="n_producer_threads"):
+        _ws(n_producer_threads=0)
+
+
+def test_rejects_nested_warp_specialize_in_producer():
+    inner = _ws()
+    with pytest.raises(ValueError, match="cannot nest"):
+        _ws(producer_body=Body((inner,)))
+
+
+def test_rejects_nested_warp_specialize_in_consumer():
+    inner = _ws()
+    with pytest.raises(ValueError, match="cannot nest"):
+        _ws(consumer_body=Body((inner,)))
+
+
+def test_rejects_nested_warp_specialize_deep_in_consumer():
+    """Nesting check looks through Cond wrappers — not just top-level."""
+    inner = _ws()
+    wrapper = Cond(cond=Var("p"), body=(inner,))
+    with pytest.raises(ValueError, match="cannot nest"):
+        _ws(consumer_body=Body((wrapper,)))
+
+
+# ---------------------------------------------------------------------------
+# Body-walker protocol — nested() / with_bodies()
+# ---------------------------------------------------------------------------
+
+
+def test_nested_returns_two_bodies():
+    ws = _ws()
+    assert ws.nested() == (ws.producer_body, ws.consumer_body)
+
+
+def test_with_bodies_round_trip():
+    ws = _ws()
+    same = ws.with_bodies(ws.nested())
+    assert same == ws
+
+
+def test_with_bodies_replaces_both():
+    ws = _ws()
+    new_prod = Body((AsyncWait(keep=2),))
+    new_cons = Body((AsyncWait(keep=3),))
+    ws2 = ws.with_bodies((new_prod, new_cons))
+    assert isinstance(ws2, WarpSpecialize)
+    assert ws2.producer_body == new_prod
+    assert ws2.consumer_body == new_cons
+    # Scalar fields preserved.
+    assert ws2.ring_depth == ws.ring_depth
+    assert ws2.n_producer_threads == ws.n_producer_threads
+
+
+def test_with_bodies_wrong_arity_raises():
+    ws = _ws()
+    with pytest.raises(ValueError, match="expected 2 bodies"):
+        ws.with_bodies((Body(()),))
+
+
+def test_body_iter_recurses_into_both_branches():
+    """Body.iter walks nested bodies via Stmt.nested(); a WarpSpecialize in
+    a parent Body should expose both branches' stmts."""
+    ws = _ws()
+    outer = Body((ws,))
+    seen = list(outer.iter())
+    # The wrapper itself + the AsyncWait from each branch.
+    assert ws in seen
+    assert AsyncWait(keep=0) in seen
+    assert AsyncWait(keep=1) in seen
+
+
+# ---------------------------------------------------------------------------
+# rewrite / simplify — both bodies are visited
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_substitutes_into_both_bodies():
+    """A Sigma substitution on ``x`` reaches AsyncWait.phase inside both
+    producer and consumer bodies."""
+    ws = WarpSpecialize(
+        producer_body=Body((AsyncWait(keep=0, phase=Var("x")),)),
+        consumer_body=Body((AsyncWait(keep=1, phase=Var("x")),)),
+        ring_depth=2,
+        n_producer_threads=32,
+    )
+    sigma = Sigma({"x": Literal(7, "int")})
+    out = ws.rewrite(lambda n: n, sigma)
+    assert isinstance(out, WarpSpecialize)
+    # Both phases are now the literal 7.
+    prod_wait = out.producer_body[0]
+    cons_wait = out.consumer_body[0]
+    assert isinstance(prod_wait, AsyncWait)
+    assert isinstance(cons_wait, AsyncWait)
+    assert prod_wait.phase == Literal(7, "int")
+    assert cons_wait.phase == Literal(7, "int")
+
+
+def test_rewrite_preserves_scalar_fields():
+    ws = _ws()
+    out = ws.rewrite(lambda n: n, Sigma.IDENTITY)
+    assert isinstance(out, WarpSpecialize)
+    assert out.ring_depth == ws.ring_depth
+    assert out.n_producer_threads == ws.n_producer_threads
+
+
+# ---------------------------------------------------------------------------
+# Pretty printing
+# ---------------------------------------------------------------------------
+
+
+def test_pretty_contains_role_labels():
+    ws = _ws()
+    text = "\n".join(ws.pretty())
+    assert "warp_specialize" in text
+    assert "ring=2" in text
+    assert "n_prod=32" in text
+    assert "producer:" in text
+    assert "consumer:" in text
+
+
+# ---------------------------------------------------------------------------
+# Hashability — required by Stmt invariant
+# ---------------------------------------------------------------------------
+
+
+def test_hashable_and_equal():
+    a = _ws()
+    b = _ws()
+    assert hash(a) == hash(b)
+    assert a == b
+    assert {a, b} == {a}

--- a/tests/compiler/passes/test_materialize_warp_specialize.py
+++ b/tests/compiler/passes/test_materialize_warp_specialize.py
@@ -90,11 +90,7 @@ def _tile_op_with_ws(
     ``normalize_body`` will canonicalize it to ``a2``; the materializer
     reads the canonical name off the matched ``SerialTile.axis``."""
     k_axis = Axis("k_outer", 8)
-    cons_body = (
-        Body((AsyncWait(keep=1, phase=Var("k_outer") % Literal(2, "int")),))
-        if consumer_has_async_wait
-        else Body(())
-    )
+    cons_body = Body((AsyncWait(keep=1, phase=Var("k_outer") % Literal(2, "int")),)) if consumer_has_async_wait else Body(())
     producer_body = Body((SerialTile(axis=k_axis, body=Body(()), kind="serial_outer"),))
     consumer_body = Body((SerialTile(axis=k_axis, body=cons_body, kind="serial_outer"),))
     ws = WarpSpecialize(
@@ -133,10 +129,7 @@ def test_materializer_emits_empty_mbar_prologue():
     assert smem.extents == (2,)
     assert smem.dtype == "unsigned long long"
     # Init Cond gated on tid==0 holds MbarrierInit per slot.
-    init_conds = [
-        s for s in items
-        if isinstance(s, Cond) and any(isinstance(c, MbarrierInit) for c in s.body)
-    ]
+    init_conds = [s for s in items if isinstance(s, Cond) and any(isinstance(c, MbarrierInit) for c in s.body)]
     assert len(init_conds) >= 1, "missing single-thread MbarrierInit prologue"
     init_cond = init_conds[0]
     inits = [c for c in init_cond.body if isinstance(c, MbarrierInit)]
@@ -157,11 +150,7 @@ def test_materializer_wraps_branches_in_setmaxnreg_cond():
     consumer branch."""
     kernel = _materialize(_tile_op_with_ws())
     top = kernel.body[0]
-    role_conds = [
-        s for s in top.body
-        if isinstance(s, Cond)
-        and any(isinstance(c, SetMaxNReg) for c in s.body)
-    ]
+    role_conds = [s for s in top.body if isinstance(s, Cond) and any(isinstance(c, SetMaxNReg) for c in s.body)]
     assert len(role_conds) == 1, f"expected exactly one role-split Cond, got {len(role_conds)}"
     cond = role_conds[0]
     # Producer branch leads with SetMaxNReg(24, "dec").

--- a/tests/compiler/passes/test_materialize_warp_specialize.py
+++ b/tests/compiler/passes/test_materialize_warp_specialize.py
@@ -1,0 +1,274 @@
+"""Materializer integration tests for ``WarpSpecialize``.
+
+Build a minimal TileOp that holds a ``WarpSpecialize`` directly (skip
+the 085 pass) and run the materializer. Check that:
+
+- the prologue has ``Smem("tma_mbar_empty", ...) + Cond(tid==0, [MbarrierInit
+  per slot]) + Sync()``;
+- producer / consumer subtrees are wrapped in
+  ``Cond(outer < extension, [SetMaxNReg(24,"dec"), ...], [SetMaxNReg(240,"inc"), ...])``;
+- producer-side ``SerialTile(serial_outer)`` matching ``serial_axis_name``
+  gets a ``MbarrierWait`` prepended inside a ``Cond(K_o >= bc-1)`` guard;
+- consumer-side ``SerialTile(serial_outer)`` matching ``serial_axis_name``
+  gets a trailing ``Sync(barrier_id=1, count=n_consumer_threads)`` +
+  single-thread ``MbarrierArrive``;
+- ``AsyncWait`` inside the consumer lowers with a named
+  ``Sync(barrier_id=1, count=n_cons)`` trailing fence;
+- ``AsyncWait`` outside any ``WarpSpecialize`` lowers with default
+  ``Sync(barrier_id=0)``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from deplodock.compiler.context import Context
+from deplodock.compiler.graph import Graph
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.kernel.ir import (
+    KernelOp,
+    MbarrierArrive,
+    MbarrierInit,
+    MbarrierWait,
+    SetMaxNReg,
+    Smem,
+    Sync,
+)
+from deplodock.compiler.ir.stmt import Body, Cond
+from deplodock.compiler.ir.tile.ir import (
+    AsyncWait,
+    SerialTile,
+    ThreadTile,
+    TileOp,
+    WarpSpecialize,
+)
+from deplodock.compiler.tensor import Tensor
+
+_mat = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.kernel.100_materialize_tile")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _materialize(tile_op: TileOp) -> KernelOp:
+    g = Graph()
+    g.add_node(op=tile_op, inputs=[], output=Tensor(tile_op.name, ()), node_id="op")
+    node = g.nodes["op"]
+    ctx = Context(compute_capability="sm_90")
+    result = _mat.rewrite(ctx, node)
+    assert isinstance(result, KernelOp), f"expected KernelOp, got {type(result).__name__}"
+    return result
+
+
+def _walk(stmts):
+    """Recursive walk yielding every Stmt in tree order."""
+    for s in stmts:
+        yield s
+        for sub in s.nested():
+            yield from _walk(sub)
+
+
+def _tile_op_with_ws(
+    *,
+    ring_depth: int = 2,
+    n_producer_threads: int = 32,
+    consumer_has_async_wait: bool = True,
+) -> TileOp:
+    """ThreadTile holding a single WarpSpecialize. Producer side has a
+    K_o ``SerialTile(serial_outer)`` (no children); consumer side has a
+    K_o ``SerialTile(serial_outer)`` optionally containing an
+    AsyncWait.
+
+    Inner thread-axis extent 16 → extension = 32 // 16 = 2. The OUTER
+    thread axis is the *post-extension* extent (the WS pass extends the
+    ThreadTile before emitting WarpSpecialize, so the materializer sees
+    the extended shape). Setting outer=6 yields consumer=(6-2)*16=64
+    threads. The bodies use axis name ``k_outer`` but TileOp's
+    ``normalize_body`` will canonicalize it to ``a2``; the materializer
+    reads the canonical name off the matched ``SerialTile.axis``."""
+    k_axis = Axis("k_outer", 8)
+    cons_body = (
+        Body((AsyncWait(keep=1, phase=Var("k_outer") % Literal(2, "int")),))
+        if consumer_has_async_wait
+        else Body(())
+    )
+    producer_body = Body((SerialTile(axis=k_axis, body=Body(()), kind="serial_outer"),))
+    consumer_body = Body((SerialTile(axis=k_axis, body=cons_body, kind="serial_outer"),))
+    ws = WarpSpecialize(
+        producer_body=producer_body,
+        consumer_body=consumer_body,
+        ring_depth=ring_depth,
+        n_producer_threads=n_producer_threads,
+    )
+    body = Body(
+        (
+            ThreadTile(
+                axes=(Axis("m_i", 6), Axis("n_i", 16)),
+                body=Body((ws,)),
+            ),
+        )
+    )
+    return TileOp(body=body, name="k_ws_test")
+
+
+# ---------------------------------------------------------------------------
+# Prologue: Smem + MbarrierInit cond + Sync
+# ---------------------------------------------------------------------------
+
+
+def test_materializer_emits_empty_mbar_prologue():
+    """The first three stmts of the materialized ThreadTile body are the
+    empty-mbarrier Smem decl, an init Cond gated on ``threadIdx.x==0``,
+    and a CTA-wide Sync."""
+    kernel = _materialize(_tile_op_with_ws(ring_depth=2))
+    # Outer is a ThreadTile; descend to its body.
+    top = kernel.body[0]
+    assert isinstance(top, ThreadTile)
+    items = list(top.body)
+    # First Smem named tma_mbar_empty.
+    smem = next(s for s in items if isinstance(s, Smem) and s.name == "tma_mbar_empty")
+    assert smem.extents == (2,)
+    assert smem.dtype == "unsigned long long"
+    # Init Cond gated on tid==0 holds MbarrierInit per slot.
+    init_conds = [
+        s for s in items
+        if isinstance(s, Cond) and any(isinstance(c, MbarrierInit) for c in s.body)
+    ]
+    assert len(init_conds) >= 1, "missing single-thread MbarrierInit prologue"
+    init_cond = init_conds[0]
+    inits = [c for c in init_cond.body if isinstance(c, MbarrierInit)]
+    assert len(inits) == 2, f"expected 2 MbarrierInit per slot, got {len(inits)}"
+    for c in inits:
+        assert c.mbar == "tma_mbar_empty"
+        assert c.count == 1
+
+
+# ---------------------------------------------------------------------------
+# Outer Cond shape — producer/consumer branches with SetMaxNReg
+# ---------------------------------------------------------------------------
+
+
+def test_materializer_wraps_branches_in_setmaxnreg_cond():
+    """The role-split Cond has SetMaxNReg(24,"dec") at the head of the
+    producer branch and SetMaxNReg(240,"inc") at the head of the
+    consumer branch."""
+    kernel = _materialize(_tile_op_with_ws())
+    top = kernel.body[0]
+    role_conds = [
+        s for s in top.body
+        if isinstance(s, Cond)
+        and any(isinstance(c, SetMaxNReg) for c in s.body)
+    ]
+    assert len(role_conds) == 1, f"expected exactly one role-split Cond, got {len(role_conds)}"
+    cond = role_conds[0]
+    # Producer branch leads with SetMaxNReg(24, "dec").
+    prod_head = cond.body[0]
+    assert isinstance(prod_head, SetMaxNReg)
+    assert prod_head.count == 24
+    assert prod_head.direction == "dec"
+    # Consumer branch leads with SetMaxNReg(240, "inc").
+    cons_head = cond.else_body[0]
+    assert isinstance(cons_head, SetMaxNReg)
+    assert cons_head.count == 240
+    assert cons_head.direction == "inc"
+
+
+# ---------------------------------------------------------------------------
+# Producer wiring — MbarrierWait inside K_o, gated by K_o >= bc-1
+# ---------------------------------------------------------------------------
+
+
+def test_producer_serial_outer_gets_mbarrier_wait():
+    """Inside the producer branch's ``SerialTile(serial_outer)``, the
+    head stmt is a ``Cond(K_o >= bc-1, [MbarrierWait(...)])``."""
+    kernel = _materialize(_tile_op_with_ws(ring_depth=2))
+    top = kernel.body[0]
+    role_cond = next(s for s in top.body if isinstance(s, Cond) and any(isinstance(c, SetMaxNReg) for c in s.body))
+    # Producer branch: SetMaxNReg, then SerialTile(serial_outer).
+    prod_loop = next(s for s in role_cond.body if isinstance(s, SerialTile) and s.kind == "serial_outer")
+    head = prod_loop.body[0]
+    assert isinstance(head, Cond), f"producer K_o head should be a Cond, got {type(head).__name__}"
+    inner_waits = [c for c in head.body if isinstance(c, MbarrierWait)]
+    assert len(inner_waits) == 1
+    assert inner_waits[0].mbar == "tma_mbar_empty"
+
+
+# ---------------------------------------------------------------------------
+# Consumer wiring — named Sync + tid-gated MbarrierArrive
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_serial_outer_gets_named_sync_and_arrive():
+    """Inside the consumer branch's ``SerialTile(serial_outer)``, the
+    tail two stmts are a named ``Sync(barrier_id=1, count=n_cons)`` and
+    a ``Cond(tid == n_producer, [MbarrierArrive])``."""
+    kernel = _materialize(_tile_op_with_ws(n_producer_threads=32, consumer_has_async_wait=False))
+    top = kernel.body[0]
+    role_cond = next(s for s in top.body if isinstance(s, Cond) and any(isinstance(c, SetMaxNReg) for c in s.body))
+    cons_loop = next(s for s in role_cond.else_body if isinstance(s, SerialTile) and s.kind == "serial_outer")
+    # Last two stmts: named Sync then single-thread MbarrierArrive Cond.
+    tail = list(cons_loop.body)[-2:]
+    assert len(tail) == 2
+    sync, arrive_cond = tail
+    assert isinstance(sync, Sync)
+    assert sync.barrier_id == 1
+    # n_cons = (outer_extent - extension) * inner_product. With
+    # n_producer_threads=32, inner_product=16, outer_extent gets
+    # extended to 4+2=6, so n_cons = (6-2)*16 = 64.
+    assert sync.count == 64
+    assert isinstance(arrive_cond, Cond)
+    arrive = next(c for c in arrive_cond.body if isinstance(c, MbarrierArrive))
+    assert arrive.mbar == "tma_mbar_empty"
+
+
+# ---------------------------------------------------------------------------
+# AsyncWait inside consumer uses named-barrier trailing fence
+# ---------------------------------------------------------------------------
+
+
+def test_async_wait_inside_consumer_routes_to_named_barrier():
+    """AsyncWait inside the consumer subtree lowers with
+    ``Sync(barrier_id=1, count=n_cons)`` for its trailing fence — not
+    the default ``Sync()`` / ``__syncthreads()``."""
+    kernel = _materialize(_tile_op_with_ws(consumer_has_async_wait=True))
+    # Find every Sync in the kernel body and check that at least one has
+    # barrier_id=1 (the named bar.sync for the consumer-side AsyncWait
+    # trailing fence and for the per-K_o consumer arrive).
+    named_syncs = [s for s in _walk(kernel.body) if isinstance(s, Sync) and s.barrier_id == 1]
+    assert len(named_syncs) >= 1, "expected at least one Sync(barrier_id=1) from consumer subtree"
+    # All named syncs should carry the same n_cons count.
+    assert all(s.count == 64 for s in named_syncs), f"named syncs have inconsistent count: {[s.count for s in named_syncs]}"
+
+
+def test_async_wait_outside_warp_specialize_uses_default_sync():
+    """A TileOp without a WarpSpecialize wrapper — AsyncWait lowers
+    with ``Sync(barrier_id=0, count=None)`` (the default
+    __syncthreads path)."""
+    k_var = "k_outer"
+    k_axis = Axis(k_var, 4)
+    body = Body(
+        (
+            ThreadTile(
+                axes=(Axis("t", 32),),
+                body=Body(
+                    (
+                        SerialTile(
+                            axis=k_axis,
+                            body=Body((AsyncWait(keep=1),)),
+                            kind="serial_outer",
+                        ),
+                    )
+                ),
+            ),
+        )
+    )
+    tile_op = TileOp(body=body, name="k_plain")
+    kernel = _materialize(tile_op)
+    # Find AsyncWait's trailing Sync — it follows a CpAsyncWait in
+    # _walk order; we just check no Sync carries barrier_id=1.
+    syncs = [s for s in _walk(kernel.body) if isinstance(s, Sync)]
+    assert any(s.barrier_id == 0 for s in syncs), "expected default __syncthreads"
+    assert not any(s.barrier_id == 1 for s in syncs), "no named bar.sync outside WS"

--- a/tests/compiler/passes/test_warp_specialize.py
+++ b/tests/compiler/passes/test_warp_specialize.py
@@ -27,6 +27,7 @@ from deplodock.compiler.ir.tile.ir import (
     SwizzleMode,
     ThreadTile,
     TileOp,
+    WarpSpecialize,
 )
 from deplodock.compiler.pipeline import RuleSkipped
 from deplodock.compiler.pipeline.pipeline import Fork
@@ -151,3 +152,49 @@ def test_env_pin_zero_returns_bare_tileop(monkeypatch):
     result = _run_rule(op)
     assert isinstance(result, TileOp)
     assert result.knobs["WS"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Boundary checks — Tile pass emits only Tile IR
+# ---------------------------------------------------------------------------
+
+
+def test_ws1_emits_warp_specialize_stmt(monkeypatch):
+    """WS=1 path produces a TileOp whose ThreadTile body contains a single
+    ``WarpSpecialize`` Stmt — not a hand-rolled Cond/Smem/MbarrierInit
+    tree. The materializer is responsible for the lowering."""
+    monkeypatch.setenv("DEPLODOCK_WS", "1")
+    op = _tile_op_tma_pipelined()
+    result = _run_rule(op)
+    assert isinstance(result, TileOp)
+    # Walk to the ThreadTile inside the body.
+    tt = next(s for s in result.body if isinstance(s, ThreadTile))
+    body = list(tt.body)
+    assert len(body) == 1, f"expected single WarpSpecialize in ThreadTile body, got {len(body)}"
+    assert isinstance(body[0], WarpSpecialize)
+
+
+def test_ws1_tile_body_contains_no_kernel_ir(monkeypatch):
+    """No Kernel-IR types (Smem / Sync / MbarrierInit / MbarrierWait /
+    MbarrierArrive / SetMaxNReg) appear anywhere inside the WS=1
+    TileOp body. The layering boundary is intact."""
+    # Local imports here — the check enforces that Kernel-IR types do
+    # not appear in the body, but we still need the types to assert.
+    from deplodock.compiler.ir.kernel.ir import (
+        MbarrierArrive,
+        MbarrierInit,
+        MbarrierWait,
+        SetMaxNReg,
+        Smem,
+        Sync,
+    )
+
+    monkeypatch.setenv("DEPLODOCK_WS", "1")
+    op = _tile_op_tma_pipelined()
+    result = _run_rule(op)
+    assert isinstance(result, TileOp)
+    forbidden = (Smem, Sync, MbarrierInit, MbarrierWait, MbarrierArrive, SetMaxNReg)
+    for stmt in result.body.iter():
+        assert not isinstance(stmt, forbidden), (
+            f"Tile-IR pass leaked Kernel-IR type {type(stmt).__name__} into TileOp body"
+        )

--- a/tests/compiler/passes/test_warp_specialize.py
+++ b/tests/compiler/passes/test_warp_specialize.py
@@ -195,6 +195,4 @@ def test_ws1_tile_body_contains_no_kernel_ir(monkeypatch):
     assert isinstance(result, TileOp)
     forbidden = (Smem, Sync, MbarrierInit, MbarrierWait, MbarrierArrive, SetMaxNReg)
     for stmt in result.body.iter():
-        assert not isinstance(stmt, forbidden), (
-            f"Tile-IR pass leaked Kernel-IR type {type(stmt).__name__} into TileOp body"
-        )
+        assert not isinstance(stmt, forbidden), f"Tile-IR pass leaked Kernel-IR type {type(stmt).__name__} into TileOp body"


### PR DESCRIPTION
## Context

PR #166 (warp specialization for TMA matmul) shipped working WS kernels but punched through the Tile-IR / Kernel-IR layering. `085_warp_specialize.py` imported `MbarrierArrive / MbarrierInit / MbarrierWait / SetMaxNReg / Smem / Sync` from `ir.kernel.ir` and spliced them into the Tile body itself; `AsyncWait` gained `barrier_id` / `barrier_count` fields that only made sense as named-`bar.sync` hardware identifiers.

The companion pass `080_pipeline_stages` (clean) declares pipelining intent with one Tile-IR Stmt (`AsyncWait`) and lets `100_materialize_tile`'s `emit_async_wait` translate to `CpAsyncWait+Sync` or `MbarrierWait+Sync` based on `StagePolicy`. WS should follow the same pattern. This PR makes it do so.

After this PR `lowering/tile/*.py` does not import from `ir.kernel.ir` — locked in by a CI guard.

## Approach

Two new artifacts, mirroring the 080 model:

1. **`WarpSpecialize` Tile-IR Stmt** (`ir/tile/ir.py`) — block Stmt with `producer_body` / `consumer_body` / `ring_depth` / `n_producer_threads`. Predicate, consumer thread count, slot/phase exprs, and mbar name are derivable at materialize time from the enclosing `ThreadTile.axes`. The K_o axis is discovered structurally (the single `SerialTile(serial_outer)` in each branch) rather than carried by name — survives `normalize_body`'s canonical Axis rename. `__post_init__` rejects nested `WarpSpecialize`.

2. **`emit_warp_specialize`** closure in `100_materialize_tile.py` — expands the marker into the empty-mbarrier ring (Smem + per-slot MbarrierInit gated on tid==0 + Sync), per-K_o handshake (MbarrierWait gated by `K_o >= bc-1` in the producer; named `bar.sync 1, n_cons` + single-thread MbarrierArrive appended in the consumer), and the producer/consumer `Cond` wrapper framed by `SetMaxNReg(24,\"dec\")` / `SetMaxNReg(240,\"inc\")`. `emit_async_wait` gains an optional `ws_consumer` kwarg; the consumer subtree walk threads it via a per-call `ews` override on `_process_stmt` so AsyncWaits inside route their trailing fence to the named bar.sync.

Pass + cleanup:

3. **`085_warp_specialize`** now packages the σ-shifted role split into a `WarpSpecialize` and stops. The hand-rolled `_wire_producer_wait` / `_wire_consumer_arrive` / `_stamp_async_wait_barrier` helpers and the inline Kernel-IR primitives are gone (pass shrinks ~430 → ~290 lines).

4. **`AsyncWait.barrier_id` / `barrier_count`** deleted — the materializer derives named-barrier params from the enclosing `WarpSpecialize` context instead.

5. **`tests/architecture/test_layering.py`** — static-import guard that scans `lowering/tile/*.py` for `from deplodock.compiler.ir.kernel` and fails CI if any reappear.

## Commit-by-commit

Each commit ends with `make test` green.

- **C1** `f48a9eb6` — Add `WarpSpecialize` Stmt + 16 protocol tests. Pure addition; nothing emits it yet.
- **C2** `62b253a2` — Add `emit_warp_specialize` + 6 materializer integration tests (build `WarpSpecialize` directly, materialize, check the lowered shape).
- **C3** `9ce8a083` — **Boundary restored.** `085_warp_specialize` emits `WarpSpecialize`; drops the Kernel-IR import and the wiring/stamping helpers. Adds 2 boundary checks to the existing pass tests.
- **C4** `f394e3c6` — Delete `AsyncWait.barrier_id` / `barrier_count` (the legacy C3-compat fields).
- **C5** `f268539e` — Add the layering CI guard.

## Verification

- `make test` — 1364 passed (+7 new), 27 skipped, 0 failed
- `make lint` — clean
- `grep -rn \"from deplodock.compiler.ir.kernel\" deplodock/compiler/pipeline/passes/lowering/tile/` — empty
- Unit-level coverage of the materializer's emitted shape: empty-mbar prologue, role-split Cond with SetMaxNReg framing, per-K_o handshake, named-bar trailing fence vs default `__syncthreads()` outside WS.

### What I didn't verify locally

End-to-end CUDA bit-equivalence vs `main` for a TMA-eligible matmul on sm_90 — I don't have a Hopper box in this session. Suggested check before merge:

\`\`\`
git checkout main
DEPLODOCK_WS=1 DEPLODOCK_DUMP_DIR=/tmp/ws_before deplodock compile --code \\
    \"import torch; torch.matmul(torch.randn(512, 512, dtype=torch.float16, device='cuda'), \\
     torch.randn(512, 512, dtype=torch.float16, device='cuda'))\" --target sm_90
git checkout feature/warp-specialize-tile-stmt
DEPLODOCK_WS=1 DEPLODOCK_DUMP_DIR=/tmp/ws_after deplodock compile --code \"...\" --target sm_90
diff -ur /tmp/ws_before /tmp/ws_after
\`\`\`

Expected: empty diff (modulo identifier shuffling if any). Then `DEPLODOCK_WS=1 deplodock run --code \"...\" --bench` for accuracy + latency parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)