### PR TITLE
Extract hierarchical Fork-tree builder to pipeline/fork_tree.py

### DIFF
--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -92,6 +92,16 @@ formula from cheap inputs (knob bundle + planner shape) so siblings rank
 without anyone instantiating a TileOp. The branch tree's `Fork.score`
 propagates max from leaves, matching MCTS's max-Q semantics.
 
+The tree-building algorithm itself (group params by per-level knob keys,
+collapse single-key levels, sort siblings by max-propagated score, defer
+leaf materialization to `expand` thunks) lives in `pipeline/fork_tree.py`
+as the reusable `Level` + `build_fork_tree` pair — `partition_loops`
+supplies the four `Level`s + `materialize=` + `score=` callables and
+forwards the result. Future rules with multi-level knob-cartesian forks
+should reuse the builder; one-shot flat forks (e.g.
+`lowering/tile/085_warp_specialize`'s `WS={0,1}` 2-element list) stay
+inline.
+
 **Register-blocked GEMM nest.** For matmul-shape kernels (`shape.k_loop is
 not None`, `params.fn > 1`, SPLITK = 1, BR = 1, no M-mask, no fused
 prologue), the planner emits the textbook blocked GEMM nest rather than

--- a/deplodock/compiler/pipeline/fork_tree.py
+++ b/deplodock/compiler/pipeline/fork_tree.py
@@ -1,0 +1,128 @@
+"""Hierarchical Fork-tree builder shared by pipeline rules that enumerate a
+knob cartesian.
+
+Converts a flat list of variant params into a Fork tree where each ``Level``
+groups siblings by a (sub)tuple of knob values, sorts siblings by max-
+propagated child score, and collapses levels whose key has a single distinct
+value across the group. The LAST level is the leaf level: its grouping
+produces one leaf Fork per param (no branch wrapper) — knobs stamped onto
+the leaf, ``expand`` thunk yields ``materialize(p)`` once the search engine
+resolves that leaf.
+
+Use this when a rule produces ≥2 hierarchical levels of knob bundling with
+score-propagated ranking (today: ``passes/lowering/tile/010_partition_loops``).
+For flat 2-element forks with no hierarchy (e.g.
+``passes/lowering/tile/085_warp_specialize``) a bare ``[Fork(...), Fork(...)]``
+list comp is shorter and clearer — don't reach for this builder.
+
+The engine in ``pipeline.py`` consumes ``fork.knobs`` flat (it doesn't walk
+ancestors), so the LAST level's knob_names land on each leaf as the
+DB-matchable knob delta. Earlier levels' knobs sit on the branch Forks
+themselves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from deplodock.compiler.pipeline.pipeline import Fork
+
+if TYPE_CHECKING:
+    from deplodock.compiler.graph import Graph
+    from deplodock.compiler.ir.base import Op
+
+
+@dataclass(frozen=True)
+class Level[P]:
+    """One grouping level in the Fork tree.
+
+    ``knob_names`` and ``key`` must agree in arity: ``key(p)`` returns a
+    tuple of the same length as ``knob_names``, in matching order. Across
+    all Levels the ``knob_names`` should partition the knob set the caller
+    wants Forks to pin (no duplicates; collapsed-constant knobs may be
+    absent — they're pinned by the materialized leaf Op itself).
+    """
+
+    knob_names: tuple[str, ...]
+    key: Callable[[P], tuple]
+
+
+def build_fork_tree[P](
+    *,
+    params: Sequence[P],
+    levels: Sequence[Level[P]],
+    materialize: Callable[[P], Op | Graph],
+    score: Callable[[P], float],
+) -> Fork | list[Fork]:
+    """Group ``params`` into a Fork tree per ``levels`` (outermost first).
+
+    The LAST level is the leaf level: each param becomes one leaf Fork
+    (``is_leaf=True``), knobs stamped from ``level.key(p)``, ``expand``
+    thunk yields ``[materialize(p)]``. Earlier levels emit branch Forks
+    keyed by ``level.key`` over the enclosing subgroup; siblings sort by
+    ``-score`` (max-of-children propagates upward); levels whose key has a
+    single distinct value across the group are collapsed (no 1-child branch
+    wrapper). Returns a single ``Fork`` when the top level collapses to one
+    branch (engine still routes through fork-spawn since
+    ``isinstance(option, Fork)``), otherwise the top-level ``list[Fork]``.
+
+    ``score(p)`` is called exactly once per param at builder entry; the
+    returned value is reused for both the leaf's own score and any branch
+    ``max(child scores)`` propagation.
+    """
+    if not params:
+        return []
+    if not levels:
+        raise ValueError("build_fork_tree: at least one Level required")
+    leaf_score = {id(p): score(p) for p in params}
+    leaf_level = levels[-1]
+    branch_levels = levels[:-1]
+
+    def _sorted(forks: list[Fork]) -> list[Fork]:
+        return sorted(forks, key=lambda f: -f.score)
+
+    def _leaves(group: list[P]) -> list[Fork]:
+        # Default-arg capture (``p=p``) avoids the late-binding closure
+        # trap — without it every thunk would see the final loop var.
+        return _sorted(
+            [
+                Fork(
+                    knobs=dict(zip(leaf_level.knob_names, leaf_level.key(p), strict=True)),
+                    expand=(lambda p=p: [materialize(p)]),
+                    score=leaf_score[id(p)],
+                    is_leaf=True,
+                )
+                for p in group
+            ]
+        )
+
+    def _branch(group: list[P], depth: int) -> list[Fork]:
+        if depth == len(branch_levels):
+            return _leaves(group)
+        level = branch_levels[depth]
+        keyed: dict[tuple, list[P]] = {}
+        for p in group:
+            keyed.setdefault(level.key(p), []).append(p)
+        # Single-value collapse: the level adds no choice, so skip the
+        # 1-child Fork wrapper and recurse straight into the next level.
+        if len(keyed) == 1:
+            return _branch(next(iter(keyed.values())), depth + 1)
+        siblings: list[Fork] = []
+        for key, sub in keyed.items():
+            children = _branch(sub, depth + 1)
+            if not children:
+                continue
+            siblings.append(
+                Fork(
+                    knobs=dict(zip(level.knob_names, key, strict=True)),
+                    expand=(lambda c=children: list(c)),
+                    score=max(c.score for c in children),
+                    is_leaf=False,
+                )
+            )
+        return _sorted(siblings)
+
+    top = _branch(list(params), 0)
+    return top[0] if len(top) == 1 else top

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -88,6 +88,7 @@ from deplodock.compiler.ir.tile.ir import (
     TileOp,
 )
 from deplodock.compiler.pipeline import Pattern, RuleSkipped
+from deplodock.compiler.pipeline.fork_tree import Level, build_fork_tree
 from deplodock.compiler.pipeline.knob import Knob, KnobType
 from deplodock.compiler.pipeline.passes.lowering.tile._helpers import is_matmul_reduce
 from deplodock.compiler.pipeline.pipeline import Fork
@@ -232,7 +233,22 @@ def rewrite(ctx: Context, root: Node, match) -> Graph | None | TileOp | Fork | l
     if len(plan.params) == 1:
         return _materialize(plan, plan.params[0])
 
-    return _build_fork_tree_lazy(plan, ctx)
+    # Hierarchical Fork tree over (BR, (BM,BN), (FM,FN), (BK,SPLITK)). The
+    # builder collapses single-key levels (e.g. pointwise's BR=1 layer),
+    # sorts siblings by max-propagated score descending, and defers
+    # ``_materialize`` to each leaf's ``expand`` thunk so greedy compile
+    # only builds one variant per LoopOp. See ``pipeline/fork_tree.py``.
+    return build_fork_tree(
+        params=plan.params,
+        levels=[
+            Level((BR.name,), lambda p: (p.br,)),
+            Level((BM.name, BN.name), lambda p: (p.bm, p.bn)),
+            Level((FM.name, FN.name), lambda p: (p.fm, p.fn)),
+            Level((BK.name, SPLITK.name), lambda p: (p.bk, p.splitk)),
+        ],
+        materialize=lambda p: _materialize(plan, p),
+        score=lambda p: _score_variant(plan, p, ctx),
+    )
 
 
 def _score_variant(plan: _Plan, params: TileParams, ctx: Context) -> float:
@@ -245,91 +261,6 @@ def _score_variant(plan: _Plan, params: TileParams, ctx: Context) -> float:
     if lazy is not None:
         return lazy
     return _materialize(plan, params).score(ctx)
-
-
-def _build_fork_tree_lazy(plan: _Plan, ctx: Context) -> Fork | list[Fork]:
-    """Convert ``plan.params`` into the hierarchical Fork tree.
-
-    Grouping order (outermost first): BR → (BM,BN) → (FM,FN) → (BK,SPLITK).
-    A level is skipped (Fork wrapper omitted) when every variant in the
-    enclosing group shares the same knob values at that level, so the
-    common case (all variants have BR=1) doesn't add a useless 1-child
-    Fork layer.
-
-    **Sibling ordering** is by max-propagated :func:`_score_variant`
-    descending — same yardstick :meth:`TileOp.score` would use post-
-    materialization, routed through :meth:`TileOp.lazy_score` (the lazy
-    cousin of ``score`` exposed on the Op base) so we don't have to
-    build every TileOp just to rank them. Leaf Fork ``expand`` thunks
-    defer ``_materialize(plan, params)`` until the search actually
-    resolves that leaf — greedy compile only fires one per LoopOp.
-
-    Returns a single ``Fork`` when the top-level group collapses to one
-    branch (engine still routes through the fork-spawn path since
-    ``isinstance(option, Fork)``), otherwise the ``list[Fork]`` of
-    siblings.
-    """
-    leaf_score: dict[int, float] = {id(p): _score_variant(plan, p, ctx) for p in plan.params}
-
-    def _sorted(forks: list[Fork]) -> list[Fork]:
-        return sorted(forks, key=lambda f: -f.score)
-
-    def _leaf_forks(group: list[TileParams]) -> list[Fork]:
-        out = [
-            Fork(
-                knobs={BK.name: p.bk, SPLITK.name: p.splitk},
-                expand=(lambda p=p: [_materialize(plan, p)]),
-                score=leaf_score[id(p)],
-                is_leaf=True,
-            )
-            for p in group
-        ]
-        return _sorted(out)
-
-    def _group_level(
-        group: list[TileParams],
-        knob_names: tuple[str, ...],
-        knob_getters: tuple,
-        child_builder,
-    ) -> list[Fork]:
-        """Build sibling Forks for one level, keyed by ``knob_names``,
-        sorted by max-propagated score descending. ``knob_getters`` reads
-        the matching field off ``TileParams`` (the planner's source of
-        truth pre-materialization)."""
-        keyed: dict[tuple, list[TileParams]] = {}
-        for p in group:
-            key = tuple(g(p) for g in knob_getters)
-            keyed.setdefault(key, []).append(p)
-        if len(keyed) == 1:
-            return child_builder(next(iter(keyed.values())))
-        siblings: list[Fork] = []
-        for key, subgroup in keyed.items():
-            children = child_builder(subgroup)
-            if not children:
-                continue
-            siblings.append(
-                Fork(
-                    knobs=dict(zip(knob_names, key, strict=True)),
-                    expand=(lambda c=children: list(c)),
-                    score=max(c.score for c in children),
-                    is_leaf=False,
-                )
-            )
-        return _sorted(siblings)
-
-    def _fmfn_level(group: list[TileParams]) -> list[Fork]:
-        return _group_level(group, (FM.name, FN.name), (lambda p: p.fm, lambda p: p.fn), _leaf_forks)
-
-    def _bmbn_level(group: list[TileParams]) -> list[Fork]:
-        return _group_level(group, (BM.name, BN.name), (lambda p: p.bm, lambda p: p.bn), _fmfn_level)
-
-    def _br_level(group: list[TileParams]) -> list[Fork]:
-        return _group_level(group, (BR.name,), (lambda p: p.br,), _bmbn_level)
-
-    top = _br_level(list(plan.params))
-    if len(top) == 1:
-        return top[0]
-    return top
 
 
 def _split_leading_non_loops(body) -> tuple[tuple[Stmt, ...], tuple[Stmt, ...]]:

--- a/deplodock/compiler/pipeline/pipeline.py
+++ b/deplodock/compiler/pipeline/pipeline.py
@@ -683,10 +683,10 @@ def _best_fork(forks, parent_cand, db):
             # in ``row.knobs`` with the same value AND at least one of
             # those knobs is constrained by the row; otherwise every
             # sibling is equally consistent and we fall back to option-0.
-            # No rule currently emits branch Forks (the partition planner's
-            # hierarchical conversion was reverted as it degraded MCTS
-            # efficiency on small-to-medium shapes); kept here as
-            # documented infrastructure for future hierarchical rules.
+            # Branch Forks are emitted by the partition planner
+            # (``010_partition_loops``, via ``fork_tree.build_fork_tree``)
+            # for the BR/(BM,BN)/(FM,FN) hierarchy when those levels carry
+            # more than one distinct knob value.
             if not opt_knobs:
                 continue
             constraining = [k for k in opt_knobs if k in row.knobs]

--- a/tests/compiler/passes/test_partition_planner_forks.py
+++ b/tests/compiler/passes/test_partition_planner_forks.py
@@ -26,12 +26,32 @@ from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
 from deplodock.compiler.ir.stmt import Accum, Assign
 from deplodock.compiler.ir.tile.ir import TileOp
+from deplodock.compiler.pipeline.fork_tree import Level, build_fork_tree
 from deplodock.compiler.pipeline.pipeline import Fork
 
 _planner = importlib.import_module("deplodock.compiler.pipeline.passes.lowering.tile.010_partition_loops")
-_build_fork_tree_lazy = _planner._build_fork_tree_lazy
 _plan_kernel = _planner._plan_kernel
 _materialize = _planner._materialize
+_score_variant = _planner._score_variant
+BR, BM, BN, FM, FN, BK, SPLITK = (_planner.BR, _planner.BM, _planner.BN, _planner.FM, _planner.FN, _planner.BK, _planner.SPLITK)
+
+
+def _build_fork_tree_lazy(plan, ctx: Context) -> Fork | list[Fork]:
+    """Mirror the planner's own call site in ``rewrite()`` — builds the same
+    Fork tree from a ``_Plan`` + ``ctx`` via the shared
+    ``pipeline/fork_tree.py`` builder, with the planner's canonical level
+    layout. Single source of truth for the test assertions below."""
+    return build_fork_tree(
+        params=plan.params,
+        levels=[
+            Level((BR.name,), lambda p: (p.br,)),
+            Level((BM.name, BN.name), lambda p: (p.bm, p.bn)),
+            Level((FM.name, FN.name), lambda p: (p.fm, p.fn)),
+            Level((BK.name, SPLITK.name), lambda p: (p.bk, p.splitk)),
+        ],
+        materialize=lambda p: _materialize(plan, p),
+        score=lambda p: _score_variant(plan, p, ctx),
+    )
 
 
 def _ctx() -> Context:

--- a/tests/compiler/pipeline/test_fork_tree.py
+++ b/tests/compiler/pipeline/test_fork_tree.py
@@ -1,0 +1,236 @@
+"""Unit tests for the hierarchical Fork-tree builder.
+
+Covers the generic builder contract using a synthetic param dataclass so
+the suite stays decoupled from any specific Tile-IR pass (`partition_loops`
+is the canonical caller; its integration tests live in
+``tests/compiler/passes/test_partition_planner_forks.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from deplodock.compiler.pipeline.fork_tree import Level, build_fork_tree
+from deplodock.compiler.pipeline.pipeline import Fork
+
+
+@dataclass(frozen=True)
+class P:
+    """Synthetic variant params — three knob fields, enough for two grouping
+    levels + a leaf level."""
+
+    a: int
+    b: int
+    c: int
+
+
+def _stub_materialize(p: P) -> str:
+    """Stand-in for a real Op materializer; returns a string so leaves'
+    ``expand()`` results are trivially comparable."""
+    return f"op({p.a},{p.b},{p.c})"
+
+
+def _identity_score(p: P) -> float:
+    return float(p.a * 100 + p.b * 10 + p.c)
+
+
+def _walk_leaves(node: Fork | list[Fork]) -> list[Fork]:
+    """Collect every leaf Fork in tree order (option-0 first)."""
+    out: list[Fork] = []
+    stack: list[Fork] = [node] if isinstance(node, Fork) else list(node)
+    while stack:
+        cur = stack.pop(0)
+        if cur.is_leaf:
+            out.append(cur)
+        else:
+            stack[:0] = list(cur.expand())
+    return out
+
+
+def _walk_branches(node: Fork | list[Fork]) -> list[Fork]:
+    """Collect every non-leaf branch Fork in the tree."""
+    out: list[Fork] = []
+    stack: list[Fork] = [node] if isinstance(node, Fork) else list(node)
+    while stack:
+        cur = stack.pop()
+        if cur.is_leaf:
+            continue
+        out.append(cur)
+        stack.extend(cur.expand())
+    return out
+
+
+# Conventional levels reused across tests: `a` is the outer branch key,
+# `b` is the inner branch key, `c` is the leaf level.
+_LEVELS = [
+    Level(("A",), lambda p: (p.a,)),
+    Level(("B",), lambda p: (p.b,)),
+    Level(("C",), lambda p: (p.c,)),
+]
+
+
+def test_empty_params_returns_empty_list():
+    out = build_fork_tree(params=[], levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    assert out == []
+
+
+def test_empty_levels_raises():
+    with pytest.raises(ValueError, match="at least one Level"):
+        build_fork_tree(params=[P(1, 2, 3)], levels=[], materialize=_stub_materialize, score=_identity_score)
+
+
+def test_single_param_single_leaf():
+    """One param → bare leaf Fork (not list), knobs from the LAST level."""
+    tree = build_fork_tree(params=[P(1, 2, 3)], levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    assert isinstance(tree, Fork)
+    assert tree.is_leaf
+    # Every level above the leaf collapses (one distinct key each); leaf
+    # carries only the deepest level's pin.
+    assert tree.knobs == {"C": 3}
+    assert tree.expand() == ["op(1,2,3)"]
+
+
+def test_two_params_identical_branch_key_collapses_branch():
+    """Two params sharing every grouping key → both branch levels collapse;
+    result is a flat list of leaf Forks at the top level."""
+    params = [P(1, 2, 3), P(1, 2, 5)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    # A and B both have one distinct key → collapse. The leaf level (C)
+    # sees two distinct values, so it emits two sibling leaves directly.
+    assert isinstance(tree, list)
+    assert all(f.is_leaf for f in tree)
+    assert {tuple(f.knobs.items()) for f in tree} == {(("C", 3),), (("C", 5),)}
+
+
+def test_two_params_distinct_branch_key_emits_branches():
+    """Two params with distinct outer keys → two branch Forks, each with
+    one leaf child."""
+    params = [P(1, 2, 3), P(2, 2, 3)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    assert isinstance(tree, list)
+    assert len(tree) == 2
+    for branch in tree:
+        assert not branch.is_leaf
+        assert set(branch.knobs.keys()) == {"A"}
+        children = branch.expand()
+        assert len(children) == 1
+        assert children[0].is_leaf
+
+
+def test_branch_score_is_max_of_children():
+    """A branch Fork's score equals max(child scores) recursively."""
+    params = [P(1, 1, 1), P(1, 1, 9), P(2, 1, 1)]  # distinct A keys → top branches
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    assert isinstance(tree, list)
+    for branch in _walk_branches(tree):
+        children = branch.expand()
+        assert children
+        expected = max(c.score for c in children)
+        assert branch.score == pytest.approx(expected)
+
+
+def test_siblings_sorted_descending_by_score():
+    """Sibling Forks at every level appear in descending score order."""
+    # Three distinct A values; identity_score makes A=3 best, A=1 worst.
+    params = [P(1, 0, 0), P(3, 0, 0), P(2, 0, 0)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    assert isinstance(tree, list)
+    scores = [f.score for f in tree]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_leaf_knobs_keys_equal_last_level_knob_names():
+    """Every leaf's ``knobs`` keys match exactly the last level's
+    ``knob_names`` (the partition invariant for the leaf layer)."""
+    params = [P(a, b, c) for a in (1, 2) for b in (1, 2) for c in (1, 2)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    for leaf in _walk_leaves(tree):
+        assert set(leaf.knobs.keys()) == {"C"}
+
+
+def test_branch_knobs_no_overlap_along_path():
+    """Knob multiset along any root→leaf path has no duplicates — each
+    knob is pinned exactly once across all Forks on the path."""
+    params = [P(a, b, c) for a in (1, 2) for b in (1, 2) for c in (1, 2)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    roots = [tree] if isinstance(tree, Fork) else list(tree)
+
+    def _first_path(root: Fork) -> list[Fork]:
+        path = [root]
+        node = root
+        while not node.is_leaf:
+            node = node.expand()[0]
+            path.append(node)
+        return path
+
+    for root in roots:
+        path = _first_path(root)
+        seen: dict[str, int] = {}
+        for f in path:
+            for k in f.knobs:
+                seen[k] = seen.get(k, 0) + 1
+        duplicates = {k: v for k, v in seen.items() if v > 1}
+        assert not duplicates, f"knob duplicated along path: {duplicates}"
+        # Every pinned knob is one of the level knob_names.
+        assert set(seen) <= {"A", "B", "C"}
+
+
+def test_collapsed_constant_level_omits_branch():
+    """A level whose key is constant across all params produces no Fork
+    wrapper for that level."""
+    # All params share A=1, vary B and C → A level collapses, B emits
+    # branches, leaves carry C.
+    params = [P(1, 1, 1), P(1, 2, 1)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    for branch in _walk_branches(tree):
+        assert "A" not in branch.knobs
+
+
+def test_materialize_is_lazy():
+    """``materialize`` fires 0 times at build, exactly once per leaf
+    ``expand()`` resolution."""
+    calls: list[P] = []
+
+    def counting_materialize(p: P) -> str:
+        calls.append(p)
+        return _stub_materialize(p)
+
+    params = [P(1, 2, 3), P(1, 2, 5)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=counting_materialize, score=_identity_score)
+    assert calls == [], "materialize fired during build"
+
+    leaves = _walk_leaves(tree)
+    leaves[0].expand()
+    assert len(calls) == 1
+    leaves[1].expand()
+    assert len(calls) == 2
+
+
+def test_score_called_once_per_param():
+    """``score`` fires exactly once per param at builder entry (the
+    ``leaf_score`` dict) — no rescoring during depth-recursion."""
+    calls: list[P] = []
+
+    def counting_score(p: P) -> float:
+        calls.append(p)
+        return _identity_score(p)
+
+    params = [P(a, b, c) for a in (1, 2) for b in (1, 2) for c in (1, 2)]  # 8 unique params
+    build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=counting_score)
+    assert len(calls) == len(params)
+    assert set(calls) == set(params)
+
+
+def test_leaf_expand_returns_own_param_materialization():
+    """Default-arg lambda capture safety: each leaf's ``expand()`` returns
+    that leaf's *own* param's materialization. Without ``lambda p=p:`` the
+    closure would late-bind and every leaf would return the last param."""
+    params = [P(1, 1, 1), P(1, 1, 2), P(1, 1, 3)]
+    tree = build_fork_tree(params=params, levels=_LEVELS, materialize=_stub_materialize, score=_identity_score)
+    leaves = _walk_leaves(tree)
+    # Map each leaf to its materialized result and check coverage matches
+    # the input params, not just the last one repeated.
+    results = sorted(leaf.expand()[0] for leaf in leaves)
+    assert results == ["op(1,1,1)", "op(1,1,2)", "op(1,1,3)"]


### PR DESCRIPTION
## Context

`partition_loops` (the first pass in Tile-IR lowering, ~1710 lines) carried ~95 lines of generic
hierarchical Fork-tree machinery — group flat params into a tree keyed by per-level knob tuples,
sort siblings by max-propagated score, collapse single-key levels, defer leaf materialization.
Nothing partition-specific in the algorithm itself; any future pass wanting a multi-level
knob-cartesian Fork tree had to reinvent or copy-paste it.

## Change

Extract to `deplodock/compiler/pipeline/fork_tree.py` as `Level` + `build_fork_tree`,
behavior-equivalent line-for-line. `partition_loops` now declares its
`BR → (BM,BN) → (FM,FN) → (BK,SPLITK)` hierarchy as four `Level`s and forwards the result:

```python
return build_fork_tree(
    params=plan.params,
    levels=[
        Level((BR.name,),              lambda p: (p.br,)),
        Level((BM.name, BN.name),      lambda p: (p.bm, p.bn)),
        Level((FM.name, FN.name),      lambda p: (p.fm, p.fn)),
        Level((BK.name, SPLITK.name),  lambda p: (p.bk, p.splitk)),
    ],
    materialize=lambda p: _materialize(plan, p),
    score=lambda p: _score_variant(plan, p, ctx),
)
```

The LAST `Level` is the leaf level — its grouping produces one leaf Fork per param (no branch
wrapper), knobs stamped onto the leaf, `expand` thunk yields `materialize(p)`. This mirrors today's
behavior where `(BK, SPLITK)` is implicitly the leaf level, and keeps the leaf-knob invariant that
`_best_fork` reads flat (no ancestor walk).

## Preserved invariants (byte-identical)

- Default-arg lambda capture (`lambda p=p:`, `lambda c=children:`) — late-binding safety.
- `dict` insertion order for sibling iteration.
- Sort key: `-score` descending; max-of-children propagates upward.
- Single-child-level collapse: no useless 1-child Fork wrappers.
- Single-top-Fork shortcut: returns `Fork` not `list[Fork]` when top collapses.
- Defensive empty-children skip.
- `score(p)` called exactly once per param.

## Engine impact

**None.** Fork-tree topology, knob deltas, sibling ordering, leaf scores are byte-identical →
no DB version bump. Drive-by refresh of the stale `_best_fork` comment that claimed "no rule
currently emits branch Forks" (`partition_loops` does today).

## What does NOT migrate

`085_warp_specialize` (the other Fork-emitting pass) stays inline. Its flat 2-element list comp
is shorter than wiring up a `Level`, and its single-choice case returns a bare `TileOp` rather
than a Fork — behavior the builder doesn't replicate.

## Tests

- **New:** `tests/compiler/pipeline/test_fork_tree.py` — 13 unit tests against a synthetic `P`
  dataclass (decoupled from `TileOp`). Covers: empty/single/collapse/sort/knob-partition/
  lazy materialization/score-called-once/default-arg-capture safety.
- **Updated:** `tests/compiler/passes/test_partition_planner_forks.py` — 9 existing assertions
  unchanged; the local helper now mirrors the planner's own call site against `build_fork_tree`.

## Verification

```bash
make test    # 1377 passed, 27 skipped
make lint    # clean
```

## Files

- `deplodock/compiler/pipeline/fork_tree.py` (new, ~120 lines)
- `deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py` (–85 lines net)
- `deplodock/compiler/pipeline/pipeline.py` (drive-by comment refresh)
- `deplodock/compiler/pipeline/ARCHITECTURE.md` (+10 lines noting the extraction)
- `tests/compiler/pipeline/test_fork_tree.py` (new)
- `tests/compiler/passes/test_partition_planner_forks.py` (helper shim mirroring the planner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)