### PR TITLE
serving: on-device torch I/O (dlpack zero-copy) + opt-in static batched mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ When the user asks about a CLI flag, recipe field, or matrix combinator, read th
 
 All `DEPLODOCK_*` config env vars (the two above plus `DEPLODOCK_NVCC_FLAGS`, `DEPLODOCK_DEBUG`, `DEPLODOCK_KNOBS`,
 `DEPLODOCK_TUNE_PATIENCE`, `DEPLODOCK_TUNE_EPS`, `DEPLODOCK_O3_TOL`, `DEPLODOCK_ANALYTIC_TILT`, `DEPLODOCK_BENCH_BACKENDS`,
-`DEPLODOCK_CUBIN_CACHE`, `DEPLODOCK_NO_NVCC`, `DEPLODOCK_GPU_LOCK`,
+`DEPLODOCK_CUBIN_CACHE`, `DEPLODOCK_NO_NVCC`, `DEPLODOCK_GPU_LOCK`, `DEPLODOCK_SERVING_STATIC` (static batched serving),
 …) are read and written through a single module, `deplodock/config.py` — the sole owner of `os.environ` for these vars.
 CLI `--flag` overrides (e.g. `--nvcc-flags`) resolve via `config.set_nvcc_flags` inside the library, not in the command
 layer, so programmatic callers and tests get the same precedence. The dynamic `DEPLODOCK_<KNOB>` namespace is owned by

--- a/deplodock/compiler/backend/cuda/program.py
+++ b/deplodock/compiler/backend/cuda/program.py
@@ -939,6 +939,26 @@ class CompiledProgram:
                 raise ValueError(f"upload_prefix: {name!r} has {flat.size} elems > capacity {arr.size}")
             arr.ravel()[: flat.size].set(flat)
 
+    def upload_prefix_device(self, input_data: dict[str, cp.ndarray]) -> None:
+        """Device-to-device twin of :meth:`upload_prefix`: copy each cupy source
+        into the contiguous PREFIX of its capacity-sized device buffer with NO
+        host round-trip — the serving zero-copy path, where the sources are cupy
+        views of the caller's torch GPU tensors (``cp.from_dlpack``). Same
+        prefix-packing contract and capacity check as :meth:`upload_prefix` (the
+        kernels launched at the real-S grid read only the prefix). Caller must
+        hold ``gpu_lock()`` and order the copy on the replay stream — the serving
+        runner enters a cupy external stream bound to torch's current stream so
+        the copy, the graph replay, and the output read all enqueue in order."""
+        import cupy as cp  # noqa: PLC0415
+
+        for name, src in input_data.items():
+            buf = self.compiled.buf_by_name[name]
+            arr = self.arrays[name]
+            flat = cp.ascontiguousarray(src, dtype=buf.dtype.np).ravel()
+            if flat.size > arr.size:
+                raise ValueError(f"upload_prefix_device: {name!r} has {flat.size} elems > capacity {arr.size}")
+            arr.ravel()[: flat.size] = flat
+
     def time_program_window(self, replays: int) -> float:
         """One event window around ``replays`` back-to-back whole-program
         replays of the captured e2e graph; returns per-replay ms. Caller
@@ -1055,6 +1075,28 @@ class CompiledProgram:
                 out[b.name] = arr.ravel()[:n].get().reshape(shape)
             else:
                 out[b.name] = arr.get()
+        return out
+
+    def output_prefix_device(self, sym_values: dict[str, int] | None = None) -> dict[str, cp.ndarray]:
+        """Device twin of :meth:`outputs`: return each output buffer's real-S
+        PREFIX as a cupy view (reshaped to the resolved shape) with NO ``.get()``
+        host copy — the serving zero-copy path, where the caller wraps the view as
+        a torch tensor (``torch.from_dlpack``) and clones it (the shared buffer is
+        overwritten by the next request's replay). ``sym_values`` slices to the
+        real shape exactly like :meth:`outputs`; without it the whole buffer view
+        is returned. Caller must hold ``gpu_lock()`` (and read on the replay
+        stream — see :meth:`upload_prefix_device`)."""
+        out: dict[str, cp.ndarray] = {}
+        for b in self.compiled.bufs:
+            if b.role != "output":
+                continue
+            arr = self.arrays[b.name]
+            if sym_values is not None:
+                shape = b.resolve_shape({**self.sym_values, **sym_values})
+                n = math.prod(shape) if shape else 1
+                out[b.name] = arr.ravel()[:n].reshape(shape)
+            else:
+                out[b.name] = arr
         return out
 
     def snapshot(self) -> dict[str, np.ndarray]:

--- a/deplodock/config.py
+++ b/deplodock/config.py
@@ -47,6 +47,7 @@ CUBIN_CACHE = "DEPLODOCK_CUBIN_CACHE"
 NO_NVCC = "DEPLODOCK_NO_NVCC"
 GPU_LOCK = "DEPLODOCK_GPU_LOCK"
 NCU_CHILD = "DEPLODOCK_NCU_CHILD"
+SERVING_STATIC = "DEPLODOCK_SERVING_STATIC"
 
 _CACHE_ROOT = Path.home() / ".cache" / "deplodock"
 
@@ -215,6 +216,18 @@ def analytic_tilt(default: float = 0.3) -> float:
     toward configs it favors without overriding the learned scale (``W=0`` =
     pure learned, large ``W`` = analytic dominates). See the method docstring."""
     return float_env(ANALYTIC_TILT, default)
+
+
+def serving_static(default: bool = False) -> bool:
+    """``DEPLODOCK_SERVING_STATIC`` — opt into the serving plugin's fully-static
+    program: **static extents for both batch and seq_len**. Off (default) keeps the
+    symbolic-seq, batch-1 path; on builds ONE static ``(max_num_seqs, max_seq_len)``
+    program (batch from vLLM's ``--max-num-seqs``, seq from ``--max-model-len``) and
+    runs each scheduler step as a padded batched forward. Only correct/efficient for
+    fixed-length workloads — it pads every sequence to ``max_seq_len`` and the
+    dynamic-seq kernels miscompute batch>1, so it is a deliberate opt-in, not a
+    default. See `serving/ARCHITECTURE.md`."""
+    return _bool(SERVING_STATIC, default)
 
 
 def bench_backends_raw(cli_value: str | None) -> str:

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -26,17 +26,26 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `attn_type = "encoder_only"` (vLLM disables chunked prefill → every request reaches `forward` whole),
   `pooler = DispatchPooler.for_embedding(...)` (last-token pooling + L2 normalize + matryoshka — identical to stock
   Qwen3-Embedding serving), stub `embed_input_ids`, no-op `load_weights` (the runner loads the checkpoint itself; not
-  consuming the iterator skips reading the safetensors).
+  consuming the iterator skips reading the safetensors). `forward` keeps everything **on-device**: it clamps + casts
+  the packed ids to int64 on the GPU, slices each span straight into the runner (torch tensors, no `.cpu()`/numpy), and
+  `torch.cat`s the torch results back. The only host touch is a small `positions.cpu()` to find span boundaries for
+  `split_spans` (a `(num_tokens,)` int vector).
 - `runner.py` — `DeplodockForwardRunner`. At engine start: load the `AutoModel` **trunk** (hidden states out — no
   lm_head), `build_full_model_wrapper(dynamic=True)`, trace with the canonical 4-spec dynamic seq_len
   (`seq_len@input_ids:1`, `@attention_mask:2`, `@attention_mask:3`, `@position_ids:1`), compile through `CudaBackend`
   (greedy fork picks from the global prior — benefits from any prior `deplodock tune`), bind weights as graph
   constants (`named_parameters` + `named_buffers`, `remove_duplicate=False`, in the traced dtype), and build ONE
   `CompiledProgram` over a buffer set sized at **`max_seq_len`** (`--max-model-len`). Per
-  sequence (`forward_hidden_states`): size the launch grids to S (`set_sym_values`), upload the request's ids / causal
-  mask / position_ids into the buffers' contiguous **prefix** (`upload_prefix`), **capture-or-reuse** the whole-program
-  CUDA graph for this S, and **replay** it — one host launch instead of the ~hundreds the uncaptured loop issues; then
-  `outputs({"seq_len": S})` slices each output to its real shape. Captured graphs are cached per seq_len (bounded LRU);
+  sequence (`forward_hidden_states`) it takes a **1-D int torch CUDA tensor** and returns an `(S, hidden)` **torch CUDA
+  tensor** — no host round-trip. It enters a cupy external stream bound to torch's current stream
+  (`cp.cuda.Stream.from_external`), then: bridge the
+  torch ids to cupy (`cp.from_dlpack`, zero-copy), size the launch grids to S (`set_sym_values`), copy ids /
+  **device-built** causal mask / position_ids into the buffers' contiguous **prefix** device-to-device
+  (`upload_prefix_device`), **capture-or-reuse** the whole-program CUDA graph for this S, **replay** it — one host launch
+  instead of the ~hundreds the uncaptured loop issues — and wrap the output buffer's real-S prefix back as a torch
+  tensor (`output_prefix_device` + `torch.from_dlpack`, cloned because the shared buffer is reused next request). The
+  causal mask is built once per S as a cupy array (the device twin of `_causal_mask_np`) and reused. Captured graphs are
+  cached per seq_len (bounded LRU);
   each is captured at its EXACT S so every kernel runs at its exact grid — no oversized-grid masking (a single
   capacity-baked graph for all S is **not** viable: several symbolic-M kernels do illegal reads at an oversized grid,
   the swizzle decode + staged loads among them). See `compiler/backend/cuda/ARCHITECTURE.md`
@@ -51,7 +60,8 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
 
 Each sequence runs **individually** through the compiled dynamic-seq_len program (batch axis is compile-time fixed at
 1), as a captured whole-program CUDA graph (one host launch) replayed over a single capacity-sized buffer set, with the
-request's inputs uploaded into the buffers' prefix and the output sliced back out. One captured graph is cached per
+request's torch inputs bridged to the buffers' prefix device-to-device (dlpack, no host hop) and the output handed back
+as a torch view of the output buffer. One captured graph is cached per
 distinct seq_len (bounded LRU); a new length pays one capture (~one forward) on first sight, then replays. The captured
 graph removes the per-launch dispatch overhead and the ~hundreds of host calls the uncaptured loop made — the
 precondition for fast low-concurrency serving. (Measured A/B is ~flat today: the uncaptured `run_once` loop already
@@ -62,10 +72,15 @@ structurally trails stock vLLM's packed-batch prefill — that gap measures the 
 Recorded follow-ups, in impact order:
 
 1. **Packed-varlen attention** (cu_seqlens-aware SDPA tiles) — run vLLM's whole packed batch in one launch; the only
-   item that makes the throughput regime apples-to-apples. Matmuls/norms/pointwise are already token-wise.
-2. **dlpack zero-copy I/O** — cupy ↔ torch without the host round-trip (`cp.from_dlpack` / `torch.from_dlpack`).
-3. **Device-side causal mask** — the `(1,1,S,S)` host mask upload (~32 MB fp16 at S=4096) per request; a tiny kernel
-   (or in-kernel `j <= i` predicate) removes the mask input + its upload entirely.
+   item that makes the throughput regime apples-to-apples. Matmuls/norms/pointwise are already token-wise. This is now
+   the dominant remaining gap: at concurrency 1 (no batching) deplodock is ~1.5× stock; the rest of the
+   concurrency-32 gap is this.
+2. **dlpack zero-copy I/O** — **done**: `forward_hidden_states` takes/returns torch CUDA tensors, bridged to the cupy
+   buffers via `cp.from_dlpack` / `torch.from_dlpack` on torch's stream — no GPU↔host round-trip (`upload_prefix_device`
+   / `output_prefix_device`). The only residual host touch is `positions.cpu()` for span boundaries.
+3. **Device-side causal mask** — host build + upload **removed**: the `(1,1,S,S)` mask is now built once per S as a cupy
+   array on the GPU (`runner._mask`) and copied into the prefix device-to-device. Still open: an in-kernel `j <= i`
+   predicate would drop the mask input + its per-request D2D copy entirely.
 4. **Single capacity-baked graph** — would collapse the per-S cache to one graph, but needs every symbolic-M kernel to
    be correct at an oversized (capacity) grid; today several aren't (swizzle decode + staged loads read OOB). Tracked
    in `plans/serving-dynamic-shape-cuda-graphs.md`.
@@ -94,6 +109,8 @@ Recorded follow-ups, in impact order:
   The three texts have different token counts, so it exercises the per-seq_len captured-graph cache end to end.
 - `tests/compiler/ir/test_dynamic_shapes.py` — the captured-replay primitives directly (RMSNorm + a 1-layer Qwen3
   trunk through `set_sym_values` + `upload_prefix` + `capture_program_graph` + `replay_program_graph` +
-  `outputs(sym_values)`); run under `compute-sanitizer` in dev to confirm zero illegal accesses.
+  `outputs(sym_values)`); run under `compute-sanitizer` in dev to confirm zero illegal accesses. Plus
+  `test_capture_replay_device_io_matches_eager` — the zero-copy device path (`upload_prefix_device` + cupy-in,
+  `output_prefix_device` + `torch.from_dlpack`-out) matches eager, the primitive behind the runner's torch I/O.
 - `scripts/compare_embeddings.py` — the accuracy gate against a *server*: embeds a fixed text set through two
   OpenAI-compatible endpoints (deplodock-backed and stock) and asserts pairwise cosine > 0.99.

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -29,7 +29,8 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   consuming the iterator skips reading the safetensors). `forward` keeps everything **on-device**: it clamps + casts
   the packed ids to int64 on the GPU, slices each span straight into the runner (torch tensors, no `.cpu()`/numpy), and
   `torch.cat`s the torch results back. The only host touch is a small `positions.cpu()` to find span boundaries for
-  `split_spans` (a `(num_tokens,)` int vector).
+  `split_spans` (a `(num_tokens,)` int vector). With `batch_cap > 1` it hands all spans to
+  `runner.forward_hidden_states_batched` (one padded batched forward) instead of looping per span.
 - `runner.py` — `DeplodockForwardRunner`. At engine start: load the `AutoModel` **trunk** (hidden states out — no
   lm_head), `build_full_model_wrapper(dynamic=True)`, trace with the canonical 4-spec dynamic seq_len
   (`seq_len@input_ids:1`, `@attention_mask:2`, `@attention_mask:3`, `@position_ids:1`), compile through `CudaBackend`
@@ -52,9 +53,39 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   → repeated execution + captured replay. Trunk compute dtype follows vLLM's `--dtype` (`mc.dtype`, mapped in
   `vllm_model._trunk_dtype_str`): `float32`→fp32, `float16`→fp16, anything else (e.g. `bfloat16`/`auto`) downcasts to
   fp16 with a warn — the runner's numpy weight carrier can't represent bf16, and only fp16/fp32 trunks are supported.
+  When `DEPLODOCK_SERVING_STATIC=1` (`config.serving_static`), `create` instead traces a **fully-static**
+  `(max_num_seqs, max_seq_len)` graph (no dynamic_shapes — static extents for both batch and seq) and
+  `forward_hidden_states_batched` runs each step as one padded batched forward — see "Static mode" below.
 - `packed.py` — `split_spans(positions, max_seq_len)`: vLLM V1 hands pooling models one packed `(num_tokens,)` tensor
   with per-request 0-based positions; spans split at `positions == 0`. Hardened for `_dummy_run`'s garbage profiling
   batches (index 0 always opens a span; overlong spans are chopped).
+
+## Static mode (`DEPLODOCK_SERVING_STATIC=1`) — static extents for both batch and seq
+
+The default path is symbolic-seq, **one sequence per forward** (`batch_cap = 1`). Setting `DEPLODOCK_SERVING_STATIC=1`
+switches the runner to a **fully-static `(N, max_seq_len)` program** (static extents for both batch and seq) so a whole
+scheduler step runs as one batched forward. The batch `N` is **vLLM's own `max_num_seqs`**
+(`vllm_config.scheduler_config.max_num_seqs`), read at init — so the batch is sized by the standard `--max-num-seqs`
+flag, not a separate deplodock knob (the toggle is boolean; the size comes from what vLLM hands us). Mind the default
+`max_num_seqs=256`: pair the opt-in with a sane `--max-num-seqs` or the static `(256, max_seq_len)` program will be huge.
+
+**Measured (RTX 5090, Qwen3-Embedding-0.6B, uniform 512 tokens, concurrency 32):** this is currently a throughput
+**regression**, not a win — the static `(32, 512)` forward takes ~1.1 s (26.6 req/s) vs the batch-1 path's 64 req/s and
+stock vLLM's ~232 req/s. Making the extents static is *not* the lever: the batched program does B× the existing,
+non-flash, O(B·H·S²)-materialized attention (Finding 2 in `plans/qwen3-embedding-0.6b-layer0-static-vs-dynamic-tune-findings.md`),
+and the static-shape kernels are cold greedy picks (untuned, unlike the batch-1 symbolic kernels which carried prior
+tuning). The throughput win needs efficient attention (flash/varlen, follow-up #1) and/or an autotune of the static
+batched shape — batching alone, over today's kernels, loses. Why static, not symbolic: the dynamic-seq
+(masked-tile) kernels **miscompute batch>1** (the batch axis isn't threaded through the masked attention/reduction
+codegen — empirically every batch row is wrong), whereas a fully-static trace bakes correct batch strides. So the
+batched program fixes both axes: every step is **padded to `(N, max_seq_len)`** — short sequences pad on the right,
+short batches pad with dummy rows (`runner.forward_hidden_states_batched`). Causal masking makes this safe: a token
+attends only to earlier positions, so a row's real prefix is independent of its right-padding, and dummy rows are never
+read out. The mask + position_ids are request-independent (full causal at `max_seq_len`, arange positions) so they are
+fed once at build and never updated — only ids change per step. **Limitation:** correct only for the static shape, so
+it pads every sequence to `max_seq_len` (zero waste when all requests are that length — the benchmark case — but
+wasteful for mixed/short lengths); set `--max-model-len` to the actual workload length. Not a general production path;
+the general fix is follow-up #1.
 
 ## Execution model (v2: captured graphs) and its known costs
 
@@ -71,10 +102,11 @@ the captured path is in place for that.) Low-concurrency latency is representati
 structurally trails stock vLLM's packed-batch prefill — that gap measures the integration, not kernel quality.
 Recorded follow-ups, in impact order:
 
-1. **Packed-varlen attention** (cu_seqlens-aware SDPA tiles) — run vLLM's whole packed batch in one launch; the only
-   item that makes the throughput regime apples-to-apples. Matmuls/norms/pointwise are already token-wise. This is now
-   the dominant remaining gap: at concurrency 1 (no batching) deplodock is ~1.5× stock; the rest of the
-   concurrency-32 gap is this.
+1. **Packed-varlen attention** (cu_seqlens-aware SDPA tiles) — run vLLM's whole packed batch in one launch at *mixed*
+   lengths; the general form of the throughput fix. At concurrency 1 (no batching) deplodock is ~1.5× stock; the rest of
+   the concurrency-32 gap is batching. The static batched mode above is the fixed-length stand-in; the remaining work is
+   (a) making the masked-tile kernels batch-correct so a symbolic-seq batched program works, then (b) cu_seqlens varlen
+   so one launch handles mixed lengths without padding to `max_seq_len`.
 2. **dlpack zero-copy I/O** — **done**: `forward_hidden_states` takes/returns torch CUDA tensors, bridged to the cupy
    buffers via `cp.from_dlpack` / `torch.from_dlpack` on torch's stream — no GPU↔host round-trip (`upload_prefix_device`
    / `output_prefix_device`). The only residual host touch is `positions.cpu()` for span boundaries.
@@ -112,5 +144,8 @@ Recorded follow-ups, in impact order:
   `outputs(sym_values)`); run under `compute-sanitizer` in dev to confirm zero illegal accesses. Plus
   `test_capture_replay_device_io_matches_eager` — the zero-copy device path (`upload_prefix_device` + cupy-in,
   `output_prefix_device` + `torch.from_dlpack`-out) matches eager, the primitive behind the runner's torch I/O.
+- `tests/serving/test_runner_batched_gpu.py` — `perf`-marked: a 1-layer static `(batch, S)` trunk wrapped in a runner;
+  `forward_hidden_states_batched` runs several different-length sequences in one padded batched forward and matches
+  eager per row (the causal-independence-under-padding gate for `DEPLODOCK_SERVING_STATIC`).
 - `scripts/compare_embeddings.py` — the accuracy gate against a *server*: embeds a fixed text set through two
   OpenAI-compatible endpoints (deplodock-backed and stock) and asserts pairwise cosine > 0.99.

--- a/deplodock/serving/runner.py
+++ b/deplodock/serving/runner.py
@@ -62,7 +62,9 @@ class DeplodockForwardRunner:
         # Shared buffer set is sized for max_seq_len; every accepted request
         # (S ≤ max_seq_len) uses the captured-graph path.
         self.max_seq_len = max_seq_len
-        self._mask_cache: dict[int, np.ndarray] = {}
+        # int seq_len -> device-built (1,1,S,S) cupy causal mask (built on first
+        # sight of each S, reused across same-S requests via a D2D prefix copy).
+        self._mask_cache: dict = {}
 
     @classmethod
     def create(cls, model_id: str, max_seq_len: int, dtype_str: str = "float16") -> DeplodockForwardRunner:
@@ -158,37 +160,51 @@ class DeplodockForwardRunner:
         out = self._program.compiled.buf_by_name[self._output_name]
         return int(out.shape[-1].as_static())
 
-    def _mask(self, s: int) -> np.ndarray:
+    def _mask(self, s: int):
+        """``(1, 1, s, s)`` additive causal mask as a cached cupy device array —
+        the device twin of :func:`_causal_mask_np`, built once per S on the GPU so
+        the hot path never builds/uploads it from host."""
+        import cupy as cp  # noqa: PLC0415
+
         cached = self._mask_cache.get(s)
         if cached is not None:
             return cached
-        mask = _causal_mask_np(s, self._np_dtype)
+        mask = cp.triu(cp.full((s, s), float("-inf"), dtype=cp.float32), k=1).astype(self._np_dtype)[None, None, :, :]
         if len(self._mask_cache) >= _MASK_CACHE_MAX:
             self._mask_cache.pop(next(iter(self._mask_cache)))
         self._mask_cache[s] = mask
         return mask
 
-    def forward_hidden_states(self, token_ids: np.ndarray) -> np.ndarray:
-        """Run one sequence: ``token_ids`` shape ``(S,)`` int64, ``S <=
-        max_seq_len``. Returns ``(S, hidden)`` numpy in the traced dtype.
+    def forward_hidden_states(self, token_ids):
+        """Run one sequence: ``token_ids`` a 1-D int torch CUDA tensor of length
+        ``S <= max_seq_len``. Returns an ``(S, hidden)`` torch CUDA tensor in the
+        trunk dtype.
 
-        Captured-graph path: size the launch grids to S, upload the request's
-        ids / causal mask / position_ids into the shared buffers' prefix,
-        capture-or-reuse the whole-program graph for this S, and replay it — one
-        host launch."""
+        Zero-copy device path: bridge the torch input to cupy (``cp.from_dlpack``,
+        no host copy), size the launch grids to S, copy ids / device-built causal
+        mask / position_ids into the shared buffers' prefix (device-to-device),
+        capture-or-reuse the whole-program graph for this S, replay it, and wrap
+        the output buffer's prefix back as a torch tensor (``torch.from_dlpack``)
+        — no GPU↔host round-trip. All cupy work runs on torch's current stream so
+        the prefix copy, the graph replay, and the output read stay ordered; the
+        result is cloned because the shared buffer is reused by the next request."""
+        import cupy as cp  # noqa: PLC0415
+        import torch
+
         from deplodock.compiler.backend.gpu_lock import gpu_lock
 
         s = int(token_ids.shape[0])
         if s > self.max_seq_len:
             raise ValueError(f"seq_len {s} exceeds max_seq_len {self.max_seq_len}")
-        feed = {
-            self._ids_name: token_ids.reshape(1, s),
-            self._mask_name: self._mask(s),
-            self._pos_name: np.arange(s, dtype=np.int64).reshape(1, s),
-        }
-        with gpu_lock():
+        with gpu_lock(), cp.cuda.Stream.from_external(torch.cuda.current_stream()):
+            feed = {
+                self._ids_name: cp.from_dlpack(token_ids.detach().reshape(1, s)),
+                self._mask_name: self._mask(s),
+                self._pos_name: cp.arange(s, dtype=cp.int64).reshape(1, s),
+            }
             self._program.set_sym_values({"seq_len": s})
-            self._program.upload_prefix(feed)
+            self._program.upload_prefix_device(feed)
             self._program.capture_program_graph()
             self._program.replay_program_graph()
-            return self._program.outputs({"seq_len": s})[self._output_name][0]
+            out = self._program.output_prefix_device({"seq_len": s})[self._output_name][0]
+            return torch.from_dlpack(out).clone()

--- a/deplodock/serving/runner.py
+++ b/deplodock/serving/runner.py
@@ -54,6 +54,7 @@ class DeplodockForwardRunner:
         output_name: str,
         np_dtype,
         max_seq_len: int,
+        batch_cap: int = 1,
     ):
         self._program = program
         self._ids_name, self._mask_name, self._pos_name = input_names
@@ -62,12 +63,16 @@ class DeplodockForwardRunner:
         # Shared buffer set is sized for max_seq_len; every accepted request
         # (S ≤ max_seq_len) uses the captured-graph path.
         self.max_seq_len = max_seq_len
+        # batch_cap == 1: symbolic-seq, one sequence per forward (the default).
+        # batch_cap > 1: ONE static (batch_cap, max_seq_len) program; each
+        # scheduler step runs as a padded batched forward (`forward_hidden_states_batched`).
+        self.batch_cap = batch_cap
         # int seq_len -> device-built (1,1,S,S) cupy causal mask (built on first
         # sight of each S, reused across same-S requests via a D2D prefix copy).
         self._mask_cache: dict = {}
 
     @classmethod
-    def create(cls, model_id: str, max_seq_len: int, dtype_str: str = "float16") -> DeplodockForwardRunner:
+    def create(cls, model_id: str, max_seq_len: int, dtype_str: str = "float16", batch: int = 1) -> DeplodockForwardRunner:
         import torch
         from transformers import AutoModel
 
@@ -85,31 +90,41 @@ class DeplodockForwardRunner:
                 f"serve with --max-model-len {DYNAMIC_DIM_MAX} or lower"
             )
         dtype = getattr(torch, dtype_str)
+        np_dtype = np.dtype(dtype_str)
 
         logger.info("[serving] loading %s trunk (dtype=%s)...", model_id, dtype_str)
         # vLLM instantiates models inside a CUDA device context; the HF trunk
         # is only traced + read for constants here (then freed), so force CPU —
         # this also sidesteps transformers' accelerate requirement for
-        # non-default device contexts.
+        # non-default device contexts. The wrapper builds buffers and the trace
+        # runs the forward on example tensors — all of it must sit on one device.
         with torch.device("cpu"):
             model = AutoModel.from_pretrained(model_id, dtype=dtype)
-        model.eval()
-
-        logger.info("[serving] tracing (dynamic seq_len, example S=%d)...", _TRACE_SEQ)
-        specs = parse_position_specs(
-            ["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"]
-        )
-        # Same CPU pin as the load above: the wrapper builds buffers and the
-        # trace runs the forward on example tensors — all of it must sit on
-        # one device, regardless of vLLM's CUDA default-device context.
-        with torch.device("cpu"):
-            wrapper = build_full_model_wrapper(model, _TRACE_SEQ, dtype, dynamic=True)
-            example = (
-                torch.zeros((1, _TRACE_SEQ), dtype=torch.long),
-                build_causal_mask(_TRACE_SEQ, dtype),
-                torch.arange(_TRACE_SEQ).unsqueeze(0),
-            )
-            graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
+            model.eval()
+            if batch > 1:
+                # Static batched path: ONE fully-static (batch, max_seq_len)
+                # program (the symbolic-seq kernels miscompute batch>1; a static
+                # trace bakes correct batch strides). Each step pads to this shape.
+                logger.info("[serving] tracing STATIC batched (batch=%d, S=%d)...", batch, max_seq_len)
+                wrapper = build_full_model_wrapper(model, max_seq_len, dtype, dynamic=True)
+                example = (
+                    torch.zeros((batch, max_seq_len), dtype=torch.long),
+                    build_causal_mask(max_seq_len, dtype),
+                    torch.arange(max_seq_len).unsqueeze(0).expand(batch, max_seq_len).contiguous(),
+                )
+                graph = trace_module(wrapper, example)  # no dynamic_shapes → fully static
+            else:
+                logger.info("[serving] tracing (dynamic seq_len, example S=%d)...", _TRACE_SEQ)
+                specs = parse_position_specs(
+                    ["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"]
+                )
+                wrapper = build_full_model_wrapper(model, _TRACE_SEQ, dtype, dynamic=True)
+                example = (
+                    torch.zeros((1, _TRACE_SEQ), dtype=torch.long),
+                    build_causal_mask(_TRACE_SEQ, dtype),
+                    torch.arange(_TRACE_SEQ).unsqueeze(0),
+                )
+                graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
 
         logger.info("[serving] compiling...")
         compiled = CudaBackend(tune_db="auto").compile(graph)
@@ -122,7 +137,6 @@ class DeplodockForwardRunner:
         # so non-persistent buffers — the wrapper's precomputed rotary
         # cos/sin — bind too; remove_duplicate=False so tied weights surface
         # under every traced alias.
-        np_dtype = np.dtype(dtype_str)
         sources: dict[str, np.ndarray] = {}
         for path, t in wrapper.named_parameters(remove_duplicate=False):
             sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
@@ -130,22 +144,33 @@ class DeplodockForwardRunner:
             sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
         const_feed = bind_constants(compiled, sources)
 
-        # Allocate the shared buffer set at max_seq_len so each captured graph
-        # (one per seq_len) replays over the same prefix-occupied buffers. Every
-        # accepted request (S ≤ max_seq_len) fits, so all use the captured path.
         ids_name, mask_name, pos_name = compiled.inputs
-        feed = {
-            ids_name: np.zeros((1, max_seq_len), dtype=np.int64),
-            mask_name: _causal_mask_np(max_seq_len, np_dtype),
-            pos_name: np.arange(max_seq_len, dtype=np.int64).reshape(1, max_seq_len),
-        }
+        if batch > 1:
+            # Static (batch, max_seq_len) buffers. The causal mask + position_ids
+            # are request-independent (full causal at max_seq_len, arange positions),
+            # so they're fed once here and never updated — only ids change per step.
+            feed = {
+                ids_name: np.zeros((batch, max_seq_len), dtype=np.int64),
+                mask_name: _causal_mask_np(max_seq_len, np_dtype),
+                pos_name: np.tile(np.arange(max_seq_len, dtype=np.int64), (batch, 1)),
+            }
+        else:
+            # Shared buffer set sized at max_seq_len so each captured graph (one per
+            # seq_len) replays over the same prefix-occupied buffers; every accepted
+            # request (S ≤ max_seq_len) fits, so all use the captured path.
+            feed = {
+                ids_name: np.zeros((1, max_seq_len), dtype=np.int64),
+                mask_name: _causal_mask_np(max_seq_len, np_dtype),
+                pos_name: np.arange(max_seq_len, dtype=np.int64).reshape(1, max_seq_len),
+            }
         with gpu_lock():
             program = CompiledProgram.build(compiled, {**const_feed, **feed})
         del model, wrapper, sources, const_feed
         logger.info(
-            "[serving] ready: %d launches, max_seq_len=%d",
+            "[serving] ready: %d launches, max_seq_len=%d, batch_cap=%d",
             len(program.compiled.launches),
             max_seq_len,
+            batch,
         )
         return cls(
             program=program,
@@ -153,6 +178,7 @@ class DeplodockForwardRunner:
             output_name=compiled.outputs[0],
             np_dtype=np_dtype,
             max_seq_len=max_seq_len,
+            batch_cap=batch,
         )
 
     @property
@@ -208,3 +234,38 @@ class DeplodockForwardRunner:
             self._program.replay_program_graph()
             out = self._program.output_prefix_device({"seq_len": s})[self._output_name][0]
             return torch.from_dlpack(out).clone()
+
+    def forward_hidden_states_batched(self, token_ids_list):
+        """Run up to ``batch_cap`` sequences (each a 1-D int torch CUDA tensor of
+        length ``S <= max_seq_len``) in ONE static batched forward. Returns a list
+        of ``(S_i, hidden)`` torch CUDA tensors in the same order.
+
+        The static program is fixed at ``(batch_cap, max_seq_len)``, so each step
+        is padded to that shape: short rows pad on the right and short batches pad
+        with dummy rows. Causal masking makes every row's real prefix independent
+        of its right-padding (a token only attends to earlier positions), and dummy
+        rows are simply not read out — so padding never corrupts a real result.
+        Inputs longer than ``batch_cap`` are processed in successive batched groups."""
+        import cupy as cp  # noqa: PLC0415
+        import torch
+
+        from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+        B, S = self.batch_cap, self.max_seq_len
+        results: list = [None] * len(token_ids_list)
+        for start in range(0, len(token_ids_list), B):
+            group = token_ids_list[start : start + B]
+            lens = [int(t.shape[0]) for t in group]
+            if any(s > S for s in lens):
+                raise ValueError(f"seq_len {max(lens)} exceeds max_seq_len {S}")
+            with gpu_lock(), cp.cuda.Stream.from_external(torch.cuda.current_stream()):
+                ids = torch.zeros((B, S), dtype=torch.int64, device=group[0].device)
+                for i, t in enumerate(group):
+                    ids[i, : lens[i]] = t.detach().to(torch.int64)
+                self._program.upload_prefix_device({self._ids_name: cp.from_dlpack(ids)})
+                self._program.capture_program_graph()  # static graph, one cached entry
+                self._program.replay_program_graph()
+                out = torch.from_dlpack(self._program.output_prefix_device()[self._output_name])
+                for i, si in enumerate(lens):
+                    results[start + i] = out[i, :si].clone()
+        return results

--- a/deplodock/serving/vllm_model.py
+++ b/deplodock/serving/vllm_model.py
@@ -25,6 +25,7 @@ import torch.nn as nn
 from vllm.model_executor.layers.pooler import DispatchPooler
 from vllm.model_executor.models.interfaces import IsAttentionFree
 
+from deplodock import config
 from deplodock.serving.packed import split_spans
 from deplodock.serving.runner import DeplodockForwardRunner
 
@@ -55,10 +56,15 @@ class DeplodockEmbedModel(nn.Module, IsAttentionFree):
         self.out_dtype = mc.dtype
         self.vocab_size = mc.get_vocab_size()
         self.pooler = DispatchPooler.for_embedding(mc.pooler_config)
+        # Static mode (opt-in): static extents for both batch and seq_len. Batch cap
+        # = vLLM's own max_num_seqs, so it's sized by --max-num-seqs (seq by
+        # --max-model-len), not a deplodock-specific knob.
+        batch = vllm_config.scheduler_config.max_num_seqs if config.serving_static() else 1
         self.runner = DeplodockForwardRunner.create(
             model_id=mc.model,
             max_seq_len=mc.max_model_len,
             dtype_str=_trunk_dtype_str(mc.dtype),
+            batch=batch,
         )
 
     def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None, **kwargs):
@@ -68,10 +74,14 @@ class DeplodockEmbedModel(nn.Module, IsAttentionFree):
         # states come back as torch CUDA tensors. Only the span boundaries need a
         # host read of positions (a tiny (num_tokens,) int vector); garbage
         # dummy-run batches survive via the vocab clamp + split_spans' chunking.
+        # With batch_cap > 1 the whole step runs as one padded batched forward.
         n = int(input_ids.shape[0])
         ids = input_ids.clamp(0, self.vocab_size - 1).to(torch.int64)
-        spans = split_spans(positions.cpu().numpy().reshape(-1), self.runner.max_seq_len)
-        chunks = [self.runner.forward_hidden_states(ids[a:b]) for a, b in spans]
+        spans = [ids[a:b] for a, b in split_spans(positions.cpu().numpy().reshape(-1), self.runner.max_seq_len)]
+        if self.runner.batch_cap > 1:
+            chunks = self.runner.forward_hidden_states_batched(spans)
+        else:
+            chunks = [self.runner.forward_hidden_states(t) for t in spans]
         if chunks:
             out = torch.cat(chunks, dim=0).to(device=input_ids.device, dtype=self.out_dtype)
         else:

--- a/deplodock/serving/vllm_model.py
+++ b/deplodock/serving/vllm_model.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 
-import numpy as np
 import torch
 import torch.nn as nn
 from vllm.model_executor.layers.pooler import DispatchPooler
@@ -64,14 +63,19 @@ class DeplodockEmbedModel(nn.Module, IsAttentionFree):
 
     def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None, **kwargs):
         # Packed (num_tokens_padded,) tensors: sequences flattened back-to-back,
-        # positions 0-based per request. Garbage dummy-run batches must survive
-        # too — hence the vocab clamp and split_spans' chunking hardening.
+        # positions 0-based per request. Everything stays on-device — each span's
+        # ids slice straight into the runner (torch→cupy zero-copy) and hidden
+        # states come back as torch CUDA tensors. Only the span boundaries need a
+        # host read of positions (a tiny (num_tokens,) int vector); garbage
+        # dummy-run batches survive via the vocab clamp + split_spans' chunking.
         n = int(input_ids.shape[0])
-        ids = input_ids.clamp(0, self.vocab_size - 1).cpu().numpy().astype(np.int64).reshape(-1)
-        pos = positions.cpu().numpy().reshape(-1)
-        chunks = [self.runner.forward_hidden_states(ids[a:b]) for a, b in split_spans(pos, self.runner.max_seq_len)]
-        hidden = np.concatenate(chunks, axis=0) if chunks else np.zeros((0, self.runner.hidden_size), dtype=np.float32)
-        out = torch.from_numpy(np.ascontiguousarray(hidden)).to(device=input_ids.device, dtype=self.out_dtype)
+        ids = input_ids.clamp(0, self.vocab_size - 1).to(torch.int64)
+        spans = split_spans(positions.cpu().numpy().reshape(-1), self.runner.max_seq_len)
+        chunks = [self.runner.forward_hidden_states(ids[a:b]) for a, b in spans]
+        if chunks:
+            out = torch.cat(chunks, dim=0).to(device=input_ids.device, dtype=self.out_dtype)
+        else:
+            out = torch.zeros((0, self.runner.hidden_size), device=input_ids.device, dtype=self.out_dtype)
         if out.shape[0] < n:  # pad back to num_tokens_padded
             out = torch.nn.functional.pad(out, (0, 0, 0, n - out.shape[0]))
         return out

--- a/tests/compiler/ir/test_dynamic_shapes.py
+++ b/tests/compiler/ir/test_dynamic_shapes.py
@@ -552,6 +552,45 @@ def test_capture_replay_cache_rmsnorm_over_capacity_buffers():
         assert set(k[0][1] for k in prog._graph_cache) == {5, 12, 33, 64}, "expected one cached graph per distinct seq_len"
 
 
+def test_capture_replay_device_io_matches_eager():
+    """Serving zero-copy device I/O: feed cupy inputs through ``upload_prefix_device``
+    and read the output buffer's prefix back as a torch tensor via ``output_prefix_device``
+    + ``torch.from_dlpack`` — NO host round-trip — and confirm it matches torch eager
+    across seq_lens. The dlpack bridge (cupy ↔ torch) is what lets the runner accept
+    torch tensors straight from vLLM. Repeats hit the per-S graph cache."""
+    pytest = __import__("pytest")
+    pytest.importorskip("cupy")
+    import cupy as cp
+    import torch
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.trace.torch import trace_module
+
+    cap = 48
+    m = torch.nn.RMSNorm(1024)
+    compiled = CudaBackend().compile(trace_module(m, (torch.randn(1, 32, 1024),), dynamic_shapes={"x": {1: _seq_len_dim()}}))
+    weight = m.weight.detach().numpy().astype(np.float32)
+    out_name = compiled.outputs[0]
+
+    with gpu_lock():
+        prog = CompiledProgram.build(compiled, {"x": np.zeros((1, cap, 1024), np.float32), "p_weight": weight})
+        for s in (7, 32, 48, 7):
+            x = np.random.RandomState(s).standard_normal((1, s, 1024)).astype(np.float32)
+            prog.set_sym_values({"seq_len": s})
+            prog.upload_prefix_device({"x": cp.asarray(x)})  # cupy in — no host upload
+            prog.capture_program_graph()
+            prog.replay_program_graph()
+            out_view = prog.output_prefix_device({"seq_len": s})[out_name]  # cupy view, no .get()
+            cp.cuda.runtime.deviceSynchronize()
+            out = torch.from_dlpack(out_view).clone().cpu().numpy()  # torch view of cupy mem
+            with torch.no_grad():
+                ref = torch.nn.functional.rms_norm(torch.from_numpy(x), (1024,), m.weight, eps=m.eps).numpy()
+            assert out.shape == (1, s, 1024)
+            np.testing.assert_allclose(out, ref, rtol=1e-4, atol=1e-4)
+
+
 def test_qwen_whole_model_capture_replay_cache_matches_eager():
     """1-layer random-weight Qwen3 trunk through the captured-graph serving path:
     build once at capacity, serve several seq_lens via the per-S graph cache

--- a/tests/serving/test_runner_batched_gpu.py
+++ b/tests/serving/test_runner_batched_gpu.py
@@ -1,0 +1,80 @@
+"""Static batched serving path (``DEPLODOCK_SERVING_STATIC=1``).
+
+``perf``-marked (deselected by default — run with ``pytest -m perf``): needs CUDA
++ cupy + the Qwen3-Embedding config. Builds a 1-layer static ``(batch, S)`` trunk,
+wraps a ``DeplodockForwardRunner`` around it, and checks that
+``forward_hidden_states_batched`` runs several different-length sequences in ONE
+padded batched forward and matches eager per row — the causal-independence claim
+(a row's real prefix is unaffected by right-padding, dummy rows below the batch cap
+are ignored). The whole-model accuracy gate lives in ``test_vllm_plugin_gpu.py``.
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.xdist_group("cuda")]
+
+MODEL = "Qwen/Qwen3-Embedding-0.6B"
+
+
+def test_runner_batched_matches_eager():
+    pytest.importorskip("cupy")
+    import torch
+    from transformers import AutoConfig, AutoModel
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.loader.binder import bind_constants
+    from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+    from deplodock.compiler.trace.torch import trace_module
+    from deplodock.serving.runner import DeplodockForwardRunner
+
+    torch.manual_seed(0)
+    cfg = AutoConfig.from_pretrained(MODEL)
+    cfg.num_hidden_layers = 1
+    model = AutoModel.from_config(cfg).float().eval()
+
+    B, S, dtype = 4, 32, torch.float32
+    wrapper = build_full_model_wrapper(model, S, dtype, dynamic=True)
+    example = (
+        torch.zeros((B, S), dtype=torch.long),
+        build_causal_mask(S, dtype),
+        torch.arange(S).unsqueeze(0).expand(B, S).contiguous(),
+    )
+    compiled = CudaBackend().compile(trace_module(wrapper, example))  # fully static
+
+    sources: dict[str, np.ndarray] = {}
+    for path, t in wrapper.named_parameters(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    for path, t in wrapper.named_buffers(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    const_feed = bind_constants(compiled, sources)
+    ids_name, mask_name, pos_name = compiled.inputs
+    feed = {
+        ids_name: np.zeros((B, S), dtype=np.int64),
+        mask_name: build_causal_mask(S, dtype).numpy(),
+        pos_name: np.tile(np.arange(S, dtype=np.int64), (B, 1)),
+    }
+    with gpu_lock():
+        program = CompiledProgram.build(compiled, {**const_feed, **feed})
+        runner = DeplodockForwardRunner(
+            program=program,
+            input_names=(ids_name, mask_name, pos_name),
+            output_name=compiled.outputs[0],
+            np_dtype=np.dtype("float32"),
+            max_seq_len=S,
+            batch_cap=B,
+        )
+        # Three different-length sequences (full, mid, short) + an implicit dummy
+        # 4th row (only 3 supplied < batch_cap=4). Each must match eager on its own
+        # length despite right-padding to S.
+        lens = [S, 20, 7]
+        seqs = [torch.from_numpy(((np.arange(n, dtype=np.int64) * 97) % 100) + 1).cuda() for n in lens]
+        outs = runner.forward_hidden_states_batched(seqs)
+        for n, out, ids_t in zip(lens, outs, seqs, strict=True):
+            with torch.no_grad():
+                ref = wrapper(ids_t.reshape(1, n).cpu(), build_causal_mask(n, dtype), torch.arange(n).reshape(1, n)).numpy()[0]
+            got = out.cpu().numpy()
+            assert got.shape == (n, 1024)
+            np.testing.assert_allclose(got, ref, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
Two related serving-perf changes (stacked commits on one branch). Both are correct + tested; the headline finding is that the **per-request latency bottleneck is kernel compute, not host I/O or batching**.

---

## 1. dlpack zero-copy I/O (`ebad93f8`)

The plugin bridged vLLM's torch CUDA tensors to the compiled program's `cupy` buffers **through host numpy** (`.cpu().numpy()` in, `.get()` + `from_numpy().to(device)` out, plus a host-built causal mask per request) — two full GPU→host→GPU round-trips every request.

Now bridged **on-device**: `runner.forward_hidden_states` takes/returns torch CUDA tensors, bridging via `cp.from_dlpack` / `torch.from_dlpack` on torch's stream (`cp.cuda.Stream.from_external`); new `CompiledProgram.upload_prefix_device` / `output_prefix_device` are device-to-device twins of the host methods; the causal mask is built once per S on-device. (Serving ARCHITECTURE follow-ups #2 + the host half of #3.)

**Perf — concurrency 1:** no change (64.0 vs 63.3 req/s; 15.45 vs 15.67 ms mean). Host round-trips cost *overlap under concurrency*, not single-request latency — at c1 the GPU forward is on the critical path regardless. Lands because it's correct, removes real CPU↔GPU syncs, and is the prerequisite for batching.

## 2. Opt-in static batched mode (`d57d95c4`)

`DEPLODOCK_SERVING_STATIC=1` builds ONE fully-static `(max_num_seqs, max_seq_len)` program (static extents for **both** batch and seq) and runs each scheduler step as a padded batched forward. Batch size = vLLM's own `--max-num-seqs` (read at init), not a new knob. Off by default.

Static-only because the dynamic-seq (masked-tile) kernels miscompute batch>1 (verified empirically); a static trace bakes correct batch strides. Padding is safe under causal masking.

**Perf — concurrency 32, uniform 512 tokens (RTX 5090, Qwen3-Embedding-0.6B):**

| config | conc. | req/s | per-forward |
|---|---|---:|---|
| deplodock batch-1 (dlpack) | 1 | 64 | 1 seq / ~15 ms |
| **deplodock static batch-32** | 32 | **26.6** | 32 seq / ~1.1 s |
| stock vLLM (warm) | 32 | ~232 | 32 seq / ~0.14 s |

**This is a throughput *regression*, not a win** — batching does B× the existing non-flash `O(B·H·S²)`-materialized attention, and the static-shape kernels are cold greedy picks (the batch-1 symbolic kernels carried prior tuning). Committed off-by-default as correct, tested scaffolding + the recorded negative result. The real lever is efficient attention (flash/varlen, follow-up #1) and/or an autotune of the static batched shape.

---

## Validation

- `tests/serving/test_vllm_plugin_gpu.py` (real in-process vLLM, cosine vs HF eager) passes through the new torch path.
- `tests/compiler/ir/test_dynamic_shapes.py::test_capture_replay_device_io_matches_eager` — the dlpack device-I/O primitives vs eager.
- `tests/serving/test_runner_batched_gpu.py` (perf) — batched forward of several different-length sequences matches eager per row (causal-independence-under-padding).
- Compiler regression suite green (1587 passed, 4 skipped); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
