### PR TITLE
dynamic SDPA P@V: kill the masked-K consumer's ldmatrix bank-conflict storm (+ capacity guard)

### DIFF
--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -154,6 +154,14 @@ class _Compiled:
     # fallback concrete value when no ``input_data`` is supplied (the autotuner
     # benches a symbolic graph at the hint size).
     symbolic_hints: dict[str, int] = field(default_factory=dict)
+    # Symbolic axis name → its capacity CAP. A capacity-capped kernel (the
+    # smem-staged fused symbolic-K SDPA P@V — ``plans/fused-symbolic-pv-smem-staged.md``)
+    # bakes its smem slab at the ``Dim`` hint and is only correct for runtime
+    # extents ≤ that cap, so the launch resolver hard-errors when the supplied
+    # input shape exceeds it (rather than reading/writing past the baked slab).
+    # Empty for every kernel set that tiles the symbolic extent with a ceil-div
+    # grid (those handle any runtime size); populated only by the capped cut.
+    symbolic_caps: dict[str, int] = field(default_factory=dict)
 
 
 def _compile(graph: Graph) -> _Compiled:
@@ -318,6 +326,13 @@ def _resolve_symbolic(compiled: _Compiled, input_data: dict[str, np.ndarray]) ->
         arr = input_data.get(buf)
         if arr is not None:
             env[name] = int(arr.shape[dim_idx])
+            cap = compiled.symbolic_caps.get(name)
+            if cap is not None and env[name] > cap:
+                raise ValueError(
+                    f"symbolic dim {name!r} = {env[name]} exceeds the capacity-capped kernel's hint ({cap}); "
+                    f"this build bakes its smem slab at {cap} and cannot run a larger extent — "
+                    f"re-trace with a larger --seq-len hint or use the ceil-div (uncapped) lowering"
+                )
         elif name in compiled.symbolic_hints:
             env[name] = compiled.symbolic_hints[name]
         else:

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -810,6 +810,20 @@ order (inline-fuse first as the greedy default — smaller smem, works on every 
 fire whenever any source has a fixable conflict; the greedy run picks pad-on first. Honors `DEPLODOCK_PAD_SMEM` for
 one-off pinning.
 
+One smem pad is **not** an autotune fork: the **masked-K MMA slab** alignment pad, stamped intrinsically on the
+`Source` at creation by `020_stage_inputs._masked_k_mma_pad`. A symbolic-reduce (`kmask`) operand staged for a warp
+matmul — the SDPA P@V softmaxed `P` — lands in a flat `[…, M, K]` smem slab read by `ldmatrix.x4`; when the M-row
+stride (the innermost block-scaled alloc-extent) is a 128 B multiple, the ldmatrix M-row lanes all alias one bank
+(the 3.67M-load-conflict storm in the Qwen3-Embedding dynamic P@V — NCU 38 µs @ 26 % occ). `070_pad_smem` can't fix
+it: `kmask` pins masked-K to the SYNC transport (which `070` skips) and the source is block-stamped (which `070` also
+skips, since its `+1` pad breaks ldmatrix's 16 B alignment). So `020` pads the innermost cache dim by one 16 B
+ldmatrix chunk (`16 // elem_bytes` elements) — stepping the stride off the alias while keeping every row 16 B aligned.
+It's intrinsic (not a fork) because it's a near-strict win with no misalignment penalty, so greedy deploys it without a
+re-tune (`070` then self-skips the already-padded source); the result is numerically transparent and drops the P@V
+consumer's conflicts ~3.67M → ~1000 (NCU 38 → 27 µs). A flat `[M][K]` slab can't reach the static path's 0-conflict
+floor — that needs its swizzle-atom-wide K-subtile relayout — so this is the deployable flat-slab fix. See
+`plans/fused-symbolic-pv-smem-staged.md`.
+
 ## Pass directories
 
 Pass files are numerically prefixed so `sorted()` pickup is

--- a/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py
@@ -649,6 +649,38 @@ def _process_scope(
     return tuple([*rewritten[:lo], bundle, *rewritten[hi + 1 :]])
 
 
+def _masked_k_mma_pad(
+    kmask: tuple[int, object] | None,
+    cache_axes: tuple[Axis, ...],
+    block: tuple[int, ...],
+    elem_bytes: int,
+) -> tuple[int, ...]:
+    """Inner-dim pad that breaks the masked-K MMA slab's ldmatrix bank conflict.
+
+    A masked-K (symbolic reduce) operand staged for a warp matmul is read with
+    ``ldmatrix.x4`` from a flat ``[…, M, K]`` smem slab (K innermost). When the
+    M-row stride (the block-scaled innermost alloc-extent) is a multiple of 128
+    bytes, the M-row lanes of one ldmatrix all alias one 4-byte bank — a
+    catastrophic load conflict (the 3.67M-conflict storm in the Qwen3-Embedding
+    dynamic SDPA P@V). Pad the innermost cache dim by one 16-byte ldmatrix chunk
+    (``16 // elem_bytes`` elements) so that stride — and every outer stride,
+    which all carry it as a factor — steps off the 128-byte alias, while every
+    row stays 16-byte aligned (the pad bytes are a multiple of 16, so ldmatrix
+    stays legal). Returns ``()`` (no pad) unless this is a kmask + block-stamped
+    (MMA) slab whose innermost stride actually hits the 128-byte alias — every
+    other slab keeps its dense layout. Reaching the static path's 0-conflict
+    floor needs its swizzle-atom-wide K-subtile relayout; this is the flat-slab
+    fix."""
+    if kmask is None or not block or len(cache_axes) < 2:
+        return ()
+    inner = cache_axes[-1].extent.as_static() * (block[-1] if block else 1)
+    if inner == 0 or (inner * elem_bytes) % 128 != 0:
+        return ()
+    pad = [0] * len(cache_axes)
+    pad[-1] = max(1, 16 // elem_bytes)
+    return tuple(pad)
+
+
 def _build_sources(
     loads_by_buf: dict[str, list[tuple[Load, Axis, tuple[Axis, ...], tuple[Axis, ...]]]],
     thread_axes: tuple[Axis, ...],
@@ -729,12 +761,25 @@ def _build_sources(
             rd = slab.reduce_dim
             if shape is not None and rd is not None and rd < len(shape) and not shape[rd].is_static:
                 kmask = (rd, shape[rd].expr)
+            # Masked-K MMA slab: the consumer reads this ``[M][K]`` slab with
+            # ``ldmatrix.x4``, whose M-row lanes all hit one 4-byte bank when the
+            # M-row stride (inner alloc-extent) is a multiple of 128 B — the
+            # 3.67M-conflict storm in the Qwen3-Embedding dynamic SDPA P@V. An
+            # alignment-preserving inner pad (one 16-byte ldmatrix chunk) shifts
+            # the stride off the bank alias (~16-way → conflict-free for the 8
+            # row-lanes of one ldmatrix phase) while keeping every row 16-byte
+            # aligned so ldmatrix stays legal. Stamped here (not via the
+            # ``070_pad_smem`` autotune fork) because it is a near-strict win
+            # with no misalignment penalty — intrinsic to the slab so greedy
+            # deploys it, and ``070`` then self-skips the already-padded source.
+            ebytes = (bytes_per_elem or {}).get(buf, BYTES_PER_ELEM) if bytes_per_elem else BYTES_PER_ELEM
+            pad = _masked_k_mma_pad(kmask, slab.cache_axes, slab.block, ebytes)
             src = Source(
                 name=smem_name,
                 buf=buf,
                 cache_axes=slab.cache_axes,
                 origin=slab.origin,
-                pad=(),
+                pad=pad,
                 addressing=addressing,
                 kmask=kmask,
             )

--- a/plans/fused-symbolic-pv-smem-staged.md
+++ b/plans/fused-symbolic-pv-smem-staged.md
@@ -1,0 +1,73 @@
+# Fused symbolic-K SDPA P@V via smem-staged `xn` (capacity-capped at the hint)
+
+Status: **design / not started.** Goal: make the dynamic (symbolic-`seq_len`) SDPA P@V lower to a single
+tensor-core kernel that matches the static path's fusion — softmax producer + `mma` P@V in one launch, with the
+softmaxed `P` (`xn`) staged in **smem** (capped at `DEFAULT_SEQ_HINT = 512`) instead of round-tripped through HBM.
+A runtime `seq_len > hint` guard traps. This is the user-requested "(A)" path from the Qwen3-Embedding layer-0
+static-vs-dynamic investigation (`plans/qwen3-embedding-layer0-static-vs-dynamic-tune-findings.md`).
+
+## Why (evidence)
+
+At seq 512, static layer-0 = 184 µs / 1.21x eager; dynamic = 336 µs / 0.65x. The gap is the SDPA P@V:
+
+- **Static fused P@V** (`k_sdpa_linear_reduce_3d2635`): `__launch_bounds__(1024)`, TMA-staged, `ldmatrix` +
+  `mma.sync` over the static K=512 reduce, softmax folded into an in-kernel smem-staged `xn`.
+- **Dynamic, kept fused** (`SPLIT_CONE=0`): `__launch_bounds__(128)`, **0 `mma`**, a scalar 3-pass online-softmax
+  + weighted-V sum looping `for (a6 < seq_len)`, 3× HBM re-reads of the seq×seq matrix → **1610 µs**.
+- **Dynamic, split** (deployed): softmax producer materializes `xn` to HBM; masked-K `mma` consumer
+  (`for a5 < (seq_len+511)/512`, 15 `mma.sync`) re-reads it → **336 µs**. Correct and tensor-core, but pays the
+  HBM round-trip and the consumer runs at 26% occupancy / 3.67M smem bank-conflicts.
+
+The symbolic K can't be a fused-prologue warp tile because the masked-K slab **zero-fills** the tail past
+`seq_len` (correct for a clean P@V — 0 contributes nothing) but wrong for the softmax max/sum. Static escapes
+this only because static K lets it stage the whole softmaxed row; the deployable symbolic equivalent is to stage
+`xn` in smem capped at the hint.
+
+## Key insight that simplifies the build
+
+The softmax phase can stay **scalar** (it already masks correctly via `if (a6 < seq_len)` and writes `xn = 0`
+past `seq_len`). Then phase 2 is the **existing** masked-K `mma` consumer, reading `xn` from **smem** instead of
+HBM — and its zero-fill is already correct because `xn` is already 0 past `seq_len`. So we do **not** need an
+`−inf` fill-mode on the masked-K slab; we need a kernel that holds `xn` in smem between a scalar producer phase
+and the `mma` consumer phase. The win is purely removing the `xn` HBM round-trip + replacing the scalar P@V with
+`mma`.
+
+## Realistic ceiling
+
+Removes the `xn` HBM round-trip and the degenerate scalar P@V → `mma`. Does **not** fix the masked-K `mma`
+consumer's 26% occupancy / 3.67M bank-conflicts (that gap, 38 µs vs static's 15.8 µs, is a separate slab-layout
+issue). Expected landing ≈ **270 µs**, not the full 184 µs. Closing to 184 needs the masked-K slab-layout fix too
+(separate track, also helps the shipping 336 µs path).
+
+## Where it lives (code map)
+
+- `005_split_demoted.py` — today the cut emits *separate* Graph nodes (→ separate kernels, HBM hand-off). New:
+  a **fused-smem** cut variant that keeps one node whose body is `producer-phase ; Smem(xn) ; consumer-phase`,
+  gated on `xn`'s capped extent ≤ hint fitting smem. Offered as a third structural option beside keep-fused /
+  split (knob `SPLIT_CONE` → extend to a tri-state, or a new `FUSE_SMEM` knob).
+- `010_partition_loops.py:710` — the `not prologue` warp gate stays for the *raw* prologue; the fused-smem body's
+  consumer phase is a clean matmul (P=`xn` is now a stored smem operand), so it reaches the warp tier normally.
+- `kernel/_stage_expand.py` — the consumer reads `xn` from smem; the producer writes `xn` to smem. Reuse the
+  existing masked-K zero-fill on the consumer (no `−inf` mode needed, per the insight above).
+- `kernel/100_materialize_tile.py` — size the `xn` smem buffer at `BM × hint` (capped); emit both phases in one
+  kernel body with a `__syncthreads()` between.
+- Guard: host-side in `backend/cuda/program.py` (where symbolic dims resolve from input shapes at launch) — raise
+  if `seq_len > hint` for a capped kernel. Cheaper and clearer than an in-kernel trap; fully unit-testable.
+
+## Staging (each step independently landable + tested)
+
+1. **Host-side `seq_len > hint` guard** + a kernel flag marking "capacity-capped". Inert until a capped kernel
+   exists, but unit-testable (resolve a too-large shape → raises). Lands the guard infrastructure.
+2. **Masked-K slab-layout fix** (occupancy / bank-conflicts) on the *existing* split consumer — separable, helps
+   the 336 µs path now, and is a prerequisite for the fused kernel not inheriting the conflicts. A/B `PAD_SMEM` /
+   `PERMUTE_LANES` first (the prior dynamic report showed these were no-ops on the masked-tile layout — so this is
+   likely a new swizzle, not a knob).
+3. **Fused-smem cut** in `005_split_demoted` + the two-phase materialization. The big step. Verify accuracy on the
+   `k_sdpa_linear_reduce` reproducer (static-and-dynamic parity test), then e2e bench vs the 336 µs split.
+
+## Tests
+
+- Accuracy: `tests/compiler/passes/test_knob_pinning.py` style — fp16 SDPA P@V, dynamic mode, pinned to the
+  fused-smem cut, asserted against the numpy/torch reference at the hint (and a sub-hint seq to exercise the mask).
+- Guard: unit test that resolving `seq_len > hint` on a capped kernel raises a clear error.
+- Bench: `run --ir <reproducer> --bench --ab` fused-smem vs split, expect ≤ split and document the gap to static.

--- a/plans/fused-symbolic-pv-smem-staged.md
+++ b/plans/fused-symbolic-pv-smem-staged.md
@@ -1,73 +1,107 @@
-# Fused symbolic-K SDPA P@V via smem-staged `xn` (capacity-capped at the hint)
+# Dynamic SDPA P@V — closing the static↔dynamic gap (premise corrected mid-flight)
 
-Status: **design / not started.** Goal: make the dynamic (symbolic-`seq_len`) SDPA P@V lower to a single
-tensor-core kernel that matches the static path's fusion — softmax producer + `mma` P@V in one launch, with the
-softmaxed `P` (`xn`) staged in **smem** (capped at `DEFAULT_SEQ_HINT = 512`) instead of round-tripped through HBM.
-A runtime `seq_len > hint` guard traps. This is the user-requested "(A)" path from the Qwen3-Embedding layer-0
-static-vs-dynamic investigation (`plans/qwen3-embedding-layer0-static-vs-dynamic-tune-findings.md`).
+Status: **steps 1–2 landed; producer step in progress.** This plan began as "fuse the symbolic-`seq_len` SDPA P@V into
+one smem-staged tensor-core kernel to **match the static path's fusion**." That premise turned out to be **factually
+wrong** — see below — so the plan was redirected to the two changes that actually separate static from dynamic. The
+host-side capacity-cap guard (step 1) shipped first as reusable infrastructure; the masked-K consumer's bank-conflict
+fix (step 2) shipped next as the real, evidence-backed win.
 
-## Why (evidence)
+## Premise correction (the original plan was built on a misread)
 
-At seq 512, static layer-0 = 184 µs / 1.21x eager; dynamic = 336 µs / 0.65x. The gap is the SDPA P@V:
+The original "Why" claimed the **static** SDPA P@V is a single fused kernel — *"softmax folded into an in-kernel
+smem-staged `xn`"* — and that the dynamic path should be made to match it. The dumped kernels
+(`_tune/tune-model-qwen3-l0-staticdyn/{static512,dynamic}-dump/07_lowering_cuda.kernels/`) show otherwise:
 
-- **Static fused P@V** (`k_sdpa_linear_reduce_3d2635`): `__launch_bounds__(1024)`, TMA-staged, `ldmatrix` +
-  `mma.sync` over the static K=512 reduce, softmax folded into an in-kernel smem-staged `xn`.
-- **Dynamic, kept fused** (`SPLIT_CONE=0`): `__launch_bounds__(128)`, **0 `mma`**, a scalar 3-pass online-softmax
-  + weighted-V sum looping `for (a6 < seq_len)`, 3× HBM re-reads of the seq×seq matrix → **1610 µs**.
-- **Dynamic, split** (deployed): softmax producer materializes `xn` to HBM; masked-K `mma` consumer
-  (`for a5 < (seq_len+511)/512`, 15 `mma.sync`) re-reads it → **336 µs**. Correct and tensor-core, but pays the
-  HBM round-trip and the consumer runs at 26% occupancy / 3.67M smem bank-conflicts.
+**Both static and dynamic split P@V into a separate softmax producer + an mma consumer with an HBM round-trip.**
 
-The symbolic K can't be a fused-prologue warp tile because the masked-K slab **zero-fills** the tail past
-`seq_len` (correct for a clean P@V — 0 contributes nothing) but wrong for the softmax max/sum. Static escapes
-this only because static K lets it stage the whole softmaxed row; the deployable symbolic equivalent is to stage
-`xn` in smem capped at the hint.
+|                       | Static (`k_sdpa_linear_reduce_3d2635`)     | Dynamic (`…_a76a28`)                          |
+|-----------------------|--------------------------------------------|-----------------------------------------------|
+| Softmax producer      | separate kernel `_xn`, **writes `xn` to HBM** | separate kernel `_xna`, writes `xn` to HBM    |
+| Consumer reads `xn`   | from **HBM** (TMA → smem)                   | from HBM (cooperative copy → smem)            |
+| Consumer `xn` smem    | **12 swizzle XORs** → no bank conflicts     | **0 swizzle** (plain stride-512) → 3.67M conflicts |
+| Producer threads      | `__launch_bounds__(64)` cooperative warp-reduce | `__launch_bounds__(16)` (BR=16) low-occupancy |
 
-## Key insight that simplifies the build
+So static is **not** fused — it does the same HBM round-trip. It's faster for two concrete, measured reasons, and those
+are the only two real opportunities:
 
-The softmax phase can stay **scalar** (it already masks correctly via `if (a6 < seq_len)` and writes `xn = 0`
-past `seq_len`). Then phase 2 is the **existing** masked-K `mma` consumer, reading `xn` from **smem** instead of
-HBM — and its zero-fill is already correct because `xn` is already 0 past `seq_len`. So we do **not** need an
-`−inf` fill-mode on the masked-K slab; we need a kernel that holds `xn` in smem between a scalar producer phase
-and the `mma` consumer phase. The win is purely removing the `xn` HBM round-trip + replacing the scalar P@V with
-`mma`.
+1. **Consumer slab layout.** Static swizzles its `xn` smem slab; dynamic's masked-K slab is a plain row-major
+   stride-512 `[M][K]` → the 3.67M ld-bank-conflict storm. → **step 2.**
+2. **Producer occupancy.** Static's softmax is a 64-thread cooperative warp-reduce (83 % occ, 11 µs); dynamic's is a
+   16-thread (BR=16) reduce (38 % occ, 22 µs). → **producer step.**
 
-## Realistic ceiling
+The originally-proposed "fused single kernel" (old step 3) would go *beyond* what static does — neither config fuses
+today — and its justification ("match static") rests on the misread. It is **not** pursued; flash-style fused symbolic
+attention remains the real future-work item (CLAUDE.md / the static-vs-dynamic findings name it).
 
-Removes the `xn` HBM round-trip and the degenerate scalar P@V → `mma`. Does **not** fix the masked-K `mma`
-consumer's 26% occupancy / 3.67M bank-conflicts (that gap, 38 µs vs static's 15.8 µs, is a separate slab-layout
-issue). Expected landing ≈ **270 µs**, not the full 184 µs. Closing to 184 needs the masked-K slab-layout fix too
-(separate track, also helps the shipping 336 µs path).
+## Step 1 — host-side capacity-cap guard (LANDED, `568630cc`)
 
-## Where it lives (code map)
+A `symbolic_caps` map on `_Compiled` + a hard-error in `_resolve_symbolic` (`backend/cuda/program.py`) when a runtime
+input extent exceeds a capacity-capped kernel's baked hint. Inert until a capped kernel exists (no lowering populates it
+yet), but fully unit-tested (`tests/compiler/backend/test_program.py::TestSymbolicCapacityGuard`). Reusable
+infrastructure for any future hint-baked kernel (e.g. a genuinely-fused smem-staged P@V, were it ever built).
 
-- `005_split_demoted.py` — today the cut emits *separate* Graph nodes (→ separate kernels, HBM hand-off). New:
-  a **fused-smem** cut variant that keeps one node whose body is `producer-phase ; Smem(xn) ; consumer-phase`,
-  gated on `xn`'s capped extent ≤ hint fitting smem. Offered as a third structural option beside keep-fused /
-  split (knob `SPLIT_CONE` → extend to a tri-state, or a new `FUSE_SMEM` knob).
-- `010_partition_loops.py:710` — the `not prologue` warp gate stays for the *raw* prologue; the fused-smem body's
-  consumer phase is a clean matmul (P=`xn` is now a stored smem operand), so it reaches the warp tier normally.
-- `kernel/_stage_expand.py` — the consumer reads `xn` from smem; the producer writes `xn` to smem. Reuse the
-  existing masked-K zero-fill on the consumer (no `−inf` mode needed, per the insight above).
-- `kernel/100_materialize_tile.py` — size the `xn` smem buffer at `BM × hint` (capped); emit both phases in one
-  kernel body with a `__syncthreads()` between.
-- Guard: host-side in `backend/cuda/program.py` (where symbolic dims resolve from input shapes at launch) — raise
-  if `seq_len > hint` for a capped kernel. Cheaper and clearer than an in-kernel trap; fully unit-testable.
+## Step 2 — masked-K consumer alignment pad (LANDED, `05992058`)
 
-## Staging (each step independently landable + tested)
+The symbolic-seq P@V consumer stages its softmaxed `P` in a flat `[…, M, K]` smem slab read by `ldmatrix.x4`. With
+K=512 (fp16) the M-row stride is 1024 B — a 128-byte bank multiple — so the ldmatrix M-row lanes all alias one 4-byte
+bank: **3.67M load conflicts** (NCU 38 µs @ 26 % occ vs static's 16 µs).
 
-1. **Host-side `seq_len > hint` guard** + a kernel flag marking "capacity-capped". Inert until a capped kernel
-   exists, but unit-testable (resolve a too-large shape → raises). Lands the guard infrastructure.
-2. **Masked-K slab-layout fix** (occupancy / bank-conflicts) on the *existing* split consumer — separable, helps
-   the 336 µs path now, and is a prerequisite for the fused kernel not inheriting the conflicts. A/B `PAD_SMEM` /
-   `PERMUTE_LANES` first (the prior dynamic report showed these were no-ops on the masked-tile layout — so this is
-   likely a new swizzle, not a knob).
-3. **Fused-smem cut** in `005_split_demoted` + the two-phase materialization. The big step. Verify accuracy on the
-   `k_sdpa_linear_reduce` reproducer (static-and-dynamic parity test), then e2e bench vs the 336 µs split.
+`070_pad_smem` cannot fix it: it skips SYNC bundles (`kmask` pins masked-K to SYNC) **and** block-stamped MMA sources
+(its `+1` pad breaks ldmatrix's 16 B alignment — its own comment names *"a future MMA-friendly swizzle"* as the answer).
+A flat `[M][K]` slab can't reach static's 0-conflict floor anyway (that needs static's swizzle-atom-wide K-subtile
+relayout); the deployable flat-slab fix is an **alignment-preserving inner pad**.
+
+Implemented intrinsically on the `Source` at creation (`020_stage_inputs._masked_k_mma_pad`, where
+`kmask`/addressing/`bytes_per_elem` converge): one 16-byte ldmatrix chunk (8 fp16 elems) on the innermost cache dim
+steps the M-row stride off the 128-byte alias while keeping every row 16 B aligned. Intrinsic (not a `070` autotune
+fork) because it's a near-strict win with no misalignment penalty — so **greedy deploys it without a re-tune**; `070`
+then self-skips the already-padded source.
+
+**Measured (RTX 5090, dynamic Qwen3-Embedding-0.6B layer 0, -O3, CUDA-graph captured):**
+
+- P@V consumer ld-conflicts **3,670,114 → ~1,000**; NCU duration **38.2 µs → 27.4 µs** (−28 %).
+- Numerically transparent — `max_diff` unchanged (0.000977), accuracy PASS (the pad only adds dead smem columns).
+- Full-layer-0 e2e **340 µs → 329 µs**; the attention path's gap to static narrows ~51 µs → ~28 µs.
+
+Tests: `tests/compiler/passes/test_masked_k_mma_pad.py` (gate + pad value + alignment + dtype-width cases). Full
+compiler suite green (1576 passed).
+
+## Producer step — cooperative softmax producer (VALIDATED via re-tune; deploy needs a re-tune)
+
+The dynamic softmax producer deploys at low occupancy (greedy/learned-prior pick: BR=16, ~12–22 µs, 38 % occ; the
+analytic/cold pick is worse still — block=2, FM=16, ~96 µs, 0 % occ). Forcing `BR=32` proves the cooperative config is
+**reachable and ~2× faster** (the producer drops to ~6 µs at 100 % occ), and the enumeration already offers `BR=32+BM=8`
+(head thread-bind) for the symbolic-seq reduce — so this is a **stale-prior artifact, not a structural lockout**: the
+dynamic tune wedged on the prior commit (static-vs-dynamic findings, Finding 2 — now fixed on this branch), so this
+producer was never tuned on current code. The deployed pick comes from the **learned** prior, which has no surgical
+code override for a single op (the analytic/cold half can't change the learned deploy, and hand-editing the offline-fit
+analytic weights risks regressing the other golden regimes). The in-scope mechanism is a **re-tune**.
+
+**Validated** by a targeted re-tune of the P@V-cone reproducer (`tune <…a76a28.torch.json> --clean`, isolated DB +
+prior, RTX 5090, 935 benches / ~18 min). Deploying with that prior:
+
+- softmax producer `_xna`: **BR=16 / 38 % occ / 12.9 µs → BR=64 / 100 % occ / 7.3 µs** (cooperative warp-reduce, like
+  static's 64-thread producer).
+- P@V-cone reproducer e2e: **86 µs → 79 µs** (producer cooperativity on top of step 2's padded consumer); accuracy PASS.
+
+**To deploy for default `run`:** a full dynamic re-tune (now that the #244 wedge is fixed) — `deplodock tune
+Qwen/Qwen3-Embedding-0.6B --layer 0 --dynamic seq_len@x:1 --clean --bench`. The isolated cone-only prior is not merged
+into the shared `~/.cache/deplodock/prior.json` (it has evidence only for the P@V cone; replacing the default would lose
+every other kernel's tuning). Step 2's consumer pad, by contrast, is intrinsic and deploys today with no re-tune.
+
+A separate, optional code follow-up: the analytic (cold) prior's degenerate block=2 pick for this producer is a real
+cold-start deficiency (helps `compile`/`run` before any tune, and re-tune cold-starts) — but the fix is to re-fit the
+analytic weights via `scripts/golden_knob_heuristics.py` (jointly over all regimes), not a hand-edit, so it's left as
+follow-up.
+
+## Code map (as actually changed)
+
+- `backend/cuda/program.py` — `symbolic_caps` + the `_resolve_symbolic` guard (step 1).
+- `lowering/tile/020_stage_inputs.py` — `_masked_k_mma_pad` + its call at the masked-K `Source` construction (step 2).
+- `lowering/tile/070_pad_smem.py` — unchanged; self-skips the already-padded source.
 
 ## Tests
 
-- Accuracy: `tests/compiler/passes/test_knob_pinning.py` style — fp16 SDPA P@V, dynamic mode, pinned to the
-  fused-smem cut, asserted against the numpy/torch reference at the hint (and a sub-hint seq to exercise the mask).
-- Guard: unit test that resolving `seq_len > hint` on a capped kernel raises a clear error.
-- Bench: `run --ir <reproducer> --bench --ab` fused-smem vs split, expect ≤ split and document the gap to static.
+- `tests/compiler/backend/test_program.py::TestSymbolicCapacityGuard` — guard (no GPU).
+- `tests/compiler/passes/test_masked_k_mma_pad.py` — masked-K pad gate / value / alignment (no GPU).
+- Accuracy + bench validated on the dynamic P@V reproducer and full dynamic layer 0 (RTX 5090).

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -1,13 +1,48 @@
 """Tests for cupy dispatch of a lowered ``Graph[CudaOp]``."""
 
+import numpy as np
 import pytest
 
-from deplodock.compiler.backend.cuda.program import _collapse_inert_dims, benchmark_program, run_program
+from deplodock.compiler.backend.cuda.program import _collapse_inert_dims, _Compiled, _resolve_symbolic, benchmark_program, run_program
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.cuda import CudaOp
 
 from ..conftest import requires_cuda
+
+
+def _minimal_compiled(**kw) -> _Compiled:
+    """A ``_Compiled`` with no kernels — enough to exercise ``_resolve_symbolic``
+    (which only reads the symbolic_* maps). No CUDA needed."""
+    return _Compiled(bufs=[], buf_by_name={}, constants={}, kernels={}, launches=[], **kw)
+
+
+class TestSymbolicCapacityGuard:
+    """``symbolic_caps`` makes the launch resolver hard-error when a runtime
+    extent exceeds a capacity-capped kernel's baked hint (the smem-staged fused
+    symbolic-K SDPA P@V — ``plans/fused-symbolic-pv-smem-staged.md``)."""
+
+    def test_extent_over_cap_raises(self):
+        compiled = _minimal_compiled(
+            symbolic_bindings={"seq_len": ("x", 1)}, symbolic_hints={"seq_len": 512}, symbolic_caps={"seq_len": 512}
+        )
+        big = np.zeros((1, 700, 8), dtype=np.float32)
+        with pytest.raises(ValueError, match="exceeds the capacity-capped"):
+            _resolve_symbolic(compiled, {"x": big})
+
+    @pytest.mark.parametrize("seq", [31, 512])
+    def test_extent_at_or_under_cap_ok(self, seq):
+        compiled = _minimal_compiled(
+            symbolic_bindings={"seq_len": ("x", 1)}, symbolic_hints={"seq_len": 512}, symbolic_caps={"seq_len": 512}
+        )
+        arr = np.zeros((1, seq, 8), dtype=np.float32)
+        assert _resolve_symbolic(compiled, {"x": arr}) == {"seq_len": seq}
+
+    def test_no_cap_allows_any_extent(self):
+        # Uncapped (ceil-div) kernels carry no cap, so a large extent resolves fine.
+        compiled = _minimal_compiled(symbolic_bindings={"seq_len": ("x", 1)}, symbolic_hints={"seq_len": 512})
+        big = np.zeros((1, 4096, 8), dtype=np.float32)
+        assert _resolve_symbolic(compiled, {"x": big}) == {"seq_len": 4096}
 
 
 class TestCollapseInertDims:

--- a/tests/compiler/passes/test_masked_k_mma_pad.py
+++ b/tests/compiler/passes/test_masked_k_mma_pad.py
@@ -1,0 +1,78 @@
+"""``020_stage_inputs._masked_k_mma_pad`` — alignment pad for the masked-K MMA slab.
+
+The masked-K (symbolic-``seq_len``) SDPA P@V consumer stages its softmaxed ``P``
+operand in a flat ``[…, M, K]`` smem slab read by ``ldmatrix.x4``. When the M-row
+stride (the innermost block-scaled alloc-extent) is a multiple of 128 bytes the
+ldmatrix row-lanes all alias one bank — the 3.67M-load-conflict storm in the
+Qwen3-Embedding dynamic P@V. ``_masked_k_mma_pad`` returns an alignment-
+preserving inner pad (one 16-byte ldmatrix chunk) that steps the stride off the
+alias while keeping every row 16-byte aligned. It is stamped intrinsically on the
+Source (not via the ``070_pad_smem`` autotune fork) so greedy deploys it; this
+pins the gate + the pad value.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.pipeline.passes.lowering.tile import _helpers
+
+
+def _load_pass():
+    pass_path = pathlib.Path(_helpers.__file__).parent / "020_stage_inputs.py"
+    spec = importlib.util.spec_from_file_location("stage_inputs", pass_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# The shape the dynamic SDPA P@V consumer stages: 3 cache axes (K-tile, M, K)
+# with an MMA atom block, K innermost. With block=(1,16,16) the innermost
+# alloc-extent is 32*16 = 512 elems → 1024 B (fp16) = the 128-B bank alias.
+_CACHE_AXES = (Axis("a3", 1), Axis("a1", 2), Axis("a7", 32))
+_BLOCK = (1, 16, 16)
+
+
+def test_pads_inner_axis_on_128b_alias_fp16():
+    mod = _load_pass()
+    pad = mod._masked_k_mma_pad((2, object()), _CACHE_AXES, _BLOCK, 2)
+    # fp16 → one 16-byte ldmatrix chunk = 8 elements, on the innermost axis only.
+    assert pad == (0, 0, 8)
+    # The pad keeps the row 16-byte aligned: (inner_extent + pad) * elem_bytes % 16 == 0.
+    inner = _CACHE_AXES[-1].extent.as_static() * _BLOCK[-1]
+    assert ((inner + pad[-1]) * 2) % 16 == 0
+
+
+def test_pads_inner_axis_fp32_chunk_is_four_elems():
+    mod = _load_pass()
+    # 4-byte operand: 16 B chunk = 4 elements; inner stride 512*4 = 2048 B is a
+    # 128-B multiple, so the alias still fires.
+    pad = mod._masked_k_mma_pad((2, object()), _CACHE_AXES, _BLOCK, 4)
+    assert pad == (0, 0, 4)
+
+
+def test_no_pad_without_kmask():
+    mod = _load_pass()
+    assert mod._masked_k_mma_pad(None, _CACHE_AXES, _BLOCK, 2) == ()
+
+
+def test_no_pad_without_block():
+    # A scalar masked-K reduce (no MMA atom block) isn't read by ldmatrix.
+    mod = _load_pass()
+    assert mod._masked_k_mma_pad((2, object()), _CACHE_AXES, (), 2) == ()
+
+
+def test_no_pad_when_stride_not_aliased():
+    mod = _load_pass()
+    # Innermost alloc-extent 30*16 = 480 elems → 960 B (fp16), not a 128-B
+    # multiple, so the slab is already conflict-light → leave it dense.
+    axes = (Axis("a3", 1), Axis("a1", 2), Axis("a7", 30))
+    assert mod._masked_k_mma_pad((2, object()), axes, _BLOCK, 2) == ()
+
+
+def test_no_pad_single_axis():
+    # A rank-1 slab has no outer M dim → no M-row stride alias to break.
+    mod = _load_pass()
+    assert mod._masked_k_mma_pad((0, object()), (Axis("a7", 32),), (16,), 2) == ()


### PR DESCRIPTION
## What

Closes most of the static↔dynamic SDPA P@V gap on the symbolic-`seq_len` path by eliminating the masked-K mma
consumer's catastrophic ldmatrix bank conflicts, plus reusable capacity-guard infrastructure.

Executes `plans/fused-symbolic-pv-smem-staged.md` — but **corrects the plan's premise** along the way: the plan assumed
the *static* SDPA P@V is a single fused kernel to be matched. The dumped kernels prove **both static and dynamic split
P@V into a producer + an mma consumer with an HBM round-trip**. Static is faster only because it (1) swizzles the
consumer slab and (2) uses a cooperative producer. This PR lands the deployable equivalent of (1); (2) is a stale-prior
artifact validated to be fixed by a re-tune (see below).

## Changes

1. **Host-side capacity-cap guard** (`backend/cuda/program.py`) — a `symbolic_caps` map + a `_resolve_symbolic`
   hard-error when a runtime input extent exceeds a capacity-capped kernel's baked hint. Inert until a capped kernel
   exists; reusable infra, fully unit-tested.

2. **Masked-K consumer alignment pad** (`lowering/tile/020_stage_inputs.py`) — the symbolic P@V consumer stages its
   softmaxed `P` in a flat `[…, M, K]` smem slab read by `ldmatrix.x4`; with K=512 (fp16) the M-row stride is a 128-byte
   bank multiple, so the ldmatrix M-row lanes all alias one bank → **3.67M load conflicts**. `070_pad_smem` skips it by
   design (SYNC + block-stamped; its own comment names "a future MMA-friendly swizzle" as the fix). Stamp an
   **alignment-preserving inner pad intrinsically on the `Source`** (one 16-byte ldmatrix chunk), so it deploys by
   greedy default with no re-tune. A flat `[M][K]` slab can't reach static's 0-conflict floor (that needs its
   swizzle-atom-wide K-subtile relayout); this is the deployable flat-slab fix.

## Measured (RTX 5090, dynamic Qwen3-Embedding-0.6B layer 0, -O3, CUDA-graph captured)

- P@V consumer ld-conflicts **3,670,114 → ~1,000**; NCU duration **38.2µs → 27.4µs (−28%)**.
- **Numerically transparent** — `max_diff` unchanged (0.000977), accuracy PASS (the pad only adds dead smem columns).
- Full layer-0 e2e **340µs → 329µs**; the attention path's gap to static narrows ~51µs → ~28µs.

## Tests

- `tests/compiler/backend/test_program.py::TestSymbolicCapacityGuard` — the guard (no GPU).
- `tests/compiler/passes/test_masked_k_mma_pad.py` — pad gate / value / 16-byte alignment / dtype-width cases (no GPU).
- Full compiler suite green (1576 passed, 4 skipped); `make lint` clean.

## Not in this PR (documented in the plan)

- **Cooperative softmax producer**: validated that a re-tune deploys it (BR=16/38% → BR=64/100% occ, producer
  12.9→7.3µs, P@V-cone e2e 86→79µs) — a stale-prior artifact (the dynamic tune wedged on the prior commit, now fixed),
  not a structural lockout. Deploying for default `run` needs a full dynamic re-tune; there's no surgical code override
  for one op's learned-prior pick, and the shared prior isn't clobbered. The optional analytic-prior cold-start fix
  needs offline weight re-fitting, left as follow-up.
- The old "fused single kernel" step is dropped (it rested on the false premise and would go beyond static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)