### PR TITLE
vm create gpu: add --provisioning-model override (on-demand / Spot GCP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ same worker.
 - `deplodock bench recipes/* --filter "KEY=PATTERN"` — run only variants matching the filter (fnmatch glob, repeatable, AND logic)
 - `deplodock bench experiments/...` — run an experiment (results stored in the experiment dir)
 - `deplodock teardown <run_dir>` — clean up VMs left running by `bench --no-teardown`
-- `deplodock vm create gpu --gpu NAME --gpu-count N [--provider X] [--authorized-key PATH ...]` — create a VM by GPU name (orchestrator: retries, candidate fallback, orphan cleanup). `--authorized-key` (repeatable, also on `deploy cloud`) installs extra SSH public keys in the VM's authorized_keys alongside `--ssh-key`'s own `.pub`
+- `deplodock vm create gpu --gpu NAME --gpu-count N [--provider X] [--provisioning-model {FLEX_START,SPOT,STANDARD}] [--authorized-key PATH ...]` — create a VM by GPU name (orchestrator: retries, candidate fallback, orphan cleanup). `--provisioning-model` overrides the per-GPU hardware-table default (`STANDARD` = on-demand) while keeping the orchestrator's full config.yaml/SSH treatment; GCP-only, ignored for CloudRift. `--authorized-key` (repeatable, also on `deploy cloud`) installs extra SSH public keys in the VM's authorized_keys alongside `--ssh-key`'s own `.pub`
 - `deplodock vm create gcp ...` — create a specific GCP GPU VM (single-shot manual)
 - `deplodock vm create cloudrift ...` — create a specific CloudRift GPU VM (single-shot manual)
 - `deplodock vm delete gcp ...` — delete a GCP GPU VM

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -274,6 +274,16 @@ deplodock vm create gpu --gpu "NVIDIA H200 141GB" --gpu-count 2 --provider cloud
   --authorized-key ~/.ssh/alice.pub --authorized-key ~/.ssh/bob.pub
 ```
 
+**GCP provisioning model.** `vm create gpu` defaults to the per-GPU model from `hardware.GPU_GCP_PROVISIONING_MODEL`
+(`DEFAULT_GCP_PROVISIONING_MODEL = FLEX_START`). Pass `--provisioning-model {FLEX_START,SPOT,STANDARD}` to override it —
+`STANDARD` rents an **on-demand** VM. Because this routes through the orchestrator, on-demand still gets the full
+`config.yaml` treatment (CUDA image, large boot disk, service account, SSH-key metadata) — the manual `vm create gcp`
+path does not. GCP-only; ignored for CloudRift candidates.
+
+```bash
+deplodock vm create gpu --gpu "NVIDIA B200" --gpu-count 8 --provider gcp --provisioning-model STANDARD
+```
+
 #### Allocation strategy (shared by `deploy cloud`, `bench`, `vm create gpu`)
 
 All three commands go through `provision_cloud_vm()` in `deplodock/provisioning/cloud.py`. It enumerates *candidates* from `hardware.GPU_INSTANCE_TYPES` (preference-ordered) and, for GCP, fans out across the zones listed in `GPU_GCP_ZONES`. For each candidate it makes up to `SAME_CANDIDATE_RETRIES` attempts on transient failures, then advances. Providers signal "no capacity, try next" by raising `CapacityExhausted`; non-retryable errors raise `TerminalProvisionError` and abort. Fallback never silently crosses provider boundaries — `--provider` (or the first hardware-table entry) bounds the search.

--- a/deplodock/commands/vm/gpu.py
+++ b/deplodock/commands/vm/gpu.py
@@ -61,6 +61,7 @@ async def _handle_create(args):
             dry_run=args.dry_run,
             provider=args.provider,
             extra_authorized_keys=extra_authorized_keys,
+            provisioning_model=args.provisioning_model,
         )
     except (CapacityExhausted, TerminalProvisionError) as exc:
         logger.error(f"{exc}")
@@ -95,6 +96,12 @@ def register_create_target(subparsers):
         choices=["cloudrift", "gcp"],
         default=None,
         help="Restrict candidates to one provider (default: hardware-table preference order)",
+    )
+    parser.add_argument(
+        "--provisioning-model",
+        choices=["FLEX_START", "SPOT", "STANDARD"],
+        default=None,
+        help="GCP provisioning model override (default: hardware-table default per GPU); STANDARD = on-demand",
     )
     parser.add_argument(
         "--config",

--- a/deplodock/provisioning/cloud.py
+++ b/deplodock/provisioning/cloud.py
@@ -128,6 +128,7 @@ async def provision_cloud_vm(
     logger=None,
     provider=None,
     extra_authorized_keys=None,
+    provisioning_model=None,
 ):
     """Provision a cloud VM for the given GPU requirements.
 
@@ -143,6 +144,9 @@ async def provision_cloud_vm(
         extra_authorized_keys: optional list of SSH public key strings to
             install in the VM's authorized_keys alongside ``ssh_key``'s own
             ``.pub`` (use :func:`read_public_key_files` to resolve paths first).
+        provisioning_model: GCP-only override for the hardware-table
+            provisioning model (FLEX_START / SPOT / STANDARD). ``None`` keeps
+            the per-GPU default; ignored for CloudRift candidates.
 
     Returns:
         VMConnectionInfo on success, None when every candidate is exhausted.
@@ -163,7 +167,16 @@ async def provision_cloud_vm(
         for attempt in range(1, SAME_CANDIDATE_RETRIES + 1):
             try:
                 conn = await _provision_candidate(
-                    cand, gpu_name, gpu_count, ssh_key, providers_config, server_name, dry_run, logger, extra_authorized_keys
+                    cand,
+                    gpu_name,
+                    gpu_count,
+                    ssh_key,
+                    providers_config,
+                    server_name,
+                    dry_run,
+                    logger,
+                    extra_authorized_keys,
+                    provisioning_model,
                 )
             except CapacityExhausted as exc:
                 logger.warning(f"{cand.describe()}: capacity exhausted ({exc}); advancing to next candidate.")
@@ -206,6 +219,7 @@ async def _provision_candidate(
     dry_run: bool,
     logger,
     extra_authorized_keys=None,
+    provisioning_model=None,
 ):
     """Single provisioning attempt for one resolved candidate.
 
@@ -217,7 +231,9 @@ async def _provision_candidate(
     if cand.provider == "cloudrift":
         return await _provision_cloudrift(cand, ssh_key, providers_config, dry_run, logger, extra_authorized_keys)
     if cand.provider == "gcp":
-        return await _provision_gcp(cand, gpu_name, ssh_key, providers_config, server_name, dry_run, logger, extra_authorized_keys)
+        return await _provision_gcp(
+            cand, gpu_name, ssh_key, providers_config, server_name, dry_run, logger, extra_authorized_keys, provisioning_model
+        )
     raise ValueError(f"Unknown provider: {cand.provider}")
 
 
@@ -254,9 +270,19 @@ async def _provision_cloudrift(cand: VmCandidate, ssh_key, providers_config, dry
     )
 
 
-async def _provision_gcp(cand: VmCandidate, gpu_name, ssh_key, providers_config, server_name, dry_run, logger, extra_authorized_keys=None):
+async def _provision_gcp(
+    cand: VmCandidate,
+    gpu_name,
+    ssh_key,
+    providers_config,
+    server_name,
+    dry_run,
+    logger,
+    extra_authorized_keys=None,
+    provisioning_model=None,
+):
     gcp_config = (providers_config or {}).get("gcp", {})
-    provisioning_model = GPU_GCP_PROVISIONING_MODEL.get(gpu_name, DEFAULT_GCP_PROVISIONING_MODEL)
+    provisioning_model = provisioning_model or GPU_GCP_PROVISIONING_MODEL.get(gpu_name, DEFAULT_GCP_PROVISIONING_MODEL)
     ssh_user = gcp_config.get("ssh_user", os.environ.get("USER", "deploy"))
     ts = datetime.now().strftime("%m%d-%H%M")
     suffix = secrets.token_hex(2)

--- a/tests/provisioning/test_provision_fallback.py
+++ b/tests/provisioning/test_provision_fallback.py
@@ -101,6 +101,28 @@ async def test_gcp_iterates_zones_before_giving_up(mock_create, ssh_key):
     assert zones_tried == ["asia-southeast1-b", "asia-northeast1-b"]
 
 
+@patch("deplodock.provisioning.cloud.gcp_provider.create_instance", new_callable=AsyncMock)
+async def test_provisioning_model_override_flows_to_gcp(mock_create, ssh_key):
+    """An explicit --provisioning-model override reaches gcp_provider.create_instance."""
+    mock_create.return_value = VMConnectionInfo(host="10.0.0.1", username="", ssh_port=22)
+    await provision_cloud_vm(
+        gpu_name="NVIDIA B200",
+        gpu_count=8,
+        ssh_key=ssh_key,
+        provider="gcp",
+        provisioning_model="STANDARD",
+    )
+    assert mock_create.await_args_list[0].kwargs["provisioning_model"] == "STANDARD"
+
+
+@patch("deplodock.provisioning.cloud.gcp_provider.create_instance", new_callable=AsyncMock)
+async def test_provisioning_model_defaults_to_hardware_table(mock_create, ssh_key):
+    """Without an override, B200 falls back to the hardware-table default (FLEX_START)."""
+    mock_create.return_value = VMConnectionInfo(host="10.0.0.1", username="", ssh_port=22)
+    await provision_cloud_vm(gpu_name="NVIDIA B200", gpu_count=8, ssh_key=ssh_key, provider="gcp")
+    assert mock_create.await_args_list[0].kwargs["provisioning_model"] == "FLEX_START"
+
+
 @patch.dict("os.environ", {"CLOUDRIFT_API_KEY": "test-key"})
 @patch("deplodock.provisioning.cloud.asyncio.sleep", new_callable=AsyncMock)
 @patch("deplodock.provisioning.cloud.cr_provider.create_instance", new_callable=AsyncMock)


### PR DESCRIPTION
Thread an optional --provisioning-model {FLEX_START,SPOT,STANDARD} through the orchestrator path (vm create gpu -> provision_cloud_vm -> _provision_candidate -> _provision_gcp) so on-demand (STANDARD) and Spot VMs inherit the full config.yaml / SSH treatment instead of the per-GPU hardware-table default. Without the flag behavior is unchanged (GPU_GCP_PROVISIONING_MODEL default). GCP-only; ignored for CloudRift candidates.

Add tests asserting the override reaches gcp_provider.create_instance and that the default still resolves from the hardware table. Update CLAUDE.md and commands/ARCHITECTURE.md.