### PR TITLE
Post-Phase-5 cleanup: remove blocked-GEMM scaffolding

### DIFF
--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -723,34 +723,8 @@ class SerialTileBase(Stmt):
 
     @property
     def is_reduce(self) -> bool:
-        """A serial tile is a reduce iff its body contains an ``Accum`` —
-        directly, or wrapped in transparent ``RegisterTile`` / ``Cond``
-        blocks. The matmul-block builder
-        (``010_partition_loops::_build_register_blocked_body``) emits
-        per-cell ``RegisterTile(N_r)`` around the K-reduce ``Accum``; the
-        masked-N path wraps each cell's leaf in a ``Cond``. Without
-        looking through, downstream passes (``020_stage_inputs``,
-        ``040_use_ring_buffers``, ``080_pipeline_stages``,
-        ``030_hoist_invariant_compute``) misclassify the wrapping
-        ``SerialTile(K_i)`` as non-reduce and skip staging / promotion."""
-        return any(_contains_accum_transparent(s) for s in self.body)
-
-
-def _contains_accum_transparent(s: Stmt) -> bool:
-    """``Accum`` directly, or inside a transparent reduce wrapper.
-
-    ``RegisterTile`` is transparent because the K-reduce accumulator
-    survives across replicated cells (each cell carries its own Accum
-    that reduces over the same K axis). ``Cond`` is transparent because
-    the masked-N path predicates per-cell work without altering the
-    enclosing reduce semantics. See :meth:`SerialTileBase.is_reduce`."""
-    if isinstance(s, Accum):
-        return True
-    if isinstance(s, RegisterTile):
-        return any(_contains_accum_transparent(c) for c in s.body)
-    if isinstance(s, Cond):
-        return any(_contains_accum_transparent(c) for c in s.body) or any(_contains_accum_transparent(c) for c in s.else_body)
-    return False
+        """A serial tile is a reduce iff its immediate body contains an ``Accum``."""
+        return any(isinstance(s, Accum) for s in self.body)
 
 
 @dataclass(frozen=True)

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -683,14 +683,15 @@ class ThreadTile(ParallelTile):
 
 @dataclass(frozen=True)
 class RegisterTile(ParallelTile):
-    """Per-thread register-cell tile. Body replicated F× per axis by 006a.
+    """Per-thread register-cell tile. Body replicated F× per axis by
+    ``010_split_register_axes``.
 
     Replaces ``Loop(role=REGISTER)``. The ``axes`` tuple carries one or
     more register axes (typically M_r / N_r for matmul); the planner
-    chooses the extents (``FM`` / ``FN`` knobs). After the 006a
-    register-tile pass runs, every ``RegisterTile`` is consumed: the
-    body is fully unrolled, SSA names get per-cell suffixes, and the
-    ``RegisterTile`` wrapper disappears.
+    chooses the extents (``FM`` / ``FN`` knobs). After the
+    ``010_split_register_axes`` pass runs, every ``RegisterTile`` is
+    consumed: the body is fully unrolled, SSA names get per-cell
+    suffixes, and the ``RegisterTile`` wrapper disappears.
     """
 
     def render(self, ctx: RenderCtx) -> list[str]:

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -102,56 +102,32 @@ should reuse the builder; one-shot flat forks (e.g.
 `lowering/tile/085_warp_specialize`'s `WS={0,1}` 2-element list) stay
 inline.
 
-**Register-blocked GEMM nest.** For matmul-shape kernels (`shape.k_loop is
-not None`, `params.fn > 1`, SPLITK = 1, BR = 1, no M-mask, no fused
-prologue), the planner emits the textbook blocked GEMM nest rather than
-wrapping the entire `{Init, K-reduce, Write}` in one outer
-`RegisterTile(N_r)`. The N_r register tile splits *around* the K-reduce:
+**FN > 1 lowering.** The partition planner always emits the per-cell
+shape — one `RegisterTile(N_r)` wrapping the whole
+`{Init, K-reduce, Write}` body, regardless of FN / SPLITK / BR / prologue
+shape:
 
     M_r REGISTER:
-      RegisterTile(N_r) { Init(acc) }            # per-cell accumulators
-      K_o SERIAL_OUTER:
-        K_i STAGE_INNER (reduce):
-          <N-invariant cone>                     # M-axis Loads, RMSNorm
-                                                 # prologue, … — runs ONCE
-                                                 # per K iter
-          RegisterTile(N_r) { Load b, Accum }    # F_N per-cell FMAs into
-                                                 # the persistent acc_i
-      RegisterTile(N_r) { Write(C, acc) }        # per-cell writes
-
-`_build_register_blocked_body` partitions the σ-rewritten K_i body by
-N-dependence (a single `body.fold` over Expr free_vars ∪ SSA def-use,
-exempting `N_r` from `bound` so RegisterTile wrappers don't mask
-references) into the N-invariant cone (no transitive `N_r` ref) and the
-N-dependent tail (everything else, including the Accum). The cone stays
-at K_i body scope; the tail wraps in `RegisterTile(N_r)`. The masked-N
-variant (e.g. lm_head with non-divisor vocab) wraps each tower's leaf
-body in its own per-cell `Cond(pred(N_r) < extent)` so the replicator
-σ-folds the predicate per cell; the matmul_add `K_s == 0` linear-epilogue
-Cond likewise gets wrapped in `RegisterTile(N_r)` so its inner Load /
-Assign / Write replicate per cell while the outer K_s predicate stays
-single. Init stays unconditional regardless — declaring `acc_i` inside a
-Cond would scope-bind it to the if-block; the K-tower's Accum and the
-Write tower (both Cond-wrapped per cell) would reference an `acc_i`
-that's no longer in scope.
-
-Shapes the blocked builder declines (returns `None`) — SDPA P@V's fused
-prologue, SPLITK > 1, BR > 1, M-overhang, F_N = 1 — fall back to the
-legacy per-cell branch in `_build_split_body` (one `RegisterTile(N_r)`
-wrapping the whole `{Init, K-reduce, Write}` body). Generalising the
-blocked nest to those shapes is follow-up work; the legacy branch is the
-safety net.
+      RegisterTile(N_r):
+        Init(acc)
+        K_o SERIAL_OUTER:
+          K_i STAGE_INNER (reduce):
+            <body>                               # M-axis Loads, prologue,
+                                                 # Load b, Accum — replicated
+                                                 # per cell by the Kernel-IR
+                                                 # replicator
+        Write(C, acc)
 
 The Kernel-IR replicator (`lowering/kernel/010_split_register_axes`)
-computes a body-global keep set for each register axis present in the
-ThreadTile body before recursing into the per-axis replication. Without
-the global keep, each sibling tower's local keep-analysis would run
-independently and the Init tower (no N_r reference in its body) would
-keep `acc` as one name while the Accum tower produced `acc_0..F-1` — a
-naming mismatch the Write tower would inherit. The global keep is also
-what lets the masked-N per-tower `Cond` survive: its predicate references
-`N_r`, the replicator descends into Cond.body, and the per-cell σ
-substitution lines up the suffixes across all three towers.
+walks the body and per-cell duplicates only statements that transitively
+depend on the register axis (dep-tracked via Expr free vars + SSA
+def-use); N-invariant statements (e.g. Load `a[m, k]`, the RMSNorm
+prologue chain) stay single-copy. `dedup_replicated`
+(`lowering/kernel/011_dedup_replicated`) then runs as content-agnostic
+defense in depth: structurally identical Loads and Assigns left over
+after replication CSE-fold into one — the same effect the deleted
+register-blocked GEMM builder used to get from its hand-written
+N-invariant-cone partition (see `plans/obsolete-blocked-gemm-builder.md`).
 
 Leaf Fork `expand` thunks call `_materialize(plan, params)` lazily —
 `_build_split_body` + `TileOp.__post_init__` (which runs the full
@@ -381,7 +357,7 @@ recipe.
 | `BM`          | INT      | `010_partition_loops`        | CTA outer THREAD-axis width (matmul only — the row tile each warp covers).                        |
 | `STAGE`       | BINMASK  | `020_stage_inputs`           | Bitmask over ranked candidate buffers — char `i` = stage buffer `i`. Selected buffers fold into one wrap-body Stage with per-source Source entries. |
 | `FM`          | INT      | `010_partition_loops`        | Register-tile factor along the matmul M (output row) axis; per-thread cell-grid height.           |
-| `FN`          | INT      | `010_partition_loops`        | Register-tile factor along the matmul N (output column) axis; per-thread cell-grid width. With `FN > 1` and the simple-shape constraints (no prologue, SPLITK = 1, BR = 1, no M-overhang), the planner emits the register-blocked GEMM nest — three sibling `RegisterTile(N_r)` towers sharing an N-invariant cone inside the K loop. |
+| `FN`          | INT      | `010_partition_loops`        | Register-tile factor along the matmul N (output column) axis; per-thread cell-grid width. The planner emits one outer `RegisterTile(N_r)` around `{Init, K-reduce, Write}`; the Kernel-IR replicator + `dedup_replicated` pass produce the textbook blocked-GEMM shape (N-invariant Loads kept single-copy, N-dependent Accums replicated). |
 | `BR`          | INT      | `010_partition_loops`        | Cooperative-K thread count (1 = pure serial chunked reduce); BR > 1 routes through the cooperative reduce path with cross-thread combine. |
 | `TMA_SWIZZLE`     | BOOL     | `050_use_tma`                       | Enable TMA hardware-swizzle modes (B128 / B64 / B32); default off.                                |
 | `HOIST_COMPUTE`   | BOOL     | `030_hoist_invariant_compute`       | False (default) → inline-fuse Stage; True → ComputeStage + transports. Autotune fork.             |
@@ -419,7 +395,7 @@ prior sibling scope and reverts its consumer Loads back to gmem — keeps the fu
 single-allocation invariant when the matmul-side K_i, now visible as a reduce through transparent
 `RegisterTile` wrappers, would otherwise re-stage `x`) → `hoist_invariant_compute` → `use_ring_buffers` →
 `use_tma` → `use_async_copy` → `pad_smem` → `pipeline_stages` → `mark_unroll`. Coordination (split-K atomic-writes, cooperative-K Combine emission, broadcast-write guards) is no longer a separate pass: the materializer / Kernel-IR render derives those decisions from `ir/tile/escape_analysis.py` queries against the tile body. Cooperativity is derived from `Accum.axes ∩ ThreadTile.axes`; atomic writes from enclosing `GridTile.axes` vs `Write.index`. `015_gate_splitk_residual` reuses the same `Body.coordination.atomic_axes` signal to identify the split-K block axis without any axis-naming convention or role tag — when SPLITK > 1, it wraps a `matmul_add`-shape linear residual epilogue under `Cond(K_s == 0, ...)` so the residual is atomic-added exactly once across the K_s CTAs (rewrite + predicates live in sibling `_splitk_residual.py`, shared with `010_partition_loops`'s `force_splitk_one` enumeration-time gate). The partition planner's knob globals + per-mode candidate tuples + the pruned `(BN, BM, FM, FN, BK, SPLITK, BR)` cartesian generator + per-mode priority/score functions live in sibling `_enumeration.py` — `010_partition_loops.py` imports the `enumerate_cartesian` entry point and the `TileParams` cartesian element; tests can hit `_enumeration` directly without routing through `_plan_kernel`. `split_register_axes` / `permute_lane_accesses` used to live here but moved to `lowering/kernel/` once dtype-aware analytical passes consolidated there (see `plans/stamp-ssa-dtypes-and-reorder.md`); they still pattern-match `TileOp` because they run pre-materialize. |
-| `lowering/kernel/`         | Pre-materialize dtype-aware analytical passes plus the final `TileOp → KernelOp` lowering. Order: `split_register_axes` (replicates REGISTER-tagged bodies per-cell) → `dedup_replicated` (CSE-folds duplicate Loads / Assigns the replicator emits across per-cell copies — content-agnostic loop-invariant code motion that subsumes the legacy `010_partition_loops` blocked-GEMM builder's five disqualifier gates; see `plans/obsolete-blocked-gemm-builder.md`) → `place_inits` (places explicit `Init` Stmts at correct accumulator scope) → `stamp_types` (single body walk populating `Load.dtype` / `Assign.dtype` / `Write.value_dtype` / `Source.dtype` from `graph.nodes[buf].output.dtype`) → `demote_to_write_dtype` (folds f16-only chains feeding f16 Writes) → `vectorize_loads` (widens consecutive scalar Loads into LDS.128 / `__half2`) → `permute_lane_accesses` (chunks the N register tile into LDS.128-sized strips to remove bank conflicts on `FN > V`) → `pack_fp16_pairs` (pairs scalar `__half` Inits/Accums into `__half2`) → `vectorize_stores` (widens consecutive scalar Writes) → `flatten_wrap_stages` (007a: flattens wrap-body `Stage(... body=[consumer])` into `[Stage(empty), *consumer]` so the materializer walks producer scaffolding then consumer siblings) → `materialize_tile` (purely-mechanical Tile → Kernel lowering; Smem decls read `Source.dtype` directly; its emit logic lives in sibling `_`-prefixed helper modules `_stage_expand` / `_combine` / `_tma_groups`, which the pass loader skips) → `drop_redundant_syncs` (Kernel-IR peephole collapsing back-to-back / leading `Sync`s at the tile-body level). Passes 000–007 and `flatten_wrap_stages` (007a) pattern-match `TileOp`; `materialize_tile` (008) consumes `TileOp` and produces the `KernelOp`; `drop_redundant_syncs` (009) rewrites `KernelOp → KernelOp`. |
+| `lowering/kernel/`         | Pre-materialize dtype-aware analytical passes plus the final `TileOp → KernelOp` lowering. Order: `split_register_axes` (replicates REGISTER-tagged bodies per-cell, with dep-tracked single-copy preservation of axis-invariant statements) → `dedup_replicated` (content-agnostic CSE: structurally identical Loads / Assigns left over after replication fold into one — the same shape the deleted blocked-GEMM builder used to produce by hand-partitioning N-invariant cones; see `plans/obsolete-blocked-gemm-builder.md`) → `place_inits` (places explicit `Init` Stmts at correct accumulator scope) → `stamp_types` (single body walk populating `Load.dtype` / `Assign.dtype` / `Write.value_dtype` / `Source.dtype` from `graph.nodes[buf].output.dtype`) → `demote_to_write_dtype` (folds f16-only chains feeding f16 Writes) → `vectorize_loads` (widens consecutive scalar Loads into LDS.128 / `__half2`) → `permute_lane_accesses` (chunks the N register tile into LDS.128-sized strips to remove bank conflicts on `FN > V`) → `pack_fp16_pairs` (pairs scalar `__half` Inits/Accums into `__half2`) → `vectorize_stores` (widens consecutive scalar Writes) → `flatten_wrap_stages` (007a: flattens wrap-body `Stage(... body=[consumer])` into `[Stage(empty), *consumer]` so the materializer walks producer scaffolding then consumer siblings) → `materialize_tile` (purely-mechanical Tile → Kernel lowering; Smem decls read `Source.dtype` directly; its emit logic lives in sibling `_`-prefixed helper modules `_stage_expand` / `_combine` / `_tma_groups`, which the pass loader skips) → `drop_redundant_syncs` (Kernel-IR peephole collapsing back-to-back / leading `Sync`s at the tile-body level). Passes 000–007 and `flatten_wrap_stages` (007a) pattern-match `TileOp`; `materialize_tile` (008) consumes `TileOp` and produces the `KernelOp`; `drop_redundant_syncs` (009) rewrites `KernelOp → KernelOp`. |
 | `lowering/cuda/`           | `lower_kernelop` renders the `KernelOp` body to a `__global__` source string (via `ir/kernel/render.py::render_kernelop`) and mutates the node's op to `CudaOp` in place. |
 
 See `ir/ARCHITECTURE.md` for what each IR dialect looks like.

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
@@ -39,13 +39,11 @@ def rewrite(root: Node) -> Graph | None:
     tt = thread_tile_of(outer)
 
     # Body-global keep set per register axis. Computed once over the entire
-    # ThreadTile body so sibling RegisterTile(axis) towers (the blocked-GEMM
-    # nest emits three: Init / K-reduce-Accum / Write) agree on which SSA
-    # names carry the per-cell ``_<i>`` suffix. Without this, each tower's
-    # local keep-analysis would run independently — the Init tower doesn't
-    # reference N_r, so ``acc`` would stay one name there, while the Accum
-    # tower produces ``acc_0..N-1`` — a naming mismatch the consumer Write
-    # would inherit.
+    # ThreadTile body so any sibling/cousin RegisterTile(axis) bodies agree
+    # on which SSA names carry the per-cell ``_<i>`` suffix. Defence in
+    # depth for hand-built fixtures — the per-cell shape the planner emits
+    # today has at most one RegisterTile(axis) per scope, so the body-local
+    # keep would suffice.
     global_keep = _collect_body_global_keep(tt.body)
     new_body, factors = _replicate_register_tiles(tt.body, global_keep=global_keep)
     if not factors:
@@ -78,10 +76,11 @@ def _replicate_register_tiles(body: Body, *, global_keep: dict[str, dict[str, bo
 
     ``global_keep`` is the body-global keep map (axis → name → True/False)
     computed at the TileOp body level. It's threaded into every per-axis
-    ``_replicate_along_axis`` call so sibling RegisterTile(axis) towers
-    agree on which names get the per-cell ``_<i>`` suffix — the local
-    fold inside one tower can't see that a name is register-tiled by
-    another sibling tower's body.
+    ``_replicate_along_axis`` call so any sibling/cousin RegisterTile(axis)
+    bodies agree on which names get the per-cell ``_<i>`` suffix. Real
+    planner output emits one RegisterTile(axis) per scope; the global keep
+    only matters for hand-built fixtures with sibling towers sharing an
+    axis.
     """
     out: list[Stmt] = []
     factors: list[int] = []
@@ -119,8 +118,8 @@ def _collect_body_global_keep(body: Body) -> dict[str, dict[str, bool]]:
     """For every register axis appearing in any ``RegisterTile`` within
     ``body``, compute the body-global keep set — which SSA names defined
     anywhere in ``body`` transitively reference that axis. Used to align
-    replicator suffixing across sibling/cousin RegisterTile(axis) towers
-    (the blocked-GEMM nest's three towers, SDPA-prologue+matmul, etc.).
+    replicator suffixing across sibling/cousin RegisterTile(axis) bodies
+    (defence in depth for hand-built fixtures).
     """
     axes: set[str] = set()
     for s in body.iter():
@@ -134,7 +133,7 @@ def _global_keep_for_axis(body: Body, axis: str) -> dict[str, bool]:
     """Body-global keep set for ``axis``: which SSA names defined anywhere
     in ``body`` transitively reference ``axis`` (and therefore must carry
     the per-cell ``_<i>`` suffix at replicate time, regardless of which
-    sibling RegisterTile(axis) tower defines them).
+    sibling RegisterTile(axis) body defines them).
 
     Mirrors the per-body fold in :func:`_replicate_along_axis`, but
     exempts ``axis`` from ``bound`` so a RegisterTile(axis) wrapper
@@ -144,9 +143,9 @@ def _global_keep_for_axis(body: Body, axis: str) -> dict[str, bool]:
     enclosing-wrapper-bound axes pass through unaffected (they aren't
     ``axis`` by construction).
 
-    Multiple defs of the same name (e.g. an Accum's name re-defined in
-    every sibling tower) OR together — keep[name]=True iff ANY definer
-    reads ``axis``.
+    Multiple defs of the same name (e.g. across hand-built sibling
+    RegisterTile bodies sharing a name) OR together — keep[name]=True
+    iff ANY definer reads ``axis``.
     """
 
     def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
@@ -221,10 +220,11 @@ def _replicate_along_axis(
 
     ``extra_keep`` is the body-global keep map for ``axis`` (see
     :func:`_global_keep_for_axis`): names True there must be suffixed
-    regardless of the local body's def-use, so an ``Init(acc)`` /
-    ``Write(C, acc)`` tower aligned with an ``Accum(acc, …N_r…)`` sibling
-    tower replicates and renames consistently (acc → acc_0..N-1) in all
-    three. OR-merged into the locally-derived keep."""
+    regardless of the local body's def-use, so sibling RegisterTile(axis)
+    bodies that share a name (e.g. hand-built fixtures where an
+    ``Init(acc)`` body sits alongside an ``Accum(acc, …N_r…)`` body)
+    replicate and rename consistently. OR-merged into the locally-derived
+    keep."""
 
     def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
         # Stage / StageBundle cache-axis Vars are smem-local — they don't vary
@@ -247,9 +247,9 @@ def _replicate_along_axis(
 
     deps = body.fold(fn)
     keep: dict[str, bool] = {n: axis in deps[id(s)] for s in body.iter() for n in s.defines()}
-    # Merge in body-global keep entries (the per-tower local fold can't see
-    # that a name register-tiled by a sibling tower must also be suffixed
-    # here). OR-merge: a name keep=True globally stays True locally.
+    # Merge in body-global keep entries (the per-body local fold can't see
+    # that a name register-tiled by a sibling RegisterTile must also be
+    # suffixed here). OR-merge: a name keep=True globally stays True locally.
     if extra_keep is not None:
         for n, v in extra_keep.items():
             if v:
@@ -310,7 +310,7 @@ def _replicate_along_axis(
                 # REGISTER axis. Stage's source-side state (cache_axes, origin)
                 # stays untouched — the per-source Vars are smem-local and
                 # the cache-axis 'bound' mask in the fold guard above prevents
-                # 006a from tagging them for replication.
+                # 010_split_register_axes from tagging them for replication.
                 out.append(s.with_bodies(tuple(go(child) for child in nested)))
             elif _needs_replication(s, axis, deps, keep):
                 for i in range(factor):

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
@@ -38,14 +38,7 @@ def rewrite(root: Node) -> Graph | None:
     idx, outer = single_tile(body)
     tt = thread_tile_of(outer)
 
-    # Body-global keep set per register axis. Computed once over the entire
-    # ThreadTile body so any sibling/cousin RegisterTile(axis) bodies agree
-    # on which SSA names carry the per-cell ``_<i>`` suffix. Defence in
-    # depth for hand-built fixtures — the per-cell shape the planner emits
-    # today has at most one RegisterTile(axis) per scope, so the body-local
-    # keep would suffice.
-    global_keep = _collect_body_global_keep(tt.body)
-    new_body, factors = _replicate_register_tiles(tt.body, global_keep=global_keep)
+    new_body, factors = _replicate_register_tiles(tt.body)
     if not factors:
         # No RegisterTile in body — non-matmul kernel (planner only emits
         # RegisterTile for matmul) or this rule has already run and
@@ -63,7 +56,7 @@ def rewrite(root: Node) -> Graph | None:
     return TileOp(body=body[:idx] + (rebuilt,) + body[idx + 1 :], name=root.op.name, knobs=knobs)
 
 
-def _replicate_register_tiles(body: Body, *, global_keep: dict[str, dict[str, bool]] | None = None) -> tuple[Body, list[int]]:
+def _replicate_register_tiles(body: Body) -> tuple[Body, list[int]]:
     """Inside-out unwrap of ``RegisterTile`` flavors. For each tile, recurse
     into nested RegisterTiles first, then replicate this layer's body by
     ``axis.extent`` with ``σ: axis → literal(i)`` for each of the tile's
@@ -73,27 +66,18 @@ def _replicate_register_tiles(body: Body, *, global_keep: dict[str, dict[str, bo
     Walks into non-RegisterTile block stmts (e.g. ``SerialTile`` wrapping
     a softmax prologue + ``RegisterTile``-tiled matmul body for SDPA P@V)
     so deeply-nested RegisterTiles get replicated too.
-
-    ``global_keep`` is the body-global keep map (axis → name → True/False)
-    computed at the TileOp body level. It's threaded into every per-axis
-    ``_replicate_along_axis`` call so any sibling/cousin RegisterTile(axis)
-    bodies agree on which names get the per-cell ``_<i>`` suffix. Real
-    planner output emits one RegisterTile(axis) per scope; the global keep
-    only matters for hand-built fixtures with sibling towers sharing an
-    axis.
     """
     out: list[Stmt] = []
     factors: list[int] = []
     for s in body:
         if isinstance(s, RegisterTile):
-            inner_unwrapped, inner_factors = _replicate_register_tiles(s.body, global_keep=global_keep)
+            inner_unwrapped, inner_factors = _replicate_register_tiles(s.body)
             current = inner_unwrapped
             local_factors: list[int] = []
             # Replicate from innermost axis outward.
             for ax in reversed(s.axes):
                 factor = ax.extent.as_static()
-                extra_keep = global_keep.get(ax.name) if global_keep is not None else None
-                current = _replicate_along_axis(current, ax.name, factor, _sigma_to_literal(ax.name), extra_keep=extra_keep)
+                current = _replicate_along_axis(current, ax.name, factor, _sigma_to_literal(ax.name))
                 local_factors.append(factor)
             local_factors.reverse()
             out.extend(current)
@@ -105,87 +89,13 @@ def _replicate_register_tiles(body: Body, *, global_keep: dict[str, dict[str, bo
             # independently and re-attached via ``with_bodies``.
             new_bodies: list[Body] = []
             for sub in s.nested():
-                new_sub, sub_factors = _replicate_register_tiles(sub, global_keep=global_keep)
+                new_sub, sub_factors = _replicate_register_tiles(sub)
                 new_bodies.append(new_sub)
                 factors.extend(sub_factors)
             out.append(s.with_bodies(tuple(new_bodies)))
         else:
             out.append(s)
     return Body(out), factors
-
-
-def _collect_body_global_keep(body: Body) -> dict[str, dict[str, bool]]:
-    """For every register axis appearing in any ``RegisterTile`` within
-    ``body``, compute the body-global keep set — which SSA names defined
-    anywhere in ``body`` transitively reference that axis. Used to align
-    replicator suffixing across sibling/cousin RegisterTile(axis) bodies
-    (defence in depth for hand-built fixtures).
-    """
-    axes: set[str] = set()
-    for s in body.iter():
-        if isinstance(s, RegisterTile):
-            for ax in s.axes:
-                axes.add(ax.name)
-    return {ax: _global_keep_for_axis(body, ax) for ax in axes}
-
-
-def _global_keep_for_axis(body: Body, axis: str) -> dict[str, bool]:
-    """Body-global keep set for ``axis``: which SSA names defined anywhere
-    in ``body`` transitively reference ``axis`` (and therefore must carry
-    the per-cell ``_<i>`` suffix at replicate time, regardless of which
-    sibling RegisterTile(axis) body defines them).
-
-    Mirrors the per-body fold in :func:`_replicate_along_axis`, but
-    exempts ``axis`` from ``bound`` so a RegisterTile(axis) wrapper
-    doesn't mask references inside it — the whole point of this walk
-    is to see those references. Stage / StageBundle cache axes stay
-    masked: they're smem-local and don't vary per replica. Other
-    enclosing-wrapper-bound axes pass through unaffected (they aren't
-    ``axis`` by construction).
-
-    Multiple defs of the same name (e.g. across hand-built sibling
-    RegisterTile bodies sharing a name) OR together — keep[name]=True
-    iff ANY definer reads ``axis``.
-    """
-
-    def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
-        if isinstance(s, Stage):
-            local_bound = bound | frozenset(ax.name for src in s.sources for ax in src.cache_axes)
-        elif isinstance(s, StageBundle):
-            local_bound = bound | frozenset(ax.name for stage in s.stages for src in stage.sources for ax in src.cache_axes)
-        else:
-            local_bound = bound
-        local_bound = local_bound - {axis}
-        own: frozenset[str] = frozenset()
-        for e in s.exprs():
-            own = own | frozenset(v for v in e.free_vars() if v not in local_bound)
-        for c in child_T:
-            if c is not None:
-                own = own | c
-        return own
-
-    deps = body.fold(fn)
-    keep: dict[str, bool] = {}
-    for s in body.iter():
-        has_axis = axis in deps[id(s)]
-        for n in s.defines():
-            keep[n] = keep.get(n, False) or has_axis
-
-    defined_names = set(keep)
-    changed = True
-    while changed:
-        changed = False
-        for s in body.iter():
-            reads: set[str] = set(s.deps())
-            for e in s.exprs():
-                reads.update(e.free_vars())
-            reads &= defined_names
-            if any(keep.get(r, False) for r in reads):
-                for n in s.defines():
-                    if not keep.get(n, False):
-                        keep[n] = True
-                        changed = True
-    return keep
 
 
 def _sigma_to_literal(axis: str) -> Callable[[int], Sigma]:
@@ -202,8 +112,6 @@ def _replicate_along_axis(
     axis: str,
     factor: int,
     sigma_for: Callable[[int], Sigma],
-    *,
-    extra_keep: dict[str, bool] | None = None,
 ) -> Body:
     """F× replicate every stmt whose value transitively depends on
     ``axis``. Each such stmt is emitted ``factor`` times with σ given
@@ -216,15 +124,7 @@ def _replicate_along_axis(
     Dependency analysis is one :meth:`Body.fold` over the def-use DAG
     with bound-axis filtering. ``keep[name]`` records which SSA names
     must carry the suffix vs. pass through unchanged (Tile-input
-    buffers, constants, axis-free producers).
-
-    ``extra_keep`` is the body-global keep map for ``axis`` (see
-    :func:`_global_keep_for_axis`): names True there must be suffixed
-    regardless of the local body's def-use, so sibling RegisterTile(axis)
-    bodies that share a name (e.g. hand-built fixtures where an
-    ``Init(acc)`` body sits alongside an ``Accum(acc, …N_r…)`` body)
-    replicate and rename consistently. OR-merged into the locally-derived
-    keep."""
+    buffers, constants, axis-free producers)."""
 
     def fn(s: Stmt, child_T: tuple[frozenset[str] | None, ...], bound: frozenset[str]) -> frozenset[str]:
         # Stage / StageBundle cache-axis Vars are smem-local — they don't vary
@@ -247,13 +147,6 @@ def _replicate_along_axis(
 
     deps = body.fold(fn)
     keep: dict[str, bool] = {n: axis in deps[id(s)] for s in body.iter() for n in s.defines()}
-    # Merge in body-global keep entries (the per-body local fold can't see
-    # that a name register-tiled by a sibling RegisterTile must also be
-    # suffixed here). OR-merge: a name keep=True globally stays True locally.
-    if extra_keep is not None:
-        for n, v in extra_keep.items():
-            if v:
-                keep[n] = True
 
     # SSA def-use propagation: if any SSA name a stmt reads has keep=True,
     # then everything it defines must also be marked keep. The fold above

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/011_dedup_replicated.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/011_dedup_replicated.py
@@ -2,16 +2,20 @@
 
 After ``010_split_register_axes`` unwraps each ``RegisterTile`` and
 replicates its body F× per axis, two ``Load``s or ``Assign``s from
-independent N-cells that originally referenced the same N-invariant
+independent cells that originally referenced the same axis-invariant
 value end up structurally identical at the same scope. Folding them
-to a single occurrence is exactly what the legacy register-blocked
-GEMM builder in ``010_partition_loops`` was hand-rolling out of the
-Tile structure: lift the N-invariant cone, share it across F_N cells.
-The blocked builder gates on five disqualifiers (FN==1, SPLITK>1, BR>1,
-M-mask, fused prologue) — content-agnostic CSE here covers all of
-them uniformly, plus accidental dedup opportunities the structural
-classifier wouldn't catch (identical user compute, dtype-stamped
-Assign equality, etc.).
+to a single occurrence is content-agnostic CSE — what the deleted
+register-blocked GEMM builder used to get by hand-partitioning
+N-invariant cones (see ``plans/obsolete-blocked-gemm-builder.md``).
+
+Empirically (sweep over the compiler test suite under
+``DEPLODOCK_LOG_DEDUP=1``; see ``plans/post-blocked-builder-cleanup.md``
+step 8) most FN > 1 matmul kernels fold nothing — 020_stage_inputs
+already deduplicates N-invariant Loads upstream. The pass earns its
+keep on reduce/norm kernels: RMSNorm's mean reduce, softmax's
+sum/max chain, and reshape-then-linear fusions all show measured folds
+(per-kernel: ~2 Loads or Assigns; one reshape-linear-mean-reduce shape
+folds 16 Loads). Defence in depth: cheap to run, occasionally meaningful.
 
 Two folds, interleaved in source order per scope:
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/020_place_inits.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/020_place_inits.py
@@ -160,9 +160,9 @@ def _accums_under_reduces_only(stmt: Stmt) -> list[Accum]:
     ``K_o`` is crossable for Init placement and the Init lands at the
     surrounding ``ThreadTile`` body head.
 
-    ``RegisterTile`` is transparent for Init scoping: 006a will replicate
-    Accums across register cells, but at placement time the inner Accums
-    are still single statements. We descend into ``RegisterTile.body``
+    ``RegisterTile`` is transparent for Init scoping: ``010_split_register_axes``
+    will replicate Accums across register cells, but at placement time the inner
+    Accums are still single statements. We descend into ``RegisterTile.body``
     unconditionally."""
     out: list[Accum] = []
     if isinstance(stmt, Accum):

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/050_vectorize_loads.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/050_vectorize_loads.py
@@ -175,11 +175,11 @@ def _try_vec_load(stmts: Iterable[Stmt], start: int, n: int, top: TileOp) -> Loa
     #
     # Earlier this check was skipped for n=2 fp16 with the comment "__half2
     # is 4-byte aligned in cuda_fp16.h" — the TYPE is, but reinterpreting a
-    # fp16 pointer at an odd-element offset still misses the alignment. The
-    # register-blocked GEMM nest (default for matmul shapes with FN > 1)
-    # exposes this: an N-stride of 3 (lm_head-style vocab=3 test case) gives
-    # a3 a stride of 3 elements = 6 bytes — not a multiple of 4 — and the
-    # half2 read faults with CUDA_ERROR_MISALIGNED_ADDRESS.
+    # fp16 pointer at an odd-element offset still misses the alignment.
+    # Per-cell matmul shapes with FN > 1 expose this: an N-stride of 3
+    # (lm_head-style vocab=3 test case) gives a3 a stride of 3 elements =
+    # 6 bytes — not a multiple of 4 — and the half2 read faults with
+    # CUDA_ERROR_MISALIGNED_ADDRESS.
     if n >= 2:
         if not all(c % n == 0 for c in coeffs_0.values()):
             return None

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/060_permute_lane_accesses.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/060_permute_lane_accesses.py
@@ -7,8 +7,9 @@ fp32 staged buffer, ``V = 8`` for fp16. The hardware constant (the
 looked up via ``match.graph.nodes[stage.buf].output.dtype.nbytes`` so
 fp16 matmuls don't waste half the LDS.128 bandwidth.
 
-After ``006a_register_tile_planned`` commits the canonical ``(THREAD-outer | RF-inner)``
-ordering on the N axis, body Loads on the B operand stage read column
+After ``010_split_register_axes`` commits the canonical
+``(THREAD-outer | RF-inner)`` ordering on the N axis, body Loads on the
+B operand stage read column
 ``Var(lane) * FN + c`` for ``c=0..FN-1``. Two regimes:
 
 * ``FN <= V`` (canonical default): lane ``l`` reads the contiguous strip

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/_combine.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/_combine.py
@@ -23,9 +23,8 @@ from deplodock.compiler.ir.tile.ir import RegisterTile, SerialTile, StridedTile
 
 
 def find_nested_reduce_accums(stmts) -> dict[str, Accum]:
-    """All ``Accum``s sitting at the body level of the first nested reduce
-    ``SerialTile`` / ``StridedTile`` subtree, keyed by Accum name, looking
-    through transparent ``RegisterTile`` / ``Cond`` wrappers.
+    """All ``Accum``s at the immediate body level of the first nested
+    reduce ``SerialTile`` / ``StridedTile`` subtree, keyed by Accum name.
 
     Used by the materializer when a non-reduce outer tile wraps a deeper
     reduce — e.g. the cooperative-K shape ``SerialTile(K_o, "serial_outer",
@@ -33,16 +32,11 @@ def find_nested_reduce_accums(stmts) -> dict[str, Accum]:
     by the partition planner's σ-split, possibly with F-replicated sibling
     Accums from ``010_split_register_axes``.
 
-    The walk-through of ``RegisterTile`` / ``Cond`` wrappers here is
-    defence in depth — real planner output never wraps ``Accum`` inside
-    ``RegisterTile`` at K_i body level (the outer ``RegisterTile(N_r)``
-    wraps the ``SerialTile(K_o)`` from outside in the per-cell shape).
-
     Returns ``{}`` when no reduce-with-Accum subtree is found, preserving
     the existing "stray Combine raises" safety net."""
     for s in stmts:
         if isinstance(s, (SerialTile, StridedTile)) and s.is_reduce:
-            accums = _accums_through_wrappers(s.body)
+            accums = {a.name: a for a in s.body if isinstance(a, Accum)}
             if accums:
                 return accums
         if isinstance(s, (SerialTile, StridedTile, RegisterTile)):
@@ -50,23 +44,6 @@ def find_nested_reduce_accums(stmts) -> dict[str, Accum]:
             if found:
                 return found
     return {}
-
-
-def _accums_through_wrappers(body) -> dict[str, Accum]:
-    """``Accum`` stmts at this body level, descending through transparent
-    ``RegisterTile`` / ``Cond`` wrappers. Matches the structure produced
-    by the blocked builder, where Accum sits inside ``RegisterTile(N_r)``
-    rather than directly in the K_i body."""
-    out: dict[str, Accum] = {}
-    for s in body:
-        if isinstance(s, Accum):
-            out[s.name] = s
-        elif isinstance(s, RegisterTile):
-            out.update(_accums_through_wrappers(s.body))
-        elif isinstance(s, Cond):
-            out.update(_accums_through_wrappers(s.body))
-            out.update(_accums_through_wrappers(s.else_body))
-    return out
 
 
 def single_thread_var(thread_axes: tuple[Axis, ...]) -> str:

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/_combine.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/_combine.py
@@ -31,14 +31,12 @@ def find_nested_reduce_accums(stmts) -> dict[str, Accum]:
     reduce — e.g. the cooperative-K shape ``SerialTile(K_o, "serial_outer",
     body=[SerialTile(K_i, "stage_inner", reduce, [Accum, ...])])`` produced
     by the partition planner's σ-split, possibly with F-replicated sibling
-    Accums from ``006a_register_tile_planned``.
+    Accums from ``010_split_register_axes``.
 
-    The blocked-GEMM builder
-    (``010_partition_loops::_build_register_blocked_body``) wraps the
-    N-dep K_i tail in ``RegisterTile(N_r, [Load b, Assign, Accum])`` —
-    walking through the ``RegisterTile`` here is the analogue of the
-    same change to ``SerialTileBase.is_reduce`` (Phase 2): both let the
-    cooperative-K materializer fire when BR > 1 takes the blocked path.
+    The walk-through of ``RegisterTile`` / ``Cond`` wrappers here is
+    defence in depth — real planner output never wraps ``Accum`` inside
+    ``RegisterTile`` at K_i body level (the outer ``RegisterTile(N_r)``
+    wraps the ``SerialTile(K_o)`` from outside in the per-cell shape).
 
     Returns ``{}`` when no reduce-with-Accum subtree is found, preserving
     the existing "stray Combine raises" safety net."""

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -402,12 +402,6 @@ def _layer_kind_for(role: Role | None) -> str:
     return "serial"
 
 
-class _BuildSkipped(Exception):
-    """Raised by ``_build_split_body`` when the body's shape doesn't match —
-    today only ``_replace_k_loops`` raises this, when ``target_names``
-    doesn't find any K-axis Loop in the body to rewrite."""
-
-
 def _plan_kernel(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "") -> _Plan | None:
     """Unified σ-split planning for matmul, pointwise, and cooperative-reduce
     kernels. Returns a :class:`_Plan` whose ``params`` enumerates every
@@ -601,7 +595,7 @@ def _materialize(plan: _Plan, params: TileParams) -> TileOp:
     fresh body) — happen here, lazily, from the chosen Fork leaf's
     ``expand`` thunk.
 
-    ``_BuildSkipped`` is shape-determined (raised only when
+    The ``RuleSkipped`` catch is shape-determined (raised only when
     ``_replace_k_loops`` can't find any K-axis Loops in the body, which
     depends on ``shape.target_names`` matching the body's axis names, not
     on params). If it ever fires here, the shape was misclassified at
@@ -610,8 +604,8 @@ def _materialize(plan: _Plan, params: TileParams) -> TileOp:
     """
     try:
         chain_body = _build_split_body(plan.shape, params)
-    except _BuildSkipped as exc:
-        raise AssertionError(f"shape-level _BuildSkipped fired at materialize time for kernel {plan.kernel_name!r}: {exc}") from exc
+    except RuleSkipped as exc:
+        raise AssertionError(f"shape-level RuleSkipped fired at materialize time for kernel {plan.kernel_name!r}: {exc}") from exc
     knobs = {
         **plan.base_knobs,
         BN.name: params.bn,
@@ -777,7 +771,7 @@ def _build_split_body(shape: KernelShape, params: TileParams) -> tuple[Stmt, ...
             K_o_ext=K_o_ext,
         )
         if n_replaced == 0:
-            raise _BuildSkipped("K reduce not found in body")
+            raise RuleSkipped("K reduce not found in body")
         # SPLITK > 1 with a linear residual epilogue (matmul_add) is gated
         # post-planner by ``015_gate_splitk_residual``, which finds the
         # K_s axis in the wrapped GridTile and hoists the linear epilogue

--- a/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
@@ -50,7 +50,6 @@ sharing the same index ⇒ temporal reuse).
 from __future__ import annotations
 
 import os
-from collections.abc import Iterator
 from typing import NamedTuple
 
 from deplodock.compiler.context import Context
@@ -58,7 +57,7 @@ from deplodock.compiler.graph import Node
 from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import BinaryExpr, Expr, Interval, Literal, SimplifyCtx, Var
 from deplodock.compiler.ir.sigma import Sigma
-from deplodock.compiler.ir.stmt import Accum, Body, Cond, Load, Stmt
+from deplodock.compiler.ir.stmt import Accum, Body, Load, Stmt
 from deplodock.compiler.ir.tile.ir import (
     BYTES_PER_ELEM,
     CacheDim,
@@ -84,55 +83,6 @@ from deplodock.compiler.pipeline.passes.lowering.tile._helpers import (
 PATTERN = [Pattern("root", TileOp)]
 
 STAGE = Knob("STAGE", KnobType.BINMASK, help="Bitmask over ranked candidate buffers (char i = buffer i)")
-
-
-def _iter_loads_through_register(body: Body, register_axes: tuple[Axis, ...] = ()) -> Iterator[tuple[Load, tuple[Axis, ...]]]:
-    """Walk ``body`` collecting every ``Load`` together with the
-    ``RegisterTile`` axes layered between it and the caller's scope.
-
-    The blocked-GEMM nest (``010_partition_loops::_build_register_blocked_body``)
-    wraps the N-dependent K_i tail in ``RegisterTile(N_r)`` while leaving
-    the N-invariant cone (e.g. ``Load a[m, k]``) at the K_i body root.
-    The legacy walker iterated ``s.body`` direct children only, so the
-    N-dependent ``Load b[k, n]`` was never collected and the matmul
-    body ended up staging just half its operands. Walking through
-    ``RegisterTile`` here threads the cell axes into the per-Load
-    ``register_axes`` channel; ``_classify`` then includes them in the
-    candidate axis set so the slab geometry covers the per-cell access
-    pattern. ``Cond`` is transparent for the same reason —
-    ``015_gate_splitk_residual`` and the masked-N path wrap per-cell
-    leaves in a ``Cond`` that doesn't affect addressing.
-
-    Size-1 ``RegisterTile`` axes are eagerly substituted to 0 in the
-    yielded Load's index (matching the kernel-IR replicator
-    ``010_split_register_axes``'s eventual ``σ axis → 0`` for a
-    single-cell unroll) and dropped from the threaded ``register_axes``
-    tuple. Without this, 020's downstream ``_classify`` builds an origin
-    expression that still references the unit axis (which never appears
-    as a cache var because the slab has no unit dim), and the
-    materializer's cooperative-load emit then references an unbound axis
-    name in the gmem index — NVRTC reports ``asm operand must have
-    scalar type`` because the SSA name is undefined at producer scope.
-    Substituting up-front makes blocked-FN=1 share both slab geometry
-    and producer-side addressing with the per-cell FN=1 path (which
-    never wrapped the inner Load in ``RegisterTile`` at all)."""
-    for s in body:
-        if isinstance(s, Load):
-            yield s, register_axes
-        elif isinstance(s, RegisterTile):
-            unit_axes = tuple(ax for ax in s.axes if ax.extent.is_static and ax.extent.as_static() == 1)
-            non_unit = tuple(ax for ax in s.axes if ax not in unit_axes)
-            new_register_axes = register_axes + non_unit
-            if unit_axes:
-                sub = Sigma({ax.name: Literal(0, "int") for ax in unit_axes})
-                for load, axes in _iter_loads_through_register(s.body, new_register_axes):
-                    new_index = tuple(sub.reduce(e, SimplifyCtx({})) for e in load.index)
-                    yield Load(names=load.names, input=load.input, index=new_index, dtype=load.dtype), axes
-            else:
-                yield from _iter_loads_through_register(s.body, new_register_axes)
-        elif isinstance(s, Cond):
-            yield from _iter_loads_through_register(s.body, register_axes)
-            yield from _iter_loads_through_register(s.else_body, register_axes)
 
 
 def _tile_is_cooperative(tt: ThreadTile) -> bool:
@@ -283,8 +233,9 @@ def _collect_candidates(
             continue
         if isinstance(s, (SerialTile, StridedTile)):
             scope_axes = (*in_scope_axes, s.axis)
-            for stmt, extra_reg in _iter_loads_through_register(s.body):
-                loads_by_buf.setdefault(stmt.input, []).append((stmt, s.axis, scope_axes, register_axes + extra_reg))
+            for stmt in s.body:
+                if isinstance(stmt, Load):
+                    loads_by_buf.setdefault(stmt.input, []).append((stmt, s.axis, scope_axes, register_axes))
     for buf, items in loads_by_buf.items():
         if block_axis_names and all(_load_free_vars(load).isdisjoint(block_axis_names) for load, _, _, _ in items):
             continue
@@ -440,9 +391,10 @@ def _process_scope(
         if isinstance(s, (SerialTile, StridedTile)):
             scope_axes = (*in_scope_axes, s.axis)
             had_load = False
-            for stmt, extra_reg in _iter_loads_through_register(s.body):
-                loads_by_buf.setdefault(stmt.input, []).append((stmt, s.axis, scope_axes, register_axes + extra_reg))
-                had_load = True
+            for stmt in s.body:
+                if isinstance(stmt, Load):
+                    loads_by_buf.setdefault(stmt.input, []).append((stmt, s.axis, scope_axes, register_axes))
+                    had_load = True
             rewritten_inner.append(s)
             if had_load:
                 stmt_contains_loads_idx.append(len(rewritten_inner) - 1)

--- a/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
@@ -6,16 +6,16 @@ consumer subtree containing the rewritten Loads. Producer cooperative
 entries (cache axes, origin, source-dim mapping); no producer body is
 stored on the Stage.
 
-Runs *before* ``006a_register_tile_planned`` (pre-register-tile: there
+Runs *before* ``010_split_register_axes`` (pre-register-tile: there
 is exactly one Load per ``(buffer, access-pattern)`` rather than F×F
 duplicates). REGISTER axes in scope join cache axes via the
 ``register_axes`` channel — the slab spans ``BM·FM × BK`` (and similar)
 with stride-1 Affine addressing, instead of ``BM × BK`` with
-TemplateAddressing as it would post-006a. Stages emit wrapping the K_o
-body; their cache-axis iteration vars shadow the outer REGISTER Loops,
-and ``006a_register_tile_planned`` treats Stages as opaque (no
-recursion into their producer-side state — only the consumer ``body``
-descends).
+TemplateAddressing as it would post-replicate. Stages emit wrapping
+the K_o body; their cache-axis iteration vars shadow the outer
+REGISTER Loops, and ``010_split_register_axes`` treats Stages as opaque
+(no recursion into their producer-side state — only the consumer
+``body`` descends).
 
 **Pipeline:**
 

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
@@ -55,8 +55,9 @@ def thread_tile_of(outer: ParallelTile) -> ThreadTile:
     The cooperative form (``GridTile`` wrapping ``ThreadTile``) puts the
     per-thread scope one level deeper; the pointwise form (standalone
     ``ThreadTile``) IS the per-thread scope. Downstream passes that operate
-    on the per-thread scope (``020_stage_inputs``, ``006a``, ...) call this
-    helper instead of branching on the outer flavor.
+    on the per-thread scope (``020_stage_inputs``,
+    ``010_split_register_axes``, ...) call this helper instead of branching
+    on the outer flavor.
     """
     if isinstance(outer, ThreadTile):
         return outer

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_splitk_residual.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_splitk_residual.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 from deplodock.compiler.ir.expr import BinaryExpr, Literal, Var
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Cond, Stmt, Write
-from deplodock.compiler.ir.tile.ir import RegisterTile
 
 
 def stmt_contains_accum(stmt: Stmt) -> bool:
@@ -115,28 +114,6 @@ def gate_linear_epilogue_on_k_s_zero(stmts: tuple[Stmt, ...], k_s_name: str) -> 
               body=[Load(r), Assign(v=acc+r), Write(out, v)],
               else_body=[Write(out, acc)])]
 
-    Blocked-builder input shape — the matmul_add epilogue lives inside the
-    Write-tower ``RegisterTile(N_r)``, separated from the reduce tower by
-    the planner's three-tower layout::
-
-        [RegisterTile(N_r, [Init]),
-         <reduce tower with Accum nested in RegisterTile(N_r)>,
-         RegisterTile(N_r, [Load(r), Assign(v=acc+r), Write(out, v)])]
-
-    Output shape (the Cond moves INSIDE the Write tower)::
-
-        [RegisterTile(N_r, [Init]),
-         <reduce tower>,
-         RegisterTile(N_r,
-             [Cond(K_s == 0,
-                   body=[Load(r), Assign(v=acc+r), Write(out, v)],
-                   else_body=[Write(out, acc)])])]
-
-    The kernel-IR replicator (``010_split_register_axes``) then unrolls
-    each ``RegisterTile(N_r)`` per cell — the Cond's predicate is K_s-only
-    and replicates verbatim, the body/else_body Loads / Assigns / Writes
-    pick up the per-cell SSA suffix as usual.
-
     Both Writes lower to ``atomicAdd`` under SPLITK > 1, so the final
     output is ``sum_i acc_i + r`` — the residual added exactly once.
     Returns ``stmts`` unchanged when no linear epilogue is present (also:
@@ -167,41 +144,15 @@ def gate_linear_epilogue_on_k_s_zero(stmts: tuple[Stmt, ...], k_s_name: str) -> 
     if acc_name is None:
         return stmts
 
-    # Blocked path: the epilogue is a single ``RegisterTile(N_r, [Load,
-    # Assign, Write])`` (the planner's Write tower). Recurse into the
-    # tower body and emit the Cond there; the surrounding RegisterTile
-    # stays untouched so the replicator can still unroll it per cell.
-    if len(epilogue) == 1 and isinstance(epilogue[0], RegisterTile):
-        rt = epilogue[0]
-        gated = _gate_linear_chain(tuple(rt.body), acc_name, k_s_name)
-        if gated is None:
-            return stmts
-        return reduce_part + (RegisterTile(axes=rt.axes, body=Body(gated)),)
-
-    # Per-cell flat epilogue.
-    gated = _gate_linear_chain(epilogue, acc_name, k_s_name)
-    if gated is None:
-        return stmts
-    return reduce_part + gated
-
-
-def _gate_linear_chain(stmts: tuple[Stmt, ...], acc_name: str, k_s_name: str) -> tuple[Stmt, ...] | None:
-    """Apply the K_s == 0 ``Cond`` wrap to a flat ``[Load*, Assign*, Write]``
-    chain that's structurally linear in ``acc_name``.
-
-    Returns ``(cond,)`` — a single-element tuple holding the wrapped
-    chain — or ``None`` if the chain doesn't match the linear-residual
-    shape (no Write, vector Write, multi-Write, non-linear Assign chain).
-    The caller splices the result into the surrounding sibling list."""
-    writes = [s for s in stmts if isinstance(s, Write)]
+    writes = [s for s in epilogue if isinstance(s, Write)]
     if len(writes) != 1:
-        return None
+        return stmts
     write = writes[0]
     if write.is_vector:
-        return None
-    assigns_by_name = {s.name: s for s in stmts if isinstance(s, Assign)}
+        return stmts
+    assigns_by_name = {s.name: s for s in epilogue if isinstance(s, Assign)}
     if not is_linear_in_accum(write.value, acc_name, assigns_by_name):
-        return None
+        return stmts
     write_acc = Write(
         output=write.output,
         index=write.index,
@@ -210,7 +161,7 @@ def _gate_linear_chain(stmts: tuple[Stmt, ...], acc_name: str, k_s_name: str) ->
     )
     cond = Cond(
         cond=BinaryExpr("==", Var(k_s_name), Literal(0, "int")),
-        body=Body(stmts),
+        body=Body(epilogue),
         else_body=Body((write_acc,)),
     )
-    return (cond,)
+    return reduce_part + (cond,)

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -71,7 +71,7 @@ tests/
 │   │   ├── test_launch_geometry_rules.py / test_masked_tile.py
 │   │   ├── test_stage_inputs_classify.py
 │   │   ├── test_lowering_accuracy.py           # 040 / 060 / 070 + TMA end-to-end
-│   │   ├── test_lowering_blocked_gemm.py       # register-blocked GEMM nest
+│   │   ├── test_lowering_blocked_gemm.py       # FN > 1 matmul accuracy (per-cell + replicator)
 │   │   ├── test_knob_pinning.py                # DEPLODOCK_KNOBS regression configs
 │   │   ├── test_tile_naming.py                 # provenance-driven kernel naming
 │   │   └── test_pipeline_semantics.py          # full pass chain vs numpy

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -33,7 +33,7 @@ tests/compiler/passes/
 ├── test_masked_tile.py             # masked-tile pass (dynamic-shape boundary guard)
 ├── test_stage_inputs_classify.py   # Stage-input classifier
 ├── test_lowering_accuracy.py       # 040 / 060 / 070 + TMA end-to-end CUDA accuracy
-├── test_lowering_blocked_gemm.py   # register-blocked GEMM nest
+├── test_lowering_blocked_gemm.py   # FN > 1 matmul accuracy (per-cell + replicator)
 ├── test_knob_pinning.py            # DEPLODOCK_KNOBS-pinned regression configs
 ├── test_tile_naming.py             # provenance-driven k_<op>_<suffix> kernel naming
 └── test_pipeline_semantics.py      # full pass chain (decompose → opt → fuse) vs numpy

--- a/tests/compiler/passes/test_lowering_blocked_gemm.py
+++ b/tests/compiler/passes/test_lowering_blocked_gemm.py
@@ -1,13 +1,13 @@
-"""CUDA accuracy regressions for the register-blocked GEMM nest.
+"""CUDA accuracy regressions for matmul shapes with FN > 1.
 
-The blocked-GEMM nest (planner default for matmul shapes with FN > 1
-under SPLITK=1 / BR=1 / no M-mask) splits the N_r register-tile around
-the K-reduce so N-invariant compute runs once per K step and is shared
-across the F_N cells. The split intersects with the smem vectorize /
-fp16 pack / fused-prologue gate machinery in ways that produced CUDA
+Each test pins the autotune knob bundle that used to fault on the
+register-blocked GEMM builder's path (deleted in
+``plans/obsolete-blocked-gemm-builder.md`` phase 5) and confirms the
+per-cell shape + Kernel-IR replicator + ``dedup_replicated`` pipeline
+reproduces the same accuracy. The pinned shapes exercise the smem
+vectorize / fp16 pack / fused-prologue intersections that produced CUDA
 runtime hangs and silently-wrong vector reads on specific autotune
-variants. Each test below pins the failing knob bundle via env and
-checks the CUDA-compiled kernel matches a NumpyBackend reference.
+variants.
 
 Skipped without CUDA.
 """
@@ -69,13 +69,13 @@ def _pin_knobs(monkeypatch, **knobs) -> None:
 def test_blocked_matmul_postmul_fn3_no_misalign(monkeypatch):
     """``BK=64 BM=32 BN=32 BR=1 FM=1 FN=3 SPLITK=1 STAGE=111`` on a matmul
     chained into a post-multiply previously hung the kernel ("did not
-    complete within 1000 ms"). Root cause: the blocked-GEMM nest emits
-    multi-dim staged smem ``[K, N_t, N_r]`` with FN=3 innermost.
-    ``050_vectorize_loads`` packed two cells into one ``float2``
-    reinterpret_cast on a last-dim constant-anchor alignment check that
-    didn't see the stride-3 base address ``a3 · FN`` — half the threads
-    read at byte 12, not 8-byte aligned for float2, and the device
-    stalled on the misaligned access (no exception, just stuck).
+    complete within 1000 ms"). Root cause: the per-cell + replicator
+    pipeline produces multi-dim staged smem ``[K, N_t, N_r]`` with FN=3
+    innermost. ``050_vectorize_loads`` packed two cells into one
+    ``float2`` reinterpret_cast on a last-dim constant-anchor alignment
+    check that didn't see the stride-3 base address ``a3 · FN`` — half
+    the threads read at byte 12, not 8-byte aligned for float2, and the
+    device stalled on the misaligned access (no exception, just stuck).
 
     The fix walks back into the Source's innermost cache-axis extent
     and refuses to vectorize when it isn't a multiple of the pack count.
@@ -112,23 +112,21 @@ def test_blocked_matmul_postmul_fn3_no_misalign(monkeypatch):
 
 @requires_cuda
 def test_blocked_matmul_fp16_odd_stride_n_no_misalign(monkeypatch):
-    """fp16 matmul where the blocked-GEMM nest stages a smem slab whose
-    innermost cache-axis extent is odd (FN=3 here) used to fault with
-    ``CUDA_ERROR_MISALIGNED_ADDRESS`` because ``050_vectorize_loads``
-    treated ``n=2 fp16`` (``__half2``) as a freebie: the TYPE is 4-byte
-    aligned, but reinterpreting an fp16 pointer at an odd-element offset
-    still misses the alignment. Two cells off an FN=3 base land at
-    consecutive odd offsets — half the threads read at byte 6, not
-    4-byte-aligned for ``__half2``. The fix walks back into the Source's
-    innermost cache-axis extent and refuses to vectorize when it isn't a
-    multiple of n.
+    """fp16 matmul whose staged smem slab has an odd innermost cache-axis
+    extent (FN=3 here) used to fault with ``CUDA_ERROR_MISALIGNED_ADDRESS``
+    because ``050_vectorize_loads`` treated ``n=2 fp16`` (``__half2``) as
+    a freebie: the TYPE is 4-byte aligned, but reinterpreting an fp16
+    pointer at an odd-element offset still misses the alignment. Two
+    cells off an FN=3 base land at consecutive odd offsets — half the
+    threads read at byte 6, not 4-byte-aligned for ``__half2``. The fix
+    walks back into the Source's innermost cache-axis extent and refuses
+    to vectorize when it isn't a multiple of n.
 
     Shape: M=32, K=64, N=96 (clean divisor 96 = BN·FN under BN=32 FN=3).
-    The pinned (BK=64 BM=32 BN=32 FM=1 FN=3 SPLITK=1 BR=1 STAGE=111)
-    is the blocked variant from the FN=3 hang reproducer in
-    ``370e6090`` — only the matmul-chained-into-mul gives the planner
-    a STAGE=111 enumeration, so the test multiplies the matmul output
-    by a scalar broadcast.
+    The pinned (BK=64 BM=32 BN=32 FM=1 FN=3 SPLITK=1 BR=1 STAGE=111) is
+    the variant from the FN=3 hang reproducer in ``370e6090`` — only the
+    matmul-chained-into-mul gives the planner a STAGE=111 enumeration,
+    so the test multiplies the matmul output by a scalar broadcast.
     """
     from deplodock.compiler import dtype as _dt  # noqa: PLC0415
 
@@ -163,26 +161,25 @@ def test_blocked_matmul_fp16_odd_stride_n_no_misalign(monkeypatch):
 @requires_cuda
 def test_fused_rmsnorm_linear_blocked_prologue(monkeypatch):
     """Fused RMSNorm + linear at lm_head-style knobs (FN=32, BK=64,
-    SPLITK=1, BR=1, FM=1) used to hit the 2 s NVRTC compile budget
-    because the planner's blocked-GEMM nest was gated by
-    ``not shape.prologue``. The fused RMSNorm reduce IS a prologue, so
-    blocking didn't fire and each of the 32 register cells re-emitted
-    the per-K-element normalization ``v_k = x[m,k] · inv_rms ·
-    norm_weight[k]`` inside its own unrolled K loop — ~3.7 s to compile
-    a ~530-line function with 32 live accumulators.
+    SPLITK=1, BR=1, FM=1) used to hit the 2 s NVRTC compile budget on
+    the legacy per-cell path, because the old blocked-GEMM builder
+    excluded fused-prologue shapes. Without it, each of the 32 register
+    cells re-emitted the per-K-element normalization
+    ``v_k = x[m,k] · inv_rms · norm_weight[k]`` inside its own unrolled
+    K loop — ~3.7 s to compile a ~530-line function with 32 live
+    accumulators.
 
-    M5 drops the prologue exclusion: the prologue itself (mean reduce +
-    rsqrt) still runs once at the M_r scope, but the matmul body inside
-    it goes through the blocked nest. The kernel structure has
-    ``v6 = norm_weight · v5`` computed once per K iter, then per-cell
-    Conds doing weight Load + multiply + Accum into persistent acc_i
-    registers — compiles in budget and runs correctly.
+    The current per-cell + replicator + ``dedup_replicated`` pipeline
+    folds the N-invariant prologue chain back into one body-level copy
+    (mean reduce + rsqrt + ``v6 = norm_weight · v5`` computed once per K
+    iter), with per-cell weight Load + multiply + Accum into persistent
+    acc_i registers — compiles in budget and runs correctly.
 
     Shape: M=2 (tiny batch — fp32 keeps the accumulator drift small),
     K=1024 (RMSNorm normalization range), N=4096 (BN=128 · FN=32 clean
-    divisor — picks the blocked variant from the failing tune log
-    without needing the full lm_head vocab=151669, which would also
-    work but compiles slower in this CI-friendly test).
+    divisor — matches the failing tune log without needing the full
+    lm_head vocab=151669, which would also work but compiles slower in
+    this CI-friendly test).
     """
     _pin_knobs(monkeypatch, BK=64, BM=1, BN=128, BR=1, FM=1, FN=32, SPLITK=1)
 
@@ -204,14 +201,12 @@ def test_fused_rmsnorm_linear_blocked_prologue(monkeypatch):
     # Compute reference BEFORE backend.compile (which mutates ops in place).
     ref = _reference(g, inputs)["o"]
 
-    # Structural check: with M5 in place, the planner emits ONE smem
-    # allocation for the RMSNorm input (``x_smem``) — both the mean
-    # reduce and the matmul body share it. Without M5, the legacy
-    # prologue path wraps the matmul body in its own RegisterTile(N_r),
-    # which forces a SECOND smem allocation (``x_smem_1``) because the
-    # blocked Loads inside the per-cell scope come from a different
-    # staging context. Detect the regression by counting distinct smem
-    # decls for the x buffer.
+    # Structural check: the per-cell + replicator + dedup pipeline emits
+    # ONE smem allocation for the RMSNorm input (``x_smem``) — both the
+    # mean reduce and the matmul body share it. A regression that wraps
+    # the matmul body in its own RegisterTile(N_r) at a different staging
+    # context would force a SECOND smem allocation (``x_smem_1``). Detect
+    # by counting distinct smem decls for the x buffer.
     from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
     from deplodock.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
 
@@ -222,23 +217,23 @@ def test_fused_rmsnorm_linear_blocked_prologue(monkeypatch):
     cuda_src = "\n".join(op.kernel_source for op in cuda_ops)
     x_smem_decls = cuda_src.count("__shared__ float x_smem")
     assert x_smem_decls == 1, (
-        f"expected 1 ``__shared__ float x_smem`` decl (blocked-prologue shares the staging); "
-        f"got {x_smem_decls} — the legacy per-cell path opens its own smem context inside RegisterTile(N_r), "
-        f"forcing a second allocation."
+        f"expected 1 ``__shared__ float x_smem`` decl (per-cell shares the staging); "
+        f"got {x_smem_decls} — a regression opening its own smem context inside RegisterTile(N_r) "
+        f"would force a second allocation."
     )
 
-    # Kernel-size check: legacy path duplicates the prologue chain inside
-    # each register cell's scope. With FN=32 and a ~5-stmt v_k chain
-    # (Load x, mul by inv_rms, Load norm_weight, mul, ...), the legacy
-    # path's body lands at ~330 lines; the blocked path's body at ~210.
-    # The renderer prepends the TMA prelude (~75 lines of mbarrier /
-    # cp_async_bulk_tensor helpers) when TMA descriptors are present, so
-    # the blocked+TMA total is ~286 and the legacy+TMA regression would
+    # Kernel-size check: a regression that duplicates the prologue chain
+    # inside each register cell's scope inflates the body. With FN=32 and
+    # a ~5-stmt v_k chain (Load x, mul by inv_rms, Load norm_weight,
+    # mul, ...), the duplicated body lands at ~330 lines; the deduped
+    # body at ~210. The renderer prepends the TMA prelude (~75 lines of
+    # mbarrier / cp_async_bulk_tensor helpers) when TMA descriptors are
+    # present, so the deduped+TMA total is ~286 and a regression would
     # land ~406. Threshold at 360 catches the regression with margin.
     cu_lines = cuda_src.count("\n")
     assert cu_lines < 360, (
-        f"rendered kernel is {cu_lines} lines — the blocked-prologue path should produce ~286 with TMA prelude; "
-        f"a regression to the legacy per-cell path inflates it to ~400+ via duplicated v_k chains."
+        f"rendered kernel is {cu_lines} lines — should produce ~286 with TMA prelude; "
+        f"a regression that fails to dedup the N-invariant prologue chain inflates it to ~400+."
     )
 
     out = backend.run(compiled, input_data=inputs)[0].outputs["o"]
@@ -261,12 +256,11 @@ def test_fused_rmsnorm_linear_blocked_prologue(monkeypatch):
     ids=["fn8_no_mr", "fm2_fn2_mr", "fn3_clean"],
 )
 def test_blocked_matmul_default_accuracy(monkeypatch, m, k, n, fm, fn):
-    """The M3 commit dropped the REG_BLOCK knob and made blocking the
-    planner's default for any matmul with FN > 1 (and SPLITK=1, BR=1,
-    no M-mask). This parametrized matrix covers the structural shapes
-    blocking touches: pure FN-only (no M_r), FM+FN (M_r register-tiled
-    too), and the FN=3 clean-divisor case (innermost cache-axis extent
-    not a multiple of 2 — exercises the vectorize alignment guard).
+    """Sanity matrix for FN > 1 matmul shapes (SPLITK=1, BR=1, no
+    M-mask) — covers pure FN-only (no M_r), FM+FN (M_r register-tiled
+    too), and FN=3 clean-divisor (innermost cache-axis extent not a
+    multiple of 2 — exercises the vectorize alignment guard). These are
+    the shapes the deleted blocked-GEMM builder used to specialize.
     """
     bn = max(1, n // fn) if (n % (n // fn) == 0 and (n // fn) <= 256) else n // fn
     bm = max(1, m // fm)

--- a/tests/compiler/passes/test_partition_planner_rules.py
+++ b/tests/compiler/passes/test_partition_planner_rules.py
@@ -11,13 +11,12 @@ were deleted in the same refactor.
 
 from __future__ import annotations
 
-from deplodock.compiler.dtype import F32
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.elementwise import ElementwiseImpl
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
-from deplodock.compiler.ir.stmt import Accum, Init
+from deplodock.compiler.ir.stmt import Accum
 from deplodock.compiler.ir.tile.ir import RegisterTile, ThreadTile, TileOp
 from deplodock.compiler.pipeline import KERNEL_PASSES, TILE_PASSES, Pipeline
 
@@ -117,68 +116,6 @@ def test_006a_replicates_register_tagged_body_loop():
         assert "a_reg" not in vars_in_index, f"unreplicated a_reg in Write: {w.index}"
     # FM gets stamped from the outermost (and only) RegisterTile axis extent.
     assert new_tile_op.knobs.get("FM") == 4
-
-
-def test_006a_sibling_register_tile_towers_share_keep():
-    """The blocked-GEMM nest emits three sibling ``RegisterTile(N_r)``
-    towers (Init / K-reduce-Accum / Write) at the same ThreadTile level.
-    Each tower's local keep-analysis is incomplete — the Init tower
-    doesn't itself reference N_r, so a per-body fold would keep ``acc``
-    one name there, while the Accum tower would produce ``acc_0..F-1``.
-    Body-global keep aligns the three towers: ``acc`` is keep=True
-    everywhere because some sibling's Accum reads N_r → all three
-    towers replicate consistently to ``acc_0..F-1``.
-    """
-    n_outer = Axis("n_outer", 8)
-    n_reg = Axis("n_reg", 4)
-    k = Axis("k", 16)
-
-    init_tower = RegisterTile(axes=(n_reg,), body=(Init(name="acc", op=ElementwiseImpl("add"), dtype=F32),))
-    reduce_tower = Loop(
-        axis=k,
-        body=(
-            Load(name="w", input="w", index=(Var("k"), Var("n_outer"), Var("n_reg"))),
-            RegisterTile(axes=(n_reg,), body=(Accum(name="acc", value="w", op=ElementwiseImpl("add")),)),
-        ),
-    )
-    write_tower = RegisterTile(
-        axes=(n_reg,),
-        body=(Write(output="o", index=(Var("n_outer"), Var("n_reg")), value="acc"),),
-    )
-    tile = ThreadTile(
-        axes=(n_outer,),
-        body=(init_tower, reduce_tower, write_tower),
-    )
-    tile_op = TileOp(body=(tile,), name="t")
-
-    g = Graph()
-    _input(g, "w", (16, 8, 4))
-    g.add_node(op=tile_op, inputs=["w"], output=Tensor("o", (8, 4)), node_id="o")
-    g.inputs = ["w"]
-    g.outputs = ["o"]
-
-    out = Pipeline.build(KERNEL_PASSES, select={"split_register_axes"}).run(g)
-    new_tile_op = next(n.op for n in out.nodes.values() if isinstance(n.op, TileOp))
-    new_thread = next(s for s in new_tile_op.body if isinstance(s, ThreadTile))
-
-    assert not any(isinstance(s, RegisterTile) for s in new_thread.body.iter()), "RegisterTile should be fully unwrapped"
-
-    # All four init / write / accum cells should reference a per-cell ``acc<i>``
-    # — body-global keep saw the Accum's N_r dep and propagated. (Post-replicate
-    # ``rename_ssa_sequential`` canonicalizes ``acc_0..3`` → ``acc0..3``.)
-    inits = [s for s in new_thread.body if isinstance(s, Init)]
-    init_names = {s.name for s in inits}
-    assert len(init_names) == 4 and all(n.startswith("acc") for n in init_names), init_names
-    writes = [s for s in new_thread.body if isinstance(s, Write)]
-    write_values = {w.value for w in writes}
-    assert len(write_values) == 4 and all(n.startswith("acc") for n in write_values), write_values
-    # The Init / Accum / Write towers must align on the SAME per-cell name
-    # — that's the whole point of body-global keep. If the Init tower kept
-    # ``acc`` as one name (local fold), the rendered kernel would have one
-    # init with four uses → name collision.
-    accums = [s for s in new_thread.body.iter() if isinstance(s, Accum)]
-    accum_names = {a.name for a in accums}
-    assert init_names == write_values == accum_names, (init_names, write_values, accum_names)
 
 
 def test_replicator_keeps_n_invariant_loads_once():


### PR DESCRIPTION
Executes `plans/post-blocked-builder-cleanup.md` — eight milestone commits removing the walk-through helpers, `global_keep` mechanism, and other scaffolding that became unreachable when PR #171 deleted the register-blocked GEMM builder.

## Commits

1. **Doc sweep** — rewrite `pipeline/ARCHITECTURE.md`, the three-tower section becomes a brief FN > 1 lowering paragraph; rename stale `006a_register_tile_planned` references to `010_split_register_axes`; rewrite the per-test docstrings in `test_lowering_blocked_gemm.py` to frame them as FN > 1 regressions against the per-cell + replicator pipeline (filename preserved for `git blame`).
2. **Revert `SerialTileBase.is_reduce` walk-through** — restore the one-line `any(isinstance(s, Accum) for s in self.body)`; delete `_contains_accum_transparent`.
3. **Inline `_iter_loads_through_register`** — both call sites in `020_stage_inputs.py` become direct iteration; drop `Iterator` / `Cond` imports.
4. **Revert `find_nested_reduce_accums` walk-through** — restore the direct comprehension; delete `_accums_through_wrappers`.
5. **Delete blocked Write-tower branch in `_splitk_residual`** — drop the `len(epilogue) == 1 and isinstance(epilogue[0], RegisterTile)` recursive case; inline `_gate_linear_chain` back into `gate_linear_epilogue_on_k_s_zero`; drop the `RegisterTile` import; strip the "Blocked-builder input shape" example block from the docstring.
6. **Delete `global_keep` mechanism** (highest blast radius) — delete `_collect_body_global_keep` + `_global_keep_for_axis` (~70 lines); drop the `global_keep` / `extra_keep` parameters; delete `test_006a_sibling_register_tile_towers_share_keep` (the only test exercising the mechanism, hand-constructing three sibling towers real planner output never produces).
7. **Inline `_BuildSkipped` → `RuleSkipped`** — cosmetic; one custom exception used only inside one module.
8. **Dedup-pass observability investigation** — temporarily instrumented `011_dedup_replicated` with a `DEPLODOCK_LOG_DEDUP=1` toggle, ran the full compiler test suite, swept fold counts. Found 96.3% of invocations fold nothing; the pass earns its keep on reduce/norm kernels (`k_rms_norm_*`, `k_softmax_*`, `k_reshape_linear_mean_reduce_*` — up to 16 Loads folded), not on FN > 1 matmul (`020_stage_inputs` already deduplicates those upstream). Kept the pass, corrected the docstring's framing, stripped the toggle.

## Verification

- `make test`: **1406 passed, 27 skipped** (one less than baseline — the deleted `test_006a_sibling_register_tile_towers_share_keep`).
- `make lint`: clean.
- Per-commit gate: `make test` + `make lint` between each commit; never below baseline.
- CUDA-emit sanity diff on `torch.matmul(randn(64,128), randn(128,64))` vs `main` (`ae28b07b`) — empty (identical, 49 lines).

## Diff size

```
16 files changed, 166 insertions(+), 513 deletions(-)
```

~347 lines net deletion. The plan's "~1000 lines" estimate was high because many of the deletions came with replacement docstrings rather than pure deletes, and the test docstrings were rewritten in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)