### PR TITLE
goldens: multi-GPU sweep (4090 + PRO 6000) + common GPU registry + per-card featurization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ recipes/*/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_*/
 .claude/settings.local.json
 *-dump/
 .claude/scheduled_tasks.lock
+
+# Local-only analysis artifacts (priors / tune DBs / harvest dumps) — never commit
+_data/

--- a/deplodock/commands/compile.py
+++ b/deplodock/commands/compile.py
@@ -149,7 +149,11 @@ def resolve_golden_arg(args) -> None:
     if getattr(args, "dynamic", None):
         logger.error("--dynamic is incompatible with --golden (a dynamic golden's spec is part of its config)")
         sys.exit(2)
-    matches = Dataset.from_golden(name=name).samples
+    # Scope to the live card's golden(s): on a multi-GPU goldens dir, A/B-ing the
+    # deployed pick against another card's recorded config (e.g. a PRO 6000 golden
+    # on a 5090 — both cc 12.0) is meaningless. Cards with no recorded golden of
+    # their own fall back to the full set (the seed / transfer flow).
+    matches = Dataset.from_golden(name=name, live_gpu=True).samples
     if not matches:
         from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig
 

--- a/deplodock/commands/eval.py
+++ b/deplodock/commands/eval.py
@@ -438,9 +438,9 @@ def _emit_golden_features(kernel_filter: str | None) -> None:
 
     from deplodock.compiler.pipeline.knob import CTX_PREFIX, STRUCT_PREFIX  # noqa: PLC0415
     from deplodock.compiler.pipeline.search.data import Sample  # noqa: PLC0415
-    from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
+    from deplodock.compiler.pipeline.search.golden import MatmulGoldenConfig, goldens_for_live_gpu  # noqa: PLC0415
 
-    configs = [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)]
+    configs = [g for g in goldens_for_live_gpu() if isinstance(g, MatmulGoldenConfig)]
     if kernel_filter:
         configs = [g for g in configs if kernel_filter in g.name]
 
@@ -473,10 +473,14 @@ def _emit_golden_features(kernel_filter: str | None) -> None:
 
 
 def _golden_configs(kernel_filter: str | None):
-    """The matmul golden configs, optionally filtered by name substring."""
-    from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
+    """The matmul golden configs for the **live** card, optionally filtered by name
+    substring. Scoping to the live GPU (:func:`goldens_for_live_gpu`) keeps the eval
+    views about the card in hand when a multi-GPU goldens dir is checked in — a name
+    recurs once per card and the GPU-blind ``ShapeKey`` join would otherwise mix
+    cards (5090 / PRO 6000 even share ``compute_cap``)."""
+    from deplodock.compiler.pipeline.search.golden import MatmulGoldenConfig, goldens_for_live_gpu  # noqa: PLC0415
 
-    configs = [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)]
+    configs = [g for g in goldens_for_live_gpu() if isinstance(g, MatmulGoldenConfig)]
     if kernel_filter:
         configs = [g for g in configs if kernel_filter in g.name]
     return configs

--- a/deplodock/compiler/context.py
+++ b/deplodock/compiler/context.py
@@ -15,7 +15,7 @@ the signature alone.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from deplodock import config, gpu
 
@@ -104,6 +104,15 @@ class Context:
     # in ``structural_key`` (device-physical, like ``max_dynamic_smem``: it steers
     # the option-0 pick, but the resulting knobs already key the perf cache).
     sm_count: int = DEFAULT_SM_COUNT
+    # Physical device feature dict (``sm_count`` / ``smem_per_sm`` / … keys, as
+    # ``gpu.GpuSpec.device_features``) for the GPU this context is *for*. Empty ⇒
+    # use the live-device probe in :meth:`features` (the live-compile default).
+    # Non-empty is the **memorized** set of a specific card, set by
+    # ``from_target(gpu_name=…)`` so a reconstructed *golden* context featurizes
+    # with its own card's regime (H_sm_count / smem / …) — not the live device's,
+    # which would mis-model an RTX PRO 6000 golden ranked on an RTX 5090 (both
+    # cc 12.0 but 188 vs 170 SMs). NOT in ``structural_key`` (device-physical).
+    device_props: dict = field(default_factory=dict)
     # Identifies which backend's perf rows this compile reads/writes — the
     # tune DB keys ``perf`` by ``(context_key, op_key, backend)``. Defaults to
     # ``"cuda"`` — the canonical autotune target. ``run_autotune`` replaces
@@ -119,11 +128,20 @@ class Context:
     compile_flags: str = ""
 
     @classmethod
-    def from_target(cls, cap: tuple[int, int]) -> Context:
+    def from_target(cls, cap: tuple[int, int], *, gpu_name: str | None = None) -> Context:
+        """A target-derived context. ``gpu_name`` (a PCIe product name) pins the
+        device-physical features to that card's **memorized** specs from the
+        :mod:`deplodock.gpu` registry — used to reconstruct a *golden* config's
+        context so it featurizes with its own card's SM count / smem (not the live
+        device's). Default ``None`` → the live device (the live-compile path)."""
+        spec = gpu.by_name(gpu_name) if gpu_name else None
+        props = spec.device_features() if spec else {}
+        sm = int(props.get("sm_count") or _live_sm_count())
         return cls(
             compute_capability=cap,
             max_dynamic_smem=_max_dynamic_smem_for(cap),
-            sm_count=_live_sm_count(),
+            sm_count=sm,
+            device_props=props,
             compile_flags=_env_compile_flags(),
         )
 
@@ -172,7 +190,9 @@ class Context:
             "H_smem_optin": float(self.max_dynamic_smem),
             "H_opt": float(m.group(1)) if m else 3.0,
         }
-        for k, v in live_device_features().items():
+        # The memorized props of this context's card (golden reconstruction) when
+        # set, else the live device's — so a golden featurizes with its own card.
+        for k, v in (self.device_props or live_device_features()).items():
             feats[f"H_{k}"] = v
         return feats
 

--- a/deplodock/compiler/context.py
+++ b/deplodock/compiler/context.py
@@ -17,51 +17,28 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from deplodock import config
+from deplodock import config, gpu
 
-# Per-block static-smem cap. Hard hardware limit since Maxwell (sm_50);
-# anything declared as ``__shared__`` at compile time must fit.
-# Universal across every arch we target.
-STATIC_SMEM_CAP = 48 * 1024
+# GPU hardware facts live in the common :mod:`deplodock.gpu` registry; these are
+# aliases so the long-standing context-local names keep working.
+#
+# ``STATIC_SMEM_CAP`` — per-block static-smem cap (hard hardware limit since
+# Maxwell; anything declared ``__shared__`` at compile time must fit; universal).
+# ``_MAX_DYNAMIC_SMEM_BY_CC`` — per-block dynamic-smem opt-in cap by cc
+# (``cudaDevAttrMaxSharedMemoryPerBlockOptin``). ``_TENSOR_CORE_GEN`` — coarse
+# tensor-core generation by cc for the learned prior's regime features.
+STATIC_SMEM_CAP = gpu.STATIC_SMEM_CAP
+_MAX_DYNAMIC_SMEM_BY_CC = gpu.MAX_DYNAMIC_SMEM_BY_CC
+_TENSOR_CORE_GEN = gpu.TENSOR_CORE_GEN
 
-# Fallback SM (streaming-multiprocessor) count when no live CUDA device is
-# present (GPU-less CI / offline eval). RTX 5090 / sm_120 = 170 — the device the
-# golden configs were measured on, so offline golden ranking matches. The live
-# count (``target.live_device_features``) overrides this in ``from_target`` /
-# ``probe``. Consumed by the occupancy-aware analytic prior (the ``D_*`` CTA /
-# waves features in ``knob.knob_features``, ranked by ``search/prior/AnalyticPrior``)
-# to size tiles to the device — keep CTA count near ~1-2 waves over the SMs.
-DEFAULT_SM_COUNT = 170
-
-# Per-block dynamic-smem opt-in cap by compute capability. NVIDIA assigns
-# different sm_XX numbers to datacenter vs consumer SKUs within the same
-# arch family (sm_80 A100 vs sm_86 RTX 30xx; sm_90 H100 vs sm_120 RTX
-# 50xx), so this is keyed on cc, not "arch generation". Values from
-# ``cudaDevAttrMaxSharedMemoryPerBlockOptin``.
-_MAX_DYNAMIC_SMEM_BY_CC: dict[tuple[int, int], int] = {
-    (7, 5): 64 * 1024,
-    (8, 0): 163 * 1024,
-    (8, 6): 99 * 1024,
-    (8, 9): 99 * 1024,
-    (9, 0): 227 * 1024,
-    (10, 0): 227 * 1024,
-    (12, 0): 99 * 1024,
-}
-
-# Tensor-core generation by compute capability — Volta(1)/Turing(2)/Ampere+Ada(3)
-# /Hopper(4)/Blackwell(5). A coarse arch-capability axis for the learned prior's
-# regime features (e.g. which mma shapes / dtypes the SM can issue); unknown ccs
-# fall back to the major version.
-_TENSOR_CORE_GEN: dict[tuple[int, int], int] = {
-    (7, 0): 1,
-    (7, 5): 2,
-    (8, 0): 3,
-    (8, 6): 3,
-    (8, 9): 3,
-    (9, 0): 4,
-    (10, 0): 5,
-    (12, 0): 5,
-}
+# Fallback SM count when no live CUDA device is present (GPU-less CI / offline
+# eval) — the memorized count of the default card (RTX 5090 / sm_120 = 170, the
+# device the golden configs were measured on, so offline golden ranking matches).
+# The live count (``target.live_device_features`` → ``gpu.probe_live_features``)
+# overrides this in ``from_target`` / ``probe``. Consumed by the occupancy-aware
+# analytic prior (the ``D_*`` CTA / waves features in ``knob.knob_features``) to
+# size tiles to the device — keep CTA count near ~1-2 waves over the SMs.
+DEFAULT_SM_COUNT = gpu.DEFAULT_GPU.sm_count
 
 
 def _env_compile_flags() -> str:

--- a/deplodock/compiler/pipeline/search/analytic.py
+++ b/deplodock/compiler/pipeline/search/analytic.py
@@ -16,10 +16,12 @@ from collections.abc import Callable
 
 from deplodock.compiler.context import Context
 from deplodock.compiler.pipeline.passes.lowering.tile._enumeration import enumerate_cartesian
+from deplodock.gpu import DEFAULT_GPU
 
-# Occupancy reference fallback when a context carries no SM count (GPU-less hosts).
-# RTX 5090 / sm_120 has 170 SMs; the golden set was measured there.
-DEFAULT_SM_COUNT = 170
+# Occupancy reference fallback when a context carries no SM count (GPU-less hosts) —
+# the default card's memorized SM count (RTX 5090 / sm_120 = 170; the golden set was
+# measured there). Single source: the common GPU registry (:mod:`deplodock.gpu`).
+DEFAULT_SM_COUNT = DEFAULT_GPU.sm_count
 
 # Knobs the thread-tier / warp-tier enumeration decides — the projection a golden
 # is matched on (STAGE / RING / WARPSPEC / NOATOMIC are stamped by later passes,

--- a/deplodock/compiler/pipeline/search/data/dataset.py
+++ b/deplodock/compiler/pipeline/search/data/dataset.py
@@ -37,14 +37,24 @@ class Dataset:
 
     @classmethod
     def from_golden(
-        cls, *, name: str | None = None, kernel: str | None = None, dtype: str | None = None, compile_s_feats: bool = False
+        cls,
+        *,
+        name: str | None = None,
+        kernel: str | None = None,
+        dtype: str | None = None,
+        compile_s_feats: bool = False,
+        live_gpu: bool = False,
     ) -> Dataset:
         """The matmul golden configs, optionally narrowed by exact ``name``, name
         substring ``kernel``, or ``dtype``. ``compile_s_feats`` derives the full
-        ``S_*`` histogram per config (needed only for learned-prior featurization)."""
-        from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
+        ``S_*`` histogram per config (needed only for learned-prior featurization).
+        ``live_gpu`` scopes to the live card's goldens (:func:`goldens_for_live_gpu`)
+        — so a multi-GPU goldens dir doesn't return another card's config under the
+        same name (cards with no recorded golden fall back to the full set)."""
+        from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig, goldens_for_live_gpu  # noqa: PLC0415
 
-        configs = [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)]
+        source = goldens_for_live_gpu() if live_gpu else GOLDEN_CONFIGS
+        configs = [g for g in source if isinstance(g, MatmulGoldenConfig)]
         if name is not None:
             configs = [g for g in configs if g.name == name]
         if kernel:

--- a/deplodock/compiler/pipeline/search/data/sample.py
+++ b/deplodock/compiler/pipeline/search/data/sample.py
@@ -139,7 +139,10 @@ class Sample:
             name=cfg.name,
             dtype=cfg.dtype,
             ref_us=cfg.cublas_us,
-            context=Context.from_target(cfg.compute_cap).features(),
+            # gpu_name pins the device-physical features (H_sm_count / smem / …) to
+            # the golden's OWN card's memorized specs, not the live device's — so a
+            # PRO 6000 golden ranked on a 5090 (both cc 12.0) gets 188 SMs, not 170.
+            context=Context.from_target(cfg.compute_cap, gpu_name=cfg.gpu_name).features(),
             snippet=cfg.snippet(),
             source="golden",
             s_full=s_full,

--- a/deplodock/compiler/pipeline/search/golden.py
+++ b/deplodock/compiler/pipeline/search/golden.py
@@ -103,6 +103,19 @@ class GoldenConfig:
         """Within 95% of cuBLAS or better."""
         return self.ratio >= 0.95
 
+    @property
+    def sm_count(self) -> int | None:
+        """The recording card's SM count, from the common GPU registry (by
+        :attr:`gpu_name`) — ``None`` if the GPU isn't registered. This is what makes
+        a same-``compute_cap`` pair distinguishable (RTX 5090 = 170 vs RTX PRO 6000
+        = 188 SMs); :meth:`~...data.sample.Sample.from_golden` threads it into the
+        reconstructed context so the golden featurizes with its own card's regime,
+        not the live device's."""
+        from deplodock import gpu  # noqa: PLC0415
+
+        spec = gpu.by_name(self.gpu_name)
+        return spec.sm_count if spec else None
+
 
 @dataclass(frozen=True, kw_only=True)
 class MatmulGoldenConfig(GoldenConfig):

--- a/deplodock/compiler/pipeline/search/golden.py
+++ b/deplodock/compiler/pipeline/search/golden.py
@@ -226,8 +226,16 @@ def _load_goldens() -> list[GoldenConfig]:
     One file per GPU: a ``gpu_name`` / ``compute_cap`` header (stamped onto every
     config so it isn't repeated per entry) plus a ``configs`` list, each tagged with
     a ``kernel`` discriminator (``matmul`` / ``reduce`` / ``pointwise``) selecting the
-    dataclass. All files are concatenated — a ``name`` may recur across GPUs, told
-    apart by ``compute_cap`` (see :func:`goldens_by_name`)."""
+    dataclass. All files are concatenated — a ``name`` may recur across GPUs.
+
+    NOTE: ``compute_cap`` does **not** uniquely identify a GPU — two different cards
+    can share a capability (e.g. ``rtx5090_sm120.yaml`` and
+    ``rtxpro6000_sm120.yaml`` are both ``(12, 0)``). The full ``(gpu_name,
+    compute_cap)`` pair is the GPU identity. The ``eval`` / ``tune --dataset golden``
+    paths currently iterate this flat list without filtering to the live GPU, so a
+    multi-GPU goldens dir intermixes cards in those views and ``ShapeKey`` joins
+    (which key on shape, not GPU) merge same-shape entries across cards — filtering
+    the consumers to the live ``(gpu_name, compute_cap)`` is a known TODO."""
     out: list[GoldenConfig] = []
     for path in sorted(_GOLDENS_DIR.glob("*.yaml")):
         doc = yaml.safe_load(path.read_text())
@@ -246,5 +254,34 @@ def goldens_by_name(name: str) -> list[MatmulGoldenConfig]:
     found faster variant alongside the old one), so callers must not assume a name
     is unique. Empty when ``name`` is unknown. All entries share the shape (so any
     one's :meth:`~MatmulGoldenConfig.snippet` is interchangeable); they differ only
-    in ``knobs`` / measured latency."""
+    in ``knobs`` / measured latency — **including across GPUs**: with multiple
+    per-GPU files the same ``name`` recurs once per card, so the returned list can
+    mix GPUs (use ``compute_cap`` **and** ``gpu_name`` to pick a specific card; cap
+    alone is ambiguous for same-capability cards like RTX 5090 / RTX PRO 6000)."""
     return [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig) and g.name == name]
+
+
+def goldens_for_live_gpu() -> list[GoldenConfig]:
+    """:data:`GOLDEN_CONFIGS` narrowed to the **live** card's ``(gpu_name,
+    compute_cap)`` when a CUDA device is visible, else the full flat list.
+
+    The shape-keyed diagnostics / ``eval`` golden views (coverage, deploy-perf,
+    prior rank) join on :class:`ShapeKey`, which is GPU-blind — so with multiple
+    per-GPU files a name recurs once per card and same-shape entries collide.
+    Two cards can even share ``compute_cap`` (RTX 5090 / RTX PRO 6000 are both
+    ``(12, 0)``), so the live ``gpu_name`` is what disambiguates them. Filtering to
+    the live card keeps those views about the card actually being tuned. Off-GPU
+    (CI, pure-logic tests) there is no live card, so the unfiltered list is
+    returned — callers that need determinism there should inject a single-GPU set.
+    """
+    try:
+        import torch  # noqa: PLC0415
+
+        if not torch.cuda.is_available():
+            return list(GOLDEN_CONFIGS)
+        name = torch.cuda.get_device_name(0)
+        major, minor = torch.cuda.get_device_capability(0)
+    except Exception:  # noqa: BLE001 — any probe failure ⇒ no live filter
+        return list(GOLDEN_CONFIGS)
+    live = [g for g in GOLDEN_CONFIGS if g.gpu_name == name and tuple(g.compute_cap) == (major, minor)]
+    return live or list(GOLDEN_CONFIGS)

--- a/deplodock/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
+++ b/deplodock/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
@@ -1,0 +1,245 @@
+gpu_name: NVIDIA GeForce RTX 4090
+compute_cap: [8, 9]
+configs:
+  - kernel: matmul
+    name: square.512
+    M: 512
+    N: 512
+    K: 512
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 1, RING: 3, STAGE: '11'}
+    deplodock_us: 13.5
+    cublas_us: 10.8
+  - kernel: matmul
+    name: square.1024
+    M: 1024
+    N: 1024
+    K: 1024
+    knobs: {BM: 16, BN: 64, BK: 64, BR: 1, FM: 8, FN: 2, FK: 1, SPLITK: 2, RING: 1, STAGE: '11'}
+    deplodock_us: 71.0
+    cublas_us: 45.4
+  - kernel: matmul
+    name: square.2048
+    M: 2048
+    N: 2048
+    K: 2048
+    knobs: {BM: 16, BN: 64, BK: 64, BR: 1, FM: 16, FN: 2, FK: 1, SPLITK: 2, RING: 1, STAGE: '11'}
+    deplodock_us: 467.5
+    cublas_us: 320.0
+  - kernel: matmul
+    name: square.4096
+    M: 4096
+    N: 4096
+    K: 4096
+    knobs: {BN: 32, BM: 16, FM: 10, FN: 4, BK: 32, SPLITK: 1, BR: 1, STAGE: '11', RING: 2, WARPSPEC: false}
+    deplodock_us: 4004.9
+    cublas_us: 2458.6
+  - kernel: matmul
+    name: square.512.fp16
+    M: 512
+    N: 512
+    K: 512
+    dtype: fp16
+    knobs: {BM: 8, BN: 32, BK: 32, BR: 1, FM: 4, FN: 1, FK: 1, SPLITK: 1, RING: 4, STAGE: '11'}
+    deplodock_us: 17.7
+    cublas_us: 5.8
+  - kernel: matmul
+    name: square.1024.fp16
+    M: 1024
+    N: 1024
+    K: 1024
+    dtype: fp16
+    knobs: {BM: 8, BN: 32, BK: 64, BR: 1, FM: 8, FN: 1, FK: 1, SPLITK: 1, RING: 2, STAGE: '11'}
+    deplodock_us: 90.7
+    cublas_us: 18.1
+  - kernel: matmul
+    name: square.2048.fp16
+    M: 2048
+    N: 2048
+    K: 2048
+    dtype: fp16
+    knobs: {BM: 16, BN: 32, BK: 32, BR: 1, FM: 4, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11'}
+    deplodock_us: 512.5
+    cublas_us: 115.2
+  - kernel: matmul
+    name: square.4096.fp16
+    M: 4096
+    N: 4096
+    K: 4096
+    dtype: fp16
+    knobs: {BM: 16, BN: 32, BK: 32, BR: 1, FM: 4, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11'}
+    deplodock_us: 3778.6
+    cublas_us: 822.3
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s32
+    M: 32
+    N: 2048
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 3, STAGE: '11'}
+    deplodock_us: 7.9
+    cublas_us: 9.9
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s32
+    M: 32
+    N: 1024
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 2, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 6.5
+    cublas_us: 6.9
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s32
+    M: 32
+    N: 1024
+    K: 2048
+    knobs: {BN: 16, BM: 8, FM: 2, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 2}
+    deplodock_us: 11.2
+    cublas_us: 9.9
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s32
+    M: 32
+    N: 3072
+    K: 1024
+    knobs: {BN: 32, BM: 8, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 4}
+    deplodock_us: 12.1
+    cublas_us: 11.3
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s32
+    M: 32
+    N: 1024
+    K: 3072
+    knobs: {BN: 16, BM: 8, FM: 2, FN: 2, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 4}
+    deplodock_us: 15.6
+    cublas_us: 13.0
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s128
+    M: 128
+    N: 2048
+    K: 1024
+    knobs: {BN: 32, BM: 8, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 1, BR: 1, STAGE: '11', RING: 3}
+    deplodock_us: 23.6
+    cublas_us: 20.2
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s128
+    M: 128
+    N: 1024
+    K: 1024
+    knobs: {BN: 32, BM: 8, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 3}
+    deplodock_us: 12.9
+    cublas_us: 12.4
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s128
+    M: 128
+    N: 1024
+    K: 2048
+    knobs: {BN: 16, BM: 16, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 4}
+    deplodock_us: 23.0
+    cublas_us: 19.0
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s128
+    M: 128
+    N: 3072
+    K: 1024
+    knobs: {BN: 16, BM: 8, FM: 6, FN: 4, FK: 1, BK: 64, SPLITK: 1, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2}
+    deplodock_us: 45.7
+    cublas_us: 25.5
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s128
+    M: 128
+    N: 1024
+    K: 3072
+    knobs: {BN: 16, BM: 8, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, STAGE: '11', RING: 3}
+    deplodock_us: 33.1
+    cublas_us: 24.5
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s512
+    M: 512
+    N: 2048
+    K: 1024
+    knobs: {BM: 8, BN: 64, BK: 32, BR: 1, FM: 14, FN: 2, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 90.4
+    cublas_us: 53.3
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s512
+    M: 512
+    N: 1024
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 3, STAGE: '11'}
+    deplodock_us: 44.9
+    cublas_us: 38.9
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s512
+    M: 512
+    N: 1024
+    K: 2048
+    knobs: {BN: 16, BM: 8, FM: 14, FN: 2, FK: 1, BK: 32, SPLITK: 2, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2}
+    deplodock_us: 85.9
+    cublas_us: 67.8
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s512
+    M: 512
+    N: 3072
+    K: 1024
+    knobs: {BN: 32, BM: 8, FM: 10, FN: 4, FK: 1, BK: 32, SPLITK: 1, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 3}
+    deplodock_us: 123.6
+    cublas_us: 85.5
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s512
+    M: 512
+    N: 1024
+    K: 3072
+    knobs: {BN: 32, BM: 8, FM: 14, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2}
+    deplodock_us: 143.1
+    cublas_us: 113.2
+  - kernel: matmul
+    name: square.512.dynM
+    M: 512
+    N: 512
+    K: 512
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 16, BK: 32, BR: 1, FM: 4, FN: 4, FK: 1, SPLITK: 2, RING: 4, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 12.8
+    cublas_us: 10.8
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s512.dynM
+    M: 512
+    N: 2048
+    K: 1024
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BN: 32, BM: 16, FM: 4, FN: 4, FK: 1, BK: 32, SPLITK: 1, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 3}
+    deplodock_us: 63.8
+    cublas_us: 53.0
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s512.dynM
+    M: 512
+    N: 1024
+    K: 1024
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BN: 16, BM: 8, FM: 8, FN: 4, FK: 1, BK: 32, SPLITK: 2, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2}
+    deplodock_us: 33.4
+    cublas_us: 37.0
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s512.dynM
+    M: 512
+    N: 1024
+    K: 2048
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 16, BK: 32, BR: 1, FM: 4, FN: 4, FK: 1, SPLITK: 1, RING: 3, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 62.0
+    cublas_us: 67.1
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s512.dynM
+    M: 512
+    N: 3072
+    K: 1024
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BN: 16, BM: 8, FM: 8, FN: 4, FK: 1, BK: 32, SPLITK: 2, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2}
+    deplodock_us: 91.1
+    cublas_us: 85.6
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s512.dynM
+    M: 512
+    N: 1024
+    K: 3072
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BN: 16, BM: 16, FM: 8, FN: 4, FK: 1, BK: 64, SPLITK: 2, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 2}
+    deplodock_us: 92.3
+    cublas_us: 119.4

--- a/deplodock/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/deplodock/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -289,8 +289,8 @@ configs:
     N: 512
     K: 512
     dynamic: {seq_len: {input: x0, axis: 0}}
-    knobs: {BN: 16, BM: 16, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 2, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 4}
-    deplodock_us: 12.8
+    knobs: {BN: 16, BM: 16, FM: 4, FN: 2, FK: 1, BK: 64, SPLITK: 1, BR: 1, OVERHANG: ['a0'], STAGE: '11', RING: 3}
+    deplodock_us: 11.0
     cublas_us: 14.0
   - kernel: matmul
     name: qwen3_06b.q_proj.s512.dynM

--- a/deplodock/compiler/pipeline/search/goldens/rtxpro6000_sm120.yaml
+++ b/deplodock/compiler/pipeline/search/goldens/rtxpro6000_sm120.yaml
@@ -1,0 +1,245 @@
+gpu_name: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition
+compute_cap: [12, 0]
+configs:
+  - kernel: matmul
+    name: square.512
+    M: 512
+    N: 512
+    K: 512
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 6, FN: 2, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 11.0
+    cublas_us: 12.6
+  - kernel: matmul
+    name: square.1024
+    M: 1024
+    N: 1024
+    K: 1024
+    knobs: {BM: 16, BN: 16, BK: 32, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 4, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 49.2
+    cublas_us: 55.6
+  - kernel: matmul
+    name: square.2048
+    M: 2048
+    N: 2048
+    K: 2048
+    knobs: {BM: 16, BN: 32, BK: 32, BR: 1, FM: 12, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 357.6
+    cublas_us: 324.8
+  - kernel: matmul
+    name: square.4096
+    M: 4096
+    N: 4096
+    K: 4096
+    knobs: {BM: 16, BN: 32, BK: 32, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 3, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 3021.4
+    cublas_us: 2426.0
+  - kernel: matmul
+    name: square.512.fp16
+    M: 512
+    N: 512
+    K: 512
+    dtype: fp16
+    knobs: {BK: 4, FM: 2, FN: 2, WM: 2, WN: 2, SPLITK: 1, RING: 3, STAGE: '11', MMA: 'mma_m16n8k16_f16'}
+    deplodock_us: 3.8
+    cublas_us: 6.1
+  - kernel: matmul
+    name: square.1024.fp16
+    M: 1024
+    N: 1024
+    K: 1024
+    dtype: fp16
+    knobs: {BK: 2, FM: 4, FN: 2, WM: 1, WN: 4, SPLITK: 1, RING: 4, STAGE: '11', MMA: 'mma_m16n8k16_f16'}
+    deplodock_us: 13.9
+    cublas_us: 12.5
+  - kernel: matmul
+    name: square.2048.fp16
+    M: 2048
+    N: 2048
+    K: 2048
+    dtype: fp16
+    knobs: {BK: 2, FM: 2, FN: 4, WM: 4, WN: 2, SPLITK: 1, RING: 2, STAGE: '11', MMA: 'mma_m16n8k16_f16'}
+    deplodock_us: 78.6
+    cublas_us: 69.9
+  - kernel: matmul
+    name: square.4096.fp16
+    M: 4096
+    N: 4096
+    K: 4096
+    dtype: fp16
+    knobs: {BK: 2, FM: 4, FN: 8, WM: 2, WN: 2, SPLITK: 1, RING: 2, STAGE: '11', MMA: 'mma_m16n8k16_f16'}
+    deplodock_us: 524.1
+    cublas_us: 467.2
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s32
+    M: 32
+    N: 2048
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 7.8
+    cublas_us: 8.7
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s32
+    M: 32
+    N: 1024
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 2, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 6.2
+    cublas_us: 8.5
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s32
+    M: 32
+    N: 1024
+    K: 2048
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 2, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 10.0
+    cublas_us: 10.3
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s32
+    M: 32
+    N: 3072
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 11.6
+    cublas_us: 12.6
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s32
+    M: 32
+    N: 1024
+    K: 3072
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 2, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 13.8
+    cublas_us: 14.4
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s128
+    M: 128
+    N: 2048
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11'}
+    deplodock_us: 18.7
+    cublas_us: 19.7
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s128
+    M: 128
+    N: 1024
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 1, RING: 2, STAGE: '11'}
+    deplodock_us: 12.1
+    cublas_us: 14.5
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s128
+    M: 128
+    N: 1024
+    K: 2048
+    knobs: {BM: 8, BN: 32, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 4, STAGE: '11'}
+    deplodock_us: 20.9
+    cublas_us: 22.6
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s128
+    M: 128
+    N: 3072
+    K: 1024
+    knobs: {BM: 8, BN: 16, BK: 32, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 1, RING: 2, STAGE: '11'}
+    deplodock_us: 30.9
+    cublas_us: 26.4
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s128
+    M: 128
+    N: 1024
+    K: 3072
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 1, RING: 2, STAGE: '11'}
+    deplodock_us: 33.3
+    cublas_us: 31.1
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s512
+    M: 512
+    N: 2048
+    K: 1024
+    knobs: {BM: 8, BN: 32, BK: 64, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 55.8
+    cublas_us: 55.4
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s512
+    M: 512
+    N: 1024
+    K: 1024
+    knobs: {BM: 8, BN: 32, BK: 64, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 2, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 30.3
+    cublas_us: 39.5
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s512
+    M: 512
+    N: 1024
+    K: 2048
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 66.3
+    cublas_us: 68.6
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s512
+    M: 512
+    N: 3072
+    K: 1024
+    knobs: {BM: 16, BN: 32, BK: 32, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 3, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 85.1
+    cublas_us: 81.3
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s512
+    M: 512
+    N: 1024
+    K: 3072
+    knobs: {BM: 8, BN: 16, BK: 64, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 97.8
+    cublas_us: 92.0
+  - kernel: matmul
+    name: square.512.dynM
+    M: 512
+    N: 512
+    K: 512
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 64, BK: 32, BR: 1, FM: 6, FN: 1, FK: 1, SPLITK: 2, RING: 4, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 13.6
+    cublas_us: 12.6
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s512.dynM
+    M: 512
+    N: 2048
+    K: 1024
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 32, BK: 32, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 1, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 55.2
+    cublas_us: 55.3
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s512.dynM
+    M: 512
+    N: 1024
+    K: 1024
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 64, BK: 32, BR: 1, FM: 6, FN: 1, FK: 1, SPLITK: 2, RING: 4, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 47.8
+    cublas_us: 39.5
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s512.dynM
+    M: 512
+    N: 1024
+    K: 2048
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 16, BN: 16, BK: 64, BR: 1, FM: 4, FN: 2, FK: 1, SPLITK: 2, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 86.9
+    cublas_us: 68.4
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s512.dynM
+    M: 512
+    N: 3072
+    K: 1024
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 16, BK: 32, BR: 1, FM: 8, FN: 4, FK: 1, SPLITK: 2, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 89.7
+    cublas_us: 80.9
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s512.dynM
+    M: 512
+    N: 1024
+    K: 3072
+    dynamic: {seq_len: {input: x0, axis: 0}}
+    knobs: {BM: 8, BN: 32, BK: 32, BR: 1, FM: 6, FN: 4, FK: 1, SPLITK: 2, RING: 2, STAGE: '11', OVERHANG: ['a0']}
+    deplodock_us: 87.5
+    cublas_us: 92.1

--- a/deplodock/compiler/pipeline/search/prior/diagnostics.py
+++ b/deplodock/compiler/pipeline/search/prior/diagnostics.py
@@ -81,9 +81,12 @@ def _calibration(prior, groups: dict) -> float | None:
 
 
 def _golden_coverage(groups: dict) -> tuple[int, int]:
-    """How many golden matmul shapes have measured data in the dataset, matched by
+    """How many golden matmul **shapes** have measured data in the dataset, matched by
     :class:`ShapeKey` (free-dim product, reduce extent, dtype flag — so an fp32
-    square and its ``.fp16`` twin are counted separately)."""
+    square and its ``.fp16`` twin are counted separately). Counts *distinct shape
+    keys*, not per-config rows, so multiple knob sets for one shape — and the same
+    shape recurring across per-GPU golden files (``ShapeKey`` is GPU-blind) — count
+    once."""
     from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
 
     have = set()
@@ -91,9 +94,9 @@ def _golden_coverage(groups: dict) -> tuple[int, int]:
         d = dict(sig)
         if _matmul_sig(d):
             have.add(ShapeKey.from_s_features(d))
-    matmuls = [g for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)]
-    covered = sum(1 for g in matmuls if g.shape_key() in have)
-    return covered, len(matmuls)
+    golden_keys = {g.shape_key() for g in GOLDEN_CONFIGS if isinstance(g, MatmulGoldenConfig)}
+    covered = sum(1 for k in golden_keys if k in have)
+    return covered, len(golden_keys)
 
 
 def golden_prior_eval(prior, kernel_filter: str | None = None) -> str:
@@ -116,7 +119,9 @@ def golden_prior_eval(prior, kernel_filter: str | None = None) -> str:
     first); the faithful deploy check is ``eval golden``'s real greedy compile."""
     from deplodock.compiler.context import Context  # noqa: PLC0415
     from deplodock.compiler.pipeline.search import analytic  # noqa: PLC0415
-    from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
+    from deplodock.compiler.pipeline.search.golden import MatmulGoldenConfig, goldens_for_live_gpu  # noqa: PLC0415
+
+    GOLDEN_CONFIGS = goldens_for_live_gpu()  # live card only — see golden_deploy_perf
 
     # Index the matmul op groups by ShapeKey (free-dim product, reduce extent,
     # dtype flag — both sides built by the ShapeKey constructors, so the fp32/fp16
@@ -183,8 +188,14 @@ def golden_deploy_perf(prior, kernel_filter: str | None = None) -> dict[str, flo
     deployable speed comparison; <1.0 = the prior's pick is faster than golden). Shapes
     with no -O3 reservoir row are omitted (the caller renders ``—``). The reservoir is
     used rather than the raw ``perf`` table because only it carries the ``H_*`` regime
-    columns needed to isolate the deployable measurements."""
-    from deplodock.compiler.pipeline.search.golden import GOLDEN_CONFIGS, MatmulGoldenConfig  # noqa: PLC0415
+    columns needed to isolate the deployable measurements.
+
+    Goldens are scoped to the live card (:func:`goldens_for_live_gpu`) so a multi-GPU
+    goldens dir doesn't make a name's per-card entries collide on the GPU-blind
+    ``ShapeKey`` (e.g. RTX 5090 / RTX PRO 6000 both ``(12, 0)``)."""
+    from deplodock.compiler.pipeline.search.golden import MatmulGoldenConfig, goldens_for_live_gpu  # noqa: PLC0415
+
+    GOLDEN_CONFIGS = goldens_for_live_gpu()
 
     # Deployable (-O3) measured rows per matmul op group, indexed by ShapeKey.
     # An fp32 square and its ``.fp16`` twin share (free_prod, reduce), so the key's

--- a/deplodock/compiler/target.py
+++ b/deplodock/compiler/target.py
@@ -97,27 +97,19 @@ def compute_capability() -> tuple[int, int]:
 
 @functools.cache
 def live_device_features() -> dict[str, float]:
-    """Best-effort physical properties of the live CUDA device — SM count,
-    shared memory per SM / per block, register file, warp size — for the learned
-    prior's hardware-regime features (see :meth:`Context.features`). These are
-    SKU facts CUDA reports but compute-capability alone doesn't fix (an sm_120
-    laptop and an sm_120 RTX 5090 differ in SM count). Empty dict when cupy is
-    unavailable (GPU-less CI → the prior simply gets fewer regime features).
-    Cached — physical, target-independent, so :func:`set_target` need not clear it."""
-    try:
-        import cupy as cp
+    """Physical properties of the live CUDA device — SM count, shared memory per
+    SM / per block, register file, warp size — for the learned prior's
+    hardware-regime features (see :meth:`Context.features`). These are SKU facts
+    CUDA reports but compute-capability alone doesn't fix (an sm_120 laptop and an
+    sm_120 RTX 5090 differ in SM count). Delegates to
+    :func:`deplodock.gpu.probe_live_features`, which probes the live device via
+    cupy and, when none is visible (GPU-less CI / offline eval), falls back to the
+    **memorized** specs of :data:`deplodock.gpu.DEFAULT_GPU` — so offline hosts get
+    faithful per-SKU features instead of none. Cached — physical and
+    target-independent, so :func:`set_target` need not clear it."""
+    from deplodock import gpu  # noqa: PLC0415
 
-        props = cp.cuda.runtime.getDeviceProperties(cp.cuda.Device().id)
-        return {
-            "sm_count": float(props["multiProcessorCount"]),
-            "smem_per_sm": float(props["sharedMemPerMultiprocessor"]),
-            "smem_per_block": float(props["sharedMemPerBlock"]),
-            "regs_per_block": float(props["regsPerBlock"]),
-            "warp_size": float(props["warpSize"]),
-        }
-    except Exception as e:  # pragma: no cover
-        _logger.debug("live_device_features query failed (%s)", e)
-        return {}
+    return gpu.probe_live_features()
 
 
 @functools.cache

--- a/deplodock/detect.py
+++ b/deplodock/detect.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 
+from deplodock import gpu
 from deplodock.provisioning.ssh_transport import ssh_base_args
 
 logger = logging.getLogger(__name__)
@@ -10,43 +11,9 @@ logger = logging.getLogger(__name__)
 NVIDIA_VENDOR = "0x10de"
 AMD_VENDOR = "0x1002"
 
-# PCI device ID (hex, no prefix) -> GPU name
-# Source: PCI ID database (vendor 10de for NVIDIA, 1002 for AMD)
-GPU_PCI_DEVICE_IDS: dict[str, str] = {
-    # NVIDIA GeForce RTX 4090
-    "2684": "NVIDIA GeForce RTX 4090",
-    # NVIDIA GeForce RTX 5090
-    "2b85": "NVIDIA GeForce RTX 5090",
-    # NVIDIA RTX PRO 6000 Blackwell Workstation Edition
-    "2ba0": "NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
-    # NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition
-    # NVIDIA ships multiple PCI device IDs under the same product name —
-    # 2ba2 is the desktop variant, 2bb4 is the variant CloudRift attaches
-    # to its Pro 6000 Max-Q VMs (confirmed via nvidia-smi vs sysfs).
-    "2ba2": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
-    "2bb4": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
-    # NVIDIA RTX PRO 6000 Blackwell Server Edition
-    "2ba4": "NVIDIA RTX PRO 6000 Blackwell Server Edition",
-    # NVIDIA L40S
-    "26b9": "NVIDIA L40S",
-    # NVIDIA H100 80GB (SXM/PCIe)
-    "2330": "NVIDIA H100 80GB",
-    "2331": "NVIDIA H100 80GB",
-    # NVIDIA H200 141GB
-    "2335": "NVIDIA H200 141GB",
-    # NVIDIA B200
-    "2900": "NVIDIA B200",
-    "2901": "NVIDIA B200",
-    # NVIDIA A100 40GB (PCIe)
-    "20f1": "NVIDIA A100 40GB",
-    # NVIDIA A100 80GB (SXM/PCIe)
-    "20b2": "NVIDIA A100 80GB",
-    "20b5": "NVIDIA A100 80GB",
-    # AMD Instinct MI350X
-    "75b0": "AMD Instinct MI350X",
-    # NVIDIA Tesla V100 SXM3 32GB (DGX-2 / HGX-2 baseboard)
-    "1db8": "NVIDIA Tesla V100 SXM3 32GB",
-}
+# PCI device ID (hex, no prefix) -> GPU name, from the common GPU registry
+# (:mod:`deplodock.gpu`) — the single source of truth for PCI ids + names.
+GPU_PCI_DEVICE_IDS: dict[str, str] = gpu.pci_device_id_to_name()
 
 _SYSFS_SCAN_CMD = (
     "for d in /sys/bus/pci/devices/*/; do "

--- a/deplodock/gpu.py
+++ b/deplodock/gpu.py
@@ -1,0 +1,292 @@
+"""Common GPU registry — the project-wide single source of truth for *physical*
+GPU facts: PCI device IDs, the canonical name, and hardware specs (compute
+capability, SM count, shared-memory sizes, register file, VRAM).
+
+By convention the **PCIe product name** (what ``cudaDeviceProp.name`` /
+``nvidia-smi --query-gpu=name`` report, e.g. ``"NVIDIA GeForce RTX 5090"``) is
+*the* GPU name used everywhere in the project — golden files, the hardware /
+provisioning tables, detection, results filenames. Look a card up by that name
+(:func:`by_name`) or by its PCI device id (:func:`by_pci_device_id`).
+
+When a live CUDA probe is available (cupy present), :func:`probe_live_features`
+returns the device's real properties; otherwise it falls back to the **memorized
+specs** recorded here for :data:`DEFAULT_GPU` (or a name passed in). This lets
+GPU-less hosts (CI, offline golden ranking, cross-target compiles) get faithful
+per-SKU regime features instead of a single hardcoded constant.
+
+Cloud-provisioning facts (instance types, zones, provisioning models) stay in
+:mod:`deplodock.hardware` — those are provider/account specifics, not physical
+properties of the silicon; this module owns only the hardware itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+_MIB = 1024 * 1024
+
+# Per-block static-smem cap — hard hardware limit since Maxwell (sm_50); anything
+# declared ``__shared__`` at compile time must fit. Universal across every arch.
+STATIC_SMEM_CAP = 48 * 1024
+
+# Common register-file-per-block ceiling (modern NVIDIA: 64K 32-bit regs/CTA).
+_REGS_PER_BLOCK = 64 * 1024
+
+# Per-block dynamic-smem opt-in cap by compute capability
+# (``cudaDevAttrMaxSharedMemoryPerBlockOptin``). Keyed on cc, not "arch
+# generation": NVIDIA assigns different sm_XX to datacenter vs consumer SKUs in
+# one arch family (sm_80 A100 vs sm_86 RTX 30xx; sm_90 H100 vs sm_120 RTX 50xx).
+MAX_DYNAMIC_SMEM_BY_CC: dict[tuple[int, int], int] = {
+    (7, 0): 96 * 1024,
+    (7, 5): 64 * 1024,
+    (8, 0): 163 * 1024,
+    (8, 6): 99 * 1024,
+    (8, 9): 99 * 1024,
+    (9, 0): 227 * 1024,
+    (10, 0): 227 * 1024,
+    (12, 0): 99 * 1024,
+}
+
+# Tensor-core generation by compute capability —
+# Volta(1)/Turing(2)/Ampere+Ada(3)/Hopper(4)/Blackwell(5). A coarse arch-capability
+# axis for the learned prior's regime features; unknown ccs fall back to the major.
+TENSOR_CORE_GEN: dict[tuple[int, int], int] = {
+    (7, 0): 1,
+    (7, 5): 2,
+    (8, 0): 3,
+    (8, 6): 3,
+    (8, 9): 3,
+    (9, 0): 4,
+    (10, 0): 5,
+    (12, 0): 5,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class GpuSpec:
+    """Physical facts for one GPU SKU. ``name`` is the canonical PCIe product
+    name used as the GPU name across the whole project.
+
+    Per-SKU fields are stored directly; cc-derived facts (``smem_optin``,
+    ``tensor_core_gen``) are looked up from the cc-keyed tables so they can't
+    drift. ``sm_count`` / ``smem_per_sm`` / ``vram_mib`` recorded here are the
+    **memorized fallback** used when no live probe is available; ``None`` means
+    "unknown" (the consumer degrades as it would on a GPU-less host)."""
+
+    name: str
+    pci_device_ids: tuple[str, ...] = ()  # hex device ids (lowercase, no 0x prefix)
+    vendor: str = "NVIDIA"
+    short_name: str | None = None  # for results filenames (see hardware.gpu_short_name)
+    compute_capability: tuple[int, int] | None = None
+    sm_count: int | None = None
+    smem_per_sm: int | None = None
+    smem_per_block: int = STATIC_SMEM_CAP
+    regs_per_block: int = _REGS_PER_BLOCK
+    warp_size: int = 32
+    vram_mib: int | None = None
+    aliases: tuple[str, ...] = field(default=())  # alternate reported names
+
+    @property
+    def vram_bytes(self) -> int | None:
+        return self.vram_mib * _MIB if self.vram_mib is not None else None
+
+    @property
+    def smem_optin(self) -> int:
+        """Per-block dynamic-smem opt-in cap (cc-derived; static cap if unknown)."""
+        return MAX_DYNAMIC_SMEM_BY_CC.get(self.compute_capability, STATIC_SMEM_CAP)
+
+    @property
+    def tensor_core_gen(self) -> int | None:
+        if self.compute_capability is None:
+            return None
+        return TENSOR_CORE_GEN.get(self.compute_capability, self.compute_capability[0])
+
+    def device_features(self) -> dict[str, float]:
+        """The ``sm_count`` / ``smem_*`` / ``regs`` / ``warp`` subset, matching the
+        keys :func:`probe_live_features` reads from a live device — the memorized
+        fallback. Empty when ``sm_count`` is unknown (degrades like a GPU-less host)."""
+        if self.sm_count is None or self.smem_per_sm is None:
+            return {}
+        return {
+            "sm_count": float(self.sm_count),
+            "smem_per_sm": float(self.smem_per_sm),
+            "smem_per_block": float(self.smem_per_block),
+            "regs_per_block": float(self.regs_per_block),
+            "warp_size": float(self.warp_size),
+        }
+
+
+# Specs marked "measured" are exact values probed off the live card (recorded in
+# the golden-sweep priors). The rest carry the canonical name / PCI ids / cc /
+# VRAM (public nominal SKU specs) so detection + name resolution work; their
+# ``sm_count`` is the documented nominal count where known.
+KNOWN_GPUS: tuple[GpuSpec, ...] = (
+    # --- measured (golden-sweep cards) ------------------------------------
+    GpuSpec(
+        name="NVIDIA GeForce RTX 4090",
+        pci_device_ids=("2684",),
+        short_name="rtx4090",
+        compute_capability=(8, 9),
+        sm_count=128,
+        smem_per_sm=102400,
+        vram_mib=24564,
+    ),  # measured
+    GpuSpec(
+        name="NVIDIA GeForce RTX 5090",
+        pci_device_ids=("2b85",),
+        short_name="rtx5090",
+        compute_capability=(12, 0),
+        sm_count=170,
+        smem_per_sm=102400,
+        vram_mib=32607,
+    ),  # measured
+    GpuSpec(
+        name="NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+        pci_device_ids=("2ba2", "2bb4"),
+        short_name="pro6000",
+        compute_capability=(12, 0),
+        sm_count=188,
+        smem_per_sm=102400,
+        vram_mib=97887,
+    ),  # measured
+    # --- other PRO 6000 Blackwell variants (same GB202 die, cc 12.0) ------
+    GpuSpec(
+        name="NVIDIA RTX PRO 6000 Blackwell Workstation Edition",
+        pci_device_ids=("2ba0",),
+        short_name="pro6000",
+        compute_capability=(12, 0),
+        sm_count=188,
+        smem_per_sm=102400,
+        vram_mib=98304,
+    ),
+    GpuSpec(
+        name="NVIDIA RTX PRO 6000 Blackwell Server Edition",
+        pci_device_ids=("2ba4",),
+        short_name="pro6000",
+        compute_capability=(12, 0),
+        sm_count=188,
+        smem_per_sm=102400,
+        vram_mib=98304,
+    ),
+    # --- datacenter / workstation (nominal public specs) -----------------
+    GpuSpec(
+        name="NVIDIA L40S",
+        pci_device_ids=("26b9",),
+        short_name="l40s",
+        compute_capability=(8, 9),
+        sm_count=142,
+        smem_per_sm=102400,
+        vram_mib=46068,
+    ),
+    GpuSpec(
+        name="NVIDIA H100 80GB",
+        pci_device_ids=("2330", "2331"),
+        short_name="h100",
+        compute_capability=(9, 0),
+        sm_count=132,
+        smem_per_sm=233472,
+        vram_mib=81559,
+    ),
+    GpuSpec(
+        name="NVIDIA H200 141GB",
+        pci_device_ids=("2335",),
+        short_name="h200",
+        compute_capability=(9, 0),
+        sm_count=132,
+        smem_per_sm=233472,
+        vram_mib=143771,
+    ),
+    GpuSpec(
+        name="NVIDIA B200",
+        pci_device_ids=("2900", "2901"),
+        short_name="b200",
+        compute_capability=(10, 0),
+        sm_count=148,
+        smem_per_sm=233472,
+        vram_mib=183359,
+    ),
+    GpuSpec(
+        name="NVIDIA A100 40GB",
+        pci_device_ids=("20f1",),
+        short_name="a100",
+        compute_capability=(8, 0),
+        sm_count=108,
+        smem_per_sm=167936,
+        vram_mib=40960,
+    ),
+    GpuSpec(
+        name="NVIDIA A100 80GB",
+        pci_device_ids=("20b2", "20b5"),
+        short_name="a100",
+        compute_capability=(8, 0),
+        sm_count=108,
+        smem_per_sm=167936,
+        vram_mib=81920,
+    ),
+    GpuSpec(
+        name="NVIDIA Tesla V100 SXM3 32GB",
+        pci_device_ids=("1db8",),
+        short_name="v100",
+        compute_capability=(7, 0),
+        sm_count=80,
+        smem_per_sm=98304,
+        vram_mib=32768,
+    ),
+    # --- AMD (no CUDA compute capability) --------------------------------
+    GpuSpec(name="AMD Instinct MI350X", pci_device_ids=("75b0",), vendor="AMD", short_name="mi350x", vram_mib=294912),
+)
+
+# The default card when no live probe is available — the GPU the golden configs
+# were measured on, so offline golden ranking matches deploy. (RTX 5090, 170 SMs.)
+DEFAULT_GPU: GpuSpec = next(g for g in KNOWN_GPUS if g.name == "NVIDIA GeForce RTX 5090")
+
+_BY_NAME: dict[str, GpuSpec] = {}
+for _g in KNOWN_GPUS:
+    _BY_NAME[_g.name] = _g
+    for _a in _g.aliases:
+        _BY_NAME.setdefault(_a, _g)
+_BY_PCI: dict[str, GpuSpec] = {pid: g for g in KNOWN_GPUS for pid in g.pci_device_ids}
+
+
+def by_name(name: str) -> GpuSpec | None:
+    """The :class:`GpuSpec` for a PCIe product name (or a recorded alias), or ``None``."""
+    return _BY_NAME.get(name)
+
+
+def by_pci_device_id(device_id: str) -> GpuSpec | None:
+    """The :class:`GpuSpec` for a PCI device id (hex, lowercase, no ``0x``), or ``None``."""
+    return _BY_PCI.get(device_id.lower().removeprefix("0x"))
+
+
+def pci_device_id_to_name() -> dict[str, str]:
+    """``{pci_device_id: canonical_name}`` over the registry — the back-compat map
+    :mod:`deplodock.detect` exposes as ``GPU_PCI_DEVICE_IDS``."""
+    return {pid: g.name for g in KNOWN_GPUS for pid in g.pci_device_ids}
+
+
+def short_names() -> dict[str, str]:
+    """``{canonical_name: short_name}`` over the registry (back-compat for
+    :data:`deplodock.hardware.GPU_SHORT_NAMES`)."""
+    return {g.name: g.short_name for g in KNOWN_GPUS if g.short_name}
+
+
+def probe_live_features(fallback_name: str | None = None) -> dict[str, float]:
+    """Physical device features (``sm_count`` / ``smem_per_sm`` / ``smem_per_block``
+    / ``regs_per_block`` / ``warp_size``) of the live CUDA device via cupy. When no
+    device is visible (or cupy is missing), fall back to the **memorized** specs of
+    ``fallback_name`` (a PCIe name) — or :data:`DEFAULT_GPU` — so GPU-less hosts
+    still get per-SKU features. Empty only when even the fallback spec is unknown."""
+    try:
+        import cupy as cp  # noqa: PLC0415
+
+        props = cp.cuda.runtime.getDeviceProperties(cp.cuda.Device().id)
+        return {
+            "sm_count": float(props["multiProcessorCount"]),
+            "smem_per_sm": float(props["sharedMemPerMultiprocessor"]),
+            "smem_per_block": float(props["sharedMemPerBlock"]),
+            "regs_per_block": float(props["regsPerBlock"]),
+            "warp_size": float(props["warpSize"]),
+        }
+    except Exception:  # noqa: BLE001 — no live device ⇒ memorized fallback
+        spec = (by_name(fallback_name) if fallback_name else None) or DEFAULT_GPU
+        return spec.device_features()

--- a/deplodock/hardware.py
+++ b/deplodock/hardware.py
@@ -1,4 +1,11 @@
-"""Hardware lookup tables: GPU brand -> provider instance types."""
+"""Hardware lookup tables: GPU brand -> provider instance types.
+
+Physical GPU facts (PCI ids, compute capability, SM count, VRAM) live in the
+common :mod:`deplodock.gpu` registry; this module owns only the cloud-provisioning
+tables (instance types, zones, provisioning models) keyed by the same GPU name.
+"""
+
+from deplodock import gpu
 
 # GPU brand -> list of (provider, base_instance_type) in preference order.
 #
@@ -60,22 +67,9 @@ GPU_INSTANCE_TYPES = {
 }
 
 
-# Full GPU name -> short name for result filenames.
-GPU_SHORT_NAMES = {
-    "NVIDIA GeForce RTX 4090": "rtx4090",
-    "NVIDIA GeForce RTX 5090": "rtx5090",
-    "NVIDIA RTX PRO 6000 Blackwell Workstation Edition": "pro6000",
-    "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition": "pro6000",
-    "NVIDIA RTX PRO 6000 Blackwell Server Edition": "pro6000",
-    "NVIDIA L40S": "l40s",
-    "NVIDIA H100 80GB": "h100",
-    "NVIDIA H200 141GB": "h200",
-    "NVIDIA B200": "b200",
-    "NVIDIA A100 40GB": "a100",
-    "NVIDIA A100 80GB": "a100",
-    "AMD Instinct MI350X": "mi350x",
-    "NVIDIA Tesla V100 SXM3 32GB": "v100",
-}
+# Full GPU name -> short name for result filenames. Derived from the common GPU
+# registry (:mod:`deplodock.gpu`), the single source of truth for GPU identity.
+GPU_SHORT_NAMES = gpu.short_names()
 
 
 # GCP zones per GPU, tried in order. Falls back to config default.

--- a/plans/golden-sweep-rtx4090-findings.md
+++ b/plans/golden-sweep-rtx4090-findings.md
@@ -1,0 +1,149 @@
+# Golden seed findings — RTX 4090 (sm_89), 2026-06-13 (first-ever 4090 golden file)
+
+- New file: `deplodock/compiler/pipeline/search/goldens/rtx4090_sm89.yaml` (29 matmul shapes), seeded on
+  `riftuser@176.124.69.200` (RTX 4090, sm_89, driver 580.65.06, CUDA 12.9, torch 2.12.0+cu130).
+- Sweep: `deplodock tune --dataset golden --clean -q` (~30 min) → seed-mode harvest (`run --bench -c snippet`, greedy
+  pick) → **diagnosis** → transfer-mode harvest (the recorded 5090 configs benched on the 4090) → per-shape merge of
+  the better of {greedy, transferred}. Prior + DB pulled to `/tmp/golden_artifacts/4090/` for offline analysis.
+- Branch: `feature/golden-multi-gpu`.
+- Headline result: a fresh single-pass tune on sm_89 produces **15/29 degenerate picks** (>1.5× eager, up to 5×). The
+  recorded file is **not** that seed — it is the per-shape best of the 4090's own greedy pick and the **transferred
+  5090 config benched on the 4090**, which recovers 16 shapes (e.g. o_proj.s128 84→23 µs, down_proj.s128 125→33 µs,
+  square.4096 11092→4005 µs). The fp16 squares remain 3–5× and are recorded as scalar fallback (see Finding 1).
+
+## Source of each recorded config (16 transferred 5090 cfg / 13 the 4090's own greedy)
+
+| shape                            | src      | deplo µs | eager µs | d/e  | greedy µs | note                                   |
+|----------------------------------|----------|---------:|---------:|-----:|----------:|----------------------------------------|
+| square.512                       | greedy   |     13.5 |     10.8 | 1.25 |      13.5 |                                        |
+| square.1024                      | greedy   |     71.0 |     45.4 | 1.56 |      71.0 | transfer cfg failed to lower (F3)      |
+| square.2048                      | greedy   |    467.5 |    320.0 | 1.46 |     467.5 | greedy beat transfer (652)             |
+| square.4096                      | transfer |   4004.9 |   2458.6 | 1.63 |   11092.0 | greedy was STAGE:'10' degenerate (F2)  |
+| square.512.fp16                  | greedy   |     17.7 |      5.8 | 3.02 |      17.7 | scalar fallback — no fp16 TC (F1)      |
+| square.1024.fp16                 | greedy   |     90.7 |     18.1 | 5.01 |      90.7 | scalar fallback (F1)                   |
+| square.2048.fp16                 | greedy   |    512.5 |    115.2 | 4.45 |     512.5 | scalar fallback (F1)                   |
+| square.4096.fp16                 | greedy   |   3778.6 |    822.3 | 4.60 |    3778.6 | scalar fallback (F1)                   |
+| qwen3_06b.q_proj.s32             | greedy   |      7.9 |      9.9 | 0.80 |       7.9 |                                        |
+| qwen3_06b.kv_proj.s32            | greedy   |      6.5 |      6.9 | 0.94 |       6.5 |                                        |
+| qwen3_06b.o_proj.s32             | transfer |     11.2 |      9.9 | 1.13 |      12.8 |                                        |
+| qwen3_06b.gate_up_proj.s32       | transfer |     12.1 |     11.3 | 1.07 |      34.3 | greedy 2.98× → transfer 1.07×          |
+| qwen3_06b.down_proj.s32          | transfer |     15.6 |     13.0 | 1.20 |      33.5 | greedy 2.55×                           |
+| qwen3_06b.q_proj.s128            | transfer |     23.6 |     20.2 | 1.17 |      28.7 |                                        |
+| qwen3_06b.kv_proj.s128           | transfer |     12.9 |     12.4 | 1.04 |      16.3 |                                        |
+| qwen3_06b.o_proj.s128            | transfer |     23.0 |     19.0 | 1.21 |      84.3 | greedy 4.35× → transfer 1.21×          |
+| qwen3_06b.gate_up_proj.s128      | transfer |     45.7 |     25.5 | 1.79 |      53.8 | both poor (sm_89, see F4)              |
+| qwen3_06b.down_proj.s128         | transfer |     33.1 |     24.5 | 1.35 |     124.5 | greedy 4.89× → transfer 1.35×          |
+| qwen3_06b.q_proj.s512            | greedy   |     90.4 |     53.3 | 1.70 |      90.4 | transfer cfg failed to lower (F3)      |
+| qwen3_06b.kv_proj.s512           | greedy   |     44.9 |     38.9 | 1.16 |      44.9 |                                        |
+| qwen3_06b.o_proj.s512            | transfer |     85.9 |     67.8 | 1.27 |     321.9 | greedy 4.60× → transfer 1.27×          |
+| qwen3_06b.gate_up_proj.s512      | transfer |    123.6 |     85.5 | 1.45 |      FAIL | greedy LoweringError (F3)              |
+| qwen3_06b.down_proj.s512         | transfer |    143.1 |    113.2 | 1.26 |     447.5 | greedy 3.77×                           |
+| square.512.dynM                  | greedy   |     12.8 |     10.8 | 1.19 |      12.8 |                                        |
+| qwen3_06b.q_proj.s512.dynM       | transfer |     63.8 |     53.0 | 1.20 |      70.3 |                                        |
+| qwen3_06b.kv_proj.s512.dynM      | transfer |     33.4 |     37.0 | 0.90 |      40.5 |                                        |
+| qwen3_06b.o_proj.s512.dynM       | greedy   |     62.0 |     67.1 | 0.92 |      62.0 |                                        |
+| qwen3_06b.gate_up_proj.s512.dynM | transfer |     91.1 |     85.6 | 1.06 |     111.3 |                                        |
+| qwen3_06b.down_proj.s512.dynM    | transfer |     92.3 |    119.4 | 0.77 |      95.9 |                                        |
+
+## Finding 1 — fp16 tensor cores on sm_89 are blocked by an NVRTC sm_89 miscompile of the plain-ldmatrix smem index (P0)
+
+Every fp16 square deploys a **scalar thread-tier** kernel (knobs `BM/BN/FM/FN…`, no `WM/WN/MMA`) and runs 3–5× slower
+than cuBLAS HGEMM. The warp/MMA tier is gated to sm_90+ at `passes/lowering/tile/010_partition_loops.py:702`
+(`ctx.compute_capability < (9, 0)` ⇒ `eligible = ()`, "pin-only" on sm_80-89). But the gate is not the real blocker —
+**pinning the atom (`DEPLODOCK_MMA=mma_m16n8k16_f16`) produces a kernel that faults on the 4090.**
+
+Root-caused with `compute-sanitizer`:
+
+```
+Invalid __shared__ read of size 16 bytes at k_matmul_207791+0x16d0
+  by thread (96,0,0)  — Access at smem offset 0x2060 (8288 B) is out of bounds
+```
+
+`x0_smem` is 8192 B, so byte 8288 is element **~4144** of a 4096-element array. The *source* address for that thread
+(warp 3, lane 0) computes **~2576** — well in bounds. The OOB read faults on Ada, wedging the context → the launch
+never completes (looks like a hang; confirmed not a deadlock — `synccheck` is clean — and not transport-specific —
+it faults identically with cp.async and plain sync staging, `ASYNC_COPY=0`).
+
+It is specifically an **NVRTC sm_89 codegen miscompile of the plain (non-swizzled) ldmatrix index expression**, not a
+logic bug:
+- The *same* sm_89-lowered kernel (same content hash, `k_matmul_207791`) runs **clean under `compute-sanitizer
+  memcheck` on the sm_120 dev box** (`run --target sm_89` — `--target` changes lowering, but NVRTC still compiles for
+  the live sm_120 arch, which compiles the index correctly). Only the **native sm_89 cubin** reads OOB.
+- The sm_120 fp16 path is an entirely **different kernel** — TMA + mbarrier + warp-specialization + a *swizzled* smem
+  layout (`addr ^ (((addr>>6)&3)<<3)`) — so the 5090 / PRO 6000 fp16 goldens never touch the plain-ldmatrix path and
+  are correct.
+
+**Tried and ruled out:** hoisting the ldmatrix smem index into an explicit `const int` local before the `&smem[...]`
+(forcing single-integer materialization — a common NVRTC-fold workaround) in `LdmatrixLoad.render`. Validated the
+sm_120 path stayed correct, deployed to the 4090 with the cubin/kernel caches cleared — **still OOB**. So the
+miscompile survives a simple reassociation; reverted (no-op that touched the hot sm_120 codegen for no gain).
+
+**Recommendation (real fix, needs the 4090):** `cuobjdump -sass` / `nvdisasm` the faulting `k_matmul_207791` cubin on
+the 4090, map `+0x16d0` to the address computation, and find what NVRTC sm_89 folds wrong (candidate triggers: the
+`%`/`/`/`*` mix in the per-lane index, or a CUDA 12.9 nvcc / cupy-cuda12x vs torch-cu130 toolchain-version skew — the
+scalar kernels compile fine, so it's specific to the warp-tier index). The workaround likely lands once the exact
+trigger is known (e.g. split the index differently, or pin an NVRTC arch/flag). Once the OOB is gone, drop the sm_90+
+gate at `010_partition_loops.py:702` for sm_80-89 (the cp.async/sync mma.sync staging the path already emits is valid
+Ampere/Ada PTX) and re-tune the fp16 goldens — cuBLAS HGEMM is 4–5× the current scalar fallback, so this is the single
+biggest sm_80-89 win available. Until then the fp16 squares are recorded as scalar fallback (ratio ≪ 0.95,
+`golden=False`) — the honest deployable number, flagged as a known limitation. The gate stays in place so the
+autotuner never deploys the faulting kernel.
+
+## Finding 2 — fresh sm_89 tune produces degenerate picks; the prior mis-searches, and higher patience does not help (P0)
+
+The clean seed deployed `square.4096` at **11.1 ms** (4.45× eager) with `STAGE:'10'` (a non-pipelined single-stage
+config) and the s128/s512 projections at 2–5× with `FM:1 FN:1` 1×1-cell thread tiles — pathological arithmetic
+intensity. This is the cold **5090-fit `AnalyticPrior`** (`_W_A` weights, code-resident, fit on sm_120 golden data)
+mis-pricing sm_89 during early exploration, then the learned half reinforcing the bad region. Crucially, **patience
+does not fix it**: re-tuning `down_proj.s128` at `--patience 120` still landed `FM:1 FN:1` at 125.6 µs (4.93×, vs the
+124.5 µs seed) — the search keeps converging to the same degenerate region, so it is a *prior/ranking* failure on
+sm_89, not a too-short search.
+
+The fix is **transfer**: the recorded 5090 scalar configs are hardware-portable and run 3–5× faster on the 4090 than
+its own greedy picks (down_proj.s128 125→33 µs, o_proj.s128 84→23 µs, square.4096 11092→4005 µs). The recorded file
+uses them wherever they win.
+
+**Recommendation:** (a) the cold `AnalyticPrior` needs sm_80-89 representation — refit `_W_A`
+(`scripts/golden_knob_heuristics.py`) jointly over a 4090 golden set (this file is the first one), or add a
+capability-tier feature so the analytic geometry terms don't extrapolate sm_120 occupancy/CTA assumptions onto Ada.
+(b) The same golden-seeding recommendation as the 5090 Finding 2 applies doubly here: seeding the inner search with
+the (transferred) golden knobs would let `evidence_pick` deploy them directly instead of the degenerate greedy.
+
+## Finding 3 — three shapes hit a hard `LoweringError` with no fallback on sm_89
+
+`gate_up_proj.s512` failed to compile at all under its greedy pick: `LoweringError: 1 node(s) left un-lowered — the
+chosen tile shape produced a kernel that failed validate(ctx) and the deterministic compile had no fallback`
+(`k:100_materialize_tile` rejected its only lowering). The transferred 5090 config for `square.1024` and
+`q_proj.s512` likewise failed to lower on the 4090 (so those two fell back to the 4090 greedy). So on sm_89 the
+deterministic compile can paint itself into a corner: a tile shape passes enumeration but fails `validate(ctx)` at
+render with no alternative, crashing the whole compile.
+
+**Recommendation:** the deterministic-compile path should fall back to the next-ranked tile when the chosen one fails
+`validate(ctx)` rather than raising — a single un-lowerable pick shouldn't make a shape uncompilable. Cite
+`passes/lowering/tile/010_partition_loops.py` (the eligibility/validate gate) and the `LoweringError` raise in
+`pipeline/pipeline.py`. This is the same class the memory note "clean tune is the real test gate" warns about
+(search surfaces unlowerable variant classes that unit tests miss).
+
+## Finding 4 — even transferred, gate_up_proj.s128 and the big fp32 squares stay 1.45–1.79× on sm_89
+
+`gate_up_proj.s128` (1.79×), `square.4096` (1.63×), `square.1024` (1.56×), `square.2048` (1.46×) are the best
+available on the 4090 but still well off cuBLAS. The 4090 has ~⅓ the fp32 throughput and far less L2 than the 5090, so
+the 5090's large-`FM` tiles (e.g. square.4096 `FM:10`) don't map as well; these want their own sm_89 tuning once
+Finding 2's prior issue is addressed. Recorded as-is (honest deployable numbers); not golden-quality.
+
+## Workflow notes
+
+- **A fresh GPU cannot be seeded by `tune` alone today** — the cold prior mis-searches off-sm_120 hardware (Finding 2).
+  The transfer approach (bench the existing 5090 goldens on the new card, keep the winners) was essential and should be
+  a first-class CLI mode: `tune --dataset golden --transfer-from rtx5090_sm120` or a `--seed-from-golden` flag that
+  benches recorded configs on the live GPU and records the per-shape best. It is exactly what produced a usable file
+  here, and it generalizes the golden-seeding recommendation.
+- **The 4090's intermittent sshd** (rate-limited `255` on rapid reconnects) made remote orchestration flaky; pulling
+  the 949 MB DB and re-launching detached jobs needed retry loops. Not a deplodock issue, noted for whoever scripts
+  multi-host sweeps — reuse one `ControlMaster` connection.
+- **Multi-GPU goldens conflate in `eval`** — the 4090 (cap `8,9`) is at least distinct from the 5090/PRO 6000 (cap
+  `12,0`), but `eval`/`tune` still iterate all cards' configs with no live-GPU filter and the names collide
+  (`square.512` exists thrice). Filtering the golden consumers to the live `(gpu_name, compute_cap)` is the carried
+  recommendation (see the 5090 report and `search/golden.py` docstrings).
+- **`tune --dataset golden --clean` retrains the global prior**, so the 4090's `prior.json` / `autotune.db` pulled for
+  analysis are the fresh sm_89-tuned artifacts (degenerate-region-trained — see Finding 2), not a curated prior.

--- a/plans/golden-sweep-rtx5090-findings.md
+++ b/plans/golden-sweep-rtx5090-findings.md
@@ -1,221 +1,114 @@
-# Golden sweep findings — RTX 5090 (sm_120), 2026-06-12 evening (third sweep; first after the evidence-pick prior fix)
+# Golden sweep findings — RTX 5090 (sm_120), 2026-06-13 (fourth sweep; first multi-GPU run)
 
-- Sweep: `deplodock tune --dataset golden --clean` — 29 matmul targets (23 static + 6 dynamic `.dynM`), 52 min wall
-  (15:40–16:32). 24 bench_fail rows total, all in fp32 `MMA=0, FK-split` classes on the big squares (slow compile /
-  slow run) — the fp16 `TMA+WARPSPEC` launch-crash class from the previous two sweeps is **gone** (its goldens bench
-  fine live now).
-- A/B: `deplodock run --bench --golden NAME` per shape — and this time the full 29-shape pass took **~3.5 min**, not
-  ~45: every kernel hit the cubin cache the tune had just filled (~7 s per cold process launch). Two full passes plus
-  a 5-shape tie-breaker pass; greedy/golden ratios were stable to ≤2% across passes, and absolute µs barely drifted
-  (back-to-back runs, no thermal swing).
-- Branch under test: `main` @ `ad08f813` (the dynM end-to-end PR, which includes the `FallbackPrior.evidence_pick`
-  measured-evidence fix the previous sweep's findings 2/4/5/6 asked for). Edits on `feature/golden-sweep-rtx5090-3`.
-- Tally: **8 replaced / 5 added / 5 exact reproductions / 11 worse** (the 5 reduce/pointwise goldens remain
-  unsweepable, as in both previous sweeps).
-- The analytic weights were refit after the YAML edits (`scripts/golden_knob_heuristics.py` → `_W_A` + `_W_A_DYN`
-  pasted into `search/prior/analytic.py`): the pre-refit `_W_A_DYN` ranked the *new* dynM goldens at median 355 (it
-  was fit to the seeds this sweep replaced); post-refit five of eight dynM rows rank ≤1, dynM median ~6, static
-  median 12.
-- **Finding 1 fixed in this branch** (`FallbackPrior.score` analytic-tilt blend — see the rewritten finding below): the
-  two fp16-square shapes the sweep deployed at 2.0–2.25× golden now deploy `BK=2` at golden parity (square.2048.fp16
-  235→105 µs, square.4096.fp16 1490→761 µs). The per-shape table below still shows the pre-fix sweep numbers.
+- Sweep: `deplodock tune --dataset golden --clean -q` — 29 matmul targets (23 static + 6 dynamic `.dynM`), ~28 min wall.
+- A/B: a scripted `deplodock run --bench --golden NAME` pass per shape (`/tmp/harvest_goldens.py --mode ab`) — greedy
+  pick benched live beside each recorded golden, all at -O3. Greedy knobs read programmatically from the compiled
+  graph (`tuning_knob_items` over the matmul `CudaOp`), latencies from `60_bench_compare.json` (Deplodock) + the live
+  golden table rows. The one win was re-benched 3× and is stable to the digit.
+- Branch under test: `main` (the analytic-tilt `FallbackPrior.score` fp16-`BK=2` fix from the third sweep is present).
+  Edits on `feature/golden-multi-gpu`.
+- Tally: **1 replaced / 0 added / 6 exact reproductions / 22 left** (of the 22 left: 17 genuinely worse, 3 fp16 squares
+  at parity-with-drift, 2 s128 RING-only adjacent configs).
 
-## Headline: the evidence-pick fix worked
+## Headline: a clean re-tune regresses 17/29 shapes vs the recorded goldens — Finding 2 from the third sweep, unchanged
 
-The previous sweep's core finding — "the deploy argmin prefers unmeasured extrapolations over configs with winning
--O3 reservoir rows" (its findings 2, 4, 5, 6) — does not reproduce. Everywhere the search measured the good region,
-the deploy pick *is* the measured -O3 best: down_proj.s512 and square.512.dynM deploy measured rank-1 configs with
--O3 rows; every dynM kernel's pick is exactly the config with the minimum -O3 reservoir latency (e.g.
-`k_matmul_701d6c` deploys -O1 rank 3 because it holds the best -O3 row, 56.2 µs, over the -O1 rank-1's 59.1). The
-previous sweep's finding-5 (down_proj.s32 FM1-over-FM2) and finding-3 (square.512 drift) are both exact
-reproductions now. The dynM shapes — five of six of which the previous sweep could only record at parity or worse —
-all came back better or equal, including a −29% on square.512.dynM.
+The recorded 5090 goldens were built up across three accumulating sweeps. `tune --dataset golden --clean` wipes the
+DB + prior and re-searches each shape from a cold (5090-fit analytic) start under default patience; the fresh search
+takes different trajectories and does not re-find most of the recorded configs. `evidence_pick` then faithfully
+deploys the best *measured* config, which sits 6–44% above goldens whose region the clean search never sampled. This
+is exactly the third sweep's Finding 2 ("clean-DB search variance unsamples the goldens"), and its recommendation
+(seed the inner search with the recorded golden knobs) is **still the top action item** — it has not been implemented.
 
-What's left over is a different failure mode: when the clean-DB search never measures the golden's region at all,
-evidence-pick (correctly) deploys its measured best, which can sit 5–20% above a golden the model itself ranks
-shallow. See findings 2–3.
+So the correct outcome for this sweep is *leave the goldens*: every "worse" shape is the search regressing against a
+config that is already recorded and known-good, not a real latency regression. The recorded 5090 set stands.
 
-## Per-shape outcome (live -O3 A/B; pass-1 µs, pass-2 ratio in parens where it mattered)
+## Per-shape outcome (live -O3 A/B; greedy µs vs best recorded-golden µs re-benched the same run)
 
-| shape                            | greedy µs | best golden µs |     greedy/golden | category                                                |
-|----------------------------------|----------:|---------------:|------------------:|---------------------------------------------------------|
-| square.512                       |      10.6 |           10.5 |       1.01 (0.98) | same knobs — exact reproduction                         |
-| square.1024                      |      53.4 |           49.2 |       1.09 (1.10) | worse (finding 3)                                       |
-| square.2048                      |     305.7 |          294.3 |       1.04 (1.03) | worse-marginal (≤4%, left)                              |
-| square.4096                      |    2525.8 |         2282.4 |       1.11 (1.10) | worse (finding 3)                                       |
-| square.512.fp16                  |       4.4 |            3.9 |              1.13 | worse (finding 1)                                       |
-| square.1024.fp16                 |      17.3 |           17.1 |              1.01 | **added** (parity, WM4 BK8 vs WM1 BK2)                  |
-| square.2048.fp16                 |     235.4 |          104.8 |       2.25 (2.24) | worse (finding 1)                                       |
-| square.4096.fp16                 |    1490.1 |          741.6 |       2.01 (2.01) | worse (finding 1)                                       |
-| qwen3_06b.q_proj.s32             |       7.5 |            8.3 |       0.90 (0.89) | **replaced** (3 entries → 1, FM4 FN2)                   |
-| qwen3_06b.kv_proj.s32            |       5.7 |            5.7 |              1.00 | same knobs — exact reproduction                         |
-| qwen3_06b.o_proj.s32             |       9.2 |            9.2 |              1.00 | same knobs — exact reproduction                         |
-| qwen3_06b.gate_up_proj.s32       |      10.9 |           11.0 |              0.99 | **added** (parity, RING 3 vs 4)                         |
-| qwen3_06b.down_proj.s32          |      14.0 |           13.9 |              1.01 | same knobs (prev sweep's finding 5: fixed)              |
-| qwen3_06b.q_proj.s128            |      19.4 |           18.5 |       1.05 (1.04) | worse-marginal (4–5%, left)                             |
-| qwen3_06b.kv_proj.s128           |      11.4 |           11.3 |              1.01 | **added** (parity, BN16 SPLITK1 RING2)                  |
-| qwen3_06b.o_proj.s128            |      19.9 |           19.9 |              1.00 | same knobs — exact reproduction                         |
-| qwen3_06b.gate_up_proj.s128      |      23.8 |           28.1 |              0.85 | **replaced** (WARPSPEC pin dropped, finding 4)          |
-| qwen3_06b.down_proj.s128         |      28.2 |           28.2 |              1.00 | **added** (parity, BM8 RING2)                           |
-| qwen3_06b.q_proj.s512            |      54.3 |           49.1 |       1.11 (1.10) | worse (finding 2) — prev sweep's win not re-found       |
-| qwen3_06b.kv_proj.s512           |      29.8 |           27.1 |       1.10 (1.09) | worse (finding 2, repeat)                               |
-| qwen3_06b.o_proj.s512            |      49.5 |           49.8 | 0.99 (1.06, 1.06) | worse-marginal (left; bimodal greedy bench)             |
-| qwen3_06b.gate_up_proj.s512      |      68.4 |           56.0 |       1.22 (1.19) | worse (finding 2) — prev sweep's −37% win not re-found  |
-| qwen3_06b.down_proj.s512         |      75.7 |           81.8 |              0.93 | **replaced** (3 entries → 1, FM14 BK64 OVERHANG)        |
-| square.512.dynM                  |      12.8 |           18.0 |              0.71 | **replaced** (BN16 FM4 FN2 RING4; sweep's big win)      |
-| qwen3_06b.q_proj.s512.dynM       |      54.4 |           56.0 | 0.97 (0.99, 0.98) | **added** (parity, BM8 FM14 SPLITK2)                    |
-| qwen3_06b.kv_proj.s512.dynM      |      30.7 |           35.0 |              0.88 | **replaced** (2 entries → 1, BM8 FM8)                   |
-| qwen3_06b.o_proj.s512.dynM       |      52.7 |           62.0 |       0.85 (0.86) | **replaced** (2 entries → 1, BM16 FM8 BK64)             |
-| qwen3_06b.gate_up_proj.s512.dynM |      72.8 |           77.0 | 0.95 (0.95, 0.94) | **replaced** (2 entries → 1, BM8 FM8 SPLITK2)           |
-| qwen3_06b.down_proj.s512.dynM    |      74.8 |           81.9 |       0.91 (0.92) | **replaced** (BM16 FM8 BK64; prev finding 6 fixed)      |
+| shape                            | greedy µs | best golden µs |   ratio | category                                  |
+|----------------------------------|----------:|---------------:|--------:|-------------------------------------------|
+| square.512                       |       9.0 |            9.1 |    0.99 | exact reproduction                        |
+| square.1024                      |      49.0 |           43.6 |    1.12 | worse (clean-tune variance)               |
+| square.2048                      |     346.7 |          265.9 |    1.30 | worse                                     |
+| square.4096                      |    2594.8 |         2202.7 |    1.18 | worse                                     |
+| square.512.fp16                  |       4.0 |            3.5 |    1.16 | worse                                     |
+| square.1024.fp16                 |      14.8 |           14.9 |    0.99 | parity (drift; left — see Finding 3)      |
+| square.2048.fp16                 |      90.8 |           91.5 |    0.99 | parity (drift; left)                      |
+| square.4096.fp16                 |     636.2 |          649.9 |    0.98 | parity (drift; left)                      |
+| qwen3_06b.q_proj.s32             |       7.2 |            6.4 |    1.12 | worse                                     |
+| qwen3_06b.kv_proj.s32            |       4.9 |            4.9 |    1.00 | exact reproduction                        |
+| qwen3_06b.o_proj.s32             |      11.2 |            8.0 |    1.40 | worse                                     |
+| qwen3_06b.gate_up_proj.s32       |      10.2 |            9.5 |    1.08 | worse                                     |
+| qwen3_06b.down_proj.s32          |      17.6 |           12.2 |    1.44 | worse                                     |
+| qwen3_06b.q_proj.s128            |      16.2 |           16.3 |    0.99 | parity (RING-adjacent; left)              |
+| qwen3_06b.kv_proj.s128           |       9.7 |            9.8 |    0.99 | parity (RING/SPLITK-adjacent; left)       |
+| qwen3_06b.o_proj.s128            |      18.3 |           17.4 |    1.05 | worse-marginal                            |
+| qwen3_06b.gate_up_proj.s128      |      21.0 |           21.0 |    1.00 | exact reproduction                        |
+| qwen3_06b.down_proj.s128         |      24.5 |           24.2 |    1.01 | exact reproduction                        |
+| qwen3_06b.q_proj.s512            |      46.6 |           44.0 |    1.06 | worse                                     |
+| qwen3_06b.kv_proj.s512           |      29.3 |           24.8 |    1.18 | worse                                     |
+| qwen3_06b.o_proj.s512            |      56.5 |           46.2 |    1.22 | worse                                     |
+| qwen3_06b.gate_up_proj.s512      |      64.1 |           52.8 |    1.21 | worse                                     |
+| qwen3_06b.down_proj.s512         |      84.6 |           69.3 |    1.22 | worse                                     |
+| square.512.dynM                  |      11.0 |           13.6 |    0.81 | **replaced** (BN16 BM16 SPLITK1 RING3)    |
+| qwen3_06b.q_proj.s512.dynM       |      71.5 |           49.6 |    1.44 | worse                                     |
+| qwen3_06b.kv_proj.s512.dynM      |      30.6 |           26.8 |    1.14 | worse                                     |
+| qwen3_06b.o_proj.s512.dynM       |      47.5 |           47.7 |    1.00 | exact reproduction                        |
+| qwen3_06b.gate_up_proj.s512.dynM |      74.0 |           67.0 |    1.10 | worse                                     |
+| qwen3_06b.down_proj.s512.dynM    |      68.1 |           67.6 |    1.01 | exact reproduction                        |
 
-All replaces verified post-edit: `run --bench --golden` on the edited shapes re-benches the new entries at parity
-with the greedy pick (gate_up_proj.s128's unpinned entry re-derives the warp-specialized form at 24.0 µs ≈ the
-23.8 µs pick).
+## Finding 1 — square.512.dynM: a genuinely faster masked-tile config (replaced, −14%)
 
-The dynM family converged onto one knob family this sweep — `FM8 FN4 SPLITK2 RING2` with per-shape BM/BN/BK — and
-it beats the seed-era `BM16 FM4 FN4` family by 5–15% everywhere; square.512.dynM (a `BN16 FM4 FN2 RING4` masked tile)
-closed from 1.29× over its static twin to ~1.21× of the static 10.6 µs.
+The only real improvement. The clean search found `{BN:16, BM:16, FM:4, FN:2, FK:1, BK:64, SPLITK:1, BR:1,
+OVERHANG:['a0'], STAGE:'11', RING:3}` at **11.0 µs**, beating the recorded `SPLITK:2 RING:4` config (12.8 µs) by 14%.
+The win reproduces to the digit across three back-to-back A/B runs (greedy 11.0 / live-golden 13.6 / ratio 0.81 every
+time), well above the dynM noise band. The difference is `SPLITK:1, RING:3` vs `SPLITK:2, RING:4` — a single-split,
+3-stage ring beats the 2-split 4-stage one for this masked-tile shape. Recorded as the sole `square.512.dynM` entry
+(old one deleted: it is now strictly slower).
 
-## Finding 1 — fp16 large squares: the learned prior buries the small-`BK` warp region; patience-bounded search never benches it (P0 — FIXED)
+## Finding 2 — the clean sweep un-finds recorded wins; seed the inner search with the golden knobs (P0, unchanged from third sweep)
 
-square.2048.fp16 deployed at **2.25×** the golden and square.4096.fp16 at **2.01×**. The sweep-time hypothesis ("the
-warp-tier enumeration floors `BK` by shape size, so `BK=2` is never offered at 2048/4096") was **wrong** — disproven by
-directly enumerating the warp variants (`_enumerate_warp_matmul_impl`, `lowering/tile/_enumeration.py`):
+17 shapes deploy 6–44% above goldens the search did not re-measure this run. The mechanism is unchanged from the third
+sweep's Finding 2: `--clean` discards the accumulated reservoir that held those configs, and a single patience-bounded
+re-search lands elsewhere; `evidence_pick` deploys its measured best, which is worse than the un-sampled golden. The
+worst cases (down_proj.s32 1.44×, q_proj.s512.dynM 1.44×, o_proj.s32 1.40×, square.2048 1.30×) are all "golden absent
+from the measured set," not a prior that ranks them deep.
 
-- The candidate set is `(64,32,16,8,4,2,1)` gated only by `k_cells_total % bk == 0`, and `k_cells_total = E_K/16` is
-  32/64/128/256 at 512/1024/2048/4096 — **all divisible by 2**. A direct probe confirms `BK=2` (and the exact golden
-  row `WM1 WN4 FM4 FN2 BK2`) is enumerated at every size: **316 / 373 / 404 / 417** `BK=2` rows for 512/1024/2048/4096.
-  The BK histogram in the original finding was what the **search benched**, not what was enumerated.
+**Recommendation (highest priority, carried over and now three sweeps old):** force-bench each recorded golden config
+as the first variant(s) of its op's inner search in `tune --dataset golden` / `tune --golden NAME`. The tuner knows the
+shape and the golden knobs; one bench per golden entry (~30 s across the sweep) guarantees `evidence_pick` can never
+deploy worse than the recorded golden after a clean tune, and turns "worse" into a signal that means *only* real
+regressions. This would also have prevented the 17 regressions above outright. Until it lands, **run routine sweeps
+without `--clean`** (accumulate) and reserve `--clean` for prior-hygiene checks — the third sweep's closing note,
+re-confirmed.
 
-The real gate is the **search/prior**, and the chain is:
+## Finding 3 — fp16 squares reproduce at parity; the stored deplodock_us are stale-by-drift, not improvable
 
-1. The learned `CatBoostPrior` regresses `log(µs)` on `knob_features`. It measured `BK=2` warp tiles only at small fp16
-   squares (512), so at 2048/4096 it **extrapolates** the fp32-thread-tier pattern (large shape → large `BK`) and
-   predicts `BK=2` is slow there — `eval prior` ranks the golden 335–592 deep. The cold `AnalyticPrior` prices it
-   correctly (`D_w_near_bk`, rank 0/2632), but `FallbackPrior` used the learned half once fitted.
-2. PUCT selection weights an unvisited child by `1/score`, so the buried `BK=2` region gets a tiny weight and patience
-   (50) expires before reaching it — a **self-reinforcing blind spot** (never benched → never measured → never learned
-   fast). Reproduced in isolation with a 6-shape "polluter" prior (sweep targets 1–6): tuning 2048.fp16 benched `BK=2`
-   **0 times**.
-3. `evidence_pick` then faithfully deploys the best **measured** `-O3` config — `BK=64` @ 235 µs — because the reservoir
-   has no `BK=2` row to deploy. Not an enumeration gate, not an evidence-pick bug: the search simply never produced the
-   evidence.
-
-**Fix (this branch): an analytic-tilt blend in `FallbackPrior.score` — the MCTS *selection* signal only.** The two
-priors are on different scales (CatBoost = calibrated µs; analytic = an ordinal learning-to-rank proxy, neutral value
-1.0), so a naive `min`/blend collapses to "always analytic" (the reverted 2× regression). Instead `score` keeps the
-learned µs as the per-shape scale and folds the analytic in as a dimensionless multiplier centered at its neutral 1.0:
-
-```
-score = learned_µs · analytic(knobs) ** W            # W = config.analytic_tilt(), default 0.3
-```
-
-A config the heuristic favors (`analytic < 1`) gets its predicted µs pulled down → larger PUCT exploration weight → it
-is explored; a no-opinion config (`analytic = 1`) is untouched. So the heuristic *perturbs* the learned order without
-replacing it, and the learned half still owns the scale. `mean_score` / `mean_scores` / `pick` (deploy, eval,
-diagnostics) stay **pure-learned + evidence** — only exploration changed. No MCTS machinery: the blend lives entirely
-in the prior, behind the regular `score` interface PUCT already calls.
-
-**Validation** (polluter prior, fresh DB, isolated; `W` swept via `DEPLODOCK_ANALYTIC_TILT`):
-
-| `W` | `BK=2` benched | tuned best µs |
-|----:|---------------:|--------------:|
-| 0 (baseline) | **0** | 99.0 (`BK=4`) |
-| 0.2 | 40 | 92.5 |
-| 0.3 (default) | 41 | 92.3 |
-| 0.5 | 45 | 92.4 |
-
-End-to-end, re-tuning the two shapes on the real cache with the fix and re-deploying: square.2048.fp16 **235 → 105 µs**
-(`BK=2`, golden parity) and square.4096.fp16 **1490 → 761 µs** (`BK=2`, golden parity). No regression where the learned
-prior is already right: square.1024 fp32 46.5 → 44.9 µs (improved), q_proj.s512 40.3 → 40.7 µs (within bench noise). The
-existing fp16 goldens already record the `BK=2` region, so no YAML change is needed — the fix makes them *reachable*.
-square.512.fp16's residual 1.13× is the same story at its mildest (a within-tier `WM 1/4` misorder, `BK=4` already
-benched) and is not load-bearing.
-
-**Follow-up:** the fix only refreshes a shape's deploy once that shape is re-tuned (it changes selection, not the
-stored reservoir). A full `tune --dataset golden` re-run on this branch would re-record every shape under the fixed
-exploration; only the two fp16 squares were re-tuned here.
-
-## Finding 2 — fp32 s512 family: clean-DB search variance unsamples the goldens; evidence-pick then deploys a worse measured best (q_proj +10%, kv_proj +10%, gate_up +20%)
-
-q_proj.s512, kv_proj.s512 and gate_up_proj.s512 are all worse with the same signature: `eval variants` shows the
-deploy pick at measured rank 1 (or the only -O3-evidenced config) — evidence-pick did its job — but the golden's
-config is **absent from the measured set** (21–39 measured configs per kernel; grepping `--top 0` for the golden's
-knob row finds nothing). Two of these goldens are the *previous sweep's own wins* (q_proj.s512's `BM16 BK32 RING4`,
-gate_up.s512's −37% `FM10 FN4 SPLITK1 RING3`): the accumulated DB that contained them was wiped by `--clean`, and
-this sweep's patience-bounded re-search took different trajectories (the learned prior ranks the q_proj.s512 golden
-3/1008 — shallow — yet the inner search still never benched it before patience ran out; kv_proj.s512's ranks 140
-learned / 331 analytic, a genuine mispricing on top).
-
-**Recommendation:** seed the inner search with the recorded golden configs. `tune --dataset golden` knows exactly
-which shape it is tuning and what the golden knobs are — force-bench each recorded golden as the first variant(s) of
-its op's inner search. Cost is one bench per golden entry (~30 s across the whole sweep); benefit is that
-evidence-pick can never deploy worse than the recorded golden after a clean tune, and "worse" findings would then
-*only* mean real regressions. This also stops wins from silently un-happening across sweeps (gate_up.s512's −37%
-existed this morning, was recorded, and is now unreachable again purely by sampling luck).
-
-## Finding 3 — big fp32 squares: FM misorder within shallow ranks persists (square.1024 +9%, square.4096 +11%)
-
-square.1024 deploys `FM10 RING3` vs golden `FM14/FM8 RING2/4` (learned ranks 3 and 47 for its two entries);
-square.4096 deploys `FM28` vs golden `FM10` (learned rank 50, `vs gold` 1.00x — the -O3 reservoir number says
-parity, the live A/B says +11%). The previous sweep's recommendation to represent the big-FM regime in the analytic
-fit was applied (FM26-class analytic ranks improved 121→147 vs 394 learned previously), but the searched-and-measured
-sets again don't contain the goldens (same mechanism as finding 2 at lower stakes). Covered by finding 2's
-golden-seeding recommendation; no separate action.
-
-## Finding 4 — the A/B knob columns hide planner-derived knobs that differ (WARPSPEC), and gate_up_proj.s128's golden was pinning the slow choice
-
-gate_up_proj.s128's greedy pick benched **−15%** vs a golden row showing *identical* knob columns — only `block`
-(160 vs 128) and `regs` betrayed the difference. `eval golden` resolved it: `WARPSPEC True/False`. The pick's variant
-space (`eval variants`) has no WARPSPEC column at all — in the fp32 thread tier it is planner-derived, not searched —
-while the YAML entry recorded `WARPSPEC: false` from an earlier era, actively pinning the kernel away from the
-warp-specialized form the planner now prefers. The fix was to drop the pin (the replacement entry records only the
-search knobs), verified at 24.0 µs.
-
-**Recommendation:** two small ones. (a) The `run --golden`/`--ab` knob table should add a column for any knob that
-*differs* between the greedy pick's resolved config and a golden row even when it isn't in the searched space —
-block-size archaeology shouldn't be needed to see a WARPSPEC diff. (b) Audit the remaining `WARPSPEC: false` pins
-(square.2048, square.4096 static) — they may be pinning those shapes away from better planner-derived forms too.
-
-## Finding 5 — `eval variants`' ◄ pick marker disagrees with the actual deploy when no -O3 evidence exists
-
-For the small s32/s128 kernels (no -O3 reservoir rows at all — e.g. `k_matmul_60e20f`, `2f6d1b`, `39c474`,
-`aaa3b2`), the ◄ marker lands on `FM6 FN4` rows while the live deploy (and `eval golden`'s found column) picks
-`FM4 FN2`. With no evidence, deploy argmins the model over the **full enumeration** while the variants view argmins
-over the **measured rows only** — both labeled "the prior's pick". Harmless this sweep (the live picks beat the
-goldens anyway) but it makes the view's `pick: rank N` line untrustworthy exactly when it's needed. Also from the
-same neighborhood: kernels this small never get -O3 re-bench rows despite the 10%-of-best tolerance band — worth a
-look at whether the re-bench is failing or the reservoir is dropping them.
-
-**Recommendation:** make the ◄ marker call the same `Prior.pick` path the deploy uses (full enumeration, evidence
-first), and flag when the resulting config is unmeasured instead of silently marking the nearest measured row.
+square.1024/2048/4096.fp16 all land within 1–2% of the recorded golden's live re-bench (0.98–0.99), and the greedy
+configs are the `BK=2` warp-tier region the third sweep's analytic-tilt fix made reachable — confirming that fix holds
+on `main`. The greedy form drops the planner-derived `WARPSPEC` pin the older entries carry (per the third sweep's
+Finding 4), but at the *search-knob* level it is the same region, so there is no new config to add. Note: the live
+re-bench (14.9 / 91.5 / 650 µs) runs faster than the entries' stored `deplodock_us` (18.5 / 106.7 / 746 µs) — pure
+measurement/codegen drift since recording, the same config. Left untouched: the deltas are within noise and conflate
+drift; refreshing the stored µs would mean picking which of the two recorded entries to rewrite with no config change.
 
 ## Workflow notes
 
-- **The A/B pass collapsed from ~45 min to ~3.5 min** because it ran right after the tune with a hot cubin cache
-  (~7 s per shape, 29 shapes). The previous report's "in-process `run --bench --dataset golden` loop" proposal is
-  much less urgent now; sequencing A/B directly after tune is the cheap fix. Three full passes cost ~10 min total,
-  which made the noise-floor confirmation (step 4) painless for the first time.
-- **Ratios were rock-solid across passes** (≤2% drift on 28/29 shapes; absolute µs steady too — back-to-back runs,
-  one thermal state). The exception: o_proj.s512's greedy bench was bimodal (49.5 / 53.2 / 53.3 µs across passes,
-  same kernel) — categorized worse-marginal on the 2-of-3 majority.
-- **`eval golden` is now the WARPSPEC oracle** (finding 4): the live A/B table hid the only differing knob, and
-  `eval golden` exposed it. Until finding 4(a) is fixed, run `eval golden` before recording any "same-knobs but
-  faster" result — a hidden planner-derived diff may be the real story.
-- **Kernel-name collisions persist** (third report in a row): square.NNNN and square.NNNN.fp16 share kernel names
-  (`bed174`, `180e20`, `262948`, `207791`), so their `eval variants` groups interleave fp32 FK-split rows with
-  fp16 warp-tier rows. This sweep's finding-1 evidence had to come from the tune log (grepping per-target BK
-  histograms) because the variants view couldn't separate the tiers. The ShapeKey-subgrouping / `--shape` filter
-  proposal stands, now with a concrete victim.
-- **The tune log was the only source for "which knob values were ever offered"** (finding 1's BK histograms). A
-  per-op enumeration summary — even just min/max per knob in `eval variants`' header — would have answered it in
-  one command.
-- **Fixed since the previous report and held**: (a) the evidence-pick work (its findings 2/4/5/6) — verified across
-  every kernel with -O3 reservoir rows; (b) the fp16 TMA+WARPSPEC launch crash (its finding 1) — zero
-  CUDA_ERROR_INVALID_VALUE rows this sweep, the fp16 golden rows bench fine; (c) fp16 shapes still appear in
-  `eval prior` rank lists (held). **Not fixed**: kernel-name collisions (above); reduce/pointwise goldens still
-  outside the tune/A-B loop (third report in a row).
-- The `--clean` sweep cost finding 2's regressions: two recorded wins became unreachable again because the DB that
-  knew about them was wiped and the re-search didn't re-find them. Until golden-seeding lands, consider running
-  routine sweeps *without* `--clean` (accumulate) and reserving `--clean` for prior-hygiene checks.
+- **The harvest is now scripted end-to-end** (`/tmp/harvest_goldens.py`): per shape it reads the greedy pick's knobs
+  programmatically (no fragile colored-table parsing) and the -O3 latencies from `run --bench`'s `60_bench_compare.json`
+  + the live golden rows, emitting JSONL. Categorization is one pass over the JSONL against `goldens_by_name`. This
+  replaced the by-hand table reading of the previous three sweeps and made the 29-shape A/B + noise re-runs a few
+  scripted minutes. Worth folding into the CLI as a `tune --dataset golden --record` mode.
+- **`tuning_knob_items` drops BOOL knobs**, so the harvested knob set already excludes `WARPSPEC`/`GROUP_M`-style
+  planner-derived flags — exactly the third sweep's Finding 4(a) record-set, for free. The `--ab`/`--golden` *table*
+  still hides those diffs (Finding 4(a) proper — surface a column for differing planner-derived knobs — remains open).
+- **Multi-GPU goldens now coexist** (`rtx5090_sm120.yaml`, `rtx4090_sm89.yaml`, `rtxpro6000_sm120.yaml`). The 5090 and
+  PRO 6000 share `compute_cap (12, 0)`, which the goldens layer assumed unique: `eval` / `tune --dataset golden`
+  iterate the flat `GOLDEN_CONFIGS` with no live-GPU filter, and `ShapeKey` joins (shape-keyed, GPU-blind) merge
+  same-shape entries across cards. `eval golden --kernel square.512` on this box now silently compares against
+  whichever card's golden the grouping surfaces. Docstrings in `search/golden.py` were corrected to flag this; the
+  real fix — filter the golden consumers to the live `(gpu_name, compute_cap)`, with an `--all-gpus` escape hatch — is
+  a focused follow-up (touches `Dataset.from_golden` + the `eval` paths + tests on each GPU). See the 4090 / PRO 6000
+  reports for the same note.
+- **Fixed since the third report and held:** the fp16-`BK=2` analytic-tilt fix (Finding 1 there) — fp16 squares
+  reproduce at parity here. **Not fixed (carried):** golden-seeding the inner search (Finding 2, now P0 across four
+  sweeps); the planner-derived knob column in the A/B table (Finding 4a).

--- a/plans/golden-sweep-rtxpro6000-findings.md
+++ b/plans/golden-sweep-rtxpro6000-findings.md
@@ -1,0 +1,90 @@
+# Golden seed findings — RTX PRO 6000 Blackwell Max-Q (sm_120), 2026-06-13 (first-ever PRO 6000 golden file)
+
+- New file: `deplodock/compiler/pipeline/search/goldens/rtxpro6000_sm120.yaml` (29 matmul shapes), seeded on
+  `riftuser@38.108.83.78:60002` (RTX PRO 6000 Blackwell Max-Q Workstation Edition, sm_120, 96 GB, driver 580.65.06,
+  CUDA 12.9, torch 2.12.0+cu130).
+- Sweep: `deplodock tune --dataset golden --clean -q` (~25 min) → seed-mode harvest (`run --bench -c snippet`, greedy
+  pick recorded directly). One shape re-tuned at higher patience (Finding 1). Prior + DB pulled to
+  `/tmp/golden_artifacts/pro6000/` for offline analysis.
+- Branch: `feature/golden-multi-gpu`.
+- Headline: the PRO 6000 is **sm_120, same capability as the RTX 5090**, so the existing sm_120-fit prior transfers
+  cleanly — unlike the 4090, the fresh seed is healthy out of the box. **20/29 shapes ≤ 1.1× eager** (median d/e
+  **1.00**, max 1.27 after the one re-tune). fp16 correctly uses the warp/MMA tensor-core tier (no Hopper-gate problem,
+  cap ≥ 9,0). Recorded the greedy picks directly as the seed.
+
+## Per-shape outcome (greedy pick benched on the PRO 6000; d/e = deplodock / eager)
+
+| shape                            | deplo µs | eager µs |  d/e | note                                  |
+|----------------------------------|---------:|---------:|-----:|---------------------------------------|
+| square.512                       |     11.0 |     12.6 | 0.87 |                                       |
+| square.1024                      |     49.2 |     55.6 | 0.89 |                                       |
+| square.2048                      |    357.6 |    324.8 | 1.10 |                                       |
+| square.4096                      |   3021.4 |   2426.0 | 1.25 | big fp32 square (F2)                   |
+| square.512.fp16                  |      3.8 |      6.1 | 0.61 | warp tier                             |
+| square.1024.fp16                 |     13.9 |     12.5 | 1.11 | warp tier (F2)                        |
+| square.2048.fp16                 |     78.6 |     69.9 | 1.12 | warp tier                             |
+| square.4096.fp16                 |    524.1 |    467.2 | 1.12 | warp tier                             |
+| qwen3_06b.q_proj.s32             |      7.8 |      8.7 | 0.90 |                                       |
+| qwen3_06b.kv_proj.s32            |      6.2 |      8.5 | 0.74 |                                       |
+| qwen3_06b.o_proj.s32             |     10.0 |     10.3 | 0.97 |                                       |
+| qwen3_06b.gate_up_proj.s32       |     11.6 |     12.6 | 0.92 |                                       |
+| qwen3_06b.down_proj.s32          |     13.8 |     14.4 | 0.96 |                                       |
+| qwen3_06b.q_proj.s128            |     18.7 |     19.7 | 0.95 |                                       |
+| qwen3_06b.kv_proj.s128           |     12.1 |     14.5 | 0.84 |                                       |
+| qwen3_06b.o_proj.s128            |     20.9 |     22.6 | 0.92 |                                       |
+| qwen3_06b.gate_up_proj.s128      |     30.9 |     26.4 | 1.17 | (F2)                                  |
+| qwen3_06b.down_proj.s128         |     33.3 |     31.1 | 1.07 |                                       |
+| qwen3_06b.q_proj.s512            |     55.8 |     55.4 | 1.01 |                                       |
+| qwen3_06b.kv_proj.s512           |     30.3 |     39.5 | 0.77 |                                       |
+| qwen3_06b.o_proj.s512            |     66.3 |     68.6 | 0.97 |                                       |
+| qwen3_06b.gate_up_proj.s512      |     85.1 |     81.3 | 1.05 |                                       |
+| qwen3_06b.down_proj.s512         |     97.8 |     92.0 | 1.06 |                                       |
+| square.512.dynM                  |     13.6 |     12.6 | 1.08 |                                       |
+| qwen3_06b.q_proj.s512.dynM       |     55.2 |     55.3 | 1.00 | **re-tuned** 89.3→55.2 (F1)           |
+| qwen3_06b.kv_proj.s512.dynM      |     47.8 |     39.5 | 1.21 | dynM masked tile (F2)                 |
+| qwen3_06b.o_proj.s512.dynM       |     86.9 |     68.4 | 1.27 | dynM masked tile (F2)                 |
+| qwen3_06b.gate_up_proj.s512.dynM |     89.7 |     80.9 | 1.11 | dynM masked tile                      |
+| qwen3_06b.down_proj.s512.dynM    |     87.5 |     92.1 | 0.95 |                                       |
+
+## Finding 1 — q_proj.s512.dynM: fresh seed was degenerate (1.63×), one higher-patience re-tune fixed it (→1.00×)
+
+The seed deployed `q_proj.s512.dynM` at 89.3 µs (1.63× eager). Unlike the 4090's degenerate picks, this one **did**
+respond to patience: `tune --golden qwen3_06b.q_proj.s512.dynM --patience 100` (accumulate, no `--clean`) found
+`{BM:8, BN:32, BK:32, FM:6, FN:4, FK:1, SPLITK:1, BR:1, OVERHANG:['a0'], STAGE:'11', RING:2}` at **55.2 µs / 1.00×**.
+Recorded. So on sm_120 the prior reaches good regions with more search budget — the cold prior just stopped early on
+this masked-tile shape. (Contrast the 4090, where patience did *not* help — Finding 2 there.)
+
+## Finding 2 — a handful of shapes sit 1.1–1.27×; expected first-seed slack, not a defect
+
+`square.4096` (1.25×), the fp16 squares (1.11–1.12×), `gate_up_proj.s128` (1.17×), and two dynM masked tiles
+(kv/o_proj.s512.dynM at 1.21/1.27×) are above parity but not degenerate. These are the same shape families that sit
+slightly off on the 5090 too; on a first clean seed they reflect search slack, not a tier/codegen lockout (fp16 is on
+the correct warp tier; the big square is a known large-`FM` tuning target). They are honest deployable seeds and are
+the natural targets for a second accumulating (non-`--clean`) sweep or the golden-seeding fix.
+
+## Finding 3 — same-cap collision with the RTX 5090 (`compute_cap (12, 0)`) (P1 for the goldens layer)
+
+The PRO 6000 and the RTX 5090 report the **identical** `compute_cap (12, 0)`. The goldens layer assumed `compute_cap`
+uniquely identifies a card (`goldens_by_name`'s contract, the `_load_goldens` doc) — now false. With both files present
+`GOLDEN_CONFIGS` carries two entries per name at the same cap, distinguishable only by `gpu_name`, and the `eval` /
+`tune --dataset golden` paths plus every `ShapeKey`-keyed join are GPU-blind: they intermix the two cards. Nothing
+crashes (the golden-config test passes; `eval golden` runs), and per-config evaluation still uses each config's own
+`Context.from_target(compute_cap)` — but cross-shape grouping and the golden↔DB join silently merge 5090 and PRO 6000
+data on the dev box. Docstrings in `search/golden.py` were corrected to state the `(gpu_name, compute_cap)` identity.
+
+**Recommendation:** filter the golden consumers to the live `(gpu_name, compute_cap)` — add the pair to
+`Dataset.from_golden` and the `eval` iterations, default to the live card, with an `--all-gpus` escape hatch for
+cross-card comparison. Touches `Dataset.from_golden` + the `eval` command paths + tests; deferred from this task as a
+focused follow-up rather than risk the eval tooling mid-sweep.
+
+## Workflow notes
+
+- **sm_120 seeds cleanly; sm_89 does not** (cf. the 4090 report). The deciding factor is whether the live capability
+  matches the prior's training data (sm_120): the PRO 6000 needed *one* re-tune, the 4090 needed config transfer for 16
+  shapes plus has no fp16 tensor-core path. A per-capability cold analytic prior (Finding 2 of the 4090 report) is the
+  general fix.
+- **The seed harvest is a single scripted pass** (`/tmp/harvest_goldens.py --mode seed`): greedy knobs read from the
+  compiled graph, -O3 latencies from `60_bench_compare.json`; `/tmp/emit_golden_yaml.py` writes the hand-style flow
+  YAML. Recording a brand-new GPU was mechanical once the prior transferred.
+- **Prior + DB** pulled post-re-tune (949 MB DB / 77 MB prior) to `/tmp/golden_artifacts/pro6000/` for offline
+  analysis; they are the clean sm_120 seed artifacts plus the one accumulated q_proj.s512.dynM re-tune.

--- a/plans/golden-sweep-rtxpro6000-findings.md
+++ b/plans/golden-sweep-rtxpro6000-findings.md
@@ -77,6 +77,15 @@ data on the dev box. Docstrings in `search/golden.py` were corrected to state th
 cross-card comparison. Touches `Dataset.from_golden` + the `eval` command paths + tests; deferred from this task as a
 focused follow-up rather than risk the eval tooling mid-sweep.
 
+**Update (implemented):** done across two follow-ups. (1) `goldens_for_live_gpu()` scopes the `eval` / diagnostics
+golden views + the `run --golden` A/B to the live card (`Dataset.from_golden(live_gpu=True)`); cards with no recorded
+golden fall back to the full set (seed / transfer flow). (2) The deeper fix the same-cap case needed: GPUs are now
+distinguished by **SM count** (the common `deplodock.gpu` registry — RTX 5090 = 170 vs RTX PRO 6000 = 188), and
+`Sample.from_golden` reconstructs each golden's context with its OWN card's memorized device features
+(`Context.from_target(gpu_name=…)`) instead of the live device's — so a PRO 6000 golden ranked on a 5090 now
+featurizes with 188 SMs, not 170. `ShapeKey` stays deliberately structural-only (the op side carries no `H_*`
+features); the per-card distinction lives where it belongs — in the features + the live-GPU scoping.
+
 ## Workflow notes
 
 - **sm_120 seeds cleanly; sm_89 does not** (cf. the 4090 report). The deciding factor is whether the live capability

--- a/tests/compiler/pipeline/search/test_data.py
+++ b/tests/compiler/pipeline/search/test_data.py
@@ -147,7 +147,10 @@ def test_golden_compile_s_feats_matches_inline(monkeypatch) -> None:
     s_feats: dict = {}
     for n in compiled.nodes.values():
         s_feats.update({k: v for k, v in (getattr(n.op, "knobs", {}) or {}).items() if k.startswith(STRUCT_PREFIX)})
-    inline = knob.knob_features({**Context.from_target(g.compute_cap).features(), **s_feats, **g.knobs})
+    # gpu_name pins the device-physical H_* features to the golden's own card's
+    # memorized specs (so a 4090 golden gets 128 SMs, not the live device's count) —
+    # Sample.from_golden does the same, so the two must still agree.
+    inline = knob.knob_features({**Context.from_target(g.compute_cap, gpu_name=g.gpu_name).features(), **s_feats, **g.knobs})
 
     assert Sample.from_golden(g, compile_s_feats=True).features() == inline
 
@@ -155,6 +158,18 @@ def test_golden_compile_s_feats_matches_inline(monkeypatch) -> None:
     full = Sample.from_golden(g, compile_s_feats=True).s_features()
     assert set(arith) <= set(full)
     assert all(arith[k] == full[k] for k in arith)
+
+
+def test_golden_features_use_own_cards_sm_count() -> None:
+    """A golden featurizes with its OWN card's SM count (from the gpu registry via
+    gpu_name), not the live device's — the fix that makes same-compute_cap cards
+    (RTX 5090 = 170 vs RTX PRO 6000 = 188 SMs) distinguishable in the model."""
+    from deplodock.compiler.pipeline.search.golden import goldens_by_name
+
+    by_gpu = {g.gpu_name: Sample.from_golden(g).context["H_sm_count"] for g in goldens_by_name("square.512")}
+    assert by_gpu["NVIDIA GeForce RTX 4090"] == 128.0
+    assert by_gpu["NVIDIA GeForce RTX 5090"] == 170.0
+    assert by_gpu["NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition"] == 188.0
 
 
 # --- Dataset adapters + grouping --------------------------------------------

--- a/tests/compiler/pipeline/search/test_golden_deploy_perf.py
+++ b/tests/compiler/pipeline/search/test_golden_deploy_perf.py
@@ -12,8 +12,20 @@ from __future__ import annotations
 
 import pytest
 
+from deplodock.compiler.pipeline.search import golden as golden_mod
 from deplodock.compiler.pipeline.search.golden import goldens_by_name
 from deplodock.compiler.pipeline.search.prior import diagnostics
+
+
+@pytest.fixture(autouse=True)
+def _single_gpu_goldens(monkeypatch):
+    """Pin the golden set to one card (RTX 5090). With multiple per-GPU files a name
+    recurs once per card and the GPU-blind ``ShapeKey`` join would mix their
+    latencies (5090 / PRO 6000 even share ``compute_cap (12, 0)``), making these
+    shape-keyed assertions depend on which goldens dir is checked in. Off-GPU here,
+    so ``goldens_for_live_gpu`` can't auto-scope — inject the single-card set."""
+    one = [g for g in golden_mod.GOLDEN_CONFIGS if g.gpu_name == "NVIDIA GeForce RTX 5090"]
+    monkeypatch.setattr(golden_mod, "GOLDEN_CONFIGS", one)
 
 
 class _FakePrior:

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,58 @@
+"""Unit tests for the common GPU registry (:mod:`deplodock.gpu`)."""
+
+from deplodock import gpu
+
+
+def test_lookup_by_name_and_pci():
+    g = gpu.by_name("NVIDIA GeForce RTX 5090")
+    assert g is not None and g.compute_capability == (12, 0) and g.sm_count == 170
+    assert gpu.by_pci_device_id("2b85") is g
+    assert gpu.by_pci_device_id("0x2B85") is g  # case / 0x-prefix tolerant
+    assert gpu.by_name("No Such GPU") is None
+    assert gpu.by_pci_device_id("ffff") is None
+
+
+def test_same_cap_cards_are_distinct_by_specs():
+    # The case that motivated the registry: 5090 and PRO 6000 share compute_cap
+    # (12, 0) but differ in SM count / VRAM, so they ARE distinguishable here.
+    a = gpu.by_name("NVIDIA GeForce RTX 5090")
+    b = gpu.by_name("NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition")
+    assert a.compute_capability == b.compute_capability == (12, 0)
+    assert a.sm_count != b.sm_count and (a.sm_count, b.sm_count) == (170, 188)
+    assert a.vram_mib != b.vram_mib
+
+
+def test_derived_cc_facts():
+    g = gpu.by_name("NVIDIA GeForce RTX 4090")  # sm_89
+    assert g.smem_optin == gpu.MAX_DYNAMIC_SMEM_BY_CC[(8, 9)]
+    assert g.tensor_core_gen == gpu.TENSOR_CORE_GEN[(8, 9)] == 3
+    assert g.vram_bytes == g.vram_mib * 1024 * 1024
+
+
+def test_device_features_shape():
+    feats = gpu.by_name("NVIDIA GeForce RTX 5090").device_features()
+    assert set(feats) == {"sm_count", "smem_per_sm", "smem_per_block", "regs_per_block", "warp_size"}
+    assert feats["sm_count"] == 170.0
+    # AMD card has no CUDA specs → empty feature dict (degrades like a GPU-less host).
+    assert gpu.by_name("AMD Instinct MI350X").device_features() == {}
+
+
+def test_probe_falls_back_to_memorized(monkeypatch):
+    # Force the cupy probe to fail → memorized fallback of the named card / default.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_cupy(name, *a, **k):
+        if name == "cupy":
+            raise ImportError("no cupy")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", no_cupy)
+    assert gpu.probe_live_features() == gpu.DEFAULT_GPU.device_features()
+    assert gpu.probe_live_features("NVIDIA GeForce RTX 4090")["sm_count"] == 128.0
+
+
+def test_back_compat_maps_match_registry():
+    assert gpu.pci_device_id_to_name()["2684"] == "NVIDIA GeForce RTX 4090"
+    assert gpu.short_names()["NVIDIA GeForce RTX 5090"] == "rtx5090"


### PR DESCRIPTION
Multi-GPU golden sweep across RTX 5090 (local), RTX 4090, and RTX PRO 6000 Blackwell Max-Q, plus the GPU-identity
infrastructure the sweep surfaced as needed.

## Golden configs
- **RTX 5090** (`rtx5090_sm120.yaml`): `square.512.dynM` replaced (`SPLITK1 RING3`, 12.8→11.0 µs, −14%, reproduces 3×).
  The clean re-tune regressed 17/29 shapes vs the recorded goldens — the documented Finding-2 `--clean` search variance
  (un-finds accumulated wins), so the mature 5090 goldens stand. fp16 squares reproduce at parity.
- **RTX 4090** (`rtx4090_sm89.yaml`, new): a fresh sm_89 tune produced 15/29 degenerate picks, so each shape is seeded
  with the best of {4090 greedy, transferred-5090-config-benched-on-4090} — 16 shapes recovered via the portable 5090
  scalar configs (o_proj.s128 84→23 µs, down_proj.s128 125→33 µs, square.4096 11092→4005 µs). fp16 squares are recorded
  as scalar fallback (3–5× cuBLAS): the warp-tier mma.sync path faults on Ada (NVRTC sm_89 OOB ldmatrix miscompile,
  root-caused with compute-sanitizer — see findings); the sm_90+ gate stays in place.
- **RTX PRO 6000** (`rtxpro6000_sm120.yaml`, new): sm_120 like the 5090, prior transfers cleanly — 20/29 ≤1.1× eager
  (median 1.00); one dynM shape re-tuned 89→55 µs.

## Common GPU registry (`deplodock/gpu.py`)
Single source of truth for physical GPU facts — PCI device IDs, the canonical PCIe name (the `gpu_name` used everywhere
by convention), compute capability, SM count, smem sizes, register file, VRAM. `probe_live_features()` probes the live
device and falls back to **memorized** specs of `DEFAULT_GPU` (or a named card) when no device is visible. `detect.py`,
`hardware.py`, `compiler/{context,target}.py`, and `search/analytic.py` now derive from it (values verified
byte-identical to the old literals).

## Same-cap conflation fix (5090 and PRO 6000 are both cc 12.0)
- `goldens_for_live_gpu()` scopes the `eval` / diagnostics golden views **and** the `run --golden` A/B to the live
  `(gpu_name, compute_cap)` (cards without their own golden fall back to the full set — seed/transfer flow).
- The deeper fix: GPUs are distinguished by **SM count** (170 vs 188), and `Sample.from_golden` reconstructs each
  golden's context with its **own** card's memorized device features (`Context.from_target(gpu_name=…)`) instead of the
  live device's — so a PRO 6000 golden ranked on a 5090 featurizes with 188 SMs, not 170. `ShapeKey` stays deliberately
  structural-only (the op side carries no `H_*` features; the joins are already single-card via the filter).

## Tests / docs
New `tests/test_gpu.py` + a per-card featurization test; updated the golden-deploy-perf / data tests for the per-card
behavior. Three findings reports under `plans/`. Lint clean; the affected search / cli / detect / hardware / provisioning
test suites pass (~430 tests green locally).

## Not in this PR
The sm_89 fp16 **tensor-core** path is diagnosed (NVRTC sm_89 ldmatrix OOB miscompile, faults on Ada, clean on sm_120)
but not fixed — it needs SASS-level work on a 4090 and is tracked in `plans/golden-sweep-rtx4090-findings.md` (Finding 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)