### PR TITLE
serving: fastapi<0.137 cap + gpu-memory-utilization, plus serving perf findings

### DIFF
--- a/deplodock/commands/serve.py
+++ b/deplodock/commands/serve.py
@@ -2,8 +2,9 @@
 
 Wraps ``vllm serve`` with the ``deplodock/serving`` plugin boilerplate
 (``--runner pooling --enforce-eager --hf-overrides …DeplodockEmbedModel…``,
-plus ``--max-model-len 4096`` — the dynamic-dim cap — unless overridden), and
-passes any unrecognized flags through to vLLM verbatim. ``--stock`` drops the
+plus ``--max-model-len 4096`` — the dynamic-dim cap — and
+``--gpu-memory-utilization=0.9`` unless overridden), and passes any
+unrecognized flags through to vLLM verbatim. ``--stock`` drops the
 plugin flags for the raw-vLLM baseline, so an A/B is two invocations of the
 same command. ``--bench`` turns it into a one-shot benchmark: start the
 server, wait for ``/health``, run ``vllm bench serve --backend
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 # runner rejects anything larger at startup. Applied to --stock too, so the
 # A/B compares both engines at the same max-model-len.
 _DEFAULT_MAX_MODEL_LEN = "4096"
+_DEFAULT_GPU_MEMORY_UTILIZATION = "0.9"
 
 _PLUGIN_ARGS = ["--enforce-eager", "--hf-overrides", '{"architectures": ["DeplodockEmbedModel"]}']
 
@@ -123,6 +125,8 @@ def build_serve_cmd(model: str, *, stock: bool, vllm_args: list[str]) -> list[st
         cmd += _PLUGIN_ARGS
     if not _has_flag(vllm_args, "--max-model-len"):
         cmd += ["--max-model-len", _DEFAULT_MAX_MODEL_LEN]
+    if not _has_flag(vllm_args, "--gpu-memory-utilization"):
+        cmd += [f"--gpu-memory-utilization={_DEFAULT_GPU_MEMORY_UTILIZATION}"]
     return cmd + vllm_args
 
 

--- a/plans/qwen3-embedding-0.6b-layer0-serving-tune-findings.md
+++ b/plans/qwen3-embedding-0.6b-layer0-serving-tune-findings.md
@@ -1,0 +1,217 @@
+# Qwen3-Embedding-0.6B layer 0 (serving shape, dynamic seq_len) — tune findings
+
+**Status:** clean dynamic tune complete and -O3 deployable-benched. The serving-shape kernels are **5–8× slower than
+eager / cuBLAS on every matmul**; root-caused to a **total tensor-core (mma.sync) lockout** with **two independent,
+empirically-confirmed blockers**. Reductions/pointwise kernels are at or ahead of eager. This is the per-kernel
+attribution behind the serving A/B in [`qwen3-embedding-serving-perf-findings.md`](qwen3-embedding-serving-perf-findings.md)
+(deplodock plugin 24×→103× slower per request than stock vLLM).
+
+**Run command** (RTX 4080, sm_89, HEAD `72a65e1a`, fp16 trunk, ncu present; isolated DB/prior/cubin under
+`_tune/tune-model-qwen3-emb-serving/`):
+
+```bash
+deplodock tune Qwen/Qwen3-Embedding-0.6B --layer 0 --dynamic seq_len@x:1 --clean --bench \
+  --dump-dir _tune/tune-model-qwen3-emb-serving/dump
+```
+
+**Date:** 2026-06-17. **Scope:** one layer, **dynamic** (symbolic `seq_len`), **benched at seq_len=512 (symbolic
+hint** — `--seq-len` only sizes trace inputs; masked-tile boundary guards `if (coord < seq_len)` are part of the
+measured cost). Whole-model not run — the 28 trunk layers are identical, so layer 0 holds every distinct kernel.
+
+**Run stats:** 16 fused terminals, **14 178 s (3.94 h)**, **7 003 perf rows (6 986 ok / 17 bench_fail)**, prior
+19 855 training benches, ranking calibration Spearman **+0.99**.
+
+**Number-family disclaimer:** headline latencies are the deployable **-O3** `--bench` re-bench (CUDA-graph captured).
+Tune-DB / `eval variants` latencies are **-O1 ranking only** (reduction/attention run 1.5–3× slower at -O1) and are
+flagged as such where quoted.
+
+---
+
+## Bench results
+
+**Layer-0 end-to-end** (eager / torch.compile / deplodock, benched at seq_len=512 symbolic hint):
+
+| Backend | Latency (µs) | vs Eager |
+|---|---|---|
+| Eager PyTorch | 341 | 1.00× |
+| torch.compile | 245 | 1.39× |
+| **Deplodock** | **2246** | **0.15×** (6.6× slower than eager, 9.2× slower than tcompile) |
+
+**Per-kernel** (-O3, sorted by deplodock µs; `vs eager` < 1.0 = deplodock slower). Layer-op from each kernel's
+`.torch.json` reproducer:
+
+| Kernel | Layer op | eager | tcompile | deplodock | vs eager | tier |
+|---|---|---|---|---|---|---|
+| k_linear_mean_reduce | q/k-norm + a projection (matmul+mean) | 171 | 92 | 453 | 0.38× | scalar |
+| k_linear_sdpa_reduce | QKᵀ→softmax fused (matmul + sdpa) | 55 | 53 | 422 | 0.13× | scalar |
+| k_sdpa_linear_reduce | P@V + o_proj (sdpa + matmul) | 38 | 38 | 316 | 0.12× | scalar |
+| k_linear | MLP `down_proj` (`x@Wᵀ`) + residual | 44 | 44 | 237 | 0.19× | scalar |
+| k_sdpa_reduce | attention softmax/reduce | 200 | 27 | 209 | 0.96× | scalar |
+| k_linear_reduce | a projection (matmul + reduce) | 30 | 30 | 182 | 0.17× | scalar |
+| k_mean_linear_reduce | norm + projection | 187 | 34 | 168 | 1.11× | scalar |
+| k_mean_linear_reduce | norm + projection | 100 | 20 | 97 | 1.03× | scalar |
+| k_linear_reduce | a projection (matmul + reduce) | 15 | 15 | 94 | 0.16× | scalar |
+| k_mean | RMSNorm mean | 81 | 5 | 2 | 37.6× | scalar |
+
+**Dominating kernels:** the top 6 (all `k_linear*` / `k_sdpa*` matmul/attention) are **1819 µs ≈ 83%** of the
+deplodock total. Every one loses 5–8× to *both* eager and torch.compile. The memory-bound reductions (`k_mean`,
+both `k_mean_linear_reduce`) match or beat eager — deplodock's scalar codegen is fine where tensor cores don't
+matter; the loss is entirely in the matmul/attention kernels.
+
+**Tier:** **0 of 7003 benched variants carry `MMA=1` / `WARPSPEC` / `TMA`** (verified by direct DB scan). The whole
+dynamic-seq layer tuned in **scalar FMA tier**. cuBLAS (eager) and torch.compile use tensor cores for these
+matmuls; deplodock cannot — the entire gap.
+
+---
+
+## Finding 1 — total tensor-core lockout, two independent blockers (≈83% of layer time)
+
+**Symptom.** Every matmul/attention kernel is scalar and 5–8× off cuBLAS; no warp-tier variant exists anywhere in
+the tune DB.
+
+**Blocker A — sm_89 auto-enum gate (correct-by-design).** The mma.sync (s16816) family **only auto-enumerates on
+sm_90+**: [`010_partition_loops.py:727-732`](deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py#L727)
+
+```python
+if not pin_is_mma_sync and ctx.compute_capability < (9, 0):
+    # on sm_80-89 it's pin-only, so drop every atom.
+    eligible = ()
+```
+
+The swizzled-TMA fast path it relies on needs Hopper; on sm_80–89 mma.sync falls back to slower cp.async staging,
+so it's deliberately **pin-only** (`DEPLODOCK_MMA=<kind>`). RTX 4080 is sm_89 → `(8,9) < (9,0)` → dropped.
+**Confirmed:** pinning `DEPLODOCK_MMA=mma_m16n8k16_f16` on a clean **NN** matmul (`a@b`, 512×3072×1024 fp16) *did*
+enumerate a warp tile — and it **hung** (`k_matmul_… did not complete within 1000 ms — bench_fail`), exactly the
+cp.async-fallback instability the gate guards against. So even with the pin, tensor cores are not deployable on this
+Ada card.
+
+**Blocker B — transposed-B (`x@Wᵀ`) layout is mma-ineligible on *every* GPU (the dominant one).** Every `nn.Linear`
+(q/k/v/o + gate/up/down projections — all the transformer's matmul content) computes `x@Wᵀ` with weight stored
+`[N,K]`, so **both operands carry the contraction K in their last dim**. `classify_matmul_operands`
+([`_atom.py:42`](deplodock/compiler/pipeline/passes/lowering/tile/_atom.py#L42)) cannot tag A vs B for that layout
+and returns `None`; `is_atom_eligible` mirrors the tagger, so the cell is **never offered the mma tier** — it falls
+to scalar on sm_90 too. **Confirmed:** pinning `DEPLODOCK_MMA=mma_m16n8k16_f16` on an **NT** linear (same
+512×3072×1024 shape via `F.linear`) deployed **scalar** (`k_linear_8c6ce2`, no `WM`/`WN`, 236 µs) — the pin had
+zero effect, in contrast to the NN matmul above which reached the warp tier. cuBLAS handles NT natively on tensor
+cores (it's the preferred GEMM layout); deplodock's tagger does not.
+
+**Net:** Blocker B alone keeps every projection scalar on all hardware; Blocker A additionally keeps the few NN
+matmuls (QKᵀ, P@V after a split) scalar on this Ada card.
+
+**Fix priority (high).** Two orthogonal levers, in impact order:
+1. **Make NT (`x@Wᵀ`) matmuls mma-eligible** — teach `classify_matmul_operands` / the tagger to recover A/B for
+   transposed-B (K-in-last on both), or have the frontend present linears as NN by transposing the weight constant
+   at trace/contiguize time. This unlocks tensor cores for the projections on **all** GPUs and is the bulk of the
+   83%. Biggest single win.
+2. **Stabilize the sm_80–89 mma.sync path** (cp.async-staged, no Hopper TMA) so it can auto-enumerate on Ada
+   instead of pin-only — but the pinned NN matmul *hung* here, so this needs the hang root-caused first; lower
+   priority than (1), and Ada-specific.
+
+---
+
+## Finding 2 — SDPA/attention kernels: scalar even on sm_90, plus symbolic-K bail
+
+**Symptom.** `k_linear_sdpa_reduce` (422 µs, 0.13×), `k_sdpa_linear_reduce` (316 µs, 0.12×), `k_sdpa_reduce`
+(209 µs; ~par eager but **7.7× slower than tcompile's 27 µs**).
+
+**Root cause.** Two compounding, documented gates:
+- **Fused softmax prologue blocks MMA.** The warp tier requires `not prologue`
+  ([`010_partition_loops.py:711`](deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py#L711)) —
+  an SDPA prologue's softmax stats can't share the zero-filled masked-K slab. So even on sm_90 these stay scalar
+  unless the demoted-matmul split (`005_split_demoted`) un-fuses them into a clean consumer.
+- **Symbolic-K P@V bails to scalar thread tiles.** `K = seq_len` is symbolic; the warp tier needs a static reduce,
+  so P@V deploys masked thread tiles at `FM=FN=1`
+  ([`010_partition_loops.py:606-613`](deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py#L606)).
+  Flash-style symbolic-K attention is **future work** (CLAUDE.md / `serving/ARCHITECTURE.md`).
+
+The split *is* offered (the leaderboards show `_xn` / `_mm1` / `_xnb` consumer terminals), but every split consumer
+is **also scalar** — because its clean matmul is still either NT (Blocker B) or NN-on-sm_89 (Blocker A). The split
+doesn't help here until Finding 1 is fixed.
+
+**Fix priority (medium, gated on Finding 1).** Flash-style symbolic-K warp attention is the real fix and is already
+recorded as future work; it only pays off once Finding 1's blockers are lifted (otherwise the consumer stays
+scalar).
+
+---
+
+## Finding 3 — search/prior is NOT the problem (the -O1 vs -O3 inversion is handled)
+
+**Symptom (apparent).** `eval variants` flags several picks as far from rank 1, e.g. `k_linear_mean_reduce_6a97e0`
+`pick: rank 212/429 … misses best`, `k_linear_sdpa_reduce_158a0f` `rank 126/495`.
+
+**Not a shortfall.** Those ranks are **-O1 ranking**; the prior re-benched at -O3 and picked the **-O3 winner**: the
+rank-212 pick's `-O3 us` is **240.1** vs the -O1 rank-1's `-O3 us` of **591.9** (and rank-126's pick is 199.7 -O3
+vs rank-1's 436.9). So the prior correctly recovers the deployable-best config despite the -O1 ranking inversion —
+exactly what the `H_opt=3` reservoir is for. Spearman +0.99 overall. **No action**: the ceiling here is the tier
+(Finding 1), not the search. Tuning harder cannot beat a scalar kernel into tensor-core territory.
+
+---
+
+## Finding 4 — class-4 bench failures: 17 oversized scalar tiles blow the nvcc compile budget (minor)
+
+**Symptom.** All 17 `bench_fail` rows are **one kernel, `k_linear_fc9a1d`** (the MLP `down_proj`), every one
+`RuntimeError: compile stage exceeded 2.0s budget (2.0–6.0 s)`. Shared knobs across the cluster: `MMA=0`, big
+unrolled scalar tiles (`FM` up to 26, `FK=64`, `STAGE=11`, `SPLITK=2`) — `eval failures` clusters them cleanly.
+
+**Root cause.** Large unrolled scalar register-tile variants hit the cicc/LLVM compile blowup the tune's `-O1`
+budget exists to dodge; the biggest tiles exceed even the 2 s ceiling and are pinned `bench_fail`. Only 0.3% of
+benches, and the kernel's final pick is fine — but it's a *symptom* of the scalar tier reaching for huge tiles to
+compensate for no tensor cores. Lifting Finding 1 removes the need for these tiles.
+
+**Fix priority (low).** Cosmetic until Finding 1 lands; the failures waste a few search slots but don't affect the
+deployed pick.
+
+---
+
+## Repro / artifacts
+
+- Tune log: `_tune/tune-model-qwen3-emb-serving/tune.log`; dump: `_tune/tune-model-qwen3-emb-serving/dump/`
+  (per-kernel `.torch.json` reproducers under `dump/07_lowering_cuda.kernels/`, `kernels.html`,
+  `62_kernel_bench.json`). Isolated DB/prior/cubin in the same dir (your global caches untouched).
+- Tier-lockout confirmation (no GPU needed for the DB scan; `sqlite3` CLI isn't installed, use the venv):
+  ```bash
+  # 0 of 7003 perf rows name a warp-tier mma atom → fully scalar tune
+  ./venv/bin/python -c "import sqlite3; c=sqlite3.connect('_tune/tune-model-qwen3-emb-serving/autotune.db'); \
+  print('warp:', c.execute(\"select count(*) from perf where knobs like '%mma_m16n8k16%'\").fetchone()[0], \
+  'of', c.execute('select count(*) from perf').fetchone()[0])"
+  ```
+- Blocker A (sm_89 pin → cp.async fallback hangs) vs Blocker B (NT linear pin → still scalar):
+  ```bash
+  REPRO=_tune/tune-model-qwen3-emb-serving/dump/07_lowering_cuda.kernels/k_linear_fc9a1d.torch.json
+  DEPLODOCK_MMA=mma_m16n8k16_f16 deplodock run \
+    --code "torch.matmul(torch.randn(512,3072,dtype=torch.float16,device='cuda'),torch.randn(3072,1024,dtype=torch.float16,device='cuda'))" --bench  # NN → warp tile, HANGS on sm_89
+  DEPLODOCK_MMA=mma_m16n8k16_f16 deplodock run \
+    --code "torch.nn.functional.linear(torch.randn(512,3072,dtype=torch.float16,device='cuda'),torch.randn(1024,3072,dtype=torch.float16,device='cuda'))" --bench  # NT → still scalar, pin no-op
+  ```
+- Per-kernel leaderboards: `deplodock eval variants --kernel k_linear_mean_reduce` (etc.); failures:
+  `deplodock eval failures`. (Set the three `DEPLODOCK_*` cache env vars to the work dir first.)
+
+---
+
+## Workflow notes
+
+For whoever maintains the deplodock CLI and this skill:
+
+- **`--ab "MMA=…"` silently no-ops when the tier wasn't enumerated.** On sm_89 the warp tier is never enumerated,
+  so `run --ir … --ab "MMA=mma_m16n8k16_f16"` returned a row byte-identical to the scalar pick — no error, no note.
+  The pin only takes via the **env** (`DEPLODOCK_MMA`), because the enumeration gate reads `mma_mode()` (global
+  env), not the per-variant `--ab` dict. *Proposed:* when an `--ab` knob names a tier/atom absent from the
+  enumerated set, print a warning (`ab MMA=… had no effect: warp tier not enumerated for this kernel/arch`) instead
+  of silently collapsing to scalar. Cost me two runs to notice.
+- **"All scalar" is invisible in `eval variants`.** The view drops constant knob columns, so a 100%-scalar kernel
+  shows no `MMA`/`WM`/`WN` column at all — indistinguishable from "warp columns omitted." I had to scan the DB by
+  hand to confirm 0 MMA rows. *Proposed:* a one-line tier banner per kernel, e.g.
+  `tier: scalar-only (no MMA enumerated — sm_89 pin-only)` or `tier: 12 warp / 417 scalar`.
+- **Pinning mma.sync on sm < 90 can hang, not just slow down.** The NN-matmul pin produced a 1 s-timeout
+  `bench_fail` (cp.async fallback). *Proposed:* a guard/warning at pin time when `cc < (9,0)` and the atom is
+  mma.sync (`DEPLODOCK_MMA on sm_89 uses the cp.async fallback — may hang; intended for bring-up only`).
+- **3.94 h for one dynamic layer (7 003 perf rows).** Long for an attribution pass whose conclusion is "tier is
+  locked, search is fine." A `--no-o3-rebench` / ranking-only fast mode (skip the -O3 reservoir re-bench) would cut
+  wall-clock substantially when the goal is structural attribution rather than deployable numbers — the -O3 numbers
+  didn't change any finding here (the tier ceiling did).
+- **No "why was MMA declined for this kernel?" introspection.** Root-causing the lockout meant reading three passes
+  (`010_partition_loops`, `_atom`, `_enumeration`) and running two synthetic `--code` A/Bs. *Proposed:* a
+  `deplodock eval eligibility --kernel <k>` (or a `--explain-tier` flag on `compile`) that prints, per matmul cell,
+  the `is_atom_eligible` verdict + the first failing predicate (`transposed-B: classify_matmul_operands → None`,
+  `cc 8.9 < 9.0 (pin-only)`, `K=… not divisible`, …). That single view would have replaced this entire
+  investigation.

--- a/plans/qwen3-embedding-serving-perf-findings.md
+++ b/plans/qwen3-embedding-serving-perf-findings.md
@@ -1,0 +1,121 @@
+# Qwen3-Embedding-0.6B `deplodock serve` — startup fix + serving perf A/B findings
+
+**Status:** `serve --bench` was broken by a transitive dependency skew (fixed); once running, the deplodock serving
+plugin is **correctness-complete but 1–2 orders of magnitude slower per request than stock vLLM**, and the gap **widens
+with sequence length**. A per-kernel tune (`tune-model`) is queued to attribute the time kernel-by-kernel.
+
+**Environment:** NVIDIA GeForce RTX 4080 (sm_89, 16 GB), HEAD `72a65e1a`, vLLM 0.22.1, Qwen/Qwen3-Embedding-0.6B,
+trunk compute dtype fp16 (bf16 unsupported by the trunk → downcast with warn). **Date:** 2026-06-17.
+
+**Bench commands** (one-shot `start → /health → vllm bench serve --backend openai-embeddings → shutdown`):
+
+```bash
+# concurrency 32 (throughput regime; the user's original two runs)
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32                 # deplodock plugin
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock         # stock vLLM baseline
+# concurrency 1 (per-request latency; the apples-to-apples regime)
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32  --max-concurrency 1 [--stock]
+deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 512 --max-concurrency 1 [--stock]
+```
+
+All four bench params default to `--max-concurrency 32 --num-prompts 256 --bench-seed 0`; only the flags shown above
+were varied. 256 prompts per run.
+
+---
+
+## Part 1 — startup bug: `serve --bench` never passed `/health` (FIXED)
+
+**Symptom.** The server booted fine (model compiled, weights loaded, `Application startup complete.`), but **every**
+HTTP request — including `/health` — returned `500`, so `_wait_for_health` (`commands/serve.py`) polled until the
+30-minute timeout, killed the server, and exited 1. The bench never started.
+
+**Root cause.** A transitive dependency skew in the vLLM env, **not** a deplodock bug:
+
+| package | resolved | role in the failure |
+|---|---|---|
+| `fastapi` | **0.137.0** | introduced `_IncludedRouter` (a `BaseRoute` subclass with no `.path`) into `app.routes` |
+| `prometheus-fastapi-instrumentator` | 8.0.0 (latest) | its `_get_route_name` reads `route.path` on every route → `AttributeError` per request |
+| `starlette` | 1.3.1 | along for the ride |
+
+vLLM 0.22.1 pins only `fastapi[standard]>=0.115.0` and `prometheus-fastapi-instrumentator>=7.0.0` — **no upper
+bound** — so a fresh install pulled FastAPI 0.137.0, which is newer than the instrumentator vLLM ships against. The
+instrumentator middleware crashed on every request inside vLLM's own metrics layer; deplodock's plugin was never
+implicated.
+
+**Fix.** Cap the `serving` extra at `fastapi[standard]<0.137` (last clean is 0.136.3). Resolves cleanly with vLLM and
+deplodock; drop the cap once vLLM ships a `_IncludedRouter`-aware `prometheus-fastapi-instrumentator`.
+
+```toml
+serving = ["vllm>=0.22.1,<0.23", "fastapi[standard]<0.137"]   # pyproject.toml
+```
+
+Already-broken envs still need a one-time `pip install 'fastapi[standard]<0.137'` (a resolution cap does not downgrade
+an existing install).
+
+---
+
+## Part 2 — serving performance A/B (deplodock plugin vs stock vLLM)
+
+### Measured numbers
+
+**Throughput regime — concurrency 32, S=32** (the user's original runs):
+
+| metric | stock vLLM | deplodock | ratio |
+|---|---|---|---|
+| benchmark duration (256 reqs) | 0.57 s | 23.43 s | 41× |
+| request throughput | 447.3 req/s | 10.93 req/s | **41× slower** |
+| median E2EL | 32.8 ms | 2908.7 ms | 89× |
+
+**Per-request regime — concurrency 1** (serialization removed; the apples-to-apples latency):
+
+| S (tokens) | stock median E2EL | deplodock median E2EL | gap | stock thru | deplodock thru |
+|---|---|---|---|---|---|
+| 32  | 4.01 ms  | 94.96 ms   | **24×**  | 194.9 req/s | 10.45 req/s |
+| 512 | 10.30 ms | 1057.60 ms | **103×** | 92.5 req/s  | 0.94 req/s  |
+| scaling 32→512 | 2.6× | **11.1×** | — | — | — |
+
+### What the data rules in and out
+
+The 41× at concurrency 32 decomposes as **per-request latency (~24×) × the batching stock can do and deplodock
+can't (~1.7×)**. deplodock's serving runner processes one sequence at a time (batch axis compile-time fixed at 1,
+`serving/ARCHITECTURE.md`), so 32 concurrent requests queue behind each other: 32 × ~91 ms ≈ the observed 2.9 s median.
+Stock packs the 32 requests into one ~1024-token prefill.
+
+But serialization is the *smaller* factor. The dominant problem is **per-request latency**, and the concurrency-1
+sweep localizes it:
+
+- **Not host overhead.** A fixed ~60 ms mask-upload / cupy↔torch round-trip cannot become 1058 ms. Single-request
+  latency growing 11× with sequence length proves the cost is **compute-bound in the kernels**, not I/O.
+- **Not serialization.** That is a throughput effect; it does not touch single-request latency, and these runs are at
+  concurrency 1.
+- **It is kernel performance.** deplodock's compiled kernels for this model's **dynamic-shape** serving path are
+  1–2 orders of magnitude slower than stock's, and worsen with S (24× → 103× from S=32 to S=512). Stock's fused
+  kernels + warm CUDA graph barely move with sequence length (4 → 10 ms); deplodock explodes (95 → 1058 ms).
+
+### Consistency with known compiler gaps
+
+This matches the documented state of the dynamic-shape path, not a regression:
+
+- **Flash-style symbolic-K attention is future work** (CLAUDE.md, `serving/ARCHITECTURE.md`) — the symbolic-seq
+  attention runs as degenerate masked thread tiles, so attention scales poorly.
+- The symbolic matmuls / norms are tuned for the symbolic **hint** (`DEFAULT_SEQ_HINT=512`), a *ranking* signal — not
+  parity with cuBLAS. At S=32 a hint-sized tile runs mostly masked-off; at S=512 the kernels are sized right yet still
+  ~100× off, which is the more damning data point.
+
+The steep-but-sub-S² scaling (11× latency for 16× tokens) means the time is a **mix** of the matmuls and attention,
+not attention alone — exact attribution needs a per-kernel profile.
+
+### Bottom line
+
+`deplodock serve` is **correctness- and integration-complete but not performance-competitive today**. The serving
+ARCHITECTURE.md frames the deficit as "the gap measures the integration, not kernel quality"; this A/B shows the gap is
+much larger than that wording implies **and it lives in the kernels**, not just the batching. There is **no flag or
+config** that closes it — the levers are compiler work (flash-style symbolic-K attention) and a deep per-kernel tune of
+the dynamic shapes.
+
+### Open follow-up (queued)
+
+Run the `tune-model` flow on Qwen/Qwen3-Embedding-0.6B at the serving shape to turn "it's the kernels" into
+"it's *these* kernels, by this many ms" — per-kernel bench vs eager / torch.compile, NCU profile, root-cause writeup.
+The whole-model serving path is symbolic `seq_len`; the per-kernel attribution is what tells us whether attention or the
+matmuls is the bigger lever (and whether tuning can move them at all, given symbolic-K attention is unimplemented).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,12 @@ dependencies = [
 test = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff"]
 compile = ["torch", "transformers>=5.10", "cppyy==3.5.0", "safetensors"]
 # vLLM out-of-tree embedding plugin (deplodock/serving); vllm pins its own torch.
-serving = ["vllm>=0.22.1,<0.23"]
+# fastapi<0.137 cap: vllm 0.22.1 pins fastapi only as `>=0.115.0` (no upper bound),
+# so a fresh install pulls fastapi>=0.137, whose new `_IncludedRouter` route objects
+# (no `.path`) crash vllm's bundled prometheus-fastapi-instrumentator 8.0.0 on every
+# request — `serve --bench` then never passes /health. Drop the cap once vllm ships
+# a prometheus-fastapi-instrumentator that handles fastapi's `_IncludedRouter`.
+serving = ["vllm>=0.22.1,<0.23", "fastapi[standard]<0.137"]
 visualize = ["playwright>=1.40"]
 # flash-attn requires torch at build time, install separately:
 #   pip install flash-attn --no-build-isolation

--- a/tests/serving/test_serve_command.py
+++ b/tests/serving/test_serve_command.py
@@ -20,6 +20,7 @@ def test_serve_cmd_plugin_defaults():
     assert "--enforce-eager" in cmd
     assert '{"architectures": ["DeplodockEmbedModel"]}' in cmd
     assert cmd[cmd.index("--max-model-len") + 1] == "4096"
+    assert "--gpu-memory-utilization=0.9" in cmd
 
 
 def test_serve_cmd_stock_drops_plugin_but_keeps_parity():
@@ -28,13 +29,21 @@ def test_serve_cmd_stock_drops_plugin_but_keeps_parity():
     assert "--hf-overrides" not in cmd
     assert "pooling" in cmd
     assert cmd[cmd.index("--max-model-len") + 1] == "4096"  # same cap as the plugin → apples-to-apples
+    assert "--gpu-memory-utilization=0.9" in cmd
 
 
 def test_serve_cmd_passthrough_and_max_model_len_override():
     cmd = build_serve_cmd(MODEL, stock=False, vllm_args=["--max-model-len", "2048", "--gpu-memory-utilization", "0.8"])
     assert cmd.count("--max-model-len") == 1
     assert cmd[cmd.index("--max-model-len") + 1] == "2048"
-    assert "--gpu-memory-utilization" in cmd
+    assert "--gpu-memory-utilization=0.9" not in cmd
+    assert cmd[cmd.index("--gpu-memory-utilization") + 1] == "0.8"
+
+
+def test_serve_cmd_gpu_memory_utilization_equals_style_override():
+    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=["--gpu-memory-utilization=0.8"])
+    assert "--gpu-memory-utilization=0.9" not in cmd
+    assert "--gpu-memory-utilization=0.8" in cmd
 
 
 def test_serve_cmd_max_model_len_equals_style():


### PR DESCRIPTION
## Summary

Three commits on this branch (`git log main..HEAD`), all serving-related:

- **`b30ed5b0` fix(serving): cap fastapi<0.137 so `serve --bench` passes /health** — `pyproject.toml`. vllm 0.22.1
  pins fastapi only `>=0.115.0` (no upper bound), so a fresh `.[serving]` install pulls fastapi≥0.137, whose new
  `_IncludedRouter` route objects (no `.path`) crash vllm's bundled `prometheus-fastapi-instrumentator` 8.0.0 on
  every request → `/health` 500s and `serve --bench` times out at startup. Cap the `serving` extra at
  `fastapi[standard]<0.137` (resolves to 0.136.3). Drop once vllm ships a `_IncludedRouter`-aware instrumentator.

- **`98432e16` docs(plans): qwen3-embedding serving perf + tensor-core lockout findings** — two reports under
  `plans/`. (1) the startup bug above + a serving A/B vs stock vLLM (deplodock plugin 24× at S=32 to 103× at S=512
  slower per request at concurrency 1, gap widening with sequence length); (2) per-kernel attribution from a clean
  dynamic-seq layer-0 tune — root cause is a total tensor-core lockout (0/7003 tuned variants use MMA), from
  transposed-B (`x@Wᵀ`) linears being mma-ineligible on all GPUs plus mma.sync being pin-only/unstable on sm_89.

- **`d60c9f1d` added gpu-memory-utilization to serve** — `serve` defaults `--gpu-memory-utilization=0.9` (overridable);
  touches `deplodock/commands/serve.py` + `tests/serving/test_serve_command.py`. Authored by @6erun separately on
  this branch.

## Test plan

- `pip install -e '.[serving]'` resolves to fastapi 0.136.3 (verified via `pip install --dry-run`); `serve --bench`
  then passes `/health` and completes the benchmark.
- Commit 2 is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)