### PR TITLE
cuda backend: liveness-based scratch-buffer reuse (one planned slab)

### DIFF
--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -58,7 +58,7 @@ arg_order).
 
 `run_program(graph, input_data) → RunResult`:
 
-1. Allocate a `cupy.ndarray` for every buffer. Inputs + optional
+1. Allocate device memory for every buffer. Inputs + optional
    constant overrides come from `input_data`; scalar `ConstantOp`s
    materialize as single-element arrays; scratch buffers zero-init.
    Inputs without supplied data get a deterministic pseudo-random fill
@@ -66,6 +66,26 @@ arg_order).
 2. Launch each kernel in topological order; `zero_outputs` fills run
    before the launch.
 3. Copy `graph.outputs` buffers back to numpy.
+
+**Scratch-buffer reuse (`_planner.py`).** Step 1 does *not* give every node its
+own permanently-live buffer — that holds all 28 layers' `[heads, S, S]` attention scratch resident at once (~29 GB for
+Qwen3-Embedding at S=4096 → cupy OOM). A scratch buffer is live only from the launch that writes it to the last launch
+that reads it, so `_allocate` packs all `role=="scratch"` buffers into **one persistent slab**: `compute_live_intervals`
+derives each buffer's half-open `[first_write, last_read+1)` interval over the topo launch order (a launch reads a buffer
+named in its `arg_names` *or* the `src_buf` of one of its TMA descriptors — TMA loads name the descriptor, not the
+buffer), then `plan_offsets` greedily assigns byte offsets so buffers with non-overlapping intervals share memory
+(largest-first, deterministic). Each scratch `arrays[name]` becomes a typed `cupy` *view* into the slab at its offset; the
+view's device pointer (`slab.data + offset`) is stable for the program lifetime, so captured graphs / TMA descriptors that
+bake `int(arr.data.ptr)` stay valid. Input/constant/output buffers stay standalone (persistent across the call). The
+half-open `+1` convention is load-bearing: a launch's output (born at `i`) overlaps its inputs (live through `i`), so an
+output never aliases its own input. **Correctness rests on the lowering contract** (`lowering/cuda/010_lower_kernelop.py`):
+only atomic-reduction (split-K) outputs need zeroing and are in `zero_outputs` (re-zeroed per launch); every other kernel
+fully overwrites its output, so a reused slot's stale contents are never read. `build` logs the slab vs naive-sum
+reduction. `rebind` re-plans + reallocates the slab when symbolic dims change (then rebuilds descs / drops graphs, as for
+any re-alloc). `set_sym_values` keeps the slab fixed (capacity slots, pointer-stable capture path). Reuse is unconditional; the only
+nuance is `run_program_debug`'s per-launch snapshots — a buffer read *after its last use* reflects the slot's new tenant
+(each kernel's own output is still valid at its launch, the usual debug read). Planner unit tests:
+`tests/compiler/backend/test_planner.py`.
 
 **Repeated execution (`CompiledProgram.rebind` / `run_once`).** One built program can serve request after request —
 the serving path (the vLLM plugin runs one compiled dynamic-seq_len program per sequence). `rebind(input_data)`

--- a/deplodock/compiler/backend/cuda/_planner.py
+++ b/deplodock/compiler/backend/cuda/_planner.py
@@ -1,0 +1,103 @@
+"""Liveness-based memory planning for the CUDA runtime allocator.
+
+The backend lowers a whole program (e.g. a 28-layer transformer) to a flat list
+of kernel launches in topological order. Naively each graph node's output gets
+its own permanently-live device buffer — so every layer's ``[heads, S, S]``
+attention scratch stays resident at once (~29 GB for Qwen3-Embedding at S=4096 →
+cupy OOM). But a *scratch* buffer is live only from the launch that writes it
+until the last launch that reads it; two scratch buffers whose live intervals
+don't overlap can share the same memory.
+
+These pure helpers compute those live intervals and pack the scratch buffers into
+one slab (offset per buffer) via a greedy-by-size memory planner (the strategy
+TFLite's ``GreedyMemoryPlanner`` uses). They take no cupy and no graph — only the
+launch list + sizes — so they unit-test on a CPU box. ``program.py`` turns the
+offsets into typed views over one persistent ``cupy`` slab.
+
+Input/constant/output buffers are NOT planned here: inputs are uploaded (and read
+across the whole call), outputs are sliced out at the end, constants are weights —
+all persistent. Only ``role == "scratch"`` buffers are reuse candidates.
+"""
+
+from __future__ import annotations
+
+
+def compute_live_intervals(scratch_names: list[str], launches: list) -> dict[str, tuple[int, int]]:
+    """Per scratch buffer, its half-open live interval ``[first_write, free_at)``
+    over the topological launch order (``launches`` is already topo-sorted).
+
+    - ``first_write`` = index of the launch whose ``node_id`` is the buffer (one
+      buffer is produced by exactly one launch).
+    - ``free_at`` = ``last_read + 1``, where ``last_read`` is the highest launch
+      index that *reads* the buffer. A launch reads buffer ``b`` when ``b`` is one
+      of its ``arg_names`` (kernel params) OR the ``src_buf`` of one of its TMA
+      descriptors (a TMA-loaded buffer appears as the descriptor name in
+      ``arg_names``, not the buffer name — so its source must be counted
+      explicitly or the buffer would look dead and be aliased while still read).
+
+    The half-open ``+1`` (free strictly after last use) is load-bearing: a launch
+    at index ``i`` produces its output (interval starts at ``i``) while reading its
+    inputs (each input's ``free_at >= i+1``), so the overlap test in
+    :func:`plan_offsets` always treats an input live at ``i`` and the output born
+    at ``i`` as overlapping — a launch's output can never alias its own live input.
+
+    Raises on a scratch buffer with no producer or no consumer (a lowering-contract
+    violation — surfaced loudly rather than silently leaked/mis-aliased).
+    """
+    scratch = set(scratch_names)
+    first_write: dict[str, int] = {}
+    last_read: dict[str, int] = {}
+    for i, ln in enumerate(launches):
+        if ln.node_id in scratch:
+            first_write[ln.node_id] = i
+        reads = set(ln.arg_names)
+        reads.update(d.src_buf for d in ln.tma_descriptors)
+        for name in reads:
+            if name in scratch and name != ln.node_id:
+                last_read[name] = i
+    intervals: dict[str, tuple[int, int]] = {}
+    for name in scratch_names:
+        if name not in first_write:
+            raise ValueError(f"scratch buffer {name!r} has no producing launch")
+        lr = last_read.get(name)
+        if lr is None:
+            raise ValueError(f"scratch buffer {name!r} has no consuming launch (dead scratch)")
+        intervals[name] = (first_write[name], lr + 1)
+    return intervals
+
+
+def plan_offsets(
+    intervals: dict[str, tuple[int, int]],
+    sizes: dict[str, int],
+    aligns: dict[str, int],
+) -> tuple[dict[str, int], int]:
+    """Assign each scratch buffer a byte offset into one slab so that buffers with
+    overlapping live intervals never share a byte. Greedy-by-size: place the
+    largest buffers first (they constrain the layout most), each at the lowest
+    aligned offset that collides with no already-placed *overlapping-interval*
+    buffer. Returns ``({name: offset}, total_bytes)``.
+
+    Deterministic: buffers are ordered by ``(-size, name)`` so the same graph +
+    sizes always yields the same layout (captured graphs bake these offsets).
+    """
+    order = sorted(intervals, key=lambda n: (-sizes[n], n))
+    placed: list[tuple[int, int, int, int]] = []  # (offset, size, first, free)
+    offsets: dict[str, int] = {}
+    total = 0
+    for name in order:
+        size = sizes[name]
+        first, free = intervals[name]
+        align = max(1, aligns.get(name, 1))
+        # Byte ranges occupied by buffers whose live interval overlaps this one,
+        # sorted by start so we can sweep a candidate offset forward past them.
+        occ = sorted((o, o + s) for (o, s, f, fr) in placed if first < fr and f < free)
+        off = 0
+        for lo, hi in occ:
+            if off + size <= lo:
+                break  # fits in the gap before this occupied range
+            if off < hi:
+                off = ((hi + align - 1) // align) * align  # bump past it, realigned
+        offsets[name] = off
+        placed.append((off, size, first, free))
+        total = max(total, off + size)
+    return offsets, total

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -27,6 +27,7 @@ import numpy as np
 
 from deplodock.compiler.backend import BenchmarkResult, LaunchTime, RunResult
 from deplodock.compiler.backend.cuda import _tma, nvcc
+from deplodock.compiler.backend.cuda._planner import compute_live_intervals, plan_offsets
 from deplodock.compiler.backend.cuda.dtype import cupy_dtype
 from deplodock.compiler.dim import Dim
 from deplodock.compiler.dtype import DataType
@@ -301,7 +302,70 @@ def _materialize(buf: _Buffer, shape: tuple[int, ...], src: np.ndarray | None, c
     return cp.zeros(shape, dtype=cp_dtype)
 
 
-def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> dict[str, cp.ndarray]:
+@dataclass
+class _SlabPlan:
+    """A liveness-planned layout of the program's scratch buffers into one
+    persistent device slab. ``offsets`` is the byte offset of each scratch
+    buffer's view into ``slab``; ``total_bytes`` is the slab size; ``sym_values``
+    are the (capacity) dims the layout was planned at — a re-plan is needed when
+    they change (``rebind``). ``naive_bytes`` is the sum of the per-scratch sizes
+    this layout replaces (for the reduction-factor log). ``slab`` is held for the
+    program lifetime so cupy never reclaims it under the views' baked pointers."""
+
+    offsets: dict[str, int]
+    total_bytes: int
+    sym_values: dict[str, int]
+    naive_bytes: int
+    slab: cp.ndarray | None = None
+
+
+def _scratch_sizes(compiled: _Compiled, sym_values: dict[str, int]) -> tuple[dict[str, int], dict[str, int]]:
+    """Byte size + alignment per ``scratch`` buffer at the resolved ``sym_values``."""
+    sizes: dict[str, int] = {}
+    aligns: dict[str, int] = {}
+    for buf in compiled.bufs:
+        if buf.role != "scratch":
+            continue
+        shape = buf.resolve_shape(sym_values) or (1,)
+        n = 1
+        for d in shape:
+            n *= int(d)
+        sizes[buf.name] = max(1, n) * buf.dtype.nbytes
+        aligns[buf.name] = buf.dtype.nbytes
+    return sizes, aligns
+
+
+def _plan_slab(compiled: _Compiled, sym_values: dict[str, int]) -> _SlabPlan:
+    """Liveness-plan the scratch buffers into one slab layout (no allocation)."""
+    sizes, aligns = _scratch_sizes(compiled, sym_values)
+    intervals = compute_live_intervals(list(sizes), compiled.launches)
+    offsets, total = plan_offsets(intervals, sizes, aligns)
+    return _SlabPlan(offsets=offsets, total_bytes=total, sym_values=dict(sym_values), naive_bytes=sum(sizes.values()))
+
+
+def _alloc_slab(compiled: _Compiled, sym_values: dict[str, int]) -> tuple[dict[str, cp.ndarray], _SlabPlan]:
+    """Plan + allocate the scratch slab and return each scratch buffer as a typed
+    view into it. One zero-init ``uint8`` allocation; each view's device pointer
+    (``slab.data + offset``) is stable for the program lifetime (the slab is pinned
+    on the returned plan), so captured graphs / TMA descriptors that bake the
+    pointer stay valid across replays."""
+    import cupy as cp  # noqa: PLC0415
+
+    plan = _plan_slab(compiled, sym_values)
+    plan.slab = cp.zeros(plan.total_bytes or 1, dtype=cp.uint8)
+    views: dict[str, cp.ndarray] = {}
+    for buf in compiled.bufs:
+        if buf.role != "scratch":
+            continue
+        shape = buf.resolve_shape(sym_values) or (1,)
+        views[buf.name] = cp.ndarray(shape, dtype=cupy_dtype(buf.dtype), memptr=plan.slab.data + plan.offsets[buf.name])
+    return views, plan
+
+
+def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> tuple[dict[str, cp.ndarray], _SlabPlan]:
+    """Materialize every buffer. ``scratch`` buffers become typed views into one
+    liveness-planned persistent slab (dead intervals share memory);
+    input/constant/output buffers stay standalone (persistent across the call)."""
     input_data = input_data or {}
     sym_values = _resolve_symbolic(compiled, input_data)
     arrays: dict[str, cp.ndarray] = {}
@@ -310,9 +374,18 @@ def _allocate(compiled: _Compiled, input_data: dict[str, np.ndarray] | None) -> 
     # softmax). Ignore the over/invalid warnings so genuine output stays clean.
     with np.errstate(over="ignore", invalid="ignore"):
         for buf in compiled.bufs:
+            if buf.role == "scratch":
+                continue  # placed into the slab below
             shape = buf.resolve_shape(sym_values) or (1,)
             arrays[buf.name] = _materialize(buf, shape, input_data.get(buf.name), compiled.constants)
-    return arrays
+    # ``scratch`` buffers become views into one zero-init slab. The build-time
+    # zero preserves the contract scratch had under ``cp.zeros``; per-launch
+    # ``zero_outputs`` re-zeros atomic-reduction outputs, and every other kernel
+    # fully overwrites its output (lowering contract), so a reused slot's stale
+    # contents are never read.
+    scratch_views, plan = _alloc_slab(compiled, sym_values)
+    arrays.update(scratch_views)
+    return arrays, plan
 
 
 def _resolve_symbolic(compiled: _Compiled, input_data: dict[str, np.ndarray]) -> dict[str, int]:
@@ -588,6 +661,10 @@ class CompiledProgram:
     # block resolution and the runtime-arg tail. Empty for fully-static
     # graphs.
     sym_values: dict[str, int] = field(default_factory=dict)
+    # Liveness-planned scratch slab: scratch ``arrays`` are views into
+    # ``slab_plan.slab``, pinned here for the program lifetime (``build`` always
+    # populates it; the default is only for dataclass construction).
+    slab_plan: _SlabPlan | None = None
     # Per-launch timing events, lazily created on first ``iter_once``
     # and reused across every subsequent call so multi-iter bench loops
     # don't churn the cupy ``Event`` pool (the pre-unification
@@ -641,7 +718,7 @@ class CompiledProgram:
         t0 = _time_module.monotonic()
         compiled = _compile(graph)
         sym_values = _resolve_symbolic(compiled, input_data or {})
-        arrays = _allocate(compiled, input_data)
+        arrays, slab_plan = _allocate(compiled, input_data)
         descs = _prebuild_descriptors(compiled, arrays)
         elapsed = _time_module.monotonic() - t0
         if compile_timeout_s is not None and elapsed > compile_timeout_s:
@@ -652,7 +729,15 @@ class CompiledProgram:
             elapsed,
             ", ".join(f"{li}:{lc.kernel_name}" for li, lc in enumerate(compiled.launches)),
         )
-        return cls(compiled=compiled, arrays=arrays, descs=descs, sym_values=sym_values)
+        if slab_plan.naive_bytes > 0:
+            logger.info(
+                "[cuda] buffer-reuse: scratch slab=%.2f GB (%.2f GB naive, %.1fx) over %d scratch buf(s)",
+                slab_plan.total_bytes / 1e9,
+                slab_plan.naive_bytes / 1e9,
+                slab_plan.naive_bytes / max(1, slab_plan.total_bytes),
+                len(slab_plan.offsets),
+            )
+        return cls(compiled=compiled, arrays=arrays, descs=descs, sym_values=sym_values, slab_plan=slab_plan)
 
     def rebind(self, input_data: dict[str, np.ndarray]) -> None:
         """Re-bind ``input_data`` on an already-built program, re-sizing
@@ -670,8 +755,11 @@ class CompiledProgram:
         pointers). Caller must hold ``gpu_lock()``."""
         new_sym = _resolve_symbolic(self.compiled, input_data)
         realloc = False
+        reuse = self.slab_plan is not None
         with np.errstate(over="ignore", invalid="ignore"):
             for buf in self.compiled.bufs:
+                if reuse and buf.role == "scratch":
+                    continue  # slab-managed; re-planned below when dims change
                 src = input_data.get(buf.name)
                 if src is None and not buf.is_symbolic:
                     continue
@@ -682,6 +770,13 @@ class CompiledProgram:
                     realloc = True
                 elif src is not None:
                     arr.set(np.ascontiguousarray(src, dtype=buf.dtype.np).reshape(shape))
+        # Scratch slab: re-plan + reallocate at the new dims (sizes scale with the
+        # symbolic extent). The fresh slab has new pointers, so descs/graphs must
+        # be rebuilt/dropped — handled by the shared ``if realloc:`` block below.
+        if reuse and new_sym != self.slab_plan.sym_values:
+            scratch_views, self.slab_plan = _alloc_slab(self.compiled, new_sym)
+            self.arrays.update(scratch_views)
+            realloc = True
         self.sym_values = new_sym
         if realloc:
             self.descs = _prebuild_descriptors(self.compiled, self.arrays)
@@ -1020,6 +1115,10 @@ def run_program_debug(
     per_launch: dict[int, dict[str, np.ndarray]] = {}
     with gpu_lock():
         pre_result = pre_run() if pre_run is not None else None
+        # Note: scratch buffers share one reused slab, so a per-launch snapshot of
+        # a buffer *after its last use* reflects whatever now occupies that slot.
+        # Each kernel's own output is valid at its launch (just written, still
+        # live) — the usual debug read.
         prog = CompiledProgram.build(graph, input_data)
         prog.iter_once(per_launch_hook=lambda li, _lc: per_launch.__setitem__(li, prog.snapshot()))
         outputs = prog.outputs()

--- a/tests/compiler/backend/test_planner.py
+++ b/tests/compiler/backend/test_planner.py
@@ -1,0 +1,130 @@
+"""Unit tests for the liveness-based scratch-buffer memory planner.
+
+Pure CPU — no cupy, no GPU. Validates the two helpers that decide how scratch
+buffers share one slab: :func:`compute_live_intervals` (def-use over the topo
+launch order, incl. TMA-source reads) and :func:`plan_offsets` (greedy packing
+where only overlapping live intervals get distinct memory).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deplodock.compiler.backend.cuda._planner import compute_live_intervals, plan_offsets
+
+
+class _Launch:
+    """Duck-typed stand-in for ``program._Launch`` (node_id, arg_names, tma)."""
+
+    def __init__(self, node_id: str, arg_names: list[str], tma_src: list[str] | None = None) -> None:
+        self.node_id = node_id
+        self.arg_names = tuple(arg_names)
+        self.tma_descriptors = tuple(_Tma(s) for s in (tma_src or []))
+
+
+class _Tma:
+    def __init__(self, src_buf: str) -> None:
+        self.src_buf = src_buf
+
+
+def _no_overlap_shares_no_bytes(intervals, sizes, offsets):
+    """Assert: any two buffers whose byte ranges overlap have disjoint intervals."""
+    names = list(offsets)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            ao, bo = offsets[a], offsets[b]
+            bytes_overlap = ao < bo + sizes[b] and bo < ao + sizes[a]
+            fa, fra = intervals[a]
+            fb, frb = intervals[b]
+            ivl_overlap = fa < frb and fb < fra
+            if bytes_overlap:
+                assert not ivl_overlap, f"{a} and {b} share bytes but their live intervals overlap"
+
+
+def test_intervals_basic_chain():
+    # in -> a (L0) -> b (L1) -> c=output (L2). a read at 1, b read at 2.
+    launches = [_Launch("a", ["in", "a"]), _Launch("b", ["a", "b"]), _Launch("c", ["b", "c"])]
+    iv = compute_live_intervals(["a", "b"], launches)
+    assert iv == {"a": (0, 2), "b": (1, 3)}
+
+
+def test_tma_source_counts_as_read():
+    # b is loaded by L2 via a TMA descriptor (its name is NOT in arg_names).
+    launches = [
+        _Launch("a", ["in", "a"]),
+        _Launch("b", ["a", "b"]),
+        _Launch("c", ["c"], tma_src=["b"]),  # reads b through TMA only
+    ]
+    iv = compute_live_intervals(["a", "b"], launches)
+    assert iv["b"] == (1, 3), "TMA-source read must extend b's live range to launch 2"
+
+
+def test_no_producer_or_consumer_raises():
+    launches = [_Launch("a", ["in", "a"]), _Launch("b", ["a", "b"])]
+    with pytest.raises(ValueError, match="no producing launch"):
+        compute_live_intervals(["ghost"], launches)
+    # 'b' is produced but never read -> dead scratch.
+    with pytest.raises(ValueError, match="no consuming launch"):
+        compute_live_intervals(["b"], launches)
+
+
+def test_disjoint_intervals_reuse_offset():
+    # a:[0,2) and d:[2,4) do not overlap -> may share offset 0.
+    intervals = {"a": (0, 2), "d": (2, 4)}
+    sizes = {"a": 512, "d": 512}
+    offsets, total = plan_offsets(intervals, sizes, {"a": 1, "d": 1})
+    assert offsets["a"] == offsets["d"] == 0
+    assert total == 512  # one slot reused, not summed
+    _no_overlap_shares_no_bytes(intervals, sizes, offsets)
+
+
+def test_overlapping_intervals_distinct_memory():
+    intervals = {"a": (0, 2), "b": (1, 3)}  # overlap at index 1
+    sizes = {"a": 512, "b": 256}
+    offsets, total = plan_offsets(intervals, sizes, {"a": 1, "b": 1})
+    assert offsets["a"] != offsets["b"]
+    assert total == 768
+    _no_overlap_shares_no_bytes(intervals, sizes, offsets)
+
+
+def test_output_never_aliases_own_input():
+    # Single launch L1 reads a (input) and writes b (output): a:[0,2), b:[1,?).
+    # With the half-open [first_write, last_read+1) convention they overlap at 1,
+    # so a and b must never share memory.
+    launches = [_Launch("a", ["in", "a"]), _Launch("b", ["a", "b"]), _Launch("c", ["b", "c"])]
+    iv = compute_live_intervals(["a", "b"], launches)
+    sizes = {"a": 128, "b": 128}
+    offsets, _ = plan_offsets(iv, sizes, {"a": 1, "b": 1})
+    assert offsets["a"] != offsets["b"]
+    _no_overlap_shares_no_bytes(iv, sizes, offsets)
+
+
+def test_determinism():
+    intervals = {"x": (0, 2), "y": (0, 2), "z": (3, 5)}
+    sizes = {"x": 100, "y": 100, "z": 100}
+    aligns = {"x": 1, "y": 1, "z": 1}
+    r1 = plan_offsets(intervals, sizes, aligns)
+    r2 = plan_offsets(dict(reversed(list(intervals.items()))), sizes, aligns)
+    assert r1 == r2, "layout must be independent of dict insertion order"
+
+
+def test_total_below_naive_sum_on_chain():
+    # A long chain of same-size buffers, each live only across one launch gap,
+    # should pack into ~2 slots, far below the naive sum.
+    n = 20
+    launches = [_Launch(f"b{i}", [f"b{i - 1}" if i else "in", f"b{i}"]) for i in range(n)]
+    names = [f"b{i}" for i in range(n - 1)]  # last is an output, exclude
+    iv = compute_live_intervals(names, launches)
+    sizes = {nm: 1000 for nm in names}
+    aligns = {nm: 1 for nm in names}
+    offsets, total = plan_offsets(iv, sizes, aligns)
+    assert total < sum(sizes.values()) // 5, "adjacent-only liveness should pack into a few slots"
+    _no_overlap_shares_no_bytes(iv, sizes, offsets)
+
+
+def test_alignment_respected():
+    intervals = {"a": (0, 2), "b": (1, 3)}
+    sizes = {"a": 100, "b": 100}
+    aligns = {"a": 256, "b": 256}
+    offsets, _ = plan_offsets(intervals, sizes, aligns)
+    assert offsets["b"] % 256 == 0

--- a/tests/compiler/backend/test_program.py
+++ b/tests/compiler/backend/test_program.py
@@ -109,6 +109,52 @@ def test_run_program_elementwise_add():
     assert all(v == v for v in result.outputs["C"].tolist())  # NaN check
 
 
+def _make_chain_graph(n: int = 8) -> Graph:
+    """Two-stage chain with a real scratch buffer: T = A + B (scratch), C = T + T."""
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("A", (n,)), node_id="A")
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("B", (n,)), node_id="B")
+    g.add_node(
+        op=CudaOp(
+            kernel_source=EW_ADD_SOURCE, kernel_name="ew_add", arg_order=("A", "B", "T"), grid=((n + 255) // 256, 1, 1), block=(256, 1, 1)
+        ),
+        inputs=["A", "B"],
+        output=Tensor("T", (n,)),
+        node_id="T",
+    )
+    g.add_node(
+        op=CudaOp(
+            kernel_source=EW_ADD_SOURCE, kernel_name="ew_add", arg_order=("T", "T", "C"), grid=((n + 255) // 256, 1, 1), block=(256, 1, 1)
+        ),
+        inputs=["T"],
+        output=Tensor("C", (n,)),
+        node_id="C",
+    )
+    g.inputs = ["A", "B"]
+    g.outputs = ["C"]
+    return g
+
+
+@requires_cuda
+def test_buffer_reuse_correct_and_slab_managed():
+    """A graph with a scratch buffer runs correctly through the reused slab, and
+    the intermediate ``T`` is slab-managed while inputs/outputs stay standalone."""
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+    graph = _make_chain_graph(8)
+    a = np.arange(8, dtype=np.float32)
+    b = np.arange(8, dtype=np.float32) * 10
+    with gpu_lock():
+        prog = CompiledProgram.build(graph, {"A": a, "B": b})
+        prog.iter_once()
+        out = prog.outputs()["C"]
+        plan = prog.slab_plan
+    np.testing.assert_array_equal(out, 2 * (a + b))  # C = T + T = 2(A+B)
+    assert plan is not None and "T" in plan.offsets  # scratch T is slab-managed
+    assert "A" not in plan.offsets and "C" not in plan.offsets  # input/output stay standalone
+
+
 @requires_cuda
 def test_benchmark_program_returns_timing():
     result = benchmark_program(_make_add_graph(1024), warmup=2, num_iters=5)


### PR DESCRIPTION
## Problem

The CUDA runtime allocator (`compiler/backend/cuda/program.py`) gave **every graph node its own permanently-live cupy buffer**. For whole-model serving (Qwen3-Embedding-0.6B: 28 layers, S=4096) that holds every layer's `[heads, S, S]` attention scratch resident at once — **~29.6 GB peak → cupy `OutOfMemoryError`**. (It's the reason the serving A/B had to shrink `DEPLODOCK_SERVING_CAPTURE_CAP` to 512.) But a scratch buffer is live only from the launch that writes it to the last launch that reads it — non-overlapping scratch buffers can share memory.

## Change

A liveness-based memory planner packs all `role=="scratch"` buffers into **one persistent slab**; each scratch `arrays[name]` becomes a typed cupy view at its offset.

- **`_planner.py`** (new, pure / CPU-testable):
  - `compute_live_intervals` — half-open `[first_write, last_read+1)` over the topo launch order. A launch reads a buffer named in its `arg_names` **or** the `src_buf` of one of its TMA descriptors (TMA loads name the descriptor, not the buffer — counting only `arg_names` would free a TMA-read buffer too early).
  - `plan_offsets` — greedy-by-size; overlapping intervals get distinct memory. Deterministic.
- **`program.py`** — `_allocate` builds the slab; views' device pointers (`slab.data + offset`) are stable for the program lifetime, so captured graphs / TMA descriptors that bake `int(arr.data.ptr)` stay valid. `rebind` re-plans + reallocates on symbolic-dim change (then rebuilds descs / drops graphs, as for any re-alloc); `set_sym_values` keeps the slab fixed (capacity slots, pointer-stable capture path). `build` logs the slab-vs-naive reduction. Input/constant/output buffers stay standalone.

**Reuse is unconditional** — no env flag, no kwarg.

## Why it's safe

The lowering contract (`lowering/cuda/010_lower_kernelop.py`): only atomic-reduction (split-K) outputs need zeroing and are in `zero_outputs` (re-zeroed per launch); **every other kernel fully overwrites its output**, so a reused slot's stale contents are never read. The half-open `+1` convention makes a launch's output (born at `i`) overlap its inputs (live through `i`), so an output **never aliases its own input**.

## Validation

- `pytest tests/compiler/` — **1586 passed, 4 skipped** (incl. the `run_program_debug` path).
- Real Qwen3-Embedding-0.6B layer 0: **accuracy vs eager OK**, **2.29× scratch-slab reduction** (40.9 → 17.8 MB, 14 bufs) — whole-model reuses across all 28 layers for a far larger drop.
- New tests: `test_planner.py` (9 CPU unit tests: no-overlap, reuse, output≠input, determinism, TMA-read, alignment) + a GPU correctness/slab test in `test_program.py`.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)