### PR TITLE
goldens: record 4 deployable wins (3 qwen3 s512 + square.512.fp16) after re-tune

### DIFF
--- a/deplodock/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/deplodock/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -221,16 +221,16 @@ configs:
     M: 512
     N: 1024
     K: 1024
-    knobs: {BN: 16, BM: 8, FM: 10, FN: 4, FK: 1, BK: 64, SPLITK: 1, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2, WARPSPEC: true}
-    deplodock_us: 36.9
+    knobs: {BN: 32, BM: 8, FM: 16, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 2}
+    deplodock_us: 32.8
     cublas_us: 39.6
   - kernel: matmul
     name: qwen3_06b.o_proj.s512
     M: 512
     N: 1024
     K: 2048
-    knobs: {BN: 16, BM: 8, FM: 10, FN: 4, FK: 1, BK: 32, SPLITK: 1, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2, WARPSPEC: true}
-    deplodock_us: 67.7
+    knobs: {BN: 32, BM: 8, FM: 16, FN: 2, FK: 1, BK: 32, SPLITK: 2, BR: 1, STAGE: '11', RING: 2}
+    deplodock_us: 59.4
     cublas_us: 58.6
   - kernel: matmul
     name: qwen3_06b.gate_up_proj.s512
@@ -245,8 +245,8 @@ configs:
     M: 512
     N: 1024
     K: 3072
-    knobs: {BN: 64, BM: 8, FM: 8, FN: 2, BK: 32, SPLITK: 2, BR: 1, STAGE: '11', RING: 2}
-    deplodock_us: 103.4
+    knobs: {BN: 32, BM: 8, FM: 16, FN: 2, FK: 1, BK: 32, SPLITK: 2, BR: 1, STAGE: '11', RING: 2}
+    deplodock_us: 86.1
     cublas_us: 79.6
   - kernel: reduce
     name: reduce.2048x2048

--- a/deplodock/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/deplodock/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -39,17 +39,8 @@ configs:
     N: 512
     K: 512
     dtype: fp16
-    knobs: {WN: 2, WM: 2, FM: 2, FN: 2, BK: 2, SPLITK: 1, MMA: 'mma_m16n8k16_f16', STAGE: '11', RING: 4}
-    deplodock_us: 6.1
-    cublas_us: 6.2
-  - kernel: matmul
-    name: square.512.fp16
-    M: 512
-    N: 512
-    K: 512
-    dtype: fp16
-    knobs: {WN: 1, WM: 8, FM: 1, FN: 2, BK: 2, SPLITK: 1, MMA: 'mma_m16n8k16_f16', STAGE: '11', RING: 2}
-    deplodock_us: 6.1
+    knobs: {WN: 4, WM: 4, FM: 1, FN: 1, BK: 4, SPLITK: 1, MMA: 'mma_m16n8k16_f16', STAGE: '11', RING: 2}
+    deplodock_us: 4.1
     cublas_us: 6.2
   - kernel: matmul
     name: square.1024.fp16


### PR DESCRIPTION
Re-ran the `/update-goldens` sweep on the RTX 5090 (sm120): tuned the whole golden dataset
(`tune --dataset golden --clean`), then A/B'd the deployable greedy pick vs each recorded golden
(`run --bench --golden`). Records the genuine, reproduced wins and leaves the rest.

## Wins recorded (`goldens/rtx5090_sm120.yaml`)

| shape | before → after | win | knob change |
|---|---|---|---|
| `qwen3_06b.kv_proj.s512` | 36.9 → 32.8 µs | +11% | FM10/FN4 OVERHANG → BN32/FM16/FN2/SPLITK2 |
| `qwen3_06b.o_proj.s512` | 67.7 → 59.4 µs | +14% | FM10/FN4 OVERHANG → BN32/FM16/FN2/SPLITK2 |
| `qwen3_06b.down_proj.s512` | 103.4 → 86.1 µs | +17% | BN64/FM8 → BN32/FM16/FN2 |
| `square.512.fp16` | 6.1 → 4.1 µs | ~33% | replaces both 6.1 entries with BK4/WM4/WN4 |

The three fp32 `s512` picks converge on the same `BN32 BM8 FM16 FN2 SPLITK2 STAGE11 RING2` family
(no OVERHANG/WARPSPEC). Each replace makes the old entry strictly slower (>3%), so the superseded
configs are deleted rather than kept as alternates. cuBLAS reference latencies are unchanged
(config-independent). All wins reproduced across re-runs, clearly above the noise floor.

## fp16 root cause (investigated)

All four fp16 squares were deploying 2–4× slower than golden. Root cause: the learned CatBoostPrior
had near-zero deployable (-O3) coverage for fp16 — only **15 of 6149** fp16 reservoir rows were
`H_opt=3`, so it ranked fp16 almost entirely by -O1 latency (a poor proxy) and deployed a **BK=1**
tile whose K-loop can't pipeline, which the downstream staging pass collapsed to **STAGE=1 / no-smem**
(e.g. `square.512.fp16` ran 12.3 µs). The fp16 shapes also got far less tune budget (~60s vs 90–300s
for the fp32 s512 shapes), so `square.512.fp16` calibration was -0.19 (anti-correlated).

Re-tuning the four fp16 shapes with `--patience 40` and `DEPLODOCK_O3_TOL=0.30` flipped calibration
positive (+0.57…+0.81) and removed the STAGE=1 collapse on all four. Only `square.512.fp16` then
deployed a greedy pick beating golden (4.1 µs); `1024/2048/4096.fp16` are de-catastrophized but golden
still wins, so their goldens are left untouched.

## Validation

- `tests/compiler/test_golden_configs.py` — 11 passed
- `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)