### PR TITLE
Enable TMA on the dynamic path + per-variant tune containment (Qwen3-Embedding layer-0 findings)

### DIFF
--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -381,14 +381,24 @@ def _collapse_inert_dims(arr_shape: tuple[int, ...], box_extents: tuple[int, ...
     box_rev = list(reversed(box_extents))
     if len(box_rev) == len(arr_rev) + 1 and arr_rev and box_rev[0] != 0 and arr_rev[0] % box_rev[0] == 0:
         arr_rev = [box_rev[0], arr_rev[0] // box_rev[0], *arr_rev[1:]]
+    # Drop exactly ``arr_rank - box_rank`` inert gap singletons — no more. A
+    # *box-carrying* dim can be a runtime-extent-1 (or any extent < its box):
+    # a masked dynamic axis (e.g. ``seq_len`` = 1, 31) is legitimately small,
+    # and TMA zero-fills the overhang where the box exceeds globalDim. The old
+    # "drop every extent-1 aligned with box>1" rule mis-dropped that masked dim
+    # whenever its runtime extent hit 1, then failed the rank match (seq_len=1
+    # → ``arr=(1, 512)`` vs ``box=(64, 32)``). Shedding only the surplus dims
+    # keeps the genuine inner gap-singleton drop (arr_rank > box_rank) intact.
+    n_drop = len(arr_rev) - len(box_rev)
     kept: list[int] = []
     bi = 0
     for a in arr_rev:
-        if bi < len(box_rev) and a == 1 and box_rev[bi] != 1:
+        if n_drop > 0 and a == 1 and bi < len(box_rev) and box_rev[bi] != 1:
+            n_drop -= 1
             continue  # dropped gap singleton
         kept.append(a)
         bi += 1
-    if bi != len(box_rev) or len(kept) != len(box_rev):
+    if n_drop != 0 or len(kept) != len(box_rev):
         raise ValueError(f"TMA descriptor rank mismatch: arr_shape={arr_shape!r} cannot be collapsed to match box_extents={box_extents!r}")
     return tuple(reversed(kept))
 

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -366,6 +366,15 @@ of letting it leak to `CudaBackend` as a cryptic `non-CudaOp` `TypeError`. The
 sink is absent under `tune`, so the fork-pruning path stays silent and a
 validate-dropped branch is a graceful dead end.
 
+A rewrite that *raises* mid-lowering (a deterministic lowering pass hitting an un-lowerable shape it can't
+represent — e.g. `100_materialize_tile`'s single-Write hoisted-compute materializer on a sibling-cell-fused slab,
+which raises `LoweringError` from `_stage_expand.compute_phase_info`) is the same kind of dead end, but for an
+*exception* rather than a validate-filter. Greedy `resolve` lets it propagate loudly; under `tune`, `Run.drive`
+catches it per-candidate, drops that candidate's subtree (the `pop()` already decremented its `live` count, so this
+is bookkeeping-identical to a dead-end terminal), logs `[tune] dropped un-lowerable candidate (…)`, and bumps
+`Run._dropped_candidates` (reported in the terminal-count line). Without this, one search-only un-lowerable fork
+aborted the whole tune.
+
 Files starting with `_` (e.g. `_broadcast.py`) are **not** loaded as
 rules — they're shared helpers for the pass's rule modules.
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/_stage_expand.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/_stage_expand.py
@@ -395,6 +395,26 @@ def compute_phase_info(compute, sources):  # noqa: ANN001 — Body, tuple[Source
     for src in sources:
         for ax in src.cache_axes:
             axis_map[ax.name] = ax
+    # Each index entry must be a bare ``Var`` naming one of the sibling cone's
+    # cache axes. A sibling-cell fusion (``012_fuse_sibling_register_cells``)
+    # can σ-collapse a cache-axis ``Var`` to a constant ``Literal`` in this
+    # self-describing Write (the compute body is exposed via
+    # ``StageBundle.nested()``, so generic index substitution reaches it) —
+    # the slab is then co-filled by N sibling bundles, each writing one pinned
+    # cell. The hoisted-compute materializer derives ONE iteration domain /
+    # slab shape from a single Write, so it can't represent that multi-bundle
+    # fill; flag it as un-lowerable. Under ``tune`` this prunes the offending
+    # search branch (``Run.drive`` containment); the deployable greedy pick
+    # never reaches this fork.
+    bad = [v for v in write.index if not (isinstance(v, Var) and v.name in axis_map)]
+    if bad:
+        from deplodock.compiler.pipeline.pipeline import LoweringError  # noqa: PLC0415
+
+        raise LoweringError(
+            f"compute phase {write.output!r}: hoisted-compute Write index {write.index!r} has non-cache-axis "
+            f"entr{'ies' if len(bad) > 1 else 'y'} {bad!r} (axes {tuple(axis_map)!r}) — a sibling-cell-fused "
+            f"slab fill the single-Write materializer can't represent"
+        )
     cache_axes = tuple(axis_map[v.name] for v in write.index)
     if not cache_axes:
         raise ValueError(f"compute phase {write.output!r}: needs at least one cache axis")

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -125,13 +125,13 @@ import enum
 from dataclasses import dataclass, replace
 
 from deplodock.compiler.context import Context
-from deplodock.compiler.dtype import F16
+from deplodock.compiler.dtype import F16, F32
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.axis import Axis
-from deplodock.compiler.ir.expr import BinaryExpr, Literal, SimplifyCtx, Var
+from deplodock.compiler.ir.expr import BinaryExpr, Literal, SimplifyCtx, TernaryExpr, Var
 from deplodock.compiler.ir.loop import LoopOp
 from deplodock.compiler.ir.sigma import Sigma
-from deplodock.compiler.ir.stmt import Accum, Body, Cond, Load, Loop, Stmt, StridedLoop, Write
+from deplodock.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
 from deplodock.compiler.ir.tile.ir import (
     ATOM_REGISTRY,
     Atom,
@@ -524,6 +524,15 @@ def _is_fp16_matmul(matmul_reduces: list, graph: Graph | None) -> bool:
     return True
 
 
+def _coop_reduce_ext(ext) -> int:
+    """Cooperative-reduce eligibility extent: the static reduce extent, or the
+    ``Dim`` hint for a SYMBOLIC reduce axis (the masked cooperative reduce —
+    tiled at the hint, ceil-div ``K_o``, with the partial last tile boundary-
+    masked to the Accum identity). ``0`` when symbolic with no hint, so the
+    ``>= warp_size`` gate falls through to the pointwise path."""
+    return ext.as_static() if ext.is_static else (ext.hint or 0)
+
+
 def _plan_kernel(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "", graph: Graph | None = None) -> _Plan | None:
     """Unified σ-split planning for matmul, pointwise, and cooperative-reduce
     kernels. Returns a :class:`_Plan` whose ``params`` enumerates every
@@ -752,7 +761,7 @@ def _plan_kernel(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "", graph:
                     param_combos = warp_combos
                 else:
                     param_combos = [*warp_combos, *param_combos]
-    elif nonmatmul_reduces and nonmatmul_reduces[0].axis.extent.is_static and nonmatmul_reduces[0].axis.extent.as_static() >= ctx.warp_size:
+    elif nonmatmul_reduces and _coop_reduce_ext(nonmatmul_reduces[0].axis.extent) >= ctx.warp_size:
         # Cooperative-K: with BN=BM=1 the combine spans the whole CTA (any
         # BR); with free-axis threads alongside (BN·BM > 1, the strided-
         # cooperative form) the enumerator clips BR to powers of two ≤
@@ -772,13 +781,29 @@ def _plan_kernel(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "", graph:
         # using its own (half-data) reduction. Forcing SPLITK=1 keeps the
         # search space honest.
         k_loop = nonmatmul_reduces[0]
-        E_K = k_loop.axis.extent.as_static()
+        k_red_symbolic = not k_loop.axis.extent.is_static
+        E_K = _coop_reduce_ext(k_loop.axis.extent)  # static extent, or the Dim hint for a symbolic reduce
         # ``is_static`` guards the ``as_static()`` read: a symbolic free Loop
         # in the body (e.g. a split producer's row sweep next to a static
-        # row-stat reduce) is never a K-target, not a crash.
-        target_names = frozenset(
-            lp.axis.name for lp in all_loops if lp.axis.extent.is_static and lp.axis.extent.as_static() == E_K and not is_matmul_reduce(lp)
-        )
+        # row-stat reduce) is never a K-target, not a crash. For a SYMBOLIC
+        # reduce axis (masked cooperative reduce) the K-targets are the loops
+        # sharing that symbolic extent — matched by ``Dim`` identity, not a
+        # static value.
+        if k_red_symbolic:
+            target_names = frozenset(lp.axis.name for lp in all_loops if lp.axis.extent == k_loop.axis.extent and not is_matmul_reduce(lp))
+        else:
+            target_names = frozenset(
+                lp.axis.name
+                for lp in all_loops
+                if lp.axis.extent.is_static and lp.axis.extent.as_static() == E_K and not is_matmul_reduce(lp)
+            )
+        # NOTE: this is the symbolic-*free*-axis case. A symbolic *reduce* axis
+        # (the softmax-producer key sweep) is now handled above — ``_coop_reduce_ext``
+        # gates it in at the Dim hint, the K_o ceil-divs the symbolic extent, and
+        # ``_mask_reduce_accums`` masks the partial last tile (clamp the K read,
+        # fold the Accum identity past seq_len) WITHOUT wrapping the Accum in a
+        # Cond, so ``is_reduce`` + the cross-thread combine stay intact.
+        #
         # A SYMBOLIC free axis stays degenerate (E=1, no forced mask): bound
         # whole-to-grid, correct at any seq_len. A masked register-tile
         # (FN>1) would wrap the reduce body in the boundary Cond and hide it
@@ -1002,17 +1027,32 @@ def _build_split_body(shape: KernelShape, params: dict) -> tuple[Stmt, ...]:
     # ``kernel/075_pack_fk_window`` off the stamped ``FK`` knob. Only the reduce
     # strip-mine consumes ``fk`` in the factorization / K_f tile below.
     fk = 1 if "FKWIN" in params else params["FK"]
+    k_masked = False
+    k_bound: object = None
     if shape.k_loop is not None:
         K_axis = shape.k_loop.axis
         K_name = K_axis.name
         K_src = K_axis.source_axis or K_axis
+        k_div = params["SPLITK"] * params["BR"] * params["BK"] * fk
         if K_axis.extent.is_static:
             E_K = K_axis.extent.as_static()
-            K_o_ext = E_K // (params["SPLITK"] * params["BR"] * params["BK"] * fk)
+            K_o_ext = E_K // k_div
+        elif k_div > 1:
+            # Masked cooperative reduce over a SYMBOLIC K: tile at the hint and
+            # ceil-div the symbolic extent so ``K_o`` covers the partial last
+            # tile at any runtime size. The final tile overruns the runtime
+            # extent, so the reduce body is wrapped in ``Cond(decoded_K <
+            # seq_len)`` (in ``_replace_k_loops``) — an overhang K step just
+            # skips (no spurious fold, no OOB read/write). ``Dim`` arithmetic
+            # builds the composite ceil-div Expr; the launch resolver evals it
+            # from sym_values (mirrors the masked block-axis ceil-div).
+            K_o_ext = (K_axis.extent + (k_div - 1)) // k_div
+            k_masked = True
+            k_bound = K_axis.extent.expr
         else:
-            # Symbolic K (params["BK"]=splitk=br=fk=1 by planner construction): whole
-            # axis stays as one serial K_o iteration. ``Axis.__post_init__``
-            # coerces the ``Dim`` straight back into the K_o axis.
+            # Symbolic K, serial (BR=BK=SPLITK=fk=1): whole axis stays as one
+            # serial K_o iteration. ``Axis.__post_init__`` coerces the ``Dim``
+            # straight back into the K_o axis.
             K_o_ext = K_axis.extent
         K_s = Axis(f"{K_name}_s", params["SPLITK"], source_axis=K_src) if params["SPLITK"] > 1 else None
         K_c = Axis(f"{K_name}_c", params["BR"], source_axis=K_src) if params["BR"] > 1 else None
@@ -1035,6 +1075,8 @@ def _build_split_body(shape: KernelShape, params: dict) -> tuple[Stmt, ...]:
             bk=params["BK"],
             fk=fk,
             K_o_ext=K_o_ext,
+            k_masked=k_masked,
+            k_bound=k_bound,
         )
         if n_replaced == 0:
             raise RuleSkipped("K reduce not found in body")
@@ -1087,6 +1129,8 @@ def _build_split_body(shape: KernelShape, params: dict) -> tuple[Stmt, ...]:
                 bk=params["BK"],
                 fk=fk,
                 K_o_ext=K_o_ext,
+                k_masked=k_masked,
+                k_bound=k_bound,
             )
         else:
             prologue_rewritten = prologue_outer
@@ -1317,6 +1361,37 @@ def _build_split_body_warp(shape: KernelShape, params: dict) -> tuple[Stmt, ...]
     return _wrap_tower(layers, new_inner, atom=atom)
 
 
+def _mask_reduce_accums(body: tuple[Stmt, ...], pred: object) -> tuple[Stmt, ...]:
+    """Mask each ``Accum``'s input value to the reduce identity past the
+    boundary (masked cooperative reduce over a symbolic K). For each
+    ``Accum(name, value=V, op)`` insert, just before it, ``Init(V_kid, op)``
+    (the op's neutral element) and ``Select(V_km, [V if pred, else V_kid])``,
+    then fold ``V_km`` instead of ``V``. The Accum stays a direct child of the
+    reduce loop (``is_reduce`` + the cross-thread combine intact); an overhang K
+    step folds the identity (no contribution). The Load was already index-
+    clamped by the caller so the read stays in-bounds."""
+    out: list[Stmt] = []
+    for c in body:
+        if isinstance(c, Accum):
+            ident = f"{c.value}_kid"
+            masked = f"{c.value}_km"
+            # The cooperative-reduce stats (softmax max/sum, RMSNorm) accumulate in
+            # f32; the identity carrier declares f32 so downstream dtype passes
+            # (030_stamp_types / 040_demote) see a concrete type, not the Accum's
+            # None loop-IR dtype.
+            out.append(Init(name=ident, op=c.op, dtype=c.dtype or F32))
+            out.append(
+                Select(
+                    name=masked,
+                    branches=(SelectBranch(value=c.value, select=pred), SelectBranch(value=ident, select=Literal(1, "int"))),
+                )
+            )
+            out.append(replace(c, value=masked))
+        else:
+            out.append(c)
+    return tuple(out)
+
+
 def _replace_k_loops(
     stmts: tuple[Stmt, ...],
     *,
@@ -1330,6 +1405,8 @@ def _replace_k_loops(
     fk: int = 1,
     K_o_ext: int,
     atom_k: int = 1,
+    k_masked: bool = False,
+    k_bound: object = None,
 ) -> tuple[tuple[Stmt, ...], int]:
     """Replace every ``Loop`` whose axis name is in ``target_names`` with a
     ``Loop(K_o, SERIAL_OUTER, Loop(K_i, STAGE_INNER, σ(body)))`` tower.
@@ -1363,7 +1440,32 @@ def _replace_k_loops(
             K_o = Axis(f"{K_canonical_name}_o", K_o_ext, source_axis=K_src)
             K_i = Axis(f"{K_canonical_name}_i", bk, source_axis=K_src)
             sigma_k = _build_k_sigma(K_name, K_s, K_o, K_c, K_i, K_f, K_o_ext, br, bk, fk, atom_k=atom_k)
-            new_body = tuple(c.rewrite(_identity_rename, sigma_k) for c in s.body)
+            # Masked cooperative reduce over a SYMBOLIC K (ceil-div K_o): the final
+            # K_o tile overruns the runtime extent. Two shapes, by whether the
+            # matched loop reduces:
+            #
+            #  - REDUCE loop: keep the ``Accum`` a DIRECT child (so ``Loop.is_reduce``
+            #    stays True and the cross-thread combine engages — wrapping it in a
+            #    ``Cond`` would flip ``is_reduce`` off). Instead clamp the K index for
+            #    a safe in-bounds read (``min(decoded, seq_len-1)``, via the σ) and
+            #    mask each Accum's input VALUE to the op identity past the bound
+            #    (``Select(decoded < seq_len ? value : identity)``) so the overhang
+            #    folds a no-op. This is the scalar-reduce twin of the masked-K mma's
+            #    clamp-read + zero-fill (``_stage_expand``).
+            #  - non-reduce (post-pointwise Write) loop: no Accum to protect, so the
+            #    simple ``Cond(decoded < seq_len)`` skips the OOB store outright.
+            if k_masked and k_bound is not None:
+                decoded_k = sigma_k.apply(Var(K_name))
+                pred = BinaryExpr("<", decoded_k, k_bound)
+                if s.is_reduce:
+                    clamp = TernaryExpr(cond=pred, if_true=decoded_k, if_false=BinaryExpr("-", k_bound, Literal(1, "int")))
+                    body_c = tuple(c.rewrite(_identity_rename, Sigma({K_name: clamp})) for c in s.body)
+                    new_body = _mask_reduce_accums(body_c, pred)
+                else:
+                    body_u = tuple(c.rewrite(_identity_rename, sigma_k) for c in s.body)
+                    new_body = (Cond(cond=pred, body=Body(body_u)),)
+            else:
+                new_body = tuple(c.rewrite(_identity_rename, sigma_k) for c in s.body)
             # FK strip-mine: the register tile sits innermost (inside K_i) so the
             # FK cells are the unrolled, ILP-exposed dimension. ``reduce=True``
             # marks it as a reduce-AXIS (K_f) tile — distinguishing it from the
@@ -1399,6 +1501,8 @@ def _replace_k_loops(
                 fk=fk,
                 K_o_ext=K_o_ext,
                 atom_k=atom_k,
+                k_masked=k_masked,
+                k_bound=k_bound,
             )
             if r:
                 out.append(replace(s, body=inner))
@@ -1417,6 +1521,8 @@ def _replace_k_loops(
                 fk=fk,
                 K_o_ext=K_o_ext,
                 atom_k=atom_k,
+                k_masked=k_masked,
+                k_bound=k_bound,
             )
             inner_e, re_ = _replace_k_loops(
                 s.else_body,
@@ -1430,6 +1536,8 @@ def _replace_k_loops(
                 fk=fk,
                 K_o_ext=K_o_ext,
                 atom_k=atom_k,
+                k_masked=k_masked,
+                k_bound=k_bound,
             )
             if rb or re_:
                 out.append(Cond(cond=s.cond, body=inner_b, else_body=inner_e))

--- a/deplodock/compiler/pipeline/passes/lowering/tile/050_use_tma.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/050_use_tma.py
@@ -28,6 +28,15 @@ Eligibility (per ``Source``):
 - Source rank ≤ 5 (TMA descriptor limit).
 - Every collapsed per-dim box extent ≤ 256 (``cuTensorMapEncodeTiled``'s
   ``boxDim`` limit — violations only surface at launch, as CUresult=1).
+- The source's innermost (fastest-varying) gmem dim is **static**. A
+  symbolic OUTER/middle dim (dynamic ``seq_len``, the M-masked case) IS
+  allowed: the descriptor's ``globalDim`` is encoded per launch from the
+  runtime input shape (``program._prebuild_descriptors``) and TMA's hardware
+  OOB handling zero-fills the masked overhang past the runtime extent. A
+  symbolic *innermost* dim is rejected — its runtime value (31, 700) gives a
+  global stride that isn't 16 B-aligned (CUresult=1 at encode), so N-masked
+  inner axes stay on cp.async. Masked-K (symbolic-reduce) sources also stay
+  on cp.async (the SYNC-pinned manual zero-fill) for now.
 
 Additionally (per tile): the ``serial_outer`` K loop holding the bundles
 must not be nested inside a serial loop with trip count > 1 — the
@@ -149,15 +158,55 @@ def rewrite(ctx: Context, match: Match, root: Node) -> TileOp | None:
             raise ValueError(f"DEPLODOCK_TMA=1 but TMA cannot fire: {msg}")
         return _off()
 
-    # TMA descriptors bake the source shape statically into the cuTensorMap; bail
-    # out cleanly if any input shape carries a symbolic dim.
-    for nid, node in match.graph.nodes.items():
+    # The TMA descriptor's globalDim is encoded per launch from the *runtime*
+    # input array shape (``program._prebuild_descriptors`` reads ``arr.shape``),
+    # not baked at compile time — so a symbolic source dim (dynamic ``seq_len``)
+    # is fine for the descriptor. The box extents stay the static hint tile, so
+    # the compile-time eligibility checks (box<=256, alignment, gap-dim) run
+    # against the Dim *hint*; the launch uses the real extent and TMA's hardware
+    # OOB handling zero-fills the masked overhang. A symbolic dim with no hint
+    # can't size the box — decline.
+    def _shape_for_tma(node) -> tuple[int, ...] | None:  # noqa: ANN001
+        dims: list[int] = []
         for d in node.output.shape:
-            if not d.is_static:
-                return _decline(f"TMA requires static shapes; node {nid!r} has symbolic dim {d!r}")
-    src_shapes = {nid: tuple(d.as_static() for d in node.output.shape) for nid, node in match.graph.nodes.items()}
+            if d.is_static:
+                dims.append(d.as_static())
+            elif d.hint is not None:
+                dims.append(int(d.hint))
+            else:
+                return None
+        return tuple(dims)
+
+    src_shapes: dict[str, tuple[int, ...]] = {}
+    for nid, node in match.graph.nodes.items():
+        shp = _shape_for_tma(node)
+        if shp is None:
+            return _decline(f"node {nid!r} has a symbolic dim with no hint — cannot size the TMA box")
+        src_shapes[nid] = shp
+    # Buffers whose innermost (fastest-varying) dim is symbolic can't be TMA
+    # *sources*: every outer dim's global stride is ``∏(inner extents)·elem_size``,
+    # which ``cuTensorMapEncodeTiled`` requires 16-byte-aligned, and a symbolic
+    # innermost dim takes runtime values (31, 700) whose stride isn't 16-aligned
+    # → ``CUresult=1`` at encode. A symbolic OUTER/middle dim (the common dynamic
+    # ``seq_len``, M-masked) is safe: its stride is a product of static inner
+    # extents and globalDim along it is unconstrained (TMA zero-fills the box
+    # overhang past the runtime extent). Only the actually-staged sources are
+    # checked (``_source_eligible``) — an in-kernel intermediate with a symbolic
+    # inner dim (e.g. the SDPA scores in the o_proj kernel) is never staged, so
+    # it must not veto the matmul operands' TMA path. N-masked inner sources stay
+    # on cp.async.
+    inner_symbolic_bufs = {nid for nid, node in match.graph.nodes.items() if node.output.shape and not node.output.shape[-1].is_static}
 
     body = root.op.body
+    # Masked-K (symbolic-reduce) sources keep their SYNC-pinned manual zero-fill
+    # for now: the masked-K overhang must be ZERO for the mma accumulation
+    # (``_stage_expand`` hand-rolls a ``(k < seq_len) ? v : 0`` ternary on the
+    # SYNC transport). TMA's hardware OOB zero-fill could replace that AND
+    # re-enable the async pipeline, but it needs the 4-D leading-batch box
+    # derivation fixed first (the P@V ``box can't collapse arr`` bench-fail), so
+    # that is follow-up — keep masked-K on cp.async.
+    if any(isinstance(s, StageBundle) and any(getattr(src, "kmask", None) is not None for src in s.sources) for s in body.iter()):
+        return _decline("masked-K (symbolic reduce) source — TMA OOB-zero-fill path is follow-up work; staying on cp.async")
     # A TMA ring pipeline must start from freshly-initialized mbarriers: the
     # materializer emits ``MbarrierInit`` once at kernel entry, and the
     # pipeline's parity schedule (steady-state wait at ``(k / RING) % 2``,
@@ -188,7 +237,7 @@ def rewrite(ctx: Context, match: Match, root: Node) -> TileOp | None:
             continue
         if s.policy == StagePolicy.TMA:
             continue
-        if s.policy in _PROMOTABLE and not _bundle_eligible(s, src_shapes):
+        if s.policy in _PROMOTABLE and not _bundle_eligible(s, src_shapes, inner_symbolic_bufs):
             return _decline(
                 f"{s.policy.name} bundle on {list(s.local_decls())!r} not TMA-eligible; "
                 "leaving the whole tile on cp.async (avoids mixed-mode pipeline deadlock)"
@@ -344,13 +393,17 @@ def _stamp_source_swizzle(src: Source, dtype_bytes: dict[str, int]) -> Source:
     return replace(src, swizzle=mode)
 
 
-def _bundle_eligible(bundle: StageBundle, src_shapes: dict[str, tuple[int, ...]]) -> bool:
+def _bundle_eligible(bundle: StageBundle, src_shapes: dict[str, tuple[int, ...]], inner_symbolic_bufs: set[str] = frozenset()) -> bool:
     """A bundle is TMA-eligible iff every Source is."""
-    return all(_source_eligible(src, src_shapes) for src in bundle.sources)
+    return all(_source_eligible(src, src_shapes, inner_symbolic_bufs) for src in bundle.sources)
 
 
-def _source_eligible(src: Source, src_shapes: dict[str, tuple[int, ...]]) -> bool:
+def _source_eligible(src: Source, src_shapes: dict[str, tuple[int, ...]], inner_symbolic_bufs: set[str] = frozenset()) -> bool:
     if not isinstance(src.addressing, AffineAddressing):
+        return False
+    # A symbolic innermost gmem dim breaks the 16-byte global-stride alignment
+    # ``cuTensorMapEncodeTiled`` requires at runtime (see the gate). Stay on cp.async.
+    if src.buf in inner_symbolic_bufs:
         return False
     cache_axes = src.cache_axes
     if not cache_axes or len(cache_axes) > _MAX_RANK:

--- a/deplodock/compiler/pipeline/pipeline.py
+++ b/deplodock/compiler/pipeline/pipeline.py
@@ -597,7 +597,13 @@ class Pipeline:
                 if o3_us is not None:
                     search.observe_o3(token, o3_us)
             yield cand
-        logger.info("compile: total %.2fs (%d terminal(s))", time.monotonic() - t_start, n_terminals)
+        dropped = run._dropped_candidates
+        logger.info(
+            "compile: total %.2fs (%d terminal(s)%s)",
+            time.monotonic() - t_start,
+            n_terminals,
+            f", {dropped} un-lowerable candidate(s) dropped" if dropped else "",
+        )
 
 
 @dataclass
@@ -692,6 +698,10 @@ class Run:
     backend: object | None = None
     dump: CompilerDump | None = None
     rejections: list[tuple[str, str, str]] | None = None
+    # Count of search candidates dropped by :meth:`drive`'s per-variant
+    # containment (un-lowerable forks that raised during lowering). Tune-only;
+    # stays 0 on the deterministic greedy path.
+    _dropped_candidates: int = 0
 
     def _step(self, cand: Candidate) -> tuple[Match, list, bool] | None:
         """Run one rule batch against ``cand`` — the per-candidate engine
@@ -844,7 +854,28 @@ class Run:
             if cand.cursor.is_done:
                 yield token, cand
                 continue
-            step = self._step(cand)
+            # Per-variant containment: a search-explored candidate can reach an
+            # un-lowerable shape that a *deterministic* lowering pass raises on
+            # (e.g. a sibling-cell-fused slab fill the single-Write hoisted-compute
+            # materializer can't represent, or an orphan AtomTile at render). The
+            # deployable greedy pick (``Run.resolve``) never reaches these forks, so
+            # under tune they are legitimate dead ends — exactly like a branch whose
+            # every option fails ``validate(ctx)``. Drop the candidate's subtree and
+            # keep driving the rest of the search instead of aborting the whole tune.
+            # (``RuleSkipped`` is handled inside ``try_rewrite``; control-flow
+            # exceptions propagate.)
+            try:
+                step = self._step(cand)
+            except (KeyboardInterrupt, SystemExit, GeneratorExit):
+                raise
+            except Exception as exc:  # noqa: BLE001 — broad by design; this is the tune dead-end sink
+                self._dropped_candidates += 1
+                logger.warning(
+                    "[tune] dropped un-lowerable candidate (%s: %s) — pruning branch, continuing search",
+                    type(exc).__name__,
+                    exc,
+                )
+                continue
             if step is None:
                 search.push(cand.lazy(), parent=token)
                 continue

--- a/plans/qwen3-embedding-layer0-dynamic-tune-findings.md
+++ b/plans/qwen3-embedding-layer0-dynamic-tune-findings.md
@@ -1,0 +1,337 @@
+# Qwen3-Embedding-0.6B layer 0 — DYNAMIC-shape tune findings (2026-06-14, post-#243)
+
+Status: **re-tune of the deployable dynamic configuration (`--dynamic seq_len@x:1`) on `main` @ `3abe9959`, one
+commit past the prior dynamic report's `c3304773`. The single landed change — #243 "masked-K mma warp tier —
+symbolic-seq P@V reaches tensor cores" — does exactly what the prior report's finding 1 flagged as future work:
+the symbolic-K P@V now reaches the `mma.sync` warp tier (NCU 40 µs vs the prior report's 259 µs scalar). But the
+masked-K split also un-fuses the attention **softmax** into a standalone scalar producer, and that softmax —
+materializing the full seq×seq probability matrix to HBM and re-reading it three times — is now the single
+largest kernel in the layer (NCU 147 µs). Net: the deployed layer runs 0.62x eager / 0.41x torch.compile at seq
+512 (fresh `run --bench`), a modest improvement on the prior report's 0.55x. The remaining gap is still the
+attention path, now split three ways: softmax (147 µs), QK^T scores (71 µs), P@V (40 µs) vs PyTorch's fused
+flash-attention (37 µs total).**
+
+- Command: `deplodock tune Qwen/Qwen3-Embedding-0.6B --layer 0 --dynamic seq_len@x:1 --clean --bench --dump-dir
+  /tmp/tune-model-qwen3-emb-l0-dyn/dump`
+- Hardware: RTX 5090 (sm_120), ncu 2025.3.1 (perf counters permitted). `main` @ `3abe9959`.
+- Run stats: tune wall **15,878.6 s** (~4.4 h — roughly 2.2x the prior report's 7,162 s; the masked-K mma adds a
+  whole new warp-tier enumeration on the symbolic-K P@V, doubling the structural search), **16 fused terminals**
+  (vs the prior report's 8 — the masked-K split offers a new keep-vs-split branch on the symbolic-K P@V),
+  **7,215 ok / 0 `bench_fail`** `perf` rows, all CUDA-graph captured; prior: 17,708 benches (158 warmup / 17,550
+  post), post-warmup Spearman **+1.00**, 94% of post benches ≥2x the running best.
+- DB / prior: **default paths, cleaned** — `~/.cache/deplodock/autotune.db` (7,215 rows),
+  `~/.cache/deplodock/prior.json`. Carries warp-tier `H_opt=3` rows for every static-K linear **and** the new
+  masked-K P@V consumer, so it is a usable greedy prior for dynamic serving.
+- **Number families**: bench tables / reproducer runs / `--ab` rows below are **-O3** (deployable, CUDA-graph
+  captured); tune-DB latencies quoted for ranking context are `-Xcicc -O1` (ranking signal only). NCU durations
+  run at locked base clock — **compare ratios, not absolutes**, and NCU is the only clean per-kernel signal
+  (finding 5).
+- **Dynamic measurement semantics**: the trace is symbolic in `seq_len` (`Dim` hint = `DEFAULT_SEQ_HINT` 512 —
+  the `--seq-len` flag does NOT set it). All per-op tune benches, reproducer benches and the full-model table run
+  at the 512 hint; the full-model table tiles the torch closures' inputs to the hint and prints `benched at
+  seq_len=512 (symbolic hint; torch inputs tiled to match)`, so its eager / tcompile / deplodock rows are one
+  shape and directly comparable.
+
+## Bench results (-O3, CUDA-graph captured)
+
+Full-model table as printed by the tune's `--bench` at the 512 hint:
+
+```
+Backend        Latency (us)  vs Eager
+-------------------------------------
+Eager PyTorch           219     1.00x
+torch.compile           147     1.49x
+Deplodock               467     0.47x      (359 us / 0.62x in a fresh `run --dynamic … --bench`; e2e whole-program)
+benched at seq_len=512 (symbolic hint; torch inputs tiled to match)
+```
+
+**Trust the 359 µs fresh-run number, not the 467 µs tune-`--bench` number.** The tune's `--bench` ran on a GPU
+thermally loaded from the 4.4 h tune that preceded it; a fresh `run --dynamic … --bench` on a cooled GPU clocks
+the identical deployed kernels at **359 µs / 0.62x eager / 0.41x torch.compile** (deployed launch table
+`TOTAL` 358.0, whole-program e2e 359.4). The 30% tune-vs-fresh spread is itself a finding (finding 7) — it is
+larger than the prior report's 7% (426→396) because the tune was twice as long and left the card hotter.
+
+Per-kernel reproducer bench at the 512 hint, as printed by `--bench` (sorted by deplodock µs; layer-op labels
+from each kernel's `.torch.json` provenance). **The top three rows re-fuse the upstream attention cone (finding
+5), so their deplodock µs is a slice-set total, not the deployed kernel alone — the clean attribution is the NCU
+table under finding 1.**
+
+| Kernel                  | Layer op                                                 | eager | tcompile | deplodock | vs eager |
+|-------------------------|----------------------------------------------------------|------:|---------:|----------:|---------:|
+| `k_linear_sdpa_reduce`  | attn-out reshape + o_proj (linear_3) + residual          |    43 |       41 |       213 |    0.20x |
+| `k_sdpa_linear_reduce`  | SDPA P@V split (softmax producer + V producer + P@V mma) |    34 |       34 |       203 |    0.17x |
+| `k_sdpa_reduce`         | RoPE(q,k) + QK^T scores (+ mask)                         |   148 |       25 |       162 |    0.91x |
+| `k_linear_mean_reduce`  | post-attn RMSNorm + MLP gate+up (linear_4/5) + SiLU·up   |   119 |       57 |        58 |    2.07x |
+| `k_linear`              | MLP down (linear_6) + residual                           |    26 |       25 |        44 |    0.60x |
+| `k_mean_linear_reduce`  | q_norm RMSNorm + rotated-q producer (xna)                |   105 |       20 |        27 |    3.93x |
+| `k_linear_reduce`       | v_proj matmul (linear_1)                                 |    16 |       16 |        27 |    0.62x |
+| `k_mean_linear_reduce`  | k_norm RMSNorm + rotated-k producer (xnb)                |    76 |       14 |        18 |    4.11x |
+| `k_linear_reduce`       | q_proj matmul (linear)                                   |    10 |       10 |        17 |    0.61x |
+| `k_mean`                | input RMSNorm                                            |    66 |        4 |         2 |   32.90x |
+
+The two pure RMSNorm-bearing reductions and the gated-MLP **win eager outright** (2–33x) and the warp-tier
+linears are at parity-to-2x of eager. Everything meaningfully behind torch.compile is in the **attention** path.
+By the clean NCU attribution (finding 1) the deployed attention kernels are **softmax 147 µs + QK^T 71 µs + P@V
+40 µs = 258 µs** of locked-clock GPU time, ~72% of the 359 µs e2e, vs flash-attention's 37 µs.
+
+## Finding 1 — #243 moved symbolic-K P@V onto tensor cores (259→40 µs), but the split exposed the softmax as a standalone 147 µs scalar kernel — now the single largest kernel in the layer
+
+**Symptom.** The masked-K mma warp tier (#243) lands exactly on the kernel the prior report flagged: the
+symbolic-K P@V consumer is now `mma_m16n8k16_f16` (10 `mma.sync` ops in its emitted CUDA) and NCU-clocks at
+**40 µs** vs the prior report's **259 µs** scalar — a 6.5x per-kernel win. But the masked-K demotion split
+(`005_split_demoted` on symbolic K) un-fuses the SDPA into a **softmax-normalizing producer** + the warp-tier
+P@V consumer, and that softmax producer is now the dominant kernel. From the clean NCU capture (one `ncu` run,
+deplodock + torch reference kernels side by side, locked base clock — `run --ir
+k_linear_sdpa_reduce_43208b.torch.json --bench --profile`, which re-lowers the whole attention→o_proj chain):
+
+```
+side  kernel                                       dur (ns)  occ%   sm%  dram%  fma%   lsu.inst  ld.cnflct  st.cnflct  regs
+dep   softmax producer (…_22a7a0_xn, scalar)        148,512   6.2   4.1    3.2   1.9  1,049,088          0          0    32
+dep   QK^T scores (k_sdpa_reduce_6874a2, scalar)     71,584  70.8  58.1   11.0  40.7  6,111,232      3,768     27,807    47
+dep   o_proj (k_linear_sdpa_reduce_43208b, mma)      47,040  13.1  19.2    8.9   2.1  1,500,160  6,815,744          0    53
+dep   P@V (k_sdpa_reduce_22a7a0, mma)                42,432  26.4  13.1   18.2   2.9    935,936  3,670,149        165    70
+dep   attn-out contiguify (…_43208b_xn)               4,256  36.1   6.0   41.3   4.0     40,960          0          0    24
+ref   pytorch_flash::flash_fwd_splitkv_kernel        24,384   8.4  16.3   21.7   2.9    300,800          0          0   206
+ref   cutlass_80_tensorop_f16_s16816gemm (o_proj)    22,176   8.3  30.0   21.6   0.2    569,856          0          0    88
+ref   pytorch_flash::flash_fwd_splitkv_combine       12,480  58.0  31.2   49.9   7.6     88,064          4          0    44
+```
+
+(A second NCU capture from the P@V reproducer agrees: softmax 146.5 µs, QK^T 70.3 µs, P@V consumer 39.2 µs.)
+
+The softmax producer (`…_xn`) is a **scalar 3-pass online-softmax** over the symbolic seq×seq matrix — its
+emitted CUDA is `__launch_bounds__(16)`, one thread per row, three sequential `for (a3 < seq_len)` loops
+(max-reduce → exp-sum → normalize), each a full HBM read of the seq×seq attention matrix, writing the
+normalized probabilities P back to HBM. NCU: **6.2% occupancy, 3.2% dram, 1.9% fma** — it is *latency*-bound, not
+bandwidth-bound: 16 threads per block cannot keep enough loads in flight to hide HBM latency.
+
+**Root cause — the split trades one big scalar kernel for one medium warp kernel + a new materialized softmax.**
+The prior report's 259 µs scalar P@V did the softmax-weighted V sum inline in registers. #243's masked-K split
+peels P@V onto tensor cores (40 µs) but must first **materialize** the normalized P matrix to HBM so the mma
+consumer can read it — that materialization is the 147 µs softmax kernel. The tuner chose the split correctly
+(40 + 147 = 187 µs < 259 µs fused, so it lowers the kernel-set Σ), but the win is smaller than the per-kernel
+P@V headline suggests because the softmax HBM round-trip is new cost that the fused scalar kernel hid.
+
+This is the documented limitation restated with a new price tag: CLAUDE.md still says *flash-style fused
+symbolic-K attention remains future work*. The masked-K mma covers the P@V matmul; it does not fuse the softmax
+into an online schedule, so the softmax pays a full materialization.
+
+**Repro.** `deplodock run --ir <dump>/07_lowering_cuda.kernels/k_linear_sdpa_reduce_43208b.torch.json --bench
+--profile` (NCU, the whole attention chain). Emitted-CUDA inspection of the scalar softmax:
+`<dump>/07_lowering_cuda.kernels/k_sdpa_linear_reduce_a76a28_xna.txt`. The masked-K mma gate that now fires for
+the consumer: `010_partition_loops.py:737` (`k_forced_mask=k_symbolic`).
+
+**Suggested fix (highest priority, large and known).** Flash-style symbolic-seq attention: a scheduled
+online-softmax warp loop over the symbolic N axis (QK^T sub-tile → running max/sum rescale → P@V mma accumulate),
+the standard flash-2 schedule, so the softmax never materializes to HBM. This collapses softmax + QK^T + P@V into
+one kernel and closes most of the 258→37 µs gap. Until then, the softmax producer itself is the cheapest standalone
+target — see finding 3.
+
+## Finding 2 — the new warp-tier P@V (and the o_proj) run at low occupancy with millions of smem load bank conflicts; PAD_SMEM / PERMUTE_LANES are no-ops on the masked-tile layout (proven)
+
+**Symptom.** Both warp-tier attention matmuls reach `mma_m16n8k16_f16` but run starved: the P@V consumer NCU
+**42.4 µs at 26.4% occupancy with 3,670,149 shared-load bank conflicts**, the o_proj NCU **47.0 µs at 13.1%
+occupancy with 6,815,744 shared-load bank conflicts** — vs the cutlass o_proj gemm at 22.2 µs / 0 conflicts and
+flash's P@V folded into 24.4 µs / 0 conflicts. They are on the right tier and on tensor cores, but serialized on
+conflicted smem loads and capped at one-to-two warps.
+
+**Evidence + A/B (the conflict levers do nothing here).** I pinned the two documented smem-conflict knobs on the
+P@V consumer reproducer:
+
+```
+deplodock run --ir k_sdpa_linear_reduce_a76a28.torch.json --bench --bench-backends deplodock \
+    --ab "PAD_SMEM=1" --ab "PERMUTE_LANES=1" --ab "PAD_SMEM=1,PERMUTE_LANES=1"
+```
+
+The P@V consumer row is **24.5 µs in the greedy pick and in all three A/B variants** — identical smem (32.0 KB),
+occupancy (50%), and regs (69). `PAD_SMEM` and `PERMUTE_LANES` **do not reach the masked-K mma's smem staging
+layout** at this shape; the bank conflicts are inherent to how the masked-K slab is laid out in smem, not a knob
+the tuner can flip. (The 24.5 µs A/B figure is the reproducer's solo P@V window — consistent with the eval-variants
+`-O3 us` pick of 24.7 µs, finding 6 — and below the 42 µs NCU locked-clock number, which includes cross-kernel
+effects.)
+
+**Root cause hypothesis.** Class 3 (codegen quality), not tier or search — the split and warp lowering are
+correct, but the masked-tile smem layout is conflict-heavy and the enumeration caps at a single/double-warp tile
+(occupancy 13–26%). The distinguishing diagnostic: conflicts persist with PAD_SMEM/PERMUTE_LANES pinned, so the
+fix is a different smem layout for the masked-K / masked-M slab, not the existing pad/permute passes.
+
+**Repro / A-B.** The `--ab` block above (P@V); for o_proj, `deplodock run --ir
+k_linear_sdpa_reduce_43208b.torch.json --bench --ab "PAD_SMEM=1" --ab "PERMUTE_LANES=1"` (caveat: that reproducer
+re-fuses the upstream attention — read the `k_linear_sdpa_reduce_43208b` row, not TOTAL).
+
+**Suggested fix (medium — ~25 µs at stake on P@V + o_proj, and it generalizes to every masked warp tile).**
+Redesign the masked-tile smem staging to be conflict-free (swizzled / padded *inside* the masked-K and masked-M
+slab fill, where the current PAD_SMEM/PERMUTE_LANES passes evidently don't apply), and let the tuner reach a
+multi-warp tile to lift occupancy above 26%. Fold the winning layout into the warp-tile defaults once found.
+
+## Finding 3 — the softmax producer stays scalar at 6% occupancy even though cooperative-reduce (BR>1) configs are enumerated — they rank worse, so it is codegen/occupancy, not a tier lockout
+
+**Symptom.** The softmax producer (finding 1, NCU 147 µs) deploys a 16-thread, BR=1, 0-KB-smem scalar config at
+6.2% occupancy. The obvious lever is the strided-cooperative-rows feature (BR>1: split each row's reduction
+across BR lanes with a segmented-shuffle combine), which would raise occupancy.
+
+**Evidence — BR>1 is enumerated and loses.** `eval variants --kernel k_sdpa_linear_reduce_a76a28_xna --top 0`:
+**65 of 238 measured configs carry BR>1**, but the pick (rank 2/239, 1.00x of measured best) is BR=1, and
+reachability classifies it as `reduce free=16 best 183.23 pick 183.51 (1.00x, 239 configs)` — the prior recovers
+the measured best essentially exactly. So this is **not** a search shortfall or a tier lockout: among everything
+enumerated (including cooperative-reduce), the scalar 16-thread config *is* the measured-fastest. The cooperative
+combine's segmented-shuffle overhead outweighs the occupancy it buys at this shape (16-head, head_dim, symbolic
+seq).
+
+**Root cause.** Class 3 within a kernel that is memory-latency-bound by construction: a 3-pass materialized
+softmax over a seq×seq matrix is inherently HBM-traffic-heavy, and the tile/cooperative knobs available can't
+hide the latency at 6% occupancy. The real fix is structural (don't materialize — finding 1), not a knob.
+
+**Repro.** `deplodock eval variants --kernel k_sdpa_linear_reduce_a76a28_xna --top 0` (BR distribution);
+emitted CUDA at `<dump>/07_lowering_cuda.kernels/k_sdpa_linear_reduce_a76a28_xna.txt`.
+
+**Suggested fix (low standalone — superseded by finding 1).** If flash-attention (finding 1) is far off, a
+two-pass (online) softmax that fuses the max+sum into one HBM read, or a warp-per-row reduction with vectorized
+loads, would cut the 3× HBM traffic. But the structural fix in finding 1 removes this kernel entirely, so it is
+only worth doing as a stopgap.
+
+## Finding 4 — QK^T scores stay scalar (71 µs) because the accumulator is consumed inside the softmax reduce; static K=128 doesn't help
+
+**Symptom.** QK^T scores (`k_sdpa_reduce_6874a2`) is scalar (0 `mma.sync`) at NCU 71.6 µs, 70.8% occupancy,
+40.7% fma, with **27,807 shared-store bank conflicts** — it stages the masked scores into smem and serializes on
+conflicted stores, on top of being scalar. Its reduce axis K is the **static** head_dim 128, so symbolic-K is
+not the blocker.
+
+**Root cause.** The QK^T accumulator feeds the softmax max/sum reduce over the symbolic N (key) axis — a
+mid-reduction use — so the mma fragment-store fold is rejected by `classify_fragment_epilogue`,
+`deplodock/compiler/pipeline/passes/lowering/tile/_atom.py:324`:
+
+> *the accumulator is consumed inside a reduce loop (mid-reduction use, not a store-time fold)*
+
+`is_atom_eligible` returns False → scalar tier. This is the same online-softmax pattern finding 1 names: a warp
+QK^T tile computes a sub-tile of N, but softmax needs the full row, so it cannot be a plain masked warp tile — it
+needs the scheduled online-softmax phase that flash implements. The static K=128 is irrelevant: the blocker is
+the epilogue, not the reduce axis.
+
+**Repro.** `deplodock compile <dump>/07_lowering_cuda.kernels/k_sdpa_reduce_042770.torch.json --ir cuda` shows
+the scalar masked tile and no `mma.sync`; the eligibility bail is `_atom.py:324`. The 27.8K store conflicts are a
+cheap PAD_SMEM/PERMUTE_LANES target *within* the scalar kernel, but like finding 3 it is superseded by the flash
+work.
+
+**Suggested fix.** Same as finding 1: the scheduled online-softmax warp loop folds QK^T, softmax, and P@V into
+one flash kernel. Standalone, QK^T is the second-cheapest attention kernel and the lowest-priority of the three.
+
+## Finding 5 — bench attribution: the deployed launch table mis-attributes attention by ~7×; only NCU + e2e are trustworthy (recurring)
+
+**Symptom.** The deployed `run --dynamic … --bench` launch table and NCU disagree wildly for the attention
+kernels, in opposite directions:
+
+- **Deployed launch table under-attributes the softmax and QK^T.** The softmax `…_xna` reads **20.3 µs / 5.7%**
+  while NCU clocks the same kernel at **148 µs**; QK^T `042770` reads **2.2 µs / 0.6%** while NCU clocks it at
+  **71 µs**; meanwhile the P@V consumer `a76a28` reads **99.4 µs / 27.8%** while NCU clocks it at **40 µs**. The
+  per-launch solo windows absorb cross-kernel latency — the `%` column actively mislabels the dominator (it
+  fingers the P@V consumer as 28% of the layer when NCU says the softmax is the dominant kernel).
+- **The `--bench` reproducer table re-fuses the upstream cone.** The o_proj and P@V reproducers each re-lower the
+  whole attention chain (softmax + QK^T + P@V + o_proj), so their printed 213 / 203 µs "deplodock" totals are
+  slice-set sums, not the named kernel.
+
+Only the **NCU single-capture table** (both sides, one clock — finding 1) and the **e2e whole-program** number
+(359 µs) are trustworthy. This is the recurring attribution problem (`plans/bench-attribution-by-slicing.md`); it
+cost real triage time again — the deployed table's 20 µs softmax row hid the layer's actual dominant kernel until
+NCU revealed it as 148 µs.
+
+**Suggested fix (high — the third dynamic report in a row to hit this).** Land per-launch attribution by slicing
+(the existing plan): attribute each deployed kernel's cost from a capture where it is the only changing slice, so
+the deployed table matches NCU. Short term, the skill already says trust NCU + e2e for attention; this run is
+fresh evidence that the deployed `%` column inverts the dominator.
+
+## Finding 6 — the P@V pick-miss is an -O1 ranking artifact, not a search shortfall
+
+**Symptom.** `eval variants --kernel k_sdpa_linear_reduce` flags the P@V consumer pick as `rank 11/886, 1.26x of
+best <-- misses best` at -O1.
+
+**Evidence (inverts at -O3 — confirmed, not assumed).** The `eval variants -O3 us` column shows the **pick**
+(rank 11, -O1 60.5 µs) re-benches to **24.7 µs** at -O3, while the -O1 rank-1 config (48.0 µs) re-benches to
+**29.3 µs** and rank-4 to 24.9 µs — the greedy pick is the *fastest deployable* config; the -O1 ranking simply
+mis-orders the warp-tile shapes (the well-known -O1-vs-O3 inversion, and consistent with the memory note that
+-O1 pick-misses usually invert). The QK^T and softmax picks are rank 1–2 at -O1 already (no miss). The
+DB-reachability aggregate (`eval prior --dataset db` mean 2.52x / median 1.24x) is likewise dominated by -O1
+inversions on the warp-tile matmuls and should not be read as a search defect.
+
+**Root cause.** Not a defect. The tune ranks at -O1 (fast compile); the deployable order is -O3, and the prior's
+reservoir carries the -O3 truth that makes the pick correct. No patience/prior change warranted.
+
+## Finding 7 — tune-`--bench` (467 µs) vs fresh-run (359 µs) e2e spread is 30%, larger than usual — thermal
+
+**Symptom.** The tune's `--bench` full-model table reports Deplodock 467 µs / 0.47x eager; an immediate fresh
+`run --dynamic … --bench` of the identical deployed kernels reports 359 µs / 0.62x eager — a 30% spread on the
+same code.
+
+**Root cause.** Thermal. The tune's `--bench` runs on a GPU loaded by the 4.4 h tune that just finished; the
+fresh run is on a cooled card. The prior report saw the same direction at 7% (426→396) after a 2 h tune; this
+run's tune was 2.2× longer, so the card was hotter and the spread bigger. Consistent with the memory note that
+absolute µs drift ±10%+ across invocations while ratios stay stable.
+
+**Suggested fix (low — measurement hygiene).** Quote the fresh-run e2e (359 µs) as the deployed number and treat
+the tune-`--bench` e2e as ranking-only when the tune was long. A short cooldown (or a clock-lock) before the
+tune's final `--bench` would make its headline number deployable; otherwise the skill should prefer a separate
+`run --bench` on a cooled GPU for the reported e2e (as the prior report already did).
+
+## Repro / artifacts
+
+- Work dir: `/tmp/tune-model-qwen3-emb-l0-dyn/` — `tune.log` (52-line tee of the 4.4 h tune), `run-dynamic.log`
+  (fresh deployed launch table + e2e 359 µs), `ncu-43208b.log` (o_proj-chain NCU capture +
+  `ncu-43208b/61_ncu_metrics.{csv,json}`), `ncu-a76a28.log` (P@V-chain NCU capture), dump at `dump/`
+  (reproducers under `07_lowering_cuda.kernels/`, machine-readable `62_kernel_bench.json`, chart `kernels.html`;
+  `.png` skipped — Playwright `Target page … closed` flake again).
+- Tune DB / prior (default paths, this run only): `~/.cache/deplodock/autotune.db` (7,215 rows, 0 bench_fail),
+  `~/.cache/deplodock/prior.json` (warp-tier `H_opt=3` rows for linears + masked-K P@V).
+- Finding-1 NCU: `DEPLODOCK_DUMP_DIR=<dir>/ncu-43208b deplodock run --ir
+  <dump>/07_lowering_cuda.kernels/k_linear_sdpa_reduce_43208b.torch.json --bench --profile` (no `--dynamic` — the
+  reproducer keeps its symbolic dims and benches at the 512 hint). Gate probes (no GPU): `_atom.py:324`
+  (online-softmax fold bail, findings 1/4), `010_partition_loops.py:737` (`k_forced_mask=k_symbolic`, the #243
+  masked-K mma gate), `010_partition_loops.py:653` (`prologue_mask_ok`).
+- Finding-2 A-B (proven no-op): `deplodock run --ir
+  <dump>/07_lowering_cuda.kernels/k_sdpa_linear_reduce_a76a28.torch.json --bench --bench-backends deplodock --ab
+  "PAD_SMEM=1" --ab "PERMUTE_LANES=1" --ab "PAD_SMEM=1,PERMUTE_LANES=1"`.
+- Finding-3 BR enumeration: `deplodock eval variants --kernel k_sdpa_linear_reduce_a76a28_xna --top 0`.
+- Finding-6 inversion: the `-O3 us` column of `deplodock eval variants --kernel k_sdpa_linear_reduce`.
+
+## Workflow notes
+
+Audit of the prior dynamic report's notes first:
+
+- **The full-model dynamic table is honest (prior finding 4, FIXED)**: held up — the table prints `benched at
+  seq_len=512 (symbolic hint; torch inputs tiled to match)` and the eager row reads 219 µs (the honest
+  static-512 number). No headline-ratio detour this run.
+- **Per-launch mis-attribution (prior finding)**: **reproduced, worse** (finding 5). This run the deployed table
+  under-attributes the softmax by ~7× (20 µs vs 148 µs NCU) and *hid the layer's dominant kernel entirely* — I
+  only found the 148 µs softmax via NCU. Now the top recurring tooling gap across three reports; strongly
+  reinforces `plans/bench-attribution-by-slicing.md`.
+- **Reproducer re-fusion (prior finding)**: **reproduced and binding.** With the warp tier live, both attention
+  reproducers re-fuse the whole cone, so their 203 / 213 µs totals are meaningless for the named kernel. I fell
+  back to NCU for every attention number. A `run --ir … --bench --no-refuse` (bench only the named provenance
+  kernel, masking upstream slices) would have saved most of the triage time.
+- **Chart PNG Playwright flake**: reproduced verbatim (`png skipped: Target page … closed`).
+- **Stable per-op identity across views (prior finding)**: **reproduced.** The same P@V op wears three hashes —
+  deployed `a76a28`, o_proj-chain NCU `22a7a0`, P@V-chain NCU `a88b4d` — because each re-lowering re-hashes. I
+  hand-cross-referenced all three. A stable provenance name (not content hash) in the NCU / leaderboard /
+  deployed tables would remove the cross-referencing.
+
+New friction this run:
+
+- **The tune is 2.2× longer with #243 (4.4 h vs 2.2 h) and near-silent under `tee`** (52-line log for a 4.4 h
+  run — the tty progress bar doesn't survive the pipe). At this scale a non-tty per-terminal heartbeat (`[tune]
+  terminal k/16 done, best Σ …`) would let the operator see liveness without `-v`'s firehose. This was the
+  single biggest wall-clock item by far.
+- **Tune-`--bench` e2e is thermally inflated (finding 7).** The 467 µs headline was 30% above the deployable
+  359 µs purely because the tune left the GPU hot. The reported e2e had to come from a separate fresh run — the
+  skill should either clock-lock before the final `--bench` or explicitly direct a cooled fresh-run e2e.
+- **`--ab` proving a no-op is valuable but easy to misread.** The PAD_SMEM/PERMUTE_LANES A/B (finding 2) printed
+  identical rows for all three variants — exactly the evidence I wanted (the levers don't reach the masked-tile
+  layout), but it took reading smem/occ/regs columns to confirm "no change" rather than "applied and helped." A
+  one-line A/B summary (`ab PAD_SMEM=1: kernel unchanged (smem/occ/regs identical to pick)`) would make a no-op
+  result unambiguous.
+
+What worked well: the triage loop was tight — `eval failures` → 0 failures in one line, `eval variants` (with the
+`-O3 us` column) → the P@V inversion proven without a separate run, `eval variants --top 0` → the BR>1-enumerated
+softmax settled "tier lockout vs codegen" in one command (finding 3), and the two NCU captures cross-checked the
+attention attribution (softmax 148/146, P@V 42/39) to within 5%. The single `--profile` run on the o_proj-chain
+reproducer gave the whole attention path + the torch flash/cutlass references in one aligned table — the clean
+signal the deployed table can't provide. The `mma.sync`-count grep over the emitted `.txt` was the fastest tier
+fingerprint (P@V went 0→10 mma ops with #243); a `tier` column (scalar / mma) in `eval variants` would make it a
+zero-step read.

--- a/plans/qwen3-embedding-layer0-static-tune-findings.md
+++ b/plans/qwen3-embedding-layer0-static-tune-findings.md
@@ -14,6 +14,13 @@ structural — it is the per-kernel masked-tile tax the symbolic path pays: a st
 pin on the P@V mma. Every one of these is gated on `*_symbolic` in `010_partition_loops.py` — they fire only under
 `--dynamic`.**
 
+> **Update (#245).** One transport item above has since been fixed: the masked-tile tax included routing the dynamic
+> matmuls onto cp.async (TMA was wholesale-declined for symbolic graphs). #245 enables **TMA for dynamic M-masked
+> matmuls with a static innermost dim** (o_proj, q/v_proj, MLP-down), closing the o_proj NCU gap (47.0 → 29.2 µs, ≈
+> static 28.6 µs; 6.8M → 0 bank conflicts) and moving whole-layer dynamic e2e **361 → 337 µs (0.62 → 0.65x eager)**.
+> The attention path (softmax materialisation, QK^T, masked-K P@V) is unchanged and remains the gap. Tables below carry
+> the post-#245 numbers inline (marked); see the finding-2 and finding-4 notes.
+
 - Command: `deplodock tune Qwen/Qwen3-Embedding-0.6B --layer 0 --seq-len 512 --clean --bench --dump-dir <dir>/dump`
   (note: **`--seq-len 512`** — static kernels are shape-specialised, so they are tuned/benched at the SAME 512 the
   dynamic report's symbolic hint uses; tuning at the default seq 32 would shrink attention ~256x and make the
@@ -60,7 +67,7 @@ attention attribution is the NCU table in finding 2.
 
 | Kernel                 | Layer op                                                 | eager | tcompile | **static** | dynamic |  static vs dyn |
 |------------------------|----------------------------------------------------------|------:|---------:|-----------:|--------:|---------------:|
-| `k_linear_sdpa_reduce` | attn-out reshape + o_proj (linear_3) + residual          |    39 |       37 |     **78** |     213 |    2.7x faster |
+| `k_linear_sdpa_reduce` † | attn-out reshape + o_proj (linear_3) + residual        |    39 |       37 |     **78** |     213 |    2.7x faster |
 | `k_sdpa_linear_reduce` | SDPA P@V split (v_proj + softmax-normalise + P@V mma)    |    29 |       29 |     **70** |     203 |    2.9x faster |
 | `k_sdpa_reduce`        | RoPE(q,k) + QK^T scores + softmax-stats                  |   148 |       25 |     **45** |     162 |    3.6x faster |
 | `k_linear_mean_reduce` | post-attn RMSNorm + MLP gate+up (linear_4/5) + SiLU·up   |   119 |       57 |     **47** |      58 |    1.2x faster |
@@ -76,6 +83,15 @@ fires for static-K too. The dominators by static deplodock µs are the three att
 (`k_linear_sdpa_reduce` 78 + `k_sdpa_linear_reduce` 70 + `k_sdpa_reduce` 45 ≈ 193 µs of slice-set total, ~80% once
 de-duplicated against the deployed total) — and every one is 2.7–3.6x faster than its dynamic twin. The linears are
 1.5–1.9x faster; the RMSNorms are at parity (already memory-bound, no masked-tile content).
+
+> **† Updated post-#245 (TMA for dynamic M-masked matmuls).** This dynamic column is the *original* cp.async
+> reproducer totals (re-fused slice-set, so the row is dominated by the unchanged upstream softmax — that is why the
+> total stays ~2.7x even though the o_proj kernel itself was fixed). The o_proj *kernel* now stages via TMA on the
+> dynamic path: its solo reproducer window is **34.4 µs (cp.async) → 19.6 µs (TMA)** and its clean NCU is **47.0 →
+> 29.2 µs, ≈ the static 28.6 µs** (finding 2 note). The other two attention rows (`k_sdpa_linear_reduce` P@V,
+> `k_sdpa_reduce` QK^T) are unchanged — still cp.async (P@V is masked-K; QK^T has a symbolic-N inner axis), so their
+> 2.9x / 3.6x gaps stand. The matmul-only kernels below (`k_linear` MLP-down, `k_linear_reduce` q/v_proj) also moved to
+> TMA on the dynamic path (per-kernel ~1.6–1.8x), shrinking their dynamic numbers toward the static ones.
 
 ## Finding 1 — a sibling-cell-fused hoisted-compute slab aborted the whole static tune; fixed with a descriptive `LoweringError` + per-variant `Run.drive` containment (fixed on this branch)
 
@@ -152,7 +168,7 @@ attention kernel (NCU, locked clock)                         static      dynamic
 QK^T scores (+ softmax max/sum stats; scalar)                 68.1 us     71.6 us  (QK^T only — softmax split out)
 standalone softmax producer (…_xn)                            14.3 us    148.5 us  ← 10.4x
 P@V (mma_m16n8k16_f16)                                         15.4 us     42.4 us
-o_proj (mma_m16n8k16_f16)                                      28.6 us     47.0 us
+o_proj (mma_m16n8k16_f16)                                      28.6 us     47.0 → 29.2 us  (dynamic TMA, #245 — see note)
 attn-out contiguify (…_xn)                                      4.4 us      4.3 us
 -----------------------------------------------------------------------------------
 torch ref: flash_fwd_splitkv + combine                        ~36 us      ~37 us
@@ -163,6 +179,16 @@ Static raw NCU rows (this run): `k_sdpa_reduce_c0c97e` (QK^T+softmax-stats, scal
 `k_sdpa_reduce_ba65cb` (P@V mma) **15,360 ns**; `k_sdpa_reduce_ba65cb_xn` (softmax-normalise producer, 67% dram —
 memory-bound but small) **14,336 ns**; `k_linear_sdpa_reduce_94ab75` (o_proj mma) **28,608 ns**;
 `k_linear_sdpa_reduce_94ab75_xn` (contiguify) **4,416 ns**.
+
+> **Update (#245 — TMA for dynamic M-masked matmuls).** The o_proj `47.0 µs` dynamic number above was the *original*
+> cp.async dynamic path. #245 enables TMA staging on the dynamic path for M-masked matmuls with a static innermost dim
+> (the descriptor's globalDim is encoded per launch from the runtime shape; TMA zero-fills the masked overhang), so the
+> deployed dynamic o_proj `k_linear_sdpa_reduce_43208b` now NCU-clocks **29,216 ns (29.2 µs), 0 smem bank conflicts**
+> (vs the cp.async 47.0 µs / 6.8M conflicts) — essentially **at parity with the static o_proj (28.6 µs)**. The o_proj
+> transport gap is closed; the other dynamic attention rows (softmax 148 µs, QK^T 71 µs, P@V 42 µs) are unchanged — they
+> stay on cp.async (QK^T's symbolic-N inner axis breaks TMA's 16 B stride alignment; P@V is masked-K). Whole-layer
+> dynamic e2e moved **361 → 337 µs (0.62 → 0.65x eager)**. Repro: `deplodock run --ir
+> dynamic.k_linear_sdpa_reduce.repro.torch.json --bench --profile` (TMA default) vs `--ab "TMA=0"`.
 
 **Root cause.** In the **dynamic** path, the masked-K demotion split (`005_split_demoted` on symbolic K) un-fuses the
 SDPA into a **standalone softmax-normalising producer** that must MATERIALISE the full normalised seq×seq P matrix to
@@ -223,9 +249,12 @@ linears (v_proj/q_proj), worth ~10–15 µs.
 
 **Symptom.** The P@V consumer reaches `mma_m16n8k16_f16` in BOTH paths (static `k_sdpa_reduce_ba65cb` mma=11; dynamic
 masked-K mma), but the dynamic one runs **42.4 µs** (dynamic finding 2, 26% occ, 3.67M smem bank conflicts) vs static
-**15.4 µs** (50% occ). Same for o_proj: dynamic 47 µs vs static 28.6 µs. The static prior recovers its measured best
-cleanly (`eval prior --dataset db`: static mean **1.25x** / median 1.09x / worst 1.97x, all -O1 inversions — vs the
-dynamic DB's mean 2.52x / worst 17.64x), so this is NOT a search shortfall or a tier lockout.
+**15.4 µs** (50% occ). (o_proj used to belong here too — dynamic 47 µs vs static 28.6 µs — but **#245 closed it**: the
+o_proj matmul is M-masked with a static innermost dim, so it now stages via TMA on the dynamic path → 29.2 µs / 0 bank
+conflicts, ≈ static. **P@V is the remaining gap**, because it's masked-K (symbolic reduce) and stays on cp.async.) The
+static prior recovers its measured best cleanly (`eval prior --dataset db`: static mean **1.25x** / median 1.09x /
+worst 1.97x, all -O1 inversions — vs the dynamic DB's mean 2.52x / worst 17.64x), so this is NOT a search shortfall or
+a tier lockout.
 
 **Root cause.** The dynamic masked-K P@V pays three symbolic-only taxes the static-K mma skips, all from the masked-K
 staging: (1) the K reduce is tiled at the hint with a partial final slab **zero-filled in smem** (`_stage_expand.py:256`
@@ -239,10 +268,12 @@ the levers the tuner has don't reach it. Static K → none of this: clean stagin
 `_stage_expand.py:179` (SYNC pin), `:256` (zero-fill), `010_partition_loops.py:737` (`k_forced_mask`). The dynamic A/B
 proving PAD_SMEM/PERMUTE_LANES are no-ops: dynamic report finding 2.
 
-**Suggested fix (medium — ~50 µs at stake across P@V + o_proj on the dynamic path, generalises to every masked warp
-tile).** A conflict-free masked-K smem layout (swizzle inside the zero-filled slab) and a cp.async-compatible masked-K
-copy (stage then mask in smem, so the ring buffer is usable) would close most of the 42→15 µs P@V gap. Folds into the
-flash work (finding 2) since that owns the symbolic-K schedule.
+**Suggested fix (medium — ~27 µs at stake on P@V; the o_proj half was already landed in #245).** The cleanest path is
+**TMA for masked-K**: TMA's hardware OOB zero-fill replaces the manual `(k < seq_len) ? v : 0` ternary AND removes the
+SYNC pin (so the async pipeline is usable again), exactly as #245 did for the M-masked matmuls — but P@V first needs
+the 4-D leading-batch box derivation fixed (finding 5's `_collapse_inert_dims` / `box can't collapse arr` bench-fail).
+Failing that, a conflict-free masked-K smem layout (swizzle inside the zero-filled slab) would close most of the
+42→15 µs P@V gap. Folds into the flash work (finding 2) since that owns the symbolic-K schedule.
 
 ## Finding 5 — TMA descriptor rank mismatch: 20 `bench_fail`s on the P@V mma + the tune's full-model `--bench` capture (static-512 codegen bug)
 

--- a/plans/qwen3-embedding-layer0-static-tune-findings.md
+++ b/plans/qwen3-embedding-layer0-static-tune-findings.md
@@ -1,0 +1,360 @@
+# Qwen3-Embedding-0.6B layer 0 — STATIC-shape tune findings + static-vs-dynamic side-by-side (2026-06-15)
+
+Status: **clean static (shape-specialised, seq_len=512) tune of layer 0 on branch `fix/hoist-compute-literal-index`
+(off `main` @ `f87098e8`). The clean tune first crashed on a lowering-contract bug — a sibling-cell-fused
+slab the single-Write materializer can't represent — that aborted the WHOLE tune with no per-variant
+containment
+(finding 1, fixed on this branch: a descriptive `LoweringError` + a tune-only `Run.drive` containment that drops the
+un-lowerable fork and keeps searching). With the fix the tune completes (16 terminals, 3 un-lowerable forks cleanly
+dropped) and the deployed static layer runs `168 µs / 1.29x eager` at seq 512 — it BEATS eager, where the deployable
+dynamic (`--dynamic seq_len@x:1`) twin runs `361 µs / 0.62x eager` on the SAME cooled card. Static is 2.15x faster
+end-to-end. The kernel SET is identical between the two (same 10 kernels, same SDPA P@V split), so the gap is NOT
+structural — it is the per-kernel masked-tile tax the symbolic path pays: a standalone 148 µs materialised softmax
+(static: 14 µs), the fp16-half2-window lockout on symbolic-K scalar matmuls, and the masked-K zero-fill + SYNC-transport
+pin on the P@V mma. Every one of these is gated on `*_symbolic` in `010_partition_loops.py` — they fire only under
+`--dynamic`.**
+
+- Command: `deplodock tune Qwen/Qwen3-Embedding-0.6B --layer 0 --seq-len 512 --clean --bench --dump-dir <dir>/dump`
+  (note: **`--seq-len 512`** — static kernels are shape-specialised, so they are tuned/benched at the SAME 512 the
+  dynamic report's symbolic hint uses; tuning at the default seq 32 would shrink attention ~256x and make the
+  side-by-side meaningless).
+- Hardware: RTX 5090 (sm_120), ncu 2025.3.1 (perf counters permitted). Branch `fix/hoist-compute-literal-index`.
+- Run stats: tune wall **12,732.5 s** (~3.5 h), **16 fused terminals**, **3 un-lowerable candidates dropped** (the
+  finding-1 containment — `[tune] dropped un-lowerable candidate (LoweringError: …)`), **5,478 ok / 47 `bench_fail`**
+  `perf` rows, all CUDA-graph captured; prior 16,001 benches, post-warmup Spearman **+0.99**, 97% of post benches ≥2x
+  the running best.
+- DB / prior: **isolated** in the work dir (`_tune/tune-model-qwen3-emb-l0-static/static.db`, `…/static-prior.json`) so
+  the clean static tune does NOT clobber the dynamic tune's DB/prior at the default path — the dynamic-side `eval` /
+  `run` comparison reads `~/.cache/deplodock/{autotune.db,prior.json}` (7,215 dynamic rows, intact).
+- **Number families**: bench tables / reproducer runs / NCU below are **-O3** (deployable, CUDA-graph captured);
+  tune-DB latencies quoted for ranking context are `-Xcicc -O1` (ranking signal only). NCU durations run at locked base
+  clock — **compare ratios, not absolutes**.
+- **Shape semantics**: this is the **static / shape-specialised** configuration (no masked-tile boundary guards, full
+  static K, fp16 windows allowed) — NOT the deployable dynamic-serving artifact. It exists here as the apples-to-apples
+  baseline for "what does the symbolic path cost", benched at the same seq 512 the dynamic twin uses. The deployable
+  dynamic numbers are `plans/qwen3-embedding-layer0-dynamic-tune-findings.md` (2026-06-14, post-#243).
+- **Single-layer scope**: no servable artifact, so no `deplodock serve` A/B (per the skill — single-layer has no served
+  e2e). The deliverable is the per-kernel table + the static-vs-dynamic contrast.
+
+## Bench results (-O3, CUDA-graph captured)
+
+End-to-end (layer 0, seq 512), both from a fresh `run --bench` on the **same cooled card** this session (eager ~220 µs
+both ways — the honest static-512 torch number):
+
+```
+Backend          static (this run)        dynamic (--dynamic seq_len@x:1)
+---------------------------------------------------------------------------
+Eager PyTorch     217 us   1.00x           223 us   1.00x
+Deplodock         168 us   1.29x           361 us   0.62x      (2.15x slower than static)
+                  (whole-program e2e 168.2 / TOTAL 165.0)   (e2e 361.4 / TOTAL 359.8)
+```
+
+The tune's own `--bench` full-model table did NOT print — its captured full-model bench failed with a TMA descriptor
+rank mismatch (finding 5); the deployable e2e above is the separate cooled `run --bench`, which picks non-TMA variants
+and succeeds. Use 168 µs as the deployed static number.
+
+Per-kernel reproducer bench at seq 512 (both from each report's `tune --bench`, sorted by static deplodock µs;
+layer-op labels read off each kernel's `.torch.json` provenance). The attention reproducers (`k_*sdpa*`) re-fuse the
+upstream cone, so their `deplodock` µs is a slice-set total, not the deployed kernel alone — the clean per-kernel
+attention attribution is the NCU table in finding 2.
+
+| Kernel                 | Layer op                                                 | eager | tcompile | **static** | dynamic |  static vs dyn |
+|------------------------|----------------------------------------------------------|------:|---------:|-----------:|--------:|---------------:|
+| `k_linear_sdpa_reduce` | attn-out reshape + o_proj (linear_3) + residual          |    39 |       37 |     **78** |     213 |    2.7x faster |
+| `k_sdpa_linear_reduce` | SDPA P@V split (v_proj + softmax-normalise + P@V mma)    |    29 |       29 |     **70** |     203 |    2.9x faster |
+| `k_sdpa_reduce`        | RoPE(q,k) + QK^T scores + softmax-stats                  |   148 |       25 |     **45** |     162 |    3.6x faster |
+| `k_linear_mean_reduce` | post-attn RMSNorm + MLP gate+up (linear_4/5) + SiLU·up   |   119 |       57 |     **47** |      58 |    1.2x faster |
+| `k_linear`             | MLP down (linear_6) + residual                           |    26 |       26 |     **26** |      44 |    1.7x faster |
+| `k_mean_linear_reduce` | q_norm RMSNorm + rotated-q producer (xna)                |   105 |       20 |     **18** |      27 |    1.5x faster |
+| `k_linear_reduce`      | v_proj matmul (linear_1)                                 |    14 |       14 |     **15** |      27 |    1.8x faster |
+| `k_mean_linear_reduce` | k_norm RMSNorm + rotated-k producer (xnb)                |    76 |       14 |     **12** |      18 |    1.5x faster |
+| `k_linear_reduce`      | q_proj matmul (linear)                                   |    10 |       10 |      **9** |      17 |    1.9x faster |
+| `k_mean`               | input RMSNorm                                            |    64 |        4 |      **2** |       2 |           same |
+
+Same 10 kernels in the same fusion/split structure as the dynamic report — the SDPA P@V split (`005_split_demoted`)
+fires for static-K too. The dominators by static deplodock µs are the three attention reproducers
+(`k_linear_sdpa_reduce` 78 + `k_sdpa_linear_reduce` 70 + `k_sdpa_reduce` 45 ≈ 193 µs of slice-set total, ~80% once
+de-duplicated against the deployed total) — and every one is 2.7–3.6x faster than its dynamic twin. The linears are
+1.5–1.9x faster; the RMSNorms are at parity (already memory-bound, no masked-tile content).
+
+## Finding 1 — a sibling-cell-fused hoisted-compute slab aborted the whole static tune; fixed with a descriptive `LoweringError` + per-variant `Run.drive` containment (fixed on this branch)
+
+**Symptom.** The first clean static seq-512 tune died ~30 min in with no traceback containment — one search-explored
+fork raised mid-lowering and took the entire tune with it:
+
+```
+AttributeError: 'Literal' object has no attribute 'name'
+  …/lowering/kernel/_stage_expand.py:398, in compute_phase_info: cache_axes = tuple(axis_map[v.name] for v in write.index)
+```
+
+**Evidence.** Instrumenting `compute_phase_info` caught the exact bundle (and a second/third like it):
+
+```
+output='linear_1_reduce_smem_position_embeddings_0_smem_fused'
+index=(Literal(value=3), Var('a2'), Var('a4'))   axis_map=('a3','a2','a4')
+```
+
+The hoisted-compute Write's index — built at `tile/030_hoist_invariant_compute.py:288` as
+`tuple(Var(ax.name) for ax in fused_cache_axes)`, i.e. all `Var`s — has had its **first** entry σ-collapsed to a
+constant `Literal(3)`. `StageBundle.nested()` (`ir/tile/ir.py:1348`) exposes the `compute` template to generic index
+substitution, so `012_fuse_sibling_register_cells` (which co-fills one smem slab from N sibling register cells) pins
+the cell's `a3` coordinate to a constant in each sibling's self-describing Write. `compute_phase_info` /
+`emit_compute_phase` (`_stage_expand.py`) derive ONE iteration domain + slab shape from a single Write, so they cannot
+represent that multi-sibling fill (the slab needs `a3`'s full extent for the decl, but this bundle must iterate only
+the non-collapsed `a2,a4` and write its pinned `a3` slice). Greedy `compile`/`run` never pick this fork (greedy at seq
+512 compiles fine), so it is a tuner-only dead end.
+
+**Root cause — two stacked defects (both the static-reference report's finding 1 pattern, recurring):**
+
+1. **Proximate**: `compute_phase_info` assumed every Write-index entry was a cache-axis `Var` and indexed `axis_map`
+   by `.name`, throwing an opaque `AttributeError` on the collapsed `Literal`.
+2. **Containment**: a *rewrite/lowering* exception in the inner search had no per-variant containment — bench failures
+   become `bench_fail` rows, but an exception while ADVANCING the lowering of one candidate propagated out of
+   `Run.drive`'s generator and aborted the whole tune. `LoweringError`'s own docstring already says the tune
+   fork-pruning path treats an un-lowerable branch as a legitimate dead end — `drive` just didn't apply that to
+   *exceptions*, only to the `validate(ctx)`-filtered case.
+
+**Fix (this branch).**
+
+- `_stage_expand.py:compute_phase_info` now detects a non-cache-axis index entry and raises a descriptive
+  `LoweringError` naming the slab, the index, and the cause ("a sibling-cell-fused slab fill the single-Write
+  materializer can't represent") instead of an opaque `AttributeError`.
+- `pipeline.py:Run.drive` wraps the per-candidate `_step` (the tune-only search driver; greedy uses the deterministic
+  `Run.resolve`, untouched and still loud): an un-lowerable lowering exception drops the candidate's subtree, logs a
+  `[tune] dropped un-lowerable candidate (…)` warning, increments `Run._dropped_candidates`, and continues the search.
+  The `pop()` already decremented the node's `live` count, so a dropped candidate is bookkeeping-identical to a
+  dead-end terminal — no wedge, and if every fork of an op is un-lowerable the run still ends cleanly. The terminal
+  count line now reports `N un-lowerable candidate(s) dropped`.
+- Tests: `tests/compiler/pipeline/test_lowering_error_guardrail.py` gains 3 — `compute_phase_info` raises a
+  `LoweringError` on a collapsed index (and still recovers a clean all-`Var` index); a *raising* lowering pass
+  propagates loudly under greedy `Pipeline.run`; and is contained (no raise, branch pruned, warning logged) under tune.
+
+**Repro.** Greedy is unaffected: `deplodock compile Qwen/Qwen3-Embedding-0.6B --layer 0 --seq-len 512` succeeds.
+The crash was tuner-only and needed default patience (50) to reach the fork; with the fix the tune logs three
+`dropped un-lowerable candidate` lines (slabs `…position_embeddings_0…`, `…_1…`, `…_0…_1…`, all
+`index=(Literal(3), Var('a2'), Var('a4'))`) and completes.
+
+**Suggested follow-up (low — the fork is not deployable).** If the sibling-cell-fused hoisted-compute producer is ever
+wanted as a real tuned variant, the materializer needs to separate "slab shape" (full extents, all siblings) from
+"this bundle's iteration domain" (non-collapsed axes only) and co-emit the N sibling Writes into one slab. Until then,
+pruning it is correct: greedy never picks it and the tuner has cheaper equivalents.
+
+## Finding 2 — WHY the dynamic path is slower (the headline): the masked-K split forces a standalone 148 µs materialised softmax; static's is a 14 µs normalise producer
+
+**Symptom.** The single largest contributor to the 361→168 µs static-vs-dynamic e2e gap is the **softmax**. NCU
+attribution of the static attention chain (one `ncu` capture, deplodock `k_*` + torch reference kernels side by side,
+locked base clock — `run --ir k_linear_sdpa_reduce_94ab75.torch.json --bench --profile`) vs the dynamic report's
+finding-1 NCU:
+
+```
+attention kernel (NCU, locked clock)                         static      dynamic
+-----------------------------------------------------------------------------------
+QK^T scores (+ softmax max/sum stats; scalar)                 68.1 us     71.6 us  (QK^T only — softmax split out)
+standalone softmax producer (…_xn)                            14.3 us    148.5 us  ← 10.4x
+P@V (mma_m16n8k16_f16)                                         15.4 us     42.4 us
+o_proj (mma_m16n8k16_f16)                                      28.6 us     47.0 us
+attn-out contiguify (…_xn)                                      4.4 us      4.3 us
+-----------------------------------------------------------------------------------
+torch ref: flash_fwd_splitkv + combine                        ~36 us      ~37 us
+torch ref: cutlass_80_tensorop_f16_s16816gemm (o_proj)        22.7 us     22.2 us
+```
+
+Static raw NCU rows (this run): `k_sdpa_reduce_c0c97e` (QK^T+softmax-stats, scalar, regs 114) **68,096 ns**;
+`k_sdpa_reduce_ba65cb` (P@V mma) **15,360 ns**; `k_sdpa_reduce_ba65cb_xn` (softmax-normalise producer, 67% dram —
+memory-bound but small) **14,336 ns**; `k_linear_sdpa_reduce_94ab75` (o_proj mma) **28,608 ns**;
+`k_linear_sdpa_reduce_94ab75_xn` (contiguify) **4,416 ns**.
+
+**Root cause.** In the **dynamic** path, the masked-K demotion split (`005_split_demoted` on symbolic K) un-fuses the
+SDPA into a **standalone softmax-normalising producer** that must MATERIALISE the full normalised seq×seq P matrix to
+HBM so the masked-K mma consumer can read it — a scalar 3-pass (`max → exp-sum → normalise`) at 6% occupancy over the
+symbolic seq×seq matrix, NCU **148 µs** (dynamic finding 1). In the **static** path the same P@V split fires, but the
+normalise producer stays a cheap **14 µs** `_xn` slab (static K, no symbolic 3-pass materialisation), and the softmax
+max/sum stats stay fused into the QK^T kernel (`k_sdpa_reduce`, the 68 µs scalar). Net softmax-path cost: ~82 µs static
+vs ~219 µs dynamic. CLAUDE.md still records *flash-style fused symbolic-K attention remains future work* — that future
+work is exactly what removes the dynamic 148 µs kernel.
+
+**Repro.** Static NCU: `DEPLODOCK_DUMP_DIR=<dir>/ncu-static-oproj deplodock run --ir
+<dump>/07_lowering_cuda.kernels/k_linear_sdpa_reduce_94ab75.torch.json --bench --profile` (raw CSV/JSON in
+`ncu-static-oproj/61_ncu_metrics.{csv,json}`). Dynamic side: the dynamic report's finding-1 NCU. The masked-K mma gate
+that creates the dynamic split: `010_partition_loops.py:737` (`k_forced_mask=k_symbolic`); the masked-K zero-fill +
+SYNC-transport pin that makes the dynamic P@V consumer expensive: `_stage_expand.py:179` (`has_kmask` → SYNC) and
+`:256`/`:305` (zero-fill, no cp.async).
+
+**Suggested fix (highest priority for dynamic serving, large + known).** Flash-style symbolic-seq attention: a
+scheduled online-softmax warp loop over the symbolic N (QK^T sub-tile → running max/sum rescale → P@V mma accumulate),
+so the softmax never materialises to HBM. The static path shows the ceiling: with the softmax cheap, the deployed layer
+beats eager (1.29x); closing the symbolic softmax gap is most of the dynamic 361→~200 µs runway.
+
+## Finding 3 — fp16-half2-window lockout: static scalar matmuls get 2× packed `__hfma2`, symbolic-K never does
+
+**Symptom.** The QK^T kernel is **scalar** (0 `mma.sync`) in BOTH static and dynamic — the online-softmax epilogue
+forbids the warp-tier fold (the accumulator feeds the softmax max/sum reduce, a mid-reduction use), `_atom.py:324`:
+
+> *the accumulator is consumed inside a reduce loop (mid-reduction use, not a store-time fold)*
+
+This bail is shape-agnostic, so it is NOT the static-vs-dynamic differentiator. The differentiator is what the *scalar*
+kernel is allowed to do: the static QK^T emits **48 `__half2` packed ops** (the fp16 half2 window, 2× `__hfma2`
+throughput) and NCU-clocks **68 µs / 36.6% fma**; the dynamic QK^T has the window **locked out** and clocks **71 µs**
+NCU / **162 µs** reproducer. Across the matmuls the same lockout costs the symbolic path: v_proj 15→27 µs, q_proj
+9→17 µs, o_proj on the static path reaches mma (the linears below).
+
+**Root cause.** `010_partition_loops.py:660`:
+
+```python
+fp16_window = (not prologue) and not k_symbolic and _is_fp16_matmul(matmul_reduces, graph)
+```
+
+`not k_symbolic` — the half2 window is gated OFF for any symbolic-K matmul (the window's bounded fp16-accumulation
+flush can't interleave with the masked-K schedule). Static K → window ON. Same for the masked-tile per-element store
+guards: symbolic M/N/K stamp `*_forced_mask` (`:670`, `:734`, `:737`) → an `if (coord < seq_len)` boundary cond on
+every store; static tiles are clean (`prologue_mask_ok`/`E_M`/`E_N` degeneration at `:653`/`:662`-`:663` only bites the
+symbolic axes).
+
+**Repro.** Tier fingerprint: `grep -c mma.sync` + `grep -c __half2` over the emitted `.txt` —
+`<dump>/07_lowering_cuda.kernels/k_sdpa_reduce_*.txt` shows `mma=0 half2=48` (static, window on). The locked-out
+dynamic twin: the dynamic dump's `k_sdpa_reduce_*` (window off). Gate probe (no GPU): `010_partition_loops.py:660`.
+
+**Suggested fix (medium, bounded by finding 2).** A masked-K-compatible fp16 window (flush the half2 accumulator at
+the masked-K tile boundary) would recover the 2× on the symbolic scalar matmuls. But the QK^T scalar tier itself is
+subsumed by the flash work (finding 2), which puts QK^T on tensor cores; the window matters mainly for the symbolic
+linears (v_proj/q_proj), worth ~10–15 µs.
+
+## Finding 4 — the masked-K P@V mma runs at 2.8× the static mma (42 vs 15 µs): zero-fill + SYNC-transport pin, not a tier or pick miss
+
+**Symptom.** The P@V consumer reaches `mma_m16n8k16_f16` in BOTH paths (static `k_sdpa_reduce_ba65cb` mma=11; dynamic
+masked-K mma), but the dynamic one runs **42.4 µs** (dynamic finding 2, 26% occ, 3.67M smem bank conflicts) vs static
+**15.4 µs** (50% occ). Same for o_proj: dynamic 47 µs vs static 28.6 µs. The static prior recovers its measured best
+cleanly (`eval prior --dataset db`: static mean **1.25x** / median 1.09x / worst 1.97x, all -O1 inversions — vs the
+dynamic DB's mean 2.52x / worst 17.64x), so this is NOT a search shortfall or a tier lockout.
+
+**Root cause.** The dynamic masked-K P@V pays three symbolic-only taxes the static-K mma skips, all from the masked-K
+staging: (1) the K reduce is tiled at the hint with a partial final slab **zero-filled in smem** (`_stage_expand.py:256`
+— `(k < seq_len) ? v : 0`, a clamped read), (2) the source carrying the kmask is **pinned to the SYNC transport**
+(`_stage_expand.py:179` — cp.async can't ternary a copied value, so no ring-buffered cp.async pipeline), and (3)
+per-element store guards from `n_forced_mask`/`m_forced_mask`. The dynamic report's finding 2 proved `PAD_SMEM` /
+`PERMUTE_LANES` are no-ops on this masked-tile smem layout (the bank conflicts are inherent to the masked-K slab), so
+the levers the tuner has don't reach it. Static K → none of this: clean staging, cp.async eligible, no guards.
+
+**Repro.** Static P@V tier: `<dump>/07_lowering_cuda.kernels/k_sdpa_reduce_ba65cb.txt` (mma=11). Gate probes:
+`_stage_expand.py:179` (SYNC pin), `:256` (zero-fill), `010_partition_loops.py:737` (`k_forced_mask`). The dynamic A/B
+proving PAD_SMEM/PERMUTE_LANES are no-ops: dynamic report finding 2.
+
+**Suggested fix (medium — ~50 µs at stake across P@V + o_proj on the dynamic path, generalises to every masked warp
+tile).** A conflict-free masked-K smem layout (swizzle inside the zero-filled slab) and a cp.async-compatible masked-K
+copy (stage then mask in smem, so the ring buffer is usable) would close most of the 42→15 µs P@V gap. Folds into the
+flash work (finding 2) since that owns the symbolic-K schedule.
+
+## Finding 5 — TMA descriptor rank mismatch: 20 `bench_fail`s on the P@V mma + the tune's full-model `--bench` capture (static-512 codegen bug)
+
+**Symptom.** 47 of 5,525 `perf` rows are `bench_fail`. The dominant cluster (`eval failures`):
+
+```
+k_sdpa_linear_reduce_3d2635 — 20 row(s)
+  error: ValueError('TMA descriptor rank mismatch: arr_shape=(1, 512, 1, 1024) cannot be collapsed to match
+                     box_extents=(1, 64, 2, 64)')  [and (1, 32, 2, 64)]
+  shared knobs: MMA=mma_m16n8k16_f16, TMA=True, SPLIT_CONE=True, STAGE=11, …
+```
+
+Every failing row has `TMA=True` on the P@V mma consumer at seq 512. The same error killed the tune's full-model
+`--bench` captured bench (`[tune] full-model bench failed (… TMA descriptor rank mismatch …); continuing to
+per-kernel`), which is why the deployed e2e (168 µs) had to come from a separate `run --bench` (greedy picks a non-TMA
+P@V variant, so it succeeds).
+
+**Root cause hypothesis.** Class 4 / class 3: the TMA descriptor builder for the static-512 P@V mma tries to collapse a
+`(1, 512, 1, 1024)` array onto a `(1, 64, 2, 64)` box and fails the rank/collapse check — a real codegen bug in the TMA
+box-extent derivation for this kernel's operand shape (the 4-D V slab with a leading batch + the s16816 box). It only
+fires for `TMA=True` variants; non-TMA cp.async/sync staging works (the deployed pick and the 70 µs reproducer are
+non-TMA). 20 wasted search slots, and it blocks the captured full-model bench. The remaining `bench_fail`s are
+**compile-budget timeouts** (`compile stage exceeded 2.0s budget (2.3–3.2s)`) on big unrolled FK-window scalar kernels
+at -O3 — the known cicc/LLVM blow-up, a budget not a correctness bug.
+
+**Repro.** `deplodock eval failures` (clusters + shared knobs). Compile-only TMA repro (no GPU, source inspection):
+`DEPLODOCK_KNOBS="MMA=mma_m16n8k16_f16,TMA=1,SPLIT_CONE=1,STAGE=11" deplodock compile
+<dump>/07_lowering_cuda.kernels/k_sdpa_linear_reduce_3d2635.torch.json --ir cuda` (expect the descriptor builder to
+raise). The TMA path: `lowering/tile/050_use_tma.py` + the descriptor box derivation.
+
+**Suggested fix (medium — blocks the captured full-model bench + wastes 20 slots).** Fix the TMA box-extent
+collapse for the leading-batch 4-D operand (or gate `TMA` off for this operand shape so the tuner doesn't enumerate a
+guaranteed-fail variant). Until then the full-model `--bench` capture is unreliable on static-512 — use a separate
+greedy `run --bench` for the deployed e2e (as this report does).
+
+## Finding 6 — bench attribution: the deployed launch table mis-attributes attention; only NCU + e2e are trustworthy (recurring, 4th report)
+
+**Symptom.** The deployed static `run --bench` launch table fingers the q_norm/k_norm RMSNorm reductions
+(`k_mean_linear_reduce_125c9c` 21.5 µs / 13%, `…_1f1bec` 22.2 µs / 13.5%) and the softmax `_xn` (22.8 µs / 13.8%) as
+the layer's biggest kernels, while NCU (finding 2) clocks the QK^T+softmax-stats at 68 µs — the per-launch solo windows
+absorb cross-kernel latency and the `%` column mislabels the dominator, exactly as the dynamic report's finding 5 and
+the two before it. The `--bench` reproducer table also re-fuses the upstream cone, so the attention reproducers'
+78/70 µs are slice-set totals, not the named kernel.
+
+Only the **NCU single-capture table** and the **whole-program e2e** (168 µs) are trustworthy for attention. This is the
+recurring attribution problem (`plans/bench-attribution-by-slicing.md`) — the static report reproduces it on the same
+kernels.
+
+**Suggested fix (high — the recurring tooling gap).** Land per-launch attribution by slicing so the deployed table
+matches NCU; until then the skill's "trust NCU + e2e for attention" holds, and this run is one more datapoint.
+
+## Repro / artifacts
+
+- Work dir: `_tune/tune-model-qwen3-emb-l0-static/` (gitignored, survives reboots) — `tune.log` (3.5 h tune tee, incl.
+  the 3 `dropped un-lowerable candidate` lines + the per-kernel -O3 table), `run-static.log` (deployed e2e 168 µs +
+  launch table), `run-dynamic-cooled.log` (cooled dynamic e2e 361 µs, same card), `ncu-static-oproj.log` +
+  `ncu-static-oproj/61_ncu_metrics.{csv,json}` (finding-2 NCU), dump at `dump/` (reproducers under
+  `07_lowering_cuda.kernels/`, `62_kernel_bench.json`, `kernels.html`; `.png` skipped — Playwright `Target page closed`
+  flake), `PRIOR-static-ref-2026-06-10.md` (the recovered static reference report for tone/structure).
+- Tune DB / prior (isolated, this run only): `_tune/tune-model-qwen3-emb-l0-static/{static.db,static-prior.json}`.
+  Dynamic-side comparison reads the preserved default `~/.cache/deplodock/{autotune.db,prior.json}`.
+- Static e2e (deployed): `DEPLODOCK_TUNE_DB=…/static.db DEPLODOCK_PRIOR_FILE=…/static-prior.json deplodock run
+  Qwen/Qwen3-Embedding-0.6B --layer 0 --seq-len 512 --bench`. Dynamic e2e (same card): `deplodock run
+  Qwen/Qwen3-Embedding-0.6B --layer 0 --dynamic seq_len@x:1 --bench` (default paths = dynamic prior).
+- Finding-1 fix (this branch): `_stage_expand.py:compute_phase_info` (descriptive `LoweringError`),
+  `pipeline.py:Run.drive` (per-variant containment) + `Run._dropped_candidates`,
+  `tests/compiler/pipeline/test_lowering_error_guardrail.py` (+3 tests). Gate probes (no GPU):
+  `_atom.py:324` (online-softmax fold bail), `010_partition_loops.py:660` (fp16-window
+  lockout), `:737` (`k_forced_mask`), `_stage_expand.py:179`/`:256` (masked-K SYNC pin + zero-fill).
+- Finding-5 failures: `deplodock eval failures` (static DB).
+
+## Workflow notes
+
+Audit of the dynamic report's notes first:
+
+- **Per-launch mis-attribution (dynamic finding 5)**: **reproduced** (finding 6). The static deployed table mislabels
+  the RMSNorms / softmax `_xn` as the dominators; only NCU revealed the 68 µs QK^T. Now 4 reports in a row — strongly
+  reinforces `plans/bench-attribution-by-slicing.md`.
+- **Reproducer re-fusion (dynamic finding 5)**: **reproduced.** The static attention reproducers re-fuse the cone
+  (78/70 µs slice-set totals), so I fell back to NCU for every attention number. A `run --ir … --bench --no-refuse`
+  (bench only the named provenance kernel) would still save the most triage time.
+- **Stable per-op identity across views**: **reproduced.** The static QK^T wears `82f310` (deployed), `3c1b01` (dump),
+  `c0c97e` (NCU re-lower) — three hashes for one op, hand-cross-referenced. A stable provenance name in the NCU /
+  leaderboard / deployed tables would remove the cross-referencing.
+- **Chart PNG Playwright flake**: reproduced verbatim (`png skipped: Target page … closed`).
+
+New friction this run:
+
+- **A single un-lowerable search fork aborted the whole 3.5 h tune (finding 1).** This is the static-reference report's
+  finding 1 recurring — "rewrite-time exceptions in the inner search have no per-variant containment." I fixed it here
+  (`Run.drive` containment), but the lesson for the skill: **a clean tune on a new shape/commit can crash on a
+  search-only lowering bug greedy never hits** — the memory note "clean-tune is the real test gate" held exactly (unit
+  tests + greedy compile both passed while the tune crashed). Budget for a fix-and-rerun on the first clean tune of a
+  new configuration.
+- **The crash took ~30 min to reach under default patience and `-q` is near-silent under `tee`** (the tty progress bar
+  doesn't survive the pipe). A non-tty per-terminal heartbeat (`[tune] terminal k/16 done, best Σ …`) would show
+  liveness without `-v`'s firehose, and would have told me the tune was alive vs wedged during the 30-min CPU-bound
+  nvcc grind (GPU sat at 5%). Biggest wall-clock uncertainty.
+- **The tune's full-model `--bench` capture is unreliable on static-512 (finding 5)** — it failed on a TMA descriptor
+  bug, so the headline e2e had to come from a separate greedy `run --bench`. The skill already prefers a cooled fresh
+  `run --bench` for the reported e2e; this run shows the tune-`--bench` full-model row can be *absent*, not just
+  thermally inflated. A `tune --bench` that falls back to the greedy (non-TMA) pick for the full-model row when the
+  captured pick fails would keep the headline number in the tune output.
+- **`--seq-len` is load-bearing for a static-vs-dynamic comparison and easy to miss.** The dynamic path benches at the
+  512 hint regardless of `--seq-len`; the static path specialises to `--seq-len` (default 32). Tuning static at the
+  default would have produced a meaningless comparison (attention ~256x smaller). The skill should call out
+  "match `--seq-len` to the dynamic hint (512) when comparing static vs dynamic."
+
+What worked well: the triage loop was tight once the tune completed — `eval failures` clustered the 47 fails into
+TMA-vs-compile-budget in one line (finding 5); the single `--profile` NCU run on the o_proj-chain reproducer gave the
+whole static attention path + the torch flash/cutlass references in one aligned table (the clean signal for finding 2,
+directly comparable to the dynamic report's NCU); `eval prior --dataset db` settled "search shortfall vs masked-tile
+tax" (static 1.25x mean reachability) in one command; and the `grep -c mma.sync` / `grep -c __half2` over the emitted
+`.txt` was the fastest tier + fp16-window fingerprint (static QK^T `mma=0 half2=48` → window on). A `tier` (scalar/mma)
++ `half2` column in `eval variants` would make findings 3–4 a zero-step read.

--- a/plans/qwen3-embedding-layer0-static-tune-findings.md
+++ b/plans/qwen3-embedding-layer0-static-tune-findings.md
@@ -65,18 +65,18 @@ layer-op labels read off each kernel's `.torch.json` provenance). The attention 
 upstream cone, so their `deplodock` µs is a slice-set total, not the deployed kernel alone — the clean per-kernel
 attention attribution is the NCU table in finding 2.
 
-| Kernel                 | Layer op                                                 | eager | tcompile | **static** | dynamic |  static vs dyn |
-|------------------------|----------------------------------------------------------|------:|---------:|-----------:|--------:|---------------:|
-| `k_linear_sdpa_reduce` † | attn-out reshape + o_proj (linear_3) + residual        |    39 |       37 |     **78** |     213 |    2.7x faster |
-| `k_sdpa_linear_reduce` | SDPA P@V split (v_proj + softmax-normalise + P@V mma)    |    29 |       29 |     **70** |     203 |    2.9x faster |
-| `k_sdpa_reduce`        | RoPE(q,k) + QK^T scores + softmax-stats                  |   148 |       25 |     **45** |     162 |    3.6x faster |
-| `k_linear_mean_reduce` | post-attn RMSNorm + MLP gate+up (linear_4/5) + SiLU·up   |   119 |       57 |     **47** |      58 |    1.2x faster |
-| `k_linear`             | MLP down (linear_6) + residual                           |    26 |       26 |     **26** |      44 |    1.7x faster |
-| `k_mean_linear_reduce` | q_norm RMSNorm + rotated-q producer (xna)                |   105 |       20 |     **18** |      27 |    1.5x faster |
-| `k_linear_reduce`      | v_proj matmul (linear_1)                                 |    14 |       14 |     **15** |      27 |    1.8x faster |
-| `k_mean_linear_reduce` | k_norm RMSNorm + rotated-k producer (xnb)                |    76 |       14 |     **12** |      18 |    1.5x faster |
-| `k_linear_reduce`      | q_proj matmul (linear)                                   |    10 |       10 |      **9** |      17 |    1.9x faster |
-| `k_mean`               | input RMSNorm                                            |    64 |        4 |      **2** |       2 |           same |
+| Kernel                 | Layer op                                                  | eager | tcompile | **static** | dynamic |  static vs dyn |
+|------------------------|-----------------------------------------------------------|------:|---------:|-----------:|--------:|---------------:|
+| `k_linear_sdpa_reduce` | attn-out reshape + o_proj (linear_3) + residual           |    39 |       37 |     **78** |     213 |    2.7x faster |
+| `k_sdpa_linear_reduce` | SDPA P@V split (v_proj + softmax-normalise + P@V mma)     |    29 |       29 |     **70** |     203 |    2.9x faster |
+| `k_sdpa_reduce`        | RoPE(q,k) + QK^T scores + softmax-stats                   |   148 |       25 |     **45** |     162 |    3.6x faster |
+| `k_linear_mean_reduce` | post-attn RMSNorm + MLP gate+up (linear_4/5) + SiLU·up    |   119 |       57 |     **47** |      58 |    1.2x faster |
+| `k_linear`             | MLP down (linear_6) + residual                            |    26 |       26 |     **26** |      44 |    1.7x faster |
+| `k_mean_linear_reduce` | q_norm RMSNorm + rotated-q producer (xna)                 |   105 |       20 |     **18** |      27 |    1.5x faster |
+| `k_linear_reduce`      | v_proj matmul (linear_1)                                  |    14 |       14 |     **15** |      27 |    1.8x faster |
+| `k_mean_linear_reduce` | k_norm RMSNorm + rotated-k producer (xnb)                 |    76 |       14 |     **12** |      18 |    1.5x faster |
+| `k_linear_reduce`      | q_proj matmul (linear)                                    |    10 |       10 |      **9** |      17 |    1.9x faster |
+| `k_mean`               | input RMSNorm                                             |    64 |        4 |      **2** |       2 |           same |
 
 Same 10 kernels in the same fusion/split structure as the dynamic report — the SDPA P@V split (`005_split_demoted`)
 fires for static-K too. The dominators by static deplodock µs are the three attention reproducers
@@ -84,7 +84,8 @@ fires for static-K too. The dominators by static deplodock µs are the three att
 de-duplicated against the deployed total) — and every one is 2.7–3.6x faster than its dynamic twin. The linears are
 1.5–1.9x faster; the RMSNorms are at parity (already memory-bound, no masked-tile content).
 
-> **† Updated post-#245 (TMA for dynamic M-masked matmuls).** This dynamic column is the *original* cp.async
+> **`k_linear_sdpa_reduce` — updated post-#245 (TMA for dynamic M-masked matmuls).** This dynamic column is the
+> *original* cp.async
 > reproducer totals (re-fused slice-set, so the row is dominated by the unchanged upstream softmax — that is why the
 > total stays ~2.7x even though the o_proj kernel itself was fixed). The o_proj *kernel* now stages via TMA on the
 > dynamic path: its solo reproducer window is **34.4 µs (cp.async) → 19.6 µs (TMA)** and its clean NCU is **47.0 →

--- a/plans/serving-dynamic-shape-cuda-graphs.md
+++ b/plans/serving-dynamic-shape-cuda-graphs.md
@@ -86,4 +86,10 @@ retained only to record the rejected approach and why; see "Status" above for wh
   nothing.)*
 - **Prefix-occupancy** for shared capacity buffers, with the 2-D causal mask generated on-device. *(Prefix occupancy
   kept; on-device mask-gen deferred to follow-up #1 — the host upload is correct and simpler for the first cut.)*
-- TMA is rejected on symbolic-dim graphs (`lowering/tile/050_use_tma.py:152-157`), so it was never a concern.
+- TMA was originally rejected on symbolic-dim graphs, so it was never a concern. **Update:** TMA now fires on
+  symbolic-dim graphs for M-masked matmuls with a static innermost dim (`lowering/tile/050_use_tma.py`) — the
+  descriptor's `globalDim` is encoded per launch from the runtime input shape (`program._prebuild_descriptors`) and TMA
+  zero-fills the masked overhang. For serving this is handled by the **capture-per-`seq_len`** model: each captured
+  graph bakes a descriptor for its exact `seq_len`, so no per-replay descriptor refresh is needed. A future
+  single-graph-across-`seq_len` mode would need the descriptor re-encoded + refreshed before each replay (stable
+  pointer, updated contents) — out of scope for the per-S capture path.

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -1,11 +1,40 @@
 """Tests for cupy dispatch of a lowered ``Graph[CudaOp]``."""
 
-from deplodock.compiler.backend.cuda.program import benchmark_program, run_program
+import pytest
+
+from deplodock.compiler.backend.cuda.program import _collapse_inert_dims, benchmark_program, run_program
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.cuda import CudaOp
 
 from ..conftest import requires_cuda
+
+
+class TestCollapseInertDims:
+    """``_collapse_inert_dims`` maps a runtime array shape onto a TMA descriptor's
+    box rank. It must keep a *box-carrying* dim even when its runtime extent is
+    small (a masked dynamic ``seq_len`` = 1, 31 — TMA zero-fills the box overhang
+    past the runtime extent), while still shedding genuine inert gap singletons
+    (arr_rank > box_rank). The old extent==1 heuristic mis-dropped the masked dim
+    at small ``seq_len`` (regression: ``arr=(1, 512)`` vs ``box=(64, 32)``)."""
+
+    def test_masked_m_runtime_extent_one(self):
+        # seq_len=1: the M dim (1) is box-carrying, not an inert singleton — keep it.
+        assert _collapse_inert_dims((1, 512), (64, 32)) == (1, 512)
+
+    @pytest.mark.parametrize("seq", [31, 512, 700])
+    def test_masked_m_runtime_extents(self, seq):
+        # Same-rank direct map at, below, and above the hint — drop nothing.
+        assert _collapse_inert_dims((seq, 512), (64, 32)) == (seq, 512)
+
+    def test_drops_inner_gap_singleton(self):
+        # arr_rank (3) > box_rank (2): the genuine inner gap singleton is dropped.
+        assert _collapse_inert_dims((512, 1, 1024), (64, 128)) == (512, 1024)
+
+    def test_rank_mismatch_raises(self):
+        with pytest.raises(ValueError, match="rank mismatch"):
+            _collapse_inert_dims((512, 768, 1024), (64, 128))
+
 
 EW_ADD_SOURCE = """
 extern "C" __global__ void ew_add(const float* A, const float* B, float* C) {

--- a/tests/compiler/conftest.py
+++ b/tests/compiler/conftest.py
@@ -245,6 +245,33 @@ def run_two_level(graph, **kwargs):
     return asyncio.run(run_two_level_tune(graph, **kwargs))
 
 
+@pytest.fixture(params=["static", "dynamic"])
+def shape_mode(request) -> str:
+    """Parametrize a test over a static vs dynamic (symbolic-M) shape. Any test
+    that names this fixture runs once per mode — the static/dynamic parity
+    automation. Pair with :func:`dyn_M` to flip a graph's leading/M axis:
+
+        def test_x(shape_mode):
+            g = build_graph(M=dyn_M(shape_mode, 256), ...)   # int 256 or Dim('seq_len')
+
+    The dynamic mode compiles ONE symbolic kernel (``Dim('seq_len')``, runtime
+    ``int seq_len`` arg) tiled at the 512 hint and run at the concrete M fed in
+    the input arrays; the static mode bakes M. Use tile-divisor M for strict
+    static-vs-dynamic parity (off-hint masked sizes live in
+    ``test_matmul_mma_masked.py``)."""
+    return request.param
+
+
+def dyn_M(mode: str, M: int):
+    """``Dim('seq_len')`` for ``mode == 'dynamic'``, else the int ``M``. The
+    one-liner that turns a static graph builder into a static/dynamic one."""
+    if mode == "dynamic":
+        from deplodock.compiler.dim import Dim
+
+        return Dim("seq_len")
+    return M
+
+
 def from_pretrained_or_skip(loader, *args, **kwargs):
     """Run a HuggingFace ``from_pretrained`` download, skipping the test on a Hub
     connection / rate-limit failure.

--- a/tests/compiler/passes/test_knob_pinning.py
+++ b/tests/compiler/passes/test_knob_pinning.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from ..conftest import requires_cuda
+from ..conftest import dyn_M, requires_cuda
 
 # Shapes match the user's offline scan.
 _MATMUL_DIMS = {"M": 32, "K": 128, "N": 64}
@@ -69,35 +69,40 @@ def _format_knobs(knobs: dict) -> str:
     return ",".join(f"{k}={v}" for k, v in knobs.items())
 
 
-def _build_matmul_graph(dims: dict):
+def _build_matmul_graph(dims: dict, mode: str = "static"):
+    """``(1, M, K) @ (K, N)``. ``mode='dynamic'`` makes the M axis symbolic
+    (``Dim('seq_len')``); the returned ``input_shapes`` stay concrete so the run
+    feeds a real (1, M, K) array the symbolic kernel resolves ``seq_len`` from."""
     from deplodock.compiler.graph import Graph, Tensor
     from deplodock.compiler.ir.base import InputOp
     from deplodock.compiler.ir.frontend.ir import MatmulOp
 
     M, K, N = dims["M"], dims["K"], dims["N"]
+    Mg = dyn_M(mode, M)
     g = Graph()
-    g.add_node(InputOp(), [], Tensor("a", (1, M, K)), node_id="a")
+    g.add_node(InputOp(), [], Tensor("a", (1, Mg, K)), node_id="a")
     g.add_node(InputOp(), [], Tensor("b", (K, N)), node_id="b")
-    g.add_node(MatmulOp(), ["a", "b"], Tensor("c", (1, M, N)), node_id="c")
+    g.add_node(MatmulOp(), ["a", "b"], Tensor("c", (1, Mg, N)), node_id="c")
     g.inputs, g.outputs = ["a", "b"], ["c"]
     return g, {"a": (1, M, K), "b": (K, N)}, ("c", (1, M, N))
 
 
-def _build_gated_graph(dims: dict):
+def _build_gated_graph(dims: dict, mode: str = "static"):
     from deplodock.compiler.graph import Graph, Tensor
     from deplodock.compiler.ir.base import InputOp
     from deplodock.compiler.ir.frontend.ir import MatmulOp
     from deplodock.compiler.ir.tensor.ir import ElementwiseOp
 
     S, H, Inter = dims["S"], dims["H"], dims["I"]
+    Sg = dyn_M(mode, S)
     g = Graph()
-    g.add_node(InputOp(), [], Tensor("x", (1, S, H)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("x", (1, Sg, H)), node_id="x")
     g.add_node(InputOp(), [], Tensor("wg", (H, Inter)), node_id="wg")
     g.add_node(InputOp(), [], Tensor("wu", (H, Inter)), node_id="wu")
-    g.add_node(MatmulOp(), ["x", "wg"], Tensor("mg", (1, S, Inter)), node_id="mg")
-    g.add_node(MatmulOp(), ["x", "wu"], Tensor("mu", (1, S, Inter)), node_id="mu")
-    g.add_node(ElementwiseOp("silu"), ["mg"], Tensor("sg", (1, S, Inter)), node_id="sg")
-    g.add_node(ElementwiseOp("multiply"), ["sg", "mu"], Tensor("y", (1, S, Inter)), node_id="y")
+    g.add_node(MatmulOp(), ["x", "wg"], Tensor("mg", (1, Sg, Inter)), node_id="mg")
+    g.add_node(MatmulOp(), ["x", "wu"], Tensor("mu", (1, Sg, Inter)), node_id="mu")
+    g.add_node(ElementwiseOp("silu"), ["mg"], Tensor("sg", (1, Sg, Inter)), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "mu"], Tensor("y", (1, Sg, Inter)), node_id="y")
     g.inputs, g.outputs = ["x", "wg", "wu"], ["y"]
     return g, {"x": (1, S, H), "wg": (H, Inter), "wu": (H, Inter)}, ("y", (1, S, Inter))
 
@@ -146,23 +151,29 @@ def _assert_match(forced: np.ndarray, ref: np.ndarray) -> None:
 
 @requires_cuda
 @pytest.mark.parametrize("knobs", _BROKEN_MATMUL, ids=lambda k: f"BN{k['BN']}_BM{k['BM']}_FM{k['FM']}_FN{k['FN']}")
-def test_matmul_single_cta_f_replicated(knobs: dict, monkeypatch):
-    """matmul (1, 32, 128) @ (128, 64) — single-CTA + F-replicated tile."""
-    graph, input_shapes, (out_name, _) = _build_matmul_graph(_MATMUL_DIMS)
+def test_matmul_single_cta_f_replicated(knobs: dict, shape_mode, monkeypatch):
+    """matmul (1, 32, 128) @ (128, 64) — single-CTA + F-replicated tile. The
+    pinned config must produce the same correct output whether M is baked
+    (static) or symbolic (dynamic ``seq_len``, masked path) — the numpy
+    reference is the static graph; the forced CUDA run uses the mode's graph."""
+    static_graph, input_shapes, (out_name, _) = _build_matmul_graph(_MATMUL_DIMS)
+    forced_graph, _, _ = _build_matmul_graph(_MATMUL_DIMS, mode=shape_mode)
     inputs = _random_inputs(input_shapes)
-    ref = _reference(graph, inputs, out_name)
-    forced = _run_with_knobs(graph, inputs, out_name, knobs, monkeypatch)
+    ref = _reference(static_graph, inputs, out_name)
+    forced = _run_with_knobs(forced_graph, inputs, out_name, knobs, monkeypatch)
     _assert_match(forced, ref)
 
 
 @requires_cuda
 @pytest.mark.parametrize("knobs", _BROKEN_GATED, ids=lambda k: f"BN{k['BN']}_BM{k['BM']}_FM{k['FM']}_FN{k['FN']}")
-def test_gated_mlp_single_cta_f_replicated(knobs: dict, monkeypatch):
-    """gated_mlp (1, 32, 128) → (1, 32, 256) — single-CTA + F-replicated tile."""
-    graph, input_shapes, (out_name, _) = _build_gated_graph(_GATED_DIMS)
+def test_gated_mlp_single_cta_f_replicated(knobs: dict, shape_mode, monkeypatch):
+    """gated_mlp (1, 32, 128) → (1, 32, 256) — single-CTA + F-replicated tile,
+    static and dynamic (symbolic ``seq_len``). Reference is the static graph."""
+    static_graph, input_shapes, (out_name, _) = _build_gated_graph(_GATED_DIMS)
+    forced_graph, _, _ = _build_gated_graph(_GATED_DIMS, mode=shape_mode)
     inputs = _random_inputs(input_shapes)
-    ref = _reference(graph, inputs, out_name)
-    forced = _run_with_knobs(graph, inputs, out_name, knobs, monkeypatch)
+    ref = _reference(static_graph, inputs, out_name)
+    forced = _run_with_knobs(forced_graph, inputs, out_name, knobs, monkeypatch)
     _assert_match(forced, ref)
 
 

--- a/tests/compiler/pipeline/test_lowering_error_guardrail.py
+++ b/tests/compiler/pipeline/test_lowering_error_guardrail.py
@@ -147,3 +147,82 @@ def test_run_leaves_no_state_on_pipeline():
     with pytest.raises(LoweringError):
         pipeline.run(_graph_with_tile(), ctx=_small_smem_ctx())
     assert not hasattr(pipeline, "_lowering_rejections")
+
+
+# ---------------------------------------------------------------------------
+# Per-variant containment: a lowering pass that *raises* (not a validate
+# filter) aborts a greedy compile loudly, but under tune is a dropped dead
+# end so one un-lowerable search fork can't abort the whole tune. This is the
+# stacked defect the static tune-findings report flagged: an un-handled
+# fused-cell slab shape (compute_phase_info LoweringError) / an orphan AtomTile
+# at render would crash mid-tune with no per-variant containment.
+# ---------------------------------------------------------------------------
+
+
+def _build_raising_pipeline() -> Pipeline:
+    """One pass, one rule matching the ``TileOp`` at ``y`` whose rewrite
+    *raises* a ``LoweringError`` (an un-lowerable shape a deterministic pass
+    chokes on), rather than returning a validate-filtered option."""
+
+    def rewrite(root):  # noqa: ARG001
+        raise LoweringError("synthetic un-lowerable shape")
+
+    rule = Rule(
+        name="__raising_lower__",
+        pattern=[Pattern(name="root", op_type=TileOp)],
+        rewrite=rewrite,
+        param_names=tuple(inspect.signature(rewrite).parameters.keys()),
+    )
+    pass_ = Pass(name="__test_raise__", rules=[rule], index=0)
+    rule.pass_ = pass_
+    return Pipeline(passes=[pass_])
+
+
+def test_greedy_run_propagates_lowering_exception():
+    # Greedy uses ``Run.resolve`` (no containment) — a raising lowering pass
+    # propagates loudly, exactly as before.
+    pipeline = _build_raising_pipeline()
+    with pytest.raises(LoweringError, match="synthetic un-lowerable shape"):
+        pipeline.run(_graph_with_tile(), ctx=_small_smem_ctx())
+
+
+def test_compute_phase_info_raises_on_collapsed_index():
+    # A hoisted-compute Write whose index has a non-cache-axis entry (a
+    # ``Literal`` left by a sibling-cell fusion) is un-lowerable by the
+    # single-Write materializer — ``compute_phase_info`` flags it as a
+    # ``LoweringError`` (caught + pruned under tune by the containment above)
+    # instead of an opaque ``AttributeError`` mid-tune.
+    from deplodock.compiler.ir.axis import Axis
+    from deplodock.compiler.ir.expr import Literal, Var
+    from deplodock.compiler.ir.stmt import Write
+    from deplodock.compiler.ir.tile.ir import Source
+    from deplodock.compiler.pipeline.passes.lowering.kernel._stage_expand import compute_phase_info
+
+    sources = (Source(name="slab", buf="x", cache_axes=(Axis("a2", 4), Axis("a4", 8)), origin=(Literal(0, "int"), Literal(0, "int"))),)
+    # Clean all-Var index → recovers the two cache axes.
+    good = [Write(output="slab", index=(Var("a2"), Var("a4")), value="v")]
+    name, axes, _ = compute_phase_info(good, sources)
+    assert name == "slab"
+    assert tuple(a.name for a in axes) == ("a2", "a4")
+    # Collapsed index (a sibling-cell-fused constant) → LoweringError.
+    bad = [Write(output="slab", index=(Var("a2"), Literal(1, "int")), value="v")]
+    with pytest.raises(LoweringError, match="sibling-cell-fused"):
+        compute_phase_info(bad, sources)
+
+
+def test_tuning_contains_raising_lowering_pass(caplog):
+    # Under tune, ``Run.drive`` catches the lowering exception, drops the
+    # candidate's subtree, logs a warning, and finishes without raising —
+    # so a single un-lowerable fork can't abort the whole tune.
+    import logging
+
+    from deplodock.compiler.pipeline import TuningSearch
+    from deplodock.compiler.pipeline.search.db import SearchDB
+
+    pipeline = _build_raising_pipeline()
+    with caplog.at_level(logging.WARNING, logger="deplodock.compiler.pipeline"):
+        terminals = drain_tune(pipeline, _graph_with_tile(), search=TuningSearch(patience=10**6), ctx=_small_smem_ctx(), db=SearchDB())
+    # The only lowering option raised, so no terminal is benchable — the search
+    # ends cleanly with zero terminals instead of crashing.
+    assert terminals == []
+    assert any("dropped un-lowerable candidate" in r.message for r in caplog.records)

--- a/tests/compiler/test_masked_cooperative_reduce.py
+++ b/tests/compiler/test_masked_cooperative_reduce.py
@@ -1,0 +1,89 @@
+"""Masked cooperative reduce over a SYMBOLIC reduce axis.
+
+A reduction whose reduce axis is symbolic (dynamic ``seq_len``) used to be
+forced onto the degenerate scalar path (``010_partition_loops``: symbolic K →
+``E_K=1``, ``BR=1``) — one thread serially reduces the whole runtime extent,
+~6% occupancy. The masked cooperative reduce tiles the symbolic reduce at the
+``Dim`` hint (ceil-div ``K_o``) and splits it across ``BR`` cooperative lanes
+with a segmented-shuffle combine, exactly like a static reduce — the partial
+last tile is handled by clamping the K gmem index for a safe read and masking
+each ``Accum``'s input value to the op identity past ``seq_len`` (so the
+overhang folds a no-op). The ``Accum`` stays a direct child of the reduce loop
+(``is_reduce`` + the combine intact); only the post-reduce Write loop gets a
+plain boundary ``Cond``.
+
+This is the softmax-producer perf path (the dominant remaining dynamic-attention
+kernel): the deployed softmax over a symbolic key axis can now reach the same
+cooperative-reduce occupancy as the static twin.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _has_cuda() -> bool:
+    try:
+        import cupy as cp
+
+        return cp.cuda.is_available()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _supports_shuffle() -> bool:
+    """The cooperative combine uses ``__shfl_xor_sync`` (sm_30+, every CUDA GPU)."""
+    return _has_cuda()
+
+
+def _dynamic_softmax_graph():
+    """Trace ``softmax(x, dim=1)`` with axis 1 (the reduce axis) symbolic."""
+    from deplodock.commands.trace import graph_from_code
+    from deplodock.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs
+
+    ds = build_torch_dynamic_shapes(parse_position_specs(["seq_len@x:1"]))
+    graph, _, _ = graph_from_code("torch.softmax(torch.randn(8, 512), dim=1)", dynamic_shapes=ds)
+    return graph
+
+
+@pytest.mark.skipif(not _supports_shuffle(), reason="masked cooperative reduce runs/renders under CUDA")
+def test_masked_cooperative_softmax_structure(monkeypatch):
+    """With a cooperative ``BR`` pinned, the symbolic-reduce softmax deploys the
+    cooperative combine (``__shfl_xor_sync``) over a hint-tiled, boundary-masked
+    K — the runtime ``seq_len`` arg, the per-tile mask, and the clamped read are
+    all present (vs the old degenerate per-thread serial reduce)."""
+    monkeypatch.setenv("DEPLODOCK_BR", "64")
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+
+    compiled = CudaBackend().compile(_dynamic_softmax_graph())
+    src = "\n".join(n.op.kernel_source for n in compiled.nodes.values() if getattr(n.op, "kernel_source", None))
+    assert "int seq_len" in src, "symbolic reduce must carry the runtime extent arg"
+    assert "__shfl_xor_sync" in src, "cooperative reduce must emit the segmented-shuffle combine"
+    assert "seq_len +" in src, "K_o must ceil-div the symbolic extent (numerator seq_len + tile-1) at the hint"
+    assert "< seq_len" in src, "the partial last tile must be boundary-masked"
+    assert "seq_len - 1" in src, "the K gmem read must clamp to seq_len-1 for a safe in-bounds load"
+
+
+@pytest.mark.skipif(not _supports_shuffle(), reason="needs CUDA")
+@pytest.mark.parametrize("seq", [1, 31, 64, 512, 513, 700])
+def test_masked_cooperative_softmax_accuracy(monkeypatch, seq):
+    """One compiled symbolic-reduce softmax kernel is accurate at runtime sizes
+    below / at / above the 512 hint — the off-hint sizes (1, 31, 513, 700)
+    straddle the BR·BK = 512-element tile, exercising the boundary mask (the
+    overhang must fold the reduce identity, not garbage past ``seq_len``)."""
+    monkeypatch.setenv("DEPLODOCK_BR", "64")
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+
+    graph = _dynamic_softmax_graph()
+    be = CudaBackend()
+    compiled = be.compile(graph)
+    inp, out = graph.inputs[0], graph.outputs[0]
+    import torch
+
+    x = np.random.default_rng(0).standard_normal((8, seq)).astype(np.float32)
+    got = be.run(compiled, input_data={inp: x})[0].outputs[out]
+    want = torch.softmax(torch.from_numpy(x), dim=1).numpy()
+    assert got.shape == (8, seq)
+    diff = float(np.abs(got - want).max())
+    assert diff < 1e-4, f"seq={seq}: masked cooperative softmax mismatch (max abs err {diff})"

--- a/tests/compiler/test_matmul_mma.py
+++ b/tests/compiler/test_matmul_mma.py
@@ -24,7 +24,7 @@ from deplodock.compiler.ir.stmt import Accum, Assign
 from deplodock.compiler.pipeline import KERNEL_PASSES, Pipeline
 from deplodock.compiler.pipeline.knob import is_warp
 
-from .conftest import requires_cuda
+from .conftest import dyn_M, requires_cuda
 
 # Route every test in this module to the single ``cuda`` xdist_group
 # (``tests/conftest.py::_is_cuda_item`` detects the ``"CUDA not available"``
@@ -123,9 +123,11 @@ def _np_dtype(dt: DataType):
         (128, 256, 128, F16),
     ],
 )
-def test_mma_matmul_matches_f32_reference(M: int, N: int, K: int, out_dtype: DataType, monkeypatch):
+def test_mma_matmul_matches_f32_reference(M: int, N: int, K: int, out_dtype: DataType, shape_mode, monkeypatch):
     """An F16×F16 matmul compiled via the mma.sync path agrees with the f32
-    reference within fp16 tolerance — for both F16 and F32 output dtypes.
+    reference within fp16 tolerance — for both F16 and F32 output dtypes, and
+    for both a STATIC M and a DYNAMIC (symbolic ``seq_len``) M run at the same
+    runtime M (the masked-tile path; ``M ∈ {128, 256}`` are tile divisors).
 
     Pins the warp-tier ``mma_m16n8k16_f16`` atom + a multi-warp 128×128
     tile (``WM=2 WN=2 FM=4 FN=8 BK=2`` — N-tile = WN·FN·atom_n = 2·8·8 = 128,
@@ -140,7 +142,8 @@ def test_mma_matmul_matches_f32_reference(M: int, N: int, K: int, out_dtype: Dat
     monkeypatch.setenv("DEPLODOCK_FN", "8")
     monkeypatch.setenv("DEPLODOCK_BK", "2")
 
-    g = _matmul_graph(M=M, N=N, K=K, out_dtype=out_dtype)
+    Mg = dyn_M(shape_mode, M)
+    g = _matmul_graph(M=Mg, N=N, K=K, out_dtype=out_dtype)
     g = Pipeline.build(KERNEL_PASSES).run(g)
     kop = g.nodes["c"].op
     assert kop.knobs.get("MMA") == "mma_m16n8k16_f16", "expected warp-tier mma.sync variant"
@@ -165,14 +168,15 @@ def test_mma_matmul_matches_f32_reference(M: int, N: int, K: int, out_dtype: Dat
     # and segfaults. The backend's ``_prebuild_descriptors`` binds every
     # ``CUtensorMap`` and opts into dynamic smem, so any geometry — TMA or
     # gmem-direct — launches correctly. The render+source asserts above still
-    # cover the KERNEL-stage IR; this only fixes the execution path.
+    # cover the KERNEL-stage IR; this only fixes the execution path. The dynamic
+    # graph resolves ``seq_len`` from the (M, K) input array shape.
     from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
 
     np.random.seed(42)
     a = (np.random.randn(M, K) * 0.1).astype(np.float16)
     b = (np.random.randn(K, N) * 0.1).astype(np.float16)
     be = CudaBackend()
-    g_run = be.compile(_matmul_graph(M=M, N=N, K=K, out_dtype=out_dtype))
+    g_run = be.compile(_matmul_graph(M=Mg, N=N, K=K, out_dtype=out_dtype))
     run_result, _ = be.run(g_run, input_data={"a": a, "b": b})
 
     expected = a.astype(np.float32) @ b.astype(np.float32)

--- a/tests/compiler/test_matmul_mma_masked.py
+++ b/tests/compiler/test_matmul_mma_masked.py
@@ -29,7 +29,12 @@ from deplodock.compiler.pipeline import CUDA_PASSES, Pipeline
 from deplodock.compiler.pipeline.passes.lowering.tile._atom import ATOM_REGISTRY
 from deplodock.compiler.pipeline.passes.lowering.tile._enumeration import _enumerate_warp_matmul_impl
 
-_WARP_KNOBS = {"MMA": "mma_m16n8k16_f16", "WM": "2", "WN": "2", "FM": "2", "FN": "2", "BK": "2"}
+# ``TMA=0`` pins the cp.async masked path: these tests assert cp.async-specific
+# codegen (the clamped A-slab fill, the "shape D" double-buffered pipeline).
+# Symbolic-M with a static innermost dim is now ALSO TMA-eligible
+# (``050_use_tma`` builds the descriptor's globalDim per launch from the runtime
+# shape; TMA zero-fills the masked overhang) — that path has its own test below.
+_WARP_KNOBS = {"MMA": "mma_m16n8k16_f16", "WM": "2", "WN": "2", "FM": "2", "FN": "2", "BK": "2", "TMA": "0"}
 
 
 def _has_cuda() -> bool:
@@ -147,6 +152,52 @@ def test_symbolic_m_masked_mma_accuracy(monkeypatch, seq):
     assert got.shape == (seq, 1024)
     diff = np.abs(got - want).max()
     assert diff < 5e-2, f"seq={seq}: masked MMA mismatch (max abs err {diff})"
+
+
+_TMA_KNOBS = {"MMA": "mma_m16n8k16_f16", "WM": "2", "WN": "2", "FM": "2", "FN": "2", "BK": "2", "TMA": "1"}
+
+
+def test_symbolic_m_masked_mma_tma_structure(monkeypatch):
+    """Symbolic-M (static innermost) reaches the warp tier staged via **TMA**:
+    the kernel carries the runtime ``seq_len`` arg + a ``CUtensorMap`` descriptor
+    param and stages the A operand with ``cp.async.bulk.tensor`` (no cp.async
+    clamp — the descriptor's globalDim is the runtime extent and TMA zero-fills
+    the masked overhang). The descriptor is encoded per launch from the input
+    array shape (``program._prebuild_descriptors``)."""
+    for k, v in _TMA_KNOBS.items():
+        monkeypatch.setenv(f"DEPLODOCK_{k}", v)
+    lowered = Pipeline.build(CUDA_PASSES).run(_symbolic_m_graph(), ctx=Context(compute_capability=(12, 0)))
+    kop = lowered.nodes["o"].op
+    assert kop.knobs.get("TMA") is True, "symbolic-M with static innermost dim must be TMA-eligible"
+    src = kop.kernel_source
+    assert "int seq_len" in src, "runtime extent must still be a kernel arg"
+    assert "cp.async.bulk.tensor" in src, "A operand must stage via TMA"
+    assert "CUtensorMap" in src, "kernel must take the TMA descriptor param"
+    assert "mma.sync.aligned.m16n8k16" in src
+
+
+@pytest.mark.skipif(not _supports_mma_sync(), reason="mma.sync.m16n8k16 needs CUDA + sm_80+")
+@pytest.mark.parametrize("seq", [1, 31, 512, 700])
+def test_symbolic_m_masked_mma_tma_accuracy(monkeypatch, seq):
+    """The TMA-staged symbolic-M kernel is accurate at runtime sizes below, at,
+    and above the 512 hint — the cases that exercise the per-launch descriptor
+    build (``_collapse_inert_dims`` must keep the masked dim even when its
+    runtime extent is 1/31, and TMA zero-fills the box overhang past ``seq_len``)."""
+    for k, v in _TMA_KNOBS.items():
+        monkeypatch.setenv(f"DEPLODOCK_{k}", v)
+    from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
+
+    be = CudaBackend()
+    compiled = be.compile(_symbolic_m_graph())
+    rng = np.random.default_rng(0)
+    b = (rng.standard_normal((512, 1024)) * 0.1).astype(np.float16)
+    a = (rng.standard_normal((seq, 512)) * 0.1).astype(np.float16)
+    result, _ = be.run(compiled, input_data={"a": a, "b": b})
+    got = result.outputs["o"].astype(np.float32)
+    want = a.astype(np.float32) @ b.astype(np.float32)
+    assert got.shape == (seq, 1024)
+    diff = np.abs(got - want).max()
+    assert diff < 5e-2, f"seq={seq}: TMA masked MMA mismatch (max abs err {diff})"
 
 
 @pytest.mark.skipif(not _supports_mma_sync(), reason="mma.sync.m16n8k16 needs CUDA + sm_80+")

--- a/tests/compiler/test_matmul_mma_parity.py
+++ b/tests/compiler/test_matmul_mma_parity.py
@@ -24,12 +24,13 @@ import numpy as np
 import pytest
 
 from deplodock.compiler.context import Context
-from deplodock.compiler.dim import Dim
 from deplodock.compiler.dtype import F16
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.frontend.ir import MatmulOp
 from deplodock.compiler.pipeline import CUDA_PASSES, Pipeline
+
+from .conftest import dyn_M
 
 # Static matmul N / K (only M flips static<->dynamic). K static so the source
 # innermost dim stays static — TMA-eligible (a symbolic innermost dim would
@@ -69,20 +70,13 @@ def _supports_tma() -> bool:
 def _mma_graph(mode: str, *, M: int):
     """``a @ b`` with the M axis static (``mode='static'``) or symbolic
     (``mode='dynamic'`` → ``Dim('seq_len')``, one kernel for every runtime M)."""
-    m_dim = Dim("seq_len") if mode == "dynamic" else M
+    m_dim = dyn_M(mode, M)
     g = Graph()
     g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (m_dim, _K), dtype=F16), node_id="a")
     g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (_K, _N), dtype=F16), node_id="b")
     g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (m_dim, _N), dtype=F16), node_id="o")
     g.inputs, g.outputs = ["a", "b"], ["o"]
     return g
-
-
-@pytest.fixture(params=["static", "dynamic"])
-def shape_mode(request) -> str:
-    """Flip the matmul's M axis static <-> symbolic. Any test that names this
-    fixture runs once per shape — the static/dynamic automation."""
-    return request.param
 
 
 @pytest.fixture(params=["cp.async", "tma"])

--- a/tests/compiler/test_matmul_mma_parity.py
+++ b/tests/compiler/test_matmul_mma_parity.py
@@ -1,0 +1,142 @@
+"""Static-vs-dynamic parity for the masked-M ``mma.sync`` matmul, across transports.
+
+One matmul op (``a[M,K] @ b[K,N]``) is compiled BOTH shape-specialised (static
+``M``) and dynamic (``Dim('seq_len')`` ``M`` — one kernel for every runtime size)
+and run at the SAME runtime ``M``, asserting both match the torch reference — across
+the cp.async AND TMA transports (pinned). This is the parity guard the
+TMA-for-dynamic work (#245) needed: the dynamic TMA path must produce the same
+result as the static path on the same shape. Parity is asserted at tile-divisor M
+(where all four static/dynamic × cp.async/tma combos fire); the dynamic path's
+extra reach to *off-hint* sizes (1, 31, 700 — masked overhang, where static under a
+pinned warp tile can't follow) is covered by ``test_matmul_mma_masked.py``.
+
+The ``shape_mode`` × ``transport`` fixtures fan one test body out over the full
+{static, dynamic} × {cp.async, tma} matrix — the fixture pattern to lift into
+``conftest`` if/when other matmul tests adopt it. The pinned-knob ``transport``
+fixture (warp tile + ``TMA=0|1``) is the "pinned knobs" half; the structure test
+asserts the pin actually selected the intended transport (and, for dynamic, the
+runtime ``seq_len`` arg) before the accuracy test trusts it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from deplodock.compiler.context import Context
+from deplodock.compiler.dim import Dim
+from deplodock.compiler.dtype import F16
+from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.frontend.ir import MatmulOp
+from deplodock.compiler.pipeline import CUDA_PASSES, Pipeline
+
+# Static matmul N / K (only M flips static<->dynamic). K static so the source
+# innermost dim stays static — TMA-eligible (a symbolic innermost dim would
+# break the 16 B global-stride alignment; that N-masked case stays on cp.async
+# and is covered by test_matmul_mma_masked.py).
+_N, _K = 1024, 512
+_WARP_KNOBS = {"MMA": "mma_m16n8k16_f16", "WM": "2", "WN": "2", "FM": "2", "FN": "2", "BK": "2"}
+
+
+def _has_cuda() -> bool:
+    try:
+        import cupy as cp
+
+        return cp.cuda.is_available()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _supports_mma_sync() -> bool:
+    """s16816 ``mma.sync.aligned.m16n8k16`` + ``ldmatrix`` need sm_80+."""
+    if not _has_cuda():
+        return False
+    import cupy as cp
+
+    return int(cp.cuda.Device().compute_capability) >= 80
+
+
+def _supports_tma() -> bool:
+    """``cp.async.bulk.tensor`` needs sm_90+ (Hopper / Blackwell)."""
+    if not _has_cuda():
+        return False
+    import cupy as cp
+
+    return int(cp.cuda.Device().compute_capability) >= 90
+
+
+def _mma_graph(mode: str, *, M: int):
+    """``a @ b`` with the M axis static (``mode='static'``) or symbolic
+    (``mode='dynamic'`` → ``Dim('seq_len')``, one kernel for every runtime M)."""
+    m_dim = Dim("seq_len") if mode == "dynamic" else M
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (m_dim, _K), dtype=F16), node_id="a")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (_K, _N), dtype=F16), node_id="b")
+    g.add_node(op=MatmulOp(), inputs=["a", "b"], output=Tensor("o", (m_dim, _N), dtype=F16), node_id="o")
+    g.inputs, g.outputs = ["a", "b"], ["o"]
+    return g
+
+
+@pytest.fixture(params=["static", "dynamic"])
+def shape_mode(request) -> str:
+    """Flip the matmul's M axis static <-> symbolic. Any test that names this
+    fixture runs once per shape — the static/dynamic automation."""
+    return request.param
+
+
+@pytest.fixture(params=["cp.async", "tma"])
+def transport(request, monkeypatch) -> str:
+    """Pin the warp tile + force the transport (``TMA=1`` = cp.async.bulk.tensor,
+    ``TMA=0`` = cp.async). The "pinned knobs" fixture."""
+    for k, v in _WARP_KNOBS.items():
+        monkeypatch.setenv(f"DEPLODOCK_{k}", v)
+    monkeypatch.setenv("DEPLODOCK_TMA", "1" if request.param == "tma" else "0")
+    return request.param
+
+
+def test_pinned_transport_and_shape_fire(shape_mode, transport):
+    """CPU render (forced sm_120): the pinned knobs select the intended
+    transport and the symbolic M threads a runtime ``seq_len`` arg — so the
+    accuracy test below is exercising the path it claims to."""
+    lowered = Pipeline.build(CUDA_PASSES).run(_mma_graph(shape_mode, M=512), ctx=Context(compute_capability=(12, 0)))
+    src = lowered.nodes["o"].op.kernel_source
+    assert "mma.sync.aligned.m16n8k16" in src and "ldmatrix" in src, "must be on the s16816 tensor-core tier"
+    if transport == "tma":
+        assert "cp.async.bulk.tensor" in src, f"{shape_mode}/tma: TMA must fire"
+        assert "CUtensorMap" in src, "TMA kernel must take the descriptor param"
+    else:
+        assert "cp.async.bulk.tensor" not in src, f"{shape_mode}/cp.async: TMA must NOT fire"
+    if shape_mode == "dynamic":
+        assert "int seq_len" in src, "dynamic kernel must carry the runtime extent arg"
+    else:
+        assert "int seq_len" not in src, "static kernel bakes M — no runtime extent arg"
+
+
+@pytest.mark.skipif(not _supports_mma_sync(), reason="mma.sync.m16n8k16 needs CUDA + sm_80+")
+@pytest.mark.parametrize("M", [256, 512])
+def test_static_dynamic_mma_parity(shape_mode, transport, M):
+    """The SAME matmul, compiled static and dynamic, on cp.async and TMA, is
+    accurate vs torch — so the four paths agree. ``M`` is a multiple of the
+    WM·FM·16 = 64-row tile, where ALL four combos fire: static-specialised
+    *non-divisor* M is degenerate under the pinned warp tile (M=1 doesn't lower)
+    and static-masked-M is not TMA-eligible (an asymmetry vs the dynamic path —
+    its globalDim isn't runtime-resolved), so strict parity is only well-defined
+    at divisor M. Dynamic robustness at off-hint sizes (1, 31, 700 — below / at /
+    above the 512 hint, masked overhang) is covered by
+    ``test_matmul_mma_masked.py``."""
+    if transport == "tma" and not _supports_tma():
+        pytest.skip("TMA needs sm_90+ (Hopper / Blackwell)")
+    from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
+
+    be = CudaBackend()
+    compiled = be.compile(_mma_graph(shape_mode, M=M))
+    rng = np.random.default_rng(0)
+    a = (rng.standard_normal((M, _K)) * 0.1).astype(np.float16)
+    b = (rng.standard_normal((_K, _N)) * 0.1).astype(np.float16)
+    result, _ = be.run(compiled, input_data={"a": a, "b": b})
+    got = result.outputs["o"].astype(np.float32)
+    want = a.astype(np.float32) @ b.astype(np.float32)
+    assert got.shape == (M, _N)
+    diff = np.abs(got - want).max()
+    assert diff < 5e-2, f"{shape_mode}/{transport} M={M}: max abs err {diff}"

--- a/tests/compiler/test_matmul_mma_tma.py
+++ b/tests/compiler/test_matmul_mma_tma.py
@@ -34,7 +34,7 @@ from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
 from deplodock.compiler.ir.stmt import Accum, Assign
 from deplodock.compiler.pipeline import KERNEL_PASSES, Pipeline
 
-from .conftest import requires_cuda
+from .conftest import dyn_M, requires_cuda
 
 # Route every test in this module to the single ``cuda`` xdist_group
 # (``tests/conftest.py::_is_cuda_item`` detects the ``"CUDA not available"``
@@ -170,9 +170,13 @@ def test_tma_mma_path_emits_bulk_tensor_ptx(pin_tma_mma):
 
 @pytest.mark.skipif(not _supports_tma(), reason="TMA needs sm_90+ (Hopper / Blackwell)")
 @pytest.mark.parametrize("M,N,K", [(256, 256, 128), (512, 512, 128), (256, 256, 64)])
-def test_tma_mma_matches_f32_reference(pin_tma_mma, M: int, N: int, K: int):
+def test_tma_mma_matches_f32_reference(pin_tma_mma, shape_mode, M: int, N: int, K: int):
     """The TMA-staged mma.sync path produces output that matches the f32
-    reference within fp16 tolerance.
+    reference within fp16 tolerance — for BOTH a static M and a dynamic
+    (symbolic ``seq_len``) M run at the same runtime M (M ∈ {256, 512} are tile
+    divisors). The dynamic case is #245: TMA stages the symbolic-M operand via a
+    per-launch descriptor (globalDim from the runtime shape) and zero-fills the
+    masked overhang — it must produce the same result as the baked-M static path.
 
     The fp16 cuTensorMap encoder enum fix (``CU_TENSOR_MAP_DATA_TYPE_FLOAT16
     = 6`` mapped via ``_DTYPE_BY_ITEMSIZE``) is exercised here — pre-fix
@@ -185,27 +189,29 @@ def test_tma_mma_matches_f32_reference(pin_tma_mma, M: int, N: int, K: int):
     this TMA-staged kernel passes garbage descriptor pointers and segfaults —
     the regression that motivated routing the launch through the backend,
     which binds every ``CUtensorMap`` via ``_prebuild_descriptors``."""
-    _, kop, src = _compile_and_render(M=M, N=N, K=K, out_dtype=F32)
+    Mg = dyn_M(shape_mode, M)
+    _, kop, src = _compile_and_render(M=Mg, N=N, K=K, out_dtype=F32)
     assert kop.knobs.get("MMA") == "mma_m16n8k16_f16"
-    assert "cp.async.bulk.tensor" in src  # smoke-check the TMA path actually fired
+    assert "cp.async.bulk.tensor" in src  # smoke-check the TMA path actually fired (static + dynamic)
 
     # Launch through the real backend so ``_prebuild_descriptors`` binds the
     # per-operand ``CUtensorMap`` args (a hand-rolled cubin launch can't) and
     # opts into the dynamic-smem allowance. Recompile from a fresh loop graph
-    # via the full ``CUDA_PASSES`` pipeline under the same pinned env.
+    # via the full ``CUDA_PASSES`` pipeline under the same pinned env. The
+    # dynamic graph resolves ``seq_len`` from the (M, K) input array shape.
     from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
 
     np.random.seed(42)
     a = (np.random.randn(M, K) * 0.1).astype(np.float16)
     b = (np.random.randn(K, N) * 0.1).astype(np.float16)
     be = CudaBackend()
-    g_run = be.compile(_matmul_graph(M=M, N=N, K=K, out_dtype=F32))
+    g_run = be.compile(_matmul_graph(M=Mg, N=N, K=K, out_dtype=F32))
     run_result, _ = be.run(g_run, input_data={"a": a, "b": b})
 
     expected = a.astype(np.float32) @ b.astype(np.float32)
     result = run_result.outputs["c"].astype(np.float32)
     diff = np.abs(result - expected).max()
-    assert diff < 1e-2, f"M={M} N={N} K={K} max-abs-err {diff}"
+    assert diff < 1e-2, f"{shape_mode} M={M} N={N} K={K} max-abs-err {diff}"
 
 
 @pytest.mark.skipif(not _supports_tma(), reason="TMA needs sm_90+ (Hopper / Blackwell)")
@@ -274,16 +280,18 @@ def test_mma_sync_path_emits_ldmatrix_and_mma_ptx(pin_mma_sync):
 
 @pytest.mark.skipif(not _supports_mma_sync(), reason="mma.sync.m16n8k16 needs sm_80+ (Ampere+)")
 @pytest.mark.parametrize("M,N,K,out_dtype", [(256, 256, 128, F32), (128, 256, 128, F32), (256, 256, 128, F16)])
-def test_mma_sync_matches_reference(pin_mma_sync, M: int, N: int, K: int, out_dtype: DataType):
-    """The s16816 path matches the f32 reference within fp16 tolerance —
-    guards the ldmatrix per-lane address map, the B-operand ``.trans``, and
-    the per-lane ``RegStore`` epilogue (a wrong lane map / trans flag yields
-    a plausible-but-wrong result that this catches). f32 output exercises the
-    direct ``RegStore`` path; f16 output exercises the ``__float2half``
-    downconvert."""
+def test_mma_sync_matches_reference(pin_mma_sync, shape_mode, M: int, N: int, K: int, out_dtype: DataType):
+    """The s16816 path matches the f32 reference within fp16 tolerance — for
+    both a static and a dynamic (symbolic ``seq_len``) M (M ∈ {128, 256} are
+    tile divisors). Guards the ldmatrix per-lane address map, the B-operand
+    ``.trans``, and the per-lane ``RegStore`` epilogue (a wrong lane map / trans
+    flag yields a plausible-but-wrong result that this catches). f32 output
+    exercises the direct ``RegStore`` path; f16 output exercises the
+    ``__float2half`` downconvert."""
     from deplodock.compiler.backend.cuda.backend import CudaBackend  # noqa: PLC0415
 
-    _, kop, src = _compile_and_render(M=M, N=N, K=K, out_dtype=out_dtype)
+    Mg = dyn_M(shape_mode, M)
+    _, kop, src = _compile_and_render(M=Mg, N=N, K=K, out_dtype=out_dtype)
     assert kop.knobs.get("MMA") == "mma_m16n8k16_f16"
     assert "mma.sync.aligned.m16n8k16" in src
 
@@ -291,7 +299,7 @@ def test_mma_sync_matches_reference(pin_mma_sync, M: int, N: int, K: int, out_dt
     a = (np.random.randn(M, K) * 0.1).astype(np.float16)
     b = (np.random.randn(K, N) * 0.1).astype(np.float16)
     be = CudaBackend()
-    g_run = be.compile(_matmul_graph(M=M, N=N, K=K, out_dtype=out_dtype))
+    g_run = be.compile(_matmul_graph(M=Mg, N=N, K=K, out_dtype=out_dtype))
     run_result, _ = be.run(g_run, input_data={"a": a, "b": b})
 
     expected = a.astype(np.float32) @ b.astype(np.float32)


### PR DESCRIPTION
## Summary

Started as a per-kernel tune-findings analysis of **Qwen3-Embedding-0.6B layer 0** (static vs the deployable dynamic
`--dynamic seq_len@x:1` configuration) and grew into two compiler fixes, a perf feature, and static/dynamic test
coverage that the analysis surfaced as missing.

### 1. Per-variant containment for un-lowerable tune forks (`pipeline.py`, `_stage_expand.py`)
A clean static seq-512 tune aborted ~30 min in: one search-explored fork reached a sibling-cell-fused hoisted-compute
slab the single-Write materializer can't represent, and a **rewrite/lowering exception in the inner search had no
per-variant containment** — so one bad fork killed the whole tune.
- `compute_phase_info` now raises a descriptive `LoweringError` (not an opaque `AttributeError`) on a collapsed index.
- `Run.drive` (tune-only) catches an un-lowerable lowering exception per candidate, drops that subtree, logs + counts
  it, and keeps searching — the "legitimate dead end under tune" semantics `LoweringError` already documents for the
  `validate(ctx)` case, extended to exceptions. Greedy `compile`/`run` (deterministic `Run.resolve`) stay loud.

### 2. Enable TMA on the dynamic path for M-masked matmuls (`050_use_tma.py`, `program.py`)
The analysis showed most of the static→dynamic gap on the linear/o_proj kernels was **transport**: static stages via
`cp.async.bulk.tensor` (TMA), dynamic was wholesale-declined TMA and fell back to cp.async (~1.6–1.8× slower/kernel).
The decline was unnecessary — the descriptor's `globalDim` is already encoded per launch from the runtime input shape.
- Lift the blanket symbolic decline; build eligibility shapes from the `Dim` hint; decline TMA **per-source only when
  the innermost dim is symbolic** (its runtime stride isn't 16 B-aligned → `cuTensorMapEncodeTiled` CUresult=1). So
  M-masked matmuls (static innermost) take TMA; N-masked (QK^T) and masked-K (P@V) stay on cp.async.
- Fix `_collapse_inert_dims` to drop only surplus gap singletons, never a box-carrying dim whose runtime extent is
  small (off-hint seq=1/31 was raising "rank mismatch"); TMA hardware-zero-fills the box overhang.

**Result:** dynamic Qwen3-Embedding-0.6B layer-0 e2e **361 → 337 µs** (0.62 → 0.65× eager); the o_proj kernel
**47.0 → 29.2 µs NCU, 6.8M → 0 bank conflicts** — at parity with the static o_proj (28.6 µs). Accuracy correct at seq
1/31/512/700.

### 3. Static/dynamic test parity (`tests/compiler/`)
- Shared `shape_mode` fixture + `dyn_M` helper in `conftest.py` (the static/dynamic automation primitive).
- New `test_matmul_mma_parity.py`: `shape_mode × transport` fixtures fan one body over {static, dynamic} ×
  {cp.async, tma}; a CPU-render structure test asserts the pin selected the intended transport.
- Extended the existing `test_matmul_mma`, `test_matmul_mma_tma`, and `test_knob_pinning` accuracy tests to run both
  shapes. Static-bug regression locks (article-reproduction, K-split, swizzle alignment) stay static by design;
  off-hint dynamic robustness stays in `test_matmul_mma_masked.py`.

### 4. Findings reports (`plans/`)
`qwen3-embedding-layer0-static-tune-findings.md` (the static tune + static-vs-dynamic side-by-side + root-cause
analysis, refreshed post-TMA) and the prior `qwen3-embedding-layer0-dynamic-tune-findings.md` it compares against.

## Test plan
- Full `tests/compiler/` suite green (final gate).
- New: 3 containment guardrail tests, `_collapse_inert_dims` unit tests, TMA masked-M structure + accuracy tests
  (seq 1/31/512/700), and the static/dynamic parity matrix across mma/tma/knob_pinning (104 tests across the five
  matmul files).
- Manual: clean static + dynamic `run --bench` on RTX 5090 (sm_120), NCU attribution, `--ab "TMA=0"` transport A/B.

## Notes
- The `(#244)`/`(#245)` refs in commit subjects are the intended logical grouping, not separate PRs — this is one PR.
- Known follow-ups (documented in the report): masked-K P@V via TMA-OOB (the next ~27 µs), static-masked-M non-divisor
  TMA eligibility, and the dynamic o_proj's register-pressure headroom (parity reached at lower occupancy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
