### PR TITLE
ir: dependence-cone analysis API on Body — one slicing substrate for the cone-parsing rules

### DIFF
--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -146,6 +146,18 @@ Body walkers: `iter_body(body)` (pre-order; powers `for s in loop_op`),
 `Stmt.pretty(indent)` (rendered lines for kernel dumps; block stmts
 recurse via `pretty_body`).
 
+Dependence cones (`ir/stmt/body.py`): `Body.backward_cone(roots)` / `Body.forward_cone(seeds)` build a `Cone` —
+the subset of the body's immediate stmts closed under SSA dependence (a wrapper joins as a unit; internally-bound
+axes excluded), plus `external_reads`, the names read from outside (axis vars and enclosing/sibling scopes alike).
+Construction never fails: unresolved names are data, and chaining scope levels means seeding the next level's
+`backward_cone` with the previous one's `external_reads`. `Body.defs_die_at(members, roots=…, allowed=…)` is the
+matching escape check (may the cone be cut out, with only the designated consumers reading its roots?). This is
+the shared substrate behind the rules that slice cones (`_split_demoted`'s producer cut, `021`'s masked-load
+guard) — eligibility judgments stay in the rules, per `pipeline/passes/ARCHITECTURE.md`. Two dataflow walks
+deliberately do NOT use it: `classify_fragment_epilogue` (single pass interleaving reduce-scope flags with its
+negative-form blocker reporting) and `030_hoist_invariant_compute` (all-deps saturation under an axis-invariance
+predicate — a different operator than the cone's any-dep taint).
+
 `rewrite` has two distinct rename channels that must stay disjoint:
 `rename_ssa` carries **SSA-name** renames, `sigma` carries **axis**
 substitutions. `Load`/`Write` index exprs apply *both*

--- a/deplodock/compiler/ir/stmt/body.py
+++ b/deplodock/compiler/ir/stmt/body.py
@@ -13,11 +13,13 @@ Phase 1 surface (this file): the protocol that lets every
 ``tuple[Stmt, ...]`` site accept Body, plus :meth:`iter` / :meth:`map`
 as method-shaped wrappers around the existing free functions.
 
-Phase 2 (follow-up): def-use queries (``def_table``,
-``external_reads``, ``backward_slice_names``), type-filtered lookups
-(``loops``, ``loads``, ``stages``), region transforms
-(``replace_at``, ``partition_at``). Add as needed; the storage shape
-is already in place.
+Phase 2 surface: def-use queries (``definitions``, ``deps_closure``,
+``depends_on`` / ``independent``, ``deps_of``), type-filtered lookups
+(``loads``, ``writes``, ``accums``, …), and dependence cones
+(:class:`Cone`, :meth:`Body.backward_cone` / :meth:`Body.forward_cone`
+/ :meth:`Body.defs_die_at`) — the shared substrate behind the rules
+that slice computed-operand cones. Region transforms (``replace_at``,
+``partition_at``) remain follow-ups; add as needed.
 """
 
 from __future__ import annotations
@@ -31,6 +33,75 @@ from deplodock.compiler.ir.stmt.base import Stmt
 
 if TYPE_CHECKING:
     from deplodock.compiler.ir.stmt.leaves import Write
+
+
+@dataclass(frozen=True)
+class Cone:
+    """A dependence cone over ONE scope level: the subset of a Body's
+    immediate stmts closed under SSA dependence (in body order), plus every
+    name the cone reads from outside itself — sibling/enclosing scopes and
+    axis vars alike. Built by :meth:`Body.backward_cone` /
+    :meth:`Body.forward_cone`.
+
+    Construction never fails and applies no eligibility judgment: an
+    unresolved name is data (``external_reads``), not an error. Which
+    external reads are acceptable, which member kinds are cuttable, and
+    whether the cone's values escape (:meth:`Body.defs_die_at`) are the
+    calling rule's conditions — bail decisions stay in rules, the dataflow
+    walk lives here (``passes/ARCHITECTURE.md``: phrase conditions over cone
+    properties instead of re-walking shapes).
+
+    A member is a whole top-level stmt: a wrapper (Loop / Cond / Tile) joins
+    as a unit, exposing names per :func:`_exposed_defines` and reading per
+    :func:`_member_reads` (subtree rolled up, internally-bound axes
+    excluded). Axis vars from enclosing scopes survive into
+    ``external_reads`` — intersect with an axis-name set to get the cone's
+    axis usage, subtract it to get the SSA names that must resolve
+    elsewhere."""
+
+    members: tuple[Stmt, ...]
+    external_reads: frozenset[str]
+
+    @property
+    def loads(self) -> tuple[Stmt, ...]:
+        """Every ``Load`` in the members, nested included, body order —
+        the cone's leaf operands (dtype checks, graph resolution)."""
+        return Body(self.members).loads
+
+
+def _exposed_defines(s: Stmt) -> set[str]:
+    """SSA names ``s`` makes visible at its own scope level — own defines
+    plus every nested define. Deliberately identical to the tile helpers'
+    ``collect_invariant_names`` over-approximation: nested non-Accum names
+    don't truly cross a Loop boundary, but well-formed SSA never reads them
+    from outside, so resolving through them is harmless and cheap."""
+    out = set(s.defines())
+    for body in s.nested():
+        for c in body.iter():
+            out.update(c.defines())
+    return out
+
+
+def _member_reads(s: Stmt) -> frozenset[str]:
+    """Names ``s`` (incl. a whole wrapper subtree) reads from its enclosing
+    scope: SSA deps + Expr free vars (Load/Write indices, Select predicates,
+    Cond conditions), recursive, minus internally-defined names and axes
+    bound inside the subtree."""
+    reads: set[str] = set()
+    defs: set[str] = set()
+
+    def walk(st: Stmt, bound: frozenset[str]) -> None:
+        reads.update(set(st.deps()) - bound)
+        for e in st.exprs():
+            reads.update(e.free_vars() - bound)
+        defs.update(st.defines())
+        inner_bound = bound | st.binds_axes()
+        for body in st.nested():
+            for c in body:
+                walk(c, inner_bound)
+
+    walk(s, frozenset())
+    return frozenset(reads - defs)
 
 
 class Body(tuple[Stmt, ...]):
@@ -374,6 +445,96 @@ class Body(tuple[Stmt, ...]):
         ``s is None`` explicitly when the gate cares about externals."""
         defs = self.definitions
         return tuple(defs.get(d) for d in stmt.deps())
+
+    # -- dependence cones --------------------------------------------------
+
+    def backward_cone(self, roots: Iterable[str]) -> Cone:
+        """The backward dependence :class:`Cone` of ``roots`` over THIS
+        body's immediate stmts: every top-level member whose exposed names
+        transitively feed a root, in body order. Names resolving to no
+        member here (axis vars, enclosing/sibling scopes, buffer constants)
+        surface in ``external_reads`` — chain another scope level by seeding
+        its ``backward_cone`` with them. A root not defined at this level is
+        itself an external read (members come out empty)."""
+        by_name: dict[str, Stmt] = {}
+        for s in self:
+            for n in _exposed_defines(s):
+                by_name[n] = s
+        member_ids: set[int] = set()
+        external: set[str] = set()
+        pending = list(roots)
+        seen: set[str] = set()
+        while pending:
+            n = pending.pop()
+            if n in seen:
+                continue
+            seen.add(n)
+            s = by_name.get(n)
+            if s is None:
+                external.add(n)
+                continue
+            if id(s) in member_ids:
+                continue
+            member_ids.add(id(s))
+            pending.extend(_member_reads(s))
+        return Cone(members=tuple(s for s in self if id(s) in member_ids), external_reads=frozenset(external))
+
+    def forward_cone(self, seeds: Iterable[Stmt]) -> Cone:
+        """The forward (taint) :class:`Cone` of the ``seeds`` — top-level
+        stmts of this body — over THIS body's immediate stmts: the seeds
+        plus every member transitively reading a name they expose, to
+        fixpoint, in body order. ``external_reads`` are the member reads not
+        produced inside the cone (reads of earlier non-member siblings
+        included)."""
+        member_ids = {id(s) for s in seeds}
+        names: set[str] = set()
+        for s in seeds:
+            names.update(_exposed_defines(s))
+        reads = {id(s): _member_reads(s) for s in self}
+        changed = True
+        while changed:
+            changed = False
+            for s in self:
+                if id(s) in member_ids:
+                    continue
+                if reads[id(s)] & names:
+                    member_ids.add(id(s))
+                    names.update(_exposed_defines(s))
+                    changed = True
+        members = tuple(s for s in self if id(s) in member_ids)
+        external = set().union(*(reads.get(id(s), _member_reads(s)) for s in members)) if members else set()
+        return Cone(members=members, external_reads=frozenset(external - names))
+
+    def defs_die_at(self, members: Iterable[Stmt], *, roots: Iterable[str], allowed: Iterable[Stmt]) -> bool:
+        """True iff no stmt in this body outside ``members`` reads a name
+        they expose — except the ``allowed`` stmts, which may read names in
+        ``roots`` (and nothing else from the cone). The escape check for
+        cutting a cone out: its values must die at the designated consumers
+        (e.g. the matmul multiplies) or the cut would break a reader left
+        behind. ``members`` may span several scope levels of this body
+        (a cell cone plus its prologue deps); each member's whole subtree
+        counts as inside."""
+        members = tuple(members)  # may arrive as a generator; iterated twice
+        member_ids = {id(s) for s in members}
+        moved_defs: set[str] = set()
+        for s in members:
+            moved_defs |= _exposed_defines(s)
+        root_set = frozenset(roots)
+        allowed_ids = {id(s) for s in allowed}
+
+        def walk(stmts: Iterable[Stmt]) -> bool:
+            for s in stmts:
+                if id(s) in member_ids:
+                    continue  # the whole subtree moves; internal uses are fine
+                reads = set(s.deps()) & moved_defs
+                if reads and not (id(s) in allowed_ids and reads <= root_set):
+                    return False
+                for sub in s.nested():
+                    if not walk(sub):
+                        return False
+            return True
+
+        return walk(self)
 
     # -- type-filtered lookups -------------------------------------------
 

--- a/deplodock/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/passes/ARCHITECTURE.md
@@ -26,5 +26,9 @@ How to comply:
 - **Bail conservatively on well-formedness, never on shape identity.** `return None` / `RuleSkipped` for a body
   the rule doesn't fully understand is fine; the conditions must be structural properties (escaping values,
   symbolic extents, mixed dtypes), not "is this the X kernel".
+- **Phrase dataflow conditions over cones, don't hand-roll the walk.** `Body.backward_cone` / `forward_cone` /
+  `defs_die_at` (`ir/stmt/body.py`) are the shared slicing substrate: a rule asks for a cone and judges its
+  *properties* (members, external reads, escapes) — construction never fails, so every bail stays a rule-side
+  condition. See the dependence-cones section of `compiler/ir/ARCHITECTURE.md`.
 - **When generalizing an existing rule, normalize its incidental divergences** (one dtype rule, one index rule)
   and name the behavioral deltas explicitly in the commit — don't preserve two behaviors behind one entry point.

--- a/deplodock/compiler/pipeline/passes/lowering/tile/021_hoist_staged_loads_above_mask.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/021_hoist_staged_loads_above_mask.py
@@ -273,23 +273,12 @@ def _guard_unsafe_loads_in_body(body: Body, predicate, gated_vars: frozenset[str
     if not unsafe_idxs:
         return Body(tuple(stmts))
 
-    # Compute forward SSA cone seeded by the unsafe Loads' defined names.
-    # A stmt joins the cone when any of its ``deps()`` is already in the
-    # cone's defined-names set. Iterate to fixpoint.
-    cone_names: set[str] = set()
-    cone_idxs: set[int] = set(unsafe_idxs)
-    for i in unsafe_idxs:
-        cone_names.update(stmts[i].defines())
-    changed = True
-    while changed:
-        changed = False
-        for i, s in enumerate(stmts):
-            if i in cone_idxs:
-                continue
-            if any(d in cone_names for d in s.deps()):
-                cone_idxs.add(i)
-                cone_names.update(s.defines())
-                changed = True
+    # Forward SSA cone seeded by the unsafe Loads — everything transitively
+    # reading them joins (``Body.forward_cone``; subtree-aware, so a wrapper
+    # whose interior reads a cone name joins as a unit).
+    cone = Body(stmts).forward_cone([stmts[i] for i in unsafe_idxs])
+    pos = {id(s): i for i, s in enumerate(stmts)}
+    cone_idxs = {pos[id(m)] for m in cone.members}
 
     # Wrap the contiguous range covering all cone stmts in a Cond.
     # The cone is typically contiguous for matmul-style bodies (Load

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
@@ -49,7 +49,6 @@ matmul's own volume — the materialization that defeats the split).
 from __future__ import annotations
 
 import importlib
-from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -58,27 +57,33 @@ from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import LoopOp
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Stmt, Write
-from deplodock.compiler.pipeline.passes.lowering.tile._helpers import collect_invariant_names, is_matmul_reduce
+from deplodock.compiler.ir.stmt.body import Cone
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import is_matmul_reduce
 
 if TYPE_CHECKING:
     from deplodock.compiler.context import Context
 
 
 @dataclass
-class _Cone:
-    """One computed multiply operand: its backward slice over the three scopes,
-    the axes it reads (recursively, prologue/leading deps included), and the
-    uniform leaf dtype its ``xn`` buffer materializes at."""
+class _RootCone:
+    """One computed multiply operand: its chained backward :class:`Cone`\\ s
+    over the cell / prologue / leading scope levels, the axes it reads
+    (recursively, prologue/leading deps included), and the uniform leaf
+    dtype its ``xn`` buffer materializes at."""
 
     root: str
-    cell_used: set[int]
-    pro_used: set[int]
-    lead_used: set[int]
-    cell_stmts: list[Stmt]
-    pro_stmts: list[Stmt]
-    lead_stmts: list[Stmt]
-    axes: set[str]
+    cell: Cone
+    pro: Cone
+    lead: Cone
+    axes: frozenset[str]
     dtype: object
+
+    @property
+    def moved(self) -> tuple[Stmt, ...]:
+        """Members the cut MOVES into the producer — cell + prologue.
+        Leading stmts are copied, not moved (a shared one stays in both
+        kernels), so they're excluded from the escape check."""
+        return (*self.cell.members, *self.pro.members)
 
 
 def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: str, out_tensor: Tensor) -> Graph | None:
@@ -99,12 +104,12 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
     if not accums:
         return None
     roots: tuple[str, ...] | None = None
-    mul_ids: set[int] = set()
+    muls: list[Assign] = []
     for acc in accums:
         mul = cell_def.get(acc.value)
         if not isinstance(mul, Assign) or mul.op.name != "multiply" or len(mul.args) != 2:
             return None
-        mul_ids.add(id(mul))
+        muls.append(mul)
         cone_args: dict[str, None] = {}  # ordered de-dup (a squared cone appears twice)
         for a in mul.args:
             d = cell_def.get(a)
@@ -126,43 +131,39 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
     assert roots is not None
 
     # --- backward-slice each cone over the cell / prologue / leading scopes --
+    # Three chained Body.backward_cone calls, one per scope level: each
+    # level's unresolved external reads seed the next. After the last level
+    # only axis vars may remain unresolved.
     axis_names = {a.name for a in loop_op.axes}
-    pro_def = _prologue_defs(prologue_level)
-    lead_def = {n: s for s in leading for n in s.defines()}
-    cones: list[_Cone] = []
+    cones: list[_RootCone] = []
     for root in roots:
-        sliced = _slice_cone(root, cell_def=cell_def, pro_def=pro_def, lead_def=lead_def, axis_names=axis_names)
-        if sliced is None:
-            return None
-        cell_used, pro_used, lead_used = sliced
-        cell_stmts = [s for s in top if id(s) in cell_used]
-        if not cell_stmts:
+        cell_cone = k_loop.body.backward_cone((root,))
+        if not cell_cone.members:
             return None  # cone root must live in the cell (a K-invariant operand isn't this pattern)
-        pro_stmts = [s for s in prologue_level if id(s) in pro_used]
-        lead_stmts = [s for s in leading if id(s) in lead_used]
+        if any(isinstance(m, Accum) for m in cell_cone.members):
+            return None  # cone reads the matmul's own running accumulator — not cuttable
+        pro_cone = Body(prologue_level).backward_cone(cell_cone.external_reads)
+        lead_cone = Body(leading).backward_cone(pro_cone.external_reads)
+        if lead_cone.external_reads - axis_names:
+            return None  # name from an unmodeled scope — bail conservatively
         # Axes the materialization must cover: everything the moved stmts read
         # (prologue deps included — their row loops rebuild around the xn Write).
-        axes = _axes_read((*cell_stmts, *pro_stmts, *lead_stmts), axis_names)
+        axes = lead_cone.external_reads & axis_names
         if not axes <= set(row_names) | {k_name, n_name}:
             return None
-        dtype = _cone_dtype((cell_stmts, pro_stmts, lead_stmts), graph)
+        dtype = _cone_dtype((*cell_cone.loads, *pro_cone.loads, *lead_cone.loads), graph)
         if dtype is None:
             return None
-        cones.append(_Cone(root, cell_used, pro_used, lead_used, cell_stmts, pro_stmts, lead_stmts, axes, dtype))
+        cones.append(_RootCone(root, cell_cone, pro_cone, lead_cone, axes, dtype))
     if sum(1 for c in cones if n_name in c.axes) > 1:
         return None  # two (…, K, N) buffers would re-do the matmul's own volume
     for i, a in enumerate(cones):
         for b in cones[i + 1 :]:
-            if (a.cell_used & b.cell_used) or (a.pro_used & b.pro_used):
+            if {id(m) for m in a.moved} & {id(m) for m in b.moved}:
                 return None  # cones sharing a stmt would compute it in both producers
 
     # --- escape check: moved values must die at the multiplies ----------------
-    moved_ids = set().union(*(c.cell_used | c.pro_used for c in cones))
-    moved_defs: set[str] = set()
-    for c in cones:
-        for s in (*c.cell_stmts, *c.pro_stmts):
-            moved_defs |= collect_invariant_names(s)
-    if not _moved_defs_die_at_cone(Body(loop_op.body), moved_ids, moved_defs, frozenset(roots), mul_ids):
+    if not loop_op.body.defs_die_at((m for c in cones for m in c.moved), roots=roots, allowed=muls):
         return None
 
     # --- build one producer per cone -------------------------------------------
@@ -178,16 +179,16 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
         row_vars = tuple(Var(lp.axis.name) for lp in rows_used)
         reads_n = n_name in c.axes
         index = (*row_vars, Var(k_name), *((Var(n_name),) if reads_n else ()))
-        inner: tuple[Stmt, ...] = (*c.cell_stmts, Write(output=xn_id, index=index, values=(c.root,)))
+        inner: tuple[Stmt, ...] = (*c.cell.members, Write(output=xn_id, index=index, values=(c.root,)))
         if reads_n:
             # N innermost: the Write walks the buffer's last dim (coalesced) and
             # K lands second-to-last — the canonical B layout, even when the
             # original access was transposed [n, k].
             inner = (Loop(axis=outer_n.axis, body=Body(inner)),)
-        level: tuple[Stmt, ...] = (*c.pro_stmts, Loop(axis=k_loop.axis, body=Body(inner)))
+        level: tuple[Stmt, ...] = (*c.pro.members, Loop(axis=k_loop.axis, body=Body(inner)))
         for lp in reversed(rows_used):
             level = (Loop(axis=lp.axis, body=Body(level)),)
-        producer = LoopOp(body=Body((*c.lead_stmts, *level)))
+        producer = LoopOp(body=Body((*c.lead.members, *level)))
         producer.name = f"{loop_op.name}_xn{sfx}" if loop_op.name else ""
         shape = tuple(lp.axis.extent.as_static() for lp in rows_used) + (k_loop.axis.extent.as_static(),)
         if reads_n:
@@ -196,7 +197,7 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
         cone_loads[id(cell_def[c.root])] = Load(names=(c.root,), input=xn_id, index=index)
 
     # --- build the consumer ----------------------------------------------------
-    moved_cell = set().union(*(c.cell_used for c in cones))
+    moved_cell = {id(m) for c in cones for m in c.cell.members}
     new_top: list[Stmt] = []
     for s in top:
         repl = cone_loads.get(id(s))
@@ -212,12 +213,12 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
         body=Body(tuple(new_k_loop if s is k_loop else s for s in outer_n.body)),
         unroll=outer_n.unroll,
     )
-    pro_used_all = set().union(*(c.pro_used for c in cones))
+    pro_used_all = {id(m) for c in cones for m in c.pro.members}
     level = tuple(new_outer_n if s is outer_n else s for s in prologue_level if id(s) not in pro_used_all or s is outer_n)
     for lp in reversed(rows):
         level = (Loop(axis=lp.axis, body=Body(level)),)
     cons_id = f"{node_id}__mm"
-    lead_used_all = set().union(*(c.lead_used for c in cones))
+    lead_used_all = {id(m) for c in cones for m in c.lead.members}
     kept_lead = tuple(s for s in leading if id(s) not in lead_used_all)
     consumer_op = LoopOp(body=Body((*kept_lead, *level)))
     consumer_op = _rename_write_output(consumer_op, old=node_id, new=cons_id)
@@ -311,121 +312,14 @@ def _contains_matmul_reduce_loop(stmt: Stmt) -> bool:
     return any(_contains_matmul_reduce_loop(c) for body in stmt.nested() for c in body)
 
 
-def _external_reads(stmt: Stmt, axis_names: set[str]) -> set[str]:
-    """Names ``stmt`` (incl. a whole Loop subtree) reads from its enclosing
-    scope — all nested deps minus internally-defined names and loop axes."""
-    reads: set[str] = set()
-    defs: set[str] = set()
-
-    def walk(s: Stmt) -> None:
-        reads.update(s.deps())
-        defs.update(s.defines())
-        for body in s.nested():
-            if isinstance(s, Loop):
-                defs.add(s.axis.name)
-            for c in body:
-                walk(c)
-
-    walk(stmt)
-    return reads - defs - axis_names
-
-
-def _moved_defs_die_at_cone(
-    body: Body, moved_ids: set[int], moved_defs: set[str], cone_roots: frozenset[str], allowed_ids: set[int]
-) -> bool:
-    """True iff no stmt outside the moved set reads a moved def — except the
-    multiplies (``allowed_ids``) reading only ``cone_roots``."""
-
-    def walk(stmts) -> bool:
-        for s in stmts:
-            if id(s) in moved_ids:
-                continue  # the whole subtree moves; internal uses are fine
-            reads = set(s.deps()) & moved_defs
-            if reads and not (id(s) in allowed_ids and reads <= cone_roots):
-                return False
-            for sub in s.nested():
-                if not walk(sub):
-                    return False
-        return True
-
-    return walk(body)
-
-
-def _prologue_defs(prologue_level) -> dict[str, Stmt]:
-    """Map every cross-scope SSA name a prologue-level stmt exposes to that
-    stmt (a whole reduce Loop exposes its Accum names)."""
-    pro_def: dict[str, Stmt] = {}
-    for s in prologue_level:
-        for n in collect_invariant_names(s):
-            pro_def[n] = s
-    return pro_def
-
-
-def _slice_cone(
-    root: str, *, cell_def: dict[str, Stmt], pro_def: dict[str, Stmt], lead_def: dict[str, Stmt], axis_names: set[str]
-) -> tuple[set[int], set[int], set[int]] | None:
-    """Backward-slice ``root`` over the cell / prologue / leading scopes.
-    Returns the ``(cell, prologue, leading)`` used-stmt id-sets, or ``None``
-    when the cone reads the matmul's own running accumulator or a name from
-    an unmodeled scope."""
-    cell_used: set[int] = set()
-    pro_used: set[int] = set()
-    lead_used: set[int] = set()
-    pending = deque([root])
-    seen: set[str] = set()
-    while pending:
-        n = pending.popleft()
-        if n in seen or n in axis_names:
-            continue
-        seen.add(n)
-        s = cell_def.get(n)
-        if s is not None:
-            if isinstance(s, Accum):
-                return None  # cone reads the matmul's own running accumulator — not cuttable
-            cell_used.add(id(s))
-            pending.extend(s.deps())
-            continue
-        s = pro_def.get(n)
-        if s is not None:
-            pro_used.add(id(s))
-            pending.extend(_external_reads(s, axis_names))
-            continue
-        s = lead_def.get(n)
-        if s is not None:
-            lead_used.add(id(s))
-            pending.extend(s.deps())
-            continue
-        return None  # name from an unmodeled scope — bail conservatively
-    return cell_used, pro_used, lead_used
-
-
-def _axes_read(stmts, axis_names: set[str]) -> set[str]:
-    """Axis names appearing in the stmts' carried Exprs (Load / Write indices,
-    Select predicates), recursively — internally-bound axes (a prologue
-    reduce's own loop var) excluded. This is the data the cut uses to size
-    each cone's ``xn`` buffer and to tell row cones from N-reading cones."""
-    out: set[str] = set()
-
-    def walk(s: Stmt, bound: frozenset[str]) -> None:
-        out.update({v for e in s.exprs() for v in e.free_vars()} - bound)
-        inner_bound = bound | s.binds_axes()
-        for body in s.nested():
-            for child in body:
-                walk(child, inner_bound)
-
-    for s in stmts:
-        walk(s, frozenset())
-    return out & axis_names
-
-
-def _cone_dtype(stmts_triple, graph: Graph):
+def _cone_dtype(loads, graph: Graph):
     """The uniform dtype of every graph-resolvable Load in the cone's moved
     stmts — the dtype its ``xn`` buffer materializes at (value-preserving;
     identical to the multiply's other-operand dtype on every shape seen so
     far). ``None`` (bail) when a Load source is unresolvable or the leaf
     dtypes disagree."""
     dtypes = set()
-    for ld in Body(tuple(s for group in stmts_triple for s in group)).iter_of_type(Load):
+    for ld in loads:
         node = graph.nodes.get(ld.input)
         if node is None:
             return None

--- a/tests/compiler/ir/test_body_cone.py
+++ b/tests/compiler/ir/test_body_cone.py
@@ -1,0 +1,149 @@
+"""Unit tests for ``Body.backward_cone`` / ``forward_cone`` / ``defs_die_at``.
+
+The cone API is the shared dataflow substrate behind the rules that used to
+hand-roll slicing (``_split_demoted``, ``021_hoist_staged_loads_above_mask``)
+— see ``passes/ARCHITECTURE.md``. Construction never fails: unresolved names
+are ``external_reads``, and every eligibility judgment stays in the rule.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Write
+from deplodock.compiler.ir.stmt.body import Body
+from deplodock.compiler.ir.stmt.leaves import SelectBranch
+
+
+def _ld(name: str, src: str, *idx: str) -> Load:
+    return Load(name=name, input=src, index=tuple(Var(v) for v in idx))
+
+
+def _asn(name: str, op: str, *args: str) -> Assign:
+    return Assign(name=name, op=op, args=args)
+
+
+def _cell() -> Body:
+    """A demoted-matmul cell: ``p = cone(x) * w`` with a plain B load."""
+    return Body(
+        [
+            _ld("a0", "x", "m", "k"),
+            _asn("a1", "negative", "a0"),
+            _ld("b", "w", "k", "n"),
+            _asn("p", "multiply", "a1", "b"),
+            Accum(name="acc", value="p"),
+        ]
+    )
+
+
+# --- backward_cone ----------------------------------------------------
+
+
+def test_backward_cone_members_in_body_order():
+    body = _cell()
+    cone = body.backward_cone(["a1"])
+    assert [s.defines()[0] for s in cone.members] == ["a0", "a1"]
+
+
+def test_backward_cone_externals_carry_axes_not_members():
+    cone = _cell().backward_cone(["a1"])
+    # The cone reads its index axes from the enclosing scope; the resolved
+    # SSA chain (a0) is internal, the untouched B side absent entirely.
+    assert cone.external_reads == frozenset({"m", "k"})
+
+
+def test_backward_cone_root_not_defined_here_is_external():
+    """A root from another scope level yields no members and surfaces as an
+    external read — the chaining signal, not an error."""
+    cone = _cell().backward_cone(["stat"])
+    assert cone.members == ()
+    assert cone.external_reads == frozenset({"stat"})
+
+
+def test_backward_cone_wrapper_member_joins_whole():
+    """A reduce Loop resolves through its exposed Accum and joins as one
+    member; its own loop axis is internal, the row axis it reads is not."""
+    stat_loop = Loop(axis=Axis("r", 32), body=(_ld("s0", "x", "m", "r"), Accum(name="stat", value="s0", op="maximum")))
+    body = Body([stat_loop, _asn("e", "exp", "stat")])
+    cone = body.backward_cone(["e"])
+    assert cone.members == (stat_loop, body[1])
+    assert "r" not in cone.external_reads
+    assert "m" in cone.external_reads
+
+
+def test_backward_cone_select_predicate_axis_is_read():
+    """An axis reaching the cone only through a Select predicate counts as
+    read — materializing without it would drop a real dependence (the
+    rotate-half rotary shape)."""
+    body = Body(
+        [
+            _ld("a0", "x", "k"),
+            _ld("a1", "x", "m"),
+            Select(name="v", branches=(SelectBranch(value="a0", select=Var("n").lt(Var("m"))), SelectBranch(value="a1", select=Var("m")))),
+        ]
+    )
+    cone = body.backward_cone(["v"])
+    assert "n" in cone.external_reads
+
+
+# --- forward_cone -----------------------------------------------------
+
+
+def test_forward_cone_taints_transitive_readers():
+    body = _cell()
+    cone = body.forward_cone([body[0]])  # seed: the unsafe Load a0
+    assert [s.defines()[0] for s in cone.members] == ["a0", "a1", "p", "acc"]
+    # b is read by a member but produced outside the cone.
+    assert "b" in cone.external_reads
+
+
+def test_forward_cone_skips_independent_stmts():
+    body = _cell()
+    cone = body.forward_cone([body[2]])  # seed: the B-side Load
+    assert [s.defines()[0] for s in cone.members] == ["b", "p", "acc"]
+
+
+# --- defs_die_at ------------------------------------------------------
+
+
+def test_defs_die_at_allows_designated_consumer():
+    body = _cell()
+    cone = body.backward_cone(["a1"])
+    assert body.defs_die_at(cone.members, roots=["a1"], allowed=[body[3]]) is True
+
+
+def test_defs_die_at_rejects_escaping_read():
+    body = Body([*_cell(), Write(output="leak", index=(Var("m"),), values=("a1",))])
+    cone = body.backward_cone(["a1"])
+    assert body.defs_die_at(cone.members, roots=["a1"], allowed=[body[3]]) is False
+
+
+def test_defs_die_at_rejects_consumer_reading_past_root():
+    """The allowed consumer may read only the roots — a multiply that also
+    reads a cone-internal temp blocks the cut."""
+    body = Body(
+        [
+            _ld("a0", "x", "m", "k"),
+            _asn("a1", "negative", "a0"),
+            _ld("b", "w", "k", "n"),
+            _asn("p", "multiply", "a1", "a0"),
+            Accum(name="acc", value="p"),
+        ]
+    )
+    cone = body.backward_cone(["a1"])
+    assert body.defs_die_at(cone.members, roots=["a1"], allowed=[body[3]]) is False
+
+
+def test_defs_die_at_member_subtree_reads_are_internal():
+    """A wrapper member's internal uses of moved names don't count as
+    escapes — the whole subtree moves."""
+    body = Body(
+        [
+            _asn("c0", "negative", "z"),
+            Loop(axis=Axis("k", 8), body=(_ld("c1", "x", "k"), _asn("c2", "multiply", "c1", "c0"), Accum(name="acc", value="c2"))),
+            _asn("out", "exp", "acc"),
+        ]
+    )
+    cone = body.backward_cone(["acc"])
+    assert body[0] in cone.members and body[1] in cone.members
+    assert body.defs_die_at(cone.members, roots=["acc"], allowed=[body[2]]) is True


### PR DESCRIPTION
Cones are sliced all over the lowering tier (`_split_demoted`, `021_hoist_staged_loads_above_mask`, the epilogue classifier, `030`…), each rule hand-rolling the same dataflow walk. This promotes the cone to a first-class **analysis** object — deliberately not an IR statement: cone-ness is consumer-relative (the escape check is a *condition*, not a given) and a carried grouping would go stale under σ-rewrites/CSE/staging, so the boundary is derived on demand from the immutable `Body` (same cache discipline as `deps_closure`).

## New API (`ir/stmt/body.py`)

- **`Cone`** — `members` (immediate stmts of ONE scope level, closed under SSA dependence, in body order; a wrapper joins as a unit, internally-bound axes excluded) + `external_reads` (axis vars and enclosing/sibling-scope names alike). Construction never fails: an unresolved name is data, and chaining scope levels = seeding the next level's `backward_cone` with the previous level's `external_reads`. Every eligibility judgment stays in the calling rule — composing with the `passes/ARCHITECTURE.md` no-shape-dispatch invariant (rules judge cone *properties*, never walk shapes).
- **`Body.backward_cone(roots)`** / **`Body.forward_cone(seeds)`** — backward slice; any-dep taint to fixpoint.
- **`Body.defs_die_at(members, roots=…, allowed=…)`** — the escape check (may the cone be cut out, with only the designated consumers reading its roots?).

## Migrated

- `_split_demoted`: the three-scope slice is three chained `backward_cone` calls; `_slice_cone`, `_external_reads`, `_axes_read`, `_prologue_defs`, `_moved_defs_die_at_cone` deleted (~120 lines).
- `021_hoist_staged_loads_above_mask`: the forward fixpoint is one `forward_cone` call. The new walk is subtree-aware — a wrapper whose interior reads a cone name now joins the guarded region (the old `deps()`-only loop could leave it outside the `Cond`; strictly safer).

## Deliberately not migrated (documented in `ir/ARCHITECTURE.md`)

`classify_fragment_epilogue` (single pass interleaving reduce-scope flags with its negative-form blocker reporting) and `030_hoist_invariant_compute` (all-deps saturation under an axis-invariance predicate — a different operator than the cone's any-dep taint). Forcing them through the API would contort load-bearing gates for zero reduction.

## Verification

- 11 new unit tests (`tests/compiler/ir/test_body_cone.py`): member order, wrapper-as-unit, Select-predicate axis reads, cross-scope chaining signal, taint growth, all three escape-check polarities.
- Full suite green (1309 compiler + 506 other); `make lint` clean.
- GPU parity: both Qwen3 layer-0 SDPA reproducers reproduce their pinned-split numbers exactly (P@V 10.8 µs with the mma consumer; rotary+QK^T 7.2 µs, same kernels and knobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)