### PR TITLE
serving: captured-graph replay over per-seq_len graph cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ When the user asks about a CLI flag, recipe field, or matrix combinator, read th
 All `DEPLODOCK_*` config env vars (the two above plus `DEPLODOCK_NVCC_FLAGS`, `DEPLODOCK_DEBUG`, `DEPLODOCK_KNOBS`,
 `DEPLODOCK_TUNE_PATIENCE`, `DEPLODOCK_TUNE_EPS`, `DEPLODOCK_O3_TOL`, `DEPLODOCK_ANALYTIC_TILT`, `DEPLODOCK_BENCH_BACKENDS`,
 `DEPLODOCK_CUBIN_CACHE`, `DEPLODOCK_NO_NVCC`, `DEPLODOCK_GPU_LOCK`, `DEPLODOCK_SERVING_DTYPE`,
+`DEPLODOCK_SERVING_CAPTURE_CAP` (serving's captured-graph buffer-allocation cap — default `max_seq_len`),
+`DEPLODOCK_SERVING_NO_GRAPHS` (force the uncaptured rebind+run_once serving path),
 …) are read and written through a single module, `deplodock/config.py` — the sole owner of `os.environ` for these vars.
 CLI `--flag` overrides (e.g. `--nvcc-flags`) resolve via `config.set_nvcc_flags` inside the library, not in the command
 layer, so programmatic callers and tests get the same precedence. The dynamic `DEPLODOCK_<KNOB>` namespace is owned by

--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -78,6 +78,21 @@ every kernel in program order with none of `iter_once`'s per-launch event record
 in `iter_once`; the caller's `outputs()` `.get()` synchronizes. Both expect the caller to hold `gpu_lock()`. See
 `tests/compiler/test_program_rebind.py`.
 
+**Captured-graph replay over a capacity buffer set (`set_sym_values` / `upload_prefix` / `capture_program_graph` /
+`replay_program_graph` / `outputs(sym_values)`).** The serving fast path: instead of `rebind` re-sizing buffers and
+`run_once` issuing ~hundreds of host launches per request, build the program once at a **capacity** seq_len, then per
+request (1) `set_sym_values({"seq_len": S})` sizes the launch grids + by-value seq_len to the real S without
+re-allocating (errors if S exceeds capacity), (2) `upload_prefix(input_data)` H2D's each input into the contiguous
+prefix of its capacity buffer (a logically `(1, S, …)` tensor occupies the first `S·…` elements), (3)
+`capture_program_graph()` captures the whole program at the current S into ONE CUDA graph — **cached per seq_len**
+(bounded LRU `_graph_cache`), so a repeated length replays with no re-capture — and (4) `replay_program_graph()` is one
+host launch; `outputs({"seq_len": S})` slices each capacity buffer to its real-S prefix. Each graph is captured at its
+EXACT S, so every kernel runs at its exact grid: no oversized-grid masking is needed (and a single capacity-baked graph
+for ALL S is not viable — several symbolic-M kernels read OOB at an oversized grid: the CTA-swizzle decode reconstructs
+`num_m` from the runtime seq_len, and ceil-div staged loads over-read; see
+`plans/serving-dynamic-shape-cuda-graphs.md`). `rebind` clears `_graph_cache` on re-allocation. Validate multi-S
+correctness under `compute-sanitizer` (`tests/compiler/ir/test_dynamic_shapes.py`).
+
 `benchmark_program(graph, input_data, warmup, num_iters)` adds a
 warmup loop + timed loop wrapped in `cupy.cuda.Event` pairs — one
 global pair for `BenchmarkResult.time_ms`, one pair per launch index

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -588,6 +588,14 @@ class CompiledProgram:
     _e2e_graph: Any | None = field(default=None, repr=False)
     _e2e_start: Any | None = field(default=None, repr=False)
     _e2e_stop: Any | None = field(default=None, repr=False)
+    # Whole-program graphs keyed by the resolved symbolic tuple — the serving
+    # captured-replay path holds one captured graph PER seq_len over a single
+    # capacity-sized buffer set (a graph baked at seq_len S only replays at S,
+    # since each kernel's grid + by-value seq_len are frozen by capture). LRU,
+    # bounded by ``_graph_cache_max``. The static-shape bench path uses the one
+    # ``()`` key, so it's unaffected.
+    _graph_cache: dict = field(default_factory=dict, repr=False)
+    _graph_cache_max: int = 64
 
     @classmethod
     def build(
@@ -655,6 +663,25 @@ class CompiledProgram:
             self._graphs = None
             self._graph_batch_sizes = None
             self._e2e_graph = None
+            self._graph_cache.clear()
+
+    def set_sym_values(self, values: dict[str, int]) -> None:
+        """Set the host symbolic values that resolve launch grids + by-value
+        kernel args, WITHOUT re-allocating buffers — they stay at the build
+        (capacity) shape. The serving capture path: buffers sized once at
+        capacity, grids + frozen seq_len baked per request via
+        :meth:`capture_program_graph`, results sliced to the real shape by
+        ``outputs(sym_values=…)``. Errors if any value exceeds the allocated
+        buffer capacity (the caller falls back to ``rebind`` above capacity)."""
+        merged = {**self.sym_values, **values}
+        for buf in self.compiled.bufs:
+            want = buf.resolve_shape(merged) or (1,)
+            if math.prod(want) > self.arrays[buf.name].size:
+                raise ValueError(
+                    f"set_sym_values {values}: buffer {buf.name!r} resolves to {want} "
+                    f"({math.prod(want)} elems) > capacity {self.arrays[buf.name].size}"
+                )
+        self.sym_values = merged
 
     def run_once(self) -> None:
         """Launch every kernel once in program order with no per-launch event
@@ -712,22 +739,31 @@ class CompiledProgram:
         self._graph_batch_sizes = list(batch_sizes)
 
     def capture_program_graph(self) -> None:
-        """Capture every launch (batch 1, program order) into ONE CUDA graph.
+        """Capture every launch (batch 1, program order) into ONE CUDA graph at
+        the CURRENT ``self.sym_values``, caching it by the resolved symbolic
+        tuple and pointing ``self._e2e_graph`` at it.
 
-        The whole-program graph backs :meth:`time_program_window` — an event
-        window around N replays of the full program, which is the same
-        semantics the captured torch closures get in the interleaved bench
-        (one graph per forward, replayed back-to-back inside one window).
-        Per-launch capture (:meth:`capture_launch_graphs`) can't provide this:
-        summing isolated single-kernel windows drops cross-kernel cache
-        effects and inter-kernel gaps, so the sum is not an end-to-end time.
+        Two callers:
+        - The bench's :meth:`time_program_window` (static graph → the single
+          ``()`` cache key): one event window around N back-to-back replays, the
+          same semantics the captured torch closures get.
+        - The serving path: one captured graph PER seq_len over a SHARED
+          capacity-sized buffer set. A graph baked at seq_len S only replays at S
+          (its grids + by-value seq_len are frozen by capture), so the cache is
+          keyed by ``self.sym_values`` and bounded LRU (``_graph_cache_max``).
+          Set ``self.sym_values`` (via :meth:`set_sym_values`) and upload the
+          request's input prefix (via :meth:`upload_prefix`) before calling.
 
-        No-op when already captured. Same error contract as
+        Cache hit ⇒ no re-capture. Same error contract as
         :meth:`capture_launch_graphs`: raises :class:`GraphCaptureError` after
         draining any partial capture state."""
         import cupy as cp
 
-        if self._e2e_graph is not None:
+        key = self._sym_key()
+        cached = self._graph_cache.get(key)
+        if cached is not None:
+            self._graph_cache[key] = self._graph_cache.pop(key)  # LRU bump
+            self._e2e_graph = cached
             return
         side = cp.cuda.Stream(non_blocking=True)
         try:
@@ -747,7 +783,41 @@ class CompiledProgram:
         # Throwaway replay absorbs graphExec instantiation/upload cost.
         graph.launch()
         cp.cuda.runtime.deviceSynchronize()
+        self._graph_cache[key] = graph
+        while len(self._graph_cache) > self._graph_cache_max:
+            self._graph_cache.pop(next(iter(self._graph_cache)))  # evict LRU
         self._e2e_graph = graph
+
+    def _sym_key(self) -> tuple:
+        """Hashable cache key for the current resolved symbolic values (``()`` for
+        a fully-static graph)."""
+        return tuple(sorted(self.sym_values.items()))
+
+    def replay_program_graph(self) -> None:
+        """Launch the whole-program graph for the current ``self.sym_values`` once
+        on the default stream — the serving hot path. The caller sets the request's
+        seq_len (:meth:`set_sym_values`), uploads its input prefix
+        (:meth:`upload_prefix`), and captures-or-reuses the graph
+        (:meth:`capture_program_graph`) first; results come from
+        ``outputs(sym_values=…)``. Caller must hold ``gpu_lock()``."""
+        if self._e2e_graph is None:
+            raise RuntimeError("replay_program_graph called before capture_program_graph")
+        self._e2e_graph.launch()
+
+    def upload_prefix(self, input_data: dict[str, np.ndarray]) -> None:
+        """H2D each host array into the contiguous PREFIX of its capacity-sized
+        device buffer — no re-allocation, so the captured graphs' baked pointers
+        stay valid (a logically ``(1, S, …)`` tensor occupies the first ``S*…``
+        elements of the ``(1, S_cap, …)`` allocation; the kernels, launched at
+        grids for the real S, only touch that prefix). Errors if a host array
+        exceeds its buffer's capacity. Caller must hold ``gpu_lock()``."""
+        for name, host in input_data.items():
+            buf = self.compiled.buf_by_name[name]
+            arr = self.arrays[name]
+            flat = np.ascontiguousarray(host, dtype=buf.dtype.np).ravel()
+            if flat.size > arr.size:
+                raise ValueError(f"upload_prefix: {name!r} has {flat.size} elems > capacity {arr.size}")
+            arr.ravel()[: flat.size].set(flat)
 
     def time_program_window(self, replays: int) -> float:
         """One event window around ``replays`` back-to-back whole-program
@@ -842,12 +912,30 @@ class CompiledProgram:
                 per_launch_hook(i, launch)
         return dts
 
-    def outputs(self) -> dict[str, np.ndarray]:
+    def outputs(self, sym_values: dict[str, int] | None = None) -> dict[str, np.ndarray]:
         """Copy every output buffer back to host. Caller must hold the
         GPU lock — ``.get()`` is an async D2H copy on the default
         stream, so peer workers' kernels would otherwise interleave
-        with our D2H on the shared device."""
-        return {b.name: self.arrays[b.name].get() for b in self.compiled.bufs if b.role == "output"}
+        with our D2H on the shared device.
+
+        ``sym_values`` (serving's capture path) slices each output to its real-S
+        shape — the buffer is allocated at capacity but only the
+        ``resolve_shape(sym_values)`` prefix holds the request's result; the rest
+        is unmasked garbage from the oversized allocation. Without it (the
+        default) the whole buffer is returned (the uncaptured rebind path already
+        sizes buffers to the request)."""
+        out: dict[str, np.ndarray] = {}
+        for b in self.compiled.bufs:
+            if b.role != "output":
+                continue
+            arr = self.arrays[b.name]
+            if sym_values is not None:
+                shape = b.resolve_shape({**self.sym_values, **sym_values})
+                n = math.prod(shape) if shape else 1
+                out[b.name] = arr.ravel()[:n].get().reshape(shape)
+            else:
+                out[b.name] = arr.get()
+        return out
 
     def snapshot(self) -> dict[str, np.ndarray]:
         """Copy every non-input buffer (scratch + constants + outputs)

--- a/deplodock/config.py
+++ b/deplodock/config.py
@@ -48,6 +48,8 @@ NO_NVCC = "DEPLODOCK_NO_NVCC"
 GPU_LOCK = "DEPLODOCK_GPU_LOCK"
 NCU_CHILD = "DEPLODOCK_NCU_CHILD"
 SERVING_DTYPE = "DEPLODOCK_SERVING_DTYPE"
+SERVING_CAPTURE_CAP = "DEPLODOCK_SERVING_CAPTURE_CAP"
+SERVING_NO_GRAPHS = "DEPLODOCK_SERVING_NO_GRAPHS"
 
 _CACHE_ROOT = Path.home() / ".cache" / "deplodock"
 
@@ -253,6 +255,23 @@ def serving_dtype(default: str = "float16") -> str:
     by default; ``float32`` is the accuracy escape hatch (doubles weight
     memory — an 8B model no longer fits a 24 GB card)."""
     return _str(SERVING_DTYPE) or default
+
+
+def serving_capture_cap(default: int) -> int:
+    """``DEPLODOCK_SERVING_CAPTURE_CAP`` — capacity seq_len the serving runner
+    allocates its (shared, capacity-sized) buffer set at. Captured CUDA graphs
+    are keyed per request seq_len ≤ this cap; requests above it fall back to the
+    uncaptured rebind path. Defaults to the server's ``max_seq_len``; lower it
+    for big models / small cards where the S² attention scratch at full capacity
+    would not fit."""
+    return int_env(SERVING_CAPTURE_CAP, default)
+
+
+def serving_no_graphs() -> bool:
+    """``DEPLODOCK_SERVING_NO_GRAPHS`` — kill switch: keep the serving runner on
+    the uncaptured rebind+run_once path (per-request shape rebind) instead of
+    captured-graph replay. Debug escape hatch + fallback-test lever."""
+    return _bool(SERVING_NO_GRAPHS)
 
 
 # Note: ``DEPLODOCK_GROUP_M`` (CTA-swizzle row-group size) used to live here as

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -32,25 +32,43 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   (`seq_len@input_ids:1`, `@attention_mask:2`, `@attention_mask:3`, `@position_ids:1`), compile through `CudaBackend`
   (greedy fork picks from the global prior — benefits from any prior `deplodock tune`), bind weights as graph
   constants (`named_parameters` + `named_buffers`, `remove_duplicate=False`, in the traced dtype), and build ONE
-  `CompiledProgram`. Per sequence: `rebind` fresh inputs → `run_once` → `outputs()` (see
-  `compiler/backend/cuda/ARCHITECTURE.md` → repeated execution). Trace dtype: `DEPLODOCK_SERVING_DTYPE`
-  (default `float16`; `float32` is the accuracy escape hatch — 2× weight memory).
+  `CompiledProgram` over a **capacity-sized** buffer set (`min(max_seq_len, DEPLODOCK_SERVING_CAPTURE_CAP)`). Per
+  sequence (`forward_hidden_states`): size the launch grids to S (`set_sym_values`), upload the request's ids / causal
+  mask / position_ids into the buffers' contiguous **prefix** (`upload_prefix`), **capture-or-reuse** the whole-program
+  CUDA graph for this S, and **replay** it — one host launch instead of the ~hundreds the uncaptured loop issues; then
+  `outputs({"seq_len": S})` slices each output to its real shape. Captured graphs are cached per seq_len (bounded LRU);
+  each is captured at its EXACT S so every kernel runs at its exact grid — no oversized-grid masking (a single
+  capacity-baked graph for all S is **not** viable: several symbolic-M kernels do illegal reads at an oversized grid,
+  the swizzle decode + staged loads among them). `DEPLODOCK_SERVING_NO_GRAPHS=1` keeps the uncaptured `rebind` →
+  `run_once` path; requests above the capture capacity fall back to it too. See `compiler/backend/cuda/ARCHITECTURE.md`
+  → repeated execution + captured replay. Trace dtype: `DEPLODOCK_SERVING_DTYPE` (default `float16`; `float32` is the
+  accuracy escape hatch — 2× weight memory).
 - `packed.py` — `split_spans(positions, max_seq_len)`: vLLM V1 hands pooling models one packed `(num_tokens,)` tensor
   with per-request 0-based positions; spans split at `positions == 0`. Hardened for `_dummy_run`'s garbage profiling
   batches (index 0 always opens a span; overlong spans are chopped).
 
-## Execution model (v1) and its known costs
+## Execution model (v2: captured graphs) and its known costs
 
 Each sequence runs **individually** through the compiled dynamic-seq_len program (batch axis is compile-time fixed at
-1), and inputs/outputs cross host memory (`rebind` uploads numpy, `outputs()` copies back). Low-concurrency latency is
-representative; high-concurrency throughput structurally trails stock vLLM's packed-batch prefill — that gap measures
-the integration, not kernel quality. Recorded follow-ups, in impact order:
+1), as a captured whole-program CUDA graph (one host launch) replayed over a single capacity-sized buffer set, with the
+request's inputs uploaded into the buffers' prefix and the output sliced back out. One captured graph is cached per
+distinct seq_len (bounded LRU); a new length pays one capture (~one forward) on first sight, then replays. The captured
+graph removes the per-launch dispatch overhead and the ~hundreds of host calls the uncaptured loop made — the
+precondition for fast low-concurrency serving. (Measured A/B is ~flat today: the uncaptured `run_once` loop already
+queues launches async, so the Python dispatch overlaps GPU execution and stays hidden while the symbolic kernels are
+slow — 0.6B at S=32 ≈ 32 ms GPU. The win materializes once those kernels are fast enough that dispatch stops hiding;
+the captured path is in place for that.) Low-concurrency latency is representative; high-concurrency throughput
+structurally trails stock vLLM's packed-batch prefill — that gap measures the integration, not kernel quality.
+Recorded follow-ups, in impact order:
 
 1. **Packed-varlen attention** (cu_seqlens-aware SDPA tiles) — run vLLM's whole packed batch in one launch; the only
    item that makes the throughput regime apples-to-apples. Matmuls/norms/pointwise are already token-wise.
 2. **dlpack zero-copy I/O** — cupy ↔ torch without the host round-trip (`cp.from_dlpack` / `torch.from_dlpack`).
-3. **Device-side causal mask** — the `(1,1,S,S)` host mask upload (~32 MB fp16 at S=4096) per *new* S; a tiny kernel
-   (or in-kernel `j <= i` predicate) removes the mask input entirely.
+3. **Device-side causal mask** — the `(1,1,S,S)` host mask upload (~32 MB fp16 at S=4096) per request; a tiny kernel
+   (or in-kernel `j <= i` predicate) removes the mask input + its upload entirely.
+4. **Single capacity-baked graph** — would collapse the per-S cache to one graph, but needs every symbolic-M kernel to
+   be correct at an oversized (capacity) grid; today several aren't (swizzle decode + staged loads read OOB). Tracked
+   in `plans/serving-dynamic-shape-cuda-graphs.md`.
 
 ## Serving constraints
 
@@ -61,6 +79,10 @@ the integration, not kernel quality. Recorded follow-ups, in impact order:
   the whole engine eager so the runner's own kernel launches can't race a capture.
 - Startup compiles the whole model (~1–2 min for 0.6B warm-cubin-cache; first boot pays nvcc). `DEPLODOCK_CUBIN_CACHE`
   persistence across container restarts is what keeps reboots fast.
+- `DEPLODOCK_SERVING_CAPTURE_CAP` caps the seq_len the shared buffer set is allocated at (default `max_seq_len`). The
+  S²-attention scratch dominates that allocation (0.6B at 4096 ≈ 15 GB), so lower the cap for bigger models / smaller
+  cards — requests above it fall back to the uncaptured rebind path (correct, just slower).
+  `DEPLODOCK_SERVING_NO_GRAPHS=1` forces that uncaptured path for every request (debug / A-B).
 - vLLM's memory profiler only sees torch allocations; the runner's cupy-held weights/activations are invisible to it.
   Leave `--gpu-memory-utilization` headroom accordingly (the attention-free model needs no KV cache, so vLLM's own
   budget is tiny).
@@ -70,5 +92,9 @@ the integration, not kernel quality. Recorded follow-ups, in impact order:
 - `tests/serving/test_packed.py` — pure span-split logic, runs everywhere.
 - `tests/serving/test_vllm_plugin_gpu.py` — `perf`-marked (deselected by default), needs CUDA + vllm: in-process
   `vllm.LLM(runner="pooling", hf_overrides=...)` on Qwen3-Embedding-0.6B, `.embed()` cosine vs the HF eager reference.
+  The three texts have different token counts, so it exercises the per-seq_len captured-graph cache end to end.
+- `tests/compiler/ir/test_dynamic_shapes.py` — the captured-replay primitives directly (RMSNorm + a 1-layer Qwen3
+  trunk through `set_sym_values` + `upload_prefix` + `capture_program_graph` + `replay_program_graph` +
+  `outputs(sym_values)`); run under `compute-sanitizer` in dev to confirm zero illegal accesses.
 - `scripts/compare_embeddings.py` — the accuracy gate against a *server*: embeds a fixed text set through two
   OpenAI-compatible endpoints (deplodock-backed and stock) and asserts pairwise cosine > 0.99.

--- a/deplodock/serving/runner.py
+++ b/deplodock/serving/runner.py
@@ -8,6 +8,15 @@ no lm_head) with a dynamic seq_len, compiles it through the CUDA backend
 launches (``run_once``) — one compiled program serves every request at any
 seq_len ≤ ``DYNAMIC_DIM_MAX``.
 
+Per request it captures (once per distinct seq_len, then replays) a whole-program
+CUDA graph over a single capacity-sized buffer set — one host-side launch instead
+of the ~hundreds the uncaptured ``rebind`` + ``run_once`` loop issues. Each graph
+is captured at its EXACT seq_len, so every kernel runs at its exact grid (no
+oversized-grid masking); the buffers are allocated once at capacity and each
+request's inputs upload into their contiguous prefix. ``DEPLODOCK_SERVING_NO_GRAPHS``
+keeps the uncaptured path; requests above ``DEPLODOCK_SERVING_CAPTURE_CAP`` fall
+back to it too.
+
 No vllm imports here — the class is driven by ``vllm_model.DeplodockEmbedModel``
 but is independently testable with torch + cupy alone.
 """
@@ -42,12 +51,23 @@ def _causal_mask_np(s: int, np_dtype) -> np.ndarray:
 class DeplodockForwardRunner:
     """One compiled dynamic-seq_len trunk + its per-sequence execution."""
 
-    def __init__(self, program: CompiledProgram, input_names: tuple[str, str, str], output_name: str, np_dtype, max_seq_len: int):
+    def __init__(
+        self,
+        program: CompiledProgram,
+        input_names: tuple[str, str, str],
+        output_name: str,
+        np_dtype,
+        max_seq_len: int,
+        capacity: int,
+    ):
         self._program = program
         self._ids_name, self._mask_name, self._pos_name = input_names
         self._output_name = output_name
         self._np_dtype = np_dtype
         self.max_seq_len = max_seq_len
+        # Shared buffer set is sized for this seq_len; requests ≤ capacity use the
+        # captured-graph path, larger ones fall back to uncaptured rebind.
+        self.capacity = capacity
         self._mask_cache: dict[int, np.ndarray] = {}
 
     @classmethod
@@ -55,6 +75,7 @@ class DeplodockForwardRunner:
         import torch
         from transformers import AutoModel
 
+        from deplodock import config
         from deplodock.compiler.backend.cuda.backend import CudaBackend
         from deplodock.compiler.backend.cuda.program import CompiledProgram
         from deplodock.compiler.backend.gpu_lock import gpu_lock
@@ -114,22 +135,34 @@ class DeplodockForwardRunner:
             sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
         const_feed = bind_constants(compiled, sources)
 
+        # Allocate the shared buffer set at capacity so each captured graph
+        # (one per seq_len) replays over the same prefix-occupied buffers. The
+        # S²-scratch at capacity dominates memory; lower the cap for big models /
+        # small cards (requests above it fall back to the uncaptured path).
+        capacity = min(max_seq_len, config.serving_capture_cap(max_seq_len))
         ids_name, mask_name, pos_name = compiled.inputs
         feed = {
-            ids_name: np.zeros((1, _TRACE_SEQ), dtype=np.int64),
-            mask_name: _causal_mask_np(_TRACE_SEQ, np_dtype),
-            pos_name: np.arange(_TRACE_SEQ, dtype=np.int64).reshape(1, _TRACE_SEQ),
+            ids_name: np.zeros((1, capacity), dtype=np.int64),
+            mask_name: _causal_mask_np(capacity, np_dtype),
+            pos_name: np.arange(capacity, dtype=np.int64).reshape(1, capacity),
         }
         with gpu_lock():
             program = CompiledProgram.build(compiled, {**const_feed, **feed})
         del model, wrapper, sources, const_feed
-        logger.info("[serving] ready: %d launches, max_seq_len=%d", len(program.compiled.launches), max_seq_len)
+        logger.info(
+            "[serving] ready: %d launches, max_seq_len=%d, capture capacity=%d%s",
+            len(program.compiled.launches),
+            max_seq_len,
+            capacity,
+            " (graphs off)" if config.serving_no_graphs() else "",
+        )
         return cls(
             program=program,
             input_names=(ids_name, mask_name, pos_name),
             output_name=compiled.outputs[0],
             np_dtype=np_dtype,
             max_seq_len=max_seq_len,
+            capacity=capacity,
         )
 
     @property
@@ -149,7 +182,15 @@ class DeplodockForwardRunner:
 
     def forward_hidden_states(self, token_ids: np.ndarray) -> np.ndarray:
         """Run one sequence: ``token_ids`` shape ``(S,)`` int64, ``S <=
-        max_seq_len``. Returns ``(S, hidden)`` numpy in the traced dtype."""
+        max_seq_len``. Returns ``(S, hidden)`` numpy in the traced dtype.
+
+        Captured-graph path (default, ``S <= capacity``): size the launch grids to
+        S, upload the request's ids / causal mask / position_ids into the shared
+        buffers' prefix, capture-or-reuse the whole-program graph for this S, and
+        replay it — one host launch. Falls back to the uncaptured rebind +
+        run_once loop when ``DEPLODOCK_SERVING_NO_GRAPHS`` is set or ``S`` exceeds
+        the capture capacity (the buffer set was sized for capacity)."""
+        from deplodock import config
         from deplodock.compiler.backend.gpu_lock import gpu_lock
 
         s = int(token_ids.shape[0])
@@ -159,6 +200,12 @@ class DeplodockForwardRunner:
             self._pos_name: np.arange(s, dtype=np.int64).reshape(1, s),
         }
         with gpu_lock():
-            self._program.rebind(feed)
-            self._program.run_once()
-            return self._program.outputs()[self._output_name][0]
+            if config.serving_no_graphs() or s > self.capacity:
+                self._program.rebind(feed)
+                self._program.run_once()
+                return self._program.outputs()[self._output_name][0]
+            self._program.set_sym_values({"seq_len": s})
+            self._program.upload_prefix(feed)
+            self._program.capture_program_graph()
+            self._program.replay_program_graph()
+            return self._program.outputs({"seq_len": s})[self._output_name][0]

--- a/plans/serving-dynamic-shape-cuda-graphs.md
+++ b/plans/serving-dynamic-shape-cuda-graphs.md
@@ -1,128 +1,89 @@
 # Dynamic-shape CUDA graphs for the serving path
 
-## Context
+## Status: shipped as a per-seq_len captured-graph cache (not capacity-baking)
 
-Serving (deplodock/serving) executes the dynamic-seq_len compiled whole model per request via `rebind()` +
-`run_once()` — a 337-launch Python loop plus numpy host I/O. Measured this session at S=32: 13.4 ms GPU (the
-symbolic-kernel quality issue, tracked separately) + ~0.5 ms dispatch + ~0.7 ms host I/O. Once the symbolic kernels
-are fixed (the static graph runs 1.98 ms), the uncaptured loop becomes a ~15 ms wall (337 × ~30 µs dispatch can no
-longer hide behind slow kernels) — CUDA graphs are a precondition for fast serving.
+The original design below (one capacity-baked graph for all seq_lens, device-resident symbolic args) was **abandoned
+during implementation** because its load-bearing premise — "oversized grids are guard-safe for every symbolic lowering
+variant" — is empirically false. The Phase-2 multi-S replay test (the gate the plan itself named for Risk #1) caught it:
+at a capacity-baked grid with a runtime `seq_len < capacity`, multiple symbolic-M kernel classes do illegal global
+reads. Confirmed on the 1-layer Qwen3-Embedding-0.6B trunk under `compute-sanitizer`:
 
-**User decision: no bucketing/padding — true dynamic shapes.** One captured graph must serve any seq_len. The design
-that achieves this (validated against the codebase this session):
+- **CTA-swizzle exact-cover kernels** (`k_linear_sdpa_reduce`, grid `(seq_len, 128)`): the swizzle decode reconstructs
+  `num_m = seq_len` (runtime) while the grid is baked at capacity, so the N-index `a1 = (bid % gsz) / gsize_m` divides
+  by a shrunk `gsize_m` and explodes → OOB read of the weight.
+- **ceil-div masked-M staged-load kernels** (`k_linear_reduce`, grid `(2, ceil_div(seq_len,32), 64)`): after disabling
+  swizzle, a vectorized (16-byte) staged global load over-reads at the oversized grid even with the output guard.
 
-- **Grids bake at a capacity size** (`ceil-div(S_cap)`), and the existing masked-tile guards (`if (coord < seq_len)`)
-  deactivate excess blocks at runtime. Guard audit says oversized grids are safe for every symbolic lowering variant:
-  masked tiles guard symbolic output axes (`lowering/tile/010_partition_loops.py:983-997`), hoisted staged loads are
-  Cond-wrapped (`021_hoist_staged_loads_above_mask.py`), split-K atomics are row-disjoint with zero-fill
-  (`lowering/cuda/010_lower_kernelop.py:57-79`), and no address math uses gridDim. Garbage in rows ≥ real S stays
-  within capacity allocations and is sliced off.
-- **`seq_len` moves from a by-value `int` kernel arg (frozen by capture) to device memory**: kernels take
-  `const int* sym_vals` and load `const int seq_len = sym_vals[i];` in a prologue. The pointer is baked into the
-  graph; the *content* changes per request. Serial loop bounds, masked guards, and S-dependent address math
-  (`row * (seq_len*128)`) all use the loaded value, so one graph computes the exact real-S result — numerics identical
-  to today's uncaptured path, no padding compute.
-- **Prefix-occupancy** (verified: inner strides are static, only the symbolic axis multiplies the runtime value): a
-  logically `(1,S,16,128)` tensor occupies the first `S*16*128` elements of a capacity allocation, so all replays
-  share ONE capacity-sized buffer set. Caveat found in review: this holds for buffers *written at the current S*, and
-  for 1-D-symbolic inputs (`input_ids`, `position_ids` — `arange(S_cap)` prefix ≡ `arange(S)`), but NOT for the 2-D
-  causal mask (layout `i*S + j` depends on S) — the mask is therefore **generated on-device inside the captured
-  graph** by a small helper kernel, which also deletes its 32 MB-at-4096 host upload.
-- TMA is a non-issue: the lowering rejects TMA on any graph with symbolic dims (`lowering/tile/050_use_tma.py:151`).
+Making *every* symbolic-M kernel correct at an oversized grid (capacity-consistent swizzle decode + guards on all staged
+loads, audited across all classes) is open-ended compiler work across several lowering passes. **User decision (this
+session): ship the per-seq_len captured-graph cache instead** — it reaches the same real goal (captured serving, exact
+per-S compute, no padding, one shared buffer set) with zero compiler changes and is `compute-sanitizer`-clean.
 
-Per-request hot path becomes: write real S into the device sym buffer (tiny H2D) → upload ids prefix → `graph.launch()`
-→ prefix D2H of hidden states. Single-digit host calls instead of ~350.
+## What shipped
 
-## Phase 1 — codegen: device-resident symbolic args (opt-in)
+**One captured graph per distinct seq_len, over a single capacity-sized buffer set.** Each graph is captured at its
+EXACT S, so every kernel runs at its exact grid — the oversized-grid problem never arises. Buffers are allocated once at
+capacity and each request's inputs upload into their contiguous prefix (prefix occupancy: a logically `(1,S,…)` tensor
+is the first `S·…` elements of the `(1,S_cap,…)` allocation; verified for ids/position_ids and, since the attention
+kernels stride the mask by the per-graph `seq_len`, for the `(1,1,S,S)` causal mask too). A repeated length replays with
+no re-capture; a new length pays one capture (~one forward). Per-request host calls drop from ~hundreds to single
+digits.
 
-**Flag carrier.** A compile-mode flag `sym_args_device` reaching the CUDA lowering. Preferred: a field on `Context`
-(`compiler/context.py:91`), threaded from `CudaBackend` (check where `Pipeline.run` builds the Context; if the backend
-can't inject Context fields cleanly, fall back to a non-tunable env knob via `deplodock/config.py` — it must NOT enter
-the tune fork space). Kernel source changes under the flag, so cubin/perf cache keys split naturally; tune/run keep
-the by-value path, zero behavior change with the flag off.
+`CompiledProgram` (`backend/cuda/program.py`) gained:
+- `set_sym_values(values)` — set the host symbolic values that resolve launch grids + by-value `seq_len`, WITHOUT
+  re-allocating buffers (errors if the value exceeds capacity).
+- `capture_program_graph()` — now captures at the current `self.sym_values` and **caches by the resolved symbolic
+  tuple** (`_graph_cache`, bounded LRU `_graph_cache_max=64`); the static-shape bench path keeps using the single `()`
+  key, unchanged. `rebind` clears the cache on re-allocation.
+- `replay_program_graph()` — one `self._e2e_graph.launch()` on the default stream.
+- `upload_prefix(input_data)` — H2D each host array into its capacity buffer's contiguous prefix (no realloc → captured
+  pointers stay valid).
+- `outputs(sym_values=None)` — with the override, slice each output to its real-S prefix before `.get()`.
 
-**Lowering** (`pipeline/passes/lowering/cuda/010_lower_kernelop.py`, `_launch_geometry` at :83):
-- `CudaOp` (`ir/cuda/ir.py`) gains `sym_args_device: bool = False` (and keeps `runtime_args` name order).
-- Global index per symbolic name = position in `sorted(all symbolic axis names of the graph)` (one name — `seq_len` —
-  in serving, but keep general). Stamp the per-kernel `runtime_args` with their global indices (e.g. a parallel
-  `runtime_arg_idx: tuple[int, ...]` field).
+Serving runner (`serving/runner.py`):
+- `create()` builds the program over a capacity-sized buffer set
+  (`capacity = min(max_seq_len, DEPLODOCK_SERVING_CAPTURE_CAP)`).
+- `forward_hidden_states(token_ids)`: `set_sym_values({"seq_len": S})` → `upload_prefix({ids, host causal mask,
+  position_ids})` → `capture_program_graph()` (cached) → `replay_program_graph()` → `outputs({"seq_len": S})[name][0]`.
+  Falls back to the uncaptured `rebind` + `run_once` path when `DEPLODOCK_SERVING_NO_GRAPHS=1` or `S > capacity`.
 
-**Render** (`ir/kernel/render.py:311`): under the flag, replace `int <name>` params with one `const int* sym_vals`
-param + prologue `const int <name> = sym_vals[<global idx>];` per runtime arg.
+Config (`config.py`): `DEPLODOCK_SERVING_CAPTURE_CAP` (buffer-allocation cap, default `max_seq_len`) and
+`DEPLODOCK_SERVING_NO_GRAPHS` (kill switch). No codegen flag, no device-resident symbolic args, no compiler-pass changes
+(the Phase-1 device-sym-args codegen was prototyped, proven unnecessary under per-S capture, and reverted).
 
-**Launch packing** (`backend/cuda/program.py::_launch` :344-348): when `launch.sym_args_device`, append the program's
-shared device sym array (stable pointer) instead of by-value ints. `CompiledProgram.build` allocates
-`self._sym_dev: cp.ndarray int32` sized to the global name list and writes the build-time `sym_values`; new method
-`set_sym_values(dict)` updates its contents (tiny H2D, never re-allocates). The uncaptured paths (`run_once`,
-`iter_once`) work unchanged in this mode — they just read the device value the caller set.
+Tests: `tests/compiler/ir/test_dynamic_shapes.py` — RMSNorm at capacity 64 and a 1-layer Qwen3 trunk, each served at
+several seq_lens through the cache (capture → replay → slice) vs torch eager, asserting one cached graph per distinct S;
+`compute-sanitizer`-clean. The existing `tests/serving/test_vllm_plugin_gpu.py` (3 texts of differing lengths) exercises
+the cache end-to-end through vLLM.
 
-Tests (CUDA): compile the small dynamic elementwise/RMSNorm graphs from `tests/compiler/ir/test_dynamic_shapes.py`
-with the flag — assert `const int* sym_vals` in the kernel source, run at multiple S via `set_sym_values` +
-`run_once`, match numpy; flag-off graphs byte-identical to today.
+Docs: `compiler/backend/cuda/ARCHITECTURE.md` (captured-graph-replay section), `serving/ARCHITECTURE.md` (execution
+model v2 + capacity/cap env + follow-ups), `CLAUDE.md` env-var list.
 
-## Phase 2 — CompiledProgram: capture/replay at capacity
+## Costs / follow-ups
 
-(`backend/cuda/program.py`, beside the existing `capture_program_graph` — reuse its side-stream + drain-on-error +
-throwaway-instantiation pattern.)
+1. **Host causal-mask upload** per request (`(1,1,S,S)`, ~32 MB fp16 at S=4096) — a device-side mask-gen kernel (or an
+   in-kernel `j <= i` predicate) removes the mask input + upload. Already listed in `serving/ARCHITECTURE.md`.
+2. **Capacity memory** — the S² attention scratch at the default cap; `DEPLODOCK_SERVING_CAPTURE_CAP` lowers it, with
+   graceful fallback above the cap.
+3. **Many distinct lengths** — N graphs (cheap: launch nodes only, buffers shared) + a re-capture per new length, LRU-
+   bounded. Worst case (all-unique lengths) degrades to ~the uncaptured cost on each first sight.
+4. **Single capacity-baked graph** — the original ambition; needs every symbolic-M kernel oversized-grid-safe (see the
+   `compute-sanitizer` findings above). Deferred.
 
-- `capture_program_graph(sym_values=None, pre_launch=None)`: extend the existing method — optional `sym_values`
-  override resolves grids at capacity for the capture (host-side `resolve_dim`, verified deterministic, no host
-  branching inside the window); optional `pre_launch(stream)` callable captured FIRST (the runner's mask-gen kernel).
-  Reject (clear error) if any `buf.resolve_shape(sym_values)` exceeds the allocated array sizes.
-- `replay_program_graph()`: `self._e2e_graph.launch()` (the bench-only `time_program_window` keeps its own path).
-- `upload_prefix(input_data)`: H2D into each buffer's contiguous prefix (`arr.ravel()[:n].set(host)`) — no realloc, no
-  graph invalidation; error if larger than capacity.
-- `outputs(sym_values=None)`: with the override, slice each output to `buf.resolve_shape(sym_values)` prefix
-  (flat-slice then reshape) before `.get()`.
-- `rebind` already drops `_e2e_graph` on realloc — that is the capacity-growth path (grow → lazy re-capture); keep.
-- Note in docstrings: zero-fill of `zero_outputs` is captured as a full-capacity memset per replay — correct (split-K
-  atomics need it), mildly wasteful, acceptable.
+---
 
-Tests (CUDA): build the flag-compiled RMSNorm graph at capacity 64; capture once; for S ∈ {5, 12, 33, 64}:
-`set_sym_values` + `upload_prefix` + `replay_program_graph` + `outputs({"seq_len": S})` vs numpy. Then a 1-layer
-random-weight Qwen3 trunk (mirror `test_qwen_whole_model_dynamic_compiles_and_matches_eager`) through the same
-captured path — validates the attention/mask/oversized-grid story end to end with non-zero ids.
+## Original design (NOT shipped — kept for context)
 
-## Phase 3 — serving runner integration
+The text below is the pre-implementation plan for the single capacity-baked graph + device-resident symbolic args. It is
+retained only to record the rejected approach and why; see "Status" above for what actually landed.
 
-(`deplodock/serving/runner.py`)
+**User decision: no bucketing/padding — true dynamic shapes.** One captured graph must serve any seq_len:
 
-- `create()` compiles with `sym_args_device=True` and builds the program at **capacity** =
-  `min(max_seq_len, DEPLODOCK_SERVING_CAPTURE_CAP)` (new env via `config.py`, default = max_seq_len). Memory note: the
-  S² attention-score scratch dominates (0.6B at 4096 ≈ 15 GB — fits the 32 GB 5090; document lowering the cap for
-  bigger models/smaller cards). Requests above capacity (only possible when the cap was lowered) fall back to the
-  existing `rebind` + `run_once` path — which drops the graph; re-capture lazily on the next in-cap request.
-- **Device mask-gen kernel**: a small cupy RawKernel owned by the runner (`mask[i*S + j] = (j > i) ? -inf : 0` for
-  `i,j < S`, grid at capacity ceil-div, guarded, dtype-matched) — captured via `pre_launch` so every replay rebuilds
-  the mask at the current S. `position_ids` uploads once at capacity (`arange` prefix property); the per-request host
-  traffic is ids in (≤ 32 KB) and hidden-states prefix out.
-- `forward_hidden_states`: `set_sym_values({"seq_len": S})` → `upload_prefix({ids})` → `replay_program_graph()` →
-  `outputs({"seq_len": S})[0]`. Kill switch `DEPLODOCK_SERVING_NO_GRAPHS=1` keeps the current rebind+run_once path for
-  debugging (also exercised by the fallback test).
-- `vllm_model.py` unchanged.
-
-## Phase 4 — validation, docs
-
-- GPU integration test (perf-marked, beside `tests/serving/test_vllm_plugin_gpu.py`): in-process `vllm.LLM` embed with
-  texts of widely differing lengths, cosine > 0.99 vs HF eager — exercises mixed seq_lens through one captured graph.
-- Live A/B on this box (RTX 5090): `deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --max-concurrency 1` before vs
-  after — expect ~14.6 → ~13.7 ms now (graphs remove dispatch+I/O; GPU time unchanged until the symbolic-kernel fix),
-  and re-run the direct probe (serving path vs captured window) to confirm the shim is gone (<0.2 ms gap).
-- Accuracy gate: `scripts/compare_embeddings.py` vs stock vLLM unchanged (> 0.99).
-- Docs: `compiler/backend/cuda/ARCHITECTURE.md` (device-sym-args mode + capture-at-capacity semantics),
-  `serving/ARCHITECTURE.md` (execution model rewrite: graph replay, mask-gen kernel, capacity/cap env, updated
-  follow-ups list), `CLAUDE.md` env-var list (`DEPLODOCK_SERVING_CAPTURE_CAP`, `DEPLODOCK_SERVING_NO_GRAPHS`),
-  `tests/ARCHITECTURE.md`.
-- `make test`, `make lint`; commit on the existing `feature/vllm-embedding-plugin` branch (or a follow-up branch off
-  it if the PR should stay reviewable — decide at commit time based on PR review state).
-
-## Risks
-
-1. **Guard coverage** — the audit says every symbolic lowering variant is oversized-grid-safe, but the multi-S
-   replay tests (Phase 2/4) are the real gate; any unguarded kernel shows up as a numeric mismatch at small S.
-2. **Capacity memory** — S² scratch at the default cap; documented env to lower it, with graceful fallback.
-3. **First-request capture latency** — one capture + instantiation (~one forward) on the first request; acceptable,
-   noted in docs (could pre-capture at startup later).
-4. **Pointer-load overhead** — one extra global load per kernel; unmeasurable against µs-scale kernels.
-5. **GPU time unchanged for now** — 13.4 ms of degenerate symbolic kernels remains; this work removes the shim and
-   unblocks the kernel fix from being masked by dispatch. Tracked separately.
+- **Grids bake at a capacity size** (`ceil-div(S_cap)`), masked-tile guards deactivate excess blocks. *(False premise —
+  see Status: several symbolic-M kernels are not oversized-grid-safe.)*
+- **`seq_len` moves to device memory** (`const int* sym_vals`), so the captured graph's content changes per request.
+  *(Prototyped + reverted: with a per-S graph each kernel bakes its own by-value `seq_len`, so device-resident args add
+  nothing.)*
+- **Prefix-occupancy** for shared capacity buffers, with the 2-D causal mask generated on-device. *(Prefix occupancy
+  kept; on-device mask-gen deferred to follow-up #1 — the host upload is correct and simpler for the first cut.)*
+- TMA is rejected on symbolic-dim graphs (`lowering/tile/050_use_tma.py:152-157`), so it was never a concern.

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -61,7 +61,7 @@ tests/
 │   │   ├── test_loop_op.py                     # LoopOp SSA body (Loop/Assign/Accum/…)
 │   │   ├── test_shape_inference.py             # infer_output_shape (static + Dim symbolic)
 │   │   ├── test_provenance.py                  # provenance data model + propagation
-│   │   ├── test_dynamic_shapes.py              # Dim round-trips through trace/lift/LoopOp
+│   │   ├── test_dynamic_shapes.py              # Dim round-trips trace/lift/LoopOp + per-seq_len captured-graph replay
 │   │   ├── test_real_trace.py                  # TinyLlama fixture sanity (op-type counts)
 │   │   ├── test_body_deps.py / test_op_shape_invariants.py / …
 │   │   ├── stmt/   — SSA-body unit tests (hoist / merge / rename / structural_key)

--- a/tests/compiler/ir/test_dynamic_shapes.py
+++ b/tests/compiler/ir/test_dynamic_shapes.py
@@ -502,3 +502,116 @@ def test_qwen_whole_model_dynamic_traces():
         node = inputs_by_name.get(name)
         assert node is not None, f"missing graph input {name!r}; got {list(inputs_by_name)}"
         assert Dim("seq_len") in node.output.shape, f"{name} shape {node.output.shape} missing Dim('seq_len')"
+
+
+# ---------------------------------------------------------------------------
+# Captured-CUDA-graph serving path: one captured whole-program graph per
+# seq_len over a shared capacity-sized buffer set (CompiledProgram
+# set_sym_values + upload_prefix + capture_program_graph[cached] +
+# replay_program_graph + outputs(sym_values)). Each graph is captured at its
+# EXACT seq_len, so every kernel runs at its exact grid — no oversized-grid
+# guard story needed. Plan: plans/serving-dynamic-shape-cuda-graphs.md.
+# ---------------------------------------------------------------------------
+
+
+def test_capture_replay_cache_rmsnorm_over_capacity_buffers():
+    """RMSNorm built once at capacity 64; serve S ∈ {5,12,33,64,12} through the
+    per-seq_len graph cache — capture lazily, replay at each S, slice the output
+    to the real shape, match torch eager. Repeats hit the cache (no re-capture)."""
+    pytest = __import__("pytest")
+    pytest.importorskip("cupy")
+    import torch
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.trace.torch import trace_module
+
+    cap = 64
+    m = torch.nn.RMSNorm(2048)
+    compiled = CudaBackend().compile(trace_module(m, (torch.randn(1, 32, 2048),), dynamic_shapes={"x": {1: _seq_len_dim()}}))
+    weight = m.weight.detach().numpy().astype(np.float32)
+    out_name = compiled.outputs[0]
+
+    def x_at(s: int) -> np.ndarray:
+        return np.random.RandomState(s).standard_normal((1, s, 2048)).astype(np.float32)
+
+    with gpu_lock():
+        prog = CompiledProgram.build(compiled, {"x": x_at(cap), "p_weight": weight})
+        for s in (5, 12, 33, 64, 12):
+            x = x_at(s)
+            prog.set_sym_values({"seq_len": s})
+            prog.upload_prefix({"x": x})
+            prog.capture_program_graph()
+            prog.replay_program_graph()
+            out = prog.outputs({"seq_len": s})[out_name]
+            with torch.no_grad():
+                ref = torch.nn.functional.rms_norm(torch.from_numpy(x), (2048,), m.weight, eps=m.eps).numpy()
+            assert out.shape == (1, s, 2048)
+            np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+        assert set(k[0][1] for k in prog._graph_cache) == {5, 12, 33, 64}, "expected one cached graph per distinct seq_len"
+
+
+def test_qwen_whole_model_capture_replay_cache_matches_eager():
+    """1-layer random-weight Qwen3 trunk through the captured-graph serving path:
+    build once at capacity, serve several seq_lens via the per-S graph cache
+    (capture at exact S, replay, slice), compare against torch eager with NON-ZERO
+    ids. End-to-end gate for the attention / mask / shared-capacity-buffer story.
+    Run under compute-sanitizer in dev to confirm zero illegal accesses."""
+    pytest = __import__("pytest")
+    pytest.importorskip("cupy")
+    import torch
+    from transformers import AutoConfig, AutoModel
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.loader.binder import bind_constants
+    from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+    from deplodock.compiler.trace.torch import trace_module
+
+    torch.manual_seed(0)
+    config = from_pretrained_or_skip(AutoConfig.from_pretrained, "Qwen/Qwen3-Embedding-0.6B")
+    config.num_hidden_layers = 1
+    model = AutoModel.from_config(config).float().eval()
+
+    hint, cap, dtype = 32, 64, torch.float32
+    wrapper = build_full_model_wrapper(model, hint, dtype, dynamic=True)
+    seq_dim = _seq_len_dim(min=1)
+    graph = trace_module(
+        wrapper,
+        (torch.zeros((1, hint), dtype=torch.long), build_causal_mask(hint, dtype), torch.arange(hint).unsqueeze(0)),
+        dynamic_shapes={"input_ids": {1: seq_dim}, "attention_mask": {2: seq_dim, 3: seq_dim}, "position_ids": {1: seq_dim}},
+    )
+    compiled = CudaBackend().compile(graph)
+
+    sources: dict[str, np.ndarray] = {}
+    for path, t in wrapper.named_parameters(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    for path, t in wrapper.named_buffers(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    const_feed = bind_constants(compiled, sources)
+    ids_name, mask_name, pos_name = compiled.inputs
+    out_name = compiled.outputs[0]
+
+    def feed(s: int) -> dict[str, np.ndarray]:
+        ids = (np.arange(s, dtype=np.int64).reshape(1, s) * 97) % config.vocab_size
+        return {
+            ids_name: ids,
+            mask_name: build_causal_mask(s, dtype).numpy(),
+            pos_name: np.arange(s, dtype=np.int64).reshape(1, s),
+        }
+
+    with gpu_lock():
+        prog = CompiledProgram.build(compiled, {**const_feed, **feed(cap)})
+        for s in (5, 17, 64, 17):
+            fd = feed(s)
+            prog.set_sym_values({"seq_len": s})
+            prog.upload_prefix(fd)
+            prog.capture_program_graph()
+            prog.replay_program_graph()
+            out = prog.outputs({"seq_len": s})[out_name]
+            with torch.no_grad():
+                ref = wrapper(torch.from_numpy(fd[ids_name]), build_causal_mask(s, dtype), torch.arange(s).unsqueeze(0)).numpy()
+            assert out.shape == ref.shape
+            np.testing.assert_allclose(out, ref, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## What

Serve each embedding request as a **captured whole-program CUDA graph** replayed over one capacity-sized buffer set,
instead of the uncaptured `rebind` + `run_once` loop (~hundreds of host launches per request). One graph is cached per
distinct `seq_len` (bounded LRU); each is captured at its **exact** seq_len, so every kernel runs at its exact grid.

## Why per-seq_len, not one capacity-baked graph

The original plan (`plans/serving-dynamic-shape-cuda-graphs.md`) aimed for a single graph baked at a capacity grid,
relying on the premise that oversized grids are guard-safe for every symbolic-M kernel. **That premise is empirically
false** — the Phase-2 multi-S replay test (the plan's own gate for this risk) caught it. Under `compute-sanitizer` on a
1-layer Qwen3-Embedding trunk, an oversized (capacity) grid makes multiple kernel classes read OOB:

- **CTA-swizzle exact-cover** (`k_linear_sdpa_reduce`): the swizzle decode reconstructs `num_m` from the runtime
  `seq_len` while the grid is baked at capacity → the N-index explodes → OOB weight read.
- **ceil-div masked-M staged loads** (`k_linear_reduce`): a vectorized staged global load over-reads at the oversized
  grid even with the output guard.

Making every symbolic-M kernel oversized-grid-safe is open-ended compiler work across several passes. Per-exact-seq_len
capture sidesteps all of it with **zero compiler changes** and is `compute-sanitizer`-clean. (The Phase-1
device-resident-symbolic-args codegen was prototyped, proven unnecessary under per-S capture, and reverted — no
changes to any lowering pass.)

## Changes

- **`backend/cuda/program.py`** (`CompiledProgram`): `set_sym_values` (size grids + by-value seq_len without realloc),
  `capture_program_graph` now caches by the resolved symbolic tuple (LRU; the static bench path keeps the single `()`
  key, unchanged), `replay_program_graph`, `upload_prefix` (prefix H2D), `outputs(sym_values)` prefix-slicing. `rebind`
  clears the cache on realloc.
- **`serving/runner.py`**: build over a capacity buffer set (`min(max_seq_len, DEPLODOCK_SERVING_CAPTURE_CAP)`); per
  request `set_sym_values` → `upload_prefix` → `capture_program_graph` (cached) → `replay_program_graph` →
  `outputs(sym_values)`. `DEPLODOCK_SERVING_NO_GRAPHS` and above-capacity requests fall back to the uncaptured path.
- **`config.py`**: `DEPLODOCK_SERVING_CAPTURE_CAP`, `DEPLODOCK_SERVING_NO_GRAPHS`.
- Docs: cuda + serving `ARCHITECTURE.md`, `CLAUDE.md` env list, `tests/ARCHITECTURE.md`, plan rewritten to record the
  finding.

## Testing

- `tests/compiler/ir/test_dynamic_shapes.py`: per-seq_len capture/replay of RMSNorm + a 1-layer Qwen3 trunk vs torch
  eager (non-zero ids); validated `compute-sanitizer`-clean in dev.
- `tests/serving/test_vllm_plugin_gpu.py` (perf): in-process vLLM embed, 3 differing-length texts → mixed-seq_len cache
  end-to-end, cosine > 0.99 vs HF eager — **passes**.
- `make test`: **2034 passed, 32 skipped**. `make lint`: clean.

## Perf note

Measured A/B (`forward_hidden_states`, graphs on vs off) is ~flat today: per-request time is dominated by GPU kernel
time (0.6B at S=32 ≈ 32 ms), and the uncaptured `run_once` loop already async-queues launches so the Python dispatch
overlaps GPU execution and stays hidden while the symbolic kernels are slow. This is the precondition infra; the win
materializes once the symbolic-kernel quality issue (tracked separately) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)