### PR TITLE
Harmonize golden / DB / prior data access behind a Dataset/Sample layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,25 +118,37 @@ same worker.
 - `deplodock run --code "EXPR" [--bench] [--warmup N] [--iters N] [--target sm_NN]` — compile + execute an inline `nn.Module`/torch expression on the CUDA backend, check accuracy vs eager, and (with `--bench`) print a latency table comparing eager PyTorch / `torch.compile` / Deplodock. Same `--code` grammar as `compile --code`. `--target sm_NN` overrides the live device's compute capability (same flag as `compile`), so feature-gated passes take the target's path while the kernel still runs on the live GPU — e.g. `--target sm_80` lowers a matmul through the cp.async transport and `--target sm_70` through plain sync staging, both runnable on a newer card, which makes the TMA / cp.async / double-buffer rungs A/B-benchable on one GPU.
 - `deplodock run --ir <file.json> [--bench]` — load a JSON IR dump (any stage), finish lowering, execute on random seeded inputs. For a **frontend-dialect** graph (e.g. a dumped `<kname>.torch.json` reproducer) it also builds a real-torch reference (`compiler/backend/torch_ref.py`) and prints the same accuracy check + eager / `torch.compile` / Deplodock table as `--code`; non-frontend IR (loop/tile/…) benches deplodock-only.
 - `deplodock inspect <ir_file>` — display graph IR summary (op counts, inputs, outputs)
-- `deplodock eval knobs [--db PATH] [--min-variants N] [--kernel SUBSTR]` — knob-impact analysis from the autotune DB:
-  the registered knob schema, then (with a tune DB) per-knob regret + a knob-interaction matrix sorted by geomean
-  impact (joins `perf` with `cuda_op`) — use the rankings to drive Fork-tree knob ordering in the planner.
-- `deplodock eval analytic [--kernel SUBSTR]` — evaluate the cold-start **`AnalyticPrior`** (the hand-coded linear model
-  over `knob.knob_features` that replaced `score_matmul_thread` / the `_priority_matmul_*` enumeration sort; the cold half
+The `eval` subcommands share a `--dataset {golden,db}` vocabulary (`commands/dataset_args.py`): `golden` reads the
+recorded `GOLDEN_CONFIGS`, `db` reads the tune DB's measured `perf` rows. Both flow through one read-view —
+`compiler/pipeline/search/data/` (`Sample` / `Dataset` / `ShapeKey`) — which also backs the prior `fit` featurization
+and the diagnostics grouping, so golden filtering, the DB join, and `knob_features` live in one place. Source is
+orthogonal to analysis: a degenerate combo (e.g. `eval knobs --dataset golden`) fails fast with a specific message.
+
+- `deplodock eval knobs [--dataset db] [--db PATH] [--min-variants N] [--kernel SUBSTR]` — knob-impact analysis from the
+  autotune DB (`--dataset db`, the default; `--dataset golden` is rejected — goldens carry no kernel C identity): the
+  registered knob schema, then (with a tune DB) per-knob regret + a knob-interaction matrix sorted by geomean impact
+  (joins `perf` with `cuda_op` via `Dataset.from_db().group_by_kernel_name()`) — drives Fork-tree knob ordering.
+- `deplodock eval analytic [--dataset golden] [--kernel SUBSTR]` — evaluate the cold-start **`AnalyticPrior`** (the
+  hand-coded linear model over `knob.knob_features` that replaced `score_matmul_thread` / the `_priority_matmul_*`
+  enumeration sort; the cold half
   of the ONE ranking path — see `compiler/pipeline/search/prior/`) on each `GOLDEN_CONFIGS` shape: the golden's **rank**
   under the prior over the shape's full enumeration (no GPU, no learned data, no measurements; the metric the tuner's
   patience must reach) + per-knob `found/golden` (mismatches in red), summarized as median + top-k. The
   `search/analytic.py` module is now just the golden-eval glue (`evaluate_golden` / `pick_matmul`) around the prior
   (`eval analytic` shows the matmul goldens; the prior also ranks the cooperative-reduce / pointwise goldens). Weights fit
   offline by `scripts/golden_knob_heuristics.py` (jointly over every kernel regime — matmul fp32/fp16, reduce, pointwise — tier-balanced).
-- `deplodock eval prior [--prior PATH] [--kernel SUBSTR] [--features]` — evaluate the learned `CatBoostPrior` on the
-  golden configs: the golden's rank under the prior over the full enumeration, then the greedy pipeline pick vs golden
-  (per-knob `found/golden`). Reads the prior JSON (`DEPLODOCK_PRIOR_FILE` or `--prior`; option-0 when none loaded) —
-  **not** the `--db` tune DB. `--features` also prints the exact regressor input per golden config (`knob.knob_features`:
-  `S_*` structural/shape + `H_*` regime + tuning knobs; note the shape enters only as coarse `S_ext_*` products/maxes,
-  so the occupancy/CTA/reuse terms the prior needs are added as engineered `D_*` features in `knob.knob_features`).
-- `deplodock eval golden [--prior PATH] [--kernel SUBSTR] [--features]` — the greedy pipeline pick vs recorded golden,
-  per config (the actionable "did the pipeline reproduce the golden knobs?" table only — no analytic-rank or
+- `deplodock eval prior [--prior PATH] [--dataset {golden,db}] [--db PATH] [--kernel SUBSTR] [--features]` — evaluate the
+  learned `CatBoostPrior`. Default `--dataset golden`: the golden's rank under the prior over the full enumeration, then
+  the greedy pipeline pick vs golden (per-knob `found/golden`). `--dataset db` instead reports the prior's pick
+  **reachability** over the tune DB's *measured* variants (does the prior recover each op's measured-best leaf?) — the
+  orthogonal counterpart to the golden views, reusing `diagnostics.reachability` over `Dataset.from_db().group_by_op()`.
+  Reads the prior JSON (`DEPLODOCK_PRIOR_FILE` or `--prior`; option-0 when none loaded). `--features` (golden mode) also
+  prints the exact regressor input per golden config (`knob.knob_features`: `S_*` structural/shape + `H_*` regime +
+  tuning knobs; the shape enters only as coarse `S_ext_*` products/maxes, so the occupancy/CTA/reuse terms the prior
+  needs are added as engineered `D_*` features). The golden `S_*` here is the full histogram (the shape's snippet is
+  compiled and cached via `data.Sample.from_golden(compile_s_feats=True)`), matching what a DB-trained prior saw.
+- `deplodock eval golden [--prior PATH] [--dataset golden] [--kernel SUBSTR] [--features]` — the greedy pipeline pick vs
+  recorded golden, per config (the actionable "did the pipeline reproduce the golden knobs?" table only — no analytic-rank or
   rank-under-prior diagnostics; use `eval analytic` / `eval prior` for those). The view to watch while iteratively
   tuning golden shapes. `--features` still prepends the per-config regressor feature vector.
 - `deplodock tune --golden NAME [--clean]` — tune the named golden config (shorthand for `--code <its snippet>`), so

--- a/deplodock/commands/compile.py
+++ b/deplodock/commands/compile.py
@@ -138,19 +138,21 @@ def resolve_golden_arg(args) -> None:
     args.golden_configs = []
     if not name:
         return
-    from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig, goldens_by_name
+    from deplodock.compiler.pipeline.search.data import Dataset
 
     if args.code or args.input or getattr(args, "ir", None):
         logger.error("--golden is mutually exclusive with --code / positional input / --ir")
         sys.exit(2)
-    matches = goldens_by_name(name)
+    matches = Dataset.from_golden(name=name).samples
     if not matches:
+        from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig
+
         names = ", ".join(sorted({g.name for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)}))
         logger.error("unknown golden config %r.\nAvailable: %s", name, names)
         sys.exit(2)
     # All configs under one name share the shape, so any snippet is interchangeable.
     args.golden_configs = matches
-    args.code = matches[0].snippet()
+    args.code = matches[0].snippet
     logger.info("[golden] %s → --code %s (%d recorded config%s)", name, args.code, len(matches), "" if len(matches) == 1 else "s")
 
 

--- a/deplodock/commands/dataset_args.py
+++ b/deplodock/commands/dataset_args.py
@@ -1,0 +1,58 @@
+"""Shared ``--dataset`` CLI vocabulary for the commands that consume measurement
+data (``eval`` today): one place registers the source flags (``--dataset`` /
+``--db`` / ``--kernel`` / ``--min-variants``), one helper publishes ``--prior``, and
+one guard fails loud on a degenerate source. Handlers then build the actual
+:class:`~deplodock.compiler.pipeline.search.data.Dataset` via its ``from_golden`` /
+``from_db`` adapters — so every command selects a golden / DB dataset (and a subset)
+through the same vocabulary instead of reimplementing golden filtering or opening
+the DB by hand.
+
+The source (golden vs db) is orthogonal to the analysis, but not every combination
+is meaningful (a DB row has no cuBLAS reference; a golden has no kernel C identity).
+:func:`require_source` lets a handler reject a degenerate combination with a
+specific message rather than emit an empty table.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def add_dataset_args(parser, *, default: str, with_min_variants: bool = False) -> None:
+    """Register the shared data-source flags on ``parser``. ``default`` is the
+    natural source for the command (``golden`` for the golden-eval views, ``db`` for
+    the regret analysis). ``with_min_variants`` adds the regret-only grouping
+    threshold."""
+    parser.add_argument(
+        "--dataset",
+        choices=["golden", "db"],
+        default=default,
+        help=f"Measurement-data source: 'golden' (recorded golden configs) or 'db' (tune DB perf rows). Default: {default}.",
+    )
+    parser.add_argument("--db", help="Tune DB path for --dataset db. Default: DEPLODOCK_TUNE_DB or ~/.cache/deplodock/autotune.db.")
+    parser.add_argument("--kernel", help="Filter by name substring (golden name, or kernel C identifier for --dataset db).")
+    if with_min_variants:
+        parser.add_argument(
+            "--min-variants", type=int, default=8, help="Skip kernels with fewer than this many measured variants (default: 8)."
+        )
+
+
+def require_source(args, allowed: set[str], msg: str) -> None:
+    """Exit 2 with ``msg`` when ``--dataset`` isn't one this analysis supports."""
+    if args.dataset not in allowed:
+        logger.error(msg)
+        sys.exit(2)
+
+
+def resolve_prior_arg(args) -> None:
+    """Publish ``--prior`` into the env (``DEPLODOCK_PRIOR_FILE``) so the prior loads
+    from it — the single owner of the formerly-duplicated env poke."""
+    if getattr(args, "prior", None):
+        from deplodock import config  # noqa: PLC0415
+
+        os.environ[config.PRIOR_FILE] = str(Path(args.prior).expanduser())

--- a/deplodock/commands/eval.py
+++ b/deplodock/commands/eval.py
@@ -37,27 +37,23 @@ is the load-bearing output here.
 
 from __future__ import annotations
 
-import json
 import logging
 import math
-import os
-import re
-import sqlite3
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from statistics import median
 
 from deplodock.commands.compile import resolve_tune_db
+from deplodock.commands.dataset_args import add_dataset_args, require_source, resolve_prior_arg
 from deplodock.commands.knobfmt import GREEN as _GREEN
 from deplodock.commands.knobfmt import RED as _RED
 from deplodock.commands.knobfmt import RESET as _RESET
 from deplodock.commands.knobfmt import YELLOW as _YELLOW
 from deplodock.commands.knobfmt import align_knob_columns
+from deplodock.compiler.pipeline.search.data import Dataset
 
 logger = logging.getLogger(__name__)
-
-_KERNEL_NAME_RE = re.compile(r"void\s+(\w+)\s*\(")
 
 
 def register_eval_command(subparsers) -> None:
@@ -70,16 +66,14 @@ def register_eval_command(subparsers) -> None:
     sub = parser.add_subparsers(dest="eval_target", required=True)
 
     pk = sub.add_parser("knobs", help="Print the registered knob schema + (with a tune DB) per-knob regret + interactions")
-    pk.add_argument("--db", help="Path to tune DB for the regret analysis. Default: DEPLODOCK_TUNE_DB or ~/.cache/deplodock/autotune.db.")
-    pk.add_argument("--min-variants", type=int, default=8, help="Skip kernels with fewer than this many measured variants (default: 8).")
-    pk.add_argument("--kernel", help="Only include kernels whose C identifier contains this substring (e.g. 'matmul').")
+    add_dataset_args(pk, default="db", with_min_variants=True)
     pk.set_defaults(func=handle_eval_knobs)
 
     ph = sub.add_parser(
         "analytic",
         help="Evaluate the cold-start AnalyticPrior on the golden configs (golden's rank under the prior over the enumeration)",
     )
-    ph.add_argument("--kernel", help="Filter golden configs by name substring (e.g. 'square', 'q_proj').")
+    add_dataset_args(ph, default="golden")
     ph.set_defaults(func=handle_eval_analytic)
 
     pp = sub.add_parser(
@@ -91,7 +85,7 @@ def register_eval_command(subparsers) -> None:
         help="Path to the learned-prior JSON to load. Default: DEPLODOCK_PRIOR_FILE or ~/.cache/deplodock/prior.json. "
         "(`deplodock tune` writes this file; it is NOT the tune DB.)",
     )
-    pp.add_argument("--kernel", help="Filter golden configs by name substring.")
+    add_dataset_args(pp, default="golden")
     pp.add_argument(
         "--features",
         action="store_true",
@@ -104,7 +98,7 @@ def register_eval_command(subparsers) -> None:
         help="Greedy pipeline pick vs recorded golden, per golden config (the reproduction check; no heuristic/rank diagnostics)",
     )
     pg.add_argument("--prior", help="Learned-prior JSON to load (default: DEPLODOCK_PRIOR_FILE or ~/.cache/deplodock/prior.json).")
-    pg.add_argument("--kernel", help="Filter golden configs by name substring.")
+    add_dataset_args(pg, default="golden")
     pg.add_argument("--features", action="store_true", help="Also print the prior's regressor feature vector per golden config.")
     pg.set_defaults(func=handle_eval_golden)
 
@@ -112,6 +106,7 @@ def register_eval_command(subparsers) -> None:
 def handle_eval_knobs(args) -> None:
     """``eval knobs`` — the registered knob schema, then (with a tune DB) per-knob
     regret + the knob-interaction matrix."""
+    require_source(args, {"db"}, "eval knobs regret needs DB rows — use --dataset db (golden configs carry no kernel identity).")
     _emit_registry()
 
     db_path = Path(args.db) if args.db else resolve_tune_db()
@@ -122,13 +117,15 @@ def handle_eval_knobs(args) -> None:
     logger.info("")
     logger.info("Reading: %s", db_path)
 
-    variants_by_kernel = _load_variants(db_path, kernel_filter=args.kernel)
-    kernels = {k: v for k, v in variants_by_kernel.items() if len(v) >= args.min_variants}
+    all_kernels = Dataset.from_db(db_path, kernel=args.kernel).group_by_kernel_name()
+    kernels = {
+        name: [(s.all_knobs(), s.latency_us) for s in samples] for name, samples in all_kernels.items() if len(samples) >= args.min_variants
+    }
     logger.info(
         "Kernels with ≥%d measured variants: %d (of %d total)",
         args.min_variants,
         len(kernels),
-        len(variants_by_kernel),
+        len(all_kernels),
     )
     if not kernels:
         return
@@ -145,17 +142,19 @@ def handle_eval_knobs(args) -> None:
 
 def handle_eval_analytic(args) -> None:
     """``eval analytic`` — the cold-start AnalyticPrior's rank of each golden."""
+    require_source(args, {"golden"}, "eval analytic ranks recorded golden configs — --dataset db has no golden to rank.")
     _emit_analytic_eval(args.kernel)
 
 
 def handle_eval_prior(args) -> None:
     """``eval prior`` — the learned prior on the golden configs: the greedy pick vs
     golden, the golden's rank under the prior, and (with ``--features``) the
-    regressor input vector."""
-    if args.prior:
-        from deplodock import config  # noqa: PLC0415
-
-        os.environ[config.PRIOR_FILE] = str(Path(args.prior).expanduser())
+    regressor input vector. With ``--dataset db`` instead reports the prior's pick
+    reachability over the tune DB's *measured* variants (the orthogonal view)."""
+    resolve_prior_arg(args)
+    if args.dataset == "db":
+        _emit_prior_db_reachability(args)
+        return
     if args.features:
         _emit_golden_features(args.kernel)
     _emit_prior_eval(args.kernel)
@@ -167,10 +166,8 @@ def handle_eval_golden(args) -> None:
     iteratively tuning golden shapes one at a time (``deplodock tune --golden
     <name>``). Use ``eval analytic`` / ``eval prior`` for the analytic-prior rank and
     the learned rank-under-prior diagnostics."""
-    if args.prior:
-        from deplodock import config  # noqa: PLC0415
-
-        os.environ[config.PRIOR_FILE] = str(Path(args.prior).expanduser())
+    require_source(args, {"golden"}, "eval golden compares against recorded golden knobs — --dataset db has no golden to compare to.")
+    resolve_prior_arg(args)
     if args.features:
         _emit_golden_features(args.kernel)
     configs, nw = _golden_configs(args.kernel)
@@ -247,10 +244,8 @@ def _emit_golden_features(kernel_filter: str | None) -> None:
     terms that drive matmul perf (the engineered ``D_*`` features) are NOT here."""
     import logging as _logging  # noqa: PLC0415
 
-    from deplodock.commands.trace import graph_from_code  # noqa: PLC0415
-    from deplodock.compiler.context import Context  # noqa: PLC0415
-    from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline, knob  # noqa: PLC0415
     from deplodock.compiler.pipeline.knob import CTX_PREFIX, STRUCT_PREFIX  # noqa: PLC0415
+    from deplodock.compiler.pipeline.search.data import Sample  # noqa: PLC0415
     from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
 
     configs = [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)]
@@ -266,13 +261,8 @@ def _emit_golden_features(kernel_filter: str | None) -> None:
     try:
         for g in configs:
             try:
-                graph, _, _ = graph_from_code(g.snippet())
-                compiled = Pipeline.build(LOOP_PASSES).run(graph)  # loop dialect — S_* stamped, no codegen
-                s_feats: dict = {}
-                for n in compiled.nodes.values():
-                    s_feats.update({k: v for k, v in (getattr(n.op, "knobs", {}) or {}).items() if k.startswith(STRUCT_PREFIX)})
-                merged = {**Context.from_target(g.compute_cap).features(), **s_feats, **g.knobs}
-                feats = knob.knob_features(merged)
+                # compile_s_feats=True derives the full S_* histogram (the CatBoost input), as eval did inline.
+                feats = Sample.from_golden(g, compile_s_feats=True).features()
             except Exception as e:  # noqa: BLE001 — one shape's error shouldn't abort the report
                 logger.info("  %-26s  ERR  %s", g.name, " ".join(f"{type(e).__name__}: {e}".split())[:100])
                 continue
@@ -362,6 +352,47 @@ def _emit_prior_eval(kernel_filter: str | None) -> None:
     _emit_prior_golden_check(configs, nw)
 
 
+def _emit_prior_db_reachability(args) -> None:
+    """``eval prior --dataset db`` body: the prior's pick **reachability** over the
+    tune DB's *measured* variants — per op structure, does the learned prior's
+    predicted-fastest config recover the measured-best leaf? The orthogonal counter
+    to the golden views: it scores the same prior over the DB rows instead of the
+    curated goldens. Reuses the diagnostics machinery (the prior's ``_dataset`` is
+    irrelevant here — the groups come from the DB)."""
+    from deplodock import config  # noqa: PLC0415
+    from deplodock.compiler.pipeline.search.prior import diagnostics, load_prior  # noqa: PLC0415
+
+    db_path = Path(args.db) if args.db else resolve_tune_db()
+    if not db_path.exists():
+        logger.error("no tune DB at %s — pass --db or run `deplodock tune` first.", db_path)
+        return
+    # FallbackPrior: the learned CatBoost when fitted, else the cold AnalyticPrior — the same ranking compile/run use.
+    prior = load_prior()
+    # Group DB variants by their full S_* signature and feed diagnostics.reachability
+    # the (full-knob-dict, latency) shape it expects.
+    groups = {
+        sig: [(s.all_knobs(), s.latency_us) for s in samples]
+        for sig, samples in Dataset.from_db(db_path, kernel=args.kernel).group_by_op().items()
+    }
+    logger.info("")
+    if not prior.fitted:
+        logger.info("No fitted prior at %s — run `deplodock tune`; the cold AnalyticPrior ranks by D_* geometry only.", config.prior_path())
+    rr = diagnostics.reachability(prior, groups)
+    if not rr:
+        logger.info("No op structure has ≥2 measured leaf configs in the DB — nothing to score.")
+        return
+    ratios = [r[3] for r in rr]
+    logger.info("[prior] pick reachability over DB variants — does the prior recover each op's measured best?")
+    logger.info("  mean %.2fx  median %.2fx  worst %.2fx   (1.00 = optimum)", _mean(ratios), median(ratios), max(ratios))
+    for label, best_us, pick_us, ratio, n in sorted(rr, key=lambda r: -r[3]):
+        flag = "  <-- misses best" if ratio > 1.2 else ""
+        logger.info("    %-26s  best %8.2fus  pick %8.2fus  (%.2fx, %d configs)%s", label, best_us, pick_us, ratio, n, flag)
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
 def _emit_prior_golden_check(configs: list, nw: int, *, title: bool = True) -> None:
     """Greedy fork pick through the tile pipeline vs recorded golden. The pick reads
     the learned-prior JSON (``config.prior_path()``: ``DEPLODOCK_PRIOR_FILE`` /
@@ -436,40 +467,6 @@ class KnobRow:
     median_regret: float
     p90_regret: float
     geomean_regret: float
-
-
-def _load_variants(db_path: Path, *, kernel_filter: str | None) -> dict[str, list[tuple[dict, float]]]:
-    """Return ``{kernel_name: [(knobs_dict, latency_us), ...]}``.
-
-    Joins ``perf`` (measured latencies) with ``cuda_op`` (for the kernel
-    source we parse the C identifier from). Opens the DB read-only so a
-    concurrent ``deplodock tune`` doesn't block on the schema check.
-    """
-    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    try:
-        cur = con.execute(
-            "SELECT cuda_op.pretty, perf.knobs, perf.latency_us_median "
-            "FROM perf JOIN cuda_op ON perf.op_key = cuda_op.key "
-            "WHERE perf.status='ok' AND perf.latency_us_median > 0"
-        )
-        rows = cur.fetchall()
-    finally:
-        con.close()
-
-    out: dict[str, list[tuple[dict, float]]] = defaultdict(list)
-    for pretty, knobs_json, us in rows:
-        m = _KERNEL_NAME_RE.search(pretty)
-        if not m:
-            continue
-        name = m.group(1)
-        if kernel_filter and kernel_filter not in name:
-            continue
-        try:
-            knobs = json.loads(knobs_json)
-        except (TypeError, json.JSONDecodeError):
-            continue
-        out[name].append((knobs, us))
-    return out
 
 
 def _hashable(v: object) -> object:

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -362,7 +362,7 @@ def _dump_bench_compare(dump_dir, results: dict, warmup: int, iters: int) -> Non
 
 
 # One recorded golden config compiled + benched with its knobs pinned this run.
-_GoldenBench = namedtuple("_GoldenBench", "config graph bench")
+_GoldenBench = namedtuple("_GoldenBench", "sample graph bench")
 
 
 @contextlib.contextmanager
@@ -388,26 +388,26 @@ def _pinned_knobs(knobs: dict):
 def _bench_golden_variants(backend, code, golden_configs, *, warmup, iters):
     """Compile + bench each recorded golden config with its knobs pinned, returning
     a ``_GoldenBench`` per config so :func:`_print_kernel_stats` can show each as a
-    measured row beside the greedy pick. Only the tunable knobs are pinned (``S_*``
-    / ``H_*`` features are not knobs). Each config re-traces a **fresh** graph from
-    ``code`` — a frontend graph can't be re-compiled (the first lowering mutates it
-    in place, so a reused graph would yield the first config's kernel every time).
-    Best-effort: a golden whose pinned knobs fail to compile / bench for the live
-    device is skipped with a warning."""
+    measured row beside the greedy pick. ``golden_configs`` are
+    :class:`~deplodock.compiler.pipeline.search.data.Sample`s, whose ``knobs`` are
+    already the tunable-only set to pin (``S_*`` / ``H_*`` features are not knobs).
+    Each config re-traces a **fresh** graph from ``code`` — a frontend graph can't be
+    re-compiled (the first lowering mutates it in place, so a reused graph would
+    yield the first config's kernel every time). Best-effort: a golden whose pinned
+    knobs fail to compile / bench for the live device is skipped with a warning."""
     from deplodock.commands.trace import graph_from_code  # noqa: PLC0415
 
     out = []
-    for cfg in golden_configs or []:
-        pins = {k: v for k, v in cfg.knobs.items() if not k.startswith(("S_", "H_"))}
+    for sample in golden_configs or []:
         try:
-            with _pinned_knobs(pins):
+            with _pinned_knobs(sample.knobs):
                 graph, _, _ = graph_from_code(code)  # fresh graph; knobs baked into the kernel source here
                 g_compiled = backend.compile(graph)
             g_bench = backend.benchmark(g_compiled, warmup=warmup, num_iters=iters)
         except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own bench table
-            logger.warning("[golden] %s: compile/bench of the pinned config failed (%s) — skipping its row", cfg.name, exc)
+            logger.warning("[golden] %s: compile/bench of the pinned config failed (%s) — skipping its row", sample.name, exc)
             continue
-        out.append(_GoldenBench(cfg, g_compiled, g_bench))
+        out.append(_GoldenBench(sample, g_compiled, g_bench))
     return out
 
 
@@ -465,7 +465,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None):
         = K``), the same shape signature the prior diagnostics match goldens on."""
         free_prod = int(getattr(op, "knobs", {}).get("S_ext_free_prod", 0))
         reduce_max = int(getattr(op, "knobs", {}).get("S_ext_reduce_max", 0))
-        return [gb for gb in (golden_benches or []) if gb.config.M * gb.config.N == free_prod and gb.config.K == reduce_max]
+        return [gb for gb in (golden_benches or []) if gb.sample.shape.free_prod == free_prod and gb.sample.shape.reduce_max == reduce_max]
 
     # Build row records first (the knob columns are aligned across all rows, so we
     # can't stream): (name, t_us, pct_cell, geom, knobs, ref_knobs_or_None). A
@@ -484,7 +484,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None):
             g_nodes = [n for n in gb.graph.nodes.values() if isinstance(n.op, CudaOp)]
             for gidx, gnode in enumerate(g_nodes):
                 gk = dict(tuning_knob_items(gnode.op.knobs or {}))
-                records.append((f"golden {gb.config.name}", g_times.get(gidx, 0.0), "--", _geom(gnode.op, g_attrs), gk, gknobs))
+                records.append((f"golden {gb.sample.name}", g_times.get(gidx, 0.0), "--", _geom(gnode.op, g_attrs), gk, gknobs))
 
     knob_lines = align_knob_columns(
         [{k: (f"{k}={v}", ref is not None and str(ref.get(k)) != str(v)) for k, v in knobs.items()} for *_, knobs, ref in records]

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -12,7 +12,8 @@ pipeline/
 ├── search/        # Autotune state: Candidate, Search policies, SearchDB + SearchTree
 │   ├── candidate.py  # Candidate / LazyCandidate / Cursor data classes
 │   ├── policy/       # Search ABC (base.py) + GreedySearch (greedy.py, compile/run) + TuningSearch (mcts.py, tune); both rank via the Prior
-│   ├── db.py         # SearchDB SQLite store: op inventory + lowering edges + perf (per-variant replay cache)
+│   ├── db.py         # SearchDB SQLite store: op inventory + lowering edges + perf (per-variant replay cache); open_readonly + iter_perf_samples (perf ⋈ cuda_op) back the data layer
+│   ├── data/         # harmonized read-view over the 3 sources (golden / DB perf / prior reservoir): Sample (one normalized row + the single knob_features path), Dataset (from_golden/from_db/from_prior + group_by_op/group_by_kernel_name), ShapeKey (arithmetic S_* identity)
 │   ├── keys.py       # op_cache_key / dialect_of / source_chain
 │   ├── slice.py      # single_node_graph: isolate one finalized kernel into a standalone graph
 │   ├── two_level.py  # two-level tuner: outer fusion MCTS + inner separable per-op reward

--- a/deplodock/compiler/pipeline/search/data/__init__.py
+++ b/deplodock/compiler/pipeline/search/data/__init__.py
@@ -1,0 +1,12 @@
+"""Harmonized read-view over the three measurement-data sources (golden configs,
+the tune DB, the learned-prior reservoir): one :class:`Sample` row type, one
+:class:`Dataset` query surface, and the cheap :class:`ShapeKey` structural identity.
+See ``sample.py`` for the featurization-fidelity contract."""
+
+from __future__ import annotations
+
+from deplodock.compiler.pipeline.search.data.dataset import Dataset
+from deplodock.compiler.pipeline.search.data.sample import KERNEL_NAME_RE, Sample, compiled_s_features
+from deplodock.compiler.pipeline.search.data.shape import ShapeKey
+
+__all__ = ["KERNEL_NAME_RE", "Dataset", "Sample", "ShapeKey", "compiled_s_features"]

--- a/deplodock/compiler/pipeline/search/data/dataset.py
+++ b/deplodock/compiler/pipeline/search/data/dataset.py
@@ -1,0 +1,98 @@
+"""``Dataset`` — a queryable read-view over a bag of :class:`Sample`s, with one
+adapter per measurement-data source (golden / tune-DB / learned-prior reservoir)
+and the two grouping axes the consumers need.
+
+The two groupings are deliberately distinct and do **not** collapse:
+
+- :meth:`group_by_op` keys on the full ``S_*`` structural signature — two different
+  shapes are different groups. This is what the prior diagnostics
+  (reachability / calibration / coverage) need.
+- :meth:`group_by_kernel_name` keys on the kernel C identifier (parsed from
+  ``cuda_op.pretty``) — which *merges* shapes of the same kernel, by design, so the
+  per-knob regret analysis measures relative knob impact across shapes.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterator
+from pathlib import Path
+
+from deplodock.compiler.pipeline.search.data.sample import Sample
+
+
+class Dataset:
+    """A bag of :class:`Sample`s plus source adapters + grouping."""
+
+    def __init__(self, samples: list[Sample]) -> None:
+        self.samples = samples
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __iter__(self) -> Iterator[Sample]:
+        return iter(self.samples)
+
+    # --- adapters: one per source -----------------------------------------
+
+    @classmethod
+    def from_golden(
+        cls, *, name: str | None = None, kernel: str | None = None, dtype: str | None = None, compile_s_feats: bool = False
+    ) -> Dataset:
+        """The matmul golden configs, optionally narrowed by exact ``name``, name
+        substring ``kernel``, or ``dtype``. ``compile_s_feats`` derives the full
+        ``S_*`` histogram per config (needed only for learned-prior featurization)."""
+        from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
+
+        configs = [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)]
+        if name is not None:
+            configs = [g for g in configs if g.name == name]
+        if kernel:
+            configs = [g for g in configs if kernel in g.name]
+        if dtype:
+            configs = [g for g in configs if g.dtype == dtype]
+        return cls([Sample.from_golden(g, compile_s_feats=compile_s_feats) for g in configs])
+
+    @classmethod
+    def from_db(cls, path: Path | str, *, kernel: str | None = None, min_latency: float = 0.0, backend: str | None = None) -> Dataset:
+        """Every measured ``ok`` variant in the tune DB (``perf ⋈ cuda_op``), opened
+        read-only so a concurrent ``tune`` writer isn't blocked. ``backend=None``
+        spans every backend (matching the legacy ``eval knobs`` query); ``kernel``
+        filters on the parsed C identifier."""
+        from deplodock.compiler.pipeline.search.db import SearchDB  # noqa: PLC0415
+
+        db = SearchDB.open_readonly(path)
+        try:
+            samples = [Sample.from_perf_sample(ps) for ps in db.iter_perf_samples(backend=backend, min_latency_us=min_latency)]
+        finally:
+            db.close()
+        if kernel:
+            samples = [s for s in samples if s.name and kernel in s.name]
+        return cls(samples)
+
+    @classmethod
+    def from_prior(cls, prior) -> Dataset:
+        """The learned prior's bounded reservoir as samples. Works through
+        ``FallbackPrior`` (it delegates ``_dataset`` to the learned half)."""
+        return cls([Sample.from_prior_row(k, v) for k, v in prior._dataset])
+
+    # --- grouping ----------------------------------------------------------
+
+    def group_by_op(self) -> dict[tuple, list[Sample]]:
+        """Group by the full ``S_*`` structural signature (sorted items) — the key
+        the prior diagnostics group on, so structurally-distinct same-extent ops
+        stay separate."""
+        g: dict[tuple, list[Sample]] = defaultdict(list)
+        for s in self.samples:
+            g[tuple(sorted(s.s_features().items()))].append(s)
+        return dict(g)
+
+    def group_by_kernel_name(self, *, min_variants: int = 1, kernel: str | None = None) -> dict[str, list[Sample]]:
+        """Group by kernel C identifier (``cuda_op.pretty``), dropping samples with
+        no identity (golden / prior rows) and groups below ``min_variants``."""
+        g: dict[str, list[Sample]] = defaultdict(list)
+        for s in self.samples:
+            if s.name is None or (kernel and kernel not in s.name):
+                continue
+            g[s.name].append(s)
+        return {k: v for k, v in g.items() if len(v) >= min_variants}

--- a/deplodock/compiler/pipeline/search/data/sample.py
+++ b/deplodock/compiler/pipeline/search/data/sample.py
@@ -1,0 +1,157 @@
+"""``Sample`` — one measured-or-recorded ``(config, latency, identity)`` row,
+the common currency over all three measurement-data sources.
+
+A golden config, a tune-DB ``perf`` row, and a learned-prior reservoir row are all
+the same thing once normalized: a tunable-knob dict, a measured latency, a
+structural identity, and (for golden) a reference latency. ``Sample`` is that
+normal form. The split into ``knobs`` (tunable) / ``context`` (``H_*``) /
+``s_features`` (``S_*``) is by key prefix and therefore lossless — :meth:`all_knobs`
+re-merges them to the exact original dict, and :meth:`features` runs the single
+featurizer (:func:`knob.knob_features`) on that merge, so a ``Sample`` reproduces
+the feature vector each source built inline today.
+
+Featurization fidelity (the load-bearing invariant): a trained ``CatBoostPrior``
+regresses on the full ``S_*`` histogram stamped by ``992_stamp_structural_features``.
+DB / prior rows carry that histogram inline already; golden rows only know
+``(M,N,K)``, so the full histogram is derived by compiling the snippet
+(:func:`compiled_s_features`, cached) and passed as ``compile_s_feats=True`` —
+*only* when a learned prior is the consumer. The cheap arithmetic
+:meth:`ShapeKey.s_features_arith` suffices for the cold ``AnalyticPrior`` (it reads
+only ``D_*`` derived from the extents) and for grouping.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+from deplodock.compiler.pipeline import knob
+from deplodock.compiler.pipeline.knob import CTX_PREFIX, STRUCT_PREFIX
+from deplodock.compiler.pipeline.search.data.shape import ShapeKey
+
+# The C identifier of a CUDA kernel, parsed from ``cuda_op.pretty`` — the grouping
+# key for the per-knob regret analysis (same regex the old ``eval._load_variants``
+# used). Kept here so the DB-row adapter and the regret grouping share one source.
+KERNEL_NAME_RE = re.compile(r"void\s+(\w+)\s*\(")
+
+
+def _split_by_prefix(knobs: dict) -> tuple[dict, dict, dict]:
+    """Split a stamped knob dict into ``(tunable, context H_*, structural S_*)`` by
+    key prefix. Disjoint prefixes → re-merging is lossless."""
+    ctx = {k: v for k, v in knobs.items() if k.startswith(CTX_PREFIX)}
+    s = {k: v for k, v in knobs.items() if k.startswith(STRUCT_PREFIX)}
+    tunable = {k: v for k, v in knobs.items() if not k.startswith((CTX_PREFIX, STRUCT_PREFIX))}
+    return tunable, ctx, s
+
+
+@lru_cache(maxsize=256)
+def compiled_s_features(M: int, N: int, K: int, dtype: str, compute_cap: tuple[int, int]) -> tuple[tuple[str, float], ...]:
+    """The full ``S_*`` structural histogram for a matmul shape — by compiling its
+    snippet to the loop dialect (where ``992_stamp_structural_features`` runs) and
+    scraping the stamped ``S_*`` knobs off the nodes. This is what a trained
+    ``CatBoostPrior`` was fit on for that shape; the cheap arithmetic extents are a
+    subset of it. Cached (the compile is ~seconds) and returned as sorted items so
+    the result is hashable / frozen-friendly. Heavy imports are deferred to here so
+    importing this module stays torch-free."""
+    from deplodock.commands.trace import graph_from_code  # noqa: PLC0415
+    from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline  # noqa: PLC0415
+    from deplodock.compiler.pipeline.search.golden import matmul_snippet  # noqa: PLC0415
+
+    graph, _, _ = graph_from_code(matmul_snippet(M, N, K, dtype))
+    compiled = Pipeline.build(LOOP_PASSES).run(graph)  # loop dialect — S_* stamped, no codegen
+    s_feats: dict[str, float] = {}
+    for n in compiled.nodes.values():
+        s_feats.update({k: v for k, v in (getattr(n.op, "knobs", {}) or {}).items() if k.startswith(STRUCT_PREFIX)})
+    return tuple(sorted(s_feats.items()))
+
+
+@dataclass(frozen=True)
+class Sample:
+    """One ``(config, latency, identity)`` row, normalized across sources.
+
+    ``knobs`` holds *only* tunable knobs (``S_*`` / ``H_*`` live in ``s_full`` /
+    ``context``); ``shape`` is the arithmetic identity; ``ref_us`` is the cuBLAS /
+    torch reference (golden only, ``None`` elsewhere); ``pretty`` / ``name`` carry
+    the kernel C identifier for DB rows; ``snippet`` reproduces a golden's torch
+    expression. ``source`` ∈ ``{"golden", "db", "prior"}`` marks provenance for the
+    orthogonality fail-fast (``dataset_args.require_source``)."""
+
+    knobs: dict
+    latency_us: float
+    shape: ShapeKey | None = None
+    name: str | None = None
+    dtype: str | None = None
+    ref_us: float | None = None
+    context: dict = field(default_factory=dict)
+    pretty: str | None = None
+    snippet: str | None = None
+    source: str = "db"
+    s_full: dict | None = None  # full compiled S_* histogram when known (db/prior rows, or golden compile_s_feats)
+
+    def s_features(self) -> dict[str, float]:
+        """The ``S_*`` features this sample featurizes on: the full stamped histogram
+        when known, else the cheap arithmetic extents, else nothing."""
+        if self.s_full is not None:
+            return self.s_full
+        return self.shape.s_features_arith() if self.shape is not None else {}
+
+    def all_knobs(self) -> dict:
+        """The original stamped dict — ``context ∪ s_features ∪ knobs``. For a DB
+        row this re-merges to exactly the recorded ``perf.knobs``; the per-knob
+        regret analysis iterates this so its output is unchanged."""
+        return {**self.context, **self.s_features(), **self.knobs}
+
+    def features(self) -> dict[str, float]:
+        """The flat numeric feature vector the priors regress on — the single
+        featurizer over the merged dict. Merge order ``context, s_*, knobs`` matches
+        the inline construction the eval / prior code used (knobs win on collision,
+        though the prefixes are disjoint)."""
+        return knob.knob_features(self.all_knobs())
+
+    @classmethod
+    def from_golden(cls, cfg, *, compile_s_feats: bool = False) -> Sample:
+        """A golden ``MatmulGoldenConfig`` as a ``Sample``. ``compile_s_feats``
+        derives the full ``S_*`` histogram (for the learned-prior featurization);
+        leave it off for the cold-analytic / grouping / bench paths."""
+        from deplodock.compiler.context import Context  # noqa: PLC0415
+
+        tunable, _ctx, _s = _split_by_prefix(cfg.knobs)
+        s_full = dict(compiled_s_features(cfg.M, cfg.N, cfg.K, cfg.dtype, cfg.compute_cap)) if compile_s_feats else None
+        return cls(
+            knobs=tunable,
+            latency_us=cfg.deplodock_us,
+            shape=ShapeKey.from_matmul(cfg.M, cfg.N, cfg.K, cfg.dtype),
+            name=cfg.name,
+            dtype=cfg.dtype,
+            ref_us=cfg.cublas_us,
+            context=Context.from_target(cfg.compute_cap).features(),
+            snippet=cfg.snippet(),
+            source="golden",
+            s_full=s_full,
+        )
+
+    @classmethod
+    def from_perf_sample(cls, ps) -> Sample:
+        """A tune-DB ``perf ⋈ cuda_op`` row (:class:`db.PerfSample`) as a ``Sample``.
+        Splits the recorded knob dict by prefix; the kernel C identifier (for
+        per-knob regret grouping) is parsed from ``cuda_op.pretty``."""
+        tunable, ctx, s = _split_by_prefix(ps.knobs)
+        m = KERNEL_NAME_RE.search(ps.pretty or "")
+        return cls(
+            knobs=tunable,
+            latency_us=ps.latency_us,
+            name=m.group(1) if m else None,
+            context=ctx,
+            pretty=ps.pretty,
+            source="db",
+            s_full=s,
+        )
+
+    @classmethod
+    def from_prior_row(cls, knobs: dict, latency_us: float) -> Sample:
+        """A learned-prior reservoir row ``(stamped_knobs, latency)`` as a ``Sample``.
+        The reservoir dicts already carry ``S_*`` / ``H_*`` inline (stamped by the
+        live pipeline), so the split + re-merge is lossless for grouping / scoring."""
+        tunable, ctx, s = _split_by_prefix(knobs)
+        return cls(knobs=tunable, latency_us=latency_us, context=ctx, source="prior", s_full=s)

--- a/deplodock/compiler/pipeline/search/data/shape.py
+++ b/deplodock/compiler/pipeline/search/data/shape.py
@@ -1,0 +1,49 @@
+"""``ShapeKey`` — the cheap arithmetic structural identity of a tiled op.
+
+A kernel's full structural signature is the ``S_*`` histogram the
+``992_stamp_structural_features`` pass stamps (op counts, dtypes, loop depths,
+extents). For grouping, the cold-start ``AnalyticPrior`` ranking, and matching a
+golden config to a kernel, only the *extents* matter — and those are derivable
+arithmetically from a matmul's ``(M, N, K)`` with no compile. ``ShapeKey`` is that
+arithmetic handle: ``(free_prod, reduce_max, is_warp)``, the same triple the prior
+diagnostics and the per-kernel golden A/B already match on.
+
+It deliberately carries only the extent keys. A *trained* ``CatBoostPrior`` regresses
+on the full ``S_*`` histogram, so the full set is derived (by compiling the snippet)
+and cached on the :class:`~deplodock.compiler.pipeline.search.data.sample.Sample`,
+not here — see that module's ``compile_s_feats`` path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ShapeKey:
+    """Arithmetic extent identity of a matmul-shaped op.
+
+    ``free_prod`` is the output free-dim product (``M*N``), ``reduce_max`` the
+    reduce extent (``K``), ``is_warp`` whether it lowers on the tensor-core warp
+    tier (any non-fp32 matmul). Hashable, so it keys ``Dataset`` groupings."""
+
+    free_prod: int
+    reduce_max: int
+    is_warp: bool
+
+    @classmethod
+    def from_matmul(cls, M: int, N: int, K: int, dtype: str) -> ShapeKey:
+        """The shape of an ``(M, K) @ (K, N)`` matmul. fp32 lowers on the scalar
+        thread tier; fp16 / bf16 on the warp (MMA) tier."""
+        return cls(free_prod=M * N, reduce_max=K, is_warp=dtype != "fp32")
+
+    def s_features_arith(self) -> dict[str, float]:
+        """The extent ``S_*`` features derivable without compiling — the exact set
+        the cold ``AnalyticPrior`` reads (``analytic._analytic_scorer`` builds the
+        same dict). For a matmul the reduce axis is a single contraction, so
+        ``S_ext_reduce_prod == S_ext_reduce_max == K``."""
+        return {
+            "S_ext_free_prod": float(self.free_prod),
+            "S_ext_reduce_prod": float(self.reduce_max),
+            "S_ext_reduce_max": float(self.reduce_max),
+        }

--- a/deplodock/compiler/pipeline/search/db.py
+++ b/deplodock/compiler/pipeline/search/db.py
@@ -80,6 +80,20 @@ class PerfRow:
 
 
 @dataclass(frozen=True)
+class PerfSample:
+    """One measured terminal kernel — a ``perf`` row joined to its ``cuda_op``.
+
+    The minimal row the dataset layer reads: the kernel's pretty source (for the C
+    identifier), the recorded knobs (which already carry the ``S_*`` / ``H_*``
+    features the variant was stamped with), and the median latency. Backs
+    :meth:`SearchDB.iter_perf_samples`."""
+
+    pretty: str
+    knobs: dict
+    latency_us: float
+
+
+@dataclass(frozen=True)
 class LoweringRow:
     """One ``lowering`` row — best-known child for a parent op.
 
@@ -199,6 +213,19 @@ class SearchDB:
             self._conn.execute(f"PRAGMA user_version = {self._SCHEMA_VERSION}")
         for stmt in self._SCHEMA:
             self._conn.execute(stmt)
+
+    @classmethod
+    def open_readonly(cls, path: Path | str) -> SearchDB:
+        """Open an existing DB **read-only** — no schema creation, no version
+        check, no ``DROP TABLE lowering``, no WAL pragma — so a read-side consumer
+        (``eval``, the dataset layer) never contends with a concurrent ``tune``
+        writer or mutates the file. The read methods (``iter_perf`` /
+        ``iter_perf_samples`` / ``lookup_*``) work; any write raises (the
+        connection is ``?mode=ro``). Raises ``sqlite3.OperationalError`` if the
+        file is absent."""
+        self = cls.__new__(cls)
+        self._conn = sqlite3.connect(f"file:{Path(path)}?mode=ro", uri=True, check_same_thread=False)
+        return self
 
     # ------------------------------------------------------------------
     # Op-inventory writes (idempotent INSERT OR IGNORE)
@@ -405,6 +432,28 @@ class SearchDB:
             )
         for row in cur:
             yield _row_to_perf(row)
+
+    def iter_perf_samples(self, *, backend: str | None = "cuda", status: str = "ok", min_latency_us: float = 0.0) -> Iterator[PerfSample]:
+        """Yield one :class:`PerfSample` per measured terminal kernel — ``perf``
+        joined to ``cuda_op`` on ``op_key = key``. The single place the two tables
+        are joined; backs ``Dataset.from_db``. ``backend=None`` spans every backend.
+        Filters to ``status`` (default ``ok``) and ``latency_us_median >
+        min_latency_us`` so callers don't re-filter stale / failed rows."""
+        sql = (
+            "SELECT cuda_op.pretty, perf.knobs, perf.latency_us_median "
+            "FROM perf JOIN cuda_op ON perf.op_key = cuda_op.key "
+            "WHERE perf.status = ? AND perf.latency_us_median > ?"
+        )
+        params: list = [status, min_latency_us]
+        if backend is not None:
+            sql += " AND perf.backend = ?"
+            params.append(backend)
+        for pretty, knobs_json, us in self._conn.execute(sql, params):
+            try:
+                knobs = json.loads(knobs_json) if knobs_json else {}
+            except (TypeError, json.JSONDecodeError):
+                continue
+            yield PerfSample(pretty=pretty, knobs=knobs, latency_us=us)
 
     # ------------------------------------------------------------------
     # Per-op best time (summed into the outer terminal reward)

--- a/deplodock/compiler/pipeline/search/prior/diagnostics.py
+++ b/deplodock/compiler/pipeline/search/prior/diagnostics.py
@@ -14,22 +14,12 @@ from __future__ import annotations
 
 import math
 import statistics
-from collections import defaultdict
 
-
-def _op_sig(knobs: dict) -> tuple:
-    return tuple(sorted((k, v) for k, v in knobs.items() if k.startswith("S_")))
+from deplodock.compiler.pipeline.search.data import Dataset
 
 
 def _n_tunable(knobs: dict) -> int:
     return sum(1 for k in knobs if not k.startswith(("S_", "H_")))
-
-
-def group_by_op(dataset: list[tuple[dict, float]]) -> dict[tuple, list[tuple[dict, float]]]:
-    g: dict[tuple, list] = defaultdict(list)
-    for k, v in dataset:
-        g[_op_sig(k)].append((k, v))
-    return dict(g)
 
 
 def _op_label(sig: tuple) -> str:
@@ -48,15 +38,16 @@ def reachability(prior, groups: dict) -> list[tuple]:
     """Per op: ``(label, best_us, pick_us, ratio, n_leaf_configs)`` — the config the
     prior predicts fastest (``mean_score`` argmin) over the op's measured *leaf*
     configs vs the measured best (ratio = the picked config's latency / the best's;
-    1.0 = recovers the optimum)."""
+    1.0 = recovers the optimum). ``groups`` maps an ``S_*`` signature to its
+    :class:`Sample`s (from :meth:`Dataset.group_by_op`)."""
     out = []
     for sig, grp in groups.items():
-        kmax = max(_n_tunable(k) for k, _ in grp)
-        leaves = [(k, v) for k, v in grp if _n_tunable(k) == kmax]
+        kmax = max(_n_tunable(s.all_knobs()) for s in grp)
+        leaves = [s for s in grp if _n_tunable(s.all_knobs()) == kmax]
         if len(leaves) < 2:
             continue
-        best_us = min(v for _, v in leaves)  # labels are latency µs — lower is better
-        pick_us = min(leaves, key=lambda t: prior.mean_score(t[0]))[1]
+        best_us = min(s.latency_us for s in leaves)  # labels are latency µs — lower is better
+        pick_us = min(leaves, key=lambda s: prior.mean_score(s.all_knobs())).latency_us
         out.append((_op_label(sig), best_us, pick_us, pick_us / best_us, len(leaves)))
     return out
 
@@ -69,11 +60,11 @@ def _calibration(prior, groups: dict) -> float | None:
 
     rhos = []
     for grp in groups.values():
-        kmax = max(_n_tunable(k) for k, _ in grp)
-        leaves = [(k, v) for k, v in grp if _n_tunable(k) == kmax]
+        kmax = max(_n_tunable(s.all_knobs()) for s in grp)
+        leaves = [s for s in grp if _n_tunable(s.all_knobs()) == kmax]
         if len(leaves) < 3:
             continue
-        rho = spearmanr([prior.mean_score(k) for k, _ in leaves], [v for _, v in leaves]).statistic
+        rho = spearmanr([prior.mean_score(s.all_knobs()) for s in leaves], [s.latency_us for s in leaves]).statistic
         if not math.isnan(rho):
             rhos.append(rho)
     return statistics.median(rhos) if rhos else None
@@ -111,7 +102,7 @@ def golden_prior_eval(prior, kernel_filter: str | None = None) -> str:
     # Index op groups by (free-dim product, reduce extent, is-matmul) so each
     # golden shape maps to the S_* signature it was tuned under.
     index: dict[tuple, dict] = {}
-    for sig in group_by_op(prior._dataset):
+    for sig in Dataset.from_prior(prior).group_by_op():
         d = dict(sig)
         key = (int(d.get("S_ext_free_prod", 0)), int(d.get("S_ext_reduce_max", 0)), d.get("S_n_mma", 0) > 0)
         index.setdefault(key, {k: v for k, v in d.items() if k.startswith("S_")})
@@ -151,7 +142,7 @@ def golden_prior_eval(prior, kernel_filter: str | None = None) -> str:
 def report(prior) -> str:
     """The full offline diagnostics block for a (re)fit prior."""
     dataset = prior._dataset
-    groups = group_by_op(dataset)
+    groups = Dataset.from_prior(prior).group_by_op()
     lines = [f"[prior] dataset: {len(dataset)} rows, {len(groups)} op-structures, fitted={prior.fitted}"]
     if not prior.fitted:
         lines.append("  no model — dataset below min_rows; run `deplodock tune <model>` to gather more")

--- a/tests/compiler/pipeline/search/test_data.py
+++ b/tests/compiler/pipeline/search/test_data.py
@@ -1,0 +1,128 @@
+"""Tests for the harmonized data layer — :class:`ShapeKey` / :class:`Sample` /
+:class:`Dataset` over golden / DB / prior sources.
+
+The load-bearing acceptance gates are the two round-trips: a DB row and a golden
+config must produce the *same* feature vector through ``Sample`` as the inline
+code each consumer used before — otherwise the learned prior's ranking degrades
+silently.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.pipeline import knob
+from deplodock.compiler.pipeline.search.data import Dataset, Sample, ShapeKey
+from deplodock.compiler.pipeline.search.db import PerfSample, PerfStats, SearchDB
+
+
+def _stats(median: float) -> PerfStats:
+    return PerfStats(median=median, min=median, max=median, mean=median, variance=0.0, n_samples=1)
+
+
+def _seed(db: SearchDB, key: str, pretty: str, knobs: dict, us: float) -> None:
+    db.record_cuda_op(key, kernel_source="", arg_order=[], grid=[1, 1, 1], block=[1, 1, 1], smem_bytes=0, pretty=pretty)
+    db.record_perf("ctx", key, backend="cuda", status="ok", stats=_stats(us), knobs=knobs)
+
+
+# --- ShapeKey ---------------------------------------------------------------
+
+
+def test_shapekey_from_matmul_arith() -> None:
+    sk = ShapeKey.from_matmul(512, 256, 64, "fp32")
+    assert (sk.free_prod, sk.reduce_max, sk.is_warp) == (512 * 256, 64, False)
+    assert sk.s_features_arith() == {"S_ext_free_prod": 131072.0, "S_ext_reduce_prod": 64.0, "S_ext_reduce_max": 64.0}
+    assert ShapeKey.from_matmul(64, 64, 64, "fp16").is_warp is True
+
+
+# --- Sample round-trips (the acceptance gates) ------------------------------
+
+
+def test_db_row_round_trip_is_lossless() -> None:
+    """``Sample.from_perf_sample`` splits the stamped dict by prefix; ``all_knobs``
+    re-merges to the exact original, and ``features`` matches ``knob_features`` of
+    the raw dict — so the prior sees an identical vector and regret sees identical
+    rows."""
+    raw = {"BN": 32, "BM": 8, "SPLITK": 1, "S_ext_free_prod": 4194304.0, "S_n_mma": 1.0, "H_cc": 120.0, "H_opt": 3.0}
+    s = Sample.from_perf_sample(PerfSample(pretty="void k_matmul(float*)", knobs=raw, latency_us=42.0))
+    assert s.all_knobs() == raw
+    assert s.features() == knob.knob_features(raw)
+    assert s.name == "k_matmul"
+    assert s.knobs == {"BN": 32, "BM": 8, "SPLITK": 1}  # tunable only
+
+
+def test_prior_row_round_trip_is_lossless() -> None:
+    raw = {"BM": 16, "S_kind": 1.0, "H_cc": 90.0}
+    s = Sample.from_prior_row(raw, 3.5)
+    assert s.all_knobs() == raw
+    assert s.features() == knob.knob_features(raw)
+    assert s.source == "prior"
+
+
+def test_golden_compile_s_feats_matches_inline(monkeypatch) -> None:
+    """The high-risk gate: a golden's full-histogram feature vector via
+    ``Sample.from_golden(compile_s_feats=True)`` equals the old inline
+    compile-and-scrape (eval's ``_emit_golden_features``), and the cheap arithmetic
+    extents are a subset that agrees on the shared keys."""
+    from deplodock.commands.trace import graph_from_code
+    from deplodock.compiler.context import Context
+    from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline
+    from deplodock.compiler.pipeline.knob import STRUCT_PREFIX
+    from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig
+
+    g = next(c for c in GOLDEN_CONFIGS if isinstance(c, MatmulGoldenConfig) and c.name == "square.512")
+
+    graph, _, _ = graph_from_code(g.snippet())
+    compiled = Pipeline.build(LOOP_PASSES).run(graph)
+    s_feats: dict = {}
+    for n in compiled.nodes.values():
+        s_feats.update({k: v for k, v in (getattr(n.op, "knobs", {}) or {}).items() if k.startswith(STRUCT_PREFIX)})
+    inline = knob.knob_features({**Context.from_target(g.compute_cap).features(), **s_feats, **g.knobs})
+
+    assert Sample.from_golden(g, compile_s_feats=True).features() == inline
+
+    arith = Sample.from_golden(g).s_features()
+    full = Sample.from_golden(g, compile_s_feats=True).s_features()
+    assert set(arith) <= set(full)
+    assert all(arith[k] == full[k] for k in arith)
+
+
+# --- Dataset adapters + grouping --------------------------------------------
+
+
+def test_from_golden_filters() -> None:
+    assert len(Dataset.from_golden()) == len(Dataset.from_golden(kernel="")) > 0
+    assert all("square" in s.name for s in Dataset.from_golden(kernel="square"))
+    assert all(s.dtype == "fp16" for s in Dataset.from_golden(dtype="fp16"))
+    named = Dataset.from_golden(name="square.512").samples
+    assert named and all(s.name == "square.512" for s in named)
+
+
+def test_from_db_grouping(tmp_path) -> None:
+    path = tmp_path / "t.db"
+    db = SearchDB(path)
+    # two shapes of one kernel name (different S_ext_free_prod) + a second kernel
+    _seed(db, "a1", "void k_matmul(float*)", {"BM": 8, "S_ext_free_prod": 1024.0, "S_n_mma": 1.0}, 10.0)
+    _seed(db, "a2", "void k_matmul(float*)", {"BM": 16, "S_ext_free_prod": 1024.0, "S_n_mma": 1.0}, 8.0)
+    _seed(db, "b1", "void k_rms(float*)", {"FK": 4, "S_ext_free_prod": 64.0, "S_reduce_add": 1.0}, 3.0)
+    ds = Dataset.from_db(path)
+
+    by_name = ds.group_by_kernel_name()
+    assert set(by_name) == {"k_matmul", "k_rms"}
+    assert len(by_name["k_matmul"]) == 2
+    assert ds.group_by_kernel_name(min_variants=2) == {"k_matmul": by_name["k_matmul"]}
+    assert set(ds.group_by_kernel_name(kernel="rms")) == {"k_rms"}
+
+    # group_by_op keys on the full S_* signature → the two matmul rows share a group
+    by_op = ds.group_by_op()
+    assert len(by_op) == 2
+    assert max(len(v) for v in by_op.values()) == 2
+
+
+def test_from_prior_group_by_op_matches_op_sig() -> None:
+    class _P:
+        _dataset = [({"S_kind": 1.0, "BM": bm}, 100.0 / bm) for bm in (2, 4, 8)]
+
+    groups = Dataset.from_prior(_P()).group_by_op()
+    assert len(groups) == 1
+    (sig,) = groups
+    assert sig == (("S_kind", 1.0),)  # only S_* enters the signature
+    assert len(groups[sig]) == 3

--- a/tests/compiler/pipeline/search/test_db.py
+++ b/tests/compiler/pipeline/search/test_db.py
@@ -7,11 +7,19 @@ Loop→Tile), and a backend-partitioned generic ``perf`` table.
 
 from __future__ import annotations
 
+import sqlite3
+
+import pytest
+
 from deplodock.compiler.pipeline.search.db import PerfStats, SearchDB
 
 
 def _stats(median: float) -> PerfStats:
     return PerfStats(median=median, min=median, max=median, mean=median, variance=0.0, n_samples=1)
+
+
+def _seed_cuda(db: SearchDB, key: str, pretty: str) -> None:
+    db.record_cuda_op(key, kernel_source="", arg_order=[], grid=[1, 1, 1], block=[1, 1, 1], smem_bytes=0, pretty=pretty)
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +82,54 @@ def test_min_latency_filters_by_backend() -> None:
     assert db.min_latency_for_context("ctx", backend="cuda") == 10.0
     assert db.min_latency_for_context("ctx", backend="loop") == 1.0
     assert db.min_latency_for_context("ctx") == 1.0  # aggregates across backends
+
+
+# ---------------------------------------------------------------------------
+# read-only open + perf ⋈ cuda_op samples
+# ---------------------------------------------------------------------------
+
+
+def test_iter_perf_samples_joins_cuda_op() -> None:
+    db = SearchDB()
+    _seed_cuda(db, "k1", "void k_matmul(float*)")
+    _seed_cuda(db, "k2", "void k_rms(float*)")
+    db.record_perf("ctx", "k1", backend="cuda", status="ok", stats=_stats(10.0), knobs={"BM": 8, "S_n_mma": 1.0})
+    db.record_perf("ctx", "k2", backend="cuda", status="ok", stats=_stats(5.0), knobs={"BN": 1})
+    db.record_perf("ctx", "k1", backend="cuda", status="bench_fail", stats=_stats(1.0))  # ok stays; fail not yielded
+
+    samples = sorted(db.iter_perf_samples(), key=lambda s: s.latency_us)
+    assert [(s.pretty, s.latency_us) for s in samples] == [("void k_rms(float*)", 5.0), ("void k_matmul(float*)", 10.0)]
+    assert samples[1].knobs == {"BM": 8, "S_n_mma": 1.0}
+
+
+def test_iter_perf_samples_backend_and_min_latency() -> None:
+    db = SearchDB()
+    _seed_cuda(db, "k1", "void k(float*)")
+    _seed_cuda(db, "k2", "void k(float*)")
+    db.record_perf("ctx", "k1", backend="cuda", status="ok", stats=_stats(10.0))
+    db.record_perf("ctx", "k2", backend="loop", status="ok", stats=_stats(2.0))
+    assert {s.latency_us for s in db.iter_perf_samples(backend="cuda")} == {10.0}
+    assert {s.latency_us for s in db.iter_perf_samples(backend=None)} == {10.0, 2.0}
+    assert {s.latency_us for s in db.iter_perf_samples(backend=None, min_latency_us=5.0)} == {10.0}
+
+
+def test_open_readonly_reads_without_mutating(tmp_path) -> None:
+    path = tmp_path / "tune.db"
+    db = SearchDB(path)
+    _seed_cuda(db, "k1", "void k_matmul(float*)")
+    db.record_perf("ctx", "k1", backend="cuda", status="ok", stats=_stats(7.0), knobs={"BM": 8})
+    db.close()
+
+    ro = SearchDB.open_readonly(path)
+    assert [s.latency_us for s in ro.iter_perf_samples()] == [7.0]
+    with pytest.raises(sqlite3.OperationalError):  # ?mode=ro rejects writes
+        ro.record_perf("ctx", "k2", backend="cuda", status="ok", stats=_stats(1.0))
+    ro.close()
+
+
+def test_open_readonly_missing_file_raises(tmp_path) -> None:
+    with pytest.raises(sqlite3.OperationalError):
+        SearchDB.open_readonly(tmp_path / "nope.db")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/search/test_online_prior.py
+++ b/tests/compiler/pipeline/search/test_online_prior.py
@@ -179,12 +179,13 @@ def test_load_tolerates_stale_checkpoint(tmp_path):
 def test_diagnostics_report_reachability():
     """``diagnostics.report`` groups by op and reports argmax reachability — on a
     perfectly-rankable synthetic op the prior recovers the best (ratio 1.0)."""
+    from deplodock.compiler.pipeline.search.data import Dataset
     from deplodock.compiler.pipeline.search.prior import diagnostics
 
     # one op-structure (S_kind), bigger BM = lower latency (label = µs)
     rows = [({"S_kind": 1.0, "BM": bm}, 100.0 / bm) for bm in (2, 4, 8, 16, 32, 64) for _ in range(6)]
     p = _fit(rows)
-    groups = diagnostics.group_by_op(p._dataset)
+    groups = Dataset.from_prior(p).group_by_op()
     assert len(groups) == 1
     rr = diagnostics.reachability(p, groups)
     assert len(rr) == 1

--- a/tests/compiler/test_golden_configs.py
+++ b/tests/compiler/test_golden_configs.py
@@ -83,20 +83,24 @@ def test_goldens_by_name_returns_every_config_under_a_name(monkeypatch):
 
 def test_resolve_golden_arg_stashes_all_matches(monkeypatch):
     """``--golden NAME`` stashes *every* recorded config under NAME on
-    ``args.golden_configs`` (all share the shape, so ``args.code`` is the snippet
-    of the first); no ``--golden`` leaves an empty list."""
+    ``args.golden_configs`` as :class:`Sample`s (all share the shape, so ``args.code``
+    is the snippet of the first); no ``--golden`` leaves an empty list."""
     from argparse import Namespace
 
-    from deplodock.commands import compile as cmod
     from deplodock.compiler.pipeline.search import golden as gmod
 
     a, b = _dup({"BM": 8}, 12.0), _dup({"BM": 16}, 14.0)
+    # Dataset.from_golden reads golden.GOLDEN_CONFIGS via a lazy import, so this patch is seen.
     monkeypatch.setattr(gmod, "GOLDEN_CONFIGS", [a, b])
+
+    from deplodock.commands import compile as cmod
 
     args = Namespace(golden="dup.512", code=None, input=None, ir=None)
     cmod.resolve_golden_arg(args)
-    assert args.golden_configs == [a, b]
+    assert [s.name for s in args.golden_configs] == ["dup.512", "dup.512"]
+    assert [s.knobs for s in args.golden_configs] == [{"BM": 8}, {"BM": 16}]
     assert args.code == a.snippet()
+    assert all(s.source == "golden" for s in args.golden_configs)
 
     none = Namespace(golden=None, code=None, input=None, ir=None)
     cmod.resolve_golden_arg(none)


### PR DESCRIPTION
## Why

Three measurement-data sources were each loaded, filtered, and featurized by ad-hoc code:

- **Golden** configs (`GOLDEN_CONFIGS`) — filtered 4 different ways across `eval`.
- **Tune DB** (`perf ⋈ cuda_op`) — opened via raw `sqlite3 ?mode=ro` in `eval`, vs `SearchDB` everywhere else.
- **Prior reservoir** — grouped by a private `diagnostics.group_by_op`.

Plus duplicated `--prior` env pokes and a per-`knob_features` feature-merge repeated at ~4 call sites. No `eval`
subcommand could point at *the other* source.

## What

A single read-view — `compiler/pipeline/search/data/` — and the consumers routed through it.

- **`data/`**: `Sample` normalizes one `(knobs, latency, identity)` row across sources and owns the single
  `knob_features` path; `Dataset` has `from_golden` / `from_db` / `from_prior` adapters plus `group_by_op` (full `S_*`
  signature) and `group_by_kernel_name` (kernel C identifier); `ShapeKey` is the cheap arithmetic `S_*` extent identity.
- **`db.py`**: `SearchDB.open_readonly` (no schema mutation / WAL — never blocks a concurrent `tune`) +
  `iter_perf_samples` (the one `perf ⋈ cuda_op` join). `eval`'s hand-rolled raw-sqlite loader is deleted.
- **Featurization fidelity**: golden rows derive the full `992` `S_*` histogram by compiling the snippet (cached) *only*
  when a trained `CatBoostPrior` consumes them (`eval prior --features`). The cheap arithmetic extents suffice for the
  cold `AnalyticPrior` (it ranks only on `D_*` derived from the extents) and for grouping.
- **Shared CLI**: `--dataset {golden,db}` vocabulary (`commands/dataset_args.py`) + `resolve_prior_arg` (dedups the
  `--prior` env poke) + `require_source` (fail-fast on degenerate combos). `eval prior --dataset db` is the orthogonal
  view — the prior's pick reachability over the DB's *measured* variants.
- **Migrated**: `eval knobs` (regret), `eval analytic/prior/golden` golden views, `diagnostics`
  `group_by_op`/`reachability`/`report`, and `run --golden` selection + bench (now carries `Sample`s, not
  `GoldenConfig`s).

## Behavior-preserving

Round-trip tests assert `Sample.features()` reproduces the exact prior input each consumer built inline — both for DB
rows (`features() == knob_features(perf.knobs)`) and for the compiled golden histogram (vs the old inline
compile-and-scrape). The regret table iterates the un-split dict, so its output (including `S_ext_*` rows) is unchanged.

`make test`: **1686 passed, 29 skipped**. `make lint`: clean.

## Notes

- `eval heuristic` → `eval analytic` and the `FallbackPrior(CatBoost, Analytic)` collapse were already in the base
  branch; this PR builds on them and only touches the data-access layer.
- `resolve_dataset` from the plan was dropped as unused (handlers need either a graceful no-DB skip or raw `M,N,K` for
  enumeration), per YAGNI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)