### PR TITLE
Greedy: flatten the fork tree so the prior picks complete tiles

### DIFF
--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -280,9 +280,9 @@ rules — they're shared helpers for the pass's rule modules.
 three entry points:
 
 - `Pipeline.run(graph, *, backend=None, db=None) -> Graph` — single-shot
-  compile via `GreedySearch` (picks each fork by the `Prior`'s `mean_score`
-  argmin — `AnalyticPrior` cold, `CatBoostPrior` once trained). Stops at the
-  first terminal candidate.
+  compile via `GreedySearch` (flattens each fork point to its complete leaves and
+  picks the `Prior`'s `mean_scores` argmin — `AnalyticPrior` cold, `CatBoostPrior`
+  once trained). Stops at the first terminal candidate.
 - `Pipeline.tune(graph, *, search, backend=None, db=None) -> Iterator[Candidate]` —
   autotune sweep. Pass a `TuningSearch(patience=, ucb_c=)`; the iterator
   yields one terminal `Candidate` per fully-explored rollout.
@@ -507,20 +507,27 @@ falls back to a uniform `P = 1`). The enumeration is itself ordered by the `Anal
 MCTS front-loads good variants and a single `tune` pass reaches the prior-best within patience. The end-of-run sanity
 block (silly-pick rate warmup-vs-post, self-calibration) prints once for the global prior.
 
-**Greedy uses the prior too.** `Pipeline.run`'s `GreedySearch` (the O(1)-per-step `compile` / `run` driver) lazy-loads the
-global `Prior` via `load_prior` (the `FallbackPrior` over `CatBoostPrior` + `AnalyticPrior`) and picks each fork by
-`mean_score` argmin (lowest predicted latency) over the candidate's `{H_* , S_* , path-deltas, fork-delta}` feature
-vector — the exact base the prior trained on. Cold (no trained `CatBoostPrior`) the `AnalyticPrior` ranks; only if
-`load_prior` returns nothing does it take option-0. (Greedy benches nothing, so it can only *use* a prior, never train
-one; routing whole-model compile through `TuningSearch` would be O(N²).)
+**Greedy uses the prior too — and flattens.** `Pipeline.run`'s `GreedySearch` (the `compile` / `run` driver) lazy-loads
+the global `Prior` via `load_prior` (the `FallbackPrior` over `CatBoostPrior` + `AnalyticPrior`). The lazy fork tree is an
+**MCTS** structure — it stages knob choices across levels (`BR` → `BM/BN` → `FM/FN`) so MCTS pays one node per pop.
+Greedy must NOT walk it level-by-level: a branch carries only a *partial* tile, and `knob.knob_features` can't compute the
+tile's area / occupancy until `FM/FN` are pinned, so the prior is **blind at the `BM/BN` choice** and defaults to `BN=16`
+for every shape (it also defaulted the warp-vs-scalar tier by emission order, not the prior). Instead greedy **flattens**
+each fork point to its complete leaves — `_leaves` expands branches depth-first (cheap; only knob dicts, materialization
+stays deferred to the one chosen leaf's `resolve`) — and picks the lowest `Prior.mean_scores` over the full
+`{H_*, S_*, complete-knob-row}` vector the prior trained on, in **one batched `predict`**. The pick equals scoring the
+flat candidate set, invariant to the tree's level order. Cold (no trained `CatBoostPrior`) the `AnalyticPrior` ranks
+(including the positive `MMA_tier` warp-preference that replaced the old warp-first emission order); only if `load_prior`
+returns nothing does it take option-0. (Greedy benches nothing, so it can only *use* a prior, never train one; routing
+whole-model compile through `TuningSearch` would be O(N²).)
 
 **Greedy validity fallback.** The prior ranks by *predicted latency*, which can rank a tile that fails `validate(ctx)`
 (smem / thread budget) first — `tune` benches-and-skips it, but greedy benches nothing. So when a deterministic compile
 leaves a node un-lowered (its only lowering rejected at `validate`), `Pipeline.run` blocklists that tile's
-`tile_identity` (its planner knobs) and **re-drives**: `GreedySearch(blocked=…)` skips the matching leaf and falls back
-to the next prior-ranked sibling (the valid runner-up is usually ranked right below). Bounded by `_MAX_GREEDY_RETRIES`
-(each retry blocks ≥1 fresh tile or stops). Only the offending leaf is skipped — a branch fork's partial knobs never
-match a full-row blocklist entry, so whole subtrees are never pruned.
+`tile_identity` (its planner knobs) and **re-drives**: `GreedySearch(blocked=…)` drops the matching leaf from the
+flattened set and picks the next-best (the valid runner-up is usually ranked right below). Bounded by
+`_MAX_GREEDY_RETRIES` (each retry blocks ≥1 fresh tile or stops). Only the offending leaf is dropped — its full-row
+`tile_identity` never matches a different tile, so no other candidate is pruned.
 
 **Reading the result.** `_bench_terminal` writes one `perf` row per CudaOp per `(context_key, backend)` keyed on
 `op_cache_key`, plus a `lowering` edge per rewrite hop carrying the knob delta the rule stamped (and the inner search

--- a/deplodock/compiler/pipeline/search/policy/greedy.py
+++ b/deplodock/compiler/pipeline/search/policy/greedy.py
@@ -1,22 +1,31 @@
-"""Single-shot compile driver — picks each fork via the global learned prior
-when one is trained, else option-0.
+"""Single-shot compile driver — picks each fork point's globally-best **complete**
+leaf via the global learned prior when one is trained, else option-0.
 
 This is the deterministic ``Pipeline.run`` driver for ``compile`` / ``run`` and
-the assembled-graph lowering, with **O(1) work per step** (a single pending
-slot, no MCTS tree — routing a whole-model compile through ``TuningSearch``
-would be O(N²) and hang). It is NOT an exploration policy: it benches nothing,
-so it can only *use* a prior trained earlier by ``tune``, never train one.
+the assembled-graph lowering, with a single pending slot and no MCTS tree
+(routing a whole-model compile through ``TuningSearch`` would be O(N²) and hang).
+It is NOT an exploration policy: it benches nothing, so it can only *use* a prior
+trained earlier by ``tune``, never train one.
 
-When a trained global prior exists (``CatBoostPrior.load`` finds a
-checkpoint), it picks the sibling with the lowest :meth:`Prior.mean_score` (the
-prior predicts latency µs — lower is better) over the same feature vector the
-prior was trained on: the ``H_*`` host/hardware regime + the op's ``S_*``
-structural knobs (read off the parent op) + the deltas chosen so far down this
-fork tree + the candidate's own delta. With no trained prior the model is unfit →
-it falls back to the first emitted sibling (option-0).
+**Flatten, don't descend.** The lazy fork tree (``lowering/tile`` planner) is an
+MCTS data structure — it stages knob choices across levels (``BR`` → ``BM/BN`` →
+``FM/FN``) so MCTS pays one node per pop. Greedy must NOT walk it level-by-level:
+a branch carries only a *partial* tile, and ``knob.knob_features`` can't compute
+the tile's area / occupancy until ``FM/FN`` are pinned — so the prior is blind at
+the ``BM/BN`` choice and defaults to ``BN=16`` for every shape. Instead greedy
+**flattens** each fork point to its complete leaves (cheap — ``expand`` builds
+only knob dicts; materialization stays deferred to the single chosen leaf's
+``resolve``) and picks the one with the lowest :meth:`Prior.mean_scores` over the
+full feature vector the prior trained on: the ``H_*`` host/hardware regime + the
+op's ``S_*`` structural knobs (read off the parent op) + the leaf's complete knob
+row. The pick equals scoring the flat candidate set, invariant to the tree's
+level order. With no trained prior the model is unfit → it falls back to the first
+emitted sibling (option-0).
 """
 
 from __future__ import annotations
+
+from collections.abc import Sequence
 
 from deplodock.compiler.pipeline.search.candidate import LazyCandidate
 from deplodock.compiler.pipeline.search.policy.base import Search
@@ -43,17 +52,37 @@ def _tile_blocked(fork_knobs: dict, blocked: set[frozenset]) -> bool:
     return tile_identity(fork_knobs) in blocked
 
 
+def _leaves(cands: Sequence[LazyCandidate]) -> list[LazyCandidate]:
+    """Expand every offered candidate down to its leaf candidates, **depth-first
+    in emission order** — each candidate's leaves precede the next's, so a tie in
+    the prior's scores still falls to enumeration order (option-0 first), the
+    no-information fallback the old per-level descent kept. Branch forks expand via
+    ``LazyCandidate.expand`` — cheap, building only the next level's knob-dict
+    forks; leaf candidates (``is_expandable`` False) terminate. Nothing is
+    materialized: ``resolve`` (the one expensive build) runs only on the single
+    leaf greedy ultimately pends. So the whole lazy tree collapses to its flat
+    leaf set for one scoring pass."""
+    out: list[LazyCandidate] = []
+    for c in cands:
+        if c.is_expandable():
+            out.extend(_leaves(c.expand()))
+        else:
+            out.append(c)
+    return out
+
+
 class GreedySearch(Search):
-    """Keep one pending candidate; pick it by the prior's ``mean_score`` argmin —
-    the learned ``CatBoostPrior`` once trained, the ``AnalyticPrior`` cold-start
-    heuristic otherwise (both behind ``load_prior``'s ``FallbackPrior``). Falls
-    to emission order (option-0) only if the prior fails to load entirely.
+    """Keep one pending candidate; pick it by the prior's ``mean_scores`` argmin
+    over the fork point's flattened complete leaves — the learned ``CatBoostPrior``
+    once trained, the ``AnalyticPrior`` cold-start heuristic otherwise (both behind
+    ``load_prior``'s ``FallbackPrior``). Falls to emission order (option-0) only if
+    the prior fails to load entirely.
 
     ``blocked`` (``{node_id: {tile_identity, ...}}``) lists tiles that failed
     ``validate(ctx)`` on a previous compile attempt — ``Pipeline.run`` retries the
-    deterministic compile with the failed leaf blocklisted so greedy falls back to
-    the next prior-ranked sibling (the analogue of how ``tune`` benches-and-skips
-    an unviable tile; greedy benches nothing, so the validity signal must come from
+    deterministic compile with the failed leaf blocklisted so greedy picks the next
+    best non-blocked leaf (the analogue of how ``tune`` benches-and-skips an
+    unviable tile; greedy benches nothing, so the validity signal must come from
     the retry)."""
 
     def __init__(self, blocked: dict[str, set[frozenset]] | None = None) -> None:
@@ -62,12 +91,6 @@ class GreedySearch(Search):
         self._prior = None  # lazily loaded on first push (the regime's checkpoint)
         self._prior_loaded = False
         self._blocked = blocked or {}
-        # Fork-tree state: ``_cur_inner`` is the shared ``inner`` Candidate of the
-        # current fork tree (changes only when a leaf resolves into a new fork
-        # point); ``_path_knobs`` accumulates the deltas chosen down that tree (the
-        # branch slices aren't applied to the graph until a leaf resolves).
-        self._cur_inner = None
-        self._path_knobs: dict = {}
 
     def push(self, *cands: LazyCandidate, parent: object | None = None) -> None:
         del parent  # greedy keeps no lineage — one pending slot, no tree
@@ -78,30 +101,35 @@ class GreedySearch(Search):
         if prior is None:
             self._pending = cands[0]  # prior failed to load → emission order
             return
-        c0 = cands[0]
-        if c0.inner is not self._cur_inner:  # new fork point → reset the path
-            self._cur_inner = c0.inner
-            self._path_knobs = {}
-        base = self._base_knobs(c0)
+        # Flatten: greedy benches nothing, so it must pick the globally best
+        # COMPLETE tile, not a partial branch. The lazy fork tree exists for MCTS
+        # (one node per pop); descending it level-by-level here would score the
+        # ``BM/BN`` branch before ``FM/FN`` exist, so ``knob_features`` can't yet
+        # compute the tile's area / occupancy and the prior is blind at the BN
+        # choice (it defaults to ``BN=16`` for every shape — see the fork-tree
+        # ``Level`` order in ``lowering/tile/010_partition_loops``). So instead
+        # expand the offered fork(s) fully to their leaves — cheap, since
+        # ``expand`` only builds knob dicts (materialization stays deferred to
+        # ``resolve``) — and score every complete row in one batched ``predict``,
+        # resolving straight to the argmin. The pick then equals scoring the flat
+        # candidate set, invariant to how the tree's levels are arranged.
+        leaves = _leaves(cands)
+        if len(leaves) <= 1:
+            self._pending = leaves[0] if leaves else cands[0]
+            return
+        base = self._base_knobs(leaves[0])
         # Tiles this node already failed to lower on an earlier attempt — skip the
-        # matching leaf so greedy falls back to the next prior-ranked sibling. A
-        # non-leaf fork's partial knobs never match a full-row entry, so only the
-        # offending leaf is skipped, never a whole branch.
-        blocked = self._blocked.get(self._node_id(c0)) if self._blocked else None
-        best, best_v = None, float("inf")
-        for c in cands:
-            fork_knobs = c.fork.knobs if c.fork is not None else {}
-            if blocked is not None and _tile_blocked(fork_knobs, blocked):
-                continue
-            full = {**base, **self._path_knobs, **fork_knobs}
-            v = prior.mean_score(full)  # predicted latency µs — lower is better
-            if v < best_v:
-                best_v, best = v, c
-        if best is None:  # every sibling blocklisted → no valid alternative left
-            best = cands[0]
-        self._pending = best
-        if best.fork is not None:
-            self._path_knobs.update(best.fork.knobs)
+        # matching leaf so greedy falls back to the next prior-ranked candidate.
+        blocked = self._blocked.get(self._node_id(leaves[0])) if self._blocked else None
+        live = [(c, c.fork.knobs if c.fork is not None else {}) for c in leaves]
+        if blocked is not None:
+            live = [(c, k) for c, k in live if not _tile_blocked(k, blocked)]
+        if not live:  # every leaf blocklisted → no valid alternative left
+            self._pending = leaves[0]
+            return
+        scores = prior.mean_scores([{**base, **k} for _, k in live])  # predicted µs — lower is better
+        best_i = min(range(len(live)), key=scores.__getitem__)
+        self._pending = live[best_i][0]
 
     def pop(self) -> tuple[object | None, LazyCandidate] | None:
         c, self._pending = self._pending, None

--- a/deplodock/compiler/pipeline/search/prior/analytic.py
+++ b/deplodock/compiler/pipeline/search/prior/analytic.py
@@ -15,11 +15,13 @@ calibrated µs; only its ordering (greedy argmin / PUCT relative ``P``) matters.
 The weights :data:`_W_A` are fit offline by ``scripts/golden_knob_heuristics.py``
 jointly over EVERY kernel regime — fp32-scalar / fp16-warp matmul, cooperative
 reduce, and pointwise goldens — so one un-gated linear model over the shared
-``D_*`` features ranks them all (the warp tier rides tier-aware targets in
-``_geom_feats``; the reduce signal rides thread-count / occupancy as cooperative
-``BR`` raises the thread count). It replaces the old per-mode ``_priority_*``
-enumeration sorts (matmul / reduce / pointwise), which were the cold ranking
-before.
+``D_*`` features (plus ``MMA_tier``) ranks them all (the warp tier rides tier-aware
+targets in ``_geom_feats`` plus a positive ``MMA_tier`` weight — fp16/bf16 prefer
+the tensor-core tile over the scalar one, the warp-first default that used to live
+in enumeration order; the reduce signal rides thread-count / occupancy as
+cooperative ``BR`` raises the thread count). It replaces the old per-mode
+``_priority_*`` enumeration sorts (matmul / reduce / pointwise), which were the
+cold ranking before.
 """
 
 from __future__ import annotations
@@ -29,54 +31,58 @@ import math
 from deplodock.compiler.pipeline import knob
 from deplodock.compiler.pipeline.search.prior.base import Prior
 
-# Linear weights over ``knob.knob_features`` ``D_*`` keys, fit offline by
-# ``scripts/golden_knob_heuristics.py`` jointly over ALL kernel regimes —
-# fp32-scalar + fp16/bf16-warp matmul, cooperative reduce, and pointwise goldens —
-# tier-balanced (each regime weighted equally so the sparse reduce/pointwise tiers
-# aren't drowned by the matmul shapes), minimizing the goldens' tier-weighted mean
-# ``log2(rank+1)``. Dominant terms: occupancy (``D_ctas_ge_sm``/``D_near_waves`` —
-# keep #CTAs ≈ 2 waves over the SMs), the ``D_bm_band`` thread-tile band, the
-# tier-split warp BK target (``D_w_near_bk`` — BK≈2 on the TMA tile), and the
-# reduce signal rides ``D_threads``/occupancy (cooperative ``BR`` raises thread
-# count toward the target). One un-gated linear model serves every regime, so some
-# band weights compromise across regimes (e.g. ``D_bn_band`` is mildly negative —
-# matmul wants the band but reduce wants BN=1; the fit trades it for occupancy).
+# Linear weights over ``knob.knob_features`` (``D_*`` geometry keys + ``MMA_tier``),
+# fit offline by ``scripts/golden_knob_heuristics.py`` jointly over ALL kernel
+# regimes — fp32-scalar + fp16/bf16-warp matmul, cooperative reduce, and pointwise
+# goldens — tier-balanced (each regime weighted equally so the sparse
+# reduce/pointwise tiers aren't drowned by the matmul shapes), minimizing the
+# goldens' tier-weighted mean ``log2(rank+1)``. Dominant terms: occupancy
+# (``D_ctas_ge_sm``/``D_near_waves`` — keep #CTAs ≈ 2 waves over the SMs), the
+# ``D_bm_band`` thread-tile band, the tier-split warp BK target (``D_w_near_bk`` —
+# BK≈2 on the TMA tile), the positive ``MMA_tier`` (fp16/bf16 prefer the warp
+# tensor-core tile — the fp16 cases enumerate BOTH tiers, so the fit must rank the
+# warp golden over the scalar candidates), and the reduce signal rides
+# ``D_threads``/occupancy (cooperative ``BR`` raises thread count toward the
+# target). One un-gated linear model serves every regime, so some band weights
+# compromise across regimes (e.g. ``D_bn_band`` is mildly negative — matmul wants
+# the band but reduce wants BN=1; the fit trades it for occupancy).
 _W_A: dict[str, float] = {
-    "D_bm_band": 14.920552348240792,
+    "D_bm_band": 10.869206451133332,
     "D_splitk_le2": 8.407426536981845,
     "D_ctas_ge_sm": -7.948709567336204,
     "D_w_near_bk": 6.8518793473315265,
-    "D_bn_ge_bm": 6.278827239141573,
+    "D_bn_ge_bm": 4.1047225430800305,
+    "D_bn_band": -3.6793127460255177,
     "D_near_waves": 3.3396197822131195,
     "D_square": 3.0592744803555165,
     "D_near_area": 2.5706036479303176,
     "D_tilen_clean": -2.5517002129957875,
     "D_splitk": -2.2594440169222545,
-    "D_bk_ge32": -2.2506127603794623,
-    "D_l2_bm": -2.1021570661314115,
+    "D_bk_ge32": -2.250612760379462,
+    "MMA_tier": 2.2010287724932924,
+    "D_w_l2_bk": 2.0808985855150666,
     "D_near_tilen": -1.8722293684790134,
-    "D_log2_area": -1.819577558854622,
-    "D_bn_band": -1.6254704053387636,
+    "D_l2_bm": -1.8244728321406853,
+    "D_log2_area": -1.5182763690806524,
     "D_l2_reuse": 1.4867241939733629,
-    "D_l2_bk": 1.259242110612971,
+    "D_near_intensity": -1.3805736365293138,
+    "D_l2_bk": 0.8774891884764401,
+    "D_neg_overhang": -0.8646029028646692,
     "D_near_kchunks": -0.8403134313789603,
+    "D_l2_bn": -0.7907502921783296,
     "D_aspect": -0.700694025296909,
-    "D_w_l2_bk": 0.5978498582272562,
-    "D_log2_ctas": 0.542881044276033,
     "D_pow2_threads": -0.4401714077219094,
-    "D_near_intensity": -0.35192753800024107,
     "D_log2_waves": -0.3096053721652958,
-    "D_l2_bn": -0.18853218023203946,
-    "D_neg_overhang": 0.1648645127840344,
+    "D_log2_ctas": 0.23685242485122074,
     "D_l2_threads": -0.15663789439639914,
-    "D_near_threads": 0.10459439545995661,
+    "D_near_threads": 0.10459439545995662,
     "D_cells_cap": -0.10275127787239871,
-    "D_near_cells": -0.05255466763042605,
-    "D_reuse": -0.03051986517890071,
-    "D_cells": -0.022208323805983393,
-    "D_threads": -0.004295893049161815,
-    "D_tile_m": -0.0026049408030261903,
-    "D_tile_n": -0.0015936106921647275,
+    "D_reuse": -0.0606460824714877,
+    "D_near_cells": -0.03521970822845533,
+    "D_cells": -0.007608072063392554,
+    "D_tile_n": -0.006832526644562641,
+    "D_threads": -0.004295893049161819,
+    "D_tile_m": -0.002604940803026191,
 }
 
 

--- a/deplodock/compiler/pipeline/search/prior/base.py
+++ b/deplodock/compiler/pipeline/search/prior/base.py
@@ -87,6 +87,13 @@ class Prior(ABC):
         """Prediction for the greedy argmax + calibration (same as :meth:`score`
         for a deterministic model)."""
 
+    def mean_scores(self, knobs_list: list[dict]) -> list[float]:
+        """Batched :meth:`mean_score` — the greedy driver flattens a kernel's whole
+        candidate set into one scoring pass, so a model with a vectorized predict
+        (``CatBoostPrior``) overrides this to score the lot in a single call. The
+        default maps element-wise (fine for the cheap analytic prior)."""
+        return [self.mean_score(k) for k in knobs_list]
+
     # --- dataset + batched refit ------------------------------------------
 
     def add_rows(self, rows: list[tuple[dict, float]]) -> None:

--- a/deplodock/compiler/pipeline/search/prior/catboost.py
+++ b/deplodock/compiler/pipeline/search/prior/catboost.py
@@ -101,6 +101,19 @@ class CatBoostPrior(Prior):
         x = np.array([[f.get(c, np.nan) for c in self._cols]], dtype=float)  # absent → NaN, matching fit (see fit docstring)
         return float(np.exp(self._model.predict(x)[0]))
 
+    def mean_scores(self, knobs_list: list[dict]) -> list[float]:
+        """Batched :meth:`mean_score` — featurize every candidate, then one
+        vectorized ``model.predict`` over the whole ``N×cols`` matrix (CatBoost
+        amortizes the per-call overhead that makes ``N`` separate ``mean_score``
+        calls slow). The greedy flatten scores ~1k tiles per matmul this way."""
+        if self._model is None:
+            return [0.0] * len(knobs_list)
+        if not knobs_list:
+            return []
+        feats = [knob.knob_features(k) for k in knobs_list]
+        x = np.array([[f.get(c, np.nan) for c in self._cols] for f in feats], dtype=float)
+        return [float(v) for v in np.exp(self._model.predict(x))]
+
     # --- persistence ------------------------------------------------------
 
     def to_json(self) -> dict | None:

--- a/deplodock/compiler/pipeline/search/prior/fallback.py
+++ b/deplodock/compiler/pipeline/search/prior/fallback.py
@@ -43,6 +43,9 @@ class FallbackPrior(Prior):
     def mean_score(self, knobs: dict) -> float:
         return self.learned.mean_score(knobs) if self.learned.fitted else self.analytic.mean_score(knobs)
 
+    def mean_scores(self, knobs_list: list[dict]) -> list[float]:
+        return self.learned.mean_scores(knobs_list) if self.learned.fitted else self.analytic.mean_scores(knobs_list)
+
     # --- training + inspection: delegate to the learned half ------------------
     def fit(self) -> None:
         self.learned.fit()

--- a/scripts/golden_knob_heuristics.py
+++ b/scripts/golden_knob_heuristics.py
@@ -17,9 +17,14 @@ regime**: fp32-scalar + fp16/bf16-warp matmul, cooperative reduce, and pointwise
 
   1. For every golden (matmul thread / warp, reduce, pointwise), reconstruct the
      planner's exact candidate enumeration for that mode and locate the golden row.
-  2. Featurize every candidate via ``knob.knob_features`` (restricted to the ``D_*``
-     engineered features — the ``S_*``/``H_*`` shape/regime features are constant
-     within a shape, so they drop out of a within-shape ranking).
+     fp16/bf16 (warp) goldens enumerate BOTH tiers — scalar + warp — since a real
+     fp16 matmul does, so the fit ranks the warp golden against the scalar tile it
+     competes with (the warp-first default greedy's flatten no longer gets from
+     enumeration order).
+  2. Featurize every candidate via ``knob.knob_features`` (the ``D_*`` engineered
+     features plus ``MMA_tier``, the warp/scalar tier discriminator — the ``S_*`` /
+     ``H_*`` shape/regime features are constant within a shape, so they drop out of
+     a within-shape ranking).
   3. Score candidates with a parameterized linear model and measure the golden's
      rank (top-k coverage, median rank).
   4. Random-search + coordinate-descent the weights to minimize mean ``log2(rank+1)``
@@ -71,7 +76,7 @@ def build_cases(ctx: Context) -> list[tuple[str, str, int, list[dict[str, float]
     """Reconstruct each matmul golden's candidate enumeration (both tiers), pin the
     golden's index, and featurize every row. Returns ``(name, tier, golden_idx,
     feats)`` where ``tier`` is ``"thread"``/``"warp"`` and ``feats`` is the per-row
-    ``D_*`` feature dict."""
+    ``D_*`` (+ ``MMA_tier``) feature dict."""
     cases = []
     for g in GOLDEN_CONFIGS:
         if isinstance(g, ReduceGoldenConfig):
@@ -93,11 +98,21 @@ def build_cases(ctx: Context) -> list[tuple[str, str, int, list[dict[str, float]
             atom = ATOM_REGISTRY.get(g.knobs.get("MMA", ""))
             if atom is None:
                 continue
-            rows = _enumerate_warp_matmul_impl(
+            warp_rows = _enumerate_warp_matmul_impl(
                 E_M=g.M, E_N=g.N, E_K=g.K, ctx=ctx, force_splitk_one=False,
                 atoms=(atom,), m_axis_name="m", n_axis_name="n", m_forced_mask=False, n_forced_mask=False,
             )  # fmt: skip
-            rows = [r for r in rows if r["WM"] * r["WN"] != 1]
+            warp_rows = [r for r in warp_rows if r["WM"] * r["WN"] != 1]
+            # Include the SCALAR tier in the candidate pool: a real fp16 matmul
+            # enumerates both tiers as leaves under one fork tree, so greedy's
+            # flattened pick ranks warp vs scalar directly. Enumerating warp-only
+            # here hid that competition, so the fit never learned to prefer tensor
+            # cores — the cold analytic ranked the scalar tile first for fp16. With
+            # both tiers in the pool the rank objective penalizes "scalar outranks
+            # the warp golden", so the joint fit learns the warp preference (via
+            # ``MMA_tier``, kept below).
+            scalar_rows = enumerate_cartesian(E_M=g.M, E_N=g.N, E_K=g.K, ctx=ctx, priority_mode="matmul", m_axis_name="m", n_axis_name="n")
+            rows = list(scalar_rows) + warp_rows
             keys, tier = _WARP_KEYS, "warp"
         else:
             continue
@@ -106,7 +121,12 @@ def build_cases(ctx: Context) -> list[tuple[str, str, int, list[dict[str, float]
         if gidx is None:
             print(f"  !! {g.name}: golden not in {len(rows)} candidates — skipping")
             continue
-        feats = [{k: v for k, v in knob.knob_features({**base, **r}).items() if k.startswith("D_")} for r in rows]
+        # Keep ``D_*`` geometry/occupancy plus ``MMA_tier`` (the warp/scalar tier
+        # discriminator) — the only non-``D_`` feature the tier choice rides on.
+        # It's constant 0 within a scalar-only shape (fp32 / reduce / pointwise),
+        # so it drops out of those within-shape rankings and only fires where both
+        # tiers compete (fp16 / bf16).
+        feats = [{k: v for k, v in knob.knob_features({**base, **r}).items() if k.startswith("D_") or k == "MMA_tier"} for r in rows]
         cases.append((g.name, tier, gidx, feats))
     return cases
 


### PR DESCRIPTION
## Problem

Large square fp32 matmuls (`square.1024`/`2048`/`4096`) missed their `BN=32`
goldens — greedy picked `BN=16` for every shape.

## Root cause (not the prior weights)

`GreedySearch` descended the lazy fork tree level-by-level, scoring each branch by
its **partial** knobs. The planner branches `BM/BN` at level 2 but `FM/FN` only at
level 4 (`lowering/tile/010_partition_loops`), so at the `BN` choice
`knob_features` can't compute the tile's area/occupancy yet — `_tile_features`
needs `FM/FN` and returns `{}`. The prior was **blind at the `BN` decision** and
fell to grouping order → `BN=16`. (It also chose warp-vs-scalar tier by emission
order, not the prior.)

Verified: at the `BM/BN` branch both `BN=16` and `BN=32` score the neutral `1.0`,
while the *complete* tiles already rank `BN=32 FM=8` (2.29) above `BN=16 FM=10`
(3.20). So `eval analytic` (which scores complete rows) looked fine while the live
greedy pick was wrong — no reweighting fixes a `1.0 == 1.0` tie.

## Fix: flatten

The lazy tree is an **MCTS** structure (one node per pop). Greedy benches nothing,
so it must pick the globally-best **complete** tile. `GreedySearch` now flattens
each fork point to its leaves (`_leaves` expands branches depth-first — cheap, only
knob dicts; materialization stays deferred to the chosen leaf's `resolve`) and
scores them all in one batched `predict`. The pick equals scoring the flat
candidate set, invariant to the tree's level order. MCTS is untouched (it
bench-corrects, so a blind branch only costs exploration efficiency).

- `Prior.mean_scores` (batched); `CatBoostPrior` overrides with one vectorized
  `predict`; `FallbackPrior` routes it like `mean_score`.
- Re-fit `AnalyticPrior._W_A`: fp16 cases now enumerate **both** tiers so the rank
  objective sees warp-vs-scalar, and `MMA_tier` enters the feature set — the cold
  prior learns the warp-first (tensor-core) default that previously lived in
  enumeration order (`MMA_tier=2.2`). This restores fp16→MMA cold-start (the
  `test_mma_default_on_picks_warp_variant` guard) without hand-hacking a weight;
  all goldens still rank top (median rank 0).

## Result

`eval golden` (trained prior): `square.1024` and `square.4096` now pick **`BN=32`**
(were `BN=16`). `square.2048` stays `BN=16` — a **separate** CatBoost ranking error
(it predicts `BN=16` faster than `BN=32` even on complete tiles), which needs
`tune --golden square.2048`, not a search-structure change.

Note: the `STAGE=00` collapse on 2048/4096 is also out of scope here — `STAGE`/`RING`
aren't featurized and are stamped by a later pass, so no prior change touches them.

## Tests

`make test`: **1687 passed, 29 skipped**. Lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)