### PR TITLE
vLLM embedding plugin: deplodock-compiled kernels behind /v1/embeddings + Qwen3-Embedding A/B recipes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Deplodock is a Python tool for deploying and benchmarking LLM inference on GPU s
 The `README.md` is intentionally short — example-driven, no narrative. For details, consult the ARCHITECTURE.md files:
 
 - **CLI usage** (deploy local/ssh/cloud, bench, teardown, vm, hardware-aware deploy, fixed-host mode, experiments, CI workflow) → [`deplodock/commands/ARCHITECTURE.md`](deplodock/commands/ARCHITECTURE.md)
+- **Serving** (vLLM out-of-tree embedding plugin — deplodock-compiled kernels behind vLLM's `/v1/embeddings`; `serving` extra) → [`deplodock/serving/ARCHITECTURE.md`](deplodock/serving/ARCHITECTURE.md)
 - **Recipe format** (matrices/cross/zip combinators, variant filtering, deep merge, named fields, extra_args validation, command recipes, aggregate, docker_options, driver/cuda pinning, SGLang) → [`deplodock/recipe/ARCHITECTURE.md`](deplodock/recipe/ARCHITECTURE.md)
 - **Compiler** (Graph IR dialects, passes, backends) → [`deplodock/compiler/ARCHITECTURE.md`](deplodock/compiler/ARCHITECTURE.md) and child docs
 
@@ -25,7 +26,7 @@ When the user asks about a CLI flag, recipe field, or matrix combinator, read th
 
 All `DEPLODOCK_*` config env vars (the two above plus `DEPLODOCK_NVCC_FLAGS`, `DEPLODOCK_DEBUG`, `DEPLODOCK_KNOBS`,
 `DEPLODOCK_TUNE_PATIENCE`, `DEPLODOCK_TUNE_EPS`, `DEPLODOCK_O3_TOL`, `DEPLODOCK_BENCH_BACKENDS`, `DEPLODOCK_CUBIN_CACHE`,
-`DEPLODOCK_NO_NVCC`, `DEPLODOCK_GPU_LOCK`,
+`DEPLODOCK_NO_NVCC`, `DEPLODOCK_GPU_LOCK`, `DEPLODOCK_SERVING_DTYPE`,
 …) are read and written through a single module, `deplodock/config.py` — the sole owner of `os.environ` for these vars.
 CLI `--flag` overrides (e.g. `--nvcc-flags`) resolve via `config.set_nvcc_flags` inside the library, not in the command
 layer, so programmatic callers and tests get the same precedence. The dynamic `DEPLODOCK_<KNOB>` namespace is owned by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,13 @@ same worker.
 - `deplodock vm create cloudrift ...` — create a specific CloudRift GPU VM (single-shot manual)
 - `deplodock vm delete gcp ...` — delete a GCP GPU VM
 - `deplodock vm delete cloudrift ...` — delete a CloudRift GPU VM
+- `deplodock serve <model> [--stock] [--bench] [vllm flags...]` — serve an embedding model via `vllm serve` with the
+  deplodock plugin flags baked in (`--runner pooling --enforce-eager --hf-overrides …DeplodockEmbedModel…`, default
+  `--max-model-len 4096`); unrecognized flags forward to vLLM (after a literal `--`, verbatim). `--stock` drops the
+  plugin for the raw-vLLM baseline (same max-model-len → apples-to-apples A/B in two invocations). `--bench` makes it
+  a one-shot benchmark: start server → wait `/health` → `vllm bench serve --backend openai-embeddings`
+  (`--max-concurrency`/`--num-prompts`/`--random-input-len`/`--bench-seed`) → print results → shut down. Needs the
+  `serving` extra.
 - `deplodock pull <model>` — download a HuggingFace model to local cache
 - `deplodock trace <model> [--layer N] [--seq-len N]` — trace a transformer layer (or the whole model if `--layer` is omitted) to Graph IR (JSON). Whole-model tracing patches HF's dynamic causal-mask construction via `trace.huggingface.build_full_model_wrapper`.
 - `deplodock trace --code "EXPR"` — trace an inline `nn.Module` expression (last stmt must be a call, e.g. `"torch.nn.RMSNorm(2048)(torch.randn(1,32,2048))"`)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ help:
 	@echo "  bench          - Run benchmarks in parallel"
 	@echo "  bench-force    - Run benchmarks in parallel (force re-run, skip cached results)"
 	@echo "  bench-kernels  - Run per-kernel perf comparison vs PyTorch (tests/perf/, requires CUDA)"
+	@echo "  wheel          - Build the deplodock wheel into dist/"
+	@echo "  vllm-deplodock-image - Build the vLLM + deplodock serving image (docker/vllm-deplodock)"
+	@echo "  vllm-deplodock-push  - Push the serving image to Docker Hub (cloudriftai/)"
 	@echo "  clean          - Remove virtual environment and generated files"
 	@echo "  test-compose   - Test docker-compose generation with sample config"
 
@@ -50,6 +53,21 @@ tune-kernels: setup
 	@rm -f /tmp/deplodock-gpu.lock
 	@rm -f ~/.cache/deplodock/tune-kernels.db
 	DEPLODOCK_TUNE=1 DEPLODOCK_TUNE_DB=~/.cache/deplodock/tune-kernels.db ./venv/bin/pytest tests/perf/ -m perf -n 4 --dist=loadgroup -v -p no:randomly --no-header
+
+# --- vLLM + deplodock serving image (deplodock/serving, docker/vllm-deplodock) ---
+VLLM_VERSION ?= v0.22.1
+VLLM_DEPLODOCK_TAG ?= cloudriftai/vllm-deplodock:$(patsubst v%,%,$(VLLM_VERSION))-$(shell git rev-parse --short HEAD)
+
+wheel: setup
+	./venv/bin/pip install --quiet build
+	rm -rf dist && ./venv/bin/python -m build --wheel -o dist/ .
+
+vllm-deplodock-image: wheel
+	docker build -f docker/vllm-deplodock/Dockerfile --build-arg VLLM_VERSION=$(VLLM_VERSION) \
+		-t $(VLLM_DEPLODOCK_TAG) .
+
+vllm-deplodock-push: vllm-deplodock-image
+	docker push $(VLLM_DEPLODOCK_TAG)
 
 bench: setup
 	@echo "Running benchmarks..."

--- a/README.md
+++ b/README.md
@@ -171,6 +171,21 @@ deplodock deploy ssh --recipe recipes/GLM-4.6-FP8 --ssh user@host --teardown
 deplodock deploy ssh --recipe recipes/GLM-4.6-FP8 --ssh user@host --dry-run
 ```
 
+## Serve (compiled embeddings via vLLM)
+
+```bash
+# vLLM's OpenAI shell (/v1/embeddings, tokenizer, scheduler, pooler) over deplodock-compiled kernels
+pip install -e ".[compile,serving]"
+vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \
+  --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
+
+curl localhost:8000/v1/embeddings -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-Embedding-0.6B","input":"Hello"}'
+```
+
+See [`deplodock/serving/ARCHITECTURE.md`](deplodock/serving/ARCHITECTURE.md); embedding recipes
+(`recipes/Qwen3-Embedding-*`) A/B this against stock vLLM via `deplodock bench`.
+
 ## Recipe
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -176,11 +176,14 @@ deplodock deploy ssh --recipe recipes/GLM-4.6-FP8 --ssh user@host --dry-run
 ```bash
 # vLLM's OpenAI shell (/v1/embeddings, tokenizer, scheduler, pooler) over deplodock-compiled kernels
 pip install -e ".[compile,serving]"
-vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \
-  --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
+deplodock serve Qwen/Qwen3-Embedding-0.6B                  # extra flags pass through to vllm serve
 
 curl localhost:8000/v1/embeddings -H 'Content-Type: application/json' \
   -d '{"model":"Qwen/Qwen3-Embedding-0.6B","input":"Hello"}'
+
+# One-shot benchmark (vllm bench serve against the started server), and the raw-vLLM baseline
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock
 ```
 
 See [`deplodock/serving/ARCHITECTURE.md`](deplodock/serving/ARCHITECTURE.md); embedding recipes

--- a/README.md
+++ b/README.md
@@ -286,11 +286,13 @@ make format    # auto-fix
       - [cuda/](deplodock/compiler/backend/cuda/) — CUDA backend internals (see [ARCHITECTURE.md](deplodock/compiler/backend/cuda/ARCHITECTURE.md))
     - [tuning.py](deplodock/compiler/tuning.py) — autotuning utilities
   - [recipe/](deplodock/recipe/) — Recipe loading, dataclass types, engine flag mapping (see [ARCHITECTURE.md](deplodock/recipe/ARCHITECTURE.md))
+  - [serving/](deplodock/serving/) — vLLM out-of-tree embedding plugin (see [ARCHITECTURE.md](deplodock/serving/ARCHITECTURE.md))
   - [deploy/](deplodock/deploy/) — Compose generation, deploy orchestration
   - [provisioning/](deplodock/provisioning/) — Cloud provisioning, SSH transport, VM lifecycle
   - [benchmark/](deplodock/benchmark/) — Benchmark tracking, config, task enumeration, execution
   - [planner/](deplodock/planner/) — Groups benchmark tasks into execution groups for VM allocation
 - [recipes/](recipes/) — Model deploy recipes (YAML configs per model)
+- [docker/](docker/) — Custom image builds ([vllm-deplodock](docker/vllm-deplodock/) — vLLM + the deplodock plugin)
 - [experiments/](experiments/) — Experiment parameter sweeps (self-contained recipe + results)
 - [kernels/](kernels/) — Standalone CUDA kernel sources
 - [docs/](docs/) — Technical notes and engine-specific guides

--- a/deplodock/benchmark/workload.py
+++ b/deplodock/benchmark/workload.py
@@ -28,26 +28,36 @@ def extract_benchmark_results(output: str) -> str:
     return output[idx:]
 
 
+def _bench_args(recipe: Recipe) -> list[str]:
+    """The vllm bench serve argument list shared by the display string and the
+    docker invocation. Embedding recipes target /v1/embeddings via the
+    openai-embeddings backend and have no output length (nothing is generated)."""
+    bench = recipe.benchmark
+    num_instances = calculate_num_instances(recipe)
+    port = 8080 if num_instances > 1 else 8000
+    args = [
+        f"--model {recipe.model_name}",
+        "--trust-remote-code",
+    ]
+    if recipe.is_embedding:
+        args += ["--backend openai-embeddings", "--endpoint /v1/embeddings"]
+    args += [
+        f"--max-concurrency {bench.max_concurrency}",
+        f"--num-prompts {bench.num_prompts}",
+        f"--random-input-len {bench.random_input_len}",
+    ]
+    if not recipe.is_embedding:
+        args.append(f"--random-output-len {bench.random_output_len}")
+    args.append(f"--base-url http://localhost:{port}")
+    return args
+
+
 def build_bench_command(recipe: Recipe) -> str:
     """Build the vllm bench serve command string (without docker wrapper).
 
     Returns the bench command as a human-readable multi-line string.
     """
-    bench = recipe.benchmark
-    model_name = recipe.model_name
-    num_instances = calculate_num_instances(recipe)
-    port = 8080 if num_instances > 1 else 8000
-
-    return (
-        f"vllm bench serve\n"
-        f"    --model {model_name}\n"
-        f"    --trust-remote-code\n"
-        f"    --max-concurrency {bench.max_concurrency}\n"
-        f"    --num-prompts {bench.num_prompts}\n"
-        f"    --random-input-len {bench.random_input_len}\n"
-        f"    --random-output-len {bench.random_output_len}\n"
-        f"    --base-url http://localhost:{port}"
-    )
+    return "vllm bench serve\n" + "\n".join(f"    {a}" for a in _bench_args(recipe))
 
 
 def format_task_yaml(task: BenchmarkTask) -> str:
@@ -96,25 +106,18 @@ async def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
     """
     bench = recipe.benchmark
 
-    # Warn if input + output lengths risk exceeding context_length
+    # Warn if input + output lengths risk exceeding context_length (embedding
+    # workloads generate nothing — only the input length counts there).
     context_length = recipe.engine.llm.context_length
-    if context_length is not None and bench.random_input_len + bench.random_output_len >= context_length:
-        logging.getLogger().warning(
-            f"benchmark random_input_len ({bench.random_input_len}) + "
-            f"random_output_len ({bench.random_output_len}) = "
-            f"{bench.random_input_len + bench.random_output_len} >= "
-            f"context_length ({context_length})"
-        )
+    request_len = bench.random_input_len + (0 if recipe.is_embedding else bench.random_output_len)
+    if context_length is not None and request_len >= context_length:
+        logging.getLogger().warning(f"benchmark request length ({request_len}) >= context_length ({context_length})")
 
-    model_name = recipe.model_name
     # vllm bench serve is an HTTP client that works against any OpenAI-compatible
     # endpoint, so we always use the vLLM image for benchmarking.
     image = recipe.engine.llm.image
     if recipe.engine.llm.engine_name != "vllm":
         image = VllmConfig().image
-
-    num_instances = calculate_num_instances(recipe)
-    port = 8080 if num_instances > 1 else 8000
 
     # The ROCm vLLM image crashes on import without GPU devices, even for
     # the pure-HTTP benchmark client.  Pass device flags so it can start.
@@ -122,16 +125,7 @@ async def run_benchmark_workload(run_cmd, recipe: Recipe, dry_run=False):
     device_flags = " --device /dev/kfd:/dev/kfd --device /dev/dri:/dev/dri" if is_amd else ""
 
     bench_cmd = (
-        f"docker run --rm --network host{device_flags} --entrypoint bash {image} -c '"
-        f"vllm bench serve "
-        f"--model {model_name} "
-        f"--trust-remote-code "
-        f"--base-url http://localhost:{port} "
-        f"--max-concurrency {bench.max_concurrency} "
-        f"--num-prompts {bench.num_prompts} "
-        f"--random-input-len {bench.random_input_len} "
-        f"--random-output-len {bench.random_output_len}"
-        f"'"
+        f"docker run --rm --network host{device_flags} --entrypoint bash {image} -c 'vllm bench serve {' '.join(_bench_args(recipe))}'"
     )
 
     bench_command_str = build_bench_command(recipe)

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -47,7 +47,11 @@ The central orchestration layer. Provides a single entry point for deploying rec
 - `params.py` — `DeployParams` dataclass (holds `recipe: Recipe`, `gpu_device_ids`, etc.)
 - `compose.py` — `calculate_num_instances()`, `generate_compose()`, `generate_nginx_conf()`
 - `orchestrate.py` — `run_deploy()`, `run_teardown()`, `deploy()`, `teardown()`. `run_deploy()` / `deploy()` accept an
-  optional `timer: PhaseTimer` that records per-step durations (see [Timing metrics](#timing-metrics))
+  optional `timer: PhaseTimer` that records per-step durations (see [Timing metrics](#timing-metrics)). The
+  post-health smoke test branches on `recipe.is_embedding` (`model.task: embed`): chat models POST
+  `/v1/chat/completions` ("What is 2+2?" must contain "4"); embedding models POST `/v1/embeddings` and require a
+  non-empty finite vector with L2 norm in [0.9, 1.1] (the pooler normalizes — garbage/NaN models fail). Same
+  retry/timeout/log-dump loop either way (`_check_chat_response` / `_check_embedding_response`).
 - `log_phases.py` — `parse_engine_load_phases()` (best-effort `weights_load` / `cuda_graph_capture` from container logs)
 - `ssh.py` — `ssh_base_args()`, `make_run_cmd()`, `scp_file()`, `make_write_file()`
 - `scale_out.py` — `ScaleOutStrategy` ABC, `DataParallelismScaleOutStrategy`, `ReplicaParallelismScaleOutStrategy`, `STRATEGIES`, `DEFAULT_STRATEGY`
@@ -76,7 +80,10 @@ Benchmark configuration, task enumeration, and execution.
 **Modules:**
 - `config.py` — `load_config()`, `validate_config()`, `_expand_path()`
 - `bench_logging.py` — `setup_logging()`, `add_file_handler()`, `add_group_file_handler()`, `_get_group_logger()`, `active_run_dir` context var, `_RunDirFilter`, `_GroupNameFilter`, `_BenchConsoleFormatter`
-- `workload.py` — `extract_benchmark_results()`, `run_benchmark_workload()`
+- `workload.py` — `extract_benchmark_results()`, `run_benchmark_workload()`. Embedding recipes
+  (`model.task: embed`) bench with `vllm bench serve --backend openai-embeddings --endpoint /v1/embeddings` and drop
+  `--random-output-len` (nothing is generated); the output's labels (request/token throughput, E2EL percentiles — no
+  TTFT/TPOT/ITL) already parse via `parse_benchmark_metrics`' missing-field-tolerant label regexes
 - `tasks.py` — `enumerate_tasks()`
 - `execution.py` — `run_execution_group()`, `_run_groups()`, `OnTaskDone` callback type. Times provisioning (per
   group) + deploy/bench/teardown (per task); task results are `(task, ok, timing)` triples

--- a/deplodock/commands/ARCHITECTURE.md
+++ b/deplodock/commands/ARCHITECTURE.md
@@ -212,6 +212,7 @@ deplodock
 |   +-- ssh      -- deploy to remote server via SSH
 |   +-- cloud    -- provision cloud VM + deploy via SSH
 +-- bench        -- deploy + benchmark + teardown on cloud VMs
++-- serve        -- vllm serve with the deplodock embedding plugin (optional one-shot bench)
 +-- teardown     -- clean up VMs left by bench --no-teardown
 +-- vm
     +-- create
@@ -252,6 +253,25 @@ deplodock deploy cloud --recipe <path> --gpu "NVIDIA H200 141GB" --gpu-count 8 [
 ### Hardware-Aware Deploy (Local / SSH)
 
 Both `deploy local` and `deploy ssh` auto-detect the target GPU by scanning PCI sysfs device IDs (locally or over SSH) and select the matching `matrices` entry. If more GPUs are available than the recipe's base configuration needs, a scale-out strategy is applied (`--scale-out-strategy {data-parallelism,replica-parallelism}`, default `data-parallelism`).
+
+### `deplodock serve`
+
+Serves an embedding model through vLLM with the deplodock plugin flags baked in (`serving/` plugin; needs the
+`serving` extra). Unrecognized flags forward to `vllm serve`; tokens after a literal `--` forward verbatim (deplodock's
+own flags are otherwise extracted wherever they appear — argparse REMAINDER swallows everything after MODEL, so the
+handler re-parses it; see `commands/serve.py::_split_own_flags`). `--max-model-len 4096` (the dynamic-dim cap) is
+applied for both engines unless overridden, so `--stock` is an apples-to-apples baseline.
+
+```bash
+deplodock serve Qwen/Qwen3-Embedding-0.6B --gpu-memory-utilization 0.8   # plugin server (Ctrl-C to stop)
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32  # start → bench → results → shutdown
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --stock                # raw-vLLM baseline of the same bench
+```
+
+Without `--bench` the process execs `vllm serve` (signals flow to vLLM directly). With `--bench` the server runs as a
+subprocess (logs to a temp file), `/health` is polled (up to 30 min — first boot compiles the model), then
+`vllm bench serve --backend openai-embeddings --endpoint /v1/embeddings` runs against it
+(`--max-concurrency` / `--num-prompts` / `--random-input-len` / `--bench-seed`) and the server is torn down.
 
 ### `deplodock bench`
 

--- a/deplodock/commands/serve.py
+++ b/deplodock/commands/serve.py
@@ -1,0 +1,240 @@
+"""``deplodock serve`` — vLLM embedding serving with deplodock kernels, one command.
+
+Wraps ``vllm serve`` with the ``deplodock/serving`` plugin boilerplate
+(``--runner pooling --enforce-eager --hf-overrides …DeplodockEmbedModel…``,
+plus ``--max-model-len 4096`` — the dynamic-dim cap — unless overridden), and
+passes any unrecognized flags through to vLLM verbatim. ``--stock`` drops the
+plugin flags for the raw-vLLM baseline, so an A/B is two invocations of the
+same command. ``--bench`` turns it into a one-shot benchmark: start the
+server, wait for ``/health``, run ``vllm bench serve --backend
+openai-embeddings`` against it, print the result table, and shut the server
+down.
+
+    deplodock serve Qwen/Qwen3-Embedding-0.6B --gpu-memory-utilization 0.8
+    deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32
+    deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --stock     # baseline
+
+Flag routing: deplodock's own flags (``--bench``, ``--stock``, the bench
+params, ``--dry-run``) are extracted wherever they appear; everything else is
+forwarded to ``vllm serve``. Tokens after a literal ``--`` are forwarded
+verbatim without extraction (the escape hatch for a hypothetical name clash).
+"""
+
+import argparse
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The dynamic-dim cap (compiler/trace/dynamic.py DYNAMIC_DIM_MAX) — the plugin
+# runner rejects anything larger at startup. Applied to --stock too, so the
+# A/B compares both engines at the same max-model-len.
+_DEFAULT_MAX_MODEL_LEN = "4096"
+
+_PLUGIN_ARGS = ["--enforce-eager", "--hf-overrides", '{"architectures": ["DeplodockEmbedModel"]}']
+
+_HEALTH_TIMEOUT_S = 1800  # first boot compiles the whole model; warm cubin cache is much faster
+
+
+def _add_own_flags(parser, *, suppress_defaults: bool) -> None:
+    """The deplodock-side flags, declared twice: on the subparser (for --help
+    and flags placed before MODEL) and on the post-MODEL re-parse (with
+    SUPPRESS defaults, so only flags actually present override)."""
+
+    def d(value):
+        return argparse.SUPPRESS if suppress_defaults else value
+
+    parser.add_argument(
+        "--stock", action="store_true", default=d(False), help="Serve stock vLLM kernels instead of the deplodock plugin (A/B baseline)."
+    )
+    parser.add_argument(
+        "--bench",
+        action="store_true",
+        default=d(False),
+        help="Start the server, run `vllm bench serve` against it, print results, shut down.",
+    )
+    parser.add_argument("--max-concurrency", type=int, default=d(32), help="Bench client concurrency (with --bench).")
+    parser.add_argument("--num-prompts", type=int, default=d(256), help="Bench request count (with --bench).")
+    parser.add_argument("--random-input-len", type=int, default=d(512), help="Bench tokens per request (with --bench).")
+    parser.add_argument(
+        "--bench-seed", type=int, default=d(0), help="Bench prompt-sampling seed (with --bench; `--seed` itself forwards to vllm serve)."
+    )
+    parser.add_argument("--dry-run", action="store_true", default=d(False), help="Print the vllm command(s) without running.")
+
+
+def register_serve_command(subparsers):
+    parser = subparsers.add_parser(
+        "serve",
+        help="Serve an embedding model via vLLM with deplodock-compiled kernels (optionally benchmark it)",
+        description="Wraps `vllm serve` with the deplodock plugin flags; unrecognized flags pass through to vLLM "
+        "(tokens after a literal `--` pass through verbatim).",
+        allow_abbrev=False,
+    )
+    parser.add_argument("model", help="HuggingFace model ID (e.g., Qwen/Qwen3-Embedding-0.6B)")
+    _add_own_flags(parser, suppress_defaults=False)
+    parser.add_argument(
+        "vllm_args",
+        nargs=argparse.REMAINDER,
+        metavar="VLLM_ARGS",
+        help="Extra args forwarded to `vllm serve` (e.g. --gpu-memory-utilization 0.8 --port 8123).",
+    )
+    parser.set_defaults(func=handle_serve)
+
+
+def _split_own_flags(args) -> list[str]:
+    """argparse REMAINDER swallows *everything* after MODEL — including our own
+    flags. Re-parse the remainder: extract deplodock flags into ``args``
+    (SUPPRESS defaults → only flags actually present override), forward the
+    rest; anything after a literal ``--`` forwards without extraction."""
+    rem = list(args.vllm_args)
+    verbatim: list[str] = []
+    if "--" in rem:
+        i = rem.index("--")
+        rem, verbatim = rem[:i], rem[i + 1 :]
+    own = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    _add_own_flags(own, suppress_defaults=True)
+    _, passthrough = own.parse_known_args(rem, namespace=args)
+    return passthrough + verbatim
+
+
+def _has_flag(vllm_args: list[str], flag: str) -> bool:
+    return any(a == flag or a.startswith(f"{flag}=") for a in vllm_args)
+
+
+def _flag_value(vllm_args: list[str], flag: str, default: str) -> str:
+    for i, a in enumerate(vllm_args):
+        if a == flag and i + 1 < len(vllm_args):
+            return vllm_args[i + 1]
+        if a.startswith(f"{flag}="):
+            return a.split("=", 1)[1]
+    return default
+
+
+def build_serve_cmd(model: str, *, stock: bool, vllm_args: list[str]) -> list[str]:
+    cmd = ["vllm", "serve", model, "--runner", "pooling"]
+    if not stock:
+        cmd += _PLUGIN_ARGS
+    if not _has_flag(vllm_args, "--max-model-len"):
+        cmd += ["--max-model-len", _DEFAULT_MAX_MODEL_LEN]
+    return cmd + vllm_args
+
+
+def build_bench_cmd(model: str, *, port: str, max_concurrency: int, num_prompts: int, random_input_len: int, seed: int) -> list[str]:
+    return [
+        "vllm",
+        "bench",
+        "serve",
+        "--model",
+        model,
+        "--backend",
+        "openai-embeddings",
+        "--endpoint",
+        "/v1/embeddings",
+        "--base-url",
+        f"http://localhost:{port}",
+        "--max-concurrency",
+        str(max_concurrency),
+        "--num-prompts",
+        str(num_prompts),
+        "--random-input-len",
+        str(random_input_len),
+        "--seed",
+        str(seed),
+    ]
+
+
+def _vllm_bin() -> str:
+    """The vllm console script from this interpreter's environment (so the
+    plugin entry point installed alongside deplodock is the one that loads),
+    falling back to PATH."""
+    candidate = Path(sys.executable).parent / "vllm"
+    if candidate.exists():
+        return str(candidate)
+    found = shutil.which("vllm")
+    if found:
+        return found
+    logger.error("vllm not found — install the serving extra: pip install -e '.[compile,serving]'")
+    sys.exit(1)
+
+
+def handle_serve(args):
+    vllm_args = _split_own_flags(args)
+    serve_cmd = build_serve_cmd(args.model, stock=args.stock, vllm_args=vllm_args)
+    port = _flag_value(vllm_args, "--port", "8000")
+    bench_cmd = build_bench_cmd(
+        args.model,
+        port=port,
+        max_concurrency=args.max_concurrency,
+        num_prompts=args.num_prompts,
+        random_input_len=args.random_input_len,
+        seed=args.bench_seed,
+    )
+
+    if args.dry_run:
+        # shlex.join so the printed line is shell-pastable (the JSON in
+        # --hf-overrides needs quoting; the real execution uses argv lists).
+        print(shlex.join(serve_cmd))
+        if args.bench:
+            print(shlex.join(bench_cmd))
+        return
+
+    vllm = _vllm_bin()
+    serve_cmd[0] = vllm
+    if not args.bench:
+        # Plain serving: replace this process so signals/Ctrl-C reach vLLM directly.
+        os.execv(vllm, serve_cmd)
+
+    bench_cmd[0] = vllm
+    _serve_and_bench(serve_cmd, bench_cmd, port)
+
+
+def _serve_and_bench(serve_cmd: list[str], bench_cmd: list[str], port: str) -> None:
+    log_file = tempfile.NamedTemporaryFile(mode="wb", prefix="deplodock-serve-", suffix=".log", delete=False)
+    logger.info("Starting server (logs: %s)...", log_file.name)
+    logger.info("  %s", shlex.join(serve_cmd))
+    server = subprocess.Popen(serve_cmd, stdout=log_file, stderr=subprocess.STDOUT)
+    try:
+        _wait_for_health(server, port, log_file.name)
+        logger.info("Server healthy — running benchmark...")
+        logger.info("  %s", shlex.join(bench_cmd))
+        rc = subprocess.run(bench_cmd).returncode
+    finally:
+        logger.info("Shutting down server...")
+        server.terminate()
+        try:
+            server.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            server.kill()
+        log_file.close()
+    if rc != 0:
+        logger.error("Benchmark failed (rc=%d); server logs: %s", rc, log_file.name)
+        sys.exit(rc)
+
+
+def _wait_for_health(server: subprocess.Popen, port: str, log_path: str) -> None:
+    """Poll /health until the server answers; fail fast if it exits first
+    (first boot may compile the whole model — be patient)."""
+    import httpx
+
+    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if server.poll() is not None:
+            tail = "".join(open(log_path, errors="replace").readlines()[-15:])
+            logger.error("Server exited during startup (rc=%d). Log tail (%s):\n%s", server.returncode, log_path, tail)
+            sys.exit(1)
+        try:
+            if httpx.get(f"http://localhost:{port}/health", timeout=3).status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        time.sleep(3)
+    logger.error("Server did not become healthy within %ds; logs: %s", _HEALTH_TIMEOUT_S, log_path)
+    server.terminate()
+    sys.exit(1)

--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -67,6 +67,17 @@ arg_order).
    before the launch.
 3. Copy `graph.outputs` buffers back to numpy.
 
+**Repeated execution (`CompiledProgram.rebind` / `run_once`).** One built program can serve request after request —
+the serving path (the vLLM plugin runs one compiled dynamic-seq_len program per sequence). `rebind(input_data)`
+re-binds fresh inputs on the existing program: supplied buffers re-upload (in place when the resolved shape is
+unchanged, re-allocated otherwise), un-supplied buffers whose shape carries a symbolic dim (seq_len-sized
+scratch/outputs) re-materialize under the same fill policy as `build` (shared `_materialize`), and static-shaped
+un-supplied buffers — the weights — keep their device arrays untouched. Any re-allocation rebuilds TMA descriptors
+(they embed device pointers + shapes) and drops captured CUDA graphs (they bake old pointers). `run_once()` launches
+every kernel in program order with none of `iter_once`'s per-launch event record/sync/watchdog — bench semantics stay
+in `iter_once`; the caller's `outputs()` `.get()` synchronizes. Both expect the caller to hold `gpu_lock()`. See
+`tests/compiler/test_program_rebind.py`.
+
 `benchmark_program(graph, input_data, warmup, num_iters)` adds a
 warmup loop + timed loop wrapped in `cupy.cuda.Event` pairs — one
 global pair for `BenchmarkResult.time_ms`, one pair per launch index

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -267,9 +267,33 @@ def _nvrtc_options(*, uses_tma: bool) -> tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
-def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> dict[str, cp.ndarray]:
+def _materialize(buf: _Buffer, shape: tuple[int, ...], src: np.ndarray | None, constants: dict[str, float]) -> cp.ndarray:
+    """Build one device array for ``buf`` at ``shape`` — the single fill
+    policy shared by :func:`_allocate` and :meth:`CompiledProgram.rebind`."""
     import cupy as cp
 
+    cp_dtype = cupy_dtype(buf.dtype)
+    np_dtype = buf.dtype.np
+    if src is not None:
+        return cp.asarray(np.ascontiguousarray(src, dtype=np_dtype).reshape(shape))
+    if buf.role == "constant" and buf.name in constants:
+        return cp.full(shape, float(constants[buf.name]), dtype=cp_dtype)
+    if buf.role == "input":
+        # Pseudo-random fill for un-supplied inputs (matches old generated program).
+        n = 1
+        for d in shape:
+            n *= int(d)
+        # Build the index ramp in int64, not ``np_dtype``: a float16 buffer
+        # past 65504 elements would overflow to ``inf`` (then ``inf % 101``
+        # → ``nan``). Compute in fp32 and cast the final values — always in
+        # ``[-0.5, 0.5]``, so fp16-safe.
+        idx = np.arange(n, dtype=np.int64)
+        vals = (0.01 * ((idx.astype(np.float32) * 7 + 13) % 101 - 50)).astype(np_dtype)
+        return cp.asarray(vals.reshape(shape))
+    return cp.zeros(shape, dtype=cp_dtype)
+
+
+def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> dict[str, cp.ndarray]:
     input_data = input_data or {}
     sym_values = _resolve_symbolic(compiled, input_data)
     arrays: dict[str, cp.ndarray] = {}
@@ -278,30 +302,8 @@ def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> 
     # softmax). Ignore the over/invalid warnings so genuine output stays clean.
     with np.errstate(over="ignore", invalid="ignore"):
         for buf in compiled.bufs:
-            resolved = buf.resolve_shape(sym_values)
-            shape = resolved or (1,)
-            cp_dtype = cupy_dtype(buf.dtype)
-            np_dtype = buf.dtype.np
-            src = input_data.get(buf.name)
-            if src is not None:
-                arr = cp.asarray(np.ascontiguousarray(src, dtype=np_dtype).reshape(shape))
-            elif buf.role == "constant" and buf.name in compiled.constants:
-                arr = cp.full(shape, float(compiled.constants[buf.name]), dtype=cp_dtype)
-            elif buf.role == "input":
-                # Pseudo-random fill for un-supplied inputs (matches old generated program).
-                n = 1
-                for d in shape:
-                    n *= int(d)
-                # Build the index ramp in int64, not ``np_dtype``: a float16 buffer
-                # past 65504 elements would overflow to ``inf`` (then ``inf % 101``
-                # → ``nan``). Compute in fp32 and cast the final values — always in
-                # ``[-0.5, 0.5]``, so fp16-safe.
-                idx = np.arange(n, dtype=np.int64)
-                vals = (0.01 * ((idx.astype(np.float32) * 7 + 13) % 101 - 50)).astype(np_dtype)
-                arr = cp.asarray(vals.reshape(shape))
-            else:
-                arr = cp.zeros(shape, dtype=cp_dtype)
-            arrays[buf.name] = arr
+            shape = buf.resolve_shape(sym_values) or (1,)
+            arrays[buf.name] = _materialize(buf, shape, input_data.get(buf.name), compiled.constants)
     return arrays
 
 
@@ -618,6 +620,49 @@ class CompiledProgram:
             ", ".join(f"{li}:{lc.kernel_name}" for li, lc in enumerate(compiled.launches)),
         )
         return cls(compiled=compiled, arrays=arrays, descs=descs, sym_values=sym_values)
+
+    def rebind(self, input_data: dict[str, np.ndarray]) -> None:
+        """Re-bind ``input_data`` on an already-built program, re-sizing
+        symbolic-shaped buffers to the new runtime dims — the serving path,
+        where one compiled dynamic-seq_len program runs request after request.
+
+        Supplied buffers are re-uploaded: in place (``arr.set``) when the
+        resolved shape is unchanged, re-allocated otherwise. Un-supplied
+        buffers whose shape carries a symbolic dim (scratch/outputs sized by
+        seq_len) re-materialize at the new shape under the same fill policy
+        as ``build``; static-shaped un-supplied buffers — the weights — keep
+        their device arrays untouched (no re-upload). When any array was
+        re-allocated, TMA descriptors are rebuilt (they embed device pointers
+        and shapes) and captured CUDA graphs are dropped (they bake old
+        pointers). Caller must hold ``gpu_lock()``."""
+        new_sym = _resolve_symbolic(self.compiled, input_data)
+        realloc = False
+        with np.errstate(over="ignore", invalid="ignore"):
+            for buf in self.compiled.bufs:
+                src = input_data.get(buf.name)
+                if src is None and not buf.is_symbolic:
+                    continue
+                shape = buf.resolve_shape(new_sym) or (1,)
+                arr = self.arrays[buf.name]
+                if tuple(arr.shape) != shape:
+                    self.arrays[buf.name] = _materialize(buf, shape, src, self.compiled.constants)
+                    realloc = True
+                elif src is not None:
+                    arr.set(np.ascontiguousarray(src, dtype=buf.dtype.np).reshape(shape))
+        self.sym_values = new_sym
+        if realloc:
+            self.descs = _prebuild_descriptors(self.compiled, self.arrays)
+            self._graphs = None
+            self._graph_batch_sizes = None
+            self._e2e_graph = None
+
+    def run_once(self) -> None:
+        """Launch every kernel once in program order with no per-launch event
+        record/sync/watchdog — the serving hot path (timing semantics live in
+        :meth:`iter_once`). The default stream orders the launches; the
+        caller's subsequent ``outputs()`` ``.get()`` synchronizes."""
+        for i, launch in enumerate(self.compiled.launches):
+            _launch(launch, self.compiled, self.arrays, self.descs.get(i), self.sym_values)
 
     def capture_launch_graphs(self, batch_sizes: list[int]) -> None:
         """Capture each launch position's batch into one CUDA graph.

--- a/deplodock/compiler/backend/torch_ref.py
+++ b/deplodock/compiler/backend/torch_ref.py
@@ -189,9 +189,14 @@ def _eval(node, ins: list):
         return ins[0].unsqueeze(op.dim)
     if name == "SliceOp":
         t = ins[0]
-        dim = int(ins[1]) if len(ins) > 1 else 0
-        start = int(ins[2]) if len(ins) > 2 else 0
-        end = int(ins[3]) if len(ins) > 3 else t.shape[dim]
+        if op.dim is not None:
+            dim, start = op.dim, op.start or 0
+            extent = op.shape[dim]
+            end = start + int(extent) if isinstance(extent, int) else t.shape[dim]
+        else:  # legacy constant-input convention (pre-field IR dumps)
+            dim = int(ins[1]) if len(ins) > 1 else 0
+            start = int(ins[2]) if len(ins) > 2 else 0
+            end = int(ins[3]) if len(ins) > 3 else t.shape[dim]
         idx = [slice(None)] * t.dim()
         idx[dim] = slice(start, end)
         return t[tuple(idx)]

--- a/deplodock/compiler/ir/frontend/ir.py
+++ b/deplodock/compiler/ir/frontend/ir.py
@@ -100,20 +100,35 @@ class ReshapeOp(Op):
 class SliceOp(Op):
     """Extract a sub-tensor along a dimension.
 
-    Inputs: [tensor, dim_const, start_const, end_const] where the
-    constants are scalar ConstantOps from the tracer.
+    ``dim`` / ``start`` are recorded by the tracer from the raw FX args —
+    the constant-input convention below can't represent them when the FX
+    ``start`` is ``None`` or the ``end`` is a SymInt (``_resolve_inputs``
+    drops both, leaving the surviving constants positionally ambiguous).
+    The end never needs recording: ``shape`` already carries the output
+    extent (symbolic or static).
+
+    Legacy inputs convention (pre-field IR dumps): [tensor, dim_const,
+    start_const, end_const] where the constants are scalar ConstantOps
+    from the tracer; consumers fall back to it when ``dim is None``.
     """
 
     shape: tuple[int | str, ...]
+    dim: int | None = None
+    start: int | None = None
 
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         return tuple(self.shape)
 
     def forward(self, *inputs):
         tensor = inputs[0]
-        dim = int(inputs[1].flat[0]) if len(inputs) > 1 else 0
-        start = int(inputs[2].flat[0]) if len(inputs) > 2 else 0
-        end = int(inputs[3].flat[0]) if len(inputs) > 3 else tensor.shape[dim]
+        if self.dim is not None:
+            dim, start = self.dim, self.start or 0
+            extent = self.shape[dim]
+            end = start + int(extent) if isinstance(extent, int) else tensor.shape[dim]
+        else:
+            dim = int(inputs[1].flat[0]) if len(inputs) > 1 else 0
+            start = int(inputs[2].flat[0]) if len(inputs) > 2 else 0
+            end = int(inputs[3].flat[0]) if len(inputs) > 3 else tensor.shape[dim]
         slices = [slice(None)] * tensor.ndim
         slices[dim] = slice(start, end)
         return tensor[tuple(slices)]

--- a/deplodock/compiler/pipeline/passes/frontend/decomposition/140_slice.py
+++ b/deplodock/compiler/pipeline/passes/frontend/decomposition/140_slice.py
@@ -1,8 +1,11 @@
 """Lower SliceOp(x, dim, start, end) → IndexMapOp.
 
-Tracer convention: SliceOp.inputs = [tensor, dim_const, start_const, end_const].
-After decomposition: IndexMapOp.inputs = [tensor]; dim/start are baked into
-the coord_map (orphan constants get cleaned up by the rewriter).
+dim/start come from ``SliceOp.dim`` / ``SliceOp.start`` (recorded by the
+tracer; pre-field IR dumps fall back to the legacy constant-input convention
+``inputs = [tensor, dim_const, start_const, end_const]``). After
+decomposition: IndexMapOp.inputs = [tensor]; dim/start are baked into the
+coord_map (orphan constants get cleaned up by the rewriter). The slice end is
+never needed — ``out.shape`` carries the extent, symbolic or static.
 """
 
 from deplodock.compiler.graph import Graph, Node, Tensor
@@ -15,20 +18,28 @@ from deplodock.compiler.pipeline.passes.frontend.decomposition._helpers import o
 PATTERN = [Pattern("root", SliceOp)]
 
 
-def rewrite(match: Match, inp_x: Node, inp_dim: Node, inp_start: Node, inp_end: Node | None, out: Tensor) -> Graph | None:
+def rewrite(match: Match, root: Node, inp_x: Node, inp_dim: Node | None, inp_start: Node | None, out: Tensor) -> Graph | None:
     graph = match.graph
     in_shape = tuple(inp_x.output.shape)
     out_shape = tuple(out.shape)
     ndim = len(in_shape)
 
-    if not (isinstance(inp_dim.op, ConstantOp) and isinstance(inp_start.op, ConstantOp)):
-        raise RuleSkipped("slice dim/start must be ConstantOp to bake into coord_map")
-    if inp_dim.op.value is None or inp_start.op.value is None:
-        raise RuleSkipped("slice dim/start ConstantOp has no value")
-
-    dim = int(inp_dim.op.value)
+    # The tracer records dim/start on the op (required when the FX start is
+    # ``None`` or the end is a SymInt — those args don't survive as constant
+    # inputs). Pre-field IR dumps fall back to the constant-input convention.
+    if root.op.dim is not None and root.op.start is not None:
+        dim = int(root.op.dim)
+        start = int(root.op.start)
+    else:
+        if inp_dim is None or inp_start is None:
+            raise RuleSkipped("slice carries no dim/start fields and no dim/start constant inputs")
+        if not (isinstance(inp_dim.op, ConstantOp) and isinstance(inp_start.op, ConstantOp)):
+            raise RuleSkipped("slice dim/start must be ConstantOp to bake into coord_map")
+        if inp_dim.op.value is None or inp_start.op.value is None:
+            raise RuleSkipped("slice dim/start ConstantOp has no value")
+        dim = int(inp_dim.op.value)
+        start = int(inp_start.op.value)
     norm_dim = dim if dim >= 0 else ndim + dim
-    start = int(inp_start.op.value)
 
     coord_map = []
     for i in range(ndim):

--- a/deplodock/compiler/trace/ARCHITECTURE.md
+++ b/deplodock/compiler/trace/ARCHITECTURE.md
@@ -41,6 +41,22 @@ ops. One helper cleans this up:
   builders (`_update_causal_mask` / `_prepare_4d_causal_attention_mask`)
   to return the precomputed mask verbatim.
 
+The wrapper also **replaces the rotary embedding in both modes** — HF's in-graph rotary silently breaks under
+`torch.export`: its `inv_freq` buffer is `persistent=False` and doesn't survive export with its real value, so the
+traced cos/sin constant-fold to `cos=1, sin=0` and RoPE degenerates to identity. Static mode precomputes cos/sin at
+the trace seq_len (`_PassThroughRotary`); dynamic mode precomputes out to `DYNAMIC_DIM_MAX + 1` positions and slices
+to the runtime seq_len in-graph (`_SlicedRotary` — the slice end is a SymInt; the `+1` exists because export guards a
+symbolic slice end strictly below the sliced extent). Beware that an accuracy check with `input_ids = zeros` cannot
+catch a degenerate RoPE or wrong attention scores — identical value rows make the attention output independent of the
+attention weights; `tests/compiler/ir/test_dynamic_shapes.py::test_qwen_whole_model_dynamic_compiles_and_matches_eager`
+checks with non-zero ids for exactly that reason. The model passed in is **not** restricted to `CausalLM` — wrapping
+an `AutoModel` trunk yields hidden states instead of logits (the serving plugin's embedding path, `deplodock/serving`).
+
+`SliceOp` nodes record `dim`/`start` as **op fields** at trace time (`torch.py`'s slice handler reads the raw FX
+args): the legacy constant-input convention can't represent a `None` start (`x[:, :s]`) or a SymInt end —
+`_resolve_inputs` drops both, leaving the surviving constants positionally ambiguous. Pre-field IR dumps still
+decompose via the constant-input fallback.
+
 ## Entry points
 
 - Whole-model trace: `trace_module(build_full_model_wrapper(model, …), (input_ids,))`.

--- a/deplodock/compiler/trace/dynamic.py
+++ b/deplodock/compiler/trace/dynamic.py
@@ -13,6 +13,11 @@ rewrite (e.g. ``--seq-len 32`` on a model whose ``num_heads == 32``).
 
 from __future__ import annotations
 
+# Upper bound on every ``--dynamic`` axis (the ``torch.export.Dim`` max below).
+# Also the length the whole-model wrapper precomputes rotary cos/sin out to
+# (``trace.huggingface._SlicedRotary``).
+DYNAMIC_DIM_MAX = 4096
+
 
 def parse_position_specs(specs: list[str] | None) -> list[tuple[str, str, int]]:
     """Parse ``--dynamic NAME@INPUT:AXIS`` CLI strings to ``(name, input,
@@ -75,9 +80,9 @@ def build_torch_dynamic_shapes(specs: list[tuple[str, str, int]]) -> dict | None
     out: dict[str, dict[int, object]] = {}
     for name, input_name, axis in specs:
         if name not in dims_by_name:
-            dims_by_name[name] = torch.export.Dim(name, min=1, max=4096)
+            dims_by_name[name] = torch.export.Dim(name, min=1, max=DYNAMIC_DIM_MAX)
         out.setdefault(input_name, {})[axis] = dims_by_name[name]
     return out
 
 
-__all__ = ["parse_position_specs", "build_torch_dynamic_shapes"]
+__all__ = ["DYNAMIC_DIM_MAX", "parse_position_specs", "build_torch_dynamic_shapes"]

--- a/deplodock/compiler/trace/huggingface.py
+++ b/deplodock/compiler/trace/huggingface.py
@@ -34,6 +34,18 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
     runs at any seq_len. ``seq_len`` is still used at construction time
     to seed the short-circuit hooks with a same-shape sentinel mask so
     HF's internal validation passes.
+
+    Dynamic mode replaces the rotary embedding too — with cos/sin
+    precomputed for positions ``0..DYNAMIC_DIM_MAX-1`` and sliced to the
+    runtime seq_len in-graph (``_SlicedRotary``). Keeping HF's in-graph
+    rotary instead silently breaks: its ``inv_freq`` buffer is
+    ``persistent=False`` and doesn't survive ``torch.export`` with its
+    real value, so the traced cos/sin constant-fold to ``cos=1, sin=0``
+    and RoPE degenerates to identity. (The bug was invisible to the
+    zero-``input_ids`` accuracy check: identical value rows make the
+    attention output independent of the attention weights.) The sliced
+    buffer assumes positions are ``0..S-1`` — true for full-sequence
+    prefill, which is the only dynamic-mode use.
     """
     import torch
     import torch.nn as nn
@@ -51,6 +63,21 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
 
         def forward(self, *_, **__):
             return self.cos, self.sin
+
+    class _SlicedRotary(nn.Module):
+        """Dynamic-mode rotary replacement: cos/sin precomputed out to
+        ``DYNAMIC_DIM_MAX`` positions, sliced to the runtime seq_len read off
+        the ``position_ids`` argument — the slice end is a SymInt, so the
+        traced graph keeps real rotary values at every seq_len."""
+
+        def __init__(self, cos, sin) -> None:
+            super().__init__()
+            self.register_buffer("cos", cos)
+            self.register_buffer("sin", sin)
+
+        def forward(self, x, position_ids, *_, **__):
+            s = position_ids.shape[1]
+            return self.cos[:, :s], self.sin[:, :s]
 
     class FullModelWrapper(nn.Module):
         def __init__(self) -> None:
@@ -73,14 +100,23 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
             # ``inv_freq`` buffer, ``persistent=False``, doesn't survive tracing
             # with its real value), so RoPE degenerates to identity. Compute the
             # real per-position cos/sin eagerly and return them verbatim — the
-            # trace then captures correct constant tensors. Dynamic mode keeps
-            # the in-graph rotary (cos/sin must follow the runtime position_ids).
+            # trace then captures correct constant tensors. Dynamic mode hits
+            # the same folding, so it precomputes out to DYNAMIC_DIM_MAX and
+            # slices to the runtime seq_len in-graph (_SlicedRotary below).
             rotary = getattr(inner, "rotary_emb", None)
             if not dynamic and rotary is not None:
                 with torch.no_grad():
                     sample = torch.zeros((1, seq_len, model.config.hidden_size), dtype=dtype)
                     cos, sin = rotary(sample, self.position_ids)
                 inner.rotary_emb = _PassThroughRotary(cos, sin)
+            elif rotary is not None:
+                from deplodock.compiler.trace.dynamic import DYNAMIC_DIM_MAX  # noqa: PLC0415
+
+                with torch.no_grad():
+                    sample = torch.zeros((1, DYNAMIC_DIM_MAX, model.config.hidden_size), dtype=dtype)
+                    full_pos = torch.arange(DYNAMIC_DIM_MAX, dtype=torch.long)[None, :]
+                    cos, sin = rotary(sample, full_pos)
+                inner.rotary_emb = _SlicedRotary(cos, sin)
 
         if dynamic:
 

--- a/deplodock/compiler/trace/huggingface.py
+++ b/deplodock/compiler/trace/huggingface.py
@@ -112,9 +112,13 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
             elif rotary is not None:
                 from deplodock.compiler.trace.dynamic import DYNAMIC_DIM_MAX  # noqa: PLC0415
 
+                # +1: torch.export guards a symbolic slice end STRICTLY below
+                # the sliced extent (``cos[:, :S]`` with S == extent would
+                # specialize), so the buffer carries one extra position.
+                n_pos = DYNAMIC_DIM_MAX + 1
                 with torch.no_grad():
-                    sample = torch.zeros((1, DYNAMIC_DIM_MAX, model.config.hidden_size), dtype=dtype)
-                    full_pos = torch.arange(DYNAMIC_DIM_MAX, dtype=torch.long)[None, :]
+                    sample = torch.zeros((1, n_pos, model.config.hidden_size), dtype=dtype)
+                    full_pos = torch.arange(n_pos, dtype=torch.long)[None, :]
                     cos, sin = rotary(sample, full_pos)
                 inner.rotary_emb = _SlicedRotary(cos, sin)
 

--- a/deplodock/compiler/trace/torch.py
+++ b/deplodock/compiler/trace/torch.py
@@ -703,8 +703,19 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, str], *, s
     # --- Slice ---
     if op_name == "slice":
         if input_ids:
+            # Record dim/start from the raw FX args: ``aten.slice.Tensor(self,
+            # dim, start, end)`` may carry ``start=None`` (``x[:, :s]``) or a
+            # SymInt ``end`` — ``_resolve_inputs`` drops both, leaving the
+            # surviving ConstantOp inputs positionally ambiguous. A non-int
+            # dim/start (a SymInt slice origin) stays ``None`` so the
+            # decomposition rule fails loudly instead of mis-slicing.
+            args = fx_node.args
+            dim_raw = args[1] if len(args) > 1 else 0
+            start_raw = args[2] if len(args) > 2 else None
+            dim = dim_raw if isinstance(dim_raw, int) and not isinstance(dim_raw, bool) else None
+            start = 0 if start_raw is None else (start_raw if isinstance(start_raw, int) and not isinstance(start_raw, bool) else None)
             nid = g.add_node(
-                op=SliceOp(shape=_dim_tuple_to_op_shape(shape)),
+                op=SliceOp(shape=_dim_tuple_to_op_shape(shape), dim=dim, start=start),
                 inputs=input_ids,
                 output=Tensor(name, shape, dtype),
                 node_id=name,

--- a/deplodock/config.py
+++ b/deplodock/config.py
@@ -46,6 +46,7 @@ CUBIN_CACHE = "DEPLODOCK_CUBIN_CACHE"
 NO_NVCC = "DEPLODOCK_NO_NVCC"
 GPU_LOCK = "DEPLODOCK_GPU_LOCK"
 NCU_CHILD = "DEPLODOCK_NCU_CHILD"
+SERVING_DTYPE = "DEPLODOCK_SERVING_DTYPE"
 
 _CACHE_ROOT = Path.home() / ".cache" / "deplodock"
 
@@ -234,6 +235,14 @@ def ncu_child() -> bool:
     """``DEPLODOCK_NCU_CHILD`` — set in the ncu-profiled child to prevent
     recursive re-spawning of ncu."""
     return _bool(NCU_CHILD)
+
+
+def serving_dtype(default: str = "float16") -> str:
+    """``DEPLODOCK_SERVING_DTYPE`` — torch dtype name the vLLM-plugin serving
+    runner traces/compiles the model at (``deplodock/serving``). ``float16``
+    by default; ``float32`` is the accuracy escape hatch (doubles weight
+    memory — an 8B model no longer fits a 24 GB card)."""
+    return _str(SERVING_DTYPE) or default
 
 
 # Note: ``DEPLODOCK_GROUP_M`` (CTA-swizzle row-group size) used to live here as

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -13,6 +13,7 @@ from deplodock.commands.eval import register_eval_command
 from deplodock.commands.inspect_graph import register_inspect_command
 from deplodock.commands.pull import register_pull_command
 from deplodock.commands.run import register_run_command
+from deplodock.commands.serve import register_serve_command
 from deplodock.commands.teardown import register_teardown_command
 from deplodock.commands.trace import register_trace_command
 from deplodock.commands.tune import register_tune_command
@@ -32,8 +33,9 @@ def main():
     register_ssh_target(deploy_subparsers)
     register_cloud_target(deploy_subparsers)
 
-    # bench, teardown, vm subcommands
+    # bench, serve, teardown, vm subcommands
     register_bench_command(subparsers)
+    register_serve_command(subparsers)
     register_teardown_command(subparsers)
     register_vm_command(subparsers)
 

--- a/deplodock/deploy/orchestrate.py
+++ b/deplodock/deploy/orchestrate.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import math
 
 from deplodock.deploy.compose import (
     calculate_num_instances,
@@ -149,17 +150,27 @@ async def run_deploy(
     logger.info(f"Status: {status}")
 
     # Step 7: Smoke test inference (retry — first request may be slow due to warmup)
-    # Asks a trivial factual question and checks the answer to detect broken models
-    # (e.g. wrong quantization producing garbage output).
+    # Chat models: asks a trivial factual question and checks the answer to detect
+    # broken models (e.g. wrong quantization producing garbage output). Embedding
+    # models: requests one embedding and checks it's a unit-norm finite vector.
     if not dry_run:
         logger.info("\nRunning smoke test...")
         async with timer.ameasure(PHASE_SMOKE_TEST):
-            prompt = "What is 2+2? Answer with just the number."
-            smoke_cmd = (
-                f"curl -s http://localhost:{internal_port}/v1/chat/completions"
-                f" -H 'Content-Type: application/json'"
-                f''' -d '{{"model":"{model_name}","messages":[{{"role":"user","content":"{prompt}"}}],"max_tokens":128}}' '''
-            )
+            if recipe.is_embedding:
+                smoke_cmd = (
+                    f"curl -s http://localhost:{internal_port}/v1/embeddings"
+                    f" -H 'Content-Type: application/json'"
+                    f''' -d '{{"model":"{model_name}","input":"What is 2+2?"}}' '''
+                )
+                check = _check_embedding_response
+            else:
+                prompt = "What is 2+2? Answer with just the number."
+                smoke_cmd = (
+                    f"curl -s http://localhost:{internal_port}/v1/chat/completions"
+                    f" -H 'Content-Type: application/json'"
+                    f''' -d '{{"model":"{model_name}","messages":[{{"role":"user","content":"{prompt}"}}],"max_tokens":128}}' '''
+                )
+                check = _check_chat_response
             smoke_timeout = 600
             smoke_interval = 10
             deadline = asyncio.get_event_loop().time() + smoke_timeout
@@ -169,22 +180,16 @@ async def run_deploy(
                     # Server not ready yet, keep retrying
                     await asyncio.sleep(smoke_interval)
                     continue
-                try:
-                    body = json.loads(stdout)
-                    message = body["choices"][0]["message"]
-                    answer = message.get("content") or message.get("reasoning_content") or message.get("reasoning") or ""
-                except (json.JSONDecodeError, KeyError, IndexError, TypeError):
-                    # Malformed response, server may still be starting
+                verdict, detail = check(stdout)
+                if verdict == "retry":
+                    # Malformed/empty response, server may still be starting
                     await asyncio.sleep(smoke_interval)
                     continue
-                if not answer:
-                    await asyncio.sleep(smoke_interval)
-                    continue
-                if "4" in answer:
+                if verdict == "pass":
                     logger.info("Smoke test passed.")
                     break
-                # Model returned a valid response but wrong answer — broken model
-                logger.error(f"Smoke test failed: model returned wrong answer: {answer!r}")
+                # Valid response, wrong content — broken model
+                logger.error(f"Smoke test failed: {detail}")
                 logger.error("Container logs:")
                 await run_cmd("docker compose logs --tail=100", timeout=60, log_output=True)
                 return False
@@ -196,17 +201,63 @@ async def run_deploy(
 
     # Print curl example
     logger.info("\nExample curl:")
-    logger.info(
-        f"  curl http://{host}:{external_port}/v1/chat/completions \\\n"
-        f"    -H 'Content-Type: application/json' \\\n"
-        f"    -d '{{\n"
-        f'      "model": "{model_name}",\n'
-        f'      "messages": [{{"role": "user", "content": "Hello"}}],\n'
-        f'      "max_tokens": 64\n'
-        f"    }}'"
-    )
+    if recipe.is_embedding:
+        logger.info(
+            f"  curl http://{host}:{external_port}/v1/embeddings \\\n"
+            f"    -H 'Content-Type: application/json' \\\n"
+            f"    -d '{{\n"
+            f'      "model": "{model_name}",\n'
+            f'      "input": "Hello"\n'
+            f"    }}'"
+        )
+    else:
+        logger.info(
+            f"  curl http://{host}:{external_port}/v1/chat/completions \\\n"
+            f"    -H 'Content-Type: application/json' \\\n"
+            f"    -d '{{\n"
+            f'      "model": "{model_name}",\n'
+            f'      "messages": [{{"role": "user", "content": "Hello"}}],\n'
+            f'      "max_tokens": 64\n'
+            f"    }}'"
+        )
 
     return True
+
+
+def _check_chat_response(stdout: str) -> tuple[str, str]:
+    """Validate a /v1/chat/completions smoke response.
+
+    Returns ``("pass" | "fail" | "retry", detail)`` — ``retry`` means the
+    response was malformed/empty (server may still be starting)."""
+    try:
+        body = json.loads(stdout)
+        message = body["choices"][0]["message"]
+        answer = message.get("content") or message.get("reasoning_content") or message.get("reasoning") or ""
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+        return "retry", ""
+    if not answer:
+        return "retry", ""
+    if "4" in answer:
+        return "pass", ""
+    return "fail", f"model returned wrong answer: {answer!r}"
+
+
+def _check_embedding_response(stdout: str) -> tuple[str, str]:
+    """Validate a /v1/embeddings smoke response: a non-empty vector of finite
+    floats with L2 norm ≈ 1 (the pooler normalizes; garbage/NaN models fail)."""
+    try:
+        body = json.loads(stdout)
+        vec = body["data"][0]["embedding"]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError):
+        return "retry", ""
+    if not isinstance(vec, list) or not vec:
+        return "retry", ""
+    if not all(isinstance(v, (int, float)) and math.isfinite(v) for v in vec):
+        return "fail", "embedding contains non-finite values"
+    norm = math.sqrt(sum(v * v for v in vec))
+    if not 0.9 <= norm <= 1.1:
+        return "fail", f"embedding L2 norm {norm:.4f} outside [0.9, 1.1] (dim={len(vec)})"
+    return "pass", ""
 
 
 async def run_teardown(run_cmd):

--- a/deplodock/deploy/orchestrate.py
+++ b/deplodock/deploy/orchestrate.py
@@ -73,10 +73,13 @@ async def run_deploy(
     port_map = dict(port_mappings or [])
     external_port = port_map.get(internal_port, internal_port)
 
-    # Step 1: Pull images
+    # Step 1: Pull images. --ignore-pull-failures keeps a locally-built image
+    # usable before it's pushed to a registry (e.g. testing a fresh
+    # vllm-deplodock build with `bench --local`); a genuinely missing image
+    # still fails clearly at `docker compose up`.
     logger.info("Pulling images...")
     async with timer.ameasure(PHASE_IMAGE_PULL):
-        rc, _, _ = await run_cmd("docker compose pull", timeout=1800, log_output=True)
+        rc, _, _ = await run_cmd("docker compose pull --ignore-pull-failures", timeout=1800, log_output=True)
     if rc != 0:
         logger.error("Failed to pull images")
         return False

--- a/deplodock/recipe/ARCHITECTURE.md
+++ b/deplodock/recipe/ARCHITECTURE.md
@@ -171,6 +171,22 @@ engine:
 
 Each key-value pair is rendered as a `- KEY=VALUE` line in the `environment` section of the generated Docker Compose file.
 
+### Embedding Recipes (`model.task`)
+
+`model.task` declares what the model serves: `"generate"` (the default — completion/chat) or `"embed"`
+(`/v1/embeddings`). `_validate_and_build()` rejects anything else. `Recipe.is_embedding` drives two behavior switches
+downstream: the post-deploy smoke test POSTs `/v1/embeddings` and checks for a finite unit-norm vector
+(`deploy/orchestrate.py`), and the bench workload runs `vllm bench serve --backend openai-embeddings --endpoint
+/v1/embeddings` without `--random-output-len` (`benchmark/workload.py`). Everything else — matrices, images,
+`extra_args`, deploy — is unchanged; serving the deplodock compiler plugin instead of stock vLLM is just a different
+image + `extra_args` pair (see `deplodock/serving/ARCHITECTURE.md` and `recipes/Qwen3-Embedding-*`).
+
+```yaml
+model:
+  huggingface: "Qwen/Qwen3-Embedding-0.6B"
+  task: embed
+```
+
 ### Command Recipes (Generic Workload)
 
 In addition to inference recipes (`engine.llm` block), a recipe may declare a `command` block to run an arbitrary tool on the provisioned VM. The two are mutually exclusive — `_validate_and_build()` raises if both are set. `Recipe.kind` is `"command"` when `command` is set, else `"inference"`.

--- a/deplodock/recipe/recipe.py
+++ b/deplodock/recipe/recipe.py
@@ -84,6 +84,10 @@ def _validate_and_build(config: dict) -> Recipe:
     if has_command and has_engine_llm:
         raise ValueError("Recipe must specify exactly one of 'engine.llm' or 'command', not both.")
 
+    task = config.get("model", {}).get("task", "generate")
+    if task not in ("generate", "embed"):
+        raise ValueError(f"model.task must be 'generate' or 'embed', got {task!r}")
+
     if has_command:
         # Command recipes don't go through engine extra_args validation.
         return Recipe.from_dict(config)

--- a/deplodock/recipe/types.py
+++ b/deplodock/recipe/types.py
@@ -99,6 +99,9 @@ class ModelConfig:
     """Model configuration."""
 
     huggingface: str = ""
+    # What the model serves: "generate" (completion/chat, the default) or
+    # "embed" (/v1/embeddings). Drives the smoke test and the bench workload.
+    task: str = "generate"
 
 
 @dataclass
@@ -180,7 +183,7 @@ class Recipe:
     def from_dict(cls, d: dict) -> "Recipe":
         """Build a Recipe from a (post-merge, post-migrate) config dict."""
         model_dict = d.get("model", {})
-        model = ModelConfig(huggingface=model_dict.get("huggingface", ""))
+        model = ModelConfig(huggingface=model_dict.get("huggingface", ""), task=model_dict.get("task", "generate"))
 
         engine_dict = d.get("engine", {})
         llm_dict = engine_dict.get("llm", {})
@@ -251,3 +254,9 @@ class Recipe:
     def model_name(self) -> str:
         """Shortcut for model.huggingface."""
         return self.model.huggingface
+
+    @property
+    def is_embedding(self) -> bool:
+        """True for embedding recipes (``model.task: embed``) — /v1/embeddings
+        smoke test + ``vllm bench serve --backend openai-embeddings`` workload."""
+        return self.model.task == "embed"

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -9,6 +9,10 @@ vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \
   --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
 ```
 
+`deplodock serve` (`commands/serve.py`) wraps that boilerplate: `deplodock serve <model> [vllm flags...]`, with
+`--stock` for the raw-vLLM baseline at the same max-model-len, and `--bench` for a one-shot start → `/health` →
+`vllm bench serve --backend openai-embeddings` → results → shutdown cycle.
+
 Requires the `serving` extra (`pip install -e ".[compile,serving]"` + cupy). vLLM discovers the plugin through the
 `vllm.general_plugins` entry point (`deplodock.serving:register` in pyproject.toml), which registers
 `DeplodockEmbedModel` by lazy string path; `--hf-overrides` swaps the served repo's `architectures` to it, so the

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -1,0 +1,70 @@
+# deplodock.serving — vLLM out-of-tree embedding plugin
+
+Serve an embedding model (Qwen3-Embedding family) with vLLM's serving shell — OpenAI `/v1/embeddings`, tokenizer,
+scheduler, pooling — while the transformer trunk runs on deplodock-compiled CUDA kernels. The point is a clean A/B
+inside one serving stack: stock vLLM kernels vs deplodock kernels, same API, same batching, same pooler.
+
+```
+vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \
+  --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
+```
+
+Requires the `serving` extra (`pip install -e ".[compile,serving]"` + cupy). vLLM discovers the plugin through the
+`vllm.general_plugins` entry point (`deplodock.serving:register` in pyproject.toml), which registers
+`DeplodockEmbedModel` by lazy string path; `--hf-overrides` swaps the served repo's `architectures` to it, so the
+checkpoint, tokenizer, and sentence-transformers pooling config still come from the original HF repo.
+
+## Module map
+
+- `__init__.py` — `register()`, the entry-point hook. Never imports vllm/torch at module level.
+- `vllm_model.py` — `DeplodockEmbedModel` (the only module importing vllm). An `nn.Module` with **no parameters**:
+  `is_pooling_model = True`, `IsAttentionFree` (no vLLM `Attention` layers → V1 builds an empty KV-cache spec),
+  `attn_type = "encoder_only"` (vLLM disables chunked prefill → every request reaches `forward` whole),
+  `pooler = DispatchPooler.for_embedding(...)` (last-token pooling + L2 normalize + matryoshka — identical to stock
+  Qwen3-Embedding serving), stub `embed_input_ids`, no-op `load_weights` (the runner loads the checkpoint itself; not
+  consuming the iterator skips reading the safetensors).
+- `runner.py` — `DeplodockForwardRunner`. At engine start: load the `AutoModel` **trunk** (hidden states out — no
+  lm_head), `build_full_model_wrapper(dynamic=True)`, trace with the canonical 4-spec dynamic seq_len
+  (`seq_len@input_ids:1`, `@attention_mask:2`, `@attention_mask:3`, `@position_ids:1`), compile through `CudaBackend`
+  (greedy fork picks from the global prior — benefits from any prior `deplodock tune`), bind weights as graph
+  constants (`named_parameters` + `named_buffers`, `remove_duplicate=False`, in the traced dtype), and build ONE
+  `CompiledProgram`. Per sequence: `rebind` fresh inputs → `run_once` → `outputs()` (see
+  `compiler/backend/cuda/ARCHITECTURE.md` → repeated execution). Trace dtype: `DEPLODOCK_SERVING_DTYPE`
+  (default `float16`; `float32` is the accuracy escape hatch — 2× weight memory).
+- `packed.py` — `split_spans(positions, max_seq_len)`: vLLM V1 hands pooling models one packed `(num_tokens,)` tensor
+  with per-request 0-based positions; spans split at `positions == 0`. Hardened for `_dummy_run`'s garbage profiling
+  batches (index 0 always opens a span; overlong spans are chopped).
+
+## Execution model (v1) and its known costs
+
+Each sequence runs **individually** through the compiled dynamic-seq_len program (batch axis is compile-time fixed at
+1), and inputs/outputs cross host memory (`rebind` uploads numpy, `outputs()` copies back). Low-concurrency latency is
+representative; high-concurrency throughput structurally trails stock vLLM's packed-batch prefill — that gap measures
+the integration, not kernel quality. Recorded follow-ups, in impact order:
+
+1. **Packed-varlen attention** (cu_seqlens-aware SDPA tiles) — run vLLM's whole packed batch in one launch; the only
+   item that makes the throughput regime apples-to-apples. Matmuls/norms/pointwise are already token-wise.
+2. **dlpack zero-copy I/O** — cupy ↔ torch without the host round-trip (`cp.from_dlpack` / `torch.from_dlpack`).
+3. **Device-side causal mask** — the `(1,1,S,S)` host mask upload (~32 MB fp16 at S=4096) per *new* S; a tiny kernel
+   (or in-kernel `j <= i` predicate) removes the mask input entirely.
+
+## Serving constraints
+
+- `--max-model-len` ≤ `DYNAMIC_DIM_MAX` (4096, `compiler/trace/dynamic.py`) — the runner raises at startup otherwise.
+  Qwen3-Embedding natively supports 32k; raising the cap means re-examining the `torch.export.Dim` bounds and the
+  rotary buffer (`_SlicedRotary` precomputes `DYNAMIC_DIM_MAX + 1` positions).
+- `--enforce-eager`: vLLM never torch.compiles/cudagraph-captures an undecorated OOT class, but enforce-eager makes
+  the whole engine eager so the runner's own kernel launches can't race a capture.
+- Startup compiles the whole model (~1–2 min for 0.6B warm-cubin-cache; first boot pays nvcc). `DEPLODOCK_CUBIN_CACHE`
+  persistence across container restarts is what keeps reboots fast.
+- vLLM's memory profiler only sees torch allocations; the runner's cupy-held weights/activations are invisible to it.
+  Leave `--gpu-memory-utilization` headroom accordingly (the attention-free model needs no KV cache, so vLLM's own
+  budget is tiny).
+
+## Testing
+
+- `tests/serving/test_packed.py` — pure span-split logic, runs everywhere.
+- `tests/serving/test_vllm_plugin_gpu.py` — `perf`-marked (deselected by default), needs CUDA + vllm: in-process
+  `vllm.LLM(runner="pooling", hf_overrides=...)` on Qwen3-Embedding-0.6B, `.embed()` cosine vs the HF eager reference.
+- `scripts/compare_embeddings.py` — the accuracy gate against a *server*: embeds a fixed text set through two
+  OpenAI-compatible endpoints (deplodock-backed and stock) and asserts pairwise cosine > 0.99.

--- a/deplodock/serving/__init__.py
+++ b/deplodock/serving/__init__.py
@@ -1,0 +1,14 @@
+"""vLLM out-of-tree model plugin: deplodock-compiled kernels behind vLLM's serving shell.
+
+``register`` is the ``vllm.general_plugins`` entry point (see pyproject.toml);
+vLLM calls it in every process at engine start. The model class itself lives in
+``vllm_model.py`` and is registered by lazy string path so importing this
+package never pulls in vllm (or CUDA) by itself.
+"""
+
+
+def register() -> None:
+    from vllm import ModelRegistry
+
+    if "DeplodockEmbedModel" not in ModelRegistry.get_supported_archs():
+        ModelRegistry.register_model("DeplodockEmbedModel", "deplodock.serving.vllm_model:DeplodockEmbedModel")

--- a/deplodock/serving/packed.py
+++ b/deplodock/serving/packed.py
@@ -1,0 +1,33 @@
+"""Span-splitting for vLLM's packed batches. Pure Python — no torch/vllm imports."""
+
+from __future__ import annotations
+
+
+def split_spans(positions, max_seq_len: int) -> list[tuple[int, int]]:
+    """Split a packed batch into per-sequence ``(start, end)`` spans.
+
+    vLLM V1 hands pooling models one flattened token tensor with per-request
+    0-based ``positions``; with chunked prefill disabled every request arrives
+    whole, so a new sequence starts exactly where ``positions[i] == 0``.
+
+    Hardened for vLLM's ``_dummy_run`` batches (garbage positions during
+    memory profiling): index 0 always starts a span even when
+    ``positions[0] != 0``, and any span longer than ``max_seq_len`` is chopped
+    into ``max_seq_len``-sized chunks — the output is garbage there, but dummy
+    runs only need the forward to not crash.
+    """
+    n = len(positions)
+    if n == 0:
+        return []
+    starts = [0]
+    for i in range(1, n):
+        if positions[i] == 0:
+            starts.append(i)
+    starts.append(n)
+    spans: list[tuple[int, int]] = []
+    for a, b in zip(starts, starts[1:], strict=False):  # pairwise: zip stops at the shorter
+        while b - a > max_seq_len:
+            spans.append((a, a + max_seq_len))
+            a += max_seq_len
+        spans.append((a, b))
+    return spans

--- a/deplodock/serving/runner.py
+++ b/deplodock/serving/runner.py
@@ -1,0 +1,164 @@
+"""Trace + compile + per-sequence execution of an embedding-model trunk.
+
+``DeplodockForwardRunner`` owns the deplodock side of the vLLM plugin: at
+server start it traces the HuggingFace ``AutoModel`` trunk (hidden states out,
+no lm_head) with a dynamic seq_len, compiles it through the CUDA backend
+(greedy fork picks from the global prior — no GPU tuning), and builds ONE
+``CompiledProgram``. Per sequence it re-binds fresh inputs (``rebind``) and
+launches (``run_once``) — one compiled program serves every request at any
+seq_len ≤ ``DYNAMIC_DIM_MAX``.
+
+No vllm imports here — the class is driven by ``vllm_model.DeplodockEmbedModel``
+but is independently testable with torch + cupy alone.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+
+logger = logging.getLogger(__name__)
+
+# Example-tensor size handed to torch.export (the CLI's --seq-len default).
+# The traced dim is symbolic, so the value never reaches the kernels.
+_TRACE_SEQ = 32
+# Per-seq_len causal-mask host cache (FIFO). At S=4096 one fp16 mask is
+# ~32 MB, so the cap keeps the cache bounded while serving mixed lengths.
+_MASK_CACHE_MAX = 16
+
+
+def _causal_mask_np(s: int, np_dtype) -> np.ndarray:
+    """``(1, 1, s, s)`` additive causal mask (0 on/below diagonal, -inf above),
+    the numpy twin of ``trace.huggingface.build_causal_mask``."""
+    mask = np.triu(np.full((s, s), -np.inf, dtype=np.float32), k=1)
+    return mask.astype(np_dtype)[None, None, :, :]
+
+
+class DeplodockForwardRunner:
+    """One compiled dynamic-seq_len trunk + its per-sequence execution."""
+
+    def __init__(self, program: CompiledProgram, input_names: tuple[str, str, str], output_name: str, np_dtype, max_seq_len: int):
+        self._program = program
+        self._ids_name, self._mask_name, self._pos_name = input_names
+        self._output_name = output_name
+        self._np_dtype = np_dtype
+        self.max_seq_len = max_seq_len
+        self._mask_cache: dict[int, np.ndarray] = {}
+
+    @classmethod
+    def create(cls, model_id: str, max_seq_len: int, dtype_str: str = "float16") -> DeplodockForwardRunner:
+        import torch
+        from transformers import AutoModel
+
+        from deplodock.compiler.backend.cuda.backend import CudaBackend
+        from deplodock.compiler.backend.cuda.program import CompiledProgram
+        from deplodock.compiler.backend.gpu_lock import gpu_lock
+        from deplodock.compiler.loader.binder import bind_constants
+        from deplodock.compiler.trace.dynamic import DYNAMIC_DIM_MAX, build_torch_dynamic_shapes, parse_position_specs
+        from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+        from deplodock.compiler.trace.torch import trace_module
+
+        if max_seq_len > DYNAMIC_DIM_MAX:
+            raise ValueError(
+                f"max_seq_len={max_seq_len} exceeds deplodock's dynamic-dim max ({DYNAMIC_DIM_MAX}); "
+                f"serve with --max-model-len {DYNAMIC_DIM_MAX} or lower"
+            )
+        dtype = getattr(torch, dtype_str)
+
+        logger.info("[serving] loading %s trunk (dtype=%s)...", model_id, dtype_str)
+        # vLLM instantiates models inside a CUDA device context; the HF trunk
+        # is only traced + read for constants here (then freed), so force CPU —
+        # this also sidesteps transformers' accelerate requirement for
+        # non-default device contexts.
+        with torch.device("cpu"):
+            model = AutoModel.from_pretrained(model_id, dtype=dtype)
+        model.eval()
+
+        logger.info("[serving] tracing (dynamic seq_len, example S=%d)...", _TRACE_SEQ)
+        specs = parse_position_specs(
+            ["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"]
+        )
+        # Same CPU pin as the load above: the wrapper builds buffers and the
+        # trace runs the forward on example tensors — all of it must sit on
+        # one device, regardless of vLLM's CUDA default-device context.
+        with torch.device("cpu"):
+            wrapper = build_full_model_wrapper(model, _TRACE_SEQ, dtype, dynamic=True)
+            example = (
+                torch.zeros((1, _TRACE_SEQ), dtype=torch.long),
+                build_causal_mask(_TRACE_SEQ, dtype),
+                torch.arange(_TRACE_SEQ).unsqueeze(0),
+            )
+            graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
+
+        logger.info("[serving] compiling...")
+        compiled = CudaBackend(tune_db="auto").compile(graph)
+        if len(compiled.inputs) != 3:
+            raise RuntimeError(f"expected 3 graph inputs (input_ids, attention_mask, position_ids), got {compiled.inputs}")
+        if len(compiled.outputs) != 1:
+            raise RuntimeError(f"expected 1 graph output (hidden states), got {compiled.outputs}")
+
+        # Weight sources in the traced dtype: named_buffers (NOT state_dict)
+        # so non-persistent buffers — the wrapper's precomputed rotary
+        # cos/sin — bind too; remove_duplicate=False so tied weights surface
+        # under every traced alias.
+        np_dtype = np.dtype(dtype_str)
+        sources: dict[str, np.ndarray] = {}
+        for path, t in wrapper.named_parameters(remove_duplicate=False):
+            sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+        for path, t in wrapper.named_buffers(remove_duplicate=False):
+            sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+        const_feed = bind_constants(compiled, sources)
+
+        ids_name, mask_name, pos_name = compiled.inputs
+        feed = {
+            ids_name: np.zeros((1, _TRACE_SEQ), dtype=np.int64),
+            mask_name: _causal_mask_np(_TRACE_SEQ, np_dtype),
+            pos_name: np.arange(_TRACE_SEQ, dtype=np.int64).reshape(1, _TRACE_SEQ),
+        }
+        with gpu_lock():
+            program = CompiledProgram.build(compiled, {**const_feed, **feed})
+        del model, wrapper, sources, const_feed
+        logger.info("[serving] ready: %d launches, max_seq_len=%d", len(program.compiled.launches), max_seq_len)
+        return cls(
+            program=program,
+            input_names=(ids_name, mask_name, pos_name),
+            output_name=compiled.outputs[0],
+            np_dtype=np_dtype,
+            max_seq_len=max_seq_len,
+        )
+
+    @property
+    def hidden_size(self) -> int:
+        out = self._program.compiled.buf_by_name[self._output_name]
+        return int(out.shape[-1].as_static())
+
+    def _mask(self, s: int) -> np.ndarray:
+        cached = self._mask_cache.get(s)
+        if cached is not None:
+            return cached
+        mask = _causal_mask_np(s, self._np_dtype)
+        if len(self._mask_cache) >= _MASK_CACHE_MAX:
+            self._mask_cache.pop(next(iter(self._mask_cache)))
+        self._mask_cache[s] = mask
+        return mask
+
+    def forward_hidden_states(self, token_ids: np.ndarray) -> np.ndarray:
+        """Run one sequence: ``token_ids`` shape ``(S,)`` int64, ``S <=
+        max_seq_len``. Returns ``(S, hidden)`` numpy in the traced dtype."""
+        from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+        s = int(token_ids.shape[0])
+        feed = {
+            self._ids_name: token_ids.reshape(1, s),
+            self._mask_name: self._mask(s),
+            self._pos_name: np.arange(s, dtype=np.int64).reshape(1, s),
+        }
+        with gpu_lock():
+            self._program.rebind(feed)
+            self._program.run_once()
+            return self._program.outputs()[self._output_name][0]

--- a/deplodock/serving/vllm_model.py
+++ b/deplodock/serving/vllm_model.py
@@ -1,0 +1,77 @@
+"""``DeplodockEmbedModel`` — the vLLM out-of-tree pooling model class.
+
+Serve any causal-trunk embedding model (e.g. Qwen3-Embedding) with vLLM's
+shell but deplodock-compiled kernels:
+
+    vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \\
+      --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
+
+The class holds no ``nn.Parameter``s — weights live inside the compiled
+program as graph constants, loaded by ``DeplodockForwardRunner.create`` at
+engine start. vLLM's V1 engine treats a model with no ``Attention`` layers as
+attention-free (empty KV-cache spec); ``attn_type = "encoder_only"`` turns
+chunked prefill off, so every request reaches ``forward`` whole and
+``positions == 0`` marks sequence starts. The runner computes everything
+itself per sequence; vLLM's pooler then does last-token pooling + L2
+normalization (+ matryoshka), identical to stock Qwen3-Embedding serving.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+import torch.nn as nn
+from vllm.model_executor.layers.pooler import DispatchPooler
+from vllm.model_executor.models.interfaces import IsAttentionFree
+
+from deplodock import config as dd_config
+from deplodock.serving.packed import split_spans
+from deplodock.serving.runner import DeplodockForwardRunner
+
+logger = logging.getLogger(__name__)
+
+
+class DeplodockEmbedModel(nn.Module, IsAttentionFree):
+    is_pooling_model = True
+    default_seq_pooling_type = "LAST"
+    attn_type = "encoder_only"  # whole-sequence prefills only (disables chunked prefill)
+
+    def __init__(self, *, vllm_config, prefix: str = ""):
+        super().__init__()
+        mc = vllm_config.model_config
+        self.out_dtype = mc.dtype
+        self.vocab_size = mc.get_vocab_size()
+        self.pooler = DispatchPooler.for_embedding(mc.pooler_config)
+        self.runner = DeplodockForwardRunner.create(
+            model_id=mc.model,
+            max_seq_len=mc.max_model_len,
+            dtype_str=dd_config.serving_dtype(),
+        )
+
+    def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None, **kwargs):
+        # Packed (num_tokens_padded,) tensors: sequences flattened back-to-back,
+        # positions 0-based per request. Garbage dummy-run batches must survive
+        # too — hence the vocab clamp and split_spans' chunking hardening.
+        n = int(input_ids.shape[0])
+        ids = input_ids.clamp(0, self.vocab_size - 1).cpu().numpy().astype(np.int64).reshape(-1)
+        pos = positions.cpu().numpy().reshape(-1)
+        chunks = [self.runner.forward_hidden_states(ids[a:b]) for a, b in split_spans(pos, self.runner.max_seq_len)]
+        hidden = np.concatenate(chunks, axis=0) if chunks else np.zeros((0, self.runner.hidden_size), dtype=np.float32)
+        out = torch.from_numpy(np.ascontiguousarray(hidden)).to(device=input_ids.device, dtype=self.out_dtype)
+        if out.shape[0] < n:  # pad back to num_tokens_padded
+            out = torch.nn.functional.pad(out, (0, 0, 0, n - out.shape[0]))
+        return out
+
+    def embed_input_ids(self, input_ids):
+        # Protocol stub (same as vLLM's Terratorch precedent): the compiled
+        # program owns the real embedding table.
+        return torch.empty((input_ids.shape[0], 0), device=input_ids.device, dtype=self.out_dtype)
+
+    def load_weights(self, weights):
+        # The wrapper has no nn.Parameters; the runner already loaded the
+        # checkpoint itself. Not consuming the iterator skips reading the
+        # safetensors entirely. An empty set satisfies the strict
+        # all-params-initialized check trivially.
+        return set()

--- a/docker/vllm-deplodock/Dockerfile
+++ b/docker/vllm-deplodock/Dockerfile
@@ -1,0 +1,29 @@
+# vLLM serving image with the deplodock embedding plugin baked in.
+#
+# Build from the repo root (the wheel must exist first — `make wheel`):
+#   make vllm-deplodock-image          # builds cloudriftai/vllm-deplodock:<vllm-ver>-<git-sha>
+#   make vllm-deplodock-push
+#
+# Serve (same entrypoint as the stock image, plus the plugin flags):
+#   docker run --gpus all -p 8000:8000 cloudriftai/vllm-deplodock:TAG \
+#     --model Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \
+#     --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
+ARG VLLM_VERSION=v0.22.1
+FROM vllm/vllm-openai:${VLLM_VERSION}
+
+# The deplodock wheel installs --no-deps so the image's pinned torch /
+# transformers / numpy (vLLM's own dependency set) are never touched; the
+# runtime deps the serving path actually uses are added explicitly. cppyy is
+# deliberately absent — the CUDA serving path compiles via nvcc/NVRTC only.
+# The cupy wheel must match the image's CUDA major (vllm-openai:v0.22.1
+# ships CUDA 13.0 + nvcc; transformers 5.10.2 satisfies the compile pin).
+ARG CUPY_PACKAGE=cupy-cuda13x
+COPY dist/deplodock-*.whl /tmp/wheels/
+RUN pip install --no-cache-dir --no-deps /tmp/wheels/deplodock-*.whl \
+    && pip install --no-cache-dir "${CUPY_PACKAGE}" catboost pyyaml httpx "huggingface_hub[hf_transfer]" safetensors \
+    && rm -rf /tmp/wheels
+
+# Compiled-cubin cache under the HF cache mount (compose mounts the model dir
+# there), so container restarts on the same VM skip recompiles. Recipes can
+# override via extra_env.
+ENV DEPLODOCK_CUBIN_CACHE=/root/.cache/huggingface/deplodock-cubins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff"]
 compile = ["torch", "transformers>=5.10", "cppyy==3.5.0", "safetensors"]
+# vLLM out-of-tree embedding plugin (deplodock/serving); vllm pins its own torch.
+serving = ["vllm>=0.22.1,<0.23"]
 visualize = ["playwright>=1.40"]
 # flash-attn requires torch at build time, install separately:
 #   pip install flash-attn --no-build-isolation
@@ -31,6 +33,9 @@ include = ["deplodock*"]
 
 [project.scripts]
 deplodock = "deplodock.deplodock:main"
+
+[project.entry-points."vllm.general_plugins"]
+deplodock_serving = "deplodock.serving:register"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/recipes/Qwen3-Embedding-0.6B/recipe.yaml
+++ b/recipes/Qwen3-Embedding-0.6B/recipe.yaml
@@ -1,0 +1,53 @@
+# Qwen3-Embedding-0.6B: stock vLLM pooling vs vLLM + deplodock compiled-kernel plugin
+# (deplodock/serving — same OpenAI /v1/embeddings shell, different kernels).
+#
+# context_length is pinned to 4096 on BOTH engines for an apples-to-apples comparison —
+# 4096 is deplodock's dynamic-dim max (compiler/trace/dynamic.py DYNAMIC_DIM_MAX); the
+# model natively supports 32k.
+#
+# The deplodock variant compiles the whole model at engine start (~3 min first boot,
+# faster after — DEPLODOCK_CUBIN_CACHE persists compiled cubins on the model volume).
+# Stock vLLM ignores that env var, so it sits at the base level for both variants.
+model:
+  huggingface: "Qwen/Qwen3-Embedding-0.6B"
+  task: embed
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    # High on purpose: the deplodock variant's cupy-held weights are non-torch memory
+    # that vLLM's profiler subtracts from this budget, and the attention-free plugin
+    # needs no KV cache anyway.
+    gpu_memory_utilization: 0.9
+    context_length: 4096
+    max_concurrent_requests: 32
+    vllm:
+      extra_env:
+        DEPLODOCK_CUBIN_CACHE: "/hf_models/deplodock-cubins"
+
+benchmark:
+  max_concurrency: 32
+  num_prompts: 256
+  random_input_len: 512   # overridden per regime by the matrix
+  random_output_len: 1    # unused for task: embed (flag omitted from the bench command)
+
+matrices:
+  cross:
+    deploy.gpu:
+      - "NVIDIA GeForce RTX 5090"
+      - "NVIDIA GeForce RTX 4090"
+    deploy.gpu_count: 1
+    benchmark.random_input_len: [32, 512]   # short-query + document regimes
+    zip:
+      engine.llm.vllm.image:
+        - "vllm/vllm-openai:v0.22.1"
+        - "cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b"
+      engine.llm.vllm.extra_args:
+        - "--runner pooling"
+        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"DeplodockEmbedModel\"]}'"
+
+aggregate:
+  run: |
+    ./venv/bin/python scripts/aggregate_embedding.py $run_dir --output $run_dir/report.md
+  timeout: 120

--- a/recipes/Qwen3-Embedding-4B/recipe.yaml
+++ b/recipes/Qwen3-Embedding-4B/recipe.yaml
@@ -1,0 +1,53 @@
+# Qwen3-Embedding-4B: stock vLLM pooling vs vLLM + deplodock compiled-kernel plugin
+# (deplodock/serving — same OpenAI /v1/embeddings shell, different kernels).
+#
+# context_length is pinned to 4096 on BOTH engines for an apples-to-apples comparison —
+# 4096 is deplodock's dynamic-dim max (compiler/trace/dynamic.py DYNAMIC_DIM_MAX); the
+# model natively supports 32k.
+#
+# The deplodock variant compiles the whole model at engine start (~3 min first boot,
+# faster after — DEPLODOCK_CUBIN_CACHE persists compiled cubins on the model volume).
+# Stock vLLM ignores that env var, so it sits at the base level for both variants.
+model:
+  huggingface: "Qwen/Qwen3-Embedding-4B"
+  task: embed
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    # High on purpose: the deplodock variant's cupy-held weights are non-torch memory
+    # that vLLM's profiler subtracts from this budget, and the attention-free plugin
+    # needs no KV cache anyway.
+    gpu_memory_utilization: 0.9
+    context_length: 4096
+    max_concurrent_requests: 32
+    vllm:
+      extra_env:
+        DEPLODOCK_CUBIN_CACHE: "/hf_models/deplodock-cubins"
+
+benchmark:
+  max_concurrency: 32
+  num_prompts: 256
+  random_input_len: 512   # overridden per regime by the matrix
+  random_output_len: 1    # unused for task: embed (flag omitted from the bench command)
+
+matrices:
+  cross:
+    deploy.gpu:
+      - "NVIDIA GeForce RTX 5090"
+      - "NVIDIA GeForce RTX 4090"
+    deploy.gpu_count: 1
+    benchmark.random_input_len: [32, 512]   # short-query + document regimes
+    zip:
+      engine.llm.vllm.image:
+        - "vllm/vllm-openai:v0.22.1"
+        - "cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b"
+      engine.llm.vllm.extra_args:
+        - "--runner pooling"
+        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"DeplodockEmbedModel\"]}'"
+
+aggregate:
+  run: |
+    ./venv/bin/python scripts/aggregate_embedding.py $run_dir --output $run_dir/report.md
+  timeout: 120

--- a/recipes/Qwen3-Embedding-8B/recipe.yaml
+++ b/recipes/Qwen3-Embedding-8B/recipe.yaml
@@ -1,0 +1,54 @@
+# Qwen3-Embedding-8B: stock vLLM pooling vs vLLM + deplodock compiled-kernel plugin
+# (deplodock/serving — same OpenAI /v1/embeddings shell, different kernels).
+#
+# context_length is pinned to 4096 on BOTH engines for an apples-to-apples comparison —
+# 4096 is deplodock's dynamic-dim max (compiler/trace/dynamic.py DYNAMIC_DIM_MAX); the
+# model natively supports 32k.
+#
+# The deplodock variant compiles the whole model at engine start (~3 min first boot,
+# faster after — DEPLODOCK_CUBIN_CACHE persists compiled cubins on the model volume).
+# Stock vLLM ignores that env var, so it sits at the base level for both variants.
+model:
+  huggingface: "Qwen/Qwen3-Embedding-8B"
+  task: embed
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    # 8B fp16 weights ≈ 16 GB. On the 24 GB 4090 the deplodock variant's cupy-held
+    # weights are non-torch memory that vLLM's profiler subtracts from this budget —
+    # utilization must clear (weights + overhead)/24 with headroom while leaving
+    # vLLM a positive remainder (the attention-free plugin needs no KV cache).
+    gpu_memory_utilization: 0.92
+    context_length: 4096
+    max_concurrent_requests: 32
+    vllm:
+      extra_env:
+        DEPLODOCK_CUBIN_CACHE: "/hf_models/deplodock-cubins"
+
+benchmark:
+  max_concurrency: 32
+  num_prompts: 256
+  random_input_len: 512   # overridden per regime by the matrix
+  random_output_len: 1    # unused for task: embed (flag omitted from the bench command)
+
+matrices:
+  cross:
+    deploy.gpu:
+      - "NVIDIA GeForce RTX 5090"
+      - "NVIDIA GeForce RTX 4090"
+    deploy.gpu_count: 1
+    benchmark.random_input_len: [32, 512]   # short-query + document regimes
+    zip:
+      engine.llm.vllm.image:
+        - "vllm/vllm-openai:v0.22.1"
+        - "cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b"
+      engine.llm.vllm.extra_args:
+        - "--runner pooling"
+        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"DeplodockEmbedModel\"]}'"
+
+aggregate:
+  run: |
+    ./venv/bin/python scripts/aggregate_embedding.py $run_dir --output $run_dir/report.md
+  timeout: 120

--- a/scripts/aggregate_embedding.py
+++ b/scripts/aggregate_embedding.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Aggregate embedding-recipe bench results into a stock-vs-deplodock report.
+
+Reads every ``*.json`` result in the run dir (written by ``deplodock bench``),
+groups variants by (GPU, random_input_len), pairs the stock-vLLM row with the
+deplodock-plugin row by image name, and emits a markdown table per group:
+request throughput, token throughput, mean/p99 E2E latency, the
+deplodock/stock throughput ratio, and each variant's model_load_and_warmup
+time (which contains the deplodock startup compile).
+
+    python scripts/aggregate_embedding.py <run_dir> --output <run_dir>/report.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _engine_label(result: dict) -> str:
+    image = result.get("recipe", {}).get("engine", {}).get("llm", {}).get("vllm", {}).get("image", "")
+    return "deplodock" if "deplodock" in image else "stock vllm"
+
+
+def _fmt(v, suffix="") -> str:
+    return f"{v:.2f}{suffix}" if isinstance(v, (int, float)) else "—"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("run_dir", type=Path)
+    ap.add_argument("--output", type=Path, default=None)
+    args = ap.parse_args()
+
+    groups: dict[tuple[str, int], dict[str, dict]] = {}
+    for path in sorted(args.run_dir.glob("*.json")):
+        if path.name == "tasks.json":
+            continue
+        try:
+            result = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if "metrics" not in result or "recipe" not in result:
+            continue
+        gpu = result.get("task", {}).get("gpu_short") or result.get("task", {}).get("gpu_name", "?")
+        input_len = result["recipe"].get("benchmark", {}).get("random_input_len", 0)
+        groups.setdefault((gpu, input_len), {})[_engine_label(result)] = result
+
+    if not groups:
+        print(f"no benchmark result JSONs found in {args.run_dir}", file=sys.stderr)
+        return 1
+
+    lines = ["# Embedding serving: stock vLLM vs deplodock plugin", ""]
+    for (gpu, input_len), rows in sorted(groups.items()):
+        lines.append(f"## {gpu} — {input_len} tokens/request")
+        lines.append("")
+        lines.append("| engine | req/s | tok/s | mean E2EL (ms) | p99 E2EL (ms) | load+warmup (s) |")
+        lines.append("|---|---|---|---|---|---|")
+        for label in ("stock vllm", "deplodock"):
+            r = rows.get(label)
+            if r is None:
+                lines.append(f"| {label} | — | — | — | — | — |")
+                continue
+            m = r["metrics"]
+            load = (r.get("timing") or {}).get("model_load_and_warmup")
+            lines.append(
+                f"| {label} | {_fmt(m.get('request_throughput'))} | {_fmt(m.get('total_token_throughput'))} "
+                f"| {_fmt(m.get('mean_e2el_ms'))} | {_fmt(m.get('p99_e2el_ms'))} | {_fmt(load)} |"
+            )
+        a, b = rows.get("deplodock"), rows.get("stock vllm")
+        if a and b:
+            ra, rb = a["metrics"].get("request_throughput"), b["metrics"].get("request_throughput")
+            if ra and rb:
+                lines.append("")
+                lines.append(f"deplodock/stock request-throughput ratio: **{ra / rb:.2f}x**")
+        lines.append("")
+
+    report = "\n".join(lines)
+    if args.output:
+        args.output.write_text(report)
+        print(f"wrote {args.output}")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_embeddings.py
+++ b/scripts/compare_embeddings.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Accuracy gate for the deplodock vLLM embedding plugin.
+
+Embeds a fixed text set through two OpenAI-compatible ``/v1/embeddings``
+endpoints (e.g. the deplodock-backed server and a stock vLLM server) and
+asserts per-text cosine similarity, plus agreement of the pairwise-similarity
+matrices (the quantity retrieval quality actually depends on).
+
+    python scripts/compare_embeddings.py --a http://localhost:8311 --b http://localhost:8312 \
+        --model Qwen/Qwen3-Embedding-0.6B [--min-cosine 0.99]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import httpx
+import numpy as np
+
+TEXTS = [
+    "What is the capital of France?",
+    "Paris is the capital and largest city of France.",
+    "The mitochondria is the powerhouse of the cell.",
+    "How do I reset my password?",
+    "To reset your password, click 'Forgot password' on the login page.",
+    "Instruct: Given a web search query, retrieve relevant passages that answer the query\nQuery: best gpu for llm inference",
+    "The RTX 5090 has 32 GB of GDDR7 memory.",
+    "El gato se sentó en la alfombra.",
+    "def fibonacci(n):\n    return n if n < 2 else fibonacci(n - 1) + fibonacci(n - 2)",
+    "A",
+    "short",
+    "This is a deliberately much longer paragraph intended to exercise a bigger sequence length. "
+    "It rambles about embedding models, retrieval-augmented generation, vector databases, cosine "
+    "similarity, and the importance of benchmarking serving stacks under realistic workloads.",
+]
+
+
+def embed(base_url: str, model: str, texts: list[str]) -> np.ndarray:
+    resp = httpx.post(f"{base_url}/v1/embeddings", json={"model": model, "input": texts}, timeout=120)
+    resp.raise_for_status()
+    data = resp.json()["data"]
+    return np.array([row["embedding"] for row in sorted(data, key=lambda r: r["index"])], dtype=np.float64)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--a", required=True, help="first server base URL (e.g. the deplodock-backed one)")
+    ap.add_argument("--b", required=True, help="second server base URL (e.g. stock vLLM)")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--min-cosine", type=float, default=0.99)
+    args = ap.parse_args()
+
+    ea, eb = embed(args.a, args.model, TEXTS), embed(args.b, args.model, TEXTS)
+    if ea.shape != eb.shape:
+        print(f"FAIL: shape mismatch {ea.shape} vs {eb.shape}")
+        return 1
+    ea /= np.linalg.norm(ea, axis=1, keepdims=True)
+    eb /= np.linalg.norm(eb, axis=1, keepdims=True)
+
+    cos = (ea * eb).sum(axis=1)
+    for t, c in zip(TEXTS, cos, strict=True):
+        marker = "" if c >= args.min_cosine else "   <-- BELOW THRESHOLD"
+        print(f"cosine={c:.6f}  {t[:60]!r}{marker}")
+    sim_diff = np.abs(ea @ ea.T - eb @ eb.T).max()
+    print(f"\nmin cosine: {cos.min():.6f}   pairwise-similarity matrix max diff: {sim_diff:.6f}")
+    if cos.min() < args.min_cosine:
+        print("FAIL")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -19,7 +19,11 @@ tests/
 │   ├── test_tasks_json.py   # BenchmarkTask.write_tasks_json(), read_tasks_json()
 │   ├── test_run_dir.py      # BenchmarkTask.create_run_dir()
 │   ├── test_results.py      # parse_benchmark_metrics(), parse_system_info(), compose_json_result()
+│   ├── test_embedding_workload.py # embed bench command, embeddings output parsing, smoke-response checks
 │   └── test_command_workload.py # build_substitution_map(), render_command()
+├── serving/                   # mirrors deplodock/serving/ (vLLM embedding plugin)
+│   ├── test_packed.py       # split_spans packed-batch span splitting (pure, no GPU)
+│   └── test_vllm_plugin_gpu.py # in-process vLLM engine + plugin vs HF eager (perf-marked, CUDA + vllm)
 ├── recipe/
 │   ├── test_types.py        # Recipe.from_dict(), LLMConfig properties, dataclass defaults
 │   └── test_engines.py      # build_engine_args(), banned_extra_arg_flags()

--- a/tests/benchmark/test_embedding_workload.py
+++ b/tests/benchmark/test_embedding_workload.py
@@ -1,0 +1,81 @@
+"""Embedding-recipe bench command + metrics parsing + smoke-response checks."""
+
+from deplodock.benchmark.results import parse_benchmark_metrics
+from deplodock.benchmark.workload import build_bench_command
+from deplodock.deploy.orchestrate import _check_chat_response, _check_embedding_response
+from deplodock.recipe.types import Recipe
+
+
+def _recipe(task: str) -> Recipe:
+    return Recipe.from_dict(
+        {
+            "model": {"huggingface": "Qwen/Qwen3-Embedding-0.6B", "task": task},
+            "engine": {"llm": {"context_length": 4096, "vllm": {}}},
+            "benchmark": {"max_concurrency": 8, "num_prompts": 32, "random_input_len": 128, "random_output_len": 1},
+        }
+    )
+
+
+def test_embed_bench_command_targets_embeddings_endpoint():
+    cmd = build_bench_command(_recipe("embed"))
+    assert "--backend openai-embeddings" in cmd
+    assert "--endpoint /v1/embeddings" in cmd
+    assert "--random-output-len" not in cmd
+    assert "--random-input-len 128" in cmd
+
+
+def test_generate_bench_command_unchanged():
+    cmd = build_bench_command(_recipe("generate"))
+    assert "--backend" not in cmd
+    assert "--random-output-len 1" in cmd
+
+
+# Captured from a real `vllm bench serve --backend openai-embeddings` run (v0.22.1).
+_EMBED_BENCH_OUTPUT = """\
+============ Serving Benchmark Result ============
+Successful requests:                     32
+Failed requests:                         0
+Maximum request concurrency:             8
+Benchmark duration (s):                  0.12
+Total input tokens:                      4096
+Request throughput (req/s):              277.99
+Total token throughput (tok/s):          35582.34
+----------------End-to-end Latency----------------
+Mean E2EL (ms):                          27.28
+Median E2EL (ms):                        15.49
+P99 E2EL (ms):                           70.07
+==================================================
+"""
+
+
+def test_parse_embeddings_bench_output():
+    m = parse_benchmark_metrics(_EMBED_BENCH_OUTPUT)
+    assert m.successful_requests == 32
+    assert m.failed_requests == 0
+    assert m.request_throughput == 277.99
+    assert m.total_token_throughput == 35582.34
+    assert m.mean_e2el_ms == 27.28
+    assert m.p99_e2el_ms == 70.07
+    # Generation-only metrics stay unset rather than mis-parsing.
+    assert m.mean_ttft_ms is None
+    assert m.total_generated_tokens is None
+
+
+def test_check_embedding_response():
+    good = '{"data": [{"embedding": [0.6, 0.8], "index": 0}]}'
+    assert _check_embedding_response(good)[0] == "pass"
+    nan = '{"data": [{"embedding": [1.0, null], "index": 0}]}'
+    assert _check_embedding_response(nan)[0] in ("fail", "retry")
+    unnormalized = '{"data": [{"embedding": [3.0, 4.0], "index": 0}]}'
+    verdict, detail = _check_embedding_response(unnormalized)
+    assert verdict == "fail" and "norm" in detail
+    not_ready = '{"error": "loading"}'
+    assert _check_embedding_response(not_ready)[0] == "retry"
+    assert _check_embedding_response("not json")[0] == "retry"
+
+
+def test_check_chat_response():
+    assert _check_chat_response('{"choices": [{"message": {"content": "The answer is 4."}}]}')[0] == "pass"
+    assert _check_chat_response('{"choices": [{"message": {"content": "five"}}]}')[0] == "fail"
+    assert _check_chat_response("oops")[0] == "retry"
+    assert _check_chat_response('{"choices": [{"message": {}}]}')[0] == "retry"

--- a/tests/compiler/ir/test_dynamic_shapes.py
+++ b/tests/compiler/ir/test_dynamic_shapes.py
@@ -321,6 +321,77 @@ def test_cuda_symbolic_linear_traced_and_run():
         np.testing.assert_allclose(y, ref, rtol=1e-4, atol=1e-4)
 
 
+def test_qwen_whole_model_dynamic_compiles_and_matches_eager():
+    """1-layer random-weight Qwen3 trunk, dynamic seq_len: compile once, run at
+    the trace size AND two other seq_lens (via ``CompiledProgram.rebind``),
+    compare against torch eager — with NON-ZERO token ids.
+
+    Non-zero ids are the load-bearing part: with ``input_ids = zeros`` every
+    value row is identical, so the attention output is independent of the
+    attention weights — an accuracy check at zero ids is blind to a degenerate
+    RoPE (the in-graph rotary used to constant-fold to ``cos=1, sin=0`` under
+    ``torch.export``; the wrapper now precomputes + slices instead) and to
+    wrong attention scores."""
+    pytest = __import__("pytest")
+    pytest.importorskip("cupy")
+    import torch
+    from transformers import AutoConfig, AutoModel
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.loader.binder import bind_constants
+    from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+    from deplodock.compiler.trace.torch import trace_module
+
+    torch.manual_seed(0)
+    config = AutoConfig.from_pretrained("Qwen/Qwen3-Embedding-0.6B")
+    config.num_hidden_layers = 1
+    model = AutoModel.from_config(config).float().eval()
+
+    hint, dtype = 32, torch.float32
+    wrapper = build_full_model_wrapper(model, hint, dtype, dynamic=True)
+    seq_dim = _seq_len_dim(min=1)
+    graph = trace_module(
+        wrapper,
+        (torch.zeros((1, hint), dtype=torch.long), build_causal_mask(hint, dtype), torch.arange(hint).unsqueeze(0)),
+        dynamic_shapes={"input_ids": {1: seq_dim}, "attention_mask": {2: seq_dim, 3: seq_dim}, "position_ids": {1: seq_dim}},
+    )
+    compiled = CudaBackend().compile(graph)
+
+    sources: dict[str, np.ndarray] = {}
+    for path, t in wrapper.named_parameters(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    for path, t in wrapper.named_buffers(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    const_feed = bind_constants(compiled, sources)
+    ids_name, mask_name, pos_name = compiled.inputs
+    out_name = compiled.outputs[0]
+
+    def feed(s: int) -> dict[str, np.ndarray]:
+        ids = (np.arange(s, dtype=np.int64).reshape(1, s) * 97) % config.vocab_size
+        return {
+            ids_name: ids,
+            mask_name: build_causal_mask(s, dtype).numpy(),
+            pos_name: np.arange(s, dtype=np.int64).reshape(1, s),
+        }
+
+    with gpu_lock():
+        prog = None
+        for s in (hint, 17, 64):
+            fd = feed(s)
+            if prog is None:
+                prog = CompiledProgram.build(compiled, {**const_feed, **fd})
+            else:
+                prog.rebind(fd)
+            prog.run_once()
+            out = prog.outputs()[out_name]
+            with torch.no_grad():
+                ref = wrapper(torch.from_numpy(fd[ids_name]), build_causal_mask(s, dtype), torch.arange(s).unsqueeze(0)).numpy()
+            assert out.shape == ref.shape
+            np.testing.assert_allclose(out, ref, rtol=1e-3, atol=1e-3)
+
+
 def test_qwen_whole_model_dynamic_traces():
     """End-to-end whole-model dynamic trace on Qwen3-Embedding-0.6B (1 layer,
     random weights so no checkpoint download). Exercises the CLI's

--- a/tests/compiler/test_program_rebind.py
+++ b/tests/compiler/test_program_rebind.py
@@ -1,0 +1,121 @@
+"""``CompiledProgram.rebind`` / ``run_once`` — the serving execution path.
+
+One compiled dynamic-seq_len program serves request after request: ``rebind``
+re-binds fresh inputs (re-sizing symbolic-shaped buffers, leaving weights
+untouched), ``run_once`` launches without bench instrumentation. Built on a
+real ``torch.nn.RMSNorm`` traced with a symbolic seq_len, mirroring
+``tests/compiler/ir/test_dynamic_shapes.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from .conftest import requires_cuda
+
+pytestmark = [requires_cuda]
+
+
+@pytest.fixture(scope="module")
+def rmsnorm_setup():
+    """Compiled dynamic-seq_len RMSNorm graph + its torch module."""
+    pytest.importorskip("cupy")
+    import torch
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+
+    m = torch.nn.RMSNorm(256)
+    with torch.no_grad():
+        m.weight.copy_(torch.rand_like(m.weight) + 0.5)
+    from deplodock.compiler.trace.torch import trace_module
+
+    seq = torch.export.Dim("seq_len", min=5, max=4096)
+    graph = trace_module(m, (torch.randn(1, 32, 256),), dynamic_shapes={"x": {1: seq}})
+    compiled = CudaBackend().compile(graph)
+    return compiled, m
+
+
+def _inputs(m, s: int) -> tuple[dict[str, np.ndarray], np.ndarray]:
+    import torch
+
+    x = np.random.RandomState(s).standard_normal((1, s, 256)).astype(np.float32)
+    weight = m.weight.detach().numpy().astype(np.float32)
+    with torch.no_grad():
+        ref = torch.nn.functional.rms_norm(torch.from_numpy(x), (256,), m.weight, eps=m.eps).numpy()
+    return {"x": x, "p_weight": weight}, ref
+
+
+def test_rebind_runs_at_new_seq_lens(rmsnorm_setup):
+    """Build at S=32, rebind through S=64 and S=8 — outputs track the new
+    runtime shape and match torch eager at every size."""
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+    compiled, m = rmsnorm_setup
+    with gpu_lock():
+        feed, ref = _inputs(m, 32)
+        prog = CompiledProgram.build(compiled, feed)
+        prog.run_once()
+        out = next(iter(prog.outputs().values()))
+        np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+        for s in (64, 8, 64):  # grow, shrink, grow again
+            feed, ref = _inputs(m, s)
+            prog.rebind(feed)
+            prog.run_once()
+            out = next(iter(prog.outputs().values()))
+            assert out.shape == (1, s, 256)
+            np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+
+def test_rebind_same_shape_reuploads_in_place(rmsnorm_setup):
+    """Same seq_len, new contents: device arrays are reused (no realloc) and
+    the fresh values flow through."""
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+    compiled, m = rmsnorm_setup
+    with gpu_lock():
+        import torch
+
+        feed, _ = _inputs(m, 16)
+        prog = CompiledProgram.build(compiled, feed)
+        before = {name: id(arr) for name, arr in prog.arrays.items()}
+
+        x2 = np.random.RandomState(99).standard_normal((1, 16, 256)).astype(np.float32)
+        prog.rebind({"x": x2, "p_weight": feed["p_weight"]})
+        prog.run_once()
+        out = next(iter(prog.outputs().values()))
+        assert {name: id(arr) for name, arr in prog.arrays.items()} == before
+        with torch.no_grad():
+            ref = torch.nn.functional.rms_norm(torch.from_numpy(x2), (256,), m.weight, eps=m.eps).numpy()
+        np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+
+def test_rebind_keeps_weight_array_and_drops_graphs(rmsnorm_setup):
+    """Weights (static-shaped, un-supplied) keep their device array across a
+    seq_len change; captured CUDA graphs are invalidated."""
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+    compiled, m = rmsnorm_setup
+    with gpu_lock():
+        feed, _ = _inputs(m, 32)
+        prog = CompiledProgram.build(compiled, feed)
+        # Every static-shaped buffer that isn't the activation input — the
+        # weight however the tracer named/classified it, plus static scratch.
+        weight_names = [b.name for b in prog.compiled.bufs if not b.is_symbolic and b.name != "x"]
+        assert weight_names, "expected at least one static-shaped buffer (the RMSNorm weight)"
+        weight_ids = {name: id(prog.arrays[name]) for name in weight_names}
+
+        prog.capture_launch_graphs([1] * len(prog.compiled.launches))
+        assert prog._graphs is not None
+
+        feed64, ref64 = _inputs(m, 64)
+        prog.rebind({"x": feed64["x"]})  # weights not re-supplied — the serving pattern
+        assert prog._graphs is None, "rebind must drop captured graphs (they bake old pointers)"
+        assert {name: id(prog.arrays[name]) for name in weight_names} == weight_ids, "weights must not re-upload on rebind"
+        prog.run_once()
+        out = next(iter(prog.outputs().values()))
+        np.testing.assert_allclose(out, ref64, rtol=1e-4, atol=1e-4)

--- a/tests/deploy/test_recipe.py
+++ b/tests/deploy/test_recipe.py
@@ -64,6 +64,21 @@ def test_load_recipe_missing_file_raises(tmp_path):
         load_recipe(str(tmp_path / "does_not_exist"))
 
 
+def test_load_recipe_rejects_unknown_model_task(tmp_path):
+    recipe_dir = tmp_path / "r"
+    recipe_dir.mkdir()
+    (recipe_dir / "recipe.yaml").write_text(yaml.dump({"model": {"huggingface": "org/m", "task": "rerank"}, "engine": {"llm": {}}}))
+    with pytest.raises(ValueError, match="model.task"):
+        load_recipe(str(recipe_dir))
+
+
+def test_load_recipe_accepts_embed_task(tmp_path):
+    recipe_dir = tmp_path / "r"
+    recipe_dir.mkdir()
+    (recipe_dir / "recipe.yaml").write_text(yaml.dump({"model": {"huggingface": "org/m", "task": "embed"}, "engine": {"llm": {}}}))
+    assert load_recipe(str(recipe_dir)).is_embedding
+
+
 def test_load_recipe_no_deploy_gpu(tmp_recipe_dir):
     """Base recipe has no deploy.gpu (it comes from matrices)."""
     recipe = load_recipe(tmp_recipe_dir)

--- a/tests/recipe/test_types.py
+++ b/tests/recipe/test_types.py
@@ -323,3 +323,15 @@ def test_from_dict_without_aggregate():
     d = {"model": {"huggingface": "org/model"}}
     recipe = Recipe.from_dict(d)
     assert recipe.aggregate is None
+
+
+def test_model_task_default_generate():
+    r = Recipe.from_dict({"model": {"huggingface": "org/m"}})
+    assert r.model.task == "generate"
+    assert not r.is_embedding
+
+
+def test_model_task_embed():
+    r = Recipe.from_dict({"model": {"huggingface": "org/m", "task": "embed"}})
+    assert r.model.task == "embed"
+    assert r.is_embedding

--- a/tests/serving/test_packed.py
+++ b/tests/serving/test_packed.py
@@ -1,0 +1,40 @@
+"""``serving.packed.split_spans`` — pure logic, no GPU/torch/vllm."""
+
+from deplodock.serving.packed import split_spans
+
+
+def test_single_sequence():
+    assert split_spans([0, 1, 2, 3], max_seq_len=16) == [(0, 4)]
+
+
+def test_multiple_sequences_split_at_position_zero():
+    # Three packed requests of lengths 3, 1, 4.
+    pos = [0, 1, 2, 0, 0, 1, 2, 3]
+    assert split_spans(pos, max_seq_len=16) == [(0, 3), (3, 4), (4, 8)]
+
+
+def test_empty_batch():
+    assert split_spans([], max_seq_len=16) == []
+
+
+def test_dummy_run_nonzero_start_still_spans_from_zero():
+    # Garbage profiling batch: positions never hit 0 — index 0 still opens a span.
+    assert split_spans([5, 6, 7], max_seq_len=16) == [(0, 3)]
+
+
+def test_overlong_span_chopped_to_max_seq_len():
+    # Garbage profiling batch longer than max_seq_len is chunked, not crashed.
+    pos = list(range(10))
+    assert split_spans(pos, max_seq_len=4) == [(0, 4), (4, 8), (8, 10)]
+
+
+def test_overlong_middle_sequence():
+    pos = [0, 1, 0, 1, 2, 3, 4, 0]
+    assert split_spans(pos, max_seq_len=3) == [(0, 2), (2, 5), (5, 7), (7, 8)]
+
+
+def test_numpy_positions():
+    import numpy as np
+
+    pos = np.array([0, 1, 0, 1, 2])
+    assert split_spans(pos, max_seq_len=16) == [(0, 2), (2, 5)]

--- a/tests/serving/test_serve_command.py
+++ b/tests/serving/test_serve_command.py
@@ -1,0 +1,94 @@
+"""``deplodock serve`` command construction + flag routing + dry-run (no vllm/GPU)."""
+
+import argparse
+
+from deplodock.commands.serve import build_bench_cmd, build_serve_cmd, handle_serve, register_serve_command
+
+MODEL = "Qwen/Qwen3-Embedding-0.6B"
+
+
+def _parse(argv):
+    parser = argparse.ArgumentParser()
+    register_serve_command(parser.add_subparsers(dest="command"))
+    return parser.parse_args(argv)
+
+
+def test_serve_cmd_plugin_defaults():
+    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=[])
+    assert cmd[:3] == ["vllm", "serve", MODEL]
+    assert "--runner" in cmd and "pooling" in cmd
+    assert "--enforce-eager" in cmd
+    assert '{"architectures": ["DeplodockEmbedModel"]}' in cmd
+    assert cmd[cmd.index("--max-model-len") + 1] == "4096"
+
+
+def test_serve_cmd_stock_drops_plugin_but_keeps_parity():
+    cmd = build_serve_cmd(MODEL, stock=True, vllm_args=[])
+    assert "--enforce-eager" not in cmd
+    assert "--hf-overrides" not in cmd
+    assert "pooling" in cmd
+    assert cmd[cmd.index("--max-model-len") + 1] == "4096"  # same cap as the plugin → apples-to-apples
+
+
+def test_serve_cmd_passthrough_and_max_model_len_override():
+    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=["--max-model-len", "2048", "--gpu-memory-utilization", "0.8"])
+    assert cmd.count("--max-model-len") == 1
+    assert cmd[cmd.index("--max-model-len") + 1] == "2048"
+    assert "--gpu-memory-utilization" in cmd
+
+
+def test_serve_cmd_max_model_len_equals_style():
+    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=["--max-model-len=2048"])
+    assert "--max-model-len" not in cmd  # no separate default token added
+    assert "--max-model-len=2048" in cmd
+    assert "4096" not in cmd
+
+
+def test_bench_cmd_targets_embeddings():
+    cmd = build_bench_cmd(MODEL, port="8123", max_concurrency=8, num_prompts=32, random_input_len=64, seed=7)
+    assert cmd[:3] == ["vllm", "bench", "serve"]
+    assert cmd[cmd.index("--backend") + 1] == "openai-embeddings"
+    assert cmd[cmd.index("--endpoint") + 1] == "/v1/embeddings"
+    assert cmd[cmd.index("--base-url") + 1] == "http://localhost:8123"
+    assert "--random-output-len" not in cmd
+
+
+def test_own_flags_after_model_are_extracted(capsys):
+    # The argparse-REMAINDER footgun: everything after MODEL lands in
+    # vllm_args, INCLUDING deplodock's own flags. They must still be honored
+    # (this exact case once exec'd a real server out of a --dry-run test).
+    args = _parse(["serve", MODEL, "--bench", "--dry-run", "--random-input-len", "32", "--gpu-memory-utilization", "0.8"])
+    handle_serve(args)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2, out
+    assert "--bench" not in out[0] and "--dry-run" not in out[0]
+    assert "--gpu-memory-utilization 0.8" in out[0]
+    assert "--random-input-len 32" in out[1]  # bench param, not forwarded to serve
+    assert "--random-input-len" not in out[0]
+
+
+def test_verbatim_passthrough_after_double_dash(capsys):
+    args = _parse(["serve", MODEL, "--bench", "--dry-run", "--", "--port", "8222", "--seed", "3"])
+    handle_serve(args)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    assert out[0].startswith(f"vllm serve {MODEL}")
+    assert "--port 8222" in out[0] and "--seed 3" in out[0]
+    assert " -- " not in out[0]  # the separator itself is not forwarded
+    assert "http://localhost:8222" in out[1]  # bench targets the passthrough port
+
+
+def test_dry_run_serve_only(capsys):
+    args = _parse(["serve", MODEL, "--dry-run"])
+    handle_serve(args)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 1
+    assert "bench" not in out[0]
+
+
+def test_bench_seed_is_distinct_from_vllm_seed(capsys):
+    args = _parse(["serve", MODEL, "--bench", "--dry-run", "--bench-seed", "9", "--seed", "1"])
+    handle_serve(args)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert "--seed 1" in out[0]  # vllm serve gets --seed
+    assert "--seed 9" in out[1]  # the bench client gets --bench-seed

--- a/tests/serving/test_vllm_plugin_gpu.py
+++ b/tests/serving/test_vllm_plugin_gpu.py
@@ -1,0 +1,60 @@
+"""In-process vLLM engine test of the deplodock embedding plugin.
+
+``perf``-marked (deselected by default — run with ``pytest -m perf``): needs
+CUDA, vllm, and the Qwen3-Embedding-0.6B checkpoint, and spends ~2 min
+compiling the whole model at startup. The fast everywhere-tests for this
+package live in ``test_packed.py``.
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.xdist_group("cuda")]
+
+MODEL = "Qwen/Qwen3-Embedding-0.6B"
+
+
+def test_vllm_plugin_embed_matches_hf_eager(monkeypatch):
+    pytest.importorskip("cupy")
+    vllm = pytest.importorskip("vllm")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    # The test process has CUDA initialized (conftest seeds it); vLLM's forked
+    # EngineCore would die on re-init. Run the engine in-process instead.
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+    texts = [
+        "What is the capital of France?",
+        "Paris is the capital and largest city of France.",
+        "The mitochondria is the powerhouse of the cell.",
+    ]
+
+    llm = vllm.LLM(
+        model=MODEL,
+        runner="pooling",
+        enforce_eager=True,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        hf_overrides={"architectures": ["DeplodockEmbedModel"]},
+    )
+    outs = llm.embed(texts)
+    got = np.array([o.outputs.embedding for o in outs], dtype=np.float64)
+
+    from transformers import AutoModel, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(MODEL)
+    ref_model = AutoModel.from_pretrained(MODEL, dtype=torch.float32).eval()
+    refs = []
+    for t in texts:
+        ids = torch.tensor(tok(t)["input_ids"])[None, :]
+        with torch.no_grad():
+            h = ref_model(input_ids=ids).last_hidden_state[0, -1].numpy()
+        refs.append(h / np.linalg.norm(h))
+    ref = np.array(refs)
+
+    got /= np.linalg.norm(got, axis=1, keepdims=True)
+    cos = (got * ref).sum(axis=1)
+    assert cos.min() > 0.99, f"cosine vs HF eager too low: {cos}"


### PR DESCRIPTION
## What

End-to-end serving for embedding models with deplodock-compiled kernels, integrated as a **vLLM out-of-tree model plugin** — vLLM provides the OpenAI `/v1/embeddings` shell (tokenizer, scheduler, pooler), our compiled program is the trunk forward. Plus recipes that A/B stock vLLM vs the plugin on Qwen3-Embedding-0.6B/4B/8B for RTX 5090 / RTX 4090.

- **`CompiledProgram.rebind` / `run_once`** — one built dynamic-seq_len program serves request after request (in-place re-upload on unchanged shapes, symbolic-shaped buffers re-materialize, weights untouched).
- **`deplodock/serving/`** — `DeplodockEmbedModel` (`vllm.general_plugins` entry point, pooling model, attention-free, no `nn.Parameter`s) + `DeplodockForwardRunner` (trace `AutoModel` trunk with dynamic seq_len → compile → per-sequence execute). `pip install -e ".[compile,serving]"`, then:
  ```bash
  vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --enforce-eager \
    --max-model-len 4096 --hf-overrides '{"architectures":["DeplodockEmbedModel"]}'
  ```
- **Compiler fixes the work surfaced** (whole-model `--dynamic` was silently broken for any non-zero `input_ids`):
  - the in-graph rotary constant-folds to `cos=1, sin=0` under `torch.export` (non-persistent `inv_freq`) — dynamic mode now precomputes cos/sin to `DYNAMIC_DIM_MAX+1` and slices in-graph (`_SlicedRotary`);
  - `SliceOp` with `start=None` / SymInt end lost its dim/start (positionally ambiguous constant inputs) — now recorded as op fields at trace time.
  - Why it was never caught: the accuracy check traces with `input_ids = zeros`, and identical value rows make attention output independent of the attention weights. New CUDA regression test compares against eager at three seq_lens with non-zero ids.
- **`model.task: embed`** recipe field → `/v1/embeddings` smoke test (finite unit-norm vector) + `vllm bench serve --backend openai-embeddings` workload.
- **`docker/vllm-deplodock`** image (`make wheel / vllm-deplodock-image / vllm-deplodock-push`), tag `cloudriftai/vllm-deplodock:0.22.1-<sha>`.
- **`recipes/Qwen3-Embedding-{0.6B,4B,8B}`** — 8 variants each (2 GPUs × 2 request-length regimes × 2 engines, both pinned to context 4096) + `scripts/aggregate_embedding.py` report.

## Verification

- Accuracy: plugin vs stock vLLM server, 12-text set — **min cosine 0.9998**, pairwise-similarity drift 3e-3 (fp16); GPU-gated in-process engine test (`perf`-marked).
- `bench --local --filter "deploy.gpu=*5090*"` on the 0.6B recipe: **4/4 variants** (run dir committed) — embeddings smoke, bench, aggregate report all exercised. 4090 variants ship untested (no machine available).
- `make test` (1906 passed), `make lint`.

## Notes

- The deplodock rows trail stock throughput by design in v1 — per-sequence serial execution + host I/O; follow-ups (packed-varlen attention, dlpack zero-copy, device-side mask) are recorded in `deplodock/serving/ARCHITECTURE.md`.
- The image is **not pushed yet** (publishing was blocked in the sandboxed session): run `make vllm-deplodock-push` before cloud/4090 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)