### PR TITLE
MMA perf-closures M1+M2: warp-tier knob narrow + staged-pipelined codegen fix

### DIFF
--- a/deplodock/compiler/pipeline/passes/lowering/kernel/005_lower_atom_tile.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/005_lower_atom_tile.py
@@ -1,34 +1,63 @@
 """Lower AtomTile to MMA fragment Stmts — M5 of
 ``plans/mma-fragment-factorization.md`` plus M5 of
-``plans/mma-smem-staging.md``.
+``plans/mma-smem-staging.md`` plus M2 of
+``plans/mma-perf-closures.md``.
 
-Runs *before* ``010_split_register_axes`` in the kernel chain. Pattern-
-matches the warp-tier matmul shape the partition planner emits
-(``RegisterTile > AtomTile > matmul-cell-body`` for the unstaged path,
-``RegisterTile > AtomTile > StageBundle > matmul-cell-body`` once
-smem-staging is on), replaces the cell body with an ``MmaFragment`` +
-``MmaFill`` + per-K_i ``MmaLoad`` / ``MmaSync`` chain plus a final
-``MmaStore``, and strips the AtomTile wrapper (its axes encoded the
-cell shape, which is now baked into the Mma* Stmts' ``shape`` field).
-When a ``StageBundle`` lives inside the AtomTile body, the lowered
-Mma chain is re-wrapped in the same bundle so the smem allocation and
-cooperative producer survive.
+Runs *before* ``010_split_register_axes`` in the kernel chain. The
+partition planner emits one of four AtomTile body shapes:
 
-For staged operands, ``MmaLoad.src_index`` is rebuilt to match the
-slab's cache-axis rank: one coord per cache axis, each
-``Var(ax) * block[i]``. ``MmaLoad.ldm`` is computed from the inner
-source-dim's slab extent product so multi-axis-per-source-dim slabs
-(N-side FN-fan-out is the common case) feed the right row stride into
-``wmma::load_matrix_sync`` — the auto path would have picked the
-trailing alloc extent, which collapses to a per-cell width when N
-splits across warp + register cache axes.
+A. Direct K-loop, no staging (gmem-direct MMA):
+   ``AtomTile > SerialTile(K_o) > SerialTile(K_i, reduce) > Load+Accum``
+B. Single-bundle staged (SYNC or single-buffer ASYNC):
+   ``AtomTile > SerialTile(K_o) > StageBundle > SerialTile(K_i, reduce) > Load+Accum``
+C. Filtered K (single-iter, no SerialTile):
+   ``AtomTile > Load+Assign+Accum`` (inline)
+D. Pipelined + buffered (cp.async double-buffered, M2 of mma-perf-closures):
+   ``AtomTile > StageBundle(prologue) > SerialTile(K_o-1) {
+       StageBundle(issue next), AsyncWait, SerialTile(K_i, reduce), AsyncWait
+   }, AsyncWait, SerialTile(K_i, reduce) (epilogue), Write``
 
-The ``RegisterTile`` wrapper is left in place — ``010_split_register_axes``
-runs next and replicates the Mma* chain per (M_r, N_r) cell. Each
-``Mma*`` Stmt's ``rewrite.register`` handler threads the per-cell
-``rename`` callback through the fragment SSA names, so the replicator
-produces ``c_frag_<i>_<j>`` / ``a_frag_<i>_<j>`` / ``b_frag_<i>_<j>``
-per cell without this pass having to know about FM / FN.
+For shapes A/B/D the rewrite is a **transform walk** that preserves every
+structural Stmt (StageBundle wraps, AsyncWait, K_o SerialTile,
+prologue/epilogue) and only rewrites:
+
+- every ``SerialTile(is_reduce=True)`` body → ``MmaLoad a + MmaLoad b + MmaSync`` chain,
+  with the ``is_reduce`` flag cleared (no more Accum inside).
+- every ``Write`` → ``MmaStore``.
+
+A pre-scan finds one ``(a_load, b_load)`` pair to seed the fragment SSA
+names and the dtypes from the atom spec; the chain inside each per-reduce
+``SerialTile`` re-classifies its own loads (shapes D has prologue/epilogue
+reduces with the same K name, so the classification is stable across all
+reduce sites).
+
+For shape C the rewrite emits the Mma chain inline alongside an MmaStore.
+
+The transform walk approach replaces the pre-2026 pattern-match-and-rebuild
+path which captured exactly one ``(outer_st, reduce_st, enclosing_bundle)``
+triple and rebuilt the AtomTile body from it — losing the prologue
+StageBundle, the epilogue AsyncWait, and the epilogue reduce SerialTile
+that shape D produces. The plan B/C bench gates need the pipelined path
+working to measure the double-buffered cp.async lever.
+
+**Phase-prefix prepend** (M2 Bug B of plans/mma-perf-closures.md). For
+BUFFERED / ASYNC stages with ``buffer_count >= 2`` the slab is allocated
+as ``[phase, …cache_axes…]`` (rank-prepended). The consumer Load gets
+rewritten by 020_stage_inputs to ``Load(input='b_smem',
+index=(phase_expr, cache_var_0, cache_var_1, …))`` — phase is the leading
+dim. ``_mma_src_index`` preserves that leading prefix on the MmaLoad
+``src_index`` by detecting ``len(load.index) > len(cache_axes)`` and
+splicing the prefix in front of the cache-coord tuple. The ``ldm``
+calculation stays per-cache-axis (the phase dim doesn't change the
+inner-source-dim row stride).
+
+**A/B classification for staged loads** (M2 Bug C). The pre-pipelined
+heuristic keys off ``K_name in load.index[-1]`` → A vs ``in load.index[0]``
+→ B. For staged smem loads the index is multi-dim slab coords (e.g.
+``(phase, a2, a4, a6)``) where the K axis sits in the *middle*. When
+``load.input`` resolves to a staged smem name, classify A vs B by reading
+``Source.cache_dims`` — the cache axis whose ``axis.name == K_name`` has
+``source_dim == 1`` for A (K inner) or ``0`` for B (K outer).
 
 Eligibility: ``op.knobs["ATOM_KIND"]`` set (only warp-tier matmul rows
 carry this knob — the scalar planner branch leaves it unset and this
@@ -43,7 +72,14 @@ from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.expr import Literal, Var
 from deplodock.compiler.ir.kernel.ir import MmaFill, MmaFragment, MmaLoad, MmaStore, MmaSync
 from deplodock.compiler.ir.stmt import Accum, Body, Load, Stmt, Write
-from deplodock.compiler.ir.tile.ir import AffineAddressing, AtomTile, SerialTile, Source, StageBundle, TileOp
+from deplodock.compiler.ir.tile.ir import (
+    AffineAddressing,
+    AtomTile,
+    SerialTile,
+    Source,
+    StageBundle,
+    TileOp,
+)
 from deplodock.compiler.pipeline import Match, Pattern, RuleSkipped
 from deplodock.compiler.pipeline.passes.lowering.tile._atom import AtomSpec, atom_spec
 from deplodock.compiler.pipeline.passes.lowering.tile._helpers import (
@@ -178,211 +214,314 @@ def _atom_body_to_mma(
     c_dtype_override: DataType,
     smem_sources: dict[str, Source],
 ) -> tuple[Stmt, ...]:
-    """Pattern-match the AtomTile's interior matmul body and rewrite it
-    to an Mma* fragment chain.
+    """Rewrite the AtomTile body to an Mma* fragment chain.
 
-    Expected shape (post-partition_loops, MMA path with no smem staging):
+    Two cases:
 
-        [Init(acc)?]                              # placed by 020_place_inits — absent here, this runs before
-        SerialTile(K_o, "serial_outer"):          # may be size-1-filtered away by _wrap_tower
-          SerialTile(K_i, "stage_inner", reduce):
-            Load a_v <- A[<m_expr>, <k_expr>]
-            Load b_v <- B[<k_expr>, <n_expr>]
-            Assign p = a_v * b_v
-            Accum acc <- p
-        Write C[<m_expr>, <n_expr>] = acc
+    - **Shape A/B/D** (has at least one ``SerialTile(is_reduce=True)``):
+      transform-walk the body in place. Each reduce SerialTile's body is
+      replaced with the Mma chain; the ``is_reduce`` flag is cleared
+      (no more Accum inside). The Write is replaced with MmaStore.
+      Every other structural Stmt (StageBundle wraps, AsyncWait, K_o
+      SerialTile, prologue/epilogue) flows through unchanged.
 
-    Emits:
+    - **Shape C** (no reduce SerialTile — single-iter K filtered away):
+      emit the Mma chain inline at the AtomTile body level alongside an
+      MmaStore.
 
-        MmaFragment(c_frag, "c", spec.shape, c_dtype)
-        MmaFragment(a_frag, "a", spec.shape, a_dtype)
-        MmaFragment(b_frag, "b", spec.shape, b_dtype)
-        MmaFill(c_frag, 0.0)
-        SerialTile(K_o, "serial_outer"):
-          SerialTile(K_i, "stage_inner"):              # no longer reduce
-            MmaLoad(a_frag, A, [<m_expr>, <k_expr>])   # ldm=0 → render-time lookup
-            MmaLoad(b_frag, B, [<k_expr>, <n_expr>])
-            MmaSync(c_frag, a_frag, b_frag)
-        MmaStore(C, [<m_expr>, <n_expr>], c_frag)
+    Both cases prepend ``MmaFragment(c/a/b)`` decls + ``MmaFill(c_frag, 0)``
+    at the head of the returned tuple.
     """
-    # Find the Write + the inner reduce SerialTile (K_i). K_o and K_i may
-    # both be size-1 filtered by ``_wrap_tower``, in which case the matmul
-    # body sits *directly* inside the AtomTile (no SerialTile wrapper).
-    # M5: a ``StageBundle`` between the AtomTile and the K-loop is the
-    # MMA-staged shape — look inside its body to find the K-loop, and
-    # capture the bundle so the lowered Mma chain re-wraps in it.
-    write_stmt: Write | None = None
-    reduce_st: SerialTile | None = None
-    outer_st: SerialTile | None = None
-    enclosing_bundle: StageBundle | None = None
-    flat_loads: list[Load] = []
-    flat_accum: Accum | None = None
     # Local copy so a bundle nested inside the AtomTile's body contributes
-    # its Sources to the lookup `_mma_src_index` consults below — without
+    # its Sources to the lookup ``_mma_src_index`` consults below — without
     # leaking back to siblings.
     bundle_sources = dict(smem_sources)
+    for stage_bundle in _iter_bundles(body):
+        for stage in stage_bundle.stages:
+            for src in stage.sources:
+                bundle_sources[src.name] = src
 
-    def _walk(stmt) -> None:
-        nonlocal write_stmt, reduce_st, outer_st, flat_accum, enclosing_bundle
-        if isinstance(stmt, Write):
-            write_stmt = stmt
-            return
-        if isinstance(stmt, StageBundle):
-            enclosing_bundle = stmt
-            for stage in stmt.stages:
-                for src in stage.sources:
-                    bundle_sources[src.name] = src
-            for inner in stmt.body:
-                _walk(inner)
-            return
-        if isinstance(stmt, SerialTile):
-            # Direct K_o > K_i shape (no staging between): record outer +
-            # reduce in one shot.
-            if any(isinstance(c, SerialTile) and c.is_reduce for c in stmt.body):
-                outer_st = stmt
-                reduce_st = next(c for c in stmt.body if isinstance(c, SerialTile) and c.is_reduce)
-                return
-            if stmt.is_reduce:
-                reduce_st = stmt
-                return
-            # Non-reduce serial: K_o wrapping a StageBundle that wraps
-            # the K_i SerialTile (the M5-staged shape). Recurse through.
-            outer_st = stmt
-            for inner in stmt.body:
-                _walk(inner)
-            return
-        if isinstance(stmt, Load):
-            flat_loads.append(stmt)
-            return
-        if isinstance(stmt, Accum):
-            flat_accum = stmt
-            return
-
-    for s in body:
-        _walk(s)
+    # Pre-scan: find one Write, one Accum, and one (a_load, b_load) sample
+    # pair to seed fragment SSA names + dtypes from the atom spec.
+    write_stmt, accum, sample_a_load, sample_b_load, has_reduce = _scan_atom_body(body, bundle_sources)
 
     if write_stmt is None:
         raise RuleSkipped("AtomTile body unrecognised — no Write")
+    if accum is None or sample_a_load is None or sample_b_load is None:
+        raise RuleSkipped(
+            f"AtomTile body unrecognised — expected Load+Load+Accum chain (got accum={accum!r}, a={sample_a_load!r}, b={sample_b_load!r})"
+        )
 
-    if reduce_st is not None:
-        # Shape A / B: extract Loads + Accum from the reduce body.
-        loads: list[Load] = []
-        accum: Accum | None = None
-        for c in reduce_st.body:
-            if isinstance(c, Load):
-                loads.append(c)
-            elif isinstance(c, Accum):
-                accum = c
-        if len(loads) != 2 or accum is None:
-            raise RuleSkipped(f"AtomTile reduce body unrecognised — expected 2 Loads + Accum, got {len(loads)} Loads")
-        K_name = reduce_st.axis.name
-    elif flat_accum is not None and len(flat_loads) == 2:
-        # Shape C: matmul body inline at the AtomTile level (single-iter K).
-        loads = flat_loads
-        accum = flat_accum
-        # K name comes from the AtomTile's K axis — but AtomTile only
-        # carries M_a / N_a; the K axis was the reduce loop the planner
-        # built and then size-1 filtered. We identify A vs B by index
-        # arity: A indexes [m_expr, k_expr] with K in the inner dim; B
-        # indexes [k_expr, n_expr] with K in the outer dim. With K
-        # filtered to a Literal(0), the inner dim of A is a constant
-        # 0-index plus the per-row stride — distinguishable from B's
-        # outer-dim constant 0 by axis ordering in the original LoopOp.
-        # Use a heuristic: A's index[0] depends on M_expr (which depends
-        # on the Write's index[0]); B's index[-1] depends on N_expr.
-        K_name = "__filtered_k__"  # sentinel — not used in shape C
-    else:
-        raise RuleSkipped("AtomTile body unrecognised — no reduce SerialTile and no inline Load+Load+Accum")
-
-    # Identify A and B operands. For shape A/B (K_name well-defined),
-    # match by which index dim carries K. For shape C (K filtered),
-    # match by which Load shares an axis with the Write's M (index[0])
-    # vs N (index[-1]) Expr.
-    a_load: Load | None = None
-    b_load: Load | None = None
-    if K_name != "__filtered_k__":
-        for ld in loads:
-            k_in_last = K_name in {v for e in ld.index[-1:] for v in e.free_vars()}
-            k_in_first = K_name in {v for e in ld.index[:1] for v in e.free_vars()}
-            if k_in_last and not k_in_first:
-                a_load = ld  # K is the inner (last) dim → row-major A (M×K).
-            elif k_in_first and not k_in_last:
-                b_load = ld  # K is the outer dim → row-major B (K×N).
-    else:
-        # Shape C heuristic: A = the Load whose outer-dim Expr shares
-        # free vars with the Write's outer-dim (M); B = whose inner-dim
-        # shares free vars with the Write's inner-dim (N).
-        w_m_vars = set(write_stmt.index[0].free_vars()) if write_stmt.index else set()
-        w_n_vars = set(write_stmt.index[-1].free_vars()) if write_stmt.index else set()
-        for ld in loads:
-            ld_outer_vars = set(ld.index[0].free_vars()) if ld.index else set()
-            ld_inner_vars = set(ld.index[-1].free_vars()) if ld.index else set()
-            if w_m_vars & ld_outer_vars and not (w_n_vars & ld_inner_vars):
-                a_load = ld
-            elif w_n_vars & ld_inner_vars and not (w_m_vars & ld_outer_vars):
-                b_load = ld
-    if a_load is None or b_load is None:
-        raise RuleSkipped("AtomTile Loads didn't match A=[M,K], B=[K,N] shape")
+    c_frag = f"{accum.name}_frag"
+    a_frag = f"{sample_a_load.names[0]}_frag"
+    b_frag = f"{sample_b_load.names[0]}_frag"
 
     a_dtype = spec.operand_dtypes["a"]
     b_dtype = spec.operand_dtypes["b"]
-    # c_dtype tracks the destination buffer dtype so ``wmma::store_matrix_sync``
-    # has a matching overload (the WMMA accumulator type must equal the
-    # destination pointer's element type). Falls back to the spec's default
-    # (F32) for non-F16/F32 outputs.
     c_dtype = c_dtype_override
-
-    c_frag = f"{accum.name}_frag"
-    a_frag = f"{a_load.names[0]}_frag"
-    b_frag = f"{b_load.names[0]}_frag"
-
-    a_src_index, a_ldm = _mma_src_index(a_load, bundle_sources)
-    b_src_index, b_ldm = _mma_src_index(b_load, bundle_sources)
-    inner: tuple[Stmt, ...] = (
-        MmaLoad(frag=a_frag, src_buffer=a_load.input, src_index=a_src_index, ldm=a_ldm),
-        MmaLoad(frag=b_frag, src_buffer=b_load.input, src_index=b_src_index, ldm=b_ldm),
-        MmaSync(c_frag=c_frag, a_frag=a_frag, b_frag=b_frag),
-    )
-    if reduce_st is not None:
-        # Body shape A / B: rebuild the K_i / K_o wrappers around the
-        # Mma* chain. The reduce SerialTile loses the ``reduce`` flag
-        # (no more Accum inside); its kind stays the same.
-        new_reduce_st = SerialTile(axis=reduce_st.axis, body=Body(inner), kind=reduce_st.kind)
-        # M5: re-wrap with the StageBundle BETWEEN K_o and K_i — the
-        # bundle's ``Source.origin`` may reference the K_o loop var
-        # (e.g. ``a[a0*16, K_o*1024]``) so the producer must fire inside
-        # K_o's scope. The structural shape we restore is exactly what
-        # 020_stage_inputs emitted:
-        # ``SerialTile(K_o) > StageBundle > SerialTile(K_i) > Mma chain``.
-        if enclosing_bundle is not None:
-            staged_inner = enclosing_bundle.with_bodies((Body(enclosing_bundle.stages), Body((new_reduce_st,))))
-            inner_for_outer: tuple[Stmt, ...] = (staged_inner,)
-        else:
-            inner_for_outer = (new_reduce_st,)
-        if outer_st is not None:
-            k_loop_stmts: tuple[Stmt, ...] = (SerialTile(axis=outer_st.axis, body=Body(inner_for_outer), kind=outer_st.kind),)
-        else:
-            k_loop_stmts = inner_for_outer
-    else:
-        # Body shape C: single-iter K, no SerialTile wrapper. Emit the
-        # Mma* chain inline (with the bundle re-wrap if applicable —
-        # origin can still reference outer scope vars, but no K_o is
-        # present so the bundle sits at the AtomTile level).
-        if enclosing_bundle is not None:
-            k_loop_stmts = (enclosing_bundle.with_bodies((Body(enclosing_bundle.stages), Body(inner))),)
-        else:
-            k_loop_stmts = inner
 
     fragments: tuple[Stmt, ...] = (
         MmaFragment(name=c_frag, role="c", shape=spec.shape, dtype=c_dtype),
         MmaFragment(name=a_frag, role="a", shape=spec.shape, dtype=a_dtype),
         MmaFragment(name=b_frag, role="b", shape=spec.shape, dtype=b_dtype),
     )
-    return (
-        *fragments,
-        MmaFill(frag=c_frag, value=0.0),
-        *k_loop_stmts,
+
+    if has_reduce:
+        transformed = _transform_walk(
+            body,
+            c_frag=c_frag,
+            a_frag=a_frag,
+            b_frag=b_frag,
+            smem_sources=bundle_sources,
+        )
+        return (*fragments, MmaFill(frag=c_frag, value=0.0), *transformed)
+
+    # Shape C: K filtered, inline Mma chain + MmaStore.
+    a_src_index, a_ldm = _mma_src_index(sample_a_load, bundle_sources)
+    b_src_index, b_ldm = _mma_src_index(sample_b_load, bundle_sources)
+    chain: tuple[Stmt, ...] = (
+        MmaLoad(frag=a_frag, src_buffer=sample_a_load.input, src_index=a_src_index, ldm=a_ldm),
+        MmaLoad(frag=b_frag, src_buffer=sample_b_load.input, src_index=b_src_index, ldm=b_ldm),
+        MmaSync(c_frag=c_frag, a_frag=a_frag, b_frag=b_frag),
         MmaStore(dst_buffer=write_stmt.output, dst_index=write_stmt.index, frag=c_frag, ldm=0),
+    )
+    return (*fragments, MmaFill(frag=c_frag, value=0.0), *chain)
+
+
+def _iter_bundles(body: Body):
+    """Yield every ``StageBundle`` reachable inside ``body``. Used by the
+    pre-scan to flatten all in-scope Sources before A/B classification
+    walks per-reduce sites — the pipelined-staged shape (D) has bundles
+    at the AtomTile-body level *and* inside the K_o SerialTile, both
+    feeding loads inside reduce SerialTiles."""
+    for s in body:
+        if isinstance(s, StageBundle):
+            yield s
+            yield from _iter_bundles(s.body)
+            continue
+        if s.nested():
+            for sub in s.nested():
+                yield from _iter_bundles(sub)
+
+
+def _scan_atom_body(body: Body, smem_sources: dict[str, Source]) -> tuple[Write | None, Accum | None, Load | None, Load | None, bool]:
+    """Recursively walk the AtomTile body. Returns the first ``Write``,
+    the first ``Accum``, one sample ``(a_load, b_load)`` pair, and
+    ``has_reduce`` (True if any reduce SerialTile was found).
+
+    The sample (a, b) pair is pulled from the FIRST reduce SerialTile if
+    present, falling back to the bare body's Loads (shape C). The
+    classification heuristic for the sample pair is the same one
+    ``_build_mma_chain`` re-uses for every reduce site — pulling it out
+    of one fixed location keeps the fragment SSA names stable across
+    prologue / inner / epilogue chains (which is what the per-cell
+    replicator in 010_split_register_axes expects).
+    """
+    write_stmt: Write | None = None
+    accum: Accum | None = None
+    sample_a: Load | None = None
+    sample_b: Load | None = None
+    has_reduce = False
+    # Fallback loads at the bare body level (shape C — no reduce ST).
+    flat_loads: list[Load] = []
+
+    def _walk(stmts: Body) -> None:
+        nonlocal write_stmt, accum, sample_a, sample_b, has_reduce
+        for s in stmts:
+            if isinstance(s, Write):
+                if write_stmt is None:
+                    write_stmt = s
+                continue
+            if isinstance(s, Accum):
+                if accum is None:
+                    accum = s
+                continue
+            if isinstance(s, Load):
+                flat_loads.append(s)
+                continue
+            if isinstance(s, SerialTile) and s.is_reduce:
+                has_reduce = True
+                # First reduce ST seeds the sample (a, b).
+                if sample_a is None or sample_b is None:
+                    loads = [c for c in s.body if isinstance(c, Load)]
+                    if len(loads) == 2:
+                        a, b = _classify_ab(loads, k_name=s.axis.name, smem_sources=smem_sources, write=write_stmt)
+                        if a is not None and b is not None:
+                            sample_a, sample_b = a, b
+                _walk(s.body)
+                continue
+            if s.nested():
+                for sub in s.nested():
+                    _walk(sub)
+
+    _walk(body)
+
+    # Shape C fallback: no reduce ST, fall back to flat Load+Accum at the
+    # bare body level. Classify by Write index (M in outer dim → A,
+    # N in inner dim → B), matching the pre-2026 heuristic.
+    if not has_reduce and sample_a is None and sample_b is None and len(flat_loads) == 2 and write_stmt is not None:
+        a, b = _classify_ab(flat_loads, k_name=None, smem_sources=smem_sources, write=write_stmt)
+        if a is not None and b is not None:
+            sample_a, sample_b = a, b
+
+    return write_stmt, accum, sample_a, sample_b, has_reduce
+
+
+def _classify_ab(
+    loads: list[Load],
+    *,
+    k_name: str | None,
+    smem_sources: dict[str, Source],
+    write: Write | None,
+) -> tuple[Load | None, Load | None]:
+    """Identify which Load is A (M×K) and which is B (K×N) inside a
+    matmul-reduce cell body.
+
+    Two cases:
+
+    1. **Staged smem load** (``load.input`` is in ``smem_sources``):
+       look up the Source's ``cache_dims``; find the cache axis whose
+       ``axis.name == k_name``. Its ``source_dim`` is 1 (K inner) for A,
+       0 (K outer) for B. The pre-2026 heuristic ("K_name in
+       ``load.index[-1]``") fails here because the staged Load index is
+       ``(phase, a8, a3, a5)`` where K sits in the middle dim.
+
+    2. **gmem-direct load** (no smem source): legacy heuristic — K in
+       ``index[-1]`` → A; K in ``index[0]`` → B. For shape C
+       (``k_name is None``) heuristic falls back to the Write's M/N free
+       vars.
+    """
+    a_load: Load | None = None
+    b_load: Load | None = None
+
+    if k_name is not None:
+        for ld in loads:
+            src = smem_sources.get(ld.input)
+            if src is not None:
+                # Staged: classify via cache_dims.
+                for cd in src.cache_dims:
+                    if cd.axis.name == k_name:
+                        if cd.source_dim == 1:
+                            a_load = ld
+                        elif cd.source_dim == 0:
+                            b_load = ld
+                        break
+                continue
+            # gmem-direct: legacy K-position heuristic.
+            k_in_last = k_name in {v for e in ld.index[-1:] for v in e.free_vars()}
+            k_in_first = k_name in {v for e in ld.index[:1] for v in e.free_vars()}
+            if k_in_last and not k_in_first:
+                a_load = ld
+            elif k_in_first and not k_in_last:
+                b_load = ld
+        return a_load, b_load
+
+    # Shape C — K filtered. Use Write's M/N free vars as the carrier.
+    if write is None:
+        return None, None
+    w_m_vars = set(write.index[0].free_vars()) if write.index else set()
+    w_n_vars = set(write.index[-1].free_vars()) if write.index else set()
+    for ld in loads:
+        ld_outer_vars = set(ld.index[0].free_vars()) if ld.index else set()
+        ld_inner_vars = set(ld.index[-1].free_vars()) if ld.index else set()
+        if w_m_vars & ld_outer_vars and not (w_n_vars & ld_inner_vars):
+            a_load = ld
+        elif w_n_vars & ld_inner_vars and not (w_m_vars & ld_outer_vars):
+            b_load = ld
+    return a_load, b_load
+
+
+def _transform_walk(
+    body: Body,
+    *,
+    c_frag: str,
+    a_frag: str,
+    b_frag: str,
+    smem_sources: dict[str, Source],
+) -> tuple[Stmt, ...]:
+    """Recursively rewrite ``body`` in place. Replaces:
+
+    - every ``SerialTile(is_reduce=True)`` body with an Mma chain
+      (clearing the ``is_reduce`` flag — no Accum remains inside).
+    - every ``Write`` with ``MmaStore``.
+
+    Preserves every other Stmt structurally — StageBundle wraps + their
+    Stages, AsyncWait, non-reduce SerialTile (K_o outer), Cond, etc.
+    Descends into nested bodies via ``s.nested()`` so deeply-nested
+    reduce sites (e.g. shape D's inner-K_o body) are reached.
+
+    ``smem_sources`` is threaded through StageBundle descent so the Mma
+    chain's A/B classification + phase-prefix prepend has the full
+    in-scope Source table.
+    """
+    out: list[Stmt] = []
+    for s in body:
+        if isinstance(s, Write):
+            out.append(MmaStore(dst_buffer=s.output, dst_index=s.index, frag=c_frag, ldm=0))
+            continue
+        if isinstance(s, SerialTile) and s.is_reduce:
+            chain = _build_mma_chain(
+                s.body,
+                k_name=s.axis.name,
+                c_frag=c_frag,
+                a_frag=a_frag,
+                b_frag=b_frag,
+                smem_sources=smem_sources,
+            )
+            # ``SerialTile.is_reduce`` is a derived property (True iff the
+            # body contains an Accum). The Mma chain has no Accum — c_frag
+            # owns the accumulation through MmaSync — so swapping the body
+            # via ``with_bodies`` implicitly flips is_reduce off. Kind is
+            # preserved (stage_inner / serial_outer / …).
+            out.append(s.with_bodies((Body(chain),)))
+            continue
+        if isinstance(s, StageBundle):
+            inner_sources = dict(smem_sources)
+            for stage in s.stages:
+                for src in stage.sources:
+                    inner_sources[src.name] = src
+            new_body = _transform_walk(s.body, c_frag=c_frag, a_frag=a_frag, b_frag=b_frag, smem_sources=inner_sources)
+            # Stages stay byte-clean — no Mma rewrite happens inside a
+            # producer scope.
+            out.append(s.with_bodies((Body(s.stages), Body(new_body))))
+            continue
+        if s.nested():
+            new_bodies = tuple(
+                Body(_transform_walk(sub, c_frag=c_frag, a_frag=a_frag, b_frag=b_frag, smem_sources=smem_sources)) for sub in s.nested()
+            )
+            out.append(s.with_bodies(new_bodies))
+            continue
+        # AsyncWait + anything else without nested bodies: keep as-is.
+        out.append(s)
+    return tuple(out)
+
+
+def _build_mma_chain(
+    reduce_body: Body,
+    *,
+    k_name: str,
+    c_frag: str,
+    a_frag: str,
+    b_frag: str,
+    smem_sources: dict[str, Source],
+) -> tuple[Stmt, ...]:
+    """Build the per-reduce ``MmaLoad a + MmaLoad b + MmaSync`` chain
+    that replaces a reduce SerialTile's body. Re-classifies A/B from
+    this reduce site's Loads — shape D has prologue/inner/epilogue
+    reduces with the same K name and the classification is stable.
+    """
+    loads = [s for s in reduce_body if isinstance(s, Load)]
+    if len(loads) != 2:
+        raise RuleSkipped(f"reduce SerialTile body unrecognised — expected 2 Loads, got {len(loads)}")
+    a_load, b_load = _classify_ab(loads, k_name=k_name, smem_sources=smem_sources, write=None)
+    if a_load is None or b_load is None:
+        raise RuleSkipped("reduce SerialTile Loads didn't match A=[M,K], B=[K,N] shape")
+    a_src_index, a_ldm = _mma_src_index(a_load, smem_sources)
+    b_src_index, b_ldm = _mma_src_index(b_load, smem_sources)
+    return (
+        MmaLoad(frag=a_frag, src_buffer=a_load.input, src_index=a_src_index, ldm=a_ldm),
+        MmaLoad(frag=b_frag, src_buffer=b_load.input, src_index=b_src_index, ldm=b_ldm),
+        MmaSync(c_frag=c_frag, a_frag=a_frag, b_frag=b_frag),
     )
 
 
@@ -392,17 +531,20 @@ def _mma_src_index(load: Load, smem_sources: dict[str, Source]) -> tuple:
     Unstaged (load.input is the gmem buffer): use the gmem ``load.index``
     verbatim — pre-M5 behavior.
 
-    Staged (load.input is an smem name registered by an enclosing
-    ``StageBundle``): the consumer Load index is the bare cache-coord
-    tuple (``020_stage_inputs`` rewrites ``smem_index = tuple(Var(ax.name)
-    for ax in cache_axes)``). The slab itself is block-scaled per
-    ``Source.alloc_extents``; the MMA fragment must read from the
-    block-scaled coordinate. ``AffineAddressing.source_index`` threads
-    ``block`` through the composite-stride decode so the resulting Expr
-    is ``cache_var · block · stride_of_inner_axes`` per cache axis,
-    relative to a zero origin (the slab is its own anchor). ``ldm``
-    auto-resolves at render time via ``ctx.shapes[smem_name][-1]`` — the
-    block-scaled inner extent.
+    Staged single-buffered (load.input is an smem name registered by an
+    enclosing ``StageBundle`` with ``buffer_count == 1``): the consumer
+    Load index is the bare cache-coord tuple. ``AffineAddressing.block``
+    threads ``Var(cache_ax) * block`` per cache axis, relative to a zero
+    origin.
+
+    Staged double-buffered (``buffer_count >= 2``, M2 of
+    plans/mma-perf-closures.md): the slab is allocated as ``[phase,
+    *cache_axes]`` (rank-prepended); ``Load.index`` carries the leading
+    phase Expr followed by the cache vars. Detect via
+    ``len(load.index) > len(cache_axes)`` and splice the leading prefix
+    in front of the computed cache coords so the MmaLoad reads from the
+    right slot. ``ldm`` stays per-cache-axis (the phase dim is uniform
+    across the slab — doesn't change the inner-source-dim row stride).
     """
     src = smem_sources.get(load.input)
     if src is None:
@@ -425,13 +567,23 @@ def _mma_src_index(load: Load, smem_sources: dict[str, Source]) -> tuple:
     cache_axes = src.cache_axes
     block = src.addressing.block
     dims = src.addressing.dims
-    out: list = []
+    cache_coords: list = []
     for i, ax in enumerate(cache_axes):
         b = block[i] if block else 1
         if b == 1:
-            out.append(Var(ax.name))
+            cache_coords.append(Var(ax.name))
         else:
-            out.append(Var(ax.name) * Literal(b, "int"))
+            cache_coords.append(Var(ax.name) * Literal(b, "int"))
+    # M2 of plans/mma-perf-closures.md (Bug B): a buffered slab is
+    # allocated as ``[phase, *cache_axes]``. ``020_stage_inputs`` /
+    # ``040_use_ring_buffers`` rewrites the consumer Load index to
+    # ``(phase_expr, *cache_vars)`` — phase is the leading dim. Splice
+    # the leading prefix (zero or one dim today; the design admits more)
+    # in front of the computed cache-coord tuple so the MmaLoad reads
+    # from the right buffer slot.
+    n_phase_dims = max(0, len(load.index) - len(cache_axes))
+    phase_prefix = tuple(load.index[:n_phase_dims])
+    out_index: tuple = phase_prefix + tuple(cache_coords)
     # ldm for WMMA row_major matrix_a / matrix_b is the row stride along
     # the leading source dim — equivalently, the product of slab dims
     # for the *inner* source dim (dim 1 here). The auto-ldm path picks
@@ -439,11 +591,12 @@ def _mma_src_index(load: Load, smem_sources: dict[str, Source]) -> tuple:
     # wrong when several cache axes share a source dim (e.g. an MMA
     # matmul whose N-side splits into warp + register cells). Compute
     # explicitly: ldm = ∏ alloc_extents[i] for i where dims[i] is the
-    # inner source dim.
+    # inner source dim. The phase prefix is uniform across the slab —
+    # doesn't change the row stride.
     alloc_extents = src.alloc_extents
     ldm_dim = max(dims) if dims else 0
     ldm = 1
     for i, d in enumerate(dims):
         if d == ldm_dim:
             ldm *= alloc_extents[i]
-    return tuple(out), ldm
+    return out_index, ldm

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py
@@ -620,7 +620,18 @@ def _enumerate_warp_matmul_impl(
 
     out: list[WarpTileParams] = []
     seen: set[WarpTileParams] = set()
-    bk_choices = _BK_CANDIDATES
+    # Knob-narrow gate: fold ``DEPLODOCK_<KNOB>`` env pins into the candidate
+    # tuples here at the warp tier, parallel to ``enumerate_cartesian``'s
+    # ``_run(apply_pins=True)`` for the scalar tier. The plan B/C sweep and
+    # any CLI repro (``DEPLODOCK_WM=2 DEPLODOCK_WN=2 DEPLODOCK_BK=2 …``) rely
+    # on this — without it, warp-tier pins silently fall through to the
+    # scalar tier's narrows and the warp tier enumerates the full cartesian
+    # regardless. ``ATOM_KIND`` narrows the caller-supplied ``atom_kinds``
+    # tuple so a pin scopes the picker to a single kind.
+    wm_choices = WM.narrow(_TUNE_WARP_AXIS_CHOICES)
+    wn_choices = WN.narrow(_TUNE_WARP_AXIS_CHOICES)
+    bk_choices = BK.narrow(_BK_CANDIDATES)
+    atom_kinds = ATOM_KIND.narrow(atom_kinds)
     # v1: MMA + SPLITK > 1 needs atomic-add on MmaStore (cross-CTA
     # accumulation), which isn't wired yet. Force SPLITK=1 so each output
     # cell is written by exactly one CTA. force_splitk_one is honoured
@@ -643,10 +654,10 @@ def _enumerate_warp_matmul_impl(
         # BK below is the inner stage_inner trip count (number of mma_syncs
         # per K_o iteration).
         k_cells_total = E_K // atom_k
-        for wm in _TUNE_WARP_AXIS_CHOICES:
+        for wm in wm_choices:
             if cells_M % wm != 0:
                 continue
-            for wn in _TUNE_WARP_AXIS_CHOICES:
+            for wn in wn_choices:
                 if cells_N % wn != 0:
                     continue
                 threads = wn * wm * 32

--- a/plans/mma-perf-closures.md
+++ b/plans/mma-perf-closures.md
@@ -1,0 +1,407 @@
+# MMA matmul perf closures — closing the cuBLAS gap
+
+## Context
+
+`feature/mma-warp-scoring` (PR #182) closed the 2048² fp16 matmul gap from **0.32× → 0.92× cuBLAS** (317 µs → 108
+µs, vs cuBLAS at 99 µs) by rewriting the warp-tier priors so the picker stops landing on `FM=1 FN=32` (the
+register-spill corner) and chooses `FM=FN=4` (the cells≈16 sweet spot). The remaining 9% gap lives in three
+hardware-level levers cuBLAS uses but deplodock doesn't:
+
+1. **Smem staging with double-buffered cp.async K-pipelining.** cuBLAS's `cutlass_80_tensorop_f16_s16816gemm_…
+   128x128_32x4_nn` uses 4 K-pipeline stages overlapping load-K+1 with mma-K. Deplodock's MMA path can plumb the
+   staged variant through `020_stage_inputs` → `040_use_ring_buffers` → `060_use_async_copy` → `080_pipeline_stages`
+   (verified at the tile-IR level), but two downstream bugs in `005_lower_atom_tile` and `MmaLoad.src_index`
+   block the lowered kernel from compiling correctly.
+2. **Warp specialization (producer/consumer split).** Hopper-style: dedicated producer warps issuing cp.async +
+   mbarrier, separate consumer warps running mma_sync. `085_warp_specialize` exists but gates on cooperative-K
+   (`BR > 1`), which the MMA warp-tier forbids by construction (`splitk_choices = (1,)`).
+3. **`mma.m16n8k16` atom (ldmatrix + PTX mma.sync).** The `cutlass_80_tensorop_*_s16816` naming reveals cuBLAS
+   uses the Ampere PTX MMA shape, not classic WMMA `m16n16k16`. `ldmatrix` does the lane-aware fragment load in
+   one instruction; the `wmma::load_matrix_sync` C++ wrapper deplodock uses today expands to a more conservative
+   SASS schedule. Documented in `project_tensor_core_dead_end.md` as a hard 5-10% gap.
+
+Plus one CTA-count signal in the score function that the empirical sweep showed leaves ~1.5% on the table.
+
+Target: ≥ 0.98× cuBLAS on 2048² fp16. The fp16 byte-correctness prerequisite already landed (PR #182 commit
+`528822c3`).
+
+## Methodology: measure each lever in isolation before touching the picker
+
+The prior optimization round had a recurring failure mode — tweaking score-function priors based on what
+*should* be faster, then discovering the new picked variant has a codegen bug, then reverting. The lesson: don't
+move the picker until the kernel under it actually runs and benches.
+
+This plan splits into three phases:
+
+**Phase A — Codegen.** Land each codegen lever (M2: pipelined staging, M3: warp specialization, M4: PTX MMA) one
+at a time. Each lever is gated on the ability to *pin* its variant from the CLI (M1 below adds the missing
+warp-tier knob narrow). For each:
+
+1. Implement the codegen change.
+2. Pin the knob set that exercises it; verify the IR has the new shape; verify the kernel compiles and matches
+   the f32 reference within tolerance.
+3. Bench the pinned variant against the current baseline and against cuBLAS.
+4. **Decision: keep or drop.** If the pinned variant doesn't beat baseline by ≥3%, the codegen change is correct
+   but the lever isn't load-bearing for this shape — drop it from the golden-tile search, don't try to make the
+   picker find it.
+
+**Phase B — Golden tile.** Sweep the kept levers' product space (pin every combination) and record the latency
+matrix. Picks the *single best pinned knob set* — the "golden tile" the picker should converge to. This becomes
+the bench-gate target for Phase C.
+
+**Phase C — Scoring.** Tune `_priority_matmul_warp` and `score_tile_geometry` so the picker selects the golden
+tile by default, *without* a pinned env override. Verified by `deplodock run --code "…" --bench` matching the
+golden bench within ±1%.
+
+Phase order is forced: B can't pick a golden until A's levers all bench; C can't aim the picker without B's
+target.
+
+## Phase A — Codegen levers, measure each in isolation
+
+### M1 — Warp-tier knob narrow [no perf — pure plumbing for Phase A]
+
+`_enumerate_warp_matmul_impl` iterates `_TUNE_WARP_AXIS_CHOICES` / `_BK_CANDIDATES` directly without applying
+`WM.narrow` / `WN.narrow` / `BK.narrow`. Means `DEPLODOCK_WM=2 DEPLODOCK_WN=2 DEPLODOCK_BK=8` are silently
+ignored at the warp tier (work at scalar tier). Every subsequent milestone needs CLI pinning to run the bench
+gate, so this lands first.
+
+Add the three `narrow` calls inside `_enumerate_warp_matmul_impl`. Also add the corresponding `WS_MMA` and
+`ATOM_KIND_KNOB` narrows (created in M3 and M4 respectively, but plumb the framework now).
+
+**Files**: `tile/_enumeration.py` (~10 lines), `tests/compiler/passes/test_partition_planner_mma.py` (extend
+existing test for the new knob-narrow gates).
+
+**Bench gate**: none — this is plumbing. Verification: `DEPLODOCK_WM=2 DEPLODOCK_WN=2 ./venv/bin/deplodock
+compile --code "…matmul(fp16)…" --ir tile` produces a tile-IR with `for a2 in 0..2 │ for a3 in 0..2  └ warp`.
+
+### M2 — Staged + pipelined MMA codegen [biggest standalone lever]
+
+**Two bugs in `005_lower_atom_tile.py` block the staged-MMA path from compiling correctly even though the
+planner already finds the right variant.** Verified at the tile-IR level — the pipelined async bundle DOES emit
+for `WM=WN=2 FM=FN=4 BK=2`:
+
+```
+AtomTile (a6, a7):
+  bundle async[2@0 depth=2]:                          # prologue ring slot 0
+    shared b_smem[…] = b[…]
+    shared a_smem[…] = a[…]
+  for a9 in 0..K_o-1:
+    bundle async[2@(a9+1) depth=2]:                   # issue next K_o+1 into slot phase=(a9+1)%2
+      shared b_smem[…] = b[…]
+      shared a_smem[…] = a[…]
+    AsyncWait(keep=1)
+    SerialTile(a8, K_i, reduce):
+      Load b_smem[(a9 % 2), …]                        # consume current K_o from slot a9%2
+      Load a_smem[(a9 % 2), …]
+      Assign / Accum
+    AsyncWait(keep=1)
+  AsyncWait(keep=0)                                   # drain
+  SerialTile(a8, K_i, reduce):                        # epilogue: last K_o
+    Load b_smem[1, …]
+    Load a_smem[1, …]
+    Assign / Accum
+  Write matmul[…]
+```
+
+Two bugs block compile:
+
+**Bug A — `_atom_body_to_mma` walk doesn't handle pipelined nesting.** The current walk does `find outer_st +
+reduce_st + bundle` then rebuilds the body from scratch. The pipelined shape has a prologue StageBundle, a K_o
+SerialTile containing yet another StageBundle + AsyncWait + reduce, an epilogue AsyncWait, and a tail reduce —
+none of which the rebuild path knows about. The walk raises `RuleSkipped` silently and the AtomTile flows
+through to render where it errors as `AtomTile must be consumed by the MMA materializer`.
+
+Fix: **transform-style rewrite** rather than pattern-match-and-rebuild. Walk the body verbatim and for each
+reduce SerialTile replace its body with the Mma chain (clearing `is_reduce`); for each Write replace with
+MmaStore; preserve everything else (StageBundle wraps, AsyncWait, K_o SerialTile, prologue/epilogue) unchanged.
+Prepend `MmaFragment` decls + `MmaFill(c_frag, 0)` at the AtomTile body's head. Was 80%-drafted during PR #182
+investigation but reverted to keep `test_matmul_mma` green; the draft handled the SYNC + single-bundle shape
+cleanly but needed the addressing-based A/B classification described below for the staged path.
+
+**Bug B — `MmaLoad.src_index` misses the buffer-phase prefix.** For `BUFFERED` / `ASYNC` stages with
+`buffer_count ≥ 2`, the slab is allocated as `[phase, …cache_axes…]` (rank-prepended). The consumer Load gets
+rewritten to `Load(input='b_smem', index=(phase_expr, cache_var_0, cache_var_1, …))` — phase is the leading dim.
+But `_mma_src_index` only emits the cache-coord part `(Var(ax) * block, …)`, never the phase. The rendered
+`wmma::load_matrix_sync` reads from the wrong slot → `CUDA_ERROR_MISALIGNED_ADDRESS` at runtime.
+
+Fix: have `005_lower_atom_tile` track the enclosing `StageBundle` during the walk and, when the bundle's
+`buffer_count > 1`, prepend `bundle.phase` to every `MmaLoad.src_index` for Loads reading from that bundle's
+sources. Matches the M8 design note in `plans/mma-smem-staging.md` ("pick (b): keep mma_view in pure cache-coord
+space, have 005 synthesize the phase prefix").
+
+**Bug C — A/B classification fails for staged smem loads** (surfaces when fixing A). The pre-pipelined A/B
+identification keys off "K_name is in load.index[-1]" → A vs "first dim" → B. For staged smem loads the index is
+multi-dim slab coords (e.g. `(phase, a2, a4, a6)`) where the K axis sits in the *middle*. Fix: when `load.input`
+is a staged smem name, classify A vs B by reading `Source.cache_dims` — the cache axis whose `axis.name == K_name`
+has `source_dim = 1` for A (K inner) or `0` for B (K outer).
+
+**Bench gate** (the lever's perf measurement, gated on M1's knob-narrow plumbing):
+
+```
+DEPLODOCK_WM=2 DEPLODOCK_WN=2 DEPLODOCK_FM=4 DEPLODOCK_FN=4 DEPLODOCK_BK=2 \
+    ./venv/bin/deplodock run --code "import torch; a=torch.randn(2048,2048,dtype=torch.float16,device='cuda'); \
+    b=torch.randn(2048,2048,dtype=torch.float16,device='cuda'); torch.matmul(a,b)" \
+    --bench --warmup 5 --iters 20
+```
+
+Expected: the rendered C source contains `cp.async.commit_group` + `wmma::mma_sync` + `cp.async.wait_group`,
+i.e. the cp.async-staged pipelined MMA path. Latency target: **≤ 102 µs** (a ≥6% improvement over the 108 µs
+baseline). If the measured latency doesn't beat baseline by ≥3%, the lever is structurally correct but doesn't
+pay for this shape — record the measured number and exclude the staged variant from the Phase B golden search.
+
+**Files**: `kernel/005_lower_atom_tile.py` (~150 lines net — transform walk replaces the rebuild path),
+`tests/compiler/test_matmul_mma_staged_pipelined.py` (new — pins the buffered shape; greps the rendered C for
+`cp.async` and matching MmaLoad src_index ranks; runs the f32 reference comparison at fp16 tolerance).
+
+### M3 — Warp specialization for MMA
+
+`085_warp_specialize` today gates on `BR > 1` and shapes the producer/consumer split around cooperative-K
+reduce. MMA forbids `BR > 1` (`splitk_choices = (1,)`; the warp-tier accumulator lives register-side). To wire
+WS for MMA, the split needs a different shape: dedicate `WS_PROD ≥ 1` warps to issuing cp.async + bumping an
+mbarrier, route the remaining `WM·WN - WS_PROD` warps through the mma_sync chain consuming from the same smem
+slab via mbarrier wait.
+
+Structural additions:
+
+1. **New knob `WS_MMA`**: 0 = no split (current); 1 = one producer warp + rest consumer; 2 = two producer warps
+   (one per operand). Enumerated only when `ATOM_KIND in knobs and buffer_count > 1` (otherwise the bundle has
+   no producer-side work to delegate). Knob-narrow gate flows through M1's plumbing.
+2. **`085_warp_specialize` extends** to detect MMA shape (look for `MmaSync` in the bundle's consumer body — runs
+   after `005_lower_atom_tile`) and apply the producer-consumer split with the right mbarrier wiring (signal on
+   cp.async commit + cp.async wait-group, wait inside consumer scope, signal back when consumer done with slot).
+3. **Per-bundle phase routing**: consumer scope's MmaLoad reads from `phase = ((K_o - WS_PROD) % buffer_count)`,
+   producer issues writes to `phase = (K_o % buffer_count)`. The handoff barrier is the existing
+   `StageBundle.phase` plus an mbarrier per slot.
+
+Hopper supports this via tcgen05 / wgmma; on sm_80 / sm_120 (Ampere / Blackwell consumer) the same shape works
+via classic `__syncthreads()` + cp.async wait-group + mbarrier on shared.
+
+**Bench gate** (depends on M2):
+
+```
+DEPLODOCK_WM=2 DEPLODOCK_WN=2 DEPLODOCK_FM=4 DEPLODOCK_FN=4 DEPLODOCK_BK=2 DEPLODOCK_WS_MMA=1 \
+    ./venv/bin/deplodock run --code "…matmul(fp16)…" --bench
+```
+
+Expected: rendered C contains `__bar_sync` / `mbarrier.arrive` / `mbarrier.wait` + the producer warp's load
+loop separated from the consumer warp's mma loop. Latency target: **≤ 100 µs** (a ≥2% improvement over M2's
+expected 102 µs — WS overlap is bounded by the existing pipeline overlap from M2; the gain comes from cleaner
+instruction scheduling and warp-disjoint smem access). If the gain is < 2%, drop WS from the golden search.
+
+**Files**: `tile/_enumeration.py` (`WS_MMA` knob, ~30 lines), `kernel/085_warp_specialize.py` (MMA detection +
+producer-consumer split, ~200 lines), `tests/compiler/test_matmul_mma_warp_specialized.py` (new).
+
+### M4 — `mma.m16n8k16` atom (ldmatrix + PTX mma)
+
+cuBLAS's `cutlass_80_tensorop_*_s16816gemm_*` reveals the Ampere+ PTX MMA shape `m16n8k16`, loaded via
+`ldmatrix.x4` (a lane-aware multi-fragment load issuing 4 32-byte fragment-loads per warp). Compared to
+`wmma::load_matrix_sync` it:
+
+- Avoids the C++ template instantiation overhead per fragment.
+- Lets the SASS scheduler interleave fragment-loads with mma.sync issuance more aggressively.
+- Naturally aligns with the 128 B `ldmatrix` per-warp access pattern (no smem swizzle padding beyond what the
+  swizzle pass already wants).
+
+Five pieces:
+
+1. **New atom kind**: `mma_m16n8k16_f16` (and `_bf16`) in `_ATOM_REGISTRY` (`tile/_atom.py`) with
+   `shape=(16, 8, 16)`, `operand_dtypes={a: f16, b: f16, c: f32}`, `min_cc=(8, 0)`.
+2. **New `MmaFragment` layout**: PTX MMA stores fragments in lane-distributed registers with a known shape
+   (`m16n8k16` fp16: `a_frag` = `__half2[4]` per lane, `b_frag` = `__half2[2]`, `c_frag` = `float[4]`). Today's
+   `MmaFragment` renders as `wmma::fragment<…>`; the new layout renders as `unsigned r0, r1, r2, r3` or
+   `__half2 a_frag[4]`.
+3. **`ldmatrix`-based `MmaLoad`**: emits PTX `ldmatrix.sync.aligned.m8n8.x4.shared.b16` with the correct per-lane
+   address calculation. Needs to know the swizzle pattern of the smem slab — for non-swizzled slabs the address
+   is `slab_base + lane * inner_stride`; for XOR-swizzled it's `slab_base + (lane ^ swizzle_xor) * inner_stride`.
+4. **PTX `mma.sync` emission**: replaces `wmma::mma_sync(c, a, b, c)` with explicit
+   `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32`. One line of inline asm.
+5. **Swizzle pattern**: for staged operands, the smem layout should be XOR-swizzled to match `ldmatrix.x4`'s
+   access pattern (each lane reads from a different 32-bank-line, no bank conflicts). M7 of
+   `plans/mma-smem-staging.md` already skips `070_pad_smem` for blocked sources; this is the constructive
+   replacement.
+
+**Bench gate**:
+
+```
+DEPLODOCK_ATOM_KIND=mma_m16n8k16_f16 DEPLODOCK_WM=2 DEPLODOCK_WN=2 DEPLODOCK_FM=4 DEPLODOCK_FN=4 \
+    ./venv/bin/deplodock run --code "…matmul(fp16)…" --bench
+```
+
+Expected: rendered C contains `ldmatrix.sync.aligned.m8n8.x4` + `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32`.
+Latency target: **≤ 99 µs** (matches cuBLAS, since cuBLAS's `s16816` is structurally the same kernel shape). If
+the gain over M3 is < 3%, drop M4 from the golden search.
+
+**Files**: `tile/_atom.py` (new atom + eligibility, ~50 lines), `kernel/ir.py` (`MmaFragment` PTX layout +
+`MmaLoad` ldmatrix render + `MmaSync` PTX mma render, ~150 lines), `kernel/005_lower_atom_tile.py` (~10 lines —
+atom-spec-aware paths factor cleanly), `tile/_enumeration.py` (~10 lines — list the new kind in
+`_ATOM_KINDS_V1`), `tests/compiler/test_matmul_mma_ptx.py` (new).
+
+## Phase B — Find the golden tile
+
+Once M2 / M3 / M4 bench-gates have passed (or been dropped), sweep their kept product space pinned end-to-end
+and pick the single best variant for the 2048² fp16 reference shape. The sweep matrix:
+
+```
+for atom_kind in [keep_set]:          # M4 kept → both wmma_m16n16k16_f16 and mma_m16n8k16_f16; else just wmma
+  for ws_mma in [keep_set]:           # M3 kept → 0, 1, 2; else just 0
+  for staged in [keep_set]:           # M2 kept → True/False; else just False
+    for wm, wn in [(1,8), (2,4), (4,2), (8,1), (2,2), (4,4)]:
+      for fm, fn in [(4,4), (2,4), (4,2), (8,2), (2,8), (8,8), (2,2)]:
+        for bk in [1, 2, 4, 8, 16, 32, 64]:
+          pin all of (atom_kind, ws_mma, staged, wm, wn, fm, fn, bk)
+          bench
+          record latency
+```
+
+That's up to **~2000 pinned variants × ~50ms compile each = 100 s of sweep time**. The result lands as
+`plans/mma-perf-closures-golden.md` (sibling) with the full latency matrix + the picked golden tile.
+
+**Golden-tile criteria**: lowest measured latency on 2048² fp16, tie-broken by lowest variance across 3 reps.
+The picked tile becomes the bench-gate for Phase C.
+
+**Files**: `scripts/sweep_mma_perf_closures.py` (new — pins variants via M1's knob-narrow, captures latencies
+through `BenchmarkResult`, dumps the CSV + golden pick).
+
+## Phase C — Tune the picker to land on the golden tile
+
+Once Phase B has the golden, tune `_priority_matmul_warp` and `score_tile_geometry` so the *default* picker (no
+env pins) selects the golden tile for this shape. Score-function changes drafted during the PR #182
+investigation that need to be re-introduced cleanly now that the codegen actually runs:
+
+1. **`score_tile_geometry`** gains an `ATOM_KIND in knobs` branch for the smem-fit penalty:
+   `macro_m = WM · FM · atom_M`, `macro_n = WN · FN · atom_N`, `base_slab = (macro_m + macro_n) · BK · atom_K
+   · bytes_per_elem` (atom_K accounts for the per-cache-axis block multiplier on K). Takes `bytes_per_elem`
+   (default fp32 = 4 for back-compat); warp tier passes 2 for fp16 / bf16 atoms.
+2. **`TileOp.lazy_score`** includes `ATOM_KIND` / `WM` / `WN` in `score_knobs` (currently only `FM` / `FN` /
+   `BK` / `SPLITK`); passes `dtype_bytes = 2` for the warp tier.
+3. **CTA-count ramp**. Replace the flat `+0.5` bonus for `target_ctas ≤ ctas ≤ 2048` with a linear ramp
+   keyed off the live device's SM count: `+0.5 · min(ctas / (2 · num_SMs), 1.0)`. Empirical (PR #182 sweep):
+   `WM=1 WN=8` (128 CTAs) ran at 109.2 µs vs `WM=WN=2` (256 CTAs) at 107.6 µs on sm_120 (170 SMs).
+4. **WS_MMA prior**: if M3 kept, add a small `+0.2` bonus when `WS_MMA > 0 and buffer_count >= 2`.
+5. **PTX-MMA atom prior**: if M4 kept, the `_ATOM_KINDS_V1` enumeration order is the prior — list
+   `mma_m16n8k16_f16` before `wmma_m16n16k16_f16` so the picker tries it first.
+
+The final test: `deplodock run --code "…matmul(fp16)…" --bench` (no env pins) hits the golden bench within
+±1%.
+
+**Files**: `ir/tile/ir.py` (`score_tile_geometry` + `lazy_score`, ~50 lines), `tile/_enumeration.py` (atom kind
+ordering + WS_MMA prior, ~10 lines), `tests/compiler/ir/tile/test_score_tile_geometry_mma.py` (new — pin the
+per-tier macro derivation + scoring-by-design rather than via end-to-end bench).
+
+## Reused machinery (no new code, just call sites)
+
+- `Source.addressing.block` / `AffineAddressing.source_index` (`ir/tile/ir.py:299, 313`) — already lifted by
+  `plans/mma-smem-staging.md` M2-M4; M2 of this plan adds the phase-prefix on top.
+- `040_use_ring_buffers` / `060_use_async_copy` / `080_pipeline_stages` — all fire automatically once a Source
+  admits (verified at the tile-IR level during PR #182 investigation). No code changes needed; M2's bug fixes
+  unlock the entire downstream chain.
+- `StageBundle.phase` field — already carries the per-bundle phase expression (`(K_o + N) % buffer_count` for
+  offset N); M2 reads it for the MmaLoad prefix; M3 routes the producer-side phase off it.
+- `_priority_matmul_warp` / `score_tile_geometry` — already cells≈16 + square-aspect aware from PR #182; Phase
+  C adds the ATOM_KIND-aware macro derivation, CTA-count ramp, WS_MMA / PTX-MMA priors.
+- `_ATOM_REGISTRY` (`tile/_atom.py`) — M4 adds entries; no structural changes.
+
+## Critical files
+
+- `deplodock/compiler/pipeline/passes/lowering/tile/_enumeration.py` — M1 (knob narrow), M3 (`WS_MMA` knob),
+  M4 (`_ATOM_KINDS_V1`), Phase C (priors).
+- `deplodock/compiler/pipeline/passes/lowering/kernel/005_lower_atom_tile.py` — M2 (transform-walk rewrite +
+  phase prefix), M4 (atom-spec dispatch for the PTX path).
+- `deplodock/compiler/pipeline/passes/lowering/kernel/085_warp_specialize.py` — M3 (MMA detection + split).
+- `deplodock/compiler/pipeline/passes/lowering/tile/_atom.py` — M4 (new atom registry entries).
+- `deplodock/compiler/ir/kernel/ir.py` — M4 (PTX MmaFragment / MmaLoad / MmaSync render paths).
+- `deplodock/compiler/ir/tile/ir.py` — Phase C (`score_tile_geometry`, `lazy_score`).
+- `scripts/sweep_mma_perf_closures.py` (new — Phase B sweep harness).
+- `tests/compiler/test_matmul_mma_staged_pipelined.py` (new — M2).
+- `tests/compiler/test_matmul_mma_warp_specialized.py` (new — M3).
+- `tests/compiler/test_matmul_mma_ptx.py` (new — M4).
+- `tests/compiler/ir/tile/test_score_tile_geometry_mma.py` (new — Phase C).
+
+## Verification
+
+The phased structure puts the bench gate at every M2-M4 step, not at the end. Each lever lives or dies on its
+measured perf number; the picker only chases gold once the gold is real.
+
+Per-milestone correctness gate: `tests/compiler/test_matmul_mma.py` (10 parametrized shapes — 16/64/128/256
+squares + 256×256×64 skewed × {F32, F16} outputs) must pass byte-clean after every milestone, with the picker
+still selecting the *current* baseline (no auto-picked staged / WS / PTX-MMA variant) until Phase C flips it.
+This decouples codegen correctness from picker behavior — a Phase A milestone that breaks `test_matmul_mma`
+broke codegen; a Phase C tweak that doesn't is a picker change.
+
+Phase-B golden gate: the sweep script asserts the picked golden beats the post-#182 baseline (108 µs) by ≥5%;
+otherwise the whole optimization round netted < 5% gain — fail loud rather than ship a tiny perf change as a
+big PR.
+
+Phase-C end-to-end gate: `deplodock run --code "…matmul(fp16)…" --bench` (no env pins) hits the golden bench
+within ±1%. `tests/perf/test_matmul_mma_perf.py` (new — same pattern as `tests/perf/ARCHITECTURE.md`'s cases)
+asserts the auto-picked latency stays within the golden ±5% on the canonical 2048² shape.
+
+| Milestone | Picked variant (when pinned) | Bench target | Decision |
+|---|---|---:|---|
+| Baseline (post #182) | `WM=1 WN=8 FM=FN=4 BK=64` gmem-direct | 108 µs | (reference) |
+| M2 (staged + pipelined) | `WM=WN=2 FM=FN=4 BK=2-4` async-buffered | ≤ 102 µs | keep iff ≥3% over 108 |
+| M3 (warp-specialized) | `WM=WN=2 FM=FN=4 BK=4 WS_MMA=1` | ≤ 100 µs | keep iff ≥2% over M2 |
+| M4 (PTX MMA + ldmatrix) | `mma_m16n8k16_f16` | ≤ 99 µs | keep iff ≥3% over M3 |
+| Phase B golden | (sweep picks) | ≤ 99 µs | gate: ≥5% over 108 µs |
+| Phase C (autotuned) | (matches golden, no env pins) | within ±1% of golden | (final) |
+
+## Out of scope
+
+- **MMA + cooperative-K** (`BR > 1` + MMA): `WarpTileParams` enforces `BR=1`; preserved.
+- **TMA for MMA** (`050_use_tma`): the eligibility check today rejects multi-axis-per-source-dim blocked slabs;
+  staged WMMA on sm_120 has no TMA path. Hopper-only follow-up (sm_90 / tcgen05 + tcgen05.cp.async.bulk).
+- **NVFP4 / wgmma / tcgen05**: separate hardware kinds with their own tmem / async issue-wait infrastructure;
+  M4's `mma.m16n8k16` is the sm_80+ Ampere/Blackwell path. The same five-piece extension pattern (atom kind,
+  fragment layout, load instruction, mma instruction, swizzle) applies but each generation needs its own work.
+- **Asymmetric M/N matmuls** (e.g. 64×1024×K): the priors should generalize but haven't been swept; out of
+  scope for these closures, planned in a separate `plans/mma-asymmetric-shapes.md`.
+
+## Failure modes to watch (load-bearing risks)
+
+1. **M2 transform-walk drops a structural variant.** The pipelined-staged shape isn't the only one MMA produces;
+   the SYNC-staged shape (no pipelining), the gmem-direct (no staging), the K_o=1 cases (no outer SerialTile),
+   and the shape-C (K-filtered) cases all need to flow through the same walk. Mitigation: the walk is structural
+   (preserve everything that isn't `Write` or reduce `SerialTile`), so new shapes flow through unchanged. The
+   per-milestone test should cover all four shapes via parametrize.
+
+2. **M2 phase prefix interacts with rank-mismatch render path.** `render_index` (`stmt/base.py:249`) flattens by
+   row-major stride when `len(indices) == len(shape)`; falls back to sum-without-strides when ranks mismatch.
+   Prepending phase to MmaLoad src_index needs to match the slab's rank exactly — Smem.render registers
+   `ctx.shapes[name] = full_extents` which is `(buffer_count, *cache_extents)` for buffered. Mitigation: assert
+   `len(src_index) == len(ctx.shapes[smem_name])` at MmaLoad render time, fail loud.
+
+3. **Phase-A bench gates flap from xdist GPU contention.** The flaky-but-real bench numbers from PR #182 showed
+   ±2 µs variance across runs. Each milestone's bench gate runs 3 reps with a stricter ±1% pass criteria; if
+   any rep fails, re-run. The decision "keep / drop" needs to outweigh the noise.
+
+4. **M3's WS_MMA enumeration explodes the search tree.** Each WS_MMA value forks the warp-tier variant set by
+   2-3×. Mitigation: gate WS_MMA enumeration on `buffer_count >= 2` (eligible only when pipelining is in play)
+   and patience-bound the per-kernel autotune to keep the inner search bounded.
+
+5. **M4's ldmatrix swizzle interacts with `070_pad_smem`'s skip predicate.** M7 of
+   `plans/mma-smem-staging.md` skips pad_smem for blocked sources. M4 introduces a constructive XOR-swizzle for
+   the PTX MMA path; the pad_smem skip should generalize to "skip when the source carries either a block or a
+   swizzle" — but the swizzle field doesn't exist on `Source` yet. Either reuse the existing `Source.pad` slot
+   with a swizzle encoding or add a `Source.swizzle` field; the latter is cleaner.
+
+6. **Phase B sweep masks compile-time outliers.** Some pinned variants compile cleanly but error at the cubin
+   cache (LLVM blowup on big unrolled register-tile kernels — see `project_tune_compile_bound.md`). The sweep
+   script needs a timeout per variant + bench_fail marker so a slow variant doesn't stall the whole sweep.
+
+7. **Phase C's score-tweaks regress scalar matmul** if the new ATOM_KIND-only branches accidentally fire on
+   scalar shapes. Mitigation: every new branch is `if "ATOM_KIND" in knobs:`-gated; the existing
+   `test_partition_planner_*` and `test_swizzle_blocks_matmul_accuracy` golden-tile assertions catch any
+   scalar drift. Run the full `tests/compiler/` suite as the byte-clean gate before merging each Phase C tweak.
+
+## Connection to prior work
+
+- **`plans/mma-fragment-factorization.md`** (PR #177): introduced the warp-tier MMA planner + AtomTile lowering.
+  M2 fixes the StageBundle-around-AtomTile case it didn't handle; M4 adds a parallel atom kind.
+- **`plans/mma-smem-staging.md`** (PR #180): lifted `Source.addressing` and added `AffineAddressing.block`. M2
+  reads `addressing.block` for the per-axis phase routing; M3 reads `StageBundle.phase` for the producer-consumer
+  split.
+- **PR #182** (`feature/mma-warp-scoring`): tweaked the warp-tier priors so the picker finds the right corner of
+  the search space. Phase C extends the same `score_tile_geometry` function for ATOM_KIND-aware macros and the
+  CTA-count term.
+- **`project_tensor_core_dead_end.md`** memory: established the hard 5-10% WMMA-vs-PTX-MMA SASS gap. M4 is the
+  unlock for the half of the remaining 9% that's intrinsic to the WMMA instruction wrapper.

--- a/plans/mma-perf-closures.md
+++ b/plans/mma-perf-closures.md
@@ -165,6 +165,16 @@ IR was previously emitting a shape that crashed at materialize.
 
 ### M3 — Warp specialization for MMA
 
+**Outcome (2026-05-30).** **Skipped — structurally depends on M2.** WS_MMA's enumeration gates on
+`ATOM_KIND in knobs and buffer_count > 1`, and the producer-consumer split routes work onto the cp.async pipeline
+that M2 lights up. With M2's bench gate failing by 2.3× (the cp.async path doesn't pay at the 2048² fp16
+geometry), an instruction-scheduling cleanup on top of the same path can't recover the 1.4× gap M2 left, let
+alone the ≥2% the plan called for. No code change; the plan's `WS_MMA` knob + `085_warp_specialize` extension
+stay queued for a future session that picks M2 back up at a different shape (asymmetric matmuls per the
+out-of-scope note) where the cp.async lever might pay.
+
+
+
 `085_warp_specialize` today gates on `BR > 1` and shapes the producer/consumer split around cooperative-K
 reduce. MMA forbids `BR > 1` (`splitk_choices = (1,)`; the warp-tier accumulator lives register-side). To wire
 WS for MMA, the split needs a different shape: dedicate `WS_PROD ≥ 1` warps to issuing cp.async + bumping an
@@ -202,6 +212,19 @@ instruction scheduling and warp-disjoint smem access). If the gain is < 2%, drop
 producer-consumer split, ~200 lines), `tests/compiler/test_matmul_mma_warp_specialized.py` (new).
 
 ### M4 — `mma.m16n8k16` atom (ldmatrix + PTX mma)
+
+**Outcome (2026-05-30).** **Deferred to a dedicated follow-up session.** The plan's 220-line estimate
+understates the work — the PTX mma.sync lane-distributed register layout (4 `__half2` per lane for A, 2 for B,
+4 `float` for C, each at specific lane-indexed bit positions) and the `ldmatrix.x4` + `.x2.trans` per-lane
+addressing arithmetic are bit-level precise: any off-by-one yields silent wrong outputs that only show up at
+runtime correctness checks (slow inner loop: render → nvcc → cubin → run → check). The full lever requires
+several hours of focused PTX work + iterative bench-testing. Doing only the cosmetic atom-kind addition + the
+mma.sync instruction swap (without ldmatrix) would necessarily run *slower* than the WMMA baseline
+(per-lane manual loads can't beat `wmma::load_matrix_sync`'s SASS scheduling), so a half-implementation can't
+even validate the lever. Reserve a dedicated session for M4 starting from a reference (CUTLASS's `s16816`
+kernel) and an isolated test harness that benches every micro-step.
+
+
 
 cuBLAS's `cutlass_80_tensorop_*_s16816gemm_*` reveals the Ampere+ PTX MMA shape `m16n8k16`, loaded via
 `ldmatrix.x4` (a lane-aware multi-fragment load issuing 4 32-byte fragment-loads per warp). Compared to
@@ -248,6 +271,15 @@ atom-spec-aware paths factor cleanly), `tile/_enumeration.py` (~10 lines — lis
 
 ## Phase B — Find the golden tile
 
+**Outcome (2026-05-30).** **Skipped — empty keep_set.** M2 dropped (pinned variant 2.3× slower than baseline);
+M3 dropped (depends on M2); M4 deferred. With every Phase-A lever excluded or deferred, the Phase-B sweep
+collapses to the existing scoring's pick — i.e. the post-#182 baseline at ~108 µs. No new golden to find, no
+Phase-C picker tweak to chase. The plan's bench-gate gate (≥5% improvement over 108 µs to validate the round)
+explicitly tells us to fail loud here rather than ship a tiny perf change as a big PR; recording the negative
+result and re-opening the round when M4 lands.
+
+
+
 Once M2 / M3 / M4 bench-gates have passed (or been dropped), sweep their kept product space pinned end-to-end
 and pick the single best variant for the 2048² fp16 reference shape. The sweep matrix:
 
@@ -273,6 +305,11 @@ The picked tile becomes the bench-gate for Phase C.
 through `BenchmarkResult`, dumps the CSV + golden pick).
 
 ## Phase C — Tune the picker to land on the golden tile
+
+**Outcome (2026-05-30).** **Skipped — no golden to chase.** Phase B produced no winner above the baseline.
+Re-open when M4 lands.
+
+
 
 Once Phase B has the golden, tune `_priority_matmul_warp` and `score_tile_geometry` so the *default* picker (no
 env pins) selects the golden tile for this shape. Score-function changes drafted during the PR #182

--- a/plans/mma-perf-closures.md
+++ b/plans/mma-perf-closures.md
@@ -153,6 +153,16 @@ pay for this shape — record the measured number and exclude the staged variant
 `tests/compiler/test_matmul_mma_staged_pipelined.py` (new — pins the buffered shape; greps the rendered C for
 `cp.async` and matching MmaLoad src_index ranks; runs the f32 reference comparison at fp16 tolerance).
 
+**Outcome (2026-05-30, sm_120 RTX 5090).** Codegen fix landed: the pipelined IR now compiles cleanly (verified at
+128² / 256²). Bench gate **FAILED — drop the lever**. Pinned `DEPLODOCK_ATOM_KIND=wmma_m16n16k16_f16 WM=WN=2
+FM=FN=4 BK=2` runs 2048² fp16 at ~249 µs vs the post-#182 baseline of ~108 µs (2.3× slower). Sweeping BK pinned
+at the same WM/WN/FM/FN: BK=1 → 109 µs, **BK=2 → 249 µs**, BK=4 → 254 µs, BK=8 → 170 µs, BK=16 → 107 µs, BK=32 →
+107 µs. The double-buffered cp.async path is structurally correct but pays an instruction-scheduling /
+syncthreads overhead that outweighs the K-load overlap at this geometry; the BK=16/32 single-bundle SYNC variant
+already matches baseline (the picker can find it from the existing scoring). Per the phase-A decision rule,
+**M2's staged-pipelined variant is excluded from the Phase B golden search**; the codegen fix stays because the
+IR was previously emitting a shape that crashed at materialize.
+
 ### M3 — Warp specialization for MMA
 
 `085_warp_specialize` today gates on `BR > 1` and shapes the producer/consumer split around cooperative-K

--- a/tests/compiler/passes/test_partition_planner_mma.py
+++ b/tests/compiler/passes/test_partition_planner_mma.py
@@ -237,6 +237,48 @@ def test_warp_enumerator_priority_orders_by_cells_sweet_spot():
     assert first_dist <= last_dist
 
 
+# --- Warp-tier knob narrow (M1, plans/mma-perf-closures.md) ----------
+
+
+def test_warp_enumerator_wm_narrow(monkeypatch):
+    """``DEPLODOCK_WM=2`` pin narrows the warp tier to ``wm=2`` only.
+    Without this plumbing the impl iterates the full
+    ``_TUNE_WARP_AXIS_CHOICES`` regardless and the CLI bench gate of
+    every Phase A milestone fails to land on the targeted variant."""
+    monkeypatch.setenv("DEPLODOCK_WM", "2")
+    rows = _enum_warp(M=128, N=128, K=128)
+    assert rows, "WM=2 should leave at least one variant at 128-square"
+    assert all(r.wm == 2 for r in rows)
+
+
+def test_warp_enumerator_wn_narrow(monkeypatch):
+    """``DEPLODOCK_WN=2`` pin narrows the warp tier to ``wn=2`` only."""
+    monkeypatch.setenv("DEPLODOCK_WN", "2")
+    rows = _enum_warp(M=128, N=128, K=128)
+    assert rows
+    assert all(r.wn == 2 for r in rows)
+
+
+def test_warp_enumerator_bk_narrow(monkeypatch):
+    """``DEPLODOCK_BK=2`` pin narrows the warp tier to ``bk=2`` only.
+    M2's staged-MMA bench gate pins ``BK=2`` so the picker lands on the
+    pipelined-async variant."""
+    monkeypatch.setenv("DEPLODOCK_BK", "2")
+    rows = _enum_warp(M=128, N=128, K=128)
+    assert rows
+    assert all(r.bk == 2 for r in rows)
+
+
+def test_warp_enumerator_atom_kind_narrow(monkeypatch):
+    """``DEPLODOCK_ATOM_KIND=wmma_m16n16k16_f16`` pins the kind even
+    when the caller passes a multi-kind tuple. M4's PTX-MMA bench
+    gate uses this to pin ``mma_m16n8k16_f16`` against the WMMA baseline."""
+    monkeypatch.setenv("DEPLODOCK_ATOM_KIND", "wmma_m16n16k16_f16")
+    rows = _enum_warp(M=128, N=128, K=128, kinds=("wmma_m16n16k16_f16", "wmma_m16n16k16_bf16"))
+    assert rows
+    assert all(r.atom_kind == "wmma_m16n16k16_f16" for r in rows)
+
+
 def test_warp_enumerator_force_splitk_one():
     """``force_splitk_one`` clamps SPLITK choices to (1,) — every emitted
     row has splitk=1."""

--- a/tests/compiler/test_matmul_mma_staged_pipelined.py
+++ b/tests/compiler/test_matmul_mma_staged_pipelined.py
@@ -1,0 +1,253 @@
+"""Tests for the staged + pipelined MMA codegen path (M2 of
+``plans/mma-perf-closures.md``).
+
+The pre-2026 ``005_lower_atom_tile._atom_body_to_mma`` walked the AtomTile
+body looking for one ``(outer_st, reduce_st, enclosing_bundle)`` triple and
+rebuilt the body from scratch. The shape ``080_pipeline_stages`` emits —
+prologue StageBundle + K_o-1 SerialTile {issue-next bundle, AsyncWait,
+K_i reduce, AsyncWait} + drain AsyncWait + epilogue K_i reduce + Write —
+has elements the rebuild path couldn't reconstruct (the prologue, the
+epilogue, the AsyncWaits). The rewrite raised ``RuleSkipped`` and the
+AtomTile flowed through to render, erroring as ``AtomTile must be
+consumed by the MMA materializer``.
+
+The M2 fix replaces the rebuild path with a **transform walk** that
+preserves every structural Stmt (StageBundle wraps, AsyncWait, K_o
+SerialTile, prologue/epilogue) and only rewrites reduce SerialTiles
+(body → Mma chain, ``is_reduce`` cleared) and Write (→ MmaStore). Two
+sub-fixes ride alongside:
+
+- **MmaLoad src_index phase prefix** — buffered slabs are
+  ``[phase, *cache_axes]``-shaped; the consumer Load index in the IR
+  carries the leading phase. ``_mma_src_index`` splices the prefix back
+  in front of the computed cache coords so the fragment reads the right
+  slot.
+- **A/B classification via Source.cache_dims** — for staged smem loads
+  the K axis sits in the *middle* of the index tuple (not the last/first
+  dim), so the legacy "K_name in load.index[-1]" heuristic misclassifies.
+  We instead read the cache_dim whose ``axis.name == K_name`` and
+  branch on ``source_dim`` (1=A, 0=B).
+
+The plan's perf bench gate (≤ 102 µs at 2048² fp16) was verified
+end-to-end by ``deplodock run --bench``: the pinned variant runs at
+~249 µs vs the post-#182 baseline of ~108 µs, **doesn't beat baseline**,
+and is therefore dropped from the Phase B golden search (per the plan's
+keep/drop decision rule). The codegen fix stays — the IR was emitting a
+pipelined-staged shape that crashed at materialize time; the fix lets it
+compile and run correctly so the lever can be measured at all.
+"""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pytest
+
+from deplodock.compiler.dtype import F16, F32, DataType
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
+from deplodock.compiler.ir.stmt import Accum, Assign
+from deplodock.compiler.pipeline import KERNEL_PASSES, Pipeline
+
+
+def _has_cuda() -> bool:
+    try:
+        import cupy as cp
+
+        return cp.cuda.is_available()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _supports_wmma() -> bool:
+    if not _has_cuda():
+        return False
+    import cupy as cp
+
+    cap = cp.cuda.Device().compute_capability
+    return int(cap) >= 70
+
+
+def _matmul_loop_op(*, M: int, N: int, K: int) -> LoopOp:
+    i = Axis("i", M)
+    j = Axis("j", N)
+    k = Axis("k", K)
+    return LoopOp(
+        body=(
+            Loop(
+                axis=i,
+                body=(
+                    Loop(
+                        axis=j,
+                        body=(
+                            Loop(
+                                axis=k,
+                                body=(
+                                    Load(name="a_v", input="a", index=(Var("i"), Var("k"))),
+                                    Load(name="b_v", input="b", index=(Var("k"), Var("j"))),
+                                    Assign(name="p", op=ElementwiseImpl("multiply"), args=("a_v", "b_v")),
+                                    Accum(name="acc", value="p"),
+                                ),
+                            ),
+                            Write(output="c", index=(Var("i"), Var("j")), value="acc"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _matmul_graph(*, M: int, N: int, K: int, out_dtype: DataType) -> Graph:
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (M, K), dtype=F16), node_id="a")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (K, N), dtype=F16), node_id="b")
+    g.add_node(
+        op=_matmul_loop_op(M=M, N=N, K=K),
+        inputs=["a", "b"],
+        output=Tensor("c", (M, N), dtype=out_dtype),
+        node_id="c",
+    )
+    g.inputs = ["a", "b"]
+    g.outputs = ["c"]
+    return g
+
+
+def _np_dtype(dt: DataType):
+    return {F16: np.float16, F32: np.float32}[dt]
+
+
+def _cp_dtype(dt: DataType, cp):
+    return {F16: cp.float16, F32: cp.float32}[dt]
+
+
+@pytest.fixture
+def pin_staged_pipelined(monkeypatch):
+    """Pin the warp-tier knob set that exercises the staged + pipelined
+    cp.async MMA path: square WMMA atom (sm_70+), WM=WN=2 warps,
+    FM=FN=4 register cells, BK=2 K-stage_inner trip count → the picker
+    lands on the buffered-async path that ``080_pipeline_stages``
+    double-buffers via cp.async."""
+    monkeypatch.setenv("DEPLODOCK_MMA", "1")
+    monkeypatch.setenv("DEPLODOCK_ATOM_KIND", "wmma_m16n16k16_f16")
+    monkeypatch.setenv("DEPLODOCK_WM", "2")
+    monkeypatch.setenv("DEPLODOCK_WN", "2")
+    monkeypatch.setenv("DEPLODOCK_FM", "4")
+    monkeypatch.setenv("DEPLODOCK_FN", "4")
+    monkeypatch.setenv("DEPLODOCK_BK", "2")
+
+
+def _compile_and_render(*, M: int, N: int, K: int, out_dtype: DataType):
+    from deplodock.compiler.ir.kernel.render import render_kernelop  # noqa: PLC0415
+
+    g = _matmul_graph(M=M, N=N, K=K, out_dtype=out_dtype)
+    g = Pipeline.build(KERNEL_PASSES).run(g)
+    kop = g.nodes["c"].op
+    tensors = {nid: n.output for nid, n in g.nodes.items() if hasattr(n.output, "shape")}
+    src = render_kernelop(kop, tensors=tensors)
+    return g, kop, src
+
+
+@pytest.mark.skipif(not _supports_wmma(), reason="WMMA needs CUDA + sm_70+")
+@pytest.mark.parametrize("M,N,K", [(128, 128, 128), (256, 256, 128)])
+def test_staged_pipelined_matches_f32_reference(pin_staged_pipelined, M: int, N: int, K: int):
+    """The staged + pipelined MMA path produces output that matches the
+    f32 reference within fp16 tolerance. Pre-M2 the AtomTile lowering
+    raised ``RuleSkipped`` on the pipelined shape, so the kernel never
+    compiled and the matmul never ran."""
+    import cupy as cp
+
+    from deplodock.compiler.backend.cuda.nvcc import compile_to_cubin  # noqa: PLC0415
+
+    g, kop, src = _compile_and_render(M=M, N=N, K=K, out_dtype=F32)
+    assert kop.knobs.get("ATOM_KIND") == "wmma_m16n16k16_f16"
+    # The pinned BK=2 with buffer_count >= 2 must produce the cp.async-staged
+    # pipelined MMA path — verified at the C source.
+    assert "cp.async.commit_group" in src
+    assert "wmma::mma_sync" in src
+    assert "cp.async.wait_group" in src
+
+    cap = cp.cuda.Device().compute_capability
+    cubin_path = compile_to_cubin(src, kop.name, arch=f"sm_{cap}")
+    mod = cp.RawModule(path=str(cubin_path))
+    k = mod.get_function(kop.name)
+
+    np.random.seed(42)
+    a = (np.random.randn(M, K) * 0.1).astype(np.float16)
+    b = (np.random.randn(K, N) * 0.1).astype(np.float16)
+    a_cp = cp.asarray(a)
+    b_cp = cp.asarray(b)
+    c_cp = cp.zeros((M, N), dtype=cp.float32)
+
+    knobs = kop.knobs
+    wm, wn = int(knobs["WM"]), int(knobs["WN"])
+    fm, fn = int(knobs["FM"]), int(knobs["FN"])
+    splitk = int(knobs.get("SPLITK", 1))
+    atom_m = atom_n = 16  # wmma_m16n16k16_f16
+    m_b = max(1, M // (wm * fm * atom_m))
+    n_b = max(1, N // (wn * fn * atom_n))
+    grid_x = m_b * n_b * splitk
+    threads_per_cta = wm * wn * 32
+    k((grid_x,), (threads_per_cta,), (a_cp, b_cp, c_cp))
+
+    expected = a.astype(np.float32) @ b.astype(np.float32)
+    result = c_cp.get()
+    diff = np.abs(result - expected).max()
+    # F32 acc — tight tolerance.
+    assert diff < 1e-2, f"M={M} N={N} K={K} max-abs-err {diff}"
+
+
+@pytest.mark.skipif(not _supports_wmma(), reason="WMMA needs CUDA + sm_70+")
+def test_staged_pipelined_phase_prefix_renders(pin_staged_pipelined):
+    """The buffered-slab phase prefix lands on every ``wmma::load_matrix_sync``
+    offset (``[phase * stride + cache_coords]``). Pre-M2 ``_mma_src_index``
+    dropped the leading phase Expr; the load addressed slot 0 every iter,
+    racing with cp.async's writes to slot 1 → garbled output."""
+    _, _, src = _compile_and_render(M=128, N=128, K=128, out_dtype=F32)
+    # ``a7 % 2`` is the inner-K_o reduce's phase Expr (``a7`` is the K_o
+    # axis after axis renumbering); ``1`` (literal) is the epilogue's
+    # last-slot read. Both must appear in the rendered load offsets.
+    a_loads = re.findall(r"wmma::load_matrix_sync\(\w+, &a_smem\[([^\]]+)\]", src)
+    b_loads = re.findall(r"wmma::load_matrix_sync\(\w+, &b_smem\[([^\]]+)\]", src)
+    assert a_loads, "expected ≥1 a_smem load"
+    assert b_loads, "expected ≥1 b_smem load"
+    # At least one inner-loop load addresses the buffered slot via a
+    # ``% 2`` phase factor on a_smem.
+    assert any("% 2" in o for o in a_loads), f"a_smem loads missing phase prefix: {a_loads}"
+    assert any("% 2" in o for o in b_loads), f"b_smem loads missing phase prefix: {b_loads}"
+
+
+@pytest.mark.skipif(not _supports_wmma(), reason="WMMA needs CUDA + sm_70+")
+def test_staged_pipelined_ab_classification(pin_staged_pipelined):
+    """A vs B classification via ``Source.cache_dims`` — the cache axis
+    whose ``axis.name == K_name`` has ``source_dim == 1`` for A (K is the
+    inner gmem dim) or ``0`` for B (K is the outer gmem dim). Pre-M2 the
+    classification used ``K_name in load.index[-1]`` which for staged
+    slabs misses (K sits in the middle of the slab-coord tuple).
+    Smoke-test: the rendered ``mma_sync`` arguments end up as
+    ``mma_sync(c, a, b, c)`` with ``a`` referring to ``in1_frag`` (the
+    A operand loaded from ``a_smem``) and ``b`` to ``in0_frag`` (the B
+    operand loaded from ``b_smem``) — i.e. no swap."""
+    _, _, src = _compile_and_render(M=128, N=128, K=128, out_dtype=F32)
+    # Find the first mma_sync call.
+    m = re.search(r"wmma::mma_sync\((\w+),\s*(\w+),\s*(\w+),\s*\1\)", src)
+    assert m is not None, "expected at least one mma_sync"
+    _, a_arg, b_arg = m.groups()
+    # The fragment SSA naming is order-dependent (pulled from the Load's
+    # ``names[0]``), so we don't pin specific names. Instead verify the
+    # round-trip: find the wmma::load_matrix_sync that defined ``a_arg``
+    # and check it reads from ``a_smem`` (M-side gmem buffer); same for
+    # ``b_arg`` and ``b_smem``. Pre-M2 the classification keyed off
+    # ``K_name in load.index[-1]`` which for staged slabs misses (K sits
+    # in the middle of the slab-coord tuple), swapping A↔B and yielding
+    # ``mma_sync(c, b_frag, a_frag, c)`` — the K↔M↔N matmul indexing
+    # collapses to wrong output.
+    a_load_m = re.search(rf"wmma::load_matrix_sync\({re.escape(a_arg)}, &(\w+)\[", src)
+    b_load_m = re.search(rf"wmma::load_matrix_sync\({re.escape(b_arg)}, &(\w+)\[", src)
+    assert a_load_m is not None and b_load_m is not None
+    assert a_load_m.group(1) == "a_smem", f"a operand should load from a_smem, got {a_load_m.group(1)}"
+    assert b_load_m.group(1) == "b_smem", f"b operand should load from b_smem, got {b_load_m.group(1)}"


### PR DESCRIPTION
Executes the first two milestones of `plans/mma-perf-closures.md` on sm_120 RTX 5090. The plan's perf round
nets 0 µs at 2048² fp16 (M2's lever doesn't pay), but two durable artifacts land: warp-tier CLI pinning works,
and the pipelined-staged AtomTile IR — which previously crashed at materialize — now compiles cleanly.

## Per-milestone disposition

| Milestone | Disposition | Latency at 2048² fp16 |
|---|---|---|
| **M1** (warp-tier knob narrow) | landed | n/a — plumbing |
| **M2** (staged-pipelined MMA codegen) | **codegen landed; lever dropped from golden search** | pinned 249 µs vs 108 µs baseline (2.3× slower) |
| **M3** (warp specialization) | skipped — depends on M2 | — |
| **M4** (PTX `mma.m16n8k16`) | deferred to a dedicated session | — |
| Phase B (golden sweep) | skipped — empty keep_set | — |
| Phase C (picker tuning) | skipped — no golden | — |

## Commits

1. `6fbc7a34` — **M1: Warp-tier knob narrow (WM/WN/BK/ATOM_KIND)**
   `_enumerate_warp_matmul_impl` was iterating `_TUNE_WARP_AXIS_CHOICES` / `_BK_CANDIDATES` directly without
   applying `WM.narrow` / `WN.narrow` / `BK.narrow` / `ATOM_KIND.narrow`, so warp-tier `DEPLODOCK_<KNOB>` env
   pins were silently ignored. Folds the narrows into the impl parallel to the scalar tier's
   `_run(apply_pins=True)`. The M2/M3/M4 bench gates of the perf-closures plan all need this to pin a variant
   from the CLI. Pure plumbing — four new `test_warp_enumerator_*_narrow` tests lock the gates in.

2. `c4a63a8b` — **M2: Staged + pipelined MMA codegen — transform walk + phase prefix + A/B classification**
   `005_lower_atom_tile._atom_body_to_mma` walked the AtomTile body looking for one
   `(outer_st, reduce_st, enclosing_bundle)` triple and rebuilt from scratch. The shape `080_pipeline_stages`
   emits — prologue StageBundle + K_o-1 SerialTile { issue-next bundle, AsyncWait, K_i reduce, AsyncWait } +
   drain AsyncWait + epilogue K_i reduce + Write — has prologue + epilogue + AsyncWaits the rebuild path
   couldn't reconstruct. The walk raised `RuleSkipped` silently and the AtomTile flowed through to render,
   erroring as `AtomTile must be consumed by the MMA materializer`.

   Replace the rebuild with a structural transform walk: every reduce `SerialTile`'s body becomes an
   `MmaLoad+MmaLoad+MmaSync` chain (`is_reduce` clears implicitly via the missing `Accum`), every `Write`
   becomes `MmaStore`, everything else flows through unchanged. Two sub-fixes ride alongside:

   - `MmaLoad.src_index` phase prefix — buffered slabs are `[phase, *cache_axes]`-shaped; the consumer Load
     index carries the leading phase. `_mma_src_index` splices it back in front of the computed cache coords.
   - A/B classification via `Source.cache_dims` — for staged smem loads K sits in the middle of the slab-coord
     tuple. Read the cache_dim whose `axis.name == K_name` and branch on `source_dim` (1=A, 0=B).

   End-to-end correctness verified: 128² / 256² pinned-pipelined matmul matches the f32 reference at fp16
   tolerance. `test_matmul_mma.py` (8 shapes × 2 dtypes) remains byte-clean.

   **Bench gate FAILED.** Pinned (`ATOM_KIND=wmma_m16n16k16_f16 WM=WN=2 FM=FN=4 BK=2`) 2048² fp16 runs at
   ~249 µs vs the post-#182 baseline of ~108 µs. BK sweep at the same WM/WN/FM/FN:

   | BK | Latency (µs) | Notes |
   |---:|---:|---|
   | 1 | 109 | near-baseline |
   | **2** | **249** | M2's plan target (double-buffered cp.async) |
   | 4 | 254 | also cp.async-buffered |
   | 8 | 170 | partial |
   | 16 | 107 | matches baseline (single-bundle SYNC) |
   | 32 | 107 | matches baseline |

   The double-buffered cp.async path pays a `__syncthreads()` / instruction-scheduling overhead at this
   geometry that outweighs the K-load overlap. BK=16/32 single-bundle SYNC already matches baseline (picker
   can find it from the existing scoring). Per the plan's keep/drop rule, **M2's staged-pipelined variant is
   excluded from the Phase B golden search**. The codegen fix stays because the IR was previously emitting a
   shape that crashed at materialize; M3 / M4 levers still need the fix to compose.

3. `0854a676` — **Plan disposition (M3 skipped, M4 deferred, Phase B/C skipped)**
   Records the per-milestone outcomes inline in `plans/mma-perf-closures.md` under each milestone's heading.

## Tests

- `tests/compiler/passes/test_partition_planner_mma.py` — 4 new `test_warp_enumerator_*_narrow` cases for M1.
- `tests/compiler/test_matmul_mma_staged_pipelined.py` (new) — 4 cases pinning the buffered shape, greping the
  rendered C for `cp.async` + matching MmaLoad src_index phase prefix, running the f32 reference comparison
  at fp16 tolerance, and locking the A/B classification at the rendered `mma_sync` operand level.
- `tests/compiler/test_matmul_mma.py` (10 parametrized shapes × 2 output dtypes) remains byte-clean.

## Verification (sm_120 RTX 5090)

```
$ ./venv/bin/pytest tests/compiler/test_matmul_mma.py tests/compiler/test_matmul_mma_staged_pipelined.py \
    tests/compiler/passes/test_partition_planner_mma.py -p no:randomly -n auto --dist=loadgroup
================================== 33 passed in 9.30s ==================================
```

End-to-end staged-pipelined run at 128²:

```
$ DEPLODOCK_MMA=1 DEPLODOCK_ATOM_KIND=wmma_m16n16k16_f16 DEPLODOCK_WM=2 DEPLODOCK_WN=2 \
  DEPLODOCK_FM=4 DEPLODOCK_FN=4 DEPLODOCK_BK=2 \
  ./venv/bin/deplodock run --code "import torch; a=torch.ones(128,128,dtype=torch.float16,device='cuda'); \
  b=torch.ones(128,128,dtype=torch.float16,device='cuda'); torch.matmul(a,b)" -v
Accuracy vs eager: max_diff=0.000000 mean_diff=0.000000 tol=128.000000 PASS
```

## Follow-up

Re-open the perf round when M4 (PTX `mma.m16n8k16` + ldmatrix) lands. The plan's 220-line estimate
understates the bit-level lane-distributed register layout work; reserve a dedicated session starting from a
CUTLASS `s16816` reference and an isolated bench-test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)