### PR TITLE
Move CloudRift client to the v059 protocol generation

### DIFF
--- a/deplodock/provisioning/ARCHITECTURE.md
+++ b/deplodock/provisioning/ARCHITECTURE.md
@@ -52,7 +52,7 @@ When every candidate is exhausted, the orchestrator returns `None` and logs the 
 
 `errors.py` defines two exceptions that providers raise to communicate intent:
 
-* **`CapacityExhausted`** — the current candidate has no capacity. Raised for CloudRift HTTP 503/429 on rent, CloudRift `Inactive` terminal status / readiness timeout, GCP `ZONE_RESOURCE_POOL_EXHAUSTED` / `QUOTA_EXCEEDED` / `STOCKOUT` in `gcloud create` stderr, and GCP RUNNING-status timeout. Recoverable by trying a different candidate.
+* **`CapacityExhausted`** — the current candidate has no capacity. Raised for CloudRift HTTP 503/429 on rent, CloudRift `Inactive` / `Failed` terminal status / readiness timeout, GCP `ZONE_RESOURCE_POOL_EXHAUSTED` / `QUOTA_EXCEEDED` / `STOCKOUT` in `gcloud create` stderr, and GCP RUNNING-status timeout. Recoverable by trying a different candidate.
 * **`TerminalProvisionError`** — auth, malformed request, anything that will recur on any candidate. Raised for CloudRift HTTP 4xx (other than 429) and unrecognized non-zero `gcloud create` exit. Not recoverable; propagated to caller.
 
 Anything else a provider raises is treated as transient by the orchestrator.
@@ -80,6 +80,28 @@ Both providers swallow termination errors and log them — the original failure 
 
 Mismatches leave the GPU unusable because the wrong kernel-module flavor is on disk. The proprietary-driver image
 mirrors the recipe CloudRift's `rift-console` surfaces only for hosts whose `brand_short` matches `/\bV100|P100\b/`.
+
+## CloudRift API protocol version
+
+Every CloudRift request carries an envelope `{"version": API_VERSION, "data": {...}}`. The server versions its public
+types by calendar date and decodes each request against the newest declared schema whose date is `<= API_VERSION` (an
+unknown in-between date silently resolves *down* to the nearest older schema). `API_VERSION` (`cloudrift.py`) is pinned
+to `2026-05-26`, the **v059** generation: `instances/rent` resolves to v059, `instances/list` to v058, and
+`instances/terminate` to v055. Pin to a date rather than `~upcoming` (CloudRift's own client default) so a future server
+release can't change request/response shapes under us.
+
+Two v059-era behaviours the client relies on:
+
+* **`instances/list` mask.** v058 added a `mask` (`with_connection_info` / `with_hardware_info` / `with_usage_info`,
+  all default-false) and honours it for v058+ callers — older callers were force-fed `ALL`. `_get_instance_info` sends
+  `{"with_connection_info": True}` only: `host_address` / `port_mappings` / login info are gated behind that flag, while
+  `status` and `virtual_machines` (the `ready` flag + credentials) are ungated. We read no hardware/usage fields, so
+  leaving those flags off lets the server skip those lookups. **Dropping the mask would null out host/port and break
+  SSH.**
+* **`Failed` status.** v059 reports a first-class `Failed` status plus a `failure` object (`cause`, `user_message`).
+  `wait_for_status` treats `Failed` as terminal regardless of the caller's `fail_statuses` and logs `user_message`, so a
+  failed rental fails fast with a reason instead of polling until timeout (the `None` return then flows through the
+  orphan-cleanup path to `CapacityExhausted`).
 
 ## Adding a new provider
 

--- a/deplodock/provisioning/cloudrift.py
+++ b/deplodock/provisioning/cloudrift.py
@@ -22,7 +22,11 @@ DEFAULT_IMAGE_URL_NVIDIA_PROPRIETARY = (
 )
 DEFAULT_IMAGE_URL_AMD = "https://storage.googleapis.com/cloudrift-vm-disks/disks/github/ubuntu-noble-server-rocm-64-20260220-025112.img"
 DEFAULT_CLOUDINIT_URL = "https://storage.googleapis.com/cloudrift-vm-disks/cloudinit/ubuntu-base.cloudinit"
-API_VERSION = "2026-02-10"
+# Pins the CloudRift v059 protocol generation: instances/rent resolves to v059,
+# instances/list to v058 (mask-aware response), instances/terminate to v055.
+# Pin to the date rather than "~upcoming" so a future server version can't silently
+# change request/response shapes (e.g. add another default-off field mask) under us.
+API_VERSION = "2026-05-26"
 
 
 def select_image_url(instance_type):
@@ -127,7 +131,10 @@ async def _get_instance_info(api_key, instance_id, api_url=DEFAULT_API_URL, dry_
     POST /api/v1/instances/list with ById selector.
     Returns the instance dict or None.
     """
-    data = {"selector": {"ById": [instance_id]}}
+    # mask requests only connection info (host_address / port_mappings / login_info); the
+    # server skips the hardware + usage lookups we never read (v058+ honours the caller mask,
+    # defaulting every flag to false — without with_connection_info host/port come back null).
+    data = {"selector": {"ById": [instance_id]}, "mask": {"with_connection_info": True}}
     result = await _api_request("POST", "/api/v1/instances/list", data, api_key, api_url, dry_run)
     if result is None:  # dry-run
         return None
@@ -231,8 +238,13 @@ async def wait_for_status(
         status = info.get("status")
         if status == target_status and _instance_fully_ready(info):
             return info
-        if status in fail_statuses:
-            logger.error(f"Instance {instance_id} reached fail status '{status}'")
+        # "Failed" is a first-class terminal state in the v059 response (carrying a `failure`
+        # detail); treat it as terminal regardless of the caller's fail_statuses so a failed
+        # rental fails fast with an actionable reason instead of polling until timeout.
+        if status == "Failed" or status in fail_statuses:
+            failure = info.get("failure") or {}
+            detail = failure.get("user_message") or failure.get("cause") or "no detail"
+            logger.error(f"Instance {instance_id} reached fail status '{status}': {detail}")
             return None
         await asyncio.sleep(interval)
         elapsed += interval

--- a/scripts/test_cloudrift_ssh.py
+++ b/scripts/test_cloudrift_ssh.py
@@ -72,7 +72,9 @@ async def rent_instance(api_key, public_key):
 
 
 async def get_instance(api_key, instance_id):
-    data = {"selector": {"ById": [instance_id]}}
+    # v058+ honours the caller mask (defaults all-false); request connection info so
+    # host_address / port_mappings come back populated.
+    data = {"selector": {"ById": [instance_id]}, "mask": {"with_connection_info": True}}
     result = await api_request("POST", "/api/v1/instances/list", data, api_key)
     instances = result.get("instances", [])
     return instances[0] if instances else None

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -262,7 +262,10 @@ async def test_get_instance_info_found(mock_api):
     assert info["id"] == "c4bf5e16-1063-11f1-9096-5f6ae8f8983f"
     assert info["status"] == "Active"
     call_data = mock_api.call_args[0][2]
-    assert call_data == {"selector": {"ById": ["c4bf5e16-1063-11f1-9096-5f6ae8f8983f"]}}
+    assert call_data == {
+        "selector": {"ById": ["c4bf5e16-1063-11f1-9096-5f6ae8f8983f"]},
+        "mask": {"with_connection_info": True},
+    }
 
 
 @patch("deplodock.provisioning.cloudrift._api_request", new_callable=AsyncMock)
@@ -532,6 +535,21 @@ async def test_wait_for_status_returns_none_on_fail_status(mock_get, mock_sleep)
     mock_get.return_value = {"id": "inst-123", "status": "Inactive"}
     info = await wait_for_status(API_KEY, "inst-123", "Active", timeout=120, fail_statuses={"Inactive"})
     assert info is None
+
+
+@patch("deplodock.provisioning.cloudrift.asyncio.sleep", new_callable=AsyncMock)
+@patch("deplodock.provisioning.cloudrift._get_instance_info", new_callable=AsyncMock)
+async def test_wait_for_status_returns_none_on_failed_status(mock_get, mock_sleep, caplog):
+    """The v059 'Failed' status short-circuits without the caller listing it, and logs the reason."""
+    mock_get.return_value = {
+        "id": "inst-123",
+        "status": "Failed",
+        "failure": {"cause": "DockerImagePullFailed", "user_message": "image pull failed: unauthorized"},
+    }
+    with caplog.at_level("ERROR"):
+        info = await wait_for_status(API_KEY, "inst-123", "Active", timeout=120)
+    assert info is None
+    assert "image pull failed: unauthorized" in caplog.text
 
 
 @patch("deplodock.provisioning.cloudrift.asyncio.sleep", new_callable=AsyncMock)


### PR DESCRIPTION
Bump API_VERSION from 2026-02-10 (which resolved to the v045 floor for all instance endpoints) to 2026-05-26, pinning the v059 generation: instances/rent resolves to v059, instances/list to v058, instances/terminate to v055.

Two v059-era behaviours are handled:

- instances/list mask: v058+ honours the caller mask (default all-false), and host_address/port_mappings are gated behind with_connection_info. Send with_connection_info only; the server skips the hardware/usage lookups we never read. Without the mask host/port come back null and SSH breaks.
- Failed status: v059 reports a first-class "Failed" status plus a `failure` detail. wait_for_status treats it as terminal regardless of fail_statuses and logs failure.user_message, so a failed rental fails fast instead of polling until timeout.

Same mask fix applied to scripts/test_cloudrift_ssh.py. Tests and the provisioning ARCHITECTURE.md updated.