### PR TITLE
Warp-tier MMA scoring: cells≈16 + square aspect for tensor cores

### DIFF
--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -1437,6 +1437,29 @@ def score_tile_geometry(
 
     if cells == 1:
         score -= 1.0
+    elif "ATOM_KIND" in knobs:
+        # Tensor-core MMA (warp-tier WMMA path): the per-lane register
+        # budget is dominated by accumulator fragments (one ~4-reg/lane
+        # frag per FM·FN cell, half acc on consumer / fp32 acc on
+        # datacenter) plus the operand frags loaded per K-iter. On
+        # sm_8x / sm_9x / sm_12x with the 255-reg/lane cap, ``cells ≈
+        # 16`` is the 2-blocks/SM occupancy knee; past ~24 the per-lane
+        # reg footprint spills to local memory (measured at 173 regs/
+        # thread on a 2048² fp16 sweep — see ``plans/mma-warp-scoring.md``
+        # and the warp-tier section of ``compiler/pipeline/ARCHITECTURE.md``).
+        # The pre-2026 cells-up-to-128 reward (tuned for scalar f32
+        # matmul where 104-cell golden tiles win) pushed the MMA picker
+        # to FM=1 FN=32, 3.0× slower than cuBLAS instead of 0.91×.
+        sweet = 16
+        score += 0.5 - min(abs(cells - sweet) / sweet, 0.5)
+        # Square per-warp tile reuses operands equally — each A frag
+        # used ``FN`` times per K-iter, each B frag used ``FM`` times.
+        # Skewed shapes (FM=1, FN=N) waste one operand's reuse and
+        # inflate the per-K-iter fragment-load count linearly.
+        fm = max(1, int(knobs.get("FM", 1)))
+        fn = max(1, int(knobs.get("FN", 1)))
+        aspect = abs(fm - fn) / max(fm, fn)  # 0 = square, 1 = fully skewed
+        score -= aspect * 0.25
     elif cells <= 128:
         # Reward register-tile budget gradually up to 128 cells (NVRTC cap +
         # fp32 register-tile sweet spot). Without this gradient every
@@ -1562,9 +1585,25 @@ def score_tile_geometry(
     # time and MCTS visits it first.
     if "FM" in knobs and isinstance(compute_capability, tuple) and compute_capability >= (9, 0):
         bk = int(knobs.get("BK", 1))
-        bn = int(knobs.get("BN", 1))
         fn = int(knobs.get("FN", 1))
-        if bk * BYTES_PER_ELEM >= 128 and bn * fn * BYTES_PER_ELEM >= 128:
+        # The N-side inner stride in elements differs by tier: scalar
+        # carries ``BN`` (per-thread N tile) explicitly; warp-tier MMA
+        # has no ``BN`` knob — its equivalent is ``WN · FN · atom_N``.
+        # Defaulting to 1 (the pre-2026 shape) under-counted the warp
+        # tier by ``WN · atom_N`` (typically 32-128×) and made the
+        # bonus fire for ``FN=32`` but not ``FN=4`` even though both
+        # comfortably clear the 128 B TMA alignment — a 1.0 spurious
+        # advantage that pushed the picker to the FM=1 FN=32 spill
+        # corner (see ``plans/mma-warp-scoring.md`` for the 2048² fp16
+        # sweep).
+        if "ATOM_KIND" in knobs:
+            from deplodock.compiler.pipeline.passes.lowering.tile._atom import atom_spec  # noqa: PLC0415
+
+            _atom_n = atom_spec(str(knobs["ATOM_KIND"])).shape[1]
+            n_stride_elems = int(knobs.get("WN", 1)) * fn * _atom_n
+        else:
+            n_stride_elems = int(knobs.get("BN", 1)) * fn
+        if bk * BYTES_PER_ELEM >= 128 and n_stride_elems * BYTES_PER_ELEM >= 128:
             score += 1.0
 
     return score
@@ -1848,7 +1887,23 @@ class TileOp(BodyOp):
         # ``self.knobs`` which already carries these; without them here the
         # lazy_score path would silently fall back to BM=BN=1 defaults).
         if is_warp:
-            score_knobs = {"FM": p.fm, "FN": p.fn, "SPLITK": p.splitk, "BK": p.bk}
+            # ATOM_KIND / WM / WN feed the warp-tier branch of
+            # ``score_tile_geometry``: the cells-sweet-spot prior keys off
+            # ``ATOM_KIND in knobs``, the aspect-ratio prior reads FM/FN
+            # (already here), and the TMA-bonus's N-stride calc uses
+            # ``WN · FN · atom_N``. Omitting them silently routed the warp
+            # tier through the scalar branch and over-counted the TMA
+            # bonus for skewed shapes — exactly the FM=1 FN=32 regression
+            # ``plans/mma-warp-scoring.md`` chases.
+            score_knobs = {
+                "FM": p.fm,
+                "FN": p.fn,
+                "SPLITK": p.splitk,
+                "BK": p.bk,
+                "WM": p.wm,
+                "WN": p.wn,
+                "ATOM_KIND": p.atom_kind,
+            }
         else:
             score_knobs = {
                 "FM": p.fm,

--- a/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
@@ -160,6 +160,12 @@ def rewrite(ctx: Context, root: Node) -> list[TileOp] | None:
         raise RuleSkipped("stage already applied (idempotence via knob)")
     budget = ctx.max_dynamic_smem
     atom_kind = root.op.knobs.get("ATOM_KIND")
+    # Per-buffer bytes-per-elem so ``_classify``'s slab-cap check sizes
+    # fp16 slabs at 2 B/elem instead of the BYTES_PER_ELEM=4 hardcoded
+    # over-count. Without this the half-precision MMA path rejects every
+    # admissable staged variant (the block-scaled slab gets over-counted
+    # 2× and trips ``slab_cap``).
+    bytes_per_elem = {buf: int(t.dtype.nbytes) for buf, t in root.op.inputs.items() if t.dtype is not None}
     variants = _enumerate_variants(
         root.op.body,
         slab_cap=budget,
@@ -167,6 +173,7 @@ def rewrite(ctx: Context, root: Node) -> list[TileOp] | None:
         parent_op=root.op,
         warp_size=ctx.warp_size,
         atom_kind=atom_kind,
+        bytes_per_elem=bytes_per_elem,
     )
     if not variants:
         raise RuleSkipped("no Load qualifies for staging")
@@ -188,6 +195,7 @@ def _enumerate_variants(
     parent_op: TileOp,
     warp_size: int,
     atom_kind: str | None = None,
+    bytes_per_elem: dict[str, int] | None = None,
 ) -> list[TileOp]:
     candidates = _candidate_buffers(body, warp_size=warp_size)
     if not candidates:
@@ -204,7 +212,13 @@ def _enumerate_variants(
     for mask in masks:
         allow = frozenset(b for i, b in enumerate(bufs_ranked) if mask & (1 << i))
         new_body = _maybe_rewrite(
-            body, slab_cap=slab_cap, scope_budget=scope_budget, allowed_bufs=allow, warp_size=warp_size, atom_kind=atom_kind
+            body,
+            slab_cap=slab_cap,
+            scope_budget=scope_budget,
+            allowed_bufs=allow,
+            warp_size=warp_size,
+            atom_kind=atom_kind,
+            bytes_per_elem=bytes_per_elem,
         )
         if new_body is None:
             continue
@@ -370,6 +384,7 @@ def _maybe_rewrite(
     allowed_bufs: frozenset[str] | None = None,
     warp_size: int,
     atom_kind: str | None = None,
+    bytes_per_elem: dict[str, int] | None = None,
 ) -> Body | None:
     idx, outer = single_tile(body)
     tt = parallel_tile_of(outer)
@@ -407,6 +422,7 @@ def _maybe_rewrite(
         allowed_bufs=allowed_bufs,
         is_cooperative=is_cooperative,
         atom_kind=atom_kind,
+        bytes_per_elem=bytes_per_elem,
     )
     if new_tile_body == tt.body:
         if allowed_bufs is None:
@@ -442,6 +458,7 @@ def _process_scope(
     is_cooperative: bool = False,
     register_axes: tuple[Axis, ...] = (),
     atom_kind: str | None = None,
+    bytes_per_elem: dict[str, int] | None = None,
 ) -> Body:
     """Walk scope.body; recurse into non-reduce free tiles; collect Loads
     from reduce tiles into per-buffer buckets. Per buffer, build a Source
@@ -485,6 +502,7 @@ def _process_scope(
                 is_cooperative=is_cooperative,
                 register_axes=new_register_axes,
                 atom_kind=atom_kind,
+                bytes_per_elem=bytes_per_elem,
             )
             rewritten_inner.append(s.with_bodies((new_body,)))
             continue
@@ -504,6 +522,7 @@ def _process_scope(
                 is_cooperative=is_cooperative,
                 register_axes=register_axes,
                 atom_kind=atom_kind,
+                bytes_per_elem=bytes_per_elem,
             )
             rewritten_inner.append(s.with_bodies((new_body,)))
             continue
@@ -520,6 +539,7 @@ def _process_scope(
                 is_cooperative=is_cooperative,
                 register_axes=register_axes,
                 atom_kind=atom_kind,
+                bytes_per_elem=bytes_per_elem,
             )
             rewritten_inner.append(s.with_bodies((new_body,)))
             continue
@@ -544,6 +564,7 @@ def _process_scope(
                 is_cooperative=is_cooperative,
                 register_axes=register_axes,
                 atom_kind=atom_kind,
+                bytes_per_elem=bytes_per_elem,
             )
             rewritten_inner.append(Cond(cond=s.cond, body=Body(new_body), else_body=s.else_body))
             continue
@@ -570,6 +591,7 @@ def _process_scope(
         slab_cap=slab_cap,
         scope_budget=scope_budget,
         atom_kind=atom_kind,
+        bytes_per_elem=bytes_per_elem,
     )
     if not sources:
         return tuple(rewritten_inner)
@@ -607,6 +629,7 @@ def _build_sources(
     slab_cap: int,
     scope_budget: int,
     atom_kind: str | None = None,
+    bytes_per_elem: dict[str, int] | None = None,
 ) -> tuple[list[Source], dict[str, tuple[str, tuple[Expr, ...]]]]:
     """Per buffer, partition Loads by index equality; per partition, derive
     slab geometry; admit Sources under budget. Returns (sources,
@@ -640,6 +663,7 @@ def _build_sources(
                 extra_candidates=rep_extra,
                 allow_no_fan_in=allow_no_fan_in,
                 atom_kind=atom_kind,
+                bytes_per_elem=(bytes_per_elem or {}).get(rep_load.input, BYTES_PER_ELEM) if bytes_per_elem else BYTES_PER_ELEM,
             )
             if slab is None:
                 continue
@@ -703,6 +727,7 @@ def _classify(
     extra_candidates: tuple[Axis, ...] = (),
     allow_no_fan_in: bool = False,
     atom_kind: str | None = None,
+    bytes_per_elem: int = BYTES_PER_ELEM,
 ) -> _Slab | None:
     candidates = (*thread_axes, reduce_axis, *extra_candidates)
     ctx = SimplifyCtx({ax.name: Interval(0, ax.extent.as_static() - 1) for ax in scope_axes if ax.extent.is_static})
@@ -735,7 +760,14 @@ def _classify(
     # seq_len-bearing loads but the load still works via direct global access.
     if any(not ax.extent.is_static for ax in cache_axes):
         return None
-    n_bytes = BYTES_PER_ELEM
+    # Per-buffer dtype size from ``parent_op.inputs`` plumbed through
+    # the rewrite chain — fp16 was previously over-counted 2× because
+    # the slab-cap check assumed fp32 (BYTES_PER_ELEM=4). For an MMA
+    # matmul with K=2048 and a 64×64 block-scaled A slab, the actual
+    # fp16 footprint is 8 KB; the legacy check rejected at 16 KB and
+    # locked out the staged variant on shapes where the picker would
+    # otherwise have admitted it.
+    n_bytes = bytes_per_elem
     for ax in cache_axes:
         n_bytes *= ax.extent.as_static()
     if n_bytes > slab_cap:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py
@@ -199,15 +199,34 @@ def _priority_matmul_thread(p: ScalarTileParams) -> tuple[int, ...]:
 
 
 def _priority_matmul_warp(p: WarpTileParams) -> tuple[int, ...]:
-    # Warp-tier ranking parallels the thread-tier priority but reads warp-tier
-    # fields. Threads = ``wn × wm × 32`` (warps × lanes-per-warp). Cells-per-
-    # cell-owner cap = 64 (looser than the thread tier's 32 — MMA amortizes
-    # K-loop overhead better, so bigger register tiles stay profitable).
-    # Stub-quality for M1: no warp rows enumerate yet (the warp impl returns
-    # []), so this function is never called. M3 wires the warp impl and this
-    # priority drives the fork tree's sibling ordering.
+    # Warp-tier ranking for tensor-core MMA matmul (fp16 / bf16 with f32
+    # accumulator, ``wmma_m16n16k16_*`` atom). The pre-2026 prior rewarded
+    # ``min(fm*fn, 64)`` monotonically — pushed the picker toward
+    # ``FM=1 FN=32`` (32 N-cells per warp, max A-frag reuse) but that
+    # shape exploded the per-lane register budget: 32 acc frags + 32 B
+    # frags + 1 A frag ≈ 4·(32+32+1) = 260 regs/lane, past the 255-reg
+    # spill cap — measured at 173 regs/thread on sm_120 with cuBLAS at
+    # 3.0× (see ``plans/mma-warp-scoring.md`` for the 2048² fp16 sweep).
+    #
+    # New prior reads off two empirical knees:
+    #
+    # 1. **Cells-per-warp sweet spot ≈ 16** (FM·FN). 16 acc frags at
+    #    ~4 regs/lane each is ~64 regs + ~30 regs of frag-load + ~30 regs
+    #    addressing overhead = ~120-130 regs/lane → 2 blocks/SM occupancy
+    #    on sm_8x/9x/12x without spilling. ``-abs(cells - 16)`` peaks
+    #    sharply at the sweet spot.
+    # 2. **Square per-warp tile** (FM == FN). Each A frag is reused
+    #    ``FN`` times across the per-K-iter MMA chain; each B frag
+    #    ``FM`` times. Square aspect ⇒ balanced reuse on both operands;
+    #    skewed (e.g. 1×32, 32×1) wastes one operand's reuse. Tiebreaker
+    #    inside the cells-band.
+    #
+    # Threads near 256 keep last among the primary signals — under the
+    # warp tier this is ``WM·WN`` (warp count), 256 / 32 = 8 warps;
+    # secondary because cell shape dominates the perf landscape.
     threads = p.wn * p.wm * 32
-    return (min(p.fm * p.fn, 64), -abs(256 - threads), p.bk, -p.splitk, -len(p.overhang))
+    cells = p.fm * p.fn
+    return (-abs(cells - 16), -abs(p.fm - p.fn), -abs(256 - threads), p.bk, -p.splitk, -len(p.overhang))
 
 
 def _priority_pointwise(p: ScalarTileParams) -> tuple[int, ...]:

--- a/tests/compiler/passes/test_partition_planner_mma.py
+++ b/tests/compiler/passes/test_partition_planner_mma.py
@@ -223,14 +223,18 @@ def test_warp_enumerator_rejects_indivisible_extents():
     assert _enum_warp(M=64, N=64, K=15) == []
 
 
-def test_warp_enumerator_priority_orders_by_cells():
-    """Higher cells-per-warp-cell ranks first (cap=64). The first row
-    should have ``min(fm·fn, 64) >= `` the last row's."""
+def test_warp_enumerator_priority_orders_by_cells_sweet_spot():
+    """Cells-near-16 ranks first; cells-far-from-16 ranks last. The
+    register-budget sweet spot for ``wmma_m16n16k16_*`` on sm_8x/9x/12x
+    is FM·FN ≈ 16 (~120 regs/lane → 2 blocks/SM occupancy). The
+    pre-2026 prior rewarded ``min(fm·fn, 64)`` monotonically and
+    pushed the picker to FM=1 FN=32 cells=32 — 3.0× slower than cuBLAS
+    on 2048² fp16. See ``plans/mma-warp-scoring.md``."""
     rows = _enum_warp(M=128, N=128, K=128)
     assert len(rows) >= 2
-    first_score = min(rows[0].fm * rows[0].fn, 64)
-    last_score = min(rows[-1].fm * rows[-1].fn, 64)
-    assert first_score >= last_score
+    first_dist = abs(rows[0].fm * rows[0].fn - 16)
+    last_dist = abs(rows[-1].fm * rows[-1].fn - 16)
+    assert first_dist <= last_dist
 
 
 def test_warp_enumerator_force_splitk_one():


### PR DESCRIPTION
Tweaks the warp-tier MMA scoring so the planner picks the right corner of the search space for tensor-core eligible matmuls. Surfaced by the ``deplodock run --code "...matmul(...fp16...)" --bench`` investigation in #180 — that PR fixed the structural staging plumbing but left perf untouched because the priors still pushed the picker to the wrong shape.

## The gap

On 2048² fp16 matmul (sm_120 / RTX 5090):

|  | Tile | Cells | Latency | vs cuBLAS |
|---|---|---:|---:|---:|
| Old prior (picked) | WM=1 WN=4 FM=1 FN=32 BK=64 | 32 | 317 µs | **0.32×** |
| New prior (picked) | WM=1 WN=8 FM=4 FN=4 BK=64 | 16 | 108 µs | **0.92×** |
| (Empirical sweet spot from sweep) | … FM=4 FN=4 … | 16 | 108 µs | 0.92× |

2.9× speedup, no knob pinning, no autotune. The empirical sweep across (FM, FN) combinations from #180 found FM=FN=4 wins by a wide margin; this PR teaches the priors why.

## Root causes (three, all in the scoring chain)

1. **``_priority_matmul_warp`` (enumerator order):** the ``min(fm·fn, 64)`` monotonic reward rewarded FM=1 FN=32 (cells=32) over FM=FN=4 (cells=16). Replace with ``-abs(cells - 16)`` primary, ``-abs(fm - fn)`` secondary. Cells≈16 is the 2-blocks/SM occupancy knee on sm_8x/9x/12x with the 255-reg/lane cap (each accumulator fragment is ~4 regs/lane; FM·FN=32 spills past the cap). Square per-warp tiles reuse A and B operands equally — each A frag used FN times per K-iter, each B frag used FM times; skewed shapes waste one operand's reuse.

2. **``score_tile_geometry`` (Fork-tree MCTS prior):** the cells-up-to-128 reward was tuned for scalar f32 matmul (104-cell golden tiles win there) and over-promoted FM=1 FN=32 for fp16 MMA. Add an ``"ATOM_KIND" in knobs`` branch with the same cells-sweet-spot + aspect-ratio shape. **Also fix a TMA-eligibility-bonus bug**: it defaulted ``knobs.get("BN", 1)`` for warp-tier params (which don't carry BN); for the tensor-core path the N-stride is ``WN · FN · atom_N``, vastly larger. The mis-default fired the +1.0 bonus for FN=32 but not FN=4 even though both clear the 128 B TMA alignment by an order of magnitude — that was the 1.0 score gap that locked in the wrong winner even after I changed the cells-prior.

3. **``TileOp.lazy_score`` (planner-side score for un-materialized warp variants):** include ``ATOM_KIND`` / ``WM`` / ``WN`` in the ``score_knobs`` passed to ``score_tile_geometry``. Without them the warp-tier branch in (2) never fired — every warp variant silently routed through the scalar branch.

## Verification

- ``test_matmul_mma`` — all 10 parametrized shapes pass (16/64/128/256 squares, F16 and F32 outputs).
- ``test_warp_enumerator_priority_orders_by_cells`` updated to assert the new sweet-spot shape (cells closest to 16 wins).
- Full ``tests/compiler/`` — 1075 passed, 2 skipped (one e2e test flakes under xdist GPU contention; passes isolated).
- 2048² fp16 ``deplodock run --bench``: **108 µs, 0.92× cuBLAS** (was 317 µs, 0.32×).

## What's still out of scope

- M9 of ``plans/mma-smem-staging.md`` (the perf gate that would put a ratchet around this number in CI) is still deferred — needs the bench harness wired into the test suite.
- The smem-staging plumbing from #180 is structurally in place but **the picked winner doesn't stage anything** (``Smem 0K`` in the rendered output). The gmem-direct WMMA path is already fast enough at the right tile shape. Staging becomes a perf lever again for larger / more-K-bound shapes where the L2 traffic dominates; the priors as written would automatically pick a staged variant when its smem-fit + bandwidth-reuse scoring beats the gmem-direct alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)