### PR TITLE
Stabilize tune + dedup leaves by op_cache_key

### DIFF
--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -85,6 +85,23 @@ worker probes its context (`_context_dirty` — a cheap `deviceSynchronize`) and
 request. Benign failures (NVRTC compile errors, cleaned-up OOM) leave the
 context healthy and keep the worker alive, so they pay no respawn cost.
 
+The dirty-exit path can race the parent's `poll()` check: by the time the
+parent writes the next request, the worker's stdin has been closed but
+`poll()` may not yet show the exit. `_BenchWorker.bench` therefore wraps the
+send in a single-retry loop — a `BrokenPipeError` on the first write triggers
+a respawn + one resend before surfacing as `bench worker died during request
+send`. Phase A of the tune-stabilization work; see
+`tests/compiler/backend/test_bench_worker_recovery.py`.
+
+`iter_once` (the per-iter sample loop) rejects a `cp.cuda.get_elapsed_time`
+reading of `<= 0.0` as `bench_fail` instead of accepting it as a 0µs sample.
+CUDA event timing has sub-µs resolution and any real launch consumes at least
+one device cycle — a 0.0 reading means a degenerate kernel (BM=1×BN=128 with
+the M tile fully masked, a kernel fused into a no-op, an event-pair quirk)
+that would otherwise lock in as the autotune DB's unbeatable best. Phase B
+of the same work; the existing worker → parent → `record_perf(bench_fail)`
+path carries the failure unchanged.
+
 `run_program_debug(...)` snapshots every non-input buffer after each
 launch — consumed by `--dump-dir` runs.
 

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -630,7 +630,21 @@ class CompiledProgram:
                 _launch(launch, self.compiled, self.arrays, self.descs.get(i), self.sym_values)
             stops[i].record()
             _wait_for_event(stops[i], _KERNEL_TIMEOUT_MS * b, launch.kernel_name)
-            dts[i] = cp.cuda.get_elapsed_time(starts[i], stops[i]) / b
+            elapsed_ms = cp.cuda.get_elapsed_time(starts[i], stops[i])
+            # CUDA event timing has sub-µs resolution and a real launch must
+            # consume at least one device cycle — a 0.0 reading means the
+            # launch was a no-op (degenerate grid like BM=1×BN=128 with the
+            # M tile entirely masked out, or a kernel that was fused into
+            # nothing). Pinning a 0µs "win" in the autotune DB would lock
+            # that variant in as the unbeatable best across re-runs. Treat
+            # as bench_fail instead — the existing worker → parent → DB
+            # path then records a normal sentinel row.
+            if elapsed_ms <= 0.0:
+                raise RuntimeError(
+                    f"kernel {launch.kernel_name!r} reported {elapsed_ms:.3f}ms elapsed — "
+                    "degenerate / no-op launch, variant marked bench_fail"
+                )
+            dts[i] = elapsed_ms / b
             if per_launch_hook is not None:
                 per_launch_hook(i, launch)
         return dts

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -896,7 +896,11 @@ class _BenchWorker:
             try:
                 self._proc.wait(timeout=2.0)
             except subprocess.TimeoutExpired:
-                pass
+                # Process is in uninterruptible-kernel state (rare —
+                # NVRTC stuck in a driver call). Nothing more we can do;
+                # init will reap once the syscall returns. Release the
+                # Python handle so the next bench respawns.
+                logger.warning("[bench-worker] pid=%s did not reap within 2s of SIGKILL", self._proc.pid)
         except ProcessLookupError:
             pass
         self._proc = None
@@ -905,19 +909,30 @@ class _BenchWorker:
         self._kill()
 
     def bench(self, graph: Graph, *, wall_timeout_s: float, **kwargs) -> BenchmarkResult:
-        if self._proc is None or self._proc.poll() is not None:
-            self._spawn()
-        assert self._proc is not None  # for type narrowing
-        proc = self._proc
-
         request = pickle.dumps({"graph": graph, "kwargs": kwargs}, protocol=pickle.HIGHEST_PROTOCOL)
-        try:
-            proc.stdin.write(len(request).to_bytes(8, "little"))
-            proc.stdin.write(request)
-            proc.stdin.flush()
-        except (BrokenPipeError, OSError) as exc:
-            self._kill()
-            raise RuntimeError(f"bench worker died during request send: {exc}") from exc
+        # A previous worker may have exited between our last interaction
+        # and this request — most commonly through the dirty-context exit
+        # path in ``_bench_worker.main``. ``poll()`` has a brief window
+        # where it still reports the worker as alive (the kernel hasn't
+        # reaped yet), so the first stdin write can hit ``BrokenPipeError``
+        # even though our state says "worker is up". Treat that as a
+        # stale-worker race: respawn and retry once. A second write
+        # failure on a fresh worker is a real bug and surfaces.
+        for attempt in (0, 1):
+            if self._proc is None or self._proc.poll() is not None:
+                self._spawn()
+            assert self._proc is not None  # for type narrowing
+            proc = self._proc
+            try:
+                proc.stdin.write(len(request).to_bytes(8, "little"))
+                proc.stdin.write(request)
+                proc.stdin.flush()
+                break
+            except (BrokenPipeError, OSError) as exc:
+                self._kill()
+                if attempt == 1:
+                    raise RuntimeError(f"bench worker died during request send: {exc}") from exc
+                logger.info("[bench-worker] stale worker on send (%s) — respawning", exc)
 
         deadline = _time_module.perf_counter() + wall_timeout_s
         out_fd = proc.stdout.fileno()

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -273,7 +273,11 @@ opposite structure, so `search/two_level.py` splits them:
   `InputOp`; the root op is shared **by reference**, so its body — and thus `op_cache_key` — is byte-for-byte the
   full-graph op's. Lowering-only (never re-running `loop/fusion`) is what keeps that body untouched. Because the inner
   tree holds one op, MCTS explores only that op's forks with `patience` as the op's own budget — `Σ_k n_k` benches,
-  never the product.
+  never the product. **Leaves are deduped by `op_cache_key`** before iteration: 24 RMSNorm LoopOps across 24 layers
+  collapse to one work unit, and the outer `total_us` accumulates `best * multiplicity` so the reward stays
+  multiplicity-weighted (bit-for-bit the same as per-node iteration). `OpResult.multiplicity` carries the count;
+  positions = `sum(r.multiplicity for r in reward.per_op)`. The progress denominator is the deduped count, so
+  Qwen3-Embedding-0.6B's ~14 unique kernels show as 14/14 not 14/337.
 
 **Separability + the structural handoff.** Op-variant forks are separable: every multi-option fork is an in-place `Op`
 rebind that leaves the graph unchanged, so whole-graph time is `Σ_k t_k`. Results key structurally (`op_cache_key` =

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py
@@ -45,8 +45,18 @@ _SPLITK_CANDIDATES = (1, 2, 4, 8, 16, 32)
 # axis for materializer's _single_thread_var).
 _BR_CANDIDATES = (1, 2, 4, 8, 16, 32, 64, 128, 256)
 _TUNE_F_CHOICES: tuple[int, ...] = (1, 2, 4, 8, 16, 32, 64, 128)
-# Cap on per-thread cell-product. NVRTC compile time explodes past this.
-_MAX_CELLS_PER_THREAD: int = 128
+# Cap on per-thread cell-product. NVRTC / cicc compile time explodes past 32
+# on the heavier fused kernels (linear+mean+reduce, sdpa-prologue matmul),
+# blowing past the autotune's 2.0 s compile-budget. ``_priority_matmul`` /
+# ``_priority_pointwise`` both already cap their cells/thread rank at 32
+# (matmul: ``min(fm*fn, 32)``; pointwise: ``-(fm*fn)`` — fewer wins), so the
+# tied / preferred variants never need fm·fn > 32. Keeping the enumeration
+# at the same cap aligns the candidate set with the priority intent and
+# stops MCTS exploration from drilling into compile-bomb tails after
+# patience on the actually-preferred variants exhausts. Raising back to 128
+# silently re-introduces the compile-budget failures on Qwen3-Embedding-
+# class fused matmul kernels.
+_MAX_CELLS_PER_THREAD: int = 32
 
 BN = Knob("BN", KnobType.INT, hints=_TUNE_AXIS_CHOICES, help="CTA innermost THREAD width (matmul output N tile)")
 BM = Knob("BM", KnobType.INT, hints=_TUNE_AXIS_CHOICES, help="CTA outer THREAD width (matmul output M tile)")

--- a/deplodock/compiler/pipeline/search/two_level.py
+++ b/deplodock/compiler/pipeline/search/two_level.py
@@ -75,12 +75,21 @@ _FAIL_US = 1e12
 
 @dataclass
 class OpResult:
-    """One kernel's inner-search outcome, for the per-op summary."""
+    """One unique kernel's inner-search outcome, for the per-op summary.
+
+    ``multiplicity`` is the number of structurally-identical ``LoopOp`` nodes
+    in the fused graph that share this ``op_key`` — 24 for a 24-layer
+    RMSNorm, 1 for a singleton. The outer reward's ``total_us`` weights
+    ``best_us`` by ``multiplicity`` so the Σ across ``per_op`` equals the
+    whole-graph latency (every node position counts, even though dedup
+    means we only run the inner search and DB lookup once per key).
+    """
 
     name: str
     op_key: str
     best_us: float | None
     benched: bool  # True when the inner search ran; False when skipped (terminated)
+    multiplicity: int = 1
 
 
 @dataclass
@@ -136,9 +145,21 @@ def inner_reward(
     is summed. Benches scale as ``Σ_k n_k`` (per op), never the product.
 
     ``progress`` (a duck-typed :class:`~deplodock.commands.tune_progress.TuneProgress`,
-    or ``None``) drives the CLI progress bar: one op leaf ticked per kernel, the
-    live tail updated per benched variant. Kept duck-typed so this module carries
-    no dependency on ``commands/``."""
+    or ``None``) drives the CLI progress bar: one op leaf ticked per *unique*
+    kernel (24-layer RMSNorm = 1 tick, not 24), the live tail updated per
+    benched variant. Kept duck-typed so this module carries no dependency on
+    ``commands/``.
+
+    Leaves are deduped by ``op_cache_key`` before iteration. The inner search
+    keys every DB write on the structural key, so iterating per occurrence
+    (337 LoopOp nodes on Qwen3-Embedding-0.6B) only differs from per-unique-key
+    iteration (~14) by an O(positions) ``db.terminated`` / ``best_per_op_time``
+    cache lookup — and gives the user a misleading progress denominator.
+    Multiplicity is preserved: ``total_us`` weights each unique kernel's best
+    by its node count, so the outer MCTS reward is bit-for-bit identical to
+    the per-node-iterated total."""
+    from collections import OrderedDict  # noqa: PLC0415
+
     from deplodock.compiler.pipeline.pipeline import variant_label  # noqa: PLC0415
 
     ctx_key = ctx.structural_key()
@@ -146,13 +167,23 @@ def inner_reward(
     total = 0.0
     ok = True
     per_op: list[OpResult] = []
-    # The tunable op leaves (skip ops with no cache key — never benched). Counted
-    # up front so the progress bar's denominator is correct before the first tick.
-    leaves = [(nid, op) for nid, op in _kernel_nodes(fused_graph) if op_cache_key(op) is not None]
-    if progress is not None:
-        progress.start_terminal(len(leaves))
-    for nid, op in leaves:
+    # Group structurally-identical LoopOps under one ``op_cache_key`` —
+    # insertion order = first occurrence (drives the progress tail name).
+    # Ops with no cache key are unreachable through the bench path so they
+    # don't enter the dedup map at all (matches the previous filter).
+    unique: OrderedDict[str, tuple[str, object, int]] = OrderedDict()
+    for nid, op in _kernel_nodes(fused_graph):
         key = op_cache_key(op)
+        if key is None:
+            continue
+        if key in unique:
+            rep_nid, rep_op, count = unique[key]
+            unique[key] = (rep_nid, rep_op, count + 1)
+        else:
+            unique[key] = (nid, op, 1)
+    if progress is not None:
+        progress.start_terminal(len(unique))
+    for key, (nid, op, count) in unique.items():
         name = getattr(op, "name", None) or nid
         if progress is not None:
             progress.op_start(name)
@@ -187,12 +218,14 @@ def inner_reward(
             db.record_effort(ctx_key, key, math.inf if exhausted else float(patience))
             benched = True
         best = db.best_per_op_time(ctx_key, key, backend=backend_name)
-        per_op.append(OpResult(name=name, op_key=key, best_us=best, benched=benched))
+        per_op.append(OpResult(name=name, op_key=key, best_us=best, benched=benched, multiplicity=count))
+        # Multiplicity-weighted accumulation — a 24-layer RMSNorm contributes
+        # 24 × best, matching the per-node total before dedup.
         if best is None:
             ok = False
-            total += _FAIL_US
+            total += _FAIL_US * count
         else:
-            total += best
+            total += best * count
         if progress is not None:
             progress.op_done(name)
     return InnerReward(total_us=total, ok=ok, per_op=per_op)
@@ -237,7 +270,14 @@ def run_two_level_tune(
         reward = inner_reward(fused.graph, ctx=ctx, db=db, backend=backend, patience=patience, ucb_c=ucb_c, progress=progress)
         stats = PerfStats(median=reward.total_us, min=reward.total_us, max=reward.total_us, mean=reward.total_us, variance=0.0, n_samples=0)
         outer.observe(stats, "ok" if reward.ok else "bench_fail")
-        logger.info("[tune] fused terminal #%d: Σ per-op = %.2f us (%d kernels)", n_terminals, reward.total_us, len(reward.per_op))
+        positions = sum(r.multiplicity for r in reward.per_op)
+        logger.info(
+            "[tune] fused terminal #%d: Σ per-op = %.2f us (%d unique kernels, %d positions)",
+            n_terminals,
+            reward.total_us,
+            len(reward.per_op),
+            positions,
+        )
         if best_reward is None or (reward.ok and reward.total_us < best_reward.total_us):
             best_fused, best_reward = fused.graph, reward
 

--- a/tests/compiler/backend/test_bench_worker_recovery.py
+++ b/tests/compiler/backend/test_bench_worker_recovery.py
@@ -94,6 +94,120 @@ def test_worker_exits_after_context_corruption() -> None:
         proc.wait(timeout=5)
 
 
+def test_kill_idempotent_when_no_proc() -> None:
+    """``_kill()`` on a worker that was never spawned must be a silent no-op."""
+    from deplodock.compiler.backend.cuda.program import _BenchWorker
+
+    w = _BenchWorker()
+    assert w._proc is None
+    w._kill()
+    assert w._proc is None
+    w._kill()  # repeated calls stay no-ops
+    assert w._proc is None
+
+
+def test_kill_releases_already_dead_subprocess() -> None:
+    """A worker subprocess that exited on its own (e.g. dirty-context path) is
+    still attached to ``self._proc``; ``_kill()`` must release it without
+    raising even though ``kill()`` on a reaped pid would normally surface a
+    ``ProcessLookupError``."""
+    from deplodock.compiler.backend.cuda.program import _BenchWorker
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.exit(0)"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.wait(timeout=5) == 0
+
+    w = _BenchWorker()
+    w._proc = proc
+    w._kill()
+    assert w._proc is None
+
+
+def test_bench_retries_after_broken_pipe_on_first_write(monkeypatch) -> None:
+    """The dirty-context exit path can race the parent's ``poll()`` check: by
+    the time we write the next request, the worker's stdin has been closed
+    but ``poll()`` may not yet show the exit. The first ``stdin.write``
+    then raises ``BrokenPipeError``. ``bench()`` must respawn and retry the
+    send once before surfacing the failure."""
+    from deplodock.compiler.backend import BenchmarkResult
+    from deplodock.compiler.backend.cuda import program as P
+
+    spawn_count = 0
+
+    class _FakeStdin:
+        def __init__(self, *, fail_first: bool) -> None:
+            self._fail_first = fail_first
+            self._writes = 0
+
+        def write(self, data: bytes) -> int:
+            self._writes += 1
+            if self._fail_first and self._writes == 1:
+                raise BrokenPipeError(32, "Broken pipe")
+            return len(data)
+
+        def flush(self) -> None:
+            pass
+
+    class _FakeStderr:
+        def read(self) -> bytes:
+            return b""
+
+    class _FakeProc:
+        def __init__(self, *, fail_first_write: bool) -> None:
+            self.pid = 1000 + (0 if fail_first_write else 1)
+            self.stdin = _FakeStdin(fail_first=fail_first_write)
+            self.stdout = type("S", (), {"fileno": lambda self: -1})()
+            self.stderr = _FakeStderr()
+            self._alive = True
+
+        def poll(self) -> int | None:
+            return None if self._alive else 0
+
+        def kill(self) -> None:
+            self._alive = False
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    procs = [_FakeProc(fail_first_write=True), _FakeProc(fail_first_write=False)]
+
+    def fake_spawn(self: P._BenchWorker) -> None:
+        nonlocal spawn_count
+        self._proc = procs[spawn_count]
+        spawn_count += 1
+
+    # Construct the wire-format response the second proc "writes" back so the
+    # recv loop pickle-loads a real BenchmarkResult.
+    response_body = pickle.dumps(
+        {"ok": True, "result": BenchmarkResult(time_ms=42.0, num_launches=0)},
+        protocol=pickle.HIGHEST_PROTOCOL,
+    )
+    response_wire = len(response_body).to_bytes(8, "little") + response_body
+    read_pos = [0]
+
+    def fake_select(rlist, wlist, xlist, timeout):  # noqa: ARG001
+        return rlist, [], []
+
+    def fake_read(fd: int, n: int) -> bytes:  # noqa: ARG001
+        chunk = response_wire[read_pos[0] : read_pos[0] + n]
+        read_pos[0] += len(chunk)
+        return chunk
+
+    monkeypatch.setattr(P._BenchWorker, "_spawn", fake_spawn)
+    monkeypatch.setattr(P.select, "select", fake_select)
+    monkeypatch.setattr(P._os, "read", fake_read)
+
+    w = P._BenchWorker()
+    result = w.bench(graph=None, wall_timeout_s=5.0)
+
+    assert spawn_count == 2, "BrokenPipeError on first write must trigger one respawn"
+    assert result.time_ms == 42.0
+
+
 def test_worker_survives_benign_error() -> None:
     # A failure that never touches CUDA (e.g. an NVRTC compile error) leaves the
     # context healthy — the worker must stay alive and keep serving so the

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -52,3 +52,37 @@ def test_benchmark_program_returns_timing():
     assert result.num_launches == 1
     assert result.per_launch is not None
     assert len(result.per_launch) == 1
+
+
+@requires_cuda
+def test_iter_once_raises_on_zero_elapsed(monkeypatch):
+    """A 0.0ms CUDA event reading means the launch was a degenerate
+    no-op (e.g. an all-masked-out grid in a BM=1×BN=128 register tile).
+    ``iter_once`` must surface this as a bench_fail RuntimeError so the
+    autotune DB never pins a 0µs "win" as the unbeatable best."""
+    import cupy as cp
+    import pytest
+
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+    monkeypatch.setattr(cp.cuda, "get_elapsed_time", lambda start, stop: 0.0)
+
+    with gpu_lock():
+        prog = CompiledProgram.build(_make_add_graph(8))
+        with pytest.raises(RuntimeError, match="reported 0.000ms elapsed"):
+            prog.iter_once()
+
+
+@requires_cuda
+def test_benchmark_program_propagates_zero_elapsed_as_bench_fail(monkeypatch):
+    """End-to-end: a 0.0ms reading inside ``benchmark_program`` must
+    bubble up as a RuntimeError, never silently produce a sample of 0.0
+    that ``_samples_to_result`` would record as the kernel's median."""
+    import cupy as cp
+    import pytest
+
+    monkeypatch.setattr(cp.cuda, "get_elapsed_time", lambda start, stop: 0.0)
+
+    with pytest.raises(RuntimeError, match="reported 0.000ms elapsed"):
+        benchmark_program(_make_add_graph(1024), warmup=2, num_iters=5)

--- a/tests/compiler/passes/test_enumeration_cap.py
+++ b/tests/compiler/passes/test_enumeration_cap.py
@@ -1,0 +1,63 @@
+"""Pin the per-thread cell-product cap on ``enumerate_cartesian``.
+
+``_priority_matmul`` / ``_priority_pointwise`` both cap the ranked
+cells/thread at 32 (matmul: ``min(fm*fn, 32)``; pointwise:
+``-(fm*fn)``), so any tied / preferred variant already lives under 32.
+Historically ``_MAX_CELLS_PER_THREAD`` admitted up to 128 — those
+larger-than-preferred variants were only reachable after MCTS exhausted
+patience on better ones, and they blew past the autotune's 2 s
+compile-budget on fused matmul kernels (Qwen3-Embedding's linear+mean
+reduce and SDPA-prologue matmul both hit this on real tunes).
+
+The fix aligns the enumeration cap with the priority cap. These tests
+codify the invariant so we don't silently re-introduce the compile-bomb
+tail. If a future change wants to raise the cap, it has to update both
+this test and the matmul / pointwise priority docstrings.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.context import Context
+from deplodock.compiler.pipeline.passes.lowering.tile._enumeration import (
+    _MAX_CELLS_PER_THREAD,
+    enumerate_cartesian,
+)
+
+# Pinned sm_80 context — matches the rest of the planner tests; the cap is
+# device-independent so a real GPU isn't required.
+_CTX = Context(compute_capability="sm_80")
+
+
+def _max_cells(extents: tuple[int, int, int], mode: str) -> int:
+    """Run the cartesian and return the largest fm·fn seen across variants."""
+    e_m, e_n, e_k = extents
+    variants = enumerate_cartesian(E_M=e_m, E_N=e_n, E_K=e_k, ctx=_CTX, priority_mode=mode)
+    assert variants, f"empty enumeration for mode={mode!r} extents={extents!r}"
+    return max(v.fm * v.fn for v in variants)
+
+
+def test_matmul_enumeration_respects_cells_cap() -> None:
+    """A real Qwen3-Embedding-style matmul shape (M=32, K=1024, N=3072) used
+    to surface FM·FN=64 / 128 variants that the autotune then pushed past
+    the 2 s compile budget. No matmul variant must exceed the cap."""
+    assert _max_cells((32, 3072, 1024), "matmul") <= _MAX_CELLS_PER_THREAD
+
+
+def test_matmul_enumeration_cap_is_thirty_two() -> None:
+    """If the cap is ever raised, this test fails loudly — the matmul priority
+    docstring (``capped at 32 (NVRTC compile time)``) needs updating at the
+    same time. Keeping the literal pinned prevents accidental drift."""
+    assert _MAX_CELLS_PER_THREAD == 32
+
+
+def test_pointwise_enumeration_respects_cells_cap() -> None:
+    """Pointwise priority prefers *fewer* cells/thread (better occupancy), so
+    the cap mostly never binds — but a tiny output extent can still emit
+    variants near the cap. Pin the invariant anyway."""
+    assert _max_cells((4, 4096, 1), "pointwise") <= _MAX_CELLS_PER_THREAD
+
+
+def test_reduce_enumeration_respects_cells_cap() -> None:
+    """Reduce uses BR rather than FM·FN as its cell driver, so FM·FN stays
+    tiny — verify nothing leaks above the cap regardless."""
+    assert _max_cells((32, 1024, 128), "reduce") <= _MAX_CELLS_PER_THREAD

--- a/tests/compiler/pipeline/search/test_two_level.py
+++ b/tests/compiler/pipeline/search/test_two_level.py
@@ -125,10 +125,12 @@ def test_inner_reward_is_separable_not_a_product() -> None:
 
     assert backend.calls == n1 + n2, f"expected separable {n1 + n2} benches, got {backend.calls}"
     assert backend.calls < n1 * n2, "separable sum must be below the cross-product"
-    # Every kernel measured; total is the sum of the per-op bests.
+    # Every kernel measured; total is the sum of the per-op bests. Two distinct
+    # structural keys → two ``per_op`` entries, each at ``multiplicity=1``.
     assert reward.ok
     assert len(reward.per_op) == 2
     assert all(r.best_us is not None for r in reward.per_op)
+    assert all(r.multiplicity == 1 for r in reward.per_op)
     assert reward.total_us == pytest.approx(sum(r.best_us for r in reward.per_op))
 
 
@@ -167,8 +169,11 @@ def test_inner_reward_deepens_only_under_tuned() -> None:
 
 
 def test_inner_reward_shares_identical_kernel() -> None:
-    """Two identical kernels in one terminal are tuned once — the second is
-    a DB hit on the same op_cache_key."""
+    """Two identical kernels in one terminal collapse to a single ``per_op``
+    entry under one ``op_cache_key`` with ``multiplicity=2``. The inner
+    search runs once; the outer total still costs 2× the shared best so the
+    outer MCTS reward stays bit-for-bit identical to the per-node-iterated
+    formulation."""
     fused = _fuse(_two_identical_matmuls())
     loops = _loop_ids(fused)
     assert len(loops) == 2
@@ -181,9 +186,9 @@ def test_inner_reward_shares_identical_kernel() -> None:
     reward = inner_reward(fused, ctx=Context.from_target((8, 0)), db=SearchDB(), backend=backend, patience=_PATIENCE)
 
     assert backend.calls == single, "shared kernel must bench once, not twice"
-    assert len(reward.per_op) == 2
-    assert reward.per_op[0].best_us == pytest.approx(reward.per_op[1].best_us)
-    # Total sums the (shared) best twice — both kernels still cost time.
+    assert len(reward.per_op) == 1, "identical kernels collapse to one per_op entry"
+    assert reward.per_op[0].multiplicity == 2, "both node positions are counted"
+    # Total weights the shared best by its multiplicity — both kernels still cost time.
     assert reward.total_us == pytest.approx(2 * reward.per_op[0].best_us)
 
 


### PR DESCRIPTION
Originating ask: the live progress bar on `deplodock tune Qwen/Qwen3-Embedding-0.6B --bench --patience 50 --clean` shows
`N/337 ops` even though the model has only ~14 unique structural kernels — 24 RMSNorms × 24 layers etc. Verifying that
change by re-running tune surfaced three pre-existing failure modes that needed fixing first; this PR lands all four
phases on one branch with milestone commits.

## End-state

After this PR, the verify command runs clean on a fresh GPU + DB:

```
[tune] fused terminal #1: Σ per-op = 9192.26 us (14 unique kernels, 337 positions)
[tune] done: 1 fused terminal(s) in 155.6s
```

- Progress denominator ≈ **14**, not 337.
- **0** `bench worker died during request send: [Errno 32] Broken pipe` events.
- **0** `0.0us` measurements silently recorded as a kernel's median.
- **0** `compile stage exceeded 2.0s budget` / `wall budget` events on the previously-failing kernels
  (`k_linear_mean_reduce_8dd6af`, `k_sdpa_reshape_unsqueeze_transpose_linear_reduce_0dd157`).

## Phases

### A — `6733ffb3` retry `_BenchWorker.bench` on stale-worker `BrokenPipeError`

The dirty-context exit path in `_bench_worker.main` can race the parent's `poll()` check: by the time the parent writes
the next request, the worker's stdin has been closed but `poll()` may not yet show the exit. The first stdin write
then raises `BrokenPipeError` and the whole bench gets marked `bench_fail` spuriously. `bench()` now wraps the send in
a bounded retry — kill, respawn, resend once. A second failure on a fresh worker is a real bug and surfaces normally.
Also: `_kill()` logs a warning when SIGKILL + wait(2s) times out (uninterruptible-kernel D-state).

Tests: `_kill()` idempotency on no-proc + on already-dead subprocess; retry via mocked `_spawn` + `select.select` +
`_os.read` so a `BrokenPipeError` on the first write deterministically triggers a respawn and the bench still returns
a valid `BenchmarkResult`.

### B — `61626e0b` reject 0.0ms CUDA-event elapsed as `bench_fail`

A degenerate launch (BM=1×BN=128 with the M tile fully masked, a kernel fused into a no-op, an event-pair quirk) can
read 0.0ms from `cp.cuda.get_elapsed_time`. The previous code accepted that as a valid sample; the median of a vector
containing 0.0s lands at 0.0 and pins the variant as the autotune DB's unbeatable best across re-runs. CUDA event
timing has sub-µs resolution and any real launch consumes at least one device cycle, so 0.0 is a measurement-integrity
failure rather than a fast kernel. `iter_once` now raises the standard bench_fail RuntimeError; per
`feedback_no_defensive_fallbacks` no clamping to 1e-6.

Tests: direct `iter_once` + end-to-end `benchmark_program` with `cp.cuda.get_elapsed_time` monkeypatched to return 0.0.

### C — `a62a3c40` align `_MAX_CELLS_PER_THREAD` with priority cap (128 → 32)

The cartesian enumeration in `_enumeration.py` admitted FM·FN candidates up to 128 cells/thread, but
`_priority_matmul` already caps its ranked cells/thread at 32 (`min(fm*fn, 32)`) and `_priority_pointwise` actively
prefers fewer cells. So every variant with FM·FN > 32 was unreachable under the priority ordering — only visited
after MCTS exhausted patience on better tied variants, where NVRTC's cicc pass blows past the autotune's 2 s
compile-budget on Qwen3-Embedding-class fused matmul kernels (the original report logged 20+ such events).

The fix aligns the enumeration cap with the priority cap. No preferred variant changes — the ones we lose were never
ranked above their FM·FN ≤ 32 siblings under the matmul/pointwise priorities. `tests/compiler/passes/test_enumeration_cap.py`
pins the matmul cap, the literal value, and the pointwise + reduce flavors so future cap-raises require explicit
updates here and in the priority docstrings.

### D — `0794dcf4` dedup tune leaves by `op_cache_key` with multiplicity weighting

`inner_reward` previously iterated `_kernel_nodes(fused_graph)` once per LoopOp position. The DB writes
(`perf` / `op_effort`) are already keyed on `op_cache_key`, so duplicate visits at the work layer were no-ops aside
from a redundant `db.terminated` + `best_per_op_time` lookup — but they showed in the progress bar as 4/337 instead
of 4/14.

`leaves` now collapses to an `OrderedDict` keyed on `op_cache_key`. The inner search runs once per unique kernel;
`total_us` weights each best by its `multiplicity` (count of node positions sharing the key) so the outer MCTS
reward is bit-for-bit identical to the per-node total. `OpResult` gains a `multiplicity: int = 1` field. The summary
log prints `Σ per-op = X us (N unique kernels, M positions)` so the deduped view doesn't hide the underlying node
count.

Tests: `test_inner_reward_shares_identical_kernel` updated — identical kernels now collapse to one `per_op` entry
with `multiplicity=2`; total still costs 2× the shared best (the load-bearing invariant). Adjacent tests gain a
`multiplicity == 1` assertion on distinct-key entries.

### Docs — `b3888a86`

`backend/cuda/ARCHITECTURE.md`: bench-worker retry + 0us rejection notes.
`pipeline/ARCHITECTURE.md`: leaves-dedup-with-multiplicity in `inner_reward` (14/14 vs 14/337 denominator).

## Verification

- Unit / integration: `make test` — 1432 passed, 27 skipped.
- End-to-end: `deplodock tune Qwen/Qwen3-Embedding-0.6B --bench --patience 10 --clean` — clean tuning run (zero
  failures across all four classes, 14 unique kernels = 337 positions, 155.6s tuning + bench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)