### PR TITLE
tune: per-kernel GPU parallelization via single-thread asyncio (--gpus / --devices)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ same worker.
   dataset (no GPU, no benching) and print diagnostics — per-op **pick reachability** (does the prior's predicted-fastest
   config recover each op's measured-best config?), median ranking calibration (Spearman), and golden-matmul coverage. Use it to see
   whether the prior can actually reach the best configs it's been tuned on (`compiler/pipeline/search/prior/diagnostics.py`).
-- `deplodock tune <model_or_ir|--code EXPR> [--patience N] [--ucb-c C] [--explore-eps E] [--bench] [-q]` — **two-level** autotune (see
+- `deplodock tune <model_or_ir|--code EXPR> [--patience N] [--ucb-c C] [--explore-eps E] [--gpus N | --devices 0,1,2] [--bench] [-q]` — **two-level** autotune (see
   `compiler/pipeline/search/two_level.py`): an outer SP-MCTS over structural forks (the graph-changing
   `frontend`+`loop` passes plus the pre-partition head of `lowering/tile`, where `005_split_demoted`'s keep-vs-split
   offer branches the outer tree — one terminal per kernel set; identical offer sites replay the trajectory's
@@ -101,7 +101,11 @@ same worker.
   single-node slice (post-partition `lowering` forks only, so `Σ_k n_k` benches not the product). Greedy `compile` /
   `run` deploy a structural option when the *trained* prior prices its kernel-set Σ cheaper (cold compiles never
   change kernel sets) — see `plans/structural-forks-in-two-level.md`. Per-op results key structurally
-  (`op_cache_key`) so they transfer/share. The inner search runs for
+  (`op_cache_key`) so they transfer/share. `--gpus N` / `--devices 0,1,2` fan the inner per-kernel search out
+  across GPUs — one in-flight bench per device-pinned `_AsyncBenchWorker` on a single asyncio event loop
+  (`two_level._inner_reward_async`); single-thread asyncio touches the shared DB / prior only between bench
+  `await`s, so no locks, and the default single-GPU path is the byte-identical one-slot serial case. Parallelism
+  is bounded by the unique-kernel count; devices must be homogeneous (one perf key per tune). The inner search runs for
   **every** op on every pass — never skipped on prior effort; replay is cheap, not gated: each benched terminal hits the
   per-variant `perf` cache, so an identical re-run (same prior) replays every variant with no GPU bench, while the
   ever-changing global prior can steer the same-patience search down a new trajectory and bench only the genuinely-new

--- a/deplodock/commands/tune.py
+++ b/deplodock/commands/tune.py
@@ -90,6 +90,24 @@ def register_tune_command(subparsers):
     parser.add_argument("--iters", type=int, default=100, help="Measurement iterations for --bench (default: 100).")
     parser.add_argument("--seed", type=int, default=0, help="RNG seed for --bench random inputs (default: 0).")
     parser.add_argument(
+        "--gpus",
+        type=int,
+        default=None,
+        help=(
+            "Tune the post-fusion kernels concurrently across this many GPUs (devices 0..N-1): one in-flight "
+            "bench per GPU on a single event loop. Default: single-GPU (serial, behaviorally identical). "
+            "Bounded by the number of unique kernels; devices must be homogeneous. ``--devices`` overrides."
+        ),
+    )
+    parser.add_argument(
+        "--devices",
+        default=None,
+        help=(
+            "Comma-separated GPU ids to tune across (e.g. ``0,1,3``), the explicit form of ``--gpus``. "
+            "Devices must be homogeneous (one perf key per tune). Default: single-GPU."
+        ),
+    )
+    parser.add_argument(
         "--bench-backends",
         default="eager,tcompile,deplodock",
         help=(
@@ -122,26 +140,71 @@ def _tune_offline(args):
     sys.stderr.write(diagnostics.golden_prior_eval(prior) + "\n")
 
 
-def _tune_backend():
+def _tune_backend(device_id: int | None = None):
     """The autotune-sweep ``CudaBackend``: benches each variant in a SIGKILL-able
     ``_bench_worker`` **subprocess** (``bench_wall_timeout_s`` set → the isolated
-    path in ``backend.benchmark``), so a wedged kernel dies with the worker and the
-    **parent** CUDA stream stays clean. Tight per-variant budgets: tune benches
-    isolated single kernels at -Xcicc -O1 (fast), so 2 s compile / 2 s run is ample
-    and the 6 s wall SIGKILLs any runaway."""
+    path in ``backend.benchmark`` / ``benchmark_async``), so a wedged kernel dies
+    with the worker and the **parent** CUDA stream stays clean. Tight per-variant
+    budgets: tune benches isolated single kernels at -Xcicc -O1 (fast), so 2 s
+    compile / 2 s run is ample and the 6 s wall SIGKILLs any runaway. ``device_id``
+    pins the async bench worker to a physical GPU (multi-GPU tune)."""
     from deplodock.compiler.backend.cuda.backend import CudaBackend
 
-    return CudaBackend(bench_compile_timeout_s=2.0, bench_run_timeout_s=2.0, bench_wall_timeout_s=6.0)
+    return CudaBackend(bench_compile_timeout_s=2.0, bench_run_timeout_s=2.0, bench_wall_timeout_s=6.0, device_id=device_id)
 
 
-def _tune_one(args, *, backend, db, ctx, dump):
+def _resolve_devices(args) -> list[int | None]:
+    """Resolve ``--gpus`` / ``--devices`` into a device-id list (``--devices`` wins).
+    Default ``[None]`` → a single unpinned slot = today's serial behavior. Two or
+    more devices must be homogeneous — the tune keys every perf row on one probed
+    ``ctx``, so mixed compute capabilities would corrupt the per-op cache."""
+    if args.devices:
+        try:
+            devices: list[int | None] = [int(x) for x in args.devices.split(",") if x.strip() != ""]
+        except ValueError:
+            logger.error("--devices must be comma-separated GPU ids, e.g. 0,1,3")
+            sys.exit(2)
+    elif args.gpus is not None:
+        if args.gpus < 1:
+            logger.error("--gpus must be >= 1")
+            sys.exit(2)
+        devices = list(range(args.gpus))
+    else:
+        return [None]
+    if len(devices) <= 1:
+        return devices or [None]
+    _require_homogeneous_devices(devices)
+    return devices
+
+
+def _require_homogeneous_devices(devices: list[int | None]) -> None:
+    try:
+        import cupy as cp
+    except Exception:  # noqa: BLE001 — no cupy → can't probe; let the bench surface any mismatch
+        return
+    caps = {}
+    for d in devices:
+        try:
+            props = cp.cuda.runtime.getDeviceProperties(d)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("--devices: GPU %s not available (%s)", d, exc)
+            sys.exit(2)
+        caps[d] = (props["major"], props["minor"])
+    if len(set(caps.values())) > 1:
+        logger.error("--devices must be homogeneous (one perf key per tune); got compute capabilities %s", caps)
+        sys.exit(2)
+
+
+def _tune_one(args, *, backends, db, ctx, dump):
     """Trace ``args.code`` / ``args.input`` and run the two-level tune on that one
     graph; return ``(result, bench_bundle)``. Manages the live progress bar (closed
     in ``finally``) and prints the per-op ``done`` summary. Lets ``KeyboardInterrupt``
     and the saturated-queue ``RuntimeError`` (dirty parent stream) **propagate** so
     the caller decides how to exit — called once per target by ``handle_tune``'s
     loop (one shape or the whole golden set). Benching itself is subprocess-isolated
-    (see ``_tune_backend``), so the parent process is safe to reuse shape-to-shape."""
+    (see ``_tune_backend``), so the parent process is safe to reuse shape-to-shape.
+    ``backends`` is the device-pinned pool (one per GPU; single-element by default)
+    fanning the inner per-kernel search across GPUs."""
     import time
 
     from deplodock.commands.tune_progress import TuneProgress
@@ -164,7 +227,7 @@ def _tune_one(args, *, backend, db, ctx, dump):
             graph,
             ctx=ctx,
             db=db,
-            backend=backend,
+            backends=backends,
             patience=patience,
             ucb_c=args.ucb_c,
             explore_eps=explore_eps,
@@ -271,9 +334,13 @@ def handle_tune(args):
         _clean_caches(db_path)
     db = SearchDB(path=db_path)
     logger.info("Tuning DB: %s", db_path)
-    # One bench worker (subprocess-isolated) + one prior shared across every target —
-    # benching can't dirty the parent, so a single long-lived process loops cleanly.
-    backend = _tune_backend()
+    # One device-pinned bench worker per GPU (subprocess-isolated) + one prior shared
+    # across every target — benching can't dirty the parent, so a single long-lived
+    # process loops cleanly. ``[None]`` (default) = one unpinned worker = serial.
+    devices = _resolve_devices(args)
+    backends = [_tune_backend(device_id=d) for d in devices]
+    if len(backends) > 1:
+        sys.stderr.write(f"[tune] per-kernel parallel across {len(backends)} GPUs: {[d for d in devices]}\n")
     ctx = Context.probe()
 
     multi = len(targets) > 1
@@ -286,7 +353,7 @@ def handle_tune(args):
             sys.stderr.write(f"\n[tune] === {i + 1}/{len(targets)}: {label} → {code} ===\n")
         dump, tmp_dump = _bench_dump(args)
         try:
-            result, bench_bundle = _tune_one(args, backend=backend, db=db, ctx=ctx, dump=dump)
+            result, bench_bundle = _tune_one(args, backends=backends, db=db, ctx=ctx, dump=dump)
         except KeyboardInterrupt:
             # Per-op bests already landed in the DB as they were measured, so a re-run resumes.
             sys.stderr.write(f"\n[tune] interrupted{f' at {label}' if multi else ''} — partial per-op results are in the DB\n")

--- a/deplodock/commands/tune_progress.py
+++ b/deplodock/commands/tune_progress.py
@@ -3,10 +3,13 @@
 The two-level tune evaluates a small number of outer fusion terminals (one today); each terminal's tuned op leaves
 are its post-fusion kernels (``LoopOp``s), tuned independently by the inner search. We measure progress as
 **completed vs total op leaves** across the registered terminals: the op counter advances once per kernel, while
-the live tail (current kernel · this variant's perf · running best · variant knobs) updates per benched variant.
-The current latency is fixed-width and the variable-length knob string sits last, so the prefix up to the knobs
-stays put as the per-variant latency changes (only a new best, which is rare, shifts the trailing part) — the
-bar / counter / kernel / current timing stay steady instead of flickering.
+the live tail shows each *currently in-flight* kernel (current variant's perf · running best · knobs). Single-GPU
+tuning runs one kernel at a time → one tail entry; multi-GPU (``--gpus``) runs one per device → the tail joins the
+active kernels with `` | `` so the line tracks every slot at once. Per active kernel the current latency is
+fixed-width (it changes every variant, so a fixed field keeps the rest from shifting).
+
+The ``slot`` key identifies the in-flight kernel (the inner driver passes each op's ``op_idx``); at most
+``#GPUs`` are active between ``op_start`` and ``op_done``, so the tail never grows past the device count.
 
 When ``enabled`` is False every method is a no-op, so ``handle_tune`` can construct one unconditionally and let it
 decide whether to draw (disabled under ``-v`` / ``-q`` / a non-tty stream). Drawing uses ``\\r\\033[K`` to clear and
@@ -26,7 +29,8 @@ class TuneProgress:
         self.bar_width = bar_width
         self.total = 0
         self.done = 0
-        self._variants = 0  # benched variants for the current op (visible activity within a single-op tune)
+        self._variants: dict[int, int] = {}  # slot → benched-variant count for its current op
+        self._tails: dict[int, str] = {}  # slot → live tail for its in-flight kernel (insertion-ordered)
         self._drawn = False
 
     def start_terminal(self, n_ops: int) -> None:
@@ -36,32 +40,44 @@ class TuneProgress:
         self.total += n_ops
         self._redraw()
 
-    def op_start(self, name: str) -> None:
+    def op_start(self, name: str, *, slot: int = 0) -> None:
         if not self.enabled:
             return
-        self._variants = 0
-        self._redraw(tail=f"{name}  …")
+        self._variants[slot] = 0
+        self._tails[slot] = f"{name}  …"
+        self._redraw()
 
-    def variant(self, kernel: str, knobs_label: str, *, median_us: float | None, status: str, best_us: float | None) -> None:
-        """Update the live tail for the variant just benched within ``kernel``.
+    def variant(
+        self,
+        kernel: str,
+        knobs_label: str,
+        *,
+        median_us: float | None,
+        status: str,
+        best_us: float | None,
+        slot: int = 0,
+    ) -> None:
+        """Update the live tail for the variant just benched within ``kernel`` on ``slot``.
 
-        Layout ``<kernel> <current> (best <best>) <knobs>``: the *current* latency is
-        fixed-width (it changes every variant, so a fixed field keeps everything after
-        it from shifting), and the variable-length knob string sits last where its churn
-        can't move the bar / counter / kernel / current timing. Only a new best (rare)
-        nudges the trailing part."""
+        Layout ``<kernel> #<n> <current> (best <best>) <knobs>``: the *current* latency is
+        fixed-width (it changes every variant, so a fixed field keeps everything after it
+        from shifting), and the variable-length knob string sits last."""
         if not self.enabled:
             return
-        self._variants += 1
+        n = self._variants.get(slot, 0) + 1
+        self._variants[slot] = n
         cur = f"{median_us:8.1f}us" if (median_us is not None and status == "ok") else f"{status or '—':>10}"
         best = f"{best_us:.1f}us" if (best_us is not None and best_us != float("inf")) else "—"
-        self._redraw(tail=f"{kernel} #{self._variants} {cur} (best {best})  {knobs_label}")
+        self._tails[slot] = f"{kernel} #{n} {cur} (best {best})  {knobs_label}"
+        self._redraw()
 
-    def op_done(self, name: str) -> None:
+    def op_done(self, name: str, *, slot: int = 0) -> None:
         if not self.enabled:
             return
         self.done += 1
-        self._redraw(tail=f"{name}  done")
+        self._tails.pop(slot, None)
+        self._variants.pop(slot, None)
+        self._redraw()
 
     def close(self) -> None:
         """Finalize the bar with a trailing newline so following output starts clean. Idempotent."""
@@ -76,8 +92,9 @@ class TuneProgress:
         filled = max(0, min(self.bar_width, round(self.bar_width * self.done / self.total)))
         return "█" * filled + "░" * (self.bar_width - filled)
 
-    def _redraw(self, tail: str = "") -> None:
+    def _redraw(self) -> None:
         line = f"[tune] [{self._bar()}] {self.done}/{self.total} ops"
+        tail = " | ".join(self._tails[s] for s in self._tails)
         if tail:
             line += f" · {tail}"
         # Truncate to the terminal width so a long variant label can't wrap onto a

--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -167,6 +167,18 @@ a respawn + one resend before surfacing as `bench worker died during request
 send`. Phase A of the tune-stabilization work; see
 `tests/compiler/backend/test_bench_worker_recovery.py`.
 
+**Async sibling for multi-GPU tune.** `_AsyncBenchWorker` / `benchmark_program_isolated_async(...)` drive the *same*
+`_bench_worker.py` subprocess protocol (`<8-byte LE length><pickle>`) over `asyncio` streams instead of blocking
+`select` — so one event loop can keep N device-pinned workers benching concurrently (`tune --gpus`, see
+`pipeline/ARCHITECTURE.md` → *Per-kernel GPU parallelism*). The wall-clock cap is `asyncio.wait_for` (same SIGKILL +
+respawn recovery contract); a stale-worker send race respawns and retries once, exactly as the sync worker.
+`CudaBackend(device_id=i)` lazily owns one such worker and exposes `benchmark_async` (always isolated, requires
+`bench_wall_timeout_s`). The device pin is a **per-worker spawn-env overlay** — `CUDA_VISIBLE_DEVICES=<id>` (so the
+child's logical device 0 *is* that GPU; every argumentless `cp.cuda.Device()` resolves correctly) plus, when a base
+`DEPLODOCK_GPU_LOCK` is set, a per-device `…-<id>` lock path so workers on different GPUs take distinct `FileLock`s
+instead of serialising on one. The overlay never mutates the parent `os.environ` (all slots share one event-loop
+thread). See `tests/compiler/backend/test_async_bench_worker.py`.
+
 `iter_once` (the per-iter sample loop) rejects a `cp.cuda.get_elapsed_time`
 reading of `<= 0.0` as `bench_fail` instead of accepting it as a 0µs sample.
 CUDA event timing has sub-µs resolution and any real launch consumes at least

--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -141,43 +141,39 @@ subprocess boundary before — run isolated. So `tune --bench` (`commands/tune.p
 `_bench_per_kernel`) and any deployable bench go through `benchmark_compare_isolated`: a hung kernel
 hangs the child, the parent SIGKILLs it at `wall_timeout_s`, the device is freed, and the per-kernel
 sweep **continues** to the next reproducer (no device-poisoning wedge, no skip). The parent transport
-is the single `_BenchWorker.run_job`; `benchmark_program_isolated` / `benchmark_compare_isolated` are
-its two thin adapters. See `tests/compiler/backend/test_bench_worker_compare.py` (compare-in-worker +
-SIGKILL recovery), `test_hung_kernel_watchdog.py` (watchdog raises promptly), and
+is the single **`_AsyncBenchWorker.run_job`** (the old sync `_BenchWorker` is gone); `benchmark_program_isolated` /
+`benchmark_compare_isolated` are synchronous `asyncio.run` bridges over a one-shot instance, and the autotune sweep
+awaits a persistent per-GPU instance directly via `benchmark_program_isolated_async`. See
+`tests/compiler/backend/test_bench_worker_compare.py` (compare-in-worker + SIGKILL recovery),
+`test_hung_kernel_watchdog.py` (watchdog raises promptly), and
 `tests/compiler/cli/test_tune_bench_hung_kernel.py` (the `_run_bench` control flow).
 
-`benchmark_program_isolated(...)` (the autotune path, gated on
-`bench_wall_timeout_s`) runs the bench in a **persistent** subprocess
-(`_bench_worker.py`, one per `CudaBackend`) so a wedged kernel can be
-SIGKILLed without dirtying the parent's stream. Because the worker is reused
-across configs, a kernel that does an illegal / misaligned access is a hazard:
-that error is **sticky** — it corrupts the CUDA context so every later call
-returns the same status until the process dies, which would cascade identical
-false `bench_fail`s across all subsequent configs. So after any failure the
-worker probes its context (`_context_dirty` — a cheap `deviceSynchronize`) and
-*exits* if it's poisoned; the parent respawns a clean context on the next
-request. Benign failures (NVRTC compile errors, cleaned-up OOM) leave the
-context healthy and keep the worker alive, so they pay no respawn cost.
+**One async transport — `_AsyncBenchWorker`.** It drives the `_bench_worker.py` subprocess protocol (`<8-byte LE
+length><pickle>`, both directions) over `asyncio` streams, so one event loop can keep N device-pinned workers benching
+concurrently (`tune --gpus`, see `pipeline/ARCHITECTURE.md` → *Per-kernel GPU parallelism*). Two entry shapes:
 
-The dirty-exit path can race the parent's `poll()` check: by the time the
-parent writes the next request, the worker's stdin has been closed but
-`poll()` may not yet show the exit. `_BenchWorker.bench` therefore wraps the
-send in a single-retry loop — a `BrokenPipeError` on the first write triggers
-a respawn + one resend before surfacing as `bench worker died during request
-send`. Phase A of the tune-stabilization work; see
-`tests/compiler/backend/test_bench_worker_recovery.py`.
+- **Autotune sweep** awaits `benchmark_program_isolated_async(graph, worker=…)`. `CudaBackend(device_id=i)` lazily owns
+  one **persistent** worker (reused across configs — pay the ~0.2 s Python spawn once) and exposes `benchmark_async`
+  (always isolated, requires `bench_wall_timeout_s`). The device pin is a **per-worker spawn-env overlay** —
+  `CUDA_VISIBLE_DEVICES=<id>` (so the child's logical device 0 *is* that GPU; every argumentless `cp.cuda.Device()`
+  resolves correctly) plus, when a base `DEPLODOCK_GPU_LOCK` is set, a per-device `…-<id>` lock path so workers on
+  different GPUs take distinct `FileLock`s instead of serialising. The overlay rides the child only — the parent's
+  `os.environ` is never mutated (all slots share one event-loop thread).
+- **Deployable `--bench`** (`benchmark_program_isolated` / `benchmark_compare_isolated`) are synchronous bridges:
+  each wraps `_run_job_oneshot` (spawn → run → `aclose`) in `asyncio.run`. The worker's streams bind to the loop, so
+  it can't persist across `asyncio.run` calls — a per-call spawn, negligible against a minutes-long deployable bench.
 
-**Async sibling for multi-GPU tune.** `_AsyncBenchWorker` / `benchmark_program_isolated_async(...)` drive the *same*
-`_bench_worker.py` subprocess protocol (`<8-byte LE length><pickle>`) over `asyncio` streams instead of blocking
-`select` — so one event loop can keep N device-pinned workers benching concurrently (`tune --gpus`, see
-`pipeline/ARCHITECTURE.md` → *Per-kernel GPU parallelism*). The wall-clock cap is `asyncio.wait_for` (same SIGKILL +
-respawn recovery contract); a stale-worker send race respawns and retries once, exactly as the sync worker.
-`CudaBackend(device_id=i)` lazily owns one such worker and exposes `benchmark_async` (always isolated, requires
-`bench_wall_timeout_s`). The device pin is a **per-worker spawn-env overlay** — `CUDA_VISIBLE_DEVICES=<id>` (so the
-child's logical device 0 *is* that GPU; every argumentless `cp.cuda.Device()` resolves correctly) plus, when a base
-`DEPLODOCK_GPU_LOCK` is set, a per-device `…-<id>` lock path so workers on different GPUs take distinct `FileLock`s
-instead of serialising on one. The overlay never mutates the parent `os.environ` (all slots share one event-loop
-thread). See `tests/compiler/backend/test_async_bench_worker.py`.
+The wall-clock cap is `asyncio.wait_for`; on overrun the child is SIGKILLed and the next bench respawns it on a clean
+device. Because the persistent worker is reused across configs, an illegal / misaligned access is a hazard: that error
+is **sticky** — it corrupts the CUDA context so every later call returns the same status until the process dies, which
+would cascade identical false `bench_fail`s across all subsequent configs. So after any failure the worker probes its
+context (`_context_dirty` — a cheap `deviceSynchronize`) and *exits* if it's poisoned; `run_job` respawns a clean
+context on the next request (the dead-proc check before `await self._spawn()`). Benign failures (NVRTC compile errors,
+cleaned-up OOM) leave the context healthy and keep the worker alive, so they pay no respawn cost. A stale-worker race
+on the send (a `BrokenPipeError`/`ConnectionResetError` from `stdin.drain` after the worker's dirty-context exit)
+triggers one respawn + resend before surfacing as `bench worker died during request send`. Error paths `await aclose()`
+(SIGKILL + reap) so the subprocess transport is cleaned before the loop closes. See
+`tests/compiler/backend/test_bench_worker_recovery.py` and `test_async_bench_worker.py`.
 
 `iter_once` (the per-iter sample loop) rejects a `cp.cuda.get_elapsed_time`
 reading of `<= 0.0` as `bench_fail` instead of accepting it as a 0µs sample.

--- a/deplodock/compiler/backend/cuda/_bench_worker.py
+++ b/deplodock/compiler/backend/cuda/_bench_worker.py
@@ -170,7 +170,7 @@ def main() -> None:
         if dirty:
             # Corrupted context — don't serve more requests from it. Exit so the
             # parent respawns a fresh context on its next bench (program.py
-            # ``_BenchWorker.bench`` re-spawns when ``poll()`` shows us dead).
+            # ``_AsyncBenchWorker.run_job`` re-spawns when the proc is dead).
             return
 
 

--- a/deplodock/compiler/backend/cuda/backend.py
+++ b/deplodock/compiler/backend/cuda/backend.py
@@ -125,6 +125,14 @@ class CudaBackend(Backend):
             self._async_worker_obj.close()
             self._async_worker_obj = None
 
+    async def aclose_async_worker(self) -> None:
+        """SIGKILL + await-reap this backend's async bench worker (driver teardown
+        from inside the event loop — cleans the subprocess transport before the loop
+        closes, so no 'Event loop is closed' GC warning)."""
+        if self._async_worker_obj is not None:
+            await self._async_worker_obj.aclose()
+            self._async_worker_obj = None
+
     def compile(self, graph: Graph) -> Graph:
         """Lower ``Graph`` → ``Graph[LoopOp]`` → ``Graph[TileOp]`` → ``Graph[CudaOp]``."""
         db = None

--- a/deplodock/compiler/backend/cuda/backend.py
+++ b/deplodock/compiler/backend/cuda/backend.py
@@ -17,6 +17,7 @@ from deplodock.compiler.backend import Backend, BenchmarkResult, RunResult
 from deplodock.compiler.backend.cuda.program import (
     benchmark_program,
     benchmark_program_isolated,
+    benchmark_program_isolated_async,
     run_program,
     run_program_debug,
 )
@@ -76,6 +77,7 @@ class CudaBackend(Backend):
         bench_compile_timeout_s: float = 30.0,
         bench_run_timeout_s: float = 10.0,
         tune_db: Path | str | None = None,
+        device_id: int | None = None,
     ) -> None:
         if debug is None:
             debug = config.debug_enabled()
@@ -103,6 +105,25 @@ class CudaBackend(Backend):
         # open if the file exists. Explicit ``Path`` → use that file
         # (open if it exists; silently skip otherwise).
         self.tune_db = _resolve_tune_db(tune_db)
+        # Physical GPU this backend's async bench worker is pinned to (multi-GPU
+        # tune). ``None`` → unpinned (default device). The pinned worker is the
+        # device-selection seam: ``benchmark_async`` drives it so one event loop
+        # can keep N GPUs benching concurrently.
+        self.device_id = device_id
+        self._async_worker_obj = None  # lazily spawned on first benchmark_async
+
+    def _async_worker(self):
+        from deplodock.compiler.backend.cuda.program import _AsyncBenchWorker  # noqa: PLC0415
+
+        if self._async_worker_obj is None:
+            self._async_worker_obj = _AsyncBenchWorker(device_id=self.device_id)
+        return self._async_worker_obj
+
+    def close_async_worker(self) -> None:
+        """SIGKILL this backend's async bench worker, if any (driver teardown)."""
+        if self._async_worker_obj is not None:
+            self._async_worker_obj.close()
+            self._async_worker_obj = None
 
     def compile(self, graph: Graph) -> Graph:
         """Lower ``Graph`` → ``Graph[LoopOp]`` → ``Graph[TileOp]`` → ``Graph[CudaOp]``."""
@@ -209,6 +230,44 @@ class CudaBackend(Backend):
                     run_timeout_s=self.bench_run_timeout_s,
                     capture_graphs=capture_graphs,
                 )
+        return BenchmarkResult(
+            time_ms=result.time_ms,
+            min_ms=result.min_ms,
+            num_launches=result.num_launches,
+            per_launch=result.per_launch,
+            captured=result.captured,
+            e2e_ms=result.e2e_ms,
+            e2e_min_ms=result.e2e_min_ms,
+        )
+
+    async def benchmark_async(
+        self,
+        compiled: Graph,
+        *,
+        warmup: int = 5,
+        num_iters: int | str = 20,
+        nvcc_flags: str | None = None,
+        capture_graphs: bool = True,
+    ) -> BenchmarkResult:
+        """Async, always-isolated bench for the parallel tune driver
+        (``two_level.inner_reward``). Drives this backend's device-pinned async
+        worker so one event loop keeps N GPUs benching concurrently. Requires
+        ``bench_wall_timeout_s`` (the tune backend always sets it) — there is no
+        in-process async path (``on_iter`` interleaving stays on the sync
+        :meth:`benchmark`)."""
+        if self.bench_wall_timeout_s is None:
+            raise RuntimeError("benchmark_async requires bench_wall_timeout_s (the autotune backend sets it)")
+        result = await benchmark_program_isolated_async(
+            compiled,
+            worker=self._async_worker(),
+            wall_timeout_s=self.bench_wall_timeout_s,
+            warmup=warmup,
+            num_iters=num_iters,
+            compile_timeout_s=self.bench_compile_timeout_s,
+            run_timeout_s=self.bench_run_timeout_s,
+            nvcc_flags=nvcc_flags,
+            capture_graphs=capture_graphs,
+        )
         return BenchmarkResult(
             time_ms=result.time_ms,
             min_ms=result.min_ms,

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -18,8 +18,6 @@ import logging
 import math
 import os as _os
 import pickle
-import select
-import subprocess
 import sys as _sys
 import time as _time_module
 from dataclasses import dataclass, field
@@ -1141,242 +1139,28 @@ def _samples_to_result(
 
 
 # ---------------------------------------------------------------------------
-# Subprocess-isolated benchmark worker
+# Subprocess-isolated benchmark worker (single async transport)
 # ---------------------------------------------------------------------------
 
 
-class _BenchWorker:
-    """Long-lived ``deplodock.compiler.backend.cuda._bench_worker`` subprocess.
-
-    Lets the parent enforce a hard wall-clock cap on a bench: if the worker
-    doesn't respond within ``wall_timeout_s``, the parent SIGKILLs it. The
-    dirty CUDA stream (and any kernels still queued behind a hung launch)
-    dies with the process, so the *next* bench starts on a clean device —
-    fixes the "autotune hangs on the variant AFTER a bench_fail" pathology
-    (see ``Pipeline._bench_terminal``).
-
-    Lifecycle: one worker per ``CudaBackend`` instance, lazily spawned on
-    the first ``bench`` call and respawned on timeout / EOF / error. The
-    worker imports cupy lazily on its first request — until then no CUDA
-    context is initialized in the worker, so the spawn cost is just Python
-    startup (~0.2 s).
-    """
-
-    _WORKER_MODULE = "deplodock.compiler.backend.cuda._bench_worker"
-
-    def __init__(self) -> None:
-        self._proc: subprocess.Popen | None = None  # noqa: UP007 — lazy-init sentinel
-
-    def _spawn(self) -> None:
-        self._proc = subprocess.Popen(  # noqa: S603
-            [_sys.executable, "-m", self._WORKER_MODULE],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=dict(_os.environ),
-            bufsize=0,
-        )
-        logger.info("[bench-worker] spawned pid=%s", self._proc.pid)
-
-    def _kill(self) -> None:
-        if self._proc is None:
-            return
-        try:
-            self._proc.kill()
-            try:
-                self._proc.wait(timeout=2.0)
-            except subprocess.TimeoutExpired:
-                # Process is in uninterruptible-kernel state (rare —
-                # NVRTC stuck in a driver call). Nothing more we can do;
-                # init will reap once the syscall returns. Release the
-                # Python handle so the next bench respawns.
-                logger.warning("[bench-worker] pid=%s did not reap within 2s of SIGKILL", self._proc.pid)
-        except ProcessLookupError:
-            pass
-        self._proc = None
-
-    def __del__(self) -> None:
-        self._kill()
-
-    @staticmethod
-    def _send_with_deadline(proc: subprocess.Popen, request: bytes, deadline: float) -> None:
-        """Write the length-prefixed request without blocking past ``deadline``.
-
-        The worker's stdin is a pipe with a ~64 KB kernel buffer; requests carry
-        pickled graphs and routinely exceed it. A blocking write to a worker
-        that is alive but not reading wedges the parent indefinitely — so write
-        through a non-blocking fd, gated on ``select`` writability with the
-        remaining budget, and raise ``_BenchTimeout`` when it runs out."""
-        import fcntl  # noqa: PLC0415
-
-        fd = proc.stdin.fileno()
-        fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | _os.O_NONBLOCK)
-        data = memoryview(len(request).to_bytes(8, "little") + request)
-        while data:
-            remaining = deadline - _time_module.perf_counter()
-            if remaining <= 0:
-                raise _BenchTimeout()
-            _, writable, _ = select.select([], [fd], [], remaining)
-            if not writable:
-                raise _BenchTimeout()
-            try:
-                n = _os.write(fd, data)
-            except BlockingIOError:  # raced a re-filled buffer between select and write
-                continue
-            data = data[n:]
-
-    def run_job(self, request_obj: dict, *, wall_timeout_s: float) -> dict:
-        """Send one length-prefixed pickle request, read the response within ``wall_timeout_s``
-        (else SIGKILL the worker and raise ``RuntimeError``), and return the unpickled response.
-        The single transport for both the deplodock-only bench and the deployable comparison — the
-        request's ``torch_spec`` decides which (see ``_bench_worker._run_job``)."""
-        request = pickle.dumps(request_obj, protocol=pickle.HIGHEST_PROTOCOL)
-        deadline = _time_module.perf_counter() + wall_timeout_s
-        # A previous worker may have exited between our last interaction
-        # and this request — most commonly through the dirty-context exit
-        # path in ``_bench_worker.main``. ``poll()`` has a brief window
-        # where it still reports the worker as alive (the kernel hasn't
-        # reaped yet), so the first stdin write can hit ``BrokenPipeError``
-        # even though our state says "worker is up". Treat that as a
-        # stale-worker race: respawn and retry once. A second write
-        # failure on a fresh worker is a real bug and surfaces.
-        for attempt in (0, 1):
-            if self._proc is None or self._proc.poll() is not None:
-                self._spawn()
-            assert self._proc is not None  # for type narrowing
-            proc = self._proc
-            try:
-                self._send_with_deadline(proc, request, deadline)
-                break
-            except _BenchTimeout as exc:
-                # The worker is alive but not reading — e.g. wedged in CUDA
-                # context teardown behind a hung kernel after a dirty exit.
-                # Before the send had its own deadline, the parent blocked
-                # forever in this pipe write (the wall budget only bounded
-                # the response read).
-                self._kill()
-                raise RuntimeError(
-                    f"bench worker did not accept the request within {wall_timeout_s:.1f}s wall budget — SIGKILL'd, stream cleaned"
-                ) from exc
-            except (BrokenPipeError, OSError) as exc:
-                self._kill()
-                if attempt == 1:
-                    raise RuntimeError(f"bench worker died during request send: {exc}") from exc
-                logger.info("[bench-worker] stale worker on send (%s) — respawning", exc)
-
-        out_fd = proc.stdout.fileno()
-
-        def _read_with_deadline(n: int) -> bytes:
-            buf = bytearray()
-            while len(buf) < n:
-                remaining = deadline - _time_module.perf_counter()
-                if remaining <= 0:
-                    raise _BenchTimeout()
-                r, _, _ = select.select([out_fd], [], [], remaining)
-                if not r:
-                    raise _BenchTimeout()
-                chunk = _os.read(out_fd, n - len(buf))
-                if not chunk:
-                    raise _BenchWorkerEOF()
-                buf.extend(chunk)
-            return bytes(buf)
-
-        try:
-            header = _read_with_deadline(8)
-            n = int.from_bytes(header, "little")
-            body = _read_with_deadline(n)
-        except _BenchTimeout as exc:
-            self._kill()
-            raise RuntimeError(f"bench worker exceeded {wall_timeout_s:.1f}s wall budget — SIGKILL'd, stream cleaned") from exc
-        except _BenchWorkerEOF as exc:
-            stderr_tail = b""
-            try:
-                stderr_tail = proc.stderr.read() or b""
-            except Exception:  # noqa: BLE001 — stderr drain is best-effort
-                pass
-            self._kill()
-            raise RuntimeError(f"bench worker EOF before response; stderr tail: {stderr_tail.decode(errors='replace')[-500:]}") from exc
-
-        resp = pickle.loads(body)
-        if not resp.get("ok"):
-            # Surface the worker-side exception verbatim. ``Pipeline._bench_terminal`` treats a
-            # failed deplodock bench as ``bench_fail``; the deployable callers report + continue.
-            raise RuntimeError(f"bench worker error: {resp.get('error', '?')}")
-        return resp
-
-
-class _BenchTimeout(Exception):
-    """Internal sentinel — converted to RuntimeError at the API boundary."""
-
-
-class _BenchWorkerEOF(Exception):
-    """Internal sentinel — worker died without writing a response."""
-
-
-# Module-level singleton. Reused across ``benchmark_program_isolated`` calls
-# in the same process so we pay the worker startup cost once.
-_bench_worker_singleton: _BenchWorker | None = None
-
-
-def _bench_worker() -> _BenchWorker:
-    global _bench_worker_singleton
-    if _bench_worker_singleton is None:
-        _bench_worker_singleton = _BenchWorker()
-    return _bench_worker_singleton
-
-
-def benchmark_program_isolated(
-    graph: Graph,
-    *,
-    wall_timeout_s: float,
-    warmup: int = 5,
-    num_iters: int | str = 20,
-    compile_timeout_s: float | None = None,
-    run_timeout_s: float | None = None,
-    nvcc_flags: str | None = None,
-    capture_graphs: bool = True,
-) -> BenchmarkResult:
-    """Wall-time-bounded ``benchmark_program``. Runs the bench in a
-    persistent subprocess; on ``wall_timeout_s`` overrun the worker is
-    SIGKILLed and the next call respawns it on a clean device.
-
-    The in-process ``compile_timeout_s`` / ``run_timeout_s`` budgets are
-    still enforced inside the worker (they're cheaper and give better
-    error messages than a SIGKILL). ``wall_timeout_s`` is the backstop
-    for the failure mode they don't cover: a kernel that keeps the GPU
-    busy past any per-launch / per-iter budget, which on cupy makes the
-    next ``deviceSynchronize`` block indefinitely.
-
-    ``on_iter`` is not supported here — interleaved benchmarking (the
-    ``deplodock run --bench`` path that alternates torch eager / compile
-    / deplodock) needs the bench to share a Python process with torch
-    and must use ``benchmark_program`` directly instead.
-    """
-    resp = _bench_worker().run_job(
-        {
-            "graph": graph,
-            "nvcc_flags": nvcc_flags,
-            "torch_spec": None,  # no torch comparison — pure deplodock bench
-            "kwargs": {
-                "warmup": warmup,
-                "num_iters": num_iters,
-                "compile_timeout_s": compile_timeout_s,
-                "run_timeout_s": run_timeout_s,
-                "capture_graphs": capture_graphs,
-            },
-        },
-        wall_timeout_s=wall_timeout_s,
-    )
-    return resp["result"]
-
-
 class _AsyncBenchWorker:
-    """Async sibling of :class:`_BenchWorker` for the parallel tune driver.
+    """The parent-side transport for the SIGKILL-able ``_bench_worker`` subprocess —
+    the **single** isolated-bench transport (the old sync ``_BenchWorker`` is gone).
 
-    Drives the same ``_bench_worker`` subprocess protocol (``<8-byte LE
-    length><pickle>``, both directions) over asyncio streams, so one event
-    loop can keep N device-pinned workers benching concurrently — the
-    per-kernel multi-GPU autotune path (``two_level.inner_reward``).
+    Lets the parent enforce a hard wall-clock cap on a bench: if the worker doesn't
+    respond within ``wall_timeout_s``, the parent SIGKILLs it. The dirty CUDA stream
+    (and any kernels still queued behind a hung launch) dies with the process, so the
+    *next* bench starts on a clean device — fixing the "autotune hangs on the variant
+    AFTER a bench_fail" pathology. The worker imports cupy lazily on its first
+    request, so spawn cost is just Python startup (~0.2 s).
+
+    Drives the ``_bench_worker`` protocol (``<8-byte LE length><pickle>``, both
+    directions) over asyncio streams, so one event loop can keep N device-pinned
+    workers benching concurrently — the per-kernel multi-GPU autotune path
+    (``two_level.inner_reward``). The sync ``benchmark_program_isolated`` /
+    ``benchmark_compare_isolated`` entry points are thin ``asyncio.run`` bridges over
+    a one-shot instance (deployable ``--bench``); the autotune sweep awaits a
+    persistent instance per GPU directly via ``benchmark_program_isolated_async``.
 
     Pin a worker to a physical GPU with ``device_id``: the spawn env gets
     ``CUDA_VISIBLE_DEVICES=<id>`` (so the child's logical device 0 *is* that
@@ -1388,8 +1172,7 @@ class _AsyncBenchWorker:
     mutated (it's shared by every slot on the one event-loop thread).
 
     The wall-clock cap is :func:`asyncio.wait_for`; on overrun the child is
-    SIGKILLed and respawned on the next bench (same recovery contract as the
-    sync worker)."""
+    SIGKILLed and respawned on the next bench."""
 
     _WORKER_MODULE = "deplodock.compiler.backend.cuda._bench_worker"
 
@@ -1437,6 +1220,20 @@ class _AsyncBenchWorker:
         reaped when the event loop closes."""
         self._kill()
 
+    async def aclose(self) -> None:
+        """Terminate the worker and await its reap — for one-shot bridges that
+        spawn + run + tear down within a single ``asyncio.run`` (so no orphaned
+        subprocess transport survives the loop)."""
+        proc = self._proc
+        self._proc = None
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+
     async def _read_stderr_tail(self, proc: asyncio.subprocess.Process) -> str:
         try:
             data = await asyncio.wait_for(proc.stderr.read(), timeout=2.0)
@@ -1446,9 +1243,9 @@ class _AsyncBenchWorker:
 
     async def run_job(self, request_obj: dict, *, wall_timeout_s: float) -> dict:
         """Send one request, read the response within ``wall_timeout_s`` (else SIGKILL
-        + raise ``RuntimeError``), and return the unpickled response. Mirrors
-        :meth:`_BenchWorker.run_job`: a stale-worker race on send respawns and retries
-        once; a response-side timeout / EOF is a hard error."""
+        + raise ``RuntimeError``), and return the unpickled response. A stale-worker
+        race on send respawns and retries once; a response-side timeout / EOF is a
+        hard error."""
         request = pickle.dumps(request_obj, protocol=pickle.HIGHEST_PROTOCOL)
         frame = len(request).to_bytes(8, "little") + request
         deadline = _time_module.perf_counter() + wall_timeout_s
@@ -1464,12 +1261,12 @@ class _AsyncBenchWorker:
                 proc.stdin.write(frame)
                 await asyncio.wait_for(proc.stdin.drain(), timeout=remaining)
             except TimeoutError as exc:
-                self._kill()
+                await self.aclose()
                 raise RuntimeError(
                     f"bench worker did not accept the request within {wall_timeout_s:.1f}s wall budget — SIGKILL'd, stream cleaned"
                 ) from exc
             except (BrokenPipeError, ConnectionResetError) as exc:
-                self._kill()
+                await self.aclose()
                 if attempt == 1:
                     raise RuntimeError(f"bench worker died during request send: {exc}") from exc
                 logger.info("[bench-worker] stale async worker on send (%s) — respawning", exc)
@@ -1486,11 +1283,11 @@ class _AsyncBenchWorker:
                     raise TimeoutError
                 body = await asyncio.wait_for(proc.stdout.readexactly(n), timeout=remaining)
             except TimeoutError as exc:
-                self._kill()
+                await self.aclose()
                 raise RuntimeError(f"bench worker exceeded {wall_timeout_s:.1f}s wall budget — SIGKILL'd, stream cleaned") from exc
             except asyncio.IncompleteReadError as exc:
                 stderr_tail = await self._read_stderr_tail(proc)
-                self._kill()
+                await self.aclose()
                 raise RuntimeError(f"bench worker EOF before response; stderr tail: {stderr_tail}") from exc
 
             resp = pickle.loads(body)
@@ -1533,6 +1330,61 @@ async def benchmark_program_isolated_async(
     return resp["result"]
 
 
+async def _run_job_oneshot(request_obj: dict, *, wall_timeout_s: float) -> dict:
+    """Spawn a fresh (unpinned) ``_AsyncBenchWorker``, run one job, tear it down.
+    The transport for the synchronous one-shot bridges below — they each wrap this
+    in ``asyncio.run`` (the worker's streams bind to the loop, so it can't persist
+    across ``asyncio.run`` calls; the per-call ~0.2 s spawn is negligible against a
+    deployable ``--bench``)."""
+    worker = _AsyncBenchWorker()
+    try:
+        return await worker.run_job(request_obj, wall_timeout_s=wall_timeout_s)
+    finally:
+        await worker.aclose()
+
+
+def benchmark_program_isolated(
+    graph: Graph,
+    *,
+    wall_timeout_s: float,
+    warmup: int = 5,
+    num_iters: int | str = 20,
+    compile_timeout_s: float | None = None,
+    run_timeout_s: float | None = None,
+    nvcc_flags: str | None = None,
+    capture_graphs: bool = True,
+) -> BenchmarkResult:
+    """Synchronous wall-time-bounded ``benchmark_program`` — a thin ``asyncio.run``
+    bridge over :class:`_AsyncBenchWorker` (the one transport). Runs the bench in a
+    SIGKILL-able subprocess; the in-worker ``compile_timeout_s`` / ``run_timeout_s``
+    budgets still apply, and ``wall_timeout_s`` is the backstop for a kernel that
+    keeps the GPU busy past them (cupy's next ``deviceSynchronize`` would block).
+
+    ``on_iter`` isn't supported here — interleaved benchmarking (``deplodock run
+    --bench``) shares a Python process with torch and uses ``benchmark_program``
+    directly. The autotune sweep awaits ``benchmark_program_isolated_async`` instead
+    (a persistent per-GPU worker); this sync entry serves ``CudaBackend.benchmark``'s
+    isolated path."""
+    resp = asyncio.run(
+        _run_job_oneshot(
+            {
+                "graph": graph,
+                "nvcc_flags": nvcc_flags,
+                "torch_spec": None,  # no torch comparison — pure deplodock bench
+                "kwargs": {
+                    "warmup": warmup,
+                    "num_iters": num_iters,
+                    "compile_timeout_s": compile_timeout_s,
+                    "run_timeout_s": run_timeout_s,
+                    "capture_graphs": capture_graphs,
+                },
+            },
+            wall_timeout_s=wall_timeout_s,
+        )
+    )
+    return resp["result"]
+
+
 def benchmark_compare_isolated(
     *,
     lowered: Graph,
@@ -1544,7 +1396,9 @@ def benchmark_compare_isolated(
     seed: int,
     nvcc_flags: str | None = None,
 ) -> tuple:
-    """Run the deployable eager / torch.compile / deplodock comparison in the SIGKILL-able worker.
+    """Run the deployable eager / torch.compile / deplodock comparison in the
+    SIGKILL-able worker — a synchronous ``asyncio.run`` bridge over
+    :class:`_AsyncBenchWorker` (the one transport).
 
     Unlike the deplodock-only autotune bench, the deployable comparison interleaves deplodock with
     real torch in one process and so couldn't be isolated before — a hung generated kernel wedged
@@ -1562,16 +1416,18 @@ def benchmark_compare_isolated(
     Returns ``(results, bench, torch_available, captured)`` — the shape ``bench_lowered_vs_torch``
     returns (``captured``: all backends were timed under CUDA graph capture; False means the
     all-or-nothing fallback ran and the timings include host dispatch)."""
-    resp = _bench_worker().run_job(
-        {
-            "graph": lowered,
-            "nvcc_flags": nvcc_flags,
-            "torch_spec": torch_spec,
-            "bench_backends": bench_backends,
-            "warmup": warmup,
-            "iters": iters,
-            "seed": seed,
-        },
-        wall_timeout_s=wall_timeout_s,
+    resp = asyncio.run(
+        _run_job_oneshot(
+            {
+                "graph": lowered,
+                "nvcc_flags": nvcc_flags,
+                "torch_spec": torch_spec,
+                "bench_backends": bench_backends,
+                "warmup": warmup,
+                "iters": iters,
+                "seed": seed,
+            },
+            wall_timeout_s=wall_timeout_s,
+        )
     )
     return resp["results"], resp["result"], resp["torch_available"], resp.get("captured", False)

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -13,12 +13,14 @@ scratch. Launch order is ``graph.topological_order()``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import os as _os
 import pickle
 import select
 import subprocess
+import sys as _sys
 import time as _time_module
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -1166,8 +1168,6 @@ class _BenchWorker:
         self._proc: subprocess.Popen | None = None  # noqa: UP007 — lazy-init sentinel
 
     def _spawn(self) -> None:
-        import sys as _sys  # noqa: PLC0415
-
         self._proc = subprocess.Popen(  # noqa: S603
             [_sys.executable, "-m", self._WORKER_MODULE],
             stdin=subprocess.PIPE,
@@ -1353,6 +1353,169 @@ def benchmark_program_isolated(
     and must use ``benchmark_program`` directly instead.
     """
     resp = _bench_worker().run_job(
+        {
+            "graph": graph,
+            "nvcc_flags": nvcc_flags,
+            "torch_spec": None,  # no torch comparison — pure deplodock bench
+            "kwargs": {
+                "warmup": warmup,
+                "num_iters": num_iters,
+                "compile_timeout_s": compile_timeout_s,
+                "run_timeout_s": run_timeout_s,
+                "capture_graphs": capture_graphs,
+            },
+        },
+        wall_timeout_s=wall_timeout_s,
+    )
+    return resp["result"]
+
+
+class _AsyncBenchWorker:
+    """Async sibling of :class:`_BenchWorker` for the parallel tune driver.
+
+    Drives the same ``_bench_worker`` subprocess protocol (``<8-byte LE
+    length><pickle>``, both directions) over asyncio streams, so one event
+    loop can keep N device-pinned workers benching concurrently — the
+    per-kernel multi-GPU autotune path (``two_level.inner_reward``).
+
+    Pin a worker to a physical GPU with ``device_id``: the spawn env gets
+    ``CUDA_VISIBLE_DEVICES=<id>`` (so the child's logical device 0 *is* that
+    GPU — every argumentless ``cp.cuda.Device()`` in the child resolves
+    correctly with no other call-site change) and, when a base
+    ``DEPLODOCK_GPU_LOCK`` is set, a per-device lock path so workers on
+    different GPUs take distinct ``FileLock``s instead of serialising. The
+    env overlay rides the child only — the parent's ``os.environ`` is never
+    mutated (it's shared by every slot on the one event-loop thread).
+
+    The wall-clock cap is :func:`asyncio.wait_for`; on overrun the child is
+    SIGKILLed and respawned on the next bench (same recovery contract as the
+    sync worker)."""
+
+    _WORKER_MODULE = "deplodock.compiler.backend.cuda._bench_worker"
+
+    def __init__(self, *, device_id: int | None = None) -> None:
+        self._proc: asyncio.subprocess.Process | None = None
+        self._device_id = device_id
+
+    def _child_env(self) -> dict:
+        env = dict(_os.environ)
+        if self._device_id is not None:
+            env["CUDA_VISIBLE_DEVICES"] = str(self._device_id)
+            from deplodock import config  # noqa: PLC0415
+
+            base = config.gpu_lock_path()
+            if base:
+                # Per-device lock so concurrent device-pinned workers don't
+                # serialise on one FileLock (the lock is taken inside the child).
+                env["DEPLODOCK_GPU_LOCK"] = f"{base}-{self._device_id}"
+        return env
+
+    async def _spawn(self) -> None:
+        self._proc = await asyncio.create_subprocess_exec(
+            _sys.executable,
+            "-m",
+            self._WORKER_MODULE,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._child_env(),
+        )
+        logger.info("[bench-worker] spawned (async) pid=%s device=%s", self._proc.pid, self._device_id)
+
+    def _kill(self) -> None:
+        proc = self._proc
+        self._proc = None
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+    def close(self) -> None:
+        """Terminate the worker (driver teardown). The subprocess transport is
+        reaped when the event loop closes."""
+        self._kill()
+
+    async def _read_stderr_tail(self, proc: asyncio.subprocess.Process) -> str:
+        try:
+            data = await asyncio.wait_for(proc.stderr.read(), timeout=2.0)
+        except (TimeoutError, Exception):  # noqa: BLE001 — stderr drain is best-effort
+            return ""
+        return data.decode(errors="replace")[-500:]
+
+    async def run_job(self, request_obj: dict, *, wall_timeout_s: float) -> dict:
+        """Send one request, read the response within ``wall_timeout_s`` (else SIGKILL
+        + raise ``RuntimeError``), and return the unpickled response. Mirrors
+        :meth:`_BenchWorker.run_job`: a stale-worker race on send respawns and retries
+        once; a response-side timeout / EOF is a hard error."""
+        request = pickle.dumps(request_obj, protocol=pickle.HIGHEST_PROTOCOL)
+        frame = len(request).to_bytes(8, "little") + request
+        deadline = _time_module.perf_counter() + wall_timeout_s
+        for attempt in (0, 1):
+            if self._proc is None or self._proc.returncode is not None:
+                await self._spawn()
+            assert self._proc is not None  # for type narrowing
+            proc = self._proc
+            try:
+                remaining = deadline - _time_module.perf_counter()
+                if remaining <= 0:
+                    raise TimeoutError
+                proc.stdin.write(frame)
+                await asyncio.wait_for(proc.stdin.drain(), timeout=remaining)
+            except TimeoutError as exc:
+                self._kill()
+                raise RuntimeError(
+                    f"bench worker did not accept the request within {wall_timeout_s:.1f}s wall budget — SIGKILL'd, stream cleaned"
+                ) from exc
+            except (BrokenPipeError, ConnectionResetError) as exc:
+                self._kill()
+                if attempt == 1:
+                    raise RuntimeError(f"bench worker died during request send: {exc}") from exc
+                logger.info("[bench-worker] stale async worker on send (%s) — respawning", exc)
+                continue
+
+            try:
+                remaining = deadline - _time_module.perf_counter()
+                if remaining <= 0:
+                    raise TimeoutError
+                header = await asyncio.wait_for(proc.stdout.readexactly(8), timeout=remaining)
+                n = int.from_bytes(header, "little")
+                remaining = deadline - _time_module.perf_counter()
+                if remaining <= 0:
+                    raise TimeoutError
+                body = await asyncio.wait_for(proc.stdout.readexactly(n), timeout=remaining)
+            except TimeoutError as exc:
+                self._kill()
+                raise RuntimeError(f"bench worker exceeded {wall_timeout_s:.1f}s wall budget — SIGKILL'd, stream cleaned") from exc
+            except asyncio.IncompleteReadError as exc:
+                stderr_tail = await self._read_stderr_tail(proc)
+                self._kill()
+                raise RuntimeError(f"bench worker EOF before response; stderr tail: {stderr_tail}") from exc
+
+            resp = pickle.loads(body)
+            if not resp.get("ok"):
+                raise RuntimeError(f"bench worker error: {resp.get('error', '?')}")
+            return resp
+        raise RuntimeError("bench worker unreachable")  # both attempts exhausted (defensive)
+
+
+async def benchmark_program_isolated_async(
+    graph: Graph,
+    *,
+    worker: _AsyncBenchWorker,
+    wall_timeout_s: float,
+    warmup: int = 5,
+    num_iters: int | str = 20,
+    compile_timeout_s: float | None = None,
+    run_timeout_s: float | None = None,
+    nvcc_flags: str | None = None,
+    capture_graphs: bool = True,
+) -> BenchmarkResult:
+    """Async mirror of :func:`benchmark_program_isolated`, benching through a
+    caller-supplied device-pinned ``worker`` so one event loop can drive N GPUs
+    concurrently. Same in-worker budgets + ``wall_timeout_s`` SIGKILL backstop."""
+    resp = await worker.run_job(
         {
             "graph": graph,
             "nvcc_flags": nvcc_flags,

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -571,6 +571,25 @@ which suppressed exactly that prior-driven re-exploration.) The inner search rec
 (`Σ` over the slice's CudaOps, so a split-K main + combine both count) under the LoopOp key via `record_perf`;
 `best_per_op_time` prefers that direct row and otherwise walks the `lowering` chain down to the `cuda` terminal.
 
+**Per-kernel GPU parallelism (`--gpus N` / `--devices 0,1,2`).** Because the inner search tunes each unique kernel
+independently, the per-op loop fans out across GPUs. `inner_reward` is a thin sync wrapper around
+`_inner_reward_async`, which runs one coroutine per unique kernel over an `asyncio.Queue` of `len(pool)`
+device-pinned `CudaBackend`s — each pops a backend, drives its op's whole inner search via `Pipeline.tune_async`
+(an async-generator mirror of `tune` whose only `await` is the per-terminal bench, `_bench_terminal_async`), then
+returns the backend. So `len(pool)` benches run at once, one per GPU. **True single-thread asyncio**: every Python
+statement (lowering, DB writes, prior `add_rows` / `maybe_refit` / `checkpoint`) runs on the one event-loop thread
+and yields only at the bench `await`, so the shared `db` / `prior` need no locks — the in-flight refit is atomic
+between awaits. Each op seeds its `TuningSearch` by `seed + op_idx` (execution-order-independent) and the reward is
+a commutative `Σ`, so the per-op DB bests and `total_us` are byte-identical regardless of slot count; only the
+learned `prior.json` varies run-to-run (rows arrive in completion order). The **default single-GPU** path is a
+one-slot pool whose coroutines acquire the lone worker in `op_idx` order → strictly sequential, identical to the
+old serial loop. A backend pins its async worker to a physical GPU via the child spawn env
+(`CUDA_VISIBLE_DEVICES`, plus a per-device `DEPLODOCK_GPU_LOCK` suffix so workers don't serialise on one lock) —
+never mutating the parent `os.environ`. Parallelism is bounded by the unique-kernel count; devices must be
+homogeneous (the tune keys every perf row on one probed `ctx`). Each terminal's `asyncio.run` SIGKILLs its workers
+on exit (their subprocess transports bind to that loop); the backend objects persist and respawn on the next
+terminal. See `plans/let-s-make-a-plan-glimmering-mist.md`.
+
 **Driving the loop.** `deplodock tune <model_or_ir | --code EXPR>` probes a `Context`, opens the tuning database
 (default `~/.cache/deplodock/autotune.db`, overridable via `DEPLODOCK_TUNE_DB`), and calls `run_two_level_tune(...)`.
 On completion it prints one `done: N fused terminal(s) in Xs` line — the deployable numbers come from the optional
@@ -581,7 +600,8 @@ tuned op leaves plus a `<kernel> <current us> (best <best us>) <knobs>` tail. Th
 variable-length `pipeline.variant_label` knob string sits last, so the prefix up to the knobs stays put as the
 per-variant latency changes (only a new best, which is rare, shifts the trailing part — no flicker). It is threaded as an optional `progress=` through `run_two_level_tune` → `inner_reward`
 (duck-typed, so the search package keeps no dependency on `commands/`): one op leaf ticked per kernel, the tail updated
-per benched variant (read off `TuningSearch.last_stats`). `-v` disables the bar (the per-`[tune]` INFO lines show
+per benched variant (read off `TuningSearch.last_stats`). Under `--gpus N` the tail keys by a per-op `slot` and joins
+every in-flight kernel with ` | ` (one per device); single-GPU shows the one active kernel as before. `-v` disables the bar (the per-`[tune]` INFO lines show
 progress instead); `-q` is quiet (errors only). `--bench` re-benches the tuned winner at **-O3** (deployable, not the -O1 ranking pass) after tuning —
 the assembled full model **against the real torch module** (eager / `torch.compile` / Deplodock, via the bundle
 plumbed from `load_or_trace` → `commands/run.bench_full_model_real`; a symbolic graph benches the torch side on

--- a/deplodock/compiler/pipeline/pipeline.py
+++ b/deplodock/compiler/pipeline/pipeline.py
@@ -575,31 +575,8 @@ class Pipeline:
         ``ctx`` is built once (probing the live device if not provided)
         and shared by every candidate. ``dump`` / ``rejections`` are
         run-scoped sinks — see :class:`Run`."""
-        from deplodock.compiler import provenance  # noqa: PLC0415
-        from deplodock.compiler.context import Context as _Context  # noqa: PLC0415
-        from deplodock.compiler.pipeline.search.db import SearchDB as _SearchDB  # noqa: PLC0415
-
-        # Seed op provenance on the input graph before any pass runs — the one
-        # universal entry both ``run`` and ``tune`` funnel through. Idempotent,
-        # so a graph reloaded mid-pipeline keeps whatever prov it carried.
-        provenance.seed(graph)
-
-        if ctx is None:
-            ctx = _Context.probe()
-        backend_name = getattr(backend, "name", "cuda")
-        if ctx.backend_name != backend_name:
-            ctx = replace(ctx, backend_name=backend_name)
+        run = self._new_run(graph, search=search, ctx=ctx, backend=backend, db=db, dump=dump, rejections=rejections)
         t_start = time.monotonic()
-
-        run = Run(
-            pipeline=self,
-            ctx=ctx,
-            search=search,
-            db=db if db is not None else _SearchDB(),
-            backend=backend,
-            dump=dump,
-            rejections=rejections,
-        )
         n_terminals = 0
         for token, cand in run.drive(graph):
             n_terminals += 1
@@ -615,6 +592,65 @@ class Pipeline:
             # Best-effort + deduped, so the cost stays bounded.
             if backend is not None and getattr(search, "last_o3_worthy", False):
                 o3_us = _rebench_o3(cand, backend)
+                if o3_us is not None:
+                    search.observe_o3(token, o3_us)
+            yield cand
+        logger.info("compile: total %.2fs (%d terminal(s))", time.monotonic() - t_start, n_terminals)
+
+    def _new_run(self, graph: Graph, *, search, ctx, backend, db, dump, rejections) -> Run:
+        """Build the :class:`Run` shared by :meth:`tune` and :meth:`tune_async`:
+        seed provenance, probe / align ``ctx``, and wire the run-scoped sinks."""
+        from deplodock.compiler import provenance  # noqa: PLC0415
+        from deplodock.compiler.context import Context as _Context  # noqa: PLC0415
+        from deplodock.compiler.pipeline.search.db import SearchDB as _SearchDB  # noqa: PLC0415
+
+        # Seed op provenance on the input graph before any pass runs — the one
+        # universal entry both ``run`` and ``tune`` funnel through. Idempotent,
+        # so a graph reloaded mid-pipeline keeps whatever prov it carried.
+        provenance.seed(graph)
+        if ctx is None:
+            ctx = _Context.probe()
+        backend_name = getattr(backend, "name", "cuda")
+        if ctx.backend_name != backend_name:
+            ctx = replace(ctx, backend_name=backend_name)
+        return Run(
+            pipeline=self,
+            ctx=ctx,
+            search=search,
+            db=db if db is not None else _SearchDB(),
+            backend=backend,
+            dump=dump,
+            rejections=rejections,
+        )
+
+    async def tune_async(
+        self,
+        graph: Graph,
+        *,
+        search: Search,
+        ctx: Context | None = None,
+        backend=None,
+        db: SearchDB | None = None,
+        dump: CompilerDump | None = None,
+        rejections: list[tuple[str, str, str]] | None = None,
+    ):
+        """Async-generator mirror of :meth:`tune` for the multi-GPU tune driver.
+
+        The lowering (``run.drive``) stays a synchronous generator — only the
+        per-terminal bench is awaited (:func:`_bench_terminal_async`), so N
+        kernels' benches overlap across device-pinned workers on one event loop
+        while the (light) Python lowering runs cooperatively between awaits."""
+        run = self._new_run(graph, search=search, ctx=ctx, backend=backend, db=db, dump=dump, rejections=rejections)
+        t_start = time.monotonic()
+        n_terminals = 0
+        for token, cand in run.drive(graph):
+            n_terminals += 1
+            if backend is not None:
+                logger.info("[tune] variant #%d  [%s]", n_terminals, variant_label(cand.graph))
+            stats, status = await _bench_terminal_async(cand, backend=backend, db=run.db)
+            search.observe(token, stats, status, candidate=cand)
+            if backend is not None and getattr(search, "last_o3_worthy", False):
+                o3_us = await _rebench_o3_async(cand, backend)
                 if o3_us is not None:
                     search.observe_o3(token, o3_us)
             yield cand
@@ -1080,27 +1116,51 @@ def _rebench_o3(cand, backend):
     return result.time_ms * 1000.0 if result.time_ms else None
 
 
-def _bench_terminal(cand, *, backend, db):
-    """Bench every ``CudaOp`` in ``cand.graph``, persist per-kernel
-    ``perf`` / inventory / lowering rows, and return ``(stats, status)``
-    where ``stats`` is the per-kernel ``PerfStats`` summed across the
-    graph (total terminal latency)."""
-    import json as _json  # noqa: PLC0415
-    import statistics as _statistics  # noqa: PLC0415
+async def _rebench_o3_async(cand, backend):
+    """Async mirror of :func:`_rebench_o3` for the multi-GPU tune driver — awaits
+    the device-pinned worker's -O3 re-bench. Best-effort: a hiccup returns ``None``."""
+    from deplodock import config  # noqa: PLC0415
 
-    from deplodock.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
-    from deplodock.compiler.pipeline.search.db import PerfStats  # noqa: PLC0415
-    from deplodock.compiler.pipeline.search.keys import (  # noqa: PLC0415
-        _is_kernel_bearing,
-        dialect_of,
-        op_cache_key,
-        source_chain,
-    )
+    if "-O3" in config.nvcc_flags():
+        return None
+    try:
+        result = await backend.benchmark_async(cand.graph, nvcc_flags="-Xcicc -O3")
+    except Exception:  # noqa: BLE001 — a re-bench failure is non-fatal to tuning
+        return None
+    return result.time_ms * 1000.0 if result.time_ms else None
 
-    def _point_stats(us: float) -> PerfStats:
+
+class _TerminalBench:
+    """Shared machinery for benching one terminal candidate's ``CudaOp``s and
+    persisting per-kernel ``perf`` / inventory / lowering rows.
+
+    The sync (:func:`_bench_terminal`) and async (:func:`_bench_terminal_async`)
+    entry points differ *only* in how they obtain the ``BenchmarkResult`` — the
+    no-cuda / cache-hit / stub short-circuits and every DB write live here, so
+    the multi-GPU async path reuses the exact persistence semantics."""
+
+    def __init__(self, cand, *, backend, db) -> None:
+        from deplodock.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
+
+        self.backend = backend
+        self.db = db
+        self.graph = cand.graph
+        self.context_key = cand.ctx.structural_key()
+        self.cuda_nodes = [self.graph.nodes[nid] for nid in self.graph.topological_order() if isinstance(self.graph.nodes[nid].op, CudaOp)]
+        self.backend_name = getattr(backend, "name", "stub")
+
+    @staticmethod
+    def _point_stats(us: float):
+        from deplodock.compiler.pipeline.search.db import PerfStats  # noqa: PLC0415
+
         return PerfStats(median=us, min=us, max=us, mean=us, variance=0.0, n_samples=0)
 
-    def _stats_from_launch(lt) -> PerfStats:
+    @classmethod
+    def _stats_from_launch(cls, lt):
+        import statistics as _statistics  # noqa: PLC0415
+
+        from deplodock.compiler.pipeline.search.db import PerfStats  # noqa: PLC0415
+
         if lt.samples and len(lt.samples) >= 1:
             us = [s * 1000.0 for s in lt.samples]
             return PerfStats(
@@ -1111,9 +1171,12 @@ def _bench_terminal(cand, *, backend, db):
                 variance=_statistics.pvariance(us) if len(us) > 1 else 0.0,
                 n_samples=len(us),
             )
-        return _point_stats(lt.time_ms * 1000.0)
+        return cls._point_stats(lt.time_ms * 1000.0)
 
+    @staticmethod
     def _body_json(op, dialect: str) -> str:
+        import json as _json  # noqa: PLC0415
+
         return _json.dumps(
             {
                 "dialect": dialect,
@@ -1123,16 +1186,18 @@ def _bench_terminal(cand, *, backend, db):
             default=str,
         )
 
-    def _record_op_inventory(op) -> None:
+    def _record_op_inventory(self, op) -> None:
+        from deplodock.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
         from deplodock.compiler.ir.kernel.ir import KernelOp  # noqa: PLC0415
         from deplodock.compiler.ir.loop.ir import LoopOp  # noqa: PLC0415
         from deplodock.compiler.ir.tile.ir import TileOp  # noqa: PLC0415
+        from deplodock.compiler.pipeline.search.keys import op_cache_key  # noqa: PLC0415
 
         key = op_cache_key(op)
         if key is None:
             return
         if isinstance(op, CudaOp):
-            db.record_cuda_op(
+            self.db.record_cuda_op(
                 key,
                 kernel_source=op.kernel_source,
                 arg_order=list(op.arg_order),
@@ -1142,19 +1207,26 @@ def _bench_terminal(cand, *, backend, db):
                 pretty=op.kernel_source,
             )
         elif isinstance(op, KernelOp):
-            db.record_kernel_op(key, _body_json(op, "kernel"), op.pretty_body())
+            self.db.record_kernel_op(key, self._body_json(op, "kernel"), op.pretty_body())
         elif isinstance(op, TileOp):
-            db.record_tile_op(key, _body_json(op, "tile"), op.pretty_body())
+            self.db.record_tile_op(key, self._body_json(op, "tile"), op.pretty_body())
         elif isinstance(op, LoopOp):
-            db.record_loop_op(key, _body_json(op, "loop"), op.pretty_body())
+            self.db.record_loop_op(key, self._body_json(op, "loop"), op.pretty_body())
 
-    def _persist(cuda_op, *, stats: PerfStats, status: str, backend_name: str, captured: bool = False, error: str | None = None) -> None:
+    def _persist(self, cuda_op, *, stats, status: str, captured: bool = False, error: str | None = None) -> None:
+        from deplodock.compiler.pipeline.search.keys import (  # noqa: PLC0415
+            _is_kernel_bearing,
+            dialect_of,
+            op_cache_key,
+            source_chain,
+        )
+
         cuda_key = op_cache_key(cuda_op)
         if cuda_key is None:
             return
         chain = [op for op in source_chain(cuda_op) if _is_kernel_bearing(op)]
         for op in chain:
-            _record_op_inventory(op)
+            self._record_op_inventory(op)
         for parent_op, child_op in zip(chain[1:], chain[:-1], strict=False):
             p_dialect = dialect_of(parent_op)
             c_dialect = dialect_of(child_op)
@@ -1179,7 +1251,7 @@ def _bench_terminal(cand, *, backend, db):
             p_knobs = getattr(parent_op, "knobs", None) or {}
             c_knobs = getattr(child_op, "knobs", None) or {}
             knobs_delta = {k: v for k, v in c_knobs.items() if p_knobs.get(k) != v}
-            db.record_lowering(
+            self.db.record_lowering(
                 p_key,
                 p_dialect,
                 c_key,
@@ -1188,10 +1260,14 @@ def _bench_terminal(cand, *, backend, db):
                 measured_median_us=stats.median if status == "ok" else None,
             )
         knobs = getattr(cuda_op, "knobs", None) or {}
-        db.record_perf(context_key, cuda_key, backend=backend_name, status=status, stats=stats, knobs=knobs, captured=captured, error=error)
+        self.db.record_perf(
+            self.context_key, cuda_key, backend=self.backend_name, status=status, stats=stats, knobs=knobs, captured=captured, error=error
+        )
         logger.info("[tune]   %s @ %.2f us  (%s)", getattr(cuda_op, "kernel_name", "?"), stats.median, status)
 
-    def _accumulate(acc: PerfStats | None, s: PerfStats) -> PerfStats:
+    def _accumulate(self, acc, s):
+        from deplodock.compiler.pipeline.search.db import PerfStats  # noqa: PLC0415
+
         if acc is None:
             return s
         return PerfStats(
@@ -1203,95 +1279,129 @@ def _bench_terminal(cand, *, backend, db):
             n_samples=min(acc.n_samples, s.n_samples) if acc.n_samples and s.n_samples else (acc.n_samples or s.n_samples),
         )
 
-    graph = cand.graph
-    context_key = cand.ctx.structural_key()
-    cuda_nodes = [graph.nodes[nid] for nid in graph.topological_order() if isinstance(graph.nodes[nid].op, CudaOp)]
-    if not cuda_nodes:
-        return _point_stats(0.0), "ok"
+    def prelude(self):
+        """Resolve everything that needs no live bench. Returns ``("done", (stats,
+        status))`` when no measurement is needed (no CudaOps / full cache hit /
+        stub backend), else ``("bench", None)`` — the caller obtains a
+        ``BenchmarkResult`` and calls :meth:`finalize_result` / :meth:`finalize_exc`."""
+        from deplodock.compiler.pipeline.search.keys import op_cache_key  # noqa: PLC0415
 
-    backend_name = getattr(backend, "name", "stub")
+        if not self.cuda_nodes:
+            return "done", (self._point_stats(0.0), "ok")
 
-    # Cache lookup: if every CudaOp already has a perf row for this
-    # (context, backend), skip the benchmark entirely and rebuild the
-    # aggregate stats from the DB. Per-kernel partial caching isn't
-    # useful here because ``backend.benchmark`` runs the whole graph.
-    cached_rows = []
-    for node in cuda_nodes:
-        key = op_cache_key(node.op)
-        row = db.lookup_perf(context_key, key, backend=backend_name) if key is not None else None
-        if row is None:
-            cached_rows = None
-            break
-        cached_rows.append(row)
-    if cached_rows is not None:
-        logger.info("[tune] cache hit for %d kernel(s) — skipping bench", len(cuda_nodes))
-        agg: PerfStats | None = None
-        status = "ok"
-        for row in cached_rows:
-            if row.status != "ok":
-                status = row.status
-            agg = _accumulate(agg, row.stats)
-            logger.info("[tune]   %s @ %.2f us  (%s, cached)", row.op_key[:12], row.stats.median, row.status)
-        return agg or _point_stats(0.0), status
+        # Cache lookup: if every CudaOp already has a perf row for this
+        # (context, backend), skip the benchmark entirely and rebuild the
+        # aggregate stats from the DB. Per-kernel partial caching isn't
+        # useful here because ``backend.benchmark`` runs the whole graph.
+        cached_rows = []
+        for node in self.cuda_nodes:
+            key = op_cache_key(node.op)
+            row = self.db.lookup_perf(self.context_key, key, backend=self.backend_name) if key is not None else None
+            if row is None:
+                cached_rows = None
+                break
+            cached_rows.append(row)
+        if cached_rows is not None:
+            logger.info("[tune] cache hit for %d kernel(s) — skipping bench", len(self.cuda_nodes))
+            agg = None
+            status = "ok"
+            for row in cached_rows:
+                if row.status != "ok":
+                    status = row.status
+                agg = self._accumulate(agg, row.stats)
+                logger.info("[tune]   %s @ %.2f us  (%s, cached)", row.op_key[:12], row.stats.median, row.status)
+            return "done", (agg or self._point_stats(0.0), status)
 
-    status = "ok"
-    agg = None
+        if self.backend is None:
+            # No real measurement → do NOT persist. Writing the 1.0us stub
+            # to a shared DB used to clobber tuned ``best_median_us`` values
+            # (record_lowering / record_perf keep the minimum), so any plain
+            # ``deplodock run`` (which routes through ``Pipeline.run`` without
+            # a backend) was overwriting real autotune rows with 1.0us stubs.
+            # Tests that need lowering edges in stub mode should pass an
+            # explicit stub backend.
+            agg = None
+            for _node in self.cuda_nodes:
+                agg = self._accumulate(agg, self._point_stats(1.0))
+            return "done", (agg or self._point_stats(0.0), "ok")
 
-    if backend is None:
-        # No real measurement → do NOT persist. Writing the 1.0us stub
-        # to a shared DB used to clobber tuned ``best_median_us`` values
-        # (record_lowering / record_perf keep the minimum), so any plain
-        # ``deplodock run`` (which routes through ``Pipeline.run`` without
-        # a backend) was overwriting real autotune rows with 1.0us stubs.
-        # Tests that need lowering edges in stub mode should pass an
-        # explicit stub backend.
-        for _node in cuda_nodes:
-            s = _point_stats(1.0)
-            agg = _accumulate(agg, s)
-    else:
-        logger.info("[tune] benching %d kernel(s) in graph", len(cuda_nodes))
-        try:
-            result = backend.benchmark(graph, num_iters="auto")
-        except Exception as exc:  # noqa: BLE001
-            fail_us = float(backend.bench_run_timeout_s) * 1_000_000.0
+        logger.info("[tune] benching %d kernel(s) in graph", len(self.cuda_nodes))
+        return "bench", None
+
+    def finalize_exc(self, exc):
+        fail_us = float(self.backend.bench_run_timeout_s) * 1_000_000.0
+        logger.warning(
+            "[tune] backend.benchmark failed (%s) — pinning bench_fail @ %.1f us for %d kernel(s)",
+            exc,
+            fail_us,
+            len(self.cuda_nodes),
+        )
+        s = self._point_stats(fail_us)
+        agg = None
+        for node in self.cuda_nodes:
+            self._persist(node.op, stats=s, status="bench_fail", error=f"{type(exc).__name__}: {exc}")
+            agg = self._accumulate(agg, s)
+        return agg or self._point_stats(0.0), "bench_fail"
+
+    def finalize_result(self, result):
+        agg = None
+        per_launch = result.per_launch or []
+        if len(per_launch) != len(self.cuda_nodes):
             logger.warning(
-                "[tune] backend.benchmark failed (%s) — pinning bench_fail @ %.1f us for %d kernel(s)",
-                exc,
-                fail_us,
-                len(cuda_nodes),
+                "[tune] per_launch count (%d) != CudaOp node count (%d); falling back to graph time_ms / N",
+                len(per_launch),
+                len(self.cuda_nodes),
             )
-            s = _point_stats(fail_us)
-            for node in cuda_nodes:
-                _persist(node.op, stats=s, status="bench_fail", backend_name=backend_name, error=f"{type(exc).__name__}: {exc}")
-                agg = _accumulate(agg, s)
-            status = "bench_fail"
+            avg_us = (result.time_ms * 1000.0) / max(len(self.cuda_nodes), 1)
+            s = self._point_stats(avg_us)
+            for node in self.cuda_nodes:
+                self._persist(node.op, stats=s, status="ok", captured=result.captured)
+                agg = self._accumulate(agg, s)
         else:
-            per_launch = result.per_launch or []
-            if len(per_launch) != len(cuda_nodes):
-                logger.warning(
-                    "[tune] per_launch count (%d) != CudaOp node count (%d); falling back to graph time_ms / N",
-                    len(per_launch),
-                    len(cuda_nodes),
-                )
-                avg_us = (result.time_ms * 1000.0) / max(len(cuda_nodes), 1)
-                s = _point_stats(avg_us)
-                for node in cuda_nodes:
-                    _persist(node.op, stats=s, status="ok", backend_name=backend_name, captured=result.captured)
-                    agg = _accumulate(agg, s)
-            else:
-                for node, lt in zip(cuda_nodes, per_launch, strict=True):
-                    s = _stats_from_launch(lt)
-                    _persist(node.op, stats=s, status="ok", backend_name=backend_name, captured=result.captured)
-                    agg = _accumulate(agg, s)
-            try:
-                import cupy as _cp  # noqa: PLC0415
+            for node, lt in zip(self.cuda_nodes, per_launch, strict=True):
+                s = self._stats_from_launch(lt)
+                self._persist(node.op, stats=s, status="ok", captured=result.captured)
+                agg = self._accumulate(agg, s)
+        try:
+            import cupy as _cp  # noqa: PLC0415
 
-                _cp.cuda.runtime.deviceSynchronize()
-                _cp.get_default_memory_pool().free_all_blocks()
-            except Exception:  # noqa: BLE001 — best-effort cleanup
-                pass
+            _cp.cuda.runtime.deviceSynchronize()
+            _cp.get_default_memory_pool().free_all_blocks()
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+        return agg or self._point_stats(0.0), "ok"
 
-    return agg or _point_stats(0.0), status
+
+def _bench_terminal(cand, *, backend, db):
+    """Bench every ``CudaOp`` in ``cand.graph``, persist per-kernel
+    ``perf`` / inventory / lowering rows, and return ``(stats, status)``
+    where ``stats`` is the per-kernel ``PerfStats`` summed across the
+    graph (total terminal latency)."""
+    b = _TerminalBench(cand, backend=backend, db=db)
+    kind, payload = b.prelude()
+    if kind == "done":
+        return payload
+    try:
+        result = backend.benchmark(b.graph, num_iters="auto")
+    except Exception as exc:  # noqa: BLE001
+        return b.finalize_exc(exc)
+    return b.finalize_result(result)
+
+
+async def _bench_terminal_async(cand, *, backend, db):
+    """Async mirror of :func:`_bench_terminal` for the multi-GPU tune driver: the
+    only ``await`` is the device-pinned bench, so N kernels' benches overlap on
+    one event loop. Cache-hit / stub / persistence semantics are identical
+    (shared :class:`_TerminalBench`)."""
+    b = _TerminalBench(cand, backend=backend, db=db)
+    kind, payload = b.prelude()
+    if kind == "done":
+        return payload
+    try:
+        result = await backend.benchmark_async(b.graph, num_iters="auto")
+    except Exception as exc:  # noqa: BLE001
+        return b.finalize_exc(exc)
+    return b.finalize_result(result)
 
 
 __all__ = ["Decision", "ForkPoint", "LoweringError", "Match", "Pass", "Pattern", "Pipeline", "Rule", "RuleSkipped"]

--- a/deplodock/compiler/pipeline/search/two_level.py
+++ b/deplodock/compiler/pipeline/search/two_level.py
@@ -56,6 +56,7 @@ whole op, which would suppress exactly that prior-driven re-exploration.)
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -226,7 +227,8 @@ def inner_reward(
     *,
     ctx: Context,
     db: SearchDB,
-    backend,
+    backend=None,
+    backends=None,
     patience: int,
     ucb_c: float = TuningSearch.DEFAULT_UCB_C,
     explore_eps: float = 0.0,
@@ -236,6 +238,15 @@ def inner_reward(
 ) -> InnerReward:
     """Tune every post-fusion kernel of ``fused_graph`` in its own single-node
     slice and return ``Σ best-per-op time`` — the outer terminal reward.
+
+    With ``backends`` (a list of device-pinned :class:`CudaBackend`s, one per
+    GPU) the unique kernels are tuned **concurrently** — each op's inner search
+    runs on its own slot via :meth:`Pipeline.tune_async` on a single event loop
+    (one in-flight bench per GPU). Single-thread asyncio: the shared ``db`` /
+    ``prior`` are touched only between bench ``await``s, so no locks. The default
+    single ``backend`` is a one-slot pool whose coroutines acquire the lone
+    worker in ``op_idx`` order → strictly sequential, byte-identical to the old
+    serial loop (in-flight prior refit in op order included).
 
     ``prior`` (a single shared
     :class:`~deplodock.compiler.pipeline.search.prior.Prior`, or ``None``) drives
@@ -266,16 +277,34 @@ def inner_reward(
     Multiplicity is preserved: ``total_us`` weights each unique kernel's best
     by its node count, so the outer MCTS reward is bit-for-bit identical to
     the per-node-iterated total."""
+    pool = list(backends) if backends else [backend]
+    return asyncio.run(
+        _inner_reward_async(
+            fused_graph,
+            ctx=ctx,
+            db=db,
+            pool=pool,
+            patience=patience,
+            ucb_c=ucb_c,
+            explore_eps=explore_eps,
+            seed=seed,
+            progress=progress,
+            prior=prior,
+        )
+    )
+
+
+async def _inner_reward_async(fused_graph, *, ctx, db, pool, patience, ucb_c, explore_eps, seed, progress, prior) -> InnerReward:
+    """Async core of :func:`inner_reward`: one coroutine per unique kernel over a
+    slot queue of ``len(pool)`` device-pinned backends (one in-flight bench per
+    slot). Single event loop, single thread — ``db`` / ``prior`` mutations sit
+    between bench ``await``s, so they're atomic with no locks."""
     from collections import OrderedDict  # noqa: PLC0415
 
     from deplodock.compiler.pipeline.pipeline import variant_label  # noqa: PLC0415
 
     ctx_key = ctx.structural_key()
-    backend_name = getattr(backend, "name", "cuda")
-    total = 0.0
-    ok = True
-    per_op: list[OpResult] = []
-    prior_summaries: list[str] = []
+    backend_name = getattr(pool[0], "name", "cuda")
     # Group structurally-identical LoopOps under one ``op_cache_key`` —
     # insertion order = first occurrence (drives the progress tail name).
     # Ops with no cache key are unreachable through the bench path so they
@@ -292,67 +321,103 @@ def inner_reward(
             unique[key] = (nid, op, 1)
     if progress is not None:
         progress.start_terminal(len(unique))
-    for op_idx, (key, (nid, op, count)) in enumerate(unique.items()):
+
+    # Slot queue: each coroutine pops a device-pinned backend, benches its op's
+    # whole inner search on it, returns it. ``len(pool)`` benches run at once.
+    slots: asyncio.Queue = asyncio.Queue()
+    for b in pool:
+        slots.put_nowait(b)
+    results: dict[int, OpResult] = {}
+
+    async def tune_op(op_idx: int, key: str, nid: str, op, count: int) -> None:
         name = getattr(op, "name", None) or nid
-        if progress is not None:
-            progress.op_start(name)
-        sub = single_node_graph(fused_graph, nid)
-        # Base knobs the prior sees on every row: the LoopOp's ``S_*``
-        # structural identity (op-aware rows) + the ``H_*`` host/hardware
-        # regime (GPU + nvcc opt level), so one global prior spans ops and
-        # regimes from the feature vector alone.
-        base_knobs = {**ctx.features(), **op.knobs}
-        # Per-op RNG seed so each kernel's ε-greedy stream differs yet the whole
-        # run is reproducible (no wall-clock seeding).
-        inner = TuningSearch(
-            patience=patience,
-            ucb_c=ucb_c,
-            explore_eps=explore_eps,
-            seed=seed + op_idx,
-            prior_model=prior,
-            base_knobs=base_knobs,
-        )
-        for cand in Pipeline.build(LOWERING_PASSES).tune(sub, search=inner, ctx=ctx, backend=backend, db=db):
+        backend = await slots.get()
+        try:
             if progress is not None:
-                st = inner.last_stats
-                best_us = (1.0 / inner.tree.best_reward) if inner.tree.best_reward > 0 else None
-                progress.variant(
-                    name,
-                    variant_label(cand.graph),
-                    median_us=st.median if st is not None else None,
-                    status=inner.last_status or "",
-                    best_us=best_us,
-                )
-        # The inner MCTS's best reward is ``1 / min whole-slice total``
-        # (``_bench_terminal`` sums every CudaOp in the slice, so a split-K
-        # main + combine both count). Record that total under the LoopOp
-        # key so ``best_per_op_time`` reads the true per-op cost.
-        best_total = 1.0 / inner.tree.best_reward if inner.tree.best_reward > 0 else None
-        if best_total is not None:
-            # captured=True: the sweep benches under graph capture by default, so
-            # this Σ-best bookkeeping row derives from captured measurements (a
-            # rare per-variant capture fallback can contaminate the min — accepted;
-            # the capture-wins overwrite then lets a re-tune upgrade it).
-            db.record_perf(ctx_key, key, backend=backend_name, status="ok", stats=_point_stats(best_total), captured=True)
-        if prior is not None:
-            # Stream this op's value-of-position rows (-O1) plus any -O3 winner
-            # samples into the global (reservoir-bounded) dataset; refit +
-            # checkpoint once enough new rows accumulate (batched — see ``Prior``).
-            prior.add_rows(inner._collect_rows() + inner.o3_rows)
-            if prior.maybe_refit():
-                prior.checkpoint()
-        best = db.best_per_op_time(ctx_key, key, backend=backend_name)
-        per_op.append(OpResult(name=name, op_key=key, best_us=best, multiplicity=count))
-        # Multiplicity-weighted accumulation — a 24-layer RMSNorm contributes
-        # 24 × best, matching the per-node total before dedup.
-        if best is None:
+                progress.op_start(name, slot=op_idx)
+            sub = single_node_graph(fused_graph, nid)
+            # Base knobs the prior sees on every row: the LoopOp's ``S_*``
+            # structural identity (op-aware rows) + the ``H_*`` host/hardware
+            # regime (GPU + nvcc opt level), so one global prior spans ops and
+            # regimes from the feature vector alone.
+            base_knobs = {**ctx.features(), **op.knobs}
+            # Per-op RNG seed so each kernel's ε-greedy stream differs yet the run
+            # is reproducible AND execution-order-independent (no wall-clock seed):
+            # op ``op_idx`` always seeds ``seed + op_idx`` regardless of which slot
+            # or completion order it ran in.
+            inner = TuningSearch(
+                patience=patience,
+                ucb_c=ucb_c,
+                explore_eps=explore_eps,
+                seed=seed + op_idx,
+                prior_model=prior,
+                base_knobs=base_knobs,
+            )
+            async for cand in Pipeline.build(LOWERING_PASSES).tune_async(sub, search=inner, ctx=ctx, backend=backend, db=db):
+                if progress is not None:
+                    st = inner.last_stats
+                    best_us = (1.0 / inner.tree.best_reward) if inner.tree.best_reward > 0 else None
+                    progress.variant(
+                        name,
+                        variant_label(cand.graph),
+                        median_us=st.median if st is not None else None,
+                        status=inner.last_status or "",
+                        best_us=best_us,
+                        slot=op_idx,
+                    )
+            # The inner MCTS's best reward is ``1 / min whole-slice total``
+            # (``_bench_terminal`` sums every CudaOp in the slice, so a split-K
+            # main + combine both count). Record that total under the LoopOp
+            # key so ``best_per_op_time`` reads the true per-op cost.
+            best_total = 1.0 / inner.tree.best_reward if inner.tree.best_reward > 0 else None
+            if best_total is not None:
+                # captured=True: the sweep benches under graph capture by default, so
+                # this Σ-best bookkeeping row derives from captured measurements (a
+                # rare per-variant capture fallback can contaminate the min — accepted;
+                # the capture-wins overwrite then lets a re-tune upgrade it).
+                db.record_perf(ctx_key, key, backend=backend_name, status="ok", stats=_point_stats(best_total), captured=True)
+            if prior is not None:
+                # In-flight refit (single-threaded → no lock): stream this op's
+                # value-of-position rows (-O1) plus any -O3 winner samples into the
+                # global reservoir; refit + checkpoint once enough new rows
+                # accumulate (batched — see ``Prior``). Rows arrive in completion
+                # order, so the trained ``prior.json`` varies run-to-run; the per-op
+                # DB best below does not (distinct ``key`` per op).
+                prior.add_rows(inner._collect_rows() + inner.o3_rows)
+                if prior.maybe_refit():
+                    prior.checkpoint()
+            best = db.best_per_op_time(ctx_key, key, backend=backend_name)
+            results[op_idx] = OpResult(name=name, op_key=key, best_us=best, multiplicity=count)
+            if progress is not None:
+                progress.op_done(name, slot=op_idx)
+        finally:
+            slots.put_nowait(backend)
+
+    try:
+        await asyncio.gather(*[tune_op(i, key, nid, op, count) for i, (key, (nid, op, count)) in enumerate(unique.items())])
+    finally:
+        # SIGKILL each slot's async bench worker (the subprocess transports are
+        # bound to this event loop). Backend objects persist — their workers
+        # respawn on the next terminal's ``asyncio.run``.
+        for b in pool:
+            close = getattr(b, "close_async_worker", None)
+            if close is not None:
+                close()
+
+    # Accumulate in ``op_idx`` order so the reward / ``per_op`` order is
+    # execution-order-independent (the float sum is order-stable, matching serial).
+    total = 0.0
+    ok = True
+    per_op: list[OpResult] = []
+    for op_idx in range(len(unique)):
+        r = results[op_idx]
+        per_op.append(r)
+        if r.best_us is None:
             ok = False
-            total += _FAIL_US * count
+            total += _FAIL_US * r.multiplicity
         else:
-            total += best * count
-        if progress is not None:
-            progress.op_done(name)
-    return InnerReward(total_us=total, ok=ok, per_op=per_op, prior_summaries=prior_summaries)
+            total += r.best_us * r.multiplicity
+    return InnerReward(total_us=total, ok=ok, per_op=per_op, prior_summaries=[])
 
 
 def run_two_level_tune(
@@ -360,7 +425,8 @@ def run_two_level_tune(
     *,
     ctx: Context,
     db: SearchDB,
-    backend,
+    backend=None,
+    backends=None,
     patience: int,
     ucb_c: float = TuningSearch.DEFAULT_UCB_C,
     explore_eps: float = 0.0,
@@ -371,6 +437,10 @@ def run_two_level_tune(
     """Drive the outer structural search, scoring each terminal by
     :func:`inner_reward`, then greedy-assemble the DB-best kernels and bench
     the whole graph once for the separability check.
+
+    ``backends`` (a list of device-pinned :class:`CudaBackend`s) fans the inner
+    per-kernel search out across GPUs; the default single ``backend`` is the
+    one-slot serial pool.
 
     The outer drives a :class:`Run` directly (manual ``observe``)
     because its terminal reward comes from the inner tuning, not
@@ -418,6 +488,7 @@ def run_two_level_tune(
             ctx=ctx,
             db=db,
             backend=backend,
+            backends=backends,
             patience=patience,
             ucb_c=ucb_c,
             explore_eps=explore_eps,

--- a/deplodock/compiler/pipeline/search/two_level.py
+++ b/deplodock/compiler/pipeline/search/two_level.py
@@ -396,13 +396,14 @@ async def _inner_reward_async(fused_graph, *, ctx, db, pool, patience, ucb_c, ex
     try:
         await asyncio.gather(*[tune_op(i, key, nid, op, count) for i, (key, (nid, op, count)) in enumerate(unique.items())])
     finally:
-        # SIGKILL each slot's async bench worker (the subprocess transports are
-        # bound to this event loop). Backend objects persist — their workers
-        # respawn on the next terminal's ``asyncio.run``.
+        # SIGKILL + await-reap each slot's async bench worker (the subprocess
+        # transports are bound to this event loop; awaiting the reap cleans them
+        # before the loop closes). Backend objects persist — their workers respawn
+        # on the next terminal's ``asyncio.run``.
         for b in pool:
-            close = getattr(b, "close_async_worker", None)
-            if close is not None:
-                close()
+            aclose = getattr(b, "aclose_async_worker", None)
+            if aclose is not None:
+                await aclose()
 
     # Accumulate in ``op_idx`` order so the reward / ``per_op`` order is
     # execution-order-independent (the float sum is order-stable, matching serial).

--- a/tests/compiler/backend/test_async_bench_worker.py
+++ b/tests/compiler/backend/test_async_bench_worker.py
@@ -1,0 +1,83 @@
+"""Unit tests for the async bench worker's device/lock env overlay.
+
+The multi-GPU tune driver pins each ``_AsyncBenchWorker`` to a physical GPU via
+the child's spawn env (``CUDA_VISIBLE_DEVICES``) plus a per-device gpu-lock path,
+and must NEVER mutate the parent's shared ``os.environ`` (every slot shares one
+event-loop thread). These tests pin that contract without spawning a subprocess
+or touching CUDA.
+"""
+
+from __future__ import annotations
+
+import os
+
+from deplodock import config
+from deplodock.compiler.backend.cuda.program import _AsyncBenchWorker
+
+from ..conftest import requires_cuda
+
+
+def test_child_env_pins_device_without_mutating_os_environ() -> None:
+    before = dict(os.environ)
+    worker = _AsyncBenchWorker(device_id=3)
+    env = worker._child_env()
+    assert env["CUDA_VISIBLE_DEVICES"] == "3"
+    # The parent env is untouched — the pin rides the child only.
+    assert os.environ == before
+    assert "CUDA_VISIBLE_DEVICES" not in os.environ or os.environ.get("CUDA_VISIBLE_DEVICES") == before.get("CUDA_VISIBLE_DEVICES")
+
+
+def test_child_env_unpinned_is_passthrough() -> None:
+    worker = _AsyncBenchWorker(device_id=None)
+    env = worker._child_env()
+    assert env.get("CUDA_VISIBLE_DEVICES") == os.environ.get("CUDA_VISIBLE_DEVICES")
+    assert "DEPLODOCK_GPU_LOCK" not in env or env["DEPLODOCK_GPU_LOCK"] == os.environ.get("DEPLODOCK_GPU_LOCK")
+
+
+def test_child_env_per_device_gpu_lock(monkeypatch) -> None:
+    monkeypatch.setenv(config.GPU_LOCK, "/tmp/deplodock-gpu.lock")
+    env = _AsyncBenchWorker(device_id=2)._child_env()
+    # Distinct devices take distinct lock files so they don't serialise on one FileLock.
+    assert env["DEPLODOCK_GPU_LOCK"] == "/tmp/deplodock-gpu.lock-2"
+    env0 = _AsyncBenchWorker(device_id=0)._child_env()
+    assert env0["DEPLODOCK_GPU_LOCK"] == "/tmp/deplodock-gpu.lock-0"
+    assert env["DEPLODOCK_GPU_LOCK"] != env0["DEPLODOCK_GPU_LOCK"]
+
+
+def test_child_env_no_lock_suffix_when_base_unset(monkeypatch) -> None:
+    monkeypatch.delenv(config.GPU_LOCK, raising=False)
+    env = _AsyncBenchWorker(device_id=1)._child_env()
+    # No base lock → no per-device suffix (one worker per GPU has its own context).
+    assert "DEPLODOCK_GPU_LOCK" not in env
+
+
+@requires_cuda
+def test_async_worker_real_roundtrip_single_gpu() -> None:
+    """Smoke the real transport: ``inner_reward``'s async pool benches a tiny matmul
+    end-to-end on GPU 0 through a real ``_AsyncBenchWorker`` (``create_subprocess_exec``
+    + framed-pickle protocol + ``asyncio.wait_for`` wall cap), producing a measured
+    per-op best. The transport mirrors the proven sync worker; this confirms the
+    asyncio I/O round-trips on real hardware. ``prior=None`` keeps it off catboost."""
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.context import Context
+    from deplodock.compiler.graph import Graph, Tensor
+    from deplodock.compiler.ir.base import InputOp
+    from deplodock.compiler.ir.frontend.ir import MatmulOp
+    from deplodock.compiler.pipeline import LOOP_PASSES, Pipeline
+    from deplodock.compiler.pipeline.search.db import SearchDB
+    from deplodock.compiler.pipeline.search.two_level import inner_reward
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("a", (64, 128)), node_id="a")
+    g.add_node(InputOp(), [], Tensor("b", (128, 48)), node_id="b")
+    g.add_node(MatmulOp(), ["a", "b"], Tensor("c", (64, 48)), node_id="c")
+    g.inputs, g.outputs = ["a", "b"], ["c"]
+    fused = Pipeline.build(LOOP_PASSES).run(g, db=SearchDB())
+
+    backend = CudaBackend(bench_compile_timeout_s=15.0, bench_run_timeout_s=15.0, bench_wall_timeout_s=40.0, device_id=0)
+    try:
+        reward = inner_reward(fused, ctx=Context.probe(), db=SearchDB(), backends=[backend], patience=2, prior=None)
+    finally:
+        backend.close_async_worker()
+    assert reward.ok
+    assert any(r.best_us and r.best_us > 0 for r in reward.per_op)

--- a/tests/compiler/backend/test_bench_worker_compare.py
+++ b/tests/compiler/backend/test_bench_worker_compare.py
@@ -13,7 +13,6 @@ freeing the device and leaving the parent clean, instead of the ~109-minute in-p
 
 from __future__ import annotations
 
-import subprocess
 import sys
 import textwrap
 import time
@@ -52,8 +51,8 @@ def test_compare_in_worker_returns_torch_and_deplodock() -> None:
 
 
 class _HangWorker:
-    """A ``_BenchWorker`` whose child's ``_run_job`` launches a non-terminating GPU kernel and blocks
-    on it forever — to exercise the parent's wall-timeout SIGKILL on a genuinely hung worker."""
+    """An ``_AsyncBenchWorker`` whose child's ``_run_job`` launches a non-terminating GPU kernel and
+    blocks on it forever — to exercise the parent's wall-timeout SIGKILL on a genuinely hung worker."""
 
     _CHILD = textwrap.dedent(
         """
@@ -71,19 +70,22 @@ class _HangWorker:
     )
 
     def __init__(self) -> None:
-        from deplodock.compiler.backend.cuda.program import _BenchWorker
+        from deplodock.compiler.backend.cuda.program import _AsyncBenchWorker
 
-        self._impl = _BenchWorker()
+        self._impl = _AsyncBenchWorker()
         # Override _spawn to launch our hanging child instead of ``-m _bench_worker``.
         self._impl._spawn = self._spawn_hang  # type: ignore[method-assign]
 
-    def _spawn_hang(self) -> None:
-        self._impl._proc = subprocess.Popen(  # noqa: S603
-            [sys.executable, "-c", self._CHILD],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            bufsize=0,
+    async def _spawn_hang(self) -> None:
+        import asyncio
+
+        self._impl._proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            self._CHILD,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
 
     def run_job(self, *a, **k):
@@ -97,34 +99,38 @@ class _HangWorker:
 def test_run_job_send_times_out_on_unresponsive_worker() -> None:
     """A worker that is alive but never reads stdin — e.g. wedged in CUDA-context
     teardown behind a hung kernel after a dirty exit — must trip the wall budget
-    during the request SEND. Previously the parent blocked forever in the pipe
-    write once the request exceeded the ~64 KB pipe buffer (the wall budget only
-    bounded the response read). No CUDA needed: the deaf child is plain Python."""
+    during the request SEND (``stdin.drain`` blocks once the request exceeds the
+    ~64 KB pipe buffer). No CUDA needed: the deaf child is plain Python."""
+    import asyncio
+
     import pytest
 
-    from deplodock.compiler.backend.cuda.program import _BenchWorker
+    from deplodock.compiler.backend.cuda.program import _AsyncBenchWorker
 
-    worker = _BenchWorker()
+    worker = _AsyncBenchWorker()
 
-    def _spawn_deaf() -> None:
-        worker._proc = subprocess.Popen(  # noqa: S603
-            [sys.executable, "-c", "import time; time.sleep(60)"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            bufsize=0,
+    async def _spawn_deaf() -> None:
+        worker._proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(60)",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
 
     worker._spawn = _spawn_deaf  # type: ignore[method-assign]
     t0 = time.time()
     with pytest.raises(RuntimeError, match="did not accept the request"):
-        worker.run_job({"blob": b"x" * (1 << 20)}, wall_timeout_s=2.0)  # 1 MB >> pipe buffer
+        asyncio.run(worker.run_job({"blob": b"x" * (1 << 20)}, wall_timeout_s=2.0))  # 1 MB >> pipe buffer
     assert time.time() - t0 < 20.0, "send must respect the wall budget, not block on the pipe"
     assert worker._proc is None, "the unresponsive worker must be killed and its handle released"
 
 
 @requires_cuda
 def test_worker_hang_is_sigkilled_not_wedged() -> None:
+    import asyncio
+
     import pytest
 
     worker = _HangWorker()
@@ -132,7 +138,7 @@ def test_worker_hang_is_sigkilled_not_wedged() -> None:
     # The child launches an infinite kernel and never responds; the parent must SIGKILL it at the
     # 3 s wall budget and raise — not block forever (the pre-isolation in-process failure mode).
     with pytest.raises(RuntimeError, match="wall budget"):
-        worker.run_job({"graph": None, "torch_spec": None, "kwargs": {}}, wall_timeout_s=3.0)
+        asyncio.run(worker.run_job({"graph": None, "torch_spec": None, "kwargs": {}}, wall_timeout_s=3.0))
     elapsed = time.time() - t0
     assert elapsed < 30.0, f"run_job took {elapsed:.1f}s — the wall-timeout SIGKILL did not fire promptly"
     assert worker.proc is None, "the hung worker must be killed and its handle released"

--- a/tests/compiler/backend/test_bench_worker_recovery.py
+++ b/tests/compiler/backend/test_bench_worker_recovery.py
@@ -7,7 +7,7 @@ subprocess reused across every autotune config, so a single such crash used to
 cascade identical false ``bench_fail``s across all later configs (and ops).
 
 The worker now probes its context after a failure (``_context_dirty``) and
-exits if it's poisoned, so the parent (``program.py`` ``_BenchWorker.bench``)
+exits if it's poisoned, so the parent (``program.py`` ``_AsyncBenchWorker.run_job``)
 respawns a clean context on the next request. A benign failure (NVRTC compile
 error, etc.) leaves the context healthy and keeps the worker alive.
 
@@ -96,9 +96,9 @@ def test_worker_exits_after_context_corruption() -> None:
 
 def test_kill_idempotent_when_no_proc() -> None:
     """``_kill()`` on a worker that was never spawned must be a silent no-op."""
-    from deplodock.compiler.backend.cuda.program import _BenchWorker
+    from deplodock.compiler.backend.cuda.program import _AsyncBenchWorker
 
-    w = _BenchWorker()
+    w = _AsyncBenchWorker()
     assert w._proc is None
     w._kill()
     assert w._proc is None
@@ -108,105 +108,99 @@ def test_kill_idempotent_when_no_proc() -> None:
 
 def test_kill_releases_already_dead_subprocess() -> None:
     """A worker subprocess that exited on its own (e.g. dirty-context path) is
-    still attached to ``self._proc``; ``_kill()`` must release it without
-    raising even though ``kill()`` on a reaped pid would normally surface a
-    ``ProcessLookupError``."""
-    from deplodock.compiler.backend.cuda.program import _BenchWorker
+    still attached to ``self._proc``; ``_kill()`` must release it without raising
+    (a dead proc has ``returncode`` set, so no SIGKILL is attempted)."""
+    import asyncio
 
-    proc = subprocess.Popen(
-        [sys.executable, "-c", "import sys; sys.exit(0)"],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    assert proc.wait(timeout=5) == 0
+    from deplodock.compiler.backend.cuda.program import _AsyncBenchWorker
 
-    w = _BenchWorker()
-    w._proc = proc
-    w._kill()
-    assert w._proc is None
+    async def _run() -> None:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import sys; sys.exit(0)",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        assert await proc.wait() == 0
+        w = _AsyncBenchWorker()
+        w._proc = proc
+        w._kill()
+        assert w._proc is None
+
+    asyncio.run(_run())
 
 
 def test_bench_retries_after_broken_pipe_on_first_write(monkeypatch) -> None:
-    """The dirty-context exit path can race the parent's ``poll()`` check: by
-    the time we write the next request, the worker's stdin has been closed
-    but ``poll()`` may not yet show the exit. The first ``stdin.write``
-    then raises ``BrokenPipeError``. ``bench()`` must respawn and retry the
-    send once before surfacing the failure."""
+    """The dirty-context exit path can race a respawn: the first ``stdin.drain``
+    raises ``BrokenPipeError`` (the worker's read end is gone). ``run_job`` must
+    respawn and retry the send once before surfacing the failure."""
+    import asyncio
+
     from deplodock.compiler.backend import BenchmarkResult
     from deplodock.compiler.backend.cuda import program as P
 
-    spawn_count = 0
-
-    class _FakeStdin:
-        """A real pipe write end (the send path uses ``fileno()`` + ``os.write``).
-        ``broken=True`` closes the read end up front, so the first ``os.write``
-        raises ``BrokenPipeError`` organically — the stale-worker race."""
-
-        def __init__(self, *, broken: bool) -> None:
-            r, w = os.pipe()
-            self._w = w
-            if broken:
-                os.close(r)
-            else:
-                self._r = r  # keep the read end open; the small request fits the pipe buffer
-
-        def fileno(self) -> int:
-            return self._w
-
-    class _FakeStderr:
-        def read(self) -> bytes:
-            return b""
-
-    class _FakeProc:
-        def __init__(self, *, fail_first_write: bool) -> None:
-            self.pid = 1000 + (0 if fail_first_write else 1)
-            self.stdin = _FakeStdin(broken=fail_first_write)
-            self.stdout = type("S", (), {"fileno": lambda self: -1})()
-            self.stderr = _FakeStderr()
-            self._alive = True
-
-        def poll(self) -> int | None:
-            return None if self._alive else 0
-
-        def kill(self) -> None:
-            self._alive = False
-
-        def wait(self, timeout: float | None = None) -> int:
-            return 0
-
-    procs = [_FakeProc(fail_first_write=True), _FakeProc(fail_first_write=False)]
-
-    def fake_spawn(self: P._BenchWorker) -> None:
-        nonlocal spawn_count
-        self._proc = procs[spawn_count]
-        spawn_count += 1
-
-    # Construct the wire-format response the second proc "writes" back so the
-    # recv loop pickle-loads a real BenchmarkResult.
     response_body = pickle.dumps(
         {"ok": True, "result": BenchmarkResult(time_ms=42.0, num_launches=0)},
         protocol=pickle.HIGHEST_PROTOCOL,
     )
     response_wire = len(response_body).to_bytes(8, "little") + response_body
-    read_pos = [0]
 
-    def fake_select(rlist, wlist, xlist, timeout):  # noqa: ARG001
-        return rlist, wlist, []  # writes (real pipe fds) and reads (faked below) both "ready"
+    class _FakeStdin:
+        def __init__(self, *, broken: bool) -> None:
+            self._broken = broken
 
-    def fake_read(fd: int, n: int) -> bytes:  # noqa: ARG001
-        chunk = response_wire[read_pos[0] : read_pos[0] + n]
-        read_pos[0] += len(chunk)
-        return chunk
+        def write(self, _data: bytes) -> None:
+            pass
 
-    monkeypatch.setattr(P._BenchWorker, "_spawn", fake_spawn)
-    monkeypatch.setattr(P.select, "select", fake_select)
-    monkeypatch.setattr(P._os, "read", fake_read)
+        async def drain(self) -> None:
+            if self._broken:
+                raise BrokenPipeError("stale worker — read end closed")
 
-    w = P._BenchWorker()
-    resp = w.run_job({"graph": None, "torch_spec": None, "kwargs": {}}, wall_timeout_s=5.0)
+    class _FakeStdout:
+        def __init__(self, wire: bytes) -> None:
+            self._buf = bytearray(wire)
 
-    assert spawn_count == 2, "BrokenPipeError on first write must trigger one respawn"
+        async def readexactly(self, n: int) -> bytes:
+            if len(self._buf) < n:
+                raise asyncio.IncompleteReadError(bytes(self._buf), n)
+            chunk = bytes(self._buf[:n])
+            del self._buf[:n]
+            return chunk
+
+    class _FakeStderr:
+        async def read(self) -> bytes:
+            return b""
+
+    class _FakeProc:
+        def __init__(self, *, fail_send: bool) -> None:
+            self.pid = 1000 + (0 if fail_send else 1)
+            self.returncode = None
+            self.stdin = _FakeStdin(broken=fail_send)
+            self.stdout = _FakeStdout(b"" if fail_send else response_wire)
+            self.stderr = _FakeStderr()
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            return -9
+
+    procs = [_FakeProc(fail_send=True), _FakeProc(fail_send=False)]
+    spawn_count = 0
+
+    async def fake_spawn(self: P._AsyncBenchWorker) -> None:
+        nonlocal spawn_count
+        self._proc = procs[spawn_count]
+        spawn_count += 1
+
+    monkeypatch.setattr(P._AsyncBenchWorker, "_spawn", fake_spawn)
+
+    w = P._AsyncBenchWorker()
+    resp = asyncio.run(w.run_job({"graph": None, "torch_spec": None, "kwargs": {}}, wall_timeout_s=5.0))
+
+    assert spawn_count == 2, "BrokenPipeError on first send must trigger one respawn"
     assert resp["result"].time_ms == 42.0
 
 

--- a/tests/compiler/cli/test_tune_dataset_golden.py
+++ b/tests/compiler/cli/test_tune_dataset_golden.py
@@ -37,6 +37,8 @@ def _args(**over):
         bench_backends="eager,deplodock",
         warmup=10,
         iters=100,
+        gpus=None,
+        devices=None,
     )
     base.update(over)
     return SimpleNamespace(**base)
@@ -136,7 +138,7 @@ def _stub_runtime(monkeypatch):
         return SimpleNamespace(best_reward=None, assembled=None), None
 
     monkeypatch.setattr(tune, "_tune_one", fake_tune_one)
-    monkeypatch.setattr(tune, "_tune_backend", lambda: object())
+    monkeypatch.setattr(tune, "_tune_backend", lambda device_id=None: object())
     monkeypatch.setattr(tune, "_bench_dump", lambda a: (None, None))
     monkeypatch.setattr(tune, "_clean_caches", lambda p: cleaned.append(p))
     monkeypatch.setattr(tune, "setup_pipeline_runtime", lambda a: None)

--- a/tests/compiler/cli/test_tune_devices.py
+++ b/tests/compiler/cli/test_tune_devices.py
@@ -1,0 +1,64 @@
+"""CLI tests for ``deplodock tune --gpus / --devices`` device resolution (no GPU).
+
+``_resolve_devices`` maps the flags to a device-id list (``--devices`` wins) and,
+for two or more devices, enforces homogeneity (one perf key per tune). The
+homogeneity probe needs cupy, so it's exercised here by monkeypatching the
+device-properties call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from deplodock.commands import tune
+
+
+def _args(*, gpus=None, devices=None):
+    return SimpleNamespace(gpus=gpus, devices=devices)
+
+
+def test_default_is_single_unpinned_slot() -> None:
+    assert tune._resolve_devices(_args()) == [None]
+
+
+def test_gpus_n_expands_to_range() -> None:
+    # cupy is absent in CI → the homogeneity probe is a no-op, so >1 resolves.
+    assert tune._resolve_devices(_args(gpus=3)) == [0, 1, 2]
+
+
+def test_devices_list_wins_over_gpus() -> None:
+    assert tune._resolve_devices(_args(gpus=8, devices="0,2,5")) == [0, 2, 5]
+
+
+def test_single_device_skips_homogeneity() -> None:
+    assert tune._resolve_devices(_args(devices="1")) == [1]
+
+
+def test_bad_devices_exits(capsys) -> None:
+    with pytest.raises(SystemExit) as e:
+        tune._resolve_devices(_args(devices="0,x,2"))
+    assert e.value.code == 2
+
+
+def test_gpus_below_one_exits() -> None:
+    with pytest.raises(SystemExit) as e:
+        tune._resolve_devices(_args(gpus=0))
+    assert e.value.code == 2
+
+
+def test_heterogeneous_devices_rejected(monkeypatch) -> None:
+    fake_cupy = SimpleNamespace(
+        cuda=SimpleNamespace(runtime=SimpleNamespace(getDeviceProperties=lambda d: {"major": 8 if d == 0 else 9, "minor": 0}))
+    )
+    monkeypatch.setitem(__import__("sys").modules, "cupy", fake_cupy)
+    with pytest.raises(SystemExit) as e:
+        tune._resolve_devices(_args(devices="0,1"))
+    assert e.value.code == 2
+
+
+def test_homogeneous_devices_accepted(monkeypatch) -> None:
+    fake_cupy = SimpleNamespace(cuda=SimpleNamespace(runtime=SimpleNamespace(getDeviceProperties=lambda d: {"major": 9, "minor": 0})))
+    monkeypatch.setitem(__import__("sys").modules, "cupy", fake_cupy)
+    assert tune._resolve_devices(_args(devices="0,1,2")) == [0, 1, 2]

--- a/tests/compiler/cli/test_tune_devices.py
+++ b/tests/compiler/cli/test_tune_devices.py
@@ -23,12 +23,33 @@ def test_default_is_single_unpinned_slot() -> None:
     assert tune._resolve_devices(_args()) == [None]
 
 
+def _device_count() -> int:
+    """Physical GPU count, or 0 if cupy can't probe (absent / no driver)."""
+    try:
+        import cupy as cp
+
+        return cp.cuda.runtime.getDeviceCount()
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _gate_multi_gpu(max_ordinal: int) -> None:
+    """Multi-device resolution runs the homogeneity probe, which queries each
+    GPU. With cupy present but too few GPUs the probe ``sys.exit(2)``s, so skip
+    unless the box has the ordinals (cupy absent → probe is a no-op, test runs)."""
+    count = _device_count()
+    if 0 < count <= max_ordinal:
+        pytest.skip(f"needs GPU ordinal {max_ordinal} (homogeneity probe), have {count}")
+
+
 def test_gpus_n_expands_to_range() -> None:
-    # cupy is absent in CI → the homogeneity probe is a no-op, so >1 resolves.
+    # cupy absent → probe is a no-op; present → needs ordinals 0,1,2.
+    _gate_multi_gpu(2)
     assert tune._resolve_devices(_args(gpus=3)) == [0, 1, 2]
 
 
 def test_devices_list_wins_over_gpus() -> None:
+    _gate_multi_gpu(5)
     assert tune._resolve_devices(_args(gpus=8, devices="0,2,5")) == [0, 2, 5]
 
 

--- a/tests/compiler/pipeline/search/test_two_level.py
+++ b/tests/compiler/pipeline/search/test_two_level.py
@@ -81,6 +81,13 @@ class _CountingBackend:
             per.append(LaunchTime(idx=i, kernel_name=getattr(n.op, "kernel_name", "k"), time_ms=us / 1000.0, samples=(us / 1000.0,)))
         return BenchmarkResult(time_ms=sum(p.time_ms for p in per), num_launches=len(per), per_launch=per)
 
+    async def benchmark_async(self, graph, num_iters="auto") -> BenchmarkResult:
+        # The two-level driver benches through the async path (``Pipeline.tune_async``);
+        # the fake has no real I/O, so delegate to the deterministic sync bench. The
+        # signature mirrors ``benchmark`` exactly (no ``nvcc_flags``) so the -O3
+        # re-bench rejects the same way → identical bench counts to the sync path.
+        return self.benchmark(graph, num_iters=num_iters)
+
 
 def _matmul(g: Graph, prefix: str, M: int, K: int, N: int) -> str:
     a, b, c = f"{prefix}a", f"{prefix}b", f"{prefix}c"
@@ -238,6 +245,26 @@ def test_inner_reward_shares_identical_kernel() -> None:
     assert reward.total_us == pytest.approx(2 * reward.per_op[0].best_us)
 
 
+def test_inner_reward_parallel_matches_serial() -> None:
+    """The core multi-GPU invariant: tuning the unique kernels concurrently across
+    a pool of N device-pinned backends yields the SAME per-op bests and summed
+    reward as the one-slot serial path. Each op's search is seeded by ``op_idx``
+    (execution-order-independent) and the fake backend's latency keys off
+    ``op_cache_key`` (slot-independent), so completion order can't change the
+    result. ``prior=None`` keeps this off the learned-prior (catboost) path."""
+    fused = _fuse(_two_distinct_matmuls())
+    ctx = Context.from_target((8, 0))
+
+    serial = inner_reward(fused, ctx=ctx, db=SearchDB(), backend=_CountingBackend(), patience=_PATIENCE)
+    parallel = inner_reward(fused, ctx=ctx, db=SearchDB(), backends=[_CountingBackend(), _CountingBackend()], patience=_PATIENCE)
+
+    assert parallel.total_us == pytest.approx(serial.total_us)
+    assert parallel.ok == serial.ok
+    s_by_key = {r.op_key: (r.best_us, r.multiplicity) for r in serial.per_op}
+    p_by_key = {r.op_key: (r.best_us, r.multiplicity) for r in parallel.per_op}
+    assert p_by_key == s_by_key, "per-op bests must be identical regardless of slot count"
+
+
 def _norm_linear(prefix: str, g: Graph | None = None) -> Graph:
     """RMSNorm → Linear (f16): fusion yields the prologue-demoted matmul whose
     keep-vs-split offer (``tile/005_split_demoted``) is a structural fork."""
@@ -265,13 +292,13 @@ class _RecordingProgress:
     def start_terminal(self, n_ops: int) -> None:
         self.terminal_sizes.append(n_ops)
 
-    def op_start(self, name: str) -> None:
+    def op_start(self, name: str, *, slot: int = 0) -> None:  # noqa: ARG002
         self.ops.append(name)
 
     def variant(self, *a, **kw) -> None:  # noqa: ANN002
         pass
 
-    def op_done(self, name: str) -> None:
+    def op_done(self, name: str, *, slot: int = 0) -> None:
         pass
 
 


### PR DESCRIPTION
## What

Adds `--gpus N` / `--devices 0,1,2` to `deplodock tune`, fanning the inner
per-kernel autotune search out across GPUs: **one in-flight bench per
device-pinned worker on a single asyncio event loop**. Because each unique
kernel is tuned independently (`op_cache_key`), the per-op loop is the natural
unit of parallelism.

## How

**True single-thread asyncio, in-flight prior refit** — every Python statement
(lowering, DB writes, prior `add_rows`/`maybe_refit`/`checkpoint`) runs on the
one event-loop thread and yields only at the bench `await`, so the shared `db`
and `prior` need **no locks**.

- **Async bench worker** (`backend/cuda/program.py`): `_AsyncBenchWorker` drives
  the *same* `_bench_worker` subprocess protocol (`<8-byte len><pickle>`) over
  asyncio streams — `create_subprocess_exec` + `asyncio.wait_for` wall cap, same
  SIGKILL/respawn recovery as the sync worker. Device pin is a **per-worker
  spawn-env overlay** (`CUDA_VISIBLE_DEVICES` + a per-device `DEPLODOCK_GPU_LOCK`
  suffix so workers don't serialise on one lock), never mutating the parent
  `os.environ`.
- **`CudaBackend(device_id=...)`** lazily owns one pinned worker and exposes
  `benchmark_async` (always isolated).
- **Async tune driver** (`pipeline.py`): `_bench_terminal` refactored into a
  shared `_TerminalBench` so the sync path and the new `_bench_terminal_async`
  share *all* cache-hit/persistence logic — only the bench call differs;
  `Pipeline.tune_async` mirrors `tune`.
- **Parallel inner loop** (`two_level.py`): `inner_reward` stays a sync wrapper
  around `_inner_reward_async`, which runs one coroutine per unique kernel over
  an `asyncio.Queue` of device-pinned backends. Each op seeds by `op_idx`
  (execution-order-independent) and the reward is a commutative Σ, so **per-op
  bests and `total_us` are byte-identical regardless of slot count**; only the
  trained `prior.json` varies run-to-run (rows arrive in completion order). The
  **default single-GPU path is the one-slot serial case**, identical to before.
- **CLI** (`tune.py`): `--gpus`/`--devices`, homogeneity check (one perf key per
  tune), device-pinned backend pool. Multi-slot progress line joins active
  kernels with ` | `.

Parallelism is bounded by the unique-kernel count; the outer SP-MCTS stays
serial.

## Design notes

Full design + reasoning in `plans/let-s-make-a-plan-glimmering-mist.md`; docs
updated in `CLAUDE.md` and the pipeline / backend `ARCHITECTURE.md`.

## Tests

- `test_inner_reward_parallel_matches_serial` — the core invariant (gpus-1 ==
  gpus-N per-op bests + total).
- Worker env-overlay (device pin + per-device lock, `os.environ` untouched) and
  device-resolution / homogeneity-guard unit tests (no GPU).
- `@requires_cuda` smoke test exercising the **real** async transport
  end-to-end (skipped without a GPU).
- The full async `run_two_level_tune` path is covered by the existing
  `test_run_two_level_tune_single_terminal_assembles_bests` (real CatBoost
  prior refit/checkpoint).

`make lint` clean.

> [!NOTE]
> Worth confirming on real 2-GPU hardware via the gated smoke test before merge
> — the live async-subprocess transport can't run in a no-GPU CI box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)