### PR TITLE
provenance: fix kernel naming — boundary prov leak, layout-op labels, unstable order

### DIFF
--- a/deplodock/compiler/ARCHITECTURE.md
+++ b/deplodock/compiler/ARCHITECTURE.md
@@ -127,10 +127,17 @@ It rides on one chokepoint: `Graph.splice` calls `provenance.propagate` with a `
 fragment node as a fresh piece of the consumed origins; fusion / lifting / optimization folds *aggregate* the consumed
 piece sets onto the merged node (unioning the dissolved producers so a multi-output splice drops nothing). Lowering is
 in-place `Op` rebinds, so prov rides through `LoopOp → TileOp → KernelOp → CudaOp` untouched. Seeded once at
-`Pipeline.tune` entry (idempotent); pure metadata, excluded from structural / cache keys.
+`Pipeline.tune` entry (idempotent); pure metadata, excluded from structural / cache keys. Boundary sentinels
+(`InputOp`/`ConstantOp`) never carry prov: `put` refuses to stamp them and `propagate` scrubs splice outputs that land
+on one (the generic hint merge would otherwise copy prov onto e.g. the ConstantOp produced by the sm_90+
+weight-transpose fold, inflating `totals` so every kernel of that origin read partial coverage).
 
 Consumers: `provenance.name_for` (called from `pipeline/passes/loop/fusion/991_stamp_loop_names`, the last
 loop-dialect rule) names kernels after the ops they realize (`k_rms_norm` when full, `k_rms_norm_reduce` when partial)
 and stamps the name onto `LoopOp.name`; every subsequent dialect (`TileOp`/`KernelOp`/`CudaOp`) just copies it
-through. `pipeline/dump._dump_torch_repro` slices the pristine frontend graph by a kernel's origins into a runnable
+through. Multi-op labels sort dominant-first (descending piece count, lexical tie-break), so the name is independent
+of fusion merge order — the attention kernel is `k_sdpa_linear_reduce`, its QKV-prologue twin `k_linear_sdpa_reduce`.
+Layout/plumbing origins (`_WEAK_KINDS`: transpose / reshape / unsqueeze / cat / slice) label a kernel only when no
+strong op is present — RoPE plumbing fused into attention doesn't pollute the name, while a standalone copy kernel
+still reads `k_cat_…` instead of the node-id fallback. `pipeline/dump._dump_torch_repro` slices the pristine frontend graph by a kernel's origins into a runnable
 `<kname>.torch.json`; `backend/torch_ref` runs that slice through real torch for the `run --ir` vs-torch comparison.

--- a/deplodock/compiler/provenance.py
+++ b/deplodock/compiler/provenance.py
@@ -51,8 +51,12 @@ def get(node: Node) -> dict:
 
 
 def put(node: Node, prov: dict) -> None:
-    """Store ``prov`` on ``node``, dropping the hint entirely when empty."""
-    if prov:
+    """Store ``prov`` on ``node``, dropping the hint entirely when empty.
+
+    Boundary sentinels never carry provenance (see :data:`_SKIP`): storing onto
+    one clears any stale hint instead — e.g. prov copied by ``Graph.splice``'s
+    generic hint merge when a fold collapses a compute op into a constant."""
+    if prov and not is_boundary(node.op):
         node.hints.set(PROV, prov)
     else:
         node.hints.remove(PROV)
@@ -130,7 +134,18 @@ def propagate(
       fragment output inherits its own consumed node's pieces unioned with the
       ``shared`` pieces of every *dissolved* consumed node (those not in
       ``output_map`` — e.g. a producer inlined into all its consumers), so no
-      origin is dropped at a multi-output splice."""
+      origin is dropped at a multi-output splice.
+
+    A fragment output that is a boundary sentinel (e.g. a fold collapsing a
+    transpose into its parameter ``ConstantOp``) gets its prov scrubbed instead:
+    the splice's generic hint merge copied the consumed node's hints — prov
+    included — onto it, and a boundary must never carry provenance (its pieces
+    would inflate :func:`totals` and make every other kernel of the origin read
+    as partial coverage)."""
+    for new_out in new_by_old.values():
+        node = graph.nodes[new_out]
+        if is_boundary(node.op):
+            node.hints.remove(PROV)
     if mint_pieces:
         origins_kind = origins(union(*consumed_prov.values())) if consumed_prov else {}
         for nid in new_compute_ids:
@@ -163,6 +178,12 @@ def coverage(node_prov: dict, all_totals: dict[str, set[str]]) -> dict[str, tupl
 # sdpa / …) is also present, the glue is dropped from the label.
 _GENERIC_KINDS = frozenset({"ElementwiseOp", "ReduceOp", "ScanOp", "IndexMapOp", "GatherOp", "ScatterOp"})
 
+# Frontend layout/plumbing ops label a kernel only when no strong op is present:
+# an attention kernel that also absorbs RoPE's cat/slice/unsqueeze plumbing
+# stays ``k_sdpa_…``, while a standalone copy kernel (e.g. a cat feeding a graph
+# output) still reads ``k_cat_…`` instead of the node-id fallback.
+_WEAK_KINDS = frozenset({"TransposeOp", "ReshapeOp", "UnsqueezeOp", "CatOp", "SliceOp"})
+
 
 def _humanize_kind(kind: str) -> str:
     """``RmsNormOp`` → ``rms_norm``, ``SdpaOp`` → ``sdpa`` (CamelCase→snake, drop ``Op``)."""
@@ -191,8 +212,11 @@ def name_for(loop: LoopOp, base_name: str, node_prov: dict, all_totals: dict[str
     A kernel that fully realizes exactly one meaningful op gets ``k_<op>_<h>``
     (e.g. ``k_rms_norm_3f2a1b``); a partial one keeps the ``_<reduce|pointwise>``
     qualifier so the reduce half is told apart from the pointwise tail. Multiple
-    meaningful ops join (``k_linear_sdpa_...``). With no provenance (or only glue
-    ops) it falls back to the node-id name.
+    meaningful ops join dominant-first — sorted by descending piece count (the op
+    the kernel mostly implements leads, e.g. ``k_sdpa_linear_...``), ties broken
+    lexically — so the label is independent of fusion merge order. Layout ops
+    (:data:`_WEAK_KINDS`) label the kernel only when no strong op is present;
+    with no provenance (or only glue ops) it falls back to the node-id name.
 
     ``<h>`` is a short structural-body hash: prov labels are *not* unique (two
     rms_norms, or SDPA's two distinct reduce kernels, share a label), but the
@@ -207,10 +231,12 @@ def name_for(loop: LoopOp, base_name: str, node_prov: dict, all_totals: dict[str
     from deplodock.compiler.ir.stmt import Accum
 
     suffix = "reduce" if any(isinstance(s, Accum) for s in loop) else "pointwise"
-    meaningful = [oid for oid, e in node_prov.items() if e["kind"] not in _GENERIC_KINDS]
+    strong = [oid for oid, e in node_prov.items() if e["kind"] not in _GENERIC_KINDS | _WEAK_KINDS]
+    meaningful = strong or [oid for oid, e in node_prov.items() if e["kind"] in _WEAK_KINDS]
     if not meaningful:
         return f"k_{_dedup_tokens(base_name)}_{suffix}"
 
+    meaningful.sort(key=lambda oid: (-len(set(node_prov[oid]["pieces"])), _humanize_kind(node_prov[oid]["kind"])))
     labels: list[str] = []
     for oid in meaningful:
         lbl = _humanize_kind(node_prov[oid]["kind"])

--- a/tests/compiler/ir/test_provenance.py
+++ b/tests/compiler/ir/test_provenance.py
@@ -39,6 +39,19 @@ def test_seed_stamps_compute_skips_boundary():
     assert prov.get(g.nodes[b]) == {}
 
 
+def test_put_skips_boundary_and_clears_stale_prov():
+    """Boundary sentinels never carry prov: ``put`` onto one is a no-op, and it
+    clears a stale hint (e.g. prov copied by ``Graph.splice``'s generic hint
+    merge when a fold collapses a compute op into a constant)."""
+    g, a, _, _, _ = _graph()
+    prov.put(g.nodes[a], {"o": {"kind": "LinearOp", "pieces": ["p"]}})
+    assert prov.get(g.nodes[a]) == {}
+    # A stale hint planted behind put's back is scrubbed by the next put.
+    g.nodes[a].hints.set(prov.PROV, {"o": {"kind": "LinearOp", "pieces": ["p"]}})
+    prov.put(g.nodes[a], {"o": {"kind": "LinearOp", "pieces": ["q"]}})
+    assert prov.get(g.nodes[a]) == {}
+
+
 def test_seed_idempotent():
     g, _, _, ew, _ = _graph()
     prov.seed(g)
@@ -145,6 +158,46 @@ def test_fusion_aggregates_origins():
     assert set(merged) == {ew, c}
     assert merged[ew]["kind"] == "ElementwiseOp"
     assert merged[c]["kind"] == "ReduceOp"
+
+
+def test_constant_fold_strands_no_prov_on_boundary():
+    """``050_fold_into_constant`` (sm_90+ TMA path) collapses the weight
+    transpose minted by the Linear decomposition into a parameter ConstantOp.
+    The splice's generic hint merge used to copy the transpose's prov onto that
+    constant, inflating ``totals`` so the matmul kernel read partial coverage
+    (the spurious ``k_linear_reduce`` instead of ``k_linear``). No boundary node
+    may carry prov, and ``totals`` must equal the union over compute nodes."""
+    from deplodock.compiler import target as target_mod
+    from deplodock.compiler.ir.base import ConstantOp
+    from deplodock.compiler.ir.frontend.ir import LinearOp
+    from deplodock.compiler.pipeline import Pipeline
+
+    g = Graph()
+    x = g.add_node(InputOp(), [], Tensor("x", (8, 16)))
+    w = g.add_node(
+        ConstantOp(name="w", source_path="linear.weight", source_shape=(16, 16), source_dtype="float32"),
+        [],
+        Tensor("w", (16, 16)),
+    )
+    g.inputs = [x]
+    lin = g.add_node(LinearOp(), [x, w], Tensor("linear_0", (8, 16)))
+    g.outputs = [lin]
+
+    target_mod.set_target((9, 0))
+    try:
+        out = Pipeline.build(["frontend/decomposition"]).run(g)
+    finally:
+        target_mod.set_target(None)
+
+    folded = [n for n in out.nodes.values() if isinstance(n.op, ConstantOp) and n.op.load_ops]
+    assert folded, "the weight transpose should have been folded into the ConstantOp"
+    for node in out.nodes.values():
+        if prov.is_boundary(node.op):
+            assert prov.get(node) == {}, f"boundary node carries prov: {prov.get(node)}"
+    compute_pieces: set[str] = set()
+    for node in out.nodes.values():
+        compute_pieces.update(prov.get(node).get("linear_0", {}).get("pieces", []))
+    assert prov.totals(out)["linear_0"] == compute_pieces
 
 
 def test_rms_norm_fully_covered_after_full_pipeline():

--- a/tests/compiler/passes/test_loop_naming.py
+++ b/tests/compiler/passes/test_loop_naming.py
@@ -63,6 +63,40 @@ def test_every_loop_op_has_name_after_loop_passes():
     assert all(n.op.name and n.op.name.startswith("k_") for n in loops), [n.op.name for n in loops]
 
 
+def test_single_kernel_linear_has_no_qualifier_under_sm90_fold():
+    """A bias-free Linear lowers to one kernel that IS the whole op, so the
+    name is ``k_linear_<6hex>`` — no ``_reduce``. Regression: the sm_90+
+    weight-transpose fold (``050_fold_into_constant``) used to strand a prov
+    piece on the folded ConstantOp, inflating ``totals`` so the kernel read
+    partial coverage and kept the qualifier."""
+    import re
+
+    from deplodock.compiler import target as target_mod
+    from deplodock.compiler.ir.base import ConstantOp
+    from deplodock.compiler.ir.frontend.ir import LinearOp
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (8, 16)), node_id="x")
+    g.add_node(
+        ConstantOp(name="w", source_path="linear.weight", source_shape=(16, 16), source_dtype="float32"),
+        [],
+        Tensor("w", (16, 16)),
+        node_id="w",
+    )
+    g.add_node(LinearOp(), ["x", "w"], Tensor("linear_0", (8, 16)), node_id="linear_0")
+    g.inputs, g.outputs = ["x"], ["linear_0"]
+
+    target_mod.set_target((9, 0))
+    try:
+        out = Pipeline.build(LOOP_PASSES).run(g)
+    finally:
+        target_mod.set_target(None)
+
+    names = [n.op.name for n in out.nodes.values() if isinstance(n.op, LoopOp)]
+    assert len(names) == 1, names
+    assert re.fullmatch(r"k_linear_[0-9a-f]{6}", names[0]), names[0]
+
+
 # ---------------------------------------------------------------------------
 # Rule idempotence
 # ---------------------------------------------------------------------------
@@ -135,6 +169,46 @@ def test_name_for_partial_coverage_keeps_qualifier():
     totals = {"rms_norm_0": {"o", "other_piece"}}
     name = prov.name_for(loop, "o", prov_map, totals)
     assert name.startswith("k_rms_norm_pointwise_")
+
+
+def test_name_for_drops_weak_kinds_when_strong_present():
+    """Layout/plumbing origins (transpose / reshape / unsqueeze / cat / slice)
+    never label a kernel that also carries a strong op — RoPE plumbing fused
+    into attention stays ``k_sdpa_…``, not ``k_sdpa_cat_slice_…``."""
+    loop = _pointwise_loop()
+    prov_map = {
+        "sdpa_0": {"kind": "SdpaOp", "pieces": ["p1", "p2"]},
+        "cat_0": {"kind": "CatOp", "pieces": ["p3"]},
+        "slice_0": {"kind": "SliceOp", "pieces": ["p4"]},
+        "transpose_0": {"kind": "TransposeOp", "pieces": ["p5"]},
+    }
+    totals = {oid: set(e["pieces"]) for oid, e in prov_map.items()}
+    name = prov.name_for(loop, "o", prov_map, totals)
+    assert name.startswith("k_sdpa_") and "cat" not in name and "slice" not in name and "transpose" not in name
+
+
+def test_name_for_pure_weak_kernel_uses_weak_label():
+    """A kernel whose only origins are layout ops (e.g. a standalone cat copy)
+    still gets the descriptive weak label, not the node-id fallback."""
+    loop = _pointwise_loop()
+    prov_map = {"cat_0": {"kind": "CatOp", "pieces": ["o"]}}
+    totals = {"cat_0": {"o"}}
+    name = prov.name_for(loop, "merged_lift_n42", prov_map, totals)
+    assert name.startswith("k_cat_")
+
+
+def test_name_for_order_is_dominant_first_and_merge_order_independent():
+    """Labels sort by descending piece count (the op the kernel mostly
+    implements leads), so the name is the same whatever order fusion merged
+    the origins in."""
+    loop = _pointwise_loop()
+    sdpa = {"kind": "SdpaOp", "pieces": ["p1", "p2", "p3"]}
+    linear = {"kind": "LinearOp", "pieces": ["p4"]}
+    totals = {"sdpa_0": {"p1", "p2", "p3"}, "linear_0": {"p4", "elsewhere"}}
+    a = prov.name_for(loop, "o", {"sdpa_0": dict(sdpa), "linear_0": dict(linear)}, totals)
+    b = prov.name_for(loop, "o", {"linear_0": dict(linear), "sdpa_0": dict(sdpa)}, totals)
+    assert a == b
+    assert a.startswith("k_sdpa_linear_")
 
 
 def test_name_for_dedups_repeated_labels():

--- a/tests/compiler/passes/test_partition_planner_mma.py
+++ b/tests/compiler/passes/test_partition_planner_mma.py
@@ -615,7 +615,8 @@ def test_planner_mma_name_pin_enables_pre_sm90(monkeypatch):
 
 def _sdpa_av_loop_op(*, B0: int = 16, M: int = 32, N: int = 128, K: int = 32) -> LoopOp:
     """The SDPA cone-split attn@V cell shape that crashed the whole-layer
-    tune (k_sdpa_transpose_reshape_linear_reduce under ``SPLIT_CONE=1`` +
+    tune (k_sdpa_linear_reduce — k_sdpa_transpose_reshape_linear_reduce
+    before layout ops were dropped from labels — under ``SPLIT_CONE=1`` +
     ``MMA``): A is 3-D ``(batch, m, k)`` — K in the LAST dim — and B is the
     4-D V slab ``(0, k, 0, n)`` — K in a MIDDLE dim (dim 1 of 4), matched by
     neither the K-in-first nor the K-in-last test. The 5-D Write's leading


### PR DESCRIPTION
## Problem

Provenance-derived kernel names read weird — e.g. a single-kernel `nn.Linear` named
`k_linear_reduce_bd419b` despite fully realizing the op, and TinyLlama layer-0 producing
`k_sdpa_transpose_reshape_linear_unsqueeze_cat_slice_reduce_f6bcb0` with the same op set ordered
differently across sibling kernels.

## Root causes & fixes (all in `deplodock/compiler/provenance.py`)

1. **Spurious `_reduce`**: `050_fold_into_constant` (sm_90+ TMA path) collapses the weight
   `TransposeOp` into a parameter `ConstantOp`; `Graph.splice`'s generic hint merge copied the
   consumed prov onto that boundary node, violating the module's documented invariant. The stranded
   piece inflated `totals()` → 9/10 coverage → partial → qualifier kept. Also corrupted the `i/N`
   coverage header in `.torch.json` dump reproducers. **Fix**: `put()` refuses to stamp boundary
   sentinels (clearing stale hints); `propagate()` scrubs boundary splice outputs.

2. **Layout-op label pollution**: new `_WEAK_KINDS` tier (transpose / reshape / unsqueeze / cat /
   slice) labels a kernel only when no strong op is present — RoPE plumbing no longer pollutes
   attention-kernel names, while a standalone copy kernel still reads `k_cat_…` instead of the
   node-id fallback.

3. **Unstable label order**: labels now sort dominant-first (descending piece count in the kernel,
   lexical tie-break) instead of fusion-merge order.

## Before / after (TinyLlama layer 0)

| before | after |
|---|---|
| `k_linear_reduce_597e3f` | `k_linear_597e3f` |
| `k_sdpa_transpose_reshape_linear_unsqueeze_cat_slice_reduce_f6bcb0` | `k_sdpa_linear_reduce_f6bcb0` |
| `k_linear_reshape_transpose_sdpa_reduce_ca4d0b` | `k_linear_sdpa_reduce_ca4d0b` |
| `k_sdpa_transpose_reshape_linear_reduce_e6cacb` | `k_sdpa_linear_reduce_e6cacb` |
| `k_linear_mean_reduce_2e8871` | unchanged (mean stays a strong label) |

`k_linear` vs `k_sdpa_linear`/`k_linear_sdpa` ordering is now semantic: the op the kernel mostly
implements leads.

## Blast radius

Cache keys (`op_cache_key` strips kernel names; structural keys ignore hints), tune DB, golden
YAMLs, and `compare`'s hash-stripped base-name matching are all name-independent — no persisted
data is invalidated.

## Testing

- New unit + end-to-end tests (boundary `put`, sm_90 fold repro asserting no boundary carries prov
  and the user-visible `k_linear_<6hex>` name, weak-tier selection, order independence) — all five
  fail against the unfixed code.
- `make test`: 1886 passed, 29 skipped; `make lint` clean.
- Empirical: `deplodock compile --code "torch.nn.Linear(512, 512)(torch.randn(8, 512))" --ir loop`
  → `k_linear_bd419b`; TinyLlama layer-0 names as in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)