### PR TITLE
warp-specialize: fail loudly when WARP_SPECIALIZE=1 pinned but can't fire

### DIFF
--- a/deplodock/compiler/pipeline/passes/lowering/tile/085_warp_specialize.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/085_warp_specialize.py
@@ -77,6 +77,7 @@ the fork via ``WARP_SPECIALIZE.narrow``.
 
 from __future__ import annotations
 
+from deplodock import config
 from deplodock.compiler.context import Context
 from deplodock.compiler.dim import Dim
 from deplodock.compiler.graph import Node
@@ -319,6 +320,15 @@ def rewrite(ctx: Context, root: Node) -> TileOp | Fork | list[Fork] | None:
 
     ok, reason = _eligible(op)
     if not ok:
+        # Fail loudly if the user explicitly pinned ``DEPLODOCK_WARP_SPECIALIZE=1``
+        # but the kernel can't be warp-specialized (e.g. a warp-tier MMA matmul
+        # — ``no ThreadTile in body``, WS+MMA is out of v1 scope). Silently
+        # RuleSkipping would hand back the *non-WS* kernel with no signal, so a
+        # pinned-but-unhonorable knob raises — same policy as the BUFFER_COUNT /
+        # TMA pins.
+        pin = config.knob_raw(WARP_SPECIALIZE.name)
+        if pin is not None and WARP_SPECIALIZE.parse(pin):
+            raise ValueError(f"DEPLODOCK_WARP_SPECIALIZE=1 pinned but warp specialization cannot fire: {reason}")
         raise RuleSkipped(reason)
 
     ws_choices = WARP_SPECIALIZE.narrow(WARP_SPECIALIZE.hints)

--- a/tests/compiler/passes/test_warp_specialize.py
+++ b/tests/compiler/passes/test_warp_specialize.py
@@ -114,6 +114,20 @@ def test_rule_skipped_on_pointwise():
         _run_rule(op)
 
 
+def test_pinned_ws1_on_ineligible_fails_loudly(monkeypatch):
+    """A pinned ``DEPLODOCK_WARP_SPECIALIZE=1`` that can't be honored must
+    **raise**, not silently RuleSkip into the non-WS kernel. (The motivating
+    case is a warp-tier MMA matmul — ``no ThreadTile in body`` — but any
+    ineligible op exercises it; the pointwise op has no TMA bundle.) A
+    pinned-but-unhonorable knob erroring matches the BUFFER_COUNT / TMA pin
+    policy, instead of handing back a kernel the pin never shaped. Without the
+    pin the same op RuleSkips cleanly (see ``test_rule_skipped_on_pointwise``)."""
+    monkeypatch.setenv("DEPLODOCK_WARP_SPECIALIZE", "1")
+    op = _tile_op_pointwise()
+    with pytest.raises(ValueError, match="WARP_SPECIALIZE=1 pinned but warp specialization cannot fire"):
+        _run_rule(op)
+
+
 def test_rule_skipped_when_ws_already_set():
     op = _tile_op_tma_pipelined()
     op_with_ws = TileOp(body=op.body, name=op.name, knobs={"WARP_SPECIALIZE": True})


### PR DESCRIPTION
`085_warp_specialize` `RuleSkipped`s when a kernel isn't warp-specializable —
e.g. a warp-tier MMA matmul, whose eligibility check returns *"no ThreadTile in
body"* (WS + MMA is out of v1 scope; the kernel is built on a planner-emitted
`WarpTile`, not a `ThreadTile`).

The problem: when the user **pins** `DEPLODOCK_WARP_SPECIALIZE=1`, that silent
skip handed back the **non-WS** kernel with no signal — so the pin appeared to
work but did nothing. (This cost real debugging time: an unchanged kernel was
mistaken for a warp-specialized one, complete with misattributed `ncu` numbers.)

## Fix

A pinned-but-unhonorable `WARP_SPECIALIZE=1` now raises:

```
ValueError: DEPLODOCK_WARP_SPECIALIZE=1 pinned but warp specialization cannot
            fire: no ThreadTile in body
```

This matches the existing pin policy for `BUFFER_COUNT` (`040_use_ring_buffers`)
and `TMA` (`050_use_tma`) — a pinned knob that can't be honored is an error, not
a silent fallback. Behavior unchanged otherwise:

- **unpinned** (autotune fork) → still `RuleSkipped` cleanly,
- **`WARP_SPECIALIZE=0`** → honored,
- **`WARP_SPECIALIZE=1` on an eligible kernel** → fires as before.

## Test

`test_pinned_ws1_on_ineligible_fails_loudly`: pinned WS=1 on an ineligible op
raises `ValueError`; the unpinned case still `RuleSkipped`s
(`test_rule_skipped_on_pointwise`). Existing WS suite green (14 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)