### PR TITLE
W4A16 (AWQ-INT4) quantization: in-kernel int4 dequant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ The `README.md` is intentionally short — example-driven, no narrative. For det
 - **Serving** (vLLM out-of-tree embedding plugin — deplodock-compiled kernels behind vLLM's `/v1/embeddings`; `serving` extra) → [`deplodock/serving/ARCHITECTURE.md`](deplodock/serving/ARCHITECTURE.md)
 - **Recipe format** (matrices/cross/zip combinators, variant filtering, deep merge, named fields, extra_args validation, command recipes, aggregate, docker_options, driver/cuda pinning, SGLang) → [`deplodock/recipe/ARCHITECTURE.md`](deplodock/recipe/ARCHITECTURE.md)
 - **Compiler** (Graph IR dialects, passes, backends) → [`deplodock/compiler/ARCHITECTURE.md`](deplodock/compiler/ARCHITECTURE.md) and child docs
+  - **W4A16 quantization** (compressed-tensors AWQ-INT4): `compile` / `run` / `tune` handle quantized models via a
+    pre-trace substitution to an opaque `deplodock::dequant_linear` custom op, decomposed to an in-kernel int4 unpack +
+    dequant + matmul (the compiler's one integer codegen path). Entry seam:
+    [`deplodock/compiler/trace/quantized.py`](deplodock/compiler/trace/quantized.py); design + status in
+    [`plans/w4a16-quantization-support.md`](plans/w4a16-quantization-support.md).
 
 When the user asks about a CLI flag, recipe field, or matrix combinator, read the relevant ARCHITECTURE.md before answering — they hold details that are no longer in the README.
 

--- a/deplodock/commands/compile.py
+++ b/deplodock/commands/compile.py
@@ -435,6 +435,15 @@ def _trace_model(model_id: str, layer: int | None, seq_len: int, *, dynamic_shap
     model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype)
     model.eval()
 
+    # W4A16: swap compressed-tensors quantized linears for DequantLinear (the
+    # opaque ``deplodock::dequant_linear`` custom op) BEFORE export, so the
+    # decompress pre-hook never fires and the packed buffers stay graph
+    # constants. No-op for non-quantized models. Reached by run / tune too
+    # (both trace through here).
+    from deplodock.compiler.trace.quantized import apply_quant_substitution
+
+    apply_quant_substitution(model)
+
     if layer is None:
         from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
 

--- a/deplodock/commands/run.py
+++ b/deplodock/commands/run.py
@@ -1240,7 +1240,7 @@ def _bind_inputs(compiled, module, example_args, example_kwargs):
     import torch
 
     from deplodock.compiler.ir.base import ConstantOp
-    from deplodock.compiler.loader.binder import bind_constants
+    from deplodock.compiler.loader.binder import bind_constants, declared_const_dtypes, source_array_at_dtype
 
     flat_inputs: list[torch.Tensor] = []
     for v in example_args:
@@ -1262,11 +1262,15 @@ def _bind_inputs(compiled, module, example_args, example_kwargs):
     # shares the embedding matrix) are surfaced under *every* name, including
     # the ``source_path`` the tracer recorded — otherwise the alias the trace
     # picked may be the one torch dedups away and the constant won't bind.
+    # Bind params/buffers at their graph-declared dtype (not blanket float32):
+    # integer-declared constants — the W4A16 packed int32 weight / zero-point —
+    # must skip the float round-trip that would corrupt the bit-packed values.
+    declared = declared_const_dtypes(compiled)
     sources: dict[str, np.ndarray] = {}
     for path, tensor in module.named_parameters(remove_duplicate=False):
-        sources[path] = tensor.detach().cpu().numpy().astype(np.float32, copy=False)
+        sources[path] = source_array_at_dtype(tensor, declared.get(path))
     for path, tensor in module.named_buffers(remove_duplicate=False):
-        sources[path] = tensor.detach().cpu().numpy().astype(np.float32, copy=False)
+        sources[path] = source_array_at_dtype(tensor, declared.get(path))
 
     input_data.update(bind_constants(compiled, sources))
 

--- a/deplodock/compiler/ARCHITECTURE.md
+++ b/deplodock/compiler/ARCHITECTURE.md
@@ -155,7 +155,20 @@ autotuning cache doesn't bust on cosmetic edits.
 - **`LoopOp.forward()` executes.** The body interpreter in
   `ir/loop/interpret.py` lets the default `Backend.run` topo-walk
   (`backend/base.py`) run post-fusion graphs on CPU — fusion
-  correctness can be checked without a GPU.
+  correctness can be checked without a GPU. **Exception: mixed-int cones.** The C++ loop runner is float-only, so
+  `LoopOp.forward` raises on any integer input (a W4A16 dequant unpack) rather than reinterpreting packed int32 as
+  float; validate those against a numpy reference (`DequantLinearOp.forward`).
+- **The IR is dtype-unified except for `CastOp`.** Every op preserves its inputs' dtype; `ir/tensor/ir.py::CastOp` is
+  the single dtype-changing primitive (emitted post-decomposition by `045_dequant_linear` at the W4A16 int→fp16
+  boundary). The lone integer path is the W4A16 weight unpack: frontend `DequantLinearOp` (+ a `QuantScheme`
+  descriptor) decomposes to a fixed-shift-lane unpack (`right_shift` / `bitwise_and` over i32, assembled by a
+  multi-source `IndexMapOp` whose lift emits an i32-typed `Select`) → `(nibble − zp)` → `CastOp(f16)` → group-scale
+  multiply → transpose → matmul. The bitwise ops are integer-only (`dtype_promote` forces an i32 result — they have no
+  float form), and the CUDA `RenderTarget` carries `i32` `type_name` / `convert` (`__int2half_rn` etc.) / native ops.
+  Integer scalar-literal constants (the shift/mask immediates) are carried as int through the lowering so `packed >> 4`
+  renders (not `packed >> 4.0f`). The default fusion pipeline already merges the dequant producer cone into the matmul
+  kernel, so gmem holds only packed int32 + scales + zp. See `trace/quantized.py` and
+  `plans/w4a16-quantization-support.md`.
 
 ## Op provenance
 

--- a/deplodock/compiler/backend/cuda/ARCHITECTURE.md
+++ b/deplodock/compiler/backend/cuda/ARCHITECTURE.md
@@ -9,10 +9,17 @@ CUDA-specific dispatch. Shared backend contract lives in
 
 ```
 cuda/
-├── backend.py   # CudaBackend(Backend) — drives lowering + delegates dispatch
-├── nvcc.py      # offline `nvcc --cubin` compile (+ content-addressed cubin cache) → RawModule load
-└── program.py   # Graph[CudaOp] → kernel dispatch (via nvcc.py) + per-kernel event timing
+├── backend.py        # CudaBackend(Backend) — drives lowering + delegates dispatch
+├── nvcc.py           # offline `nvcc --cubin` compile (+ content-addressed cubin cache) → RawModule load
+├── program.py        # Graph[CudaOp] → kernel dispatch (via nvcc.py) + per-kernel event timing
+└── render_target.py  # CudaRenderTarget — every CUDA C spelling the Stmt renderer makes
 ```
+
+`render_target.py` owns `type_name` (`f32`→`float`, `f16`→`__half`, **`i32`→`int`**), `convert` (f16↔f32 plus the W4A16
+int boundary: `__int2half_rn` / `__int2float_rn` / `__half2int_rn` / `__float2int_rn`), per-dtype `intrinsic`
+spellings, and `has_native_op` (the `_NATIVE_FP16_OPS` set plus `_NATIVE_I32_OPS` = `+ - * >> &` for the dequant
+unpack). `i32` exists so the W4A16 weight-unpack cone (packed int32 → nibbles) renders natively; without `i32` in
+`type_name` an integer local silently defaulted to `float`.
 
 ## Compile
 

--- a/deplodock/compiler/backend/cuda/render_target.py
+++ b/deplodock/compiler/backend/cuda/render_target.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from deplodock.compiler import dtype as _dtype
 
-_TYPE_NAME: dict[str, str] = {"f32": "float", "f16": "__half", "f16x2": "__half2"}
+_TYPE_NAME: dict[str, str] = {"f32": "float", "f16": "__half", "f16x2": "__half2", "i32": "int", "i64": "long long"}
 
 # Intrinsic spellings — per dtype.  Keys are abstract op names emitted
 # by ``op_to_expr`` (``"exp"``, ``"fmax"``, ``"fabs"``, ...).
@@ -86,6 +86,12 @@ _NATIVE_FP16_OPS: frozenset[str] = frozenset(
     }
 )
 
+# Integer ops with a native C form (plain ``int`` operators). The W4A16
+# weight unpack lowers to these; ``has_native_op`` returns True for them on
+# ``i32`` so ``Assign.render`` takes the native-int path (``packed >> 4``)
+# instead of the f32-promote detour (which would shift a float).
+_NATIVE_I32_OPS: frozenset[str] = frozenset({"add", "subtract", "multiply", "right_shift", "bitwise_and", "copy"})
+
 
 class CudaRenderTarget:
     """CUDA C / cuda_fp16.h spellings for :class:`RenderTarget`.
@@ -122,6 +128,19 @@ class CudaRenderTarget:
             return f"__half2half2({value})"
         if dst_dt == "f16x2" and src_dt == "f32":
             return f"__float2half2_rn({value})"
+        # Integer <-> float boundary (W4A16 dequant: the unpacked int nibble
+        # casts to fp16 before the scale multiply). Every form is a single
+        # CUDA intrinsic call ``name(value)`` so ``Assign``'s arg-promotion
+        # helpers (which parse ``convert``'s output back into a FuncCallExpr)
+        # can re-thread it through the Expr renderer.
+        if dst_dt == "f16" and src_dt == "i32":
+            return f"__int2half_rn({value})"
+        if dst_dt == "i32" and src_dt == "f16":
+            return f"__half2int_rn({value})"
+        if dst_dt == "f32" and src_dt == "i32":
+            return f"__int2float_rn({value})"
+        if dst_dt == "i32" and src_dt == "f32":
+            return f"__float2int_rn({value})"
         return value
 
     def intrinsic(self, op_name: str, result_dt: str) -> str:
@@ -137,6 +156,8 @@ class CudaRenderTarget:
             return True
         if dtype in ("f16", "f16x2"):
             return op_name in _NATIVE_FP16_OPS
+        if dtype == "i32":
+            return op_name in _NATIVE_I32_OPS
         return False
 
     def vector_type(self, dtype: str, n: int) -> tuple[str, str] | None:

--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -99,6 +99,7 @@ remain.
 |---------------|-------------------------------------------------------------------------------------------|
 | Layout-only   | `TransposeOp`, `ReshapeOp`, `SliceOp`, `CatOp`, `UnsqueezeOp` — rewrite to `IndexMapOp`.  |
 | Compound math | `LinearOp`, `MatmulOp`, `SdpaOp`, `MeanOp`, `RmsNormOp`, `LayerNormOp`, `SoftmaxOp` — rewrite to elementwise + reduce chains. |
+| Quantized     | `DequantLinearOp` (+ `QuantScheme` metadata, `dequant_weight_numpy` oracle) — the W4A16 weight-only quantized linear; rewrites (`045_dequant_linear`) to int4 unpack → dequant → transpose → matmul. |
 
 ## `tensor/ir.py`
 

--- a/deplodock/compiler/ir/elementwise.py
+++ b/deplodock/compiler/ir/elementwise.py
@@ -39,6 +39,11 @@ _NAME_TO_FN: dict[str, object] = {
     "gelu": lambda x: 0.5 * x * (1.0 + _erf(x / np.sqrt(2.0))),
     "gelu_tanh": lambda x: 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (x + 0.044715 * x**3))),
     "copy": lambda x: x,
+    # Integer bitwise ops (W4A16 weight unpack: ``(packed >> 4i) & 0xF``).
+    # Registered as the numpy *ufuncs* (not lambdas) so ``__init__`` reads
+    # ``nin == 2`` for the binary arity — a lambda would default to unary.
+    "right_shift": np.right_shift,
+    "bitwise_and": np.bitwise_and,
 }
 
 
@@ -173,6 +178,10 @@ _OP_CLUSTERS: dict[str, str] = {
     "gelu_tanh": "exp",
     "pow": "exp",
     "relu": "exp",
+    # bitwise (integer unpack) — own cluster so a W4A16 dequant kernel keys
+    # distinctly from the float arithmetic around it.
+    "right_shift": "right_shift",
+    "bitwise_and": "right_shift",
     # passthrough
     "copy": "copy",
 }

--- a/deplodock/compiler/ir/expr.py
+++ b/deplodock/compiler/ir/expr.py
@@ -170,6 +170,10 @@ def apply_binop(op: str, lv: object, rv: object) -> object:
             import numpy as np
 
             return np.logical_or(lv, rv)
+    if op == ">>":
+        return int(lv) >> int(rv)
+    if op == "&":
+        return int(lv) & int(rv)
     raise ValueError(f"Unknown BinOp: {op}")
 
 
@@ -203,7 +207,13 @@ class Var(_ExprOps):
         # corresponding ``Load`` decl.
         lit_map = getattr(ctx, "literal_ssa", None)
         if lit_map and self.name in lit_map:
-            return _float_lit(lit_map[self.name])
+            v = lit_map[self.name]
+            # Integer-typed inlined constants (the W4A16 unpack ``4i`` / ``0xF``)
+            # render as bare int literals so ``packed >> 4`` compiles; float
+            # constants keep the ``4.0f`` form.
+            if isinstance(v, int) and not isinstance(v, bool):
+                return str(v)
+            return _float_lit(v)
         return self.name
 
     def simplify(self, ctx: SimplifyCtx) -> Expr:
@@ -271,7 +281,7 @@ class BinaryExpr(_ExprOps):
     coercion would raise).
     """
 
-    op: str  # "+", "-", "*", "/", "//", "%", "<", "<=", ">", ">=", "==", "&&", "||", "^"
+    op: str  # "+", "-", "*", "/", "//", "%", "<", "<=", ">", ">=", "==", "&&", "||", "^", ">>", "&"
     left: Expr
     right: Expr
 
@@ -316,6 +326,10 @@ class BinaryExpr(_ExprOps):
                 return np.logical_or(lv, rv)
         if op == "^":
             return int(lv) ^ int(rv)
+        if op == ">>":
+            return int(lv) >> int(rv)
+        if op == "&":
+            return int(lv) & int(rv)
         raise ValueError(f"Unknown BinaryExpr: {op}")
 
     def pretty(self) -> str:
@@ -622,6 +636,9 @@ _PRECEDENCE: dict[str, int] = {
     "^": 4,  # bitwise XOR — match relational so ``a ^ b + c`` always parens
     "&": 4,  # bitwise AND — same intent: ``a & b * c`` must paren as ``(a & b) * c``
     "|": 4,  # bitwise OR — symmetric with ``&`` / ``^``
+    ">>": 4,  # right shift — same level as ``&`` (W4A16 unpack ``(packed >> 4i) & 0xF``
+    #         emits the shift + mask as separate SSA Assigns, so cross-op precedence
+    #         never actually composes them in one rendered expr)
     "+": 5,
     "-": 5,
     "*": 6,

--- a/deplodock/compiler/ir/frontend/ir.py
+++ b/deplodock/compiler/ir/frontend/ir.py
@@ -217,6 +217,125 @@ class LinearOp(Op):
         return result
 
 
+@dataclass(frozen=True)
+class QuantScheme:
+    """Format descriptor for a weight-only quantized linear.
+
+    The single seam that carries format-specific numbers into the
+    otherwise format-agnostic dequant pipeline. Phase 0 (compressed-
+    tensors AWQ-INT4) needs four fields; richer formats (other bit
+    widths, GPTQ packing, codebook lookups) extend this descriptor and
+    the decomposition rule, leaving the bitwise IR / fusion / kernel
+    tiers untouched.
+
+    - ``num_bits`` — bits per packed weight element (4 here). ``32 //
+      num_bits`` elements pack into each int32 lane.
+    - ``group_size`` — the K/in-axis group the scale (and zero-point)
+      index by: ``scale[o, k // group_size]``.
+    - ``packed_dim`` — the weight axis the nibbles interleave along
+      (``1`` = the in/K axis: ``nibble[:, i::8] = (packed >> 4i) & 0xF``).
+    - ``symmetric`` — ``False`` (asymmetric) subtracts the unpacked
+      per-group zero-point; ``True`` subtracts the implicit midpoint
+      ``2**(num_bits-1)`` (``8``) instead. Never both — applying −8 *and*
+      an unsigned-zp subtract double-shifts.
+    """
+
+    num_bits: int = 4
+    group_size: int = 32
+    packed_dim: int = 1
+    symmetric: bool = False
+
+    @property
+    def pack_factor(self) -> int:
+        """Number of weight elements packed into one int32 lane (8 for 4-bit)."""
+        return 32 // self.num_bits
+
+
+def dequant_weight_numpy(weight_packed, weight_scale, weight_zero_point, scheme: QuantScheme):
+    """Reference int4 → fp16 weight dequant (the numerics oracle).
+
+    Mirrors ``compressed_tensors.dequantize`` for the verified pack-quantized
+    AWQ-INT4 format: the packed weight carries ``pack_factor`` unsigned
+    nibbles per int32 interleaved along ``packed_dim`` (the K/in axis); the
+    zero-point is itself int4-packed along OUT. Returns the ``[out, in]`` fp16
+    weight ``(nibble − zp) · scale`` (asymmetric) or ``(nibble − 8) · scale``
+    (symmetric). Integer-exact on the unpack; the only rounding is the fp16
+    scale multiply.
+    """
+    nbits = scheme.num_bits
+    per = scheme.pack_factor
+    mask = (1 << nbits) - 1
+    g = scheme.group_size
+
+    packed = np.asarray(weight_packed).astype(np.int64)
+    out_f, in_packed = packed.shape
+    in_f = in_packed * per
+    # Unpack weight nibbles along the in/K axis (packed_dim == 1): output
+    # column k reads lane k // per, nibble k % per.
+    nib = np.empty((out_f, in_f), dtype=np.int64)
+    for i in range(per):
+        nib[:, i::per] = (packed >> (nbits * i)) & mask
+
+    if scheme.symmetric:
+        deq_int = nib - (1 << (nbits - 1))
+    else:
+        # Zero-point is int4-packed along OUT (a different axis than the
+        # weight): output row o reads lane o // per, nibble o % per.
+        zpp = np.asarray(weight_zero_point).astype(np.int64)
+        out_packed, zp_groups = zpp.shape
+        zp = np.empty((out_packed * per, zp_groups), dtype=np.int64)
+        for i in range(per):
+            zp[i::per, :] = (zpp >> (nbits * i)) & mask
+        zp = zp[:out_f, :]
+        zp_bc = np.repeat(zp, g, axis=1)[:, :in_f]
+        deq_int = nib - zp_bc
+
+    scale_bc = np.repeat(np.asarray(weight_scale).astype(np.float32), g, axis=1)[:, :in_f]
+    return (deq_int.astype(np.float32) * scale_bc).astype(np.float16)
+
+
+@dataclass
+class DequantLinearOp(Op):
+    """Weight-only quantized linear: ``x @ dequant(W).T [+ bias]``.
+
+    The frontend surface of W4A16. Surfaces as a single opaque
+    ``call_function`` node from the ``deplodock::dequant_linear`` custom
+    op (tracing never sees the unpack/dequant cone — that's authored in
+    the ``045_dequant_linear`` decomposition). Inputs, in order:
+    ``x``, ``weight_packed`` (int32), ``weight_scale`` (fp16),
+    ``weight_zero_point`` (int32), and — when ``has_bias`` — ``bias``.
+
+    The non-tensor format numbers ride as op metadata (a
+    :class:`QuantScheme`, built from the scalar fields) rather than graph
+    constants. ``has_bias`` distinguishes a real bias from a ``None``
+    bias (the tracer's generic resolver drops a ``None`` arg, so the two
+    are otherwise indistinguishable).
+    """
+
+    has_bias: bool = False
+    num_bits: int = 4
+    group_size: int = 32
+    packed_dim: int = 1
+    symmetric: bool = False
+
+    @property
+    def scheme(self) -> QuantScheme:
+        return QuantScheme(self.num_bits, self.group_size, self.packed_dim, self.symmetric)
+
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+        x_shape = input_shapes[0]
+        wp_shape = input_shapes[1]  # (out_features, in_features // pack_factor)
+        return tuple(x_shape[:-1]) + (wp_shape[0],)
+
+    def forward(self, *inputs):
+        x = inputs[0]
+        weight = dequant_weight_numpy(inputs[1], inputs[2], inputs[3], self.scheme)
+        result = np.asarray(x).astype(np.float32) @ weight.astype(np.float32).T
+        if self.has_bias:
+            result = result + np.asarray(inputs[4]).astype(np.float32)
+        return result.astype(np.asarray(x).dtype)
+
+
 @dataclass
 class MatmulOp(Op):
     """PyTorch aten.mm/matmul/addmm: output = A @ B [+ bias]."""

--- a/deplodock/compiler/ir/loop/ir.py
+++ b/deplodock/compiler/ir/loop/ir.py
@@ -212,6 +212,18 @@ class LoopOp(BodyOp):
         bufs = tuple(self.inputs)
         if len(inputs) != len(bufs):
             raise ValueError(f"LoopOp.forward: expected {len(bufs)} inputs (matching input_bufs={list(bufs)}), got {len(inputs)}")
+        # The C++ loop runner is float-only (``render_loopop_cpp`` emits
+        # ``const float*`` params + coerces inputs to float32). A mixed-int cone
+        # — the W4A16 dequant unpack — can't ride that path: reinterpreting a
+        # packed int32 as float would corrupt the bit math. Skip CPU interpret
+        # loudly so callers validate against a numpy reference instead; the GPU
+        # path stays covered by the accuracy check. (Phase 0 option b — see
+        # plans/w4a16-quantization-support.md.)
+        if any(np.issubdtype(np.asarray(x).dtype, np.integer) for x in inputs):
+            raise NotImplementedError(
+                "LoopOp.forward: the C++ loop runner is float-only; validate a mixed-int "
+                "(W4A16 dequant) cone against a numpy reference (DequantLinearOp.forward) instead."
+            )
         input_arrays = {name: np.asarray(x, dtype=np.float32) for name, x in zip(bufs, inputs, strict=True)}
         loop = _specialize_symbolic_axes(self, input_arrays)
         out_shape = loop._infer_write_shape()

--- a/deplodock/compiler/ir/stmt/base.py
+++ b/deplodock/compiler/ir/stmt/base.py
@@ -67,7 +67,10 @@ class RenderCtx:
     intrinsics: dict[str, str] = field(default_factory=dict)
     builtins: dict[str, str] = field(default_factory=dict)
     explicit_inits: set[str] = field(default_factory=set)
-    literal_constants: dict[str, float] = field(default_factory=dict)
+    # Values are ``int`` for integer-typed scalar constants (W4A16 unpack
+    # immediates) and ``float`` otherwise — the type drives int-vs-float
+    # literal rendering at the use site.
+    literal_constants: dict[str, float | int] = field(default_factory=dict)
     # SSA names whose defining Load came from a ``literal_constants``
     # input — populated by ``render_body`` after scanning the body, and
     # consumed by ``Var.render`` to inline the float at use sites instead
@@ -173,9 +176,26 @@ def dtype_promote(op_name: str, arg_dtypes: list[str]) -> str:
 
     Lifted out of ``Assign.render`` so the ``030_stamp_types`` pass can
     reuse the same rule when stamping ``Assign.dtype`` on the IR.
+
+    Integer ops (the W4A16 unpack ``>>`` / ``&`` and the zero-point
+    ``subtract``) stay integer: all-i32 args → i32. Promoting them to
+    f32 — the old behavior — would render ``packed >> 4.0f`` and fail to
+    compile, so the integer rule is checked before the f32 fallback.
+
+    ``right_shift`` / ``bitwise_and`` are **integer-only** — they have no
+    float form at all (``float >> float`` doesn't compile). Their result
+    is forced i32 regardless of the arg dtypes the stamp pass resolved,
+    because a Load from a staged smem slab can stay unresolved (→ a
+    spurious f32 default) at stamp time even though the slab is declared
+    ``int``; without this, the shift/mask would freeze to f32 and render
+    the invalid ``>>`` / ``&`` on a promoted float.
     """
+    if op_name in ("right_shift", "bitwise_and"):
+        return "i32"
     if arg_dtypes and all(d == "f16" for d in arg_dtypes):
         return "f16"
+    if arg_dtypes and all(d == "i32" for d in arg_dtypes):
+        return "i32"
     return "f32"
 
 
@@ -200,6 +220,9 @@ _BINARY_OP: dict[str, str] = {
     "multiply": "*",
     "divide": "/",
     "mod": "%",
+    # Integer bitwise ops — the W4A16 weight unpack ``(packed >> 4i) & 0xF``.
+    "right_shift": ">>",
+    "bitwise_and": "&",
 }
 
 
@@ -237,20 +260,24 @@ def op_to_expr(fn: str, inputs: list[Expr]) -> Expr:
     raise NotImplementedError(f"render: elementwise fn={fn!r} not supported")
 
 
-def select_to_ternary(s: Select) -> Expr:
+def select_to_ternary(s: Select, c_type: str = "float") -> Expr:
     """Build a chained ternary from a ``Select``'s branch list.
 
-    Each branch value is cast to ``float`` to match the ``float`` result
-    ``Select.render`` declares. Without it, a branch list mixing ``__half``
-    SSA values (a raw smem/gmem load) with ``float`` ones (a computed value)
-    makes the C++ conditional operator's common type ambiguous
-    (``cond ? float : __half`` — each converts to the other), which nvcc
-    rejects. The casts are no-ops when a value is already ``float``.
+    Each branch value is cast to ``c_type`` (the C spelling of the
+    Select's result dtype — ``"float"`` by default, ``"int"`` for an
+    i32 lane select) to match the type ``Select.render`` declares.
+    Without it, a branch list mixing ``__half`` SSA values (a raw
+    smem/gmem load) with ``float`` ones (a computed value) makes the C++
+    conditional operator's common type ambiguous (``cond ? float :
+    __half`` — each converts to the other), which nvcc rejects. The
+    casts are no-ops when a value is already at ``c_type``. The i32 form
+    keeps the W4A16 lane select (``(packed >> 4i) & 0xF``) integer
+    instead of forcing the nibbles to float before the ``- zp`` subtract.
     """
     branches = list(s.branches)
-    result: Expr = CastExpr("float", Var(branches[-1].value))
+    result: Expr = CastExpr(c_type, Var(branches[-1].value))
     for b in reversed(branches[:-1]):
-        result = TernaryExpr(cond=b.select, if_true=CastExpr("float", Var(b.value)), if_false=result)
+        result = TernaryExpr(cond=b.select, if_true=CastExpr(c_type, Var(b.value)), if_false=result)
     return result
 
 
@@ -528,7 +555,13 @@ def render_body(body: Body, ctx: RenderCtx) -> list[str]:
             # Literal-const Loads are always scalar (the vectorize pass
             # excludes literal-const buffers from its widening logic).
             if isinstance(s, Load) and s.is_scalar and s.is_literal(ctx.literal_constants):
-                new_map[s.name] = ctx.literal_constants[s.input]
+                val = ctx.literal_constants[s.input]
+                new_map[s.name] = val
+                # Pre-register the use-site dtype so a downstream ``Assign``
+                # whose Load was skipped still sees an integer arg (the W4A16
+                # ``packed >> 4`` shift amount). ``ssa_dtypes`` is shared across
+                # the ``replace`` below, so mutating it here is visible at render.
+                ctx.ssa_dtypes[s.name] = "i32" if isinstance(val, int) and not isinstance(val, bool) else "f32"
                 changed = True
         if changed:
             ctx = replace(ctx, literal_ssa=new_map)

--- a/deplodock/compiler/ir/stmt/leaves.py
+++ b/deplodock/compiler/ir/stmt/leaves.py
@@ -235,8 +235,15 @@ class Load(Stmt):
         # literal-const buffers.)
         lit = ctx.literal_constants.get(self.input) if ctx.literal_constants else None
         if lit is not None and self.is_scalar:
-            ctx.ssa_dtypes[self.names[0]] = "f32"
-            return [f"{pad}{ctx.type_name('f32')} {self.names[0]} = {_float_lit(lit)};"]
+            # Integer-typed inlined constants (the W4A16 unpack ``4i`` / ``0xF`` /
+            # ``8``) keep an ``int`` decl + literal; float constants stay f32.
+            # ``010_lower_kernelop`` carries the int-ness via the value's Python
+            # type, so a plain ``isinstance`` check recovers the dtype here.
+            is_int = isinstance(lit, int) and not isinstance(lit, bool)
+            dt = "i32" if is_int else "f32"
+            ctx.ssa_dtypes[self.names[0]] = dt
+            lit_txt = str(int(lit)) if is_int else _float_lit(lit)
+            return [f"{pad}{ctx.type_name(dt)} {self.names[0]} = {lit_txt};"]
         # Prefer the stamped ``self.dtype`` (set by ``030_stamp_types``);
         # fall back to ``ctx.buffer_dtypes`` so handwritten test fixtures
         # without a stamped dtype still render correctly.
@@ -410,6 +417,16 @@ class Assign(Stmt):
             result_dt = self.dtype.name
         else:
             result_dt = dtype_promote(op_name, arg_dtypes)
+
+        # Copy/cast fast path: a single-arg ``copy`` whose result dtype differs
+        # from its source is a pure dtype cast (the W4A16 int→fp16 boundary,
+        # emitted by ``015_lift_cast``). Convert directly via the target so
+        # i32→f16 emits one ``__int2half_rn`` instead of the f32-promote detour
+        # (``__float2half(__int2float_rn(x))``).
+        if op_name == "copy" and len(self.args) == 1 and arg_dtypes and arg_dtypes[0] != result_dt:
+            rhs = ctx.target.convert(_resolve_value(self.args[0], ctx), arg_dtypes[0], result_dt)
+            ctx.ssa_dtypes[self.name] = result_dt
+            return [f"{pad}{ctx.type_name(result_dt)} {self.name} = {rhs};"]
 
         all_args_at_result = bool(arg_dtypes) and all(d == result_dt for d in arg_dtypes)
         if result_dt != "f32" and ctx.target.has_native_op(op_name, result_dt) and all_args_at_result:
@@ -844,10 +861,18 @@ class Select(Stmt):
     should be True; its ``value`` is bound to ``name`` in the SSA scope.
     Branches are expected to be disjoint; later branches act as
     catch-alls when no earlier predicate matches.
+
+    ``dtype`` is the result dtype (the branch values' common dtype). It
+    drives the declared local type + the per-branch ternary casts.
+    ``None`` keeps the legacy ``float`` rendering — the multi-source
+    layout (cat / W4A16 8-lane unpack assembly) stamps it (``F16`` /
+    ``I32``) so an integer lane select stays integer rather than being
+    forced to float before a downstream ``- zp`` subtract.
     """
 
     name: str
     branches: tuple[SelectBranch, ...]
+    dtype: DataType | None = None
 
     def __post_init__(self) -> None:
         if not self.branches:
@@ -870,5 +895,8 @@ class Select(Stmt):
         return lines
 
     def render(self, ctx: RenderCtx) -> list[str]:
-        expr = select_to_ternary(self)
-        return [f"{_pad(ctx.indent)}float {self.name} = {expr.render(ctx)};"]
+        result_dt = self.dtype.name if self.dtype is not None else "f32"
+        c_type = ctx.type_name(result_dt)
+        expr = select_to_ternary(self, c_type)
+        ctx.ssa_dtypes[self.name] = result_dt
+        return [f"{_pad(ctx.indent)}{c_type} {self.name} = {expr.render(ctx)};"]

--- a/deplodock/compiler/ir/stmt/passes.py
+++ b/deplodock/compiler/ir/stmt/passes.py
@@ -163,6 +163,7 @@ def _(s: Select, rename: Rename, sigma: Sigma, axis_fn: AxisFn) -> Stmt:
     return Select(
         name=rename(s.name),
         branches=tuple(SelectBranch(value=rename(b.value), select=sigma.apply(b.select)) for b in s.branches),
+        dtype=s.dtype,
     )
 
 
@@ -224,7 +225,7 @@ def _(s: Write, ctx: SimplifyCtx) -> Stmt:
 
 @simplify.register
 def _(s: Select, ctx: SimplifyCtx) -> Stmt:
-    return Select(name=s.name, branches=tuple(SelectBranch(b.value, b.select.simplify(ctx)) for b in s.branches))
+    return Select(name=s.name, branches=tuple(SelectBranch(b.value, b.select.simplify(ctx)) for b in s.branches), dtype=s.dtype)
 
 
 @simplify.register

--- a/deplodock/compiler/ir/tensor/ir.py
+++ b/deplodock/compiler/ir/tensor/ir.py
@@ -12,6 +12,8 @@ remain in the graph:
 - ``IndexMapOp`` — unified layout-only op (subsumes slice / cat / transpose
   / reshape / unsqueeze) described by affine coord arithmetic over
   placeholder vars from ``ir.expr``.
+- ``CastOp`` — the lone dtype-changing primitive (the otherwise dtype-unified
+  IR's int→fp boundary for W4A16 dequant). Emitted post-decomposition.
 
 Plus the boundary sentinels ``InputOp`` and ``ConstantOp`` from ``ir.base``.
 The ``lifting/`` pass wraps each tensor op in a trivial ``ir.loop.LoopOp``
@@ -174,6 +176,39 @@ class ScanOp(Op):
         if name in ("prod", "multiply"):
             return np.cumprod(a, axis=self.axis)
         raise NotImplementedError(f"ScanOp.forward: unknown fn {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Cast — the only dtype-changing primitive
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CastOp(Op):
+    """Cast a tensor to ``target_dtype`` element-wise.
+
+    The IR is otherwise "dtype-unified" (every op preserves its inputs'
+    dtype); ``CastOp`` is the single exception. It's emitted by the
+    ``045_dequant_linear`` decomposition at the W4A16 int→fp16 boundary:
+    the unpacked, zero-point-subtracted integer nibble is cast to fp16
+    before the group-scale multiply. Rank-preserving — the output
+    ``Tensor`` carries ``target_dtype`` while the input keeps its own
+    (typically i32) dtype.
+
+    ``target_dtype`` is a canonical dtype token (``"f16"`` / ``"f32"`` /
+    ...) kept as a string so it serializes plainly through
+    ``Graph.to_dict`` (no special-casing in ``_serialize_field``).
+    """
+
+    target_dtype: str = "f16"
+
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+        return tuple(input_shapes[0])
+
+    def forward(self, *inputs):
+        from deplodock.compiler.dtype import get as _get  # noqa: PLC0415
+
+        return inputs[0].astype(_get(self.target_dtype).np)
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/loader/binder.py
+++ b/deplodock/compiler/loader/binder.py
@@ -75,6 +75,31 @@ def bind_constants(graph: Graph, sources: dict[str, np.ndarray]) -> dict[str, np
     return out
 
 
+def declared_const_dtypes(graph: Graph) -> dict[str, np.dtype]:
+    """Map each ``ConstantOp.source_path`` to its graph-declared numpy dtype.
+
+    Lets the source loaders bind a constant at the dtype the graph expects —
+    crucial for W4A16, whose packed-int32 weight / zero-point must NOT be cast
+    through float32 (which would corrupt the bit-packed values)."""
+    out: dict[str, np.dtype] = {}
+    for node in graph.nodes.values():
+        if isinstance(node.op, ConstantOp) and node.op.source_path is not None:
+            out[node.op.source_path] = node.output.dtype.np
+    return out
+
+
+def source_array_at_dtype(tensor, np_dtype) -> np.ndarray:  # noqa: ANN001 — torch.Tensor, duck-typed
+    """Convert a torch tensor to numpy at ``np_dtype``.
+
+    Integer-declared dtypes go straight to numpy (no float round-trip — a
+    ``.float()`` detour would corrupt a packed int32 weight). Everything else
+    routes through ``.float()`` (also sidesteps reading bf16 through numpy) and
+    keeps the legacy float32 binding so non-quant graphs are byte-identical."""
+    if np_dtype is not None and np.issubdtype(np_dtype, np.integer):
+        return tensor.detach().cpu().numpy().astype(np_dtype, copy=False)
+    return tensor.detach().cpu().float().numpy().astype(np.float32, copy=False)
+
+
 def bind_constants_from_module(graph: Graph, module) -> dict[str, np.ndarray]:  # noqa: ANN001 — torch.nn.Module, duck-typed
     """Bind every parameter/buffer ``ConstantOp`` from a *live* ``nn.Module``.
 
@@ -92,7 +117,8 @@ def bind_constants_from_module(graph: Graph, module) -> dict[str, np.ndarray]:  
     only, leaving the final projection unbound (→ zero logits). Tensors are cast
     to float32 numpy (the backend dtype; also sidesteps reading bf16 checkpoints
     through numpy)."""
+    declared = declared_const_dtypes(graph)
     sources: dict[str, np.ndarray] = {}
     for name, t in module.state_dict().items():
-        sources[name] = t.detach().cpu().float().numpy()
+        sources[name] = source_array_at_dtype(t, declared.get(name))
     return bind_constants(graph, sources)

--- a/deplodock/compiler/pipeline/passes/frontend/decomposition/045_dequant_linear.py
+++ b/deplodock/compiler/pipeline/passes/frontend/decomposition/045_dequant_linear.py
@@ -1,0 +1,50 @@
+"""Decompose ``DequantLinearOp`` into unpack → dequant → transpose → matmul [→ bias].
+
+The W4A16 frontend op expands here into the int4 weight-unpack + dequant cone
+plus the matmul the rest of the pipeline lowers. Inputs, in order: ``x``,
+``weight_packed`` (i32), ``weight_scale`` (f16), ``weight_zero_point`` (i32),
+and — when ``has_bias`` — ``bias``. The format numbers ride as ``root.op.scheme``
+metadata (a ``QuantScheme``), never as graph constants.
+
+Mirrors ``040_linear``: ``dequant_decompose`` builds the weight cone + matmul,
+this rule wires the optional bias add exactly as the linear rule does.
+"""
+
+from deplodock.compiler.graph import Graph, Node, Tensor
+from deplodock.compiler.ir.frontend.ir import DequantLinearOp
+from deplodock.compiler.ir.tensor.ir import ElementwiseOp
+from deplodock.compiler.pipeline import Match, Pattern
+from deplodock.compiler.pipeline.passes.frontend.decomposition._helpers import (
+    broadcast_to,
+    dequant_decompose,
+    open_fragment,
+)
+
+PATTERN = [Pattern("root", DequantLinearOp)]
+
+
+def rewrite(
+    match: Match, root: Node, inp_x: Node, inp_w: Node, inp_scale: Node, inp_zp: Node, inp_b: Node | None, out: Tensor
+) -> Graph | None:
+    graph = match.graph
+    has_bias = root.op.has_bias
+    scheme = root.op.scheme
+
+    exts = [inp_x, inp_w, inp_scale, inp_zp] + ([inp_b] if has_bias else [])
+    frag = open_fragment(graph, exts)
+
+    matmul_name = f"{out.name}_mm" if has_bias else out.name
+    mm = dequant_decompose(frag, inp_x, inp_w, inp_scale, inp_zp, scheme=scheme, matmul_name=matmul_name, out_dtype=out.dtype)
+
+    if has_bias:
+        bias_bc = broadcast_to(frag, inp_b, out.shape)
+        add_id = frag.add_node(
+            op=ElementwiseOp(op="add"),
+            inputs=[mm, bias_bc],
+            output=Tensor(out.name, out.shape, out.dtype),
+        )
+        frag.outputs = [add_id]
+    else:
+        frag.outputs = [mm.id]
+
+    return frag

--- a/deplodock/compiler/pipeline/passes/frontend/decomposition/_helpers.py
+++ b/deplodock/compiler/pipeline/passes/frontend/decomposition/_helpers.py
@@ -247,6 +247,18 @@ def dequant_decompose(
     in_features = wp_shape[1] * per
     weight_int_shape = (out_features, in_features)
 
+    # Per-group quant (the only granularity real compressed-tensors AWQ models
+    # use, e.g. G=32 / G=128) is supported. A *single* group (group_size >=
+    # in_features → per-channel / per-tensor-along-K) collapses ``k // G`` to a
+    # constant 0, and the resulting broadcast trips a splicer def-use scope check
+    # when it merges with the multi-lane unpack — a fusion-hardening follow-up.
+    if in_features.is_static and in_features.as_static() <= g:
+        raise NotImplementedError(
+            f"W4A16 single-group quant (group_size={g} >= in_features={in_features.as_static()}, "
+            "i.e. per-channel / per-tensor-along-K) is not yet supported; per-group (G < in_features) works. "
+            "See plans/w4a16-quantization-support.md (Phase 2)."
+        )
+
     # 1. Unpack the weight nibbles along the in/K axis (packed_dim == 1).
     nibble = _unpack_nibbles(frag, wp, axis=1, pack_factor=per, num_bits=num_bits, out_shape=weight_int_shape, name=f"{matmul_name}_wq")
 

--- a/deplodock/compiler/pipeline/passes/frontend/decomposition/_helpers.py
+++ b/deplodock/compiler/pipeline/passes/frontend/decomposition/_helpers.py
@@ -17,13 +17,15 @@ from collections.abc import Iterable
 from deplodock.compiler.graph import Graph, Node, Tensor
 from deplodock.compiler.ir.base import ConstantOp, InputOp
 from deplodock.compiler.ir.expr import BinaryExpr, Literal, placeholder
-from deplodock.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp, IndexSource, ReduceOp
+from deplodock.compiler.ir.frontend.ir import TransposeOp
+from deplodock.compiler.ir.tensor.ir import CastOp, ElementwiseOp, IndexMapOp, IndexSource, ReduceOp
 from deplodock.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to, squeeze_axis
 from deplodock.compiler.pipeline.passes.frontend.decomposition._matmul_helpers import matmul_unsqueeze
 
 __all__ = [
     "broadcast_to",
     "const_bc",
+    "dequant_decompose",
     "gqa_broadcast",
     "matmul_decompose",
     "matmul_unsqueeze",
@@ -155,3 +157,157 @@ def gqa_broadcast(
         p = placeholder(d)
         coord_map.append(BinaryExpr("/", p, Literal(group_size, "int")) if d == head_axis else p)
     return single_indexmap(frag, src, out_shape=target_shape, coord_map=coord_map, name=name, dtype=dtype)
+
+
+def _unpack_nibbles(frag: Graph, packed: Node | str, *, axis: int, pack_factor: int, num_bits: int, out_shape: tuple, name: str) -> Node:
+    """Unpack ``pack_factor`` unsigned nibbles per int32 along ``axis``.
+
+    ``pack_factor`` fixed-shift lanes ``lane_i = (packed >> num_bits*i) & mask``
+    (each an i32 tensor the shape of ``packed``), assembled into ``out_shape``
+    by a multi-source ``IndexMapOp``: output coord ``j`` along ``axis`` reads
+    ``lane_{j % pack_factor}`` at ``j // pack_factor`` (the interleaved
+    ``i::pack_factor`` layout). Stays integer end-to-end. The shift / mask
+    immediates flow as i32 scalar ``ConstantOp``s (inlined as int literals at
+    lowering); no coordinate-dependent shift, so Phase 0 needs no IR gap.
+    """
+    packed = _node(frag, packed)
+    packed_shape = tuple(packed.output.shape)
+    mask = (1 << num_bits) - 1
+
+    lanes: list[Node] = []
+    for i in range(pack_factor):
+        shift_bc = const_bc(frag, name=f"{name}_sh{i}", value=num_bits * i, target_shape=packed_shape, dtype="i32")
+        shifted = frag.add_node(
+            op=ElementwiseOp(op="right_shift"),
+            inputs=[packed, shift_bc],
+            output=Tensor(f"{name}_shifted{i}", packed_shape, "i32"),
+        )
+        mask_bc = const_bc(frag, name=f"{name}_mk{i}", value=mask, target_shape=packed_shape, dtype="i32")
+        lane = frag.add_node(
+            op=ElementwiseOp(op="bitwise_and"),
+            inputs=[shifted, mask_bc],
+            output=Tensor(f"{name}_lane{i}", packed_shape, "i32"),
+        )
+        lanes.append(frag.nodes[lane])
+
+    ndim = len(out_shape)
+    sources: list[IndexSource] = []
+    for i in range(pack_factor):
+        coord_map = tuple(
+            BinaryExpr("/", placeholder(d), Literal(pack_factor, "int")) if d == axis else placeholder(d) for d in range(ndim)
+        )
+        # Last lane is the default (else) branch — no select; earlier lanes fire
+        # on ``coord[axis] % pack_factor == i``.
+        sel = None
+        if i != pack_factor - 1:
+            sel = BinaryExpr("==", BinaryExpr("%", placeholder(axis), Literal(pack_factor, "int")), Literal(i, "int"))
+        sources.append(IndexSource(input_idx=i, coord_map=coord_map, select=sel))
+
+    nid = frag.add_node(
+        op=IndexMapOp(out_shape=tuple(out_shape), sources=tuple(sources)),
+        inputs=lanes,
+        output=Tensor(name, tuple(out_shape), "i32"),
+    )
+    return frag.nodes[nid]
+
+
+def dequant_decompose(
+    frag: Graph,
+    x: Node | str,
+    weight_packed: Node | str,
+    scale: Node | str,
+    zp: Node | str | None,
+    *,
+    scheme,
+    matmul_name: str,
+    out_dtype,
+) -> Node:
+    """Build the W4A16 unpack → dequant → transpose → matmul cone.
+
+    Mirrors ``matmul_decompose``'s role for ``045_dequant_linear``: returns the
+    matmul output node named ``matmul_name`` (the rule adds bias after).
+
+    Asymmetric (``symmetric=False``, the verified format): two independent
+    unsigned-nibble unpacks — the weight along the in/K axis, the zero-point
+    along OUT — then ``(nibble − zp)`` with zp group-broadcast on K, an
+    int→fp16 ``CastOp``, the group-broadcast ``· scale``, a transpose to
+    ``[in, out]``, and the matmul. Symmetric subtracts the constant midpoint
+    ``2**(num_bits-1)`` instead of the unpacked zp (never both).
+    """
+    x = _node(frag, x)
+    wp = _node(frag, weight_packed)
+    sc = _node(frag, scale)
+    per = scheme.pack_factor
+    num_bits = scheme.num_bits
+    g = scheme.group_size
+    weight_dtype = sc.output.dtype
+
+    wp_shape = tuple(wp.output.shape)
+    out_features = wp_shape[0]
+    in_features = wp_shape[1] * per
+    weight_int_shape = (out_features, in_features)
+
+    # 1. Unpack the weight nibbles along the in/K axis (packed_dim == 1).
+    nibble = _unpack_nibbles(frag, wp, axis=1, pack_factor=per, num_bits=num_bits, out_shape=weight_int_shape, name=f"{matmul_name}_wq")
+
+    # 2. (nibble − zp) [asymmetric]  /  (nibble − 8) [symmetric].
+    if scheme.symmetric:
+        offset_bc = const_bc(frag, name=f"{matmul_name}_off", value=1 << (num_bits - 1), target_shape=weight_int_shape, dtype="i32")
+        diff_b = offset_bc
+    else:
+        zp_node = _node(frag, zp)
+        zp_shape = tuple(zp_node.output.shape)
+        zp_groups = zp_shape[1]
+        # Zero-point is int4-packed along OUT (axis 0) — a distinct axis from the
+        # weight's in-axis pack.
+        zp_unpacked = _unpack_nibbles(
+            frag, zp_node, axis=0, pack_factor=per, num_bits=num_bits, out_shape=(out_features, zp_groups), name=f"{matmul_name}_zq"
+        )
+        # Broadcast zp on K (group-indexed): zp_bc[o, k] = zp_unpacked[o, k // g].
+        diff_b = single_indexmap(
+            frag,
+            zp_unpacked,
+            out_shape=weight_int_shape,
+            coord_map=(placeholder(0), BinaryExpr("/", placeholder(1), Literal(g, "int"))),
+            name=f"{matmul_name}_zpbc",
+            dtype="i32",
+        )
+    diff = frag.add_node(
+        op=ElementwiseOp(op="subtract"),
+        inputs=[nibble, diff_b],
+        output=Tensor(f"{matmul_name}_diff", weight_int_shape, "i32"),
+    )
+
+    # 3. int → fp16 cast (the dequant boundary).
+    cast = frag.add_node(
+        op=CastOp(target_dtype=weight_dtype.name),
+        inputs=[diff],
+        output=Tensor(f"{matmul_name}_wf", weight_int_shape, weight_dtype),
+    )
+
+    # 4. Group-broadcast scale on K: scale_bc[o, k] = scale[o, k // g].
+    scale_bc = single_indexmap(
+        frag,
+        sc,
+        out_shape=weight_int_shape,
+        coord_map=(placeholder(0), BinaryExpr("/", placeholder(1), Literal(g, "int"))),
+        name=f"{matmul_name}_scbc",
+        dtype=weight_dtype,
+    )
+
+    # 5. w = cast · scale_bc (fp16).
+    w = frag.add_node(
+        op=ElementwiseOp(op="multiply"),
+        inputs=[cast, scale_bc],
+        output=Tensor(f"{matmul_name}_w", weight_int_shape, weight_dtype),
+    )
+
+    # 6. Transpose [out, in] → [in, out] (matmul wants A[…,K] @ B[K,N]).
+    wt = frag.add_node(
+        op=TransposeOp(axes=(-2, -1)),
+        inputs=[w],
+        output=Tensor(f"{matmul_name}_wt", (in_features, out_features), weight_dtype),
+    )
+
+    # 7. x @ wt.
+    return matmul_decompose(frag, x, wt, name=matmul_name, dtype=out_dtype)

--- a/deplodock/compiler/pipeline/passes/loop/lifting/015_lift_cast.py
+++ b/deplodock/compiler/pipeline/passes/loop/lifting/015_lift_cast.py
@@ -1,0 +1,61 @@
+"""Lift ``CastOp`` to a single-op ``LoopOp`` copy-with-dtype kernel.
+
+The cast is rank-preserving with no broadcast (input shape == output
+shape), so the read is a plain identity index. The body is one
+``Load`` → ``Assign(op="copy", dtype=<target>)`` → ``Write``; the
+``copy`` Assign carries the target dtype so ``Assign.render`` takes its
+copy/cast fast path (i32→f16 = a single ``__int2half_rn``, no f32
+detour). The W4A16 int→fp16 boundary lowers through here.
+
+Mergeable into its consumer (the group-scale multiply) by the later
+fusion pass — after fusion the dequant cone holds no materialized cast
+buffer; the int nibble casts to fp16 in registers right before the
+multiply.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.graph import Graph, Node, Tensor
+from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.expr import Var
+from deplodock.compiler.ir.loop import Assign, Axis, Load, Loop, LoopOp, Write
+from deplodock.compiler.ir.stmt import Body
+from deplodock.compiler.ir.tensor.ir import CastOp
+from deplodock.compiler.pipeline import Match, Pattern
+
+PATTERN = [Pattern("root", CastOp)]
+
+
+def rewrite(match: Match, root: Node) -> Graph | None:
+    graph = match.graph
+    out_shape = tuple(root.output.shape)
+    axes = tuple(Axis(name=f"a{i}", extent=d) for i, d in enumerate(out_shape))
+    write_index = tuple(Var(a.name) for a in axes)
+
+    src_id = root.inputs[0]
+    # Shape-preserving cast: identity read index (one axis Var per dim).
+    idx = write_index
+
+    inner: Body = (
+        Load(name="in0", input=src_id, index=idx),
+        Assign(name="v", op="copy", args=("in0",), dtype=root.output.dtype),
+        Write(output=f"lift_{root.id}", index=write_index, value="v"),
+    )
+    body: Body = inner
+    for a in reversed(axes):
+        body = (Loop(axis=a, body=body),)
+    kernel = LoopOp(body=body)
+
+    frag = Graph()
+    ext = graph.nodes.get(src_id)
+    shape = ext.output.shape if ext is not None else ()
+    dtype = ext.output.dtype if ext is not None else "f32"
+    frag.add_node(InputOp(), [], Tensor(src_id, shape, dtype), node_id=src_id)
+    out_id = frag.add_node(
+        kernel,
+        list(kernel.inputs),
+        Tensor(root.output.name, root.output.shape, root.output.dtype),
+        node_id=f"lift_{root.id}",
+    )
+    frag.outputs = [out_id]
+    return frag

--- a/deplodock/compiler/pipeline/passes/loop/lifting/030_lift_indexmap.py
+++ b/deplodock/compiler/pipeline/passes/loop/lifting/030_lift_indexmap.py
@@ -50,7 +50,14 @@ def rewrite(match: Match, root: Node) -> Graph | None:
             body.append(Load(name=name, input=src_id, index=idx))
             select_expr = src.select.substitute(mapping) if src.select is not None else Literal(1, "int")
             branches.append(SelectBranch(value=name, select=select_expr))
-        body.append(Select(name="v", branches=tuple(branches)))
+        # Carry the IndexMap's result dtype ONLY for an integer assembly so it
+        # renders as an ``int`` lane select rather than being forced to float
+        # (W4A16 8-lane unpack: ``unpacked[o,k] = lane_{k%8}[o, k//8]``). Float /
+        # half cats keep ``dtype=None`` → the legacy float-detour rendering, so
+        # this change is a strict no-op for every existing (non-quant) graph.
+        out_dt = root.output.dtype
+        sel_dtype = out_dt if out_dt.name in ("i32", "i64") else None
+        body.append(Select(name="v", branches=tuple(branches), dtype=sel_dtype))
         body.append(Write(output=out_buf, index=write_index, value="v"))
 
     # Wrap in nested free Loops.

--- a/deplodock/compiler/pipeline/passes/lowering/cuda/010_lower_kernelop.py
+++ b/deplodock/compiler/pipeline/passes/lowering/cuda/010_lower_kernelop.py
@@ -32,9 +32,16 @@ def rewrite(match: Match, root: Node) -> Graph | None:  # noqa: ARG001 — match
     # the ``constant`` / ``value`` flags for ConstantOp predecessors.
     tensors: dict[str, Tensor] = {**root.op.inputs, **root.op.outputs}
 
-    # Scalar ConstantOp inputs get embedded as float literals in the kernel
-    # body — no kernel parameter, no buffer load.
-    literal_constants: dict[str, float] = {n: float(t.value) for n, t in root.op.inputs.items() if t.constant and t.value is not None}
+    # Scalar ConstantOp inputs get embedded as literals in the kernel body —
+    # no kernel parameter, no buffer load. Integer-typed scalars (the W4A16
+    # unpack immediates ``4i`` / ``0xF`` / ``8``) are carried as Python ``int``
+    # so the inlining renders ``packed >> 4`` (not the invalid ``packed >> 4.0f``)
+    # and stamps the use site as i32; float scalars stay ``float``.
+    literal_constants: dict[str, float | int] = {
+        n: (int(t.value) if t.dtype.name in ("i32", "i64") else float(t.value))
+        for n, t in root.op.inputs.items()
+        if t.constant and t.value is not None
+    }
 
     runtime_inputs = tuple(b for b in root.op.inputs if b not in literal_constants)
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/030_stamp_types.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/030_stamp_types.py
@@ -48,6 +48,7 @@ from deplodock.compiler.ir.stmt import (
     Load,
     Loop,
     Pack,
+    Select,
     Stmt,
     StridedLoop,
     Unpack,
@@ -93,6 +94,8 @@ def _stamp_stmt(s: Stmt, ctx: _StampCtx) -> Stmt:
         return _stamp_assign(s, ctx)
     if isinstance(s, Write):
         return _stamp_write(s, ctx)
+    if isinstance(s, Select):
+        return _stamp_select(s, ctx)
     if isinstance(s, (Accum, Init)):
         ctx.ssa_dtypes[s.name] = s.dtype or F32
         return s
@@ -201,6 +204,17 @@ def _is_overflow_prone(s: Assign) -> bool:
     if s.op.name == "pow":
         return True
     return s.op.name == "multiply" and len(s.args) == 2 and s.args[0] == s.args[1]
+
+
+def _stamp_select(s: Select, ctx: _StampCtx) -> Select:
+    """Register the Select's result dtype in the running ssa map so a
+    downstream Assign (e.g. the W4A16 ``nibble - zp`` subtract) sees the
+    assembled lane as i32. The integer assembly stamps ``dtype`` at lift
+    time; a legacy float cat leaves it ``None`` and is left untouched
+    (its render keeps the float-detour path)."""
+    if s.dtype is not None:
+        ctx.ssa_dtypes[s.name] = s.dtype
+    return s
 
 
 def _stamp_write(s: Write, ctx: _StampCtx) -> Write:

--- a/deplodock/compiler/trace/ARCHITECTURE.md
+++ b/deplodock/compiler/trace/ARCHITECTURE.md
@@ -64,6 +64,24 @@ args): the legacy constant-input convention can't represent a `None` start (`x[:
 `_resolve_inputs` drops both, leaving the surviving constants positionally ambiguous. Pre-field IR dumps still
 decompose via the constant-input fallback.
 
+### `quantized.py` — W4A16 (compressed-tensors AWQ-INT4) pre-trace substitution
+
+A compressed-tensors checkpoint registers a forward *decompress pre-hook* that unpacks the int4 weights on first
+forward; under `torch.export` that hook fires mid-trace and injects a data-dependent slice (`unpack_from_int32 →
+int(shape[1])`) export can't specialize. `apply_quant_substitution(model)` walks the loaded model **before** export
+(the established `huggingface.py` submodule-swap pattern) and replaces each targeted quantized linear with a
+`DequantLinear` whose `forward` is a single opaque custom op `deplodock::dequant_linear` (registered via
+`torch.library.custom_op` + `register_fake`). This keeps the packed int32 / fp16-scale / int32-zp tensors as graph
+**constants** (passed as explicit tensor args, never closed over), prevents the decompress hook from firing, and emits
+one `DequantLinearOp` node the `045_dequant_linear` decomposition expands. The tracer maps the custom op by name in
+`_op_name` / `_handle_dequant_linear` (a dedicated arg branch peels the tensor inputs from the scalar `QuantScheme`,
+which becomes op metadata — never graph `ConstantOp`s). `parse_quant_config` handles the transformers wrapper
+(`CompressedTensorsConfig → .quantization_config.config_groups`) and skips `ignore` modules (`lm_head`). The module is
+deliberately written **without** `from __future__ import annotations` so `torch.library` can infer the op schema from
+real annotations. No-op for non-quantized models. Wired into `commands/compile.py::_trace_model` (so `run` / `tune`
+reach it). All format-specific logic (config parse + the torch dequant the eager impl runs) lives here; everything
+below `DequantLinearOp` is format-agnostic. See `plans/w4a16-quantization-support.md`.
+
 ## Entry points
 
 - Whole-model trace: `trace_module(build_full_model_wrapper(model, …), (input_ids,))`.

--- a/deplodock/compiler/trace/quantized.py
+++ b/deplodock/compiler/trace/quantized.py
@@ -1,0 +1,255 @@
+"""Pre-trace substitution for compressed-tensors weight-only quantized models.
+
+A compressed-tensors checkpoint registers a forward *decompress pre-hook* that
+unpacks the int4 weights on first forward. When ``torch.export`` traces the
+model that hook fires mid-trace and injects a data-dependent slice
+(``unpack_from_int32`` → ``int(shape[1])``) that export can't specialize, so
+the whole model fails to trace.
+
+This module walks the loaded model *before* export and swaps each quantized
+linear for a deplodock-authored :class:`DequantLinear` whose ``forward`` is the
+single opaque custom op ``deplodock::dequant_linear``. That (1) keeps the packed
+int32 / fp16-scale / int32-zp tensors as graph constants for the binder, (2)
+prevents the decompress hook from ever firing, and (3) emits one
+``DequantLinearOp`` node the ``045_dequant_linear`` decomposition expands into
+the unpack → dequant → matmul cone the rest of the pipeline lowers.
+
+The format-specific logic (config parse + the torch dequant the custom op's
+eager impl runs) is isolated here; everything below the ``DequantLinearOp`` is
+format-agnostic. See ``plans/w4a16-quantization-support.md``.
+"""
+
+# NOTE: deliberately NO ``from __future__ import annotations`` — ``torch.library``
+# infers the custom-op schema from the eager impl's real type annotations, and
+# stringized annotations break its schema inference (it can't resolve ``torch``).
+
+import logging
+from typing import Optional
+
+from deplodock.compiler.ir.frontend.ir import QuantScheme
+
+logger = logging.getLogger(__name__)
+
+_CUSTOM_OP_REGISTERED = False
+
+
+def _ensure_custom_op() -> None:
+    """Register ``deplodock::dequant_linear`` once per process.
+
+    The op is opaque to ``torch.export`` (preserved as one ``call_function``
+    node via ``register_fake``); its eager impl runs the real dequant so a
+    substituted ``DequantLinear`` is the deployed accuracy reference. Buffers
+    are passed as explicit tensor args (not closed over) so they surface as
+    graph constants for binding.
+    """
+    global _CUSTOM_OP_REGISTERED
+    if _CUSTOM_OP_REGISTERED:
+        return
+    import torch
+
+    @torch.library.custom_op("deplodock::dequant_linear", mutates_args=())
+    def dequant_linear(  # noqa: F811 — registered into torch.ops, never called by name
+        x: torch.Tensor,
+        weight_packed: torch.Tensor,
+        weight_scale: torch.Tensor,
+        weight_zero_point: torch.Tensor,
+        bias: Optional[torch.Tensor],  # noqa: UP045 — torch schema infer needs typing.Optional, not ``| None``
+        num_bits: int,
+        group_size: int,
+        packed_dim: int,
+        symmetric: bool,
+    ) -> torch.Tensor:
+        weight = _dequant_weight_torch(weight_packed, weight_scale, weight_zero_point, num_bits, group_size, symmetric)
+        return torch.nn.functional.linear(x, weight, bias)
+
+    @dequant_linear.register_fake
+    def _(x, weight_packed, weight_scale, weight_zero_point, bias, num_bits, group_size, packed_dim, symmetric):
+        out_features = weight_packed.shape[0]
+        return x.new_empty((*x.shape[:-1], out_features))
+
+    _CUSTOM_OP_REGISTERED = True
+
+
+def _dequant_weight_torch(weight_packed, weight_scale, weight_zero_point, num_bits, group_size, symmetric):
+    """Torch twin of ``ir.frontend.ir.dequant_weight_numpy`` — returns the
+    ``[out, in]`` weight in the scale's dtype (fp16). Kept in lock-step with
+    the numpy oracle (and cross-checked against ``compressed_tensors.dequantize``
+    in the gated parity test)."""
+    import torch
+
+    per = 32 // num_bits
+    mask = (1 << num_bits) - 1
+    out_f, in_packed = weight_packed.shape
+    in_f = in_packed * per
+
+    wp = weight_packed.to(torch.int64)
+    nib = torch.empty((out_f, in_f), dtype=torch.int64, device=wp.device)
+    for i in range(per):
+        nib[:, i::per] = (wp >> (num_bits * i)) & mask
+
+    if symmetric:
+        deq_int = nib - (1 << (num_bits - 1))
+    else:
+        zpp = weight_zero_point.to(torch.int64)
+        out_packed, zp_groups = zpp.shape
+        zp = torch.empty((out_packed * per, zp_groups), dtype=torch.int64, device=zpp.device)
+        for i in range(per):
+            zp[i::per, :] = (zpp >> (num_bits * i)) & mask
+        zp = zp[:out_f, :]
+        zp_bc = zp.repeat_interleave(group_size, dim=1)[:, :in_f]
+        deq_int = nib - zp_bc
+
+    scale_bc = weight_scale.repeat_interleave(group_size, dim=1)[:, :in_f]
+    return deq_int.to(scale_bc.dtype) * scale_bc
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+
+def _config_get(cfg, key, default=None):
+    """Read ``key`` off a config that may be a dict or a config object."""
+    if cfg is None:
+        return default
+    if isinstance(cfg, dict):
+        return cfg.get(key, default)
+    return getattr(cfg, key, default)
+
+
+def parse_quant_config(model_config) -> tuple[QuantScheme, list[str]] | None:
+    """Return ``(scheme, ignore)`` for a compressed-tensors model, else ``None``.
+
+    Handles both ``quantization_config`` and the legacy ``compression_config``,
+    and a dict- or object-shaped config. Transformers wraps the compressed-tensors
+    ``QuantizationConfig`` one level deep (``CompressedTensorsConfig`` →
+    ``.quantization_config``), so descend when ``config_groups`` isn't at the top.
+    Reads the first weight config group (uniform across linears for the verified
+    format). The ``quant_method`` enum compares equal to its ``"compressed-tensors"``
+    string value.
+    """
+    qc = getattr(model_config, "quantization_config", None) or getattr(model_config, "compression_config", None)
+    if qc is None:
+        return None
+    if _config_get(qc, "quant_method") != "compressed-tensors":
+        return None
+
+    # The transformers wrapper holds the real groups under a nested config.
+    inner = qc
+    if _config_get(inner, "config_groups") is None and _config_get(inner, "quantization_config") is not None:
+        inner = _config_get(inner, "quantization_config")
+
+    groups = _config_get(inner, "config_groups") or {}
+    weights = None
+    for group in groups.values() if isinstance(groups, dict) else groups:
+        weights = _config_get(group, "weights")
+        if weights is not None:
+            break
+    if weights is None:
+        logger.warning("compressed-tensors config has no weight group; skipping quant substitution")
+        return None
+
+    scheme = QuantScheme(
+        num_bits=int(_config_get(weights, "num_bits", 4)),
+        group_size=int(_config_get(weights, "group_size", 32)),
+        packed_dim=1,  # pack-quantized interleaves nibbles along the in/K axis
+        symmetric=bool(_config_get(weights, "symmetric", False)),
+    )
+    ignore = list(_config_get(inner, "ignore", []) or [])
+    return scheme, ignore
+
+
+# ---------------------------------------------------------------------------
+# DequantLinear module + substitution walker
+# ---------------------------------------------------------------------------
+
+
+def _build_dequant_linear(module, scheme: QuantScheme):
+    """Wrap a quantized linear's packed buffers in a ``DequantLinear``."""
+    import torch.nn as nn
+
+    _ensure_custom_op()
+
+    class DequantLinear(nn.Module):
+        """Trace-friendly replacement: ``forward`` is the opaque custom op.
+
+        Holds the packed int32 weight / fp16 scale / int32 zero-point (and
+        optional bias) as buffers so they trace as graph constants. The format
+        numbers ride as scalar args to the custom op (recorded as
+        ``DequantLinearOp`` metadata by the tracer, never as graph constants)."""
+
+        def __init__(self, weight_packed, weight_scale, weight_zero_point, bias):
+            super().__init__()
+            self.register_buffer("weight_packed", weight_packed)
+            self.register_buffer("weight_scale", weight_scale)
+            self.register_buffer("weight_zero_point", weight_zero_point)
+            self.register_buffer("bias", bias)  # None registers a None buffer
+            self._num_bits = scheme.num_bits
+            self._group_size = scheme.group_size
+            self._packed_dim = scheme.packed_dim
+            self._symmetric = scheme.symmetric
+
+        def forward(self, x):
+            import torch  # noqa: PLC0415
+
+            return torch.ops.deplodock.dequant_linear(
+                x,
+                self.weight_packed,
+                self.weight_scale,
+                self.weight_zero_point,
+                self.bias,
+                self._num_bits,
+                self._group_size,
+                self._packed_dim,
+                self._symmetric,
+            )
+
+    bias = getattr(module, "bias", None)
+    return DequantLinear(module.weight_packed, module.weight_scale, module.weight_zero_point, bias)
+
+
+def _is_quantized_linear(module) -> bool:
+    """A compressed-tensors packed linear carries these three buffers."""
+    return all(hasattr(module, attr) for attr in ("weight_packed", "weight_scale", "weight_zero_point"))
+
+
+def _is_ignored(name: str, ignore: list[str]) -> bool:
+    """Match a module name against the config ``ignore`` list (final-component
+    or substring match — covers ``"lm_head"`` and ``"re:.*lm_head"`` forms)."""
+    leaf = name.rsplit(".", 1)[-1]
+    for ig in ignore:
+        pat = ig[3:] if ig.startswith("re:") else ig
+        if pat == leaf or pat == name or pat in name:
+            return True
+    return False
+
+
+def apply_quant_substitution(model) -> int:
+    """Swap every targeted quantized linear for a ``DequantLinear``, in place.
+
+    No-op (returns 0) for a non-compressed-tensors model. Skips ``ignore``
+    modules (e.g. ``lm_head``, which stays dense fp16). Returns the number of
+    modules substituted so callers can log / assert.
+    """
+    parsed = parse_quant_config(getattr(model, "config", None))
+    if parsed is None:
+        return 0
+    scheme, ignore = parsed
+
+    targets: list[tuple[str, object]] = [
+        (name, m) for name, m in model.named_modules() if _is_quantized_linear(m) and not _is_ignored(name, ignore)
+    ]
+    for name, module in targets:
+        parent = model.get_submodule(name.rsplit(".", 1)[0]) if "." in name else model
+        attr = name.rsplit(".", 1)[-1]
+        setattr(parent, attr, _build_dequant_linear(module, scheme))
+
+    if targets:
+        logger.info(
+            "W4A16: substituted %d quantized linears (num_bits=%d group_size=%d symmetric=%s)",
+            len(targets),
+            scheme.num_bits,
+            scheme.group_size,
+            scheme.symmetric,
+        )
+    return len(targets)

--- a/deplodock/compiler/trace/torch.py
+++ b/deplodock/compiler/trace/torch.py
@@ -18,6 +18,7 @@ from deplodock.compiler.ir.elementwise import ElementwiseImpl
 from deplodock.compiler.ir.expr import Literal, placeholder
 from deplodock.compiler.ir.frontend.ir import (
     CatOp,
+    DequantLinearOp,
     LayerNormOp,
     LinearOp,
     MatmulOp,
@@ -396,12 +397,20 @@ def _handle_output(g: Graph, fx_node: Any, node_map: dict[str, str]) -> None:
 
 
 def _op_name(target: Any) -> str | None:
-    """Extract a short op name from an ATen target."""
+    """Extract a short op name from an ATen (or deplodock custom-op) target."""
     s = str(target)
     if "aten." in s:
         parts = s.split(".")
         for i, p in enumerate(parts):
             if p == "aten" and i + 1 < len(parts):
+                return parts[i + 1]
+    # Deplodock custom ops surface as ``deplodock.<name>.default`` — recognize
+    # them here so they don't fall through to the ``op_name is None`` first-input
+    # alias (which would silently drop the op). Currently: ``dequant_linear``.
+    if "deplodock." in s:
+        parts = s.split(".")
+        for i, p in enumerate(parts):
+            if p == "deplodock" and i + 1 < len(parts):
                 return parts[i + 1]
     return None
 
@@ -449,6 +458,44 @@ def _squeeze_indexmap(in_shape: tuple, out_shape: tuple, axis: int | str) -> Ind
     return IndexMapOp(out_shape=tuple(out_shape), sources=(IndexSource(input_idx=0, coord_map=tuple(coord_map)),))
 
 
+def _handle_dequant_linear(g: Graph, fx_node: Any, node_map: dict[str, str], name: str, shape: tuple, dtype: str) -> None:
+    """Map a ``deplodock::dequant_linear`` custom-op node to ``DequantLinearOp``.
+
+    Custom-op call: ``dequant_linear(x, weight_packed, weight_scale,
+    weight_zero_point, bias, num_bits, group_size, packed_dim, symmetric)``. The
+    five leading tensor args become the op's graph inputs (peeled by name from
+    ``node_map``; a ``None`` bias is dropped and recorded via ``has_bias``); the
+    four trailing scalars become op metadata (read from both ``args`` and
+    ``kwargs``), never graph constants.
+    """
+    args = fx_node.args
+    kwargs = fx_node.kwargs or {}
+
+    def _tensor(a) -> str | None:
+        return node_map.get(a.name) if (a is not None and hasattr(a, "name") and a.name in node_map) else None
+
+    inputs = [_tensor(args[0]), _tensor(args[1]), _tensor(args[2]), _tensor(args[3])]
+    bias_id = _tensor(args[4]) if len(args) > 4 else None
+    has_bias = bias_id is not None
+    if has_bias:
+        inputs.append(bias_id)
+
+    def _scalar(pos: int, key: str, default):
+        if key in kwargs:
+            return kwargs[key]
+        return args[pos] if len(args) > pos else default
+
+    op = DequantLinearOp(
+        has_bias=has_bias,
+        num_bits=int(_scalar(5, "num_bits", 4)),
+        group_size=int(_scalar(6, "group_size", 32)),
+        packed_dim=int(_scalar(7, "packed_dim", 1)),
+        symmetric=bool(_scalar(8, "symmetric", False)),
+    )
+    nid = g.add_node(op=op, inputs=inputs, output=Tensor(name, shape, dtype), node_id=name)
+    node_map[name] = nid
+
+
 def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, str], *, sym_rename: dict[str, str] | None = None) -> None:
     """Handle call_function nodes — faithful 1:1 capture of FX ops."""
     # ``aten.sym_size.int`` and similar shape-metadata ops return a
@@ -462,6 +509,17 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, str], *, s
     shape = _get_shape(fx_node, sym_rename)
     dtype = _get_dtype(fx_node)
     op_name = _op_name(fx_node.target)
+
+    # --- W4A16 dequant-linear custom op ---
+    # A dedicated resolver: the generic ``_resolve_inputs`` walks only
+    # positional ``args`` and turns the scalar scheme (num_bits / group_size /
+    # …) into bogus ``ConstantOp`` graph inputs. Here we peel the tensor inputs
+    # (x, weight_packed, weight_scale, weight_zero_point, optional bias) and
+    # record the scheme as ``DequantLinearOp`` metadata instead.
+    if op_name == "dequant_linear":
+        _handle_dequant_linear(g, fx_node, node_map, name, shape, dtype)
+        return
+
     input_ids = _resolve_inputs(fx_node, node_map, g)
 
     if op_name is None:

--- a/plans/w4a16-quantization-support.md
+++ b/plans/w4a16-quantization-support.md
@@ -1,0 +1,364 @@
+# W4A16 (AWQ-INT4) quantization support in the deplodock compiler
+
+> Status: **Phase 0 implemented** (functional correctness). Phases 1–6 below are forward-looking.
+>
+> Phase 0 landed the full op + trace integration + integer/cast codegen: a compressed-tensors AWQ-INT4 model
+> traces, compiles, and runs on the CUDA backend with in-kernel dequant. Verified end-to-end on
+> `cyankiwi/Llama-3.1-8B-Instruct-AWQ-INT4 --layer 0` (224 linears substituted; accuracy vs eager
+> `max_diff=0.0020, mean_diff=8e-6 PASS`) plus a hermetic `tests/compiler/test_dequant.py` suite (numerics oracle,
+> `compressed_tensors` parity, integer/cast codegen, substitution walker, CUDA e2e). Notably the default fusion
+> pipeline already pulls the dequant producer cone *into* the matmul kernel (gmem holds only packed int32 + scales +
+> zp, the fp16 weight lives transiently in registers), so this build already realizes much of the Phase 3 VRAM goal —
+> no separate `DEPLODOCK_W4A16_FUSE` gate was needed. One real codegen fix beyond the plan: `right_shift` /
+> `bitwise_and` are forced to an i32 result in `dtype_promote` (they are integer-only and have no float form), which
+> keeps the unpack correct when a staged-smem Load's dtype is unresolved at stamp time.
+
+## Context
+
+`deplodock serve cyankiwi/Llama-3.1-8B-Instruct-AWQ-INT4` (and equally `compile`/`run`/`tune` on any
+compressed-tensors AWQ model) fails. Root cause: deplodock's compiler is **fp16/fp32-dense only** — it has zero
+quantization handling. Today the only path that "works" is `serve --stock` (raw vLLM, native AWQ), which bypasses
+deplodock kernels entirely.
+
+The compressed-tensors checkpoint registers a forward **decompress pre-hook** that unpacks int4 weights on first
+forward. When `torch.export` traces the model, that hook fires mid-trace and injects a data-dependent slice
+(`unpack_from_int32 → int(shape[1])`, `compressed_tensors/.../pack_quantized/helpers.py:141/153`), which torch.export
+cannot specialize → `GuardOnDataDependentSymNode: ...u0`.
+
+**Goal (chosen scope):** true **W4A16 in-kernel dequant** — packed int4 weights stay packed in GPU memory and are
+dequantized in registers/smem *before* the matmul, preserving the VRAM savings (not materializing a full fp16 weight in
+gmem). Surfaced through **`deplodock compile` / `run` / `tune`** (the CLI trace+compile paths). `serve` is out of scope for
+now — and **not** free: it has its own live-module constant-binding path (`serving/runner.py:119-128`) that
+blanket-casts every parameter/buffer through `float32` → `dtype_str`, which would corrupt packed int32 weights and
+zero-points. It reuses the same *trace* path, but needs the same dtype-preserving binding fix (below) applied to that
+runner before it works.
+
+This is a multi-phase compiler feature. The plan is **correctness-first, then performance**: prove numerics with a
+materialized fp16 weight, then fuse, then move dequant into the kernel for the actual VRAM win.
+
+## Verified format (this exact model)
+
+`config.quantization_config`: `format=pack-quantized`, `num_bits=4`, `group_size=32`, `strategy=group`,
+**`symmetric=false`** (asymmetric → zero-points present), `targets=["Linear"]`, `ignore=["lm_head"]`.
+
+Per-linear on-disk tensors (e.g. `mlp.gate_proj`, out=14336, in=4096):
+- `weight_packed` **I32 `[out, in/8]`** — 8 **unsigned** int4 nibbles per int32, **interleaved** along dim 1
+  (`packed_dim=1`): `nibble[:, i::8] = (packed >> (4*i)) & 0xF`, i in 0..7 (values 0..15).
+- `weight_scale` **F16 `[out, in/group]`** — group along the K/in axis (G=32).
+- `weight_zero_point` **I32 `[out/8, in/group]`** — zp is itself **int4-packed along OUT** (different axis than the
+  weight), also unsigned nibbles. **Dequant (asymmetric, this model): `w = (nibble − zp) · scale`** — unsigned nibble
+  minus unsigned zp, **no −8**.
+- **Offset is conditional, not unconditional.** The symmetric/no-zp case is `(nibble − 8) · scale` (the `8` is the
+  implicit zero-point). compressed-tensors' `unpack_from_int32` subtracts 8 from **both** weight and zp
+  (`helpers.py:158-159`), then `dequantize` does `(w−zp)·scale` — the two −8s cancel, reducing to the same
+  `nibble − zp`. So the decomposition must subtract zp **xor** 8 (gated on `symmetric`), never both — applying −8 *and*
+  an unsigned-zp subtract double-shifts. (Matches the vLLM W4A16 triton reference: unsigned nibbles − zp, 8 only as the
+  no-zp bias.)
+- `lm_head` is in `ignore` → stays dense fp16, must NOT be substituted.
+
+## Approach (decided)
+
+**Pre-trace submodule substitution** (the established `trace/huggingface.py` `_PassThroughRotary` /
+rotary→buffer-swap pattern, lines ~53-123). Walk the loaded model, `setattr` each targeted quant linear with a
+deplodock-authored `DequantLinear` (holding `weight_packed`/`weight_scale`/`weight_zero_point` as buffers + optional
+bias) **before** `torch.export`. This: (1) keeps the packed int32 / fp16-scale / int32-zp tensors as graph
+**constants**, so the binder + the already-dtype-generic uploader carry them packed to gmem with no new plumbing; (2)
+prevents the decompress pre-hook from ever firing, so the data-dependent guard never arises; (3) emits a single opaque
+custom op carrying the packed buffers + scheme metadata, which the Phase 0 decomposition (`045_dequant_linear`) expands
+into the unpack/dequant/matmul cone the rest of the pipeline lowers. (Rejected: trace-through-and-fix-the-guard —
+fights torch.export and still materializes a full fp16 weight; post-trace IR rewrite — must re-derive quant metadata
+from shapes, strictly harder.)
+
+**Trace integration — `DequantLinear.forward` is a registered custom op.** `torch.export` decomposes a plain
+`nn.Module` into constituent ATen calls, and the tracer (`trace/torch.py`) maps only `call_function` nodes by name
+(`linear`→`LinearOp` at `:526`, `mm`/`addmm`→`MatmulOp` at `:538/548`); a `DequantLinear` module would therefore
+dissolve into a cone of aten ops, *not* surface as one op. Two further tracer facts make tracing that cone hostile:
+`aten.to`/`type_as` are **pass-through** (`trace/torch.py:698` — the pipeline is "dtype-unified", so a dtype-changing
+cast is silently dropped), and the unpack surfaces as `aten.__rshift__.Scalar` / `aten.__and__.Scalar` (verified in the
+failed-trace dump), names the tracer doesn't canonicalize. **Decision:** make `DequantLinear.forward` a
+`torch.library.custom_op` (`deplodock::dequant_linear`, with a `register_fake` for shape prop) so export preserves it
+as a single opaque `call_function` node; map that name in `trace/torch.py` beside `linear`/`mm` to a new frontend
+`DequantLinearOp`. **The buffers must be passed as explicit tensor arguments**, not closed over — the module forward
+calls `dequant_linear(x, self.weight_packed, self.weight_scale, self.weight_zero_point, self.bias, ...scheme...)`; an
+opaque op that reads `self.weight_packed` internally would hide those tensors from export, so they'd never surface as
+graph constants for binding. The op's **non-tensor `QuantScheme`** (num_bits / group_size / packed_dim / symmetric) is
+recorded as `DequantLinearOp` metadata (scalar args), not as tensors. The unpack/dequant arithmetic is then **authored
+in deplodock's Phase 0 decomposition** (`045_dequant_linear`), using deplodock-internal op names and an explicit cast
+op — so the tracer never has to handle aten casts or `__rshift__` name variants at all. (Fallback if the custom op is
+impractical:
+pattern-collapse the exported aten cone into
+`DequantLinearOp`; that route *does* require canonicalizing `__rshift__`/`__and__`/`bitwise_right_shift`/`bitwise_and`
+and intercepting the dtype-changing `to`.)
+
+## Phases
+
+### Phase 0 — Functional correctness: a quantized linear compiles + runs (no VRAM win yet)
+The dequant cone lowers to its own kernel(s) materializing a full fp16 weight in gmem; the matmul reads it. Isolates
+numerics from fusion. This phase carries the **op + trace integration + integer/cast codegen** — everything needed for a
+`DequantLinearOp` to execute correctly.
+- **New** `compiler/trace/quantized.py`: parse `quantization_config` (handle `quantization_config` and legacy
+  `compression_config`; `num_bits/group_size/symmetric/strategy/packed_dim/targets/ignore`); a `DequantLinear` module
+  whose `forward` is the registered `torch.library.custom_op` `deplodock::dequant_linear` (eager impl delegates to a
+  clean torch dequant for the accuracy reference; `register_fake` returns `[*x.shape[:-1], out]`), holding
+  `weight_packed`/`weight_scale`/`weight_zero_point` (+bias) as buffers; a module-substitution walker. Detect via
+  `quant_method == "compressed-tensors"`; no-op (byte-identical) when absent. Skip `ignore` modules (`lm_head`).
+- **Trace integration** (the answer to "how the op gets into the graph"): **new** frontend `DequantLinearOp` beside
+  `LinearOp` (`compiler/ir/frontend/ir.py`) with a numpy `forward()` (CPU interpret + accuracy harness); map the custom
+  op's name to it in `trace/torch.py` (beside the `linear`/`mm`/`addmm` cases at `:526-548`). **Extend `_op_name`**
+  (`trace/torch.py:398`, today `aten.`-only) to return a name for the `deplodock::dequant_linear` target — otherwise it
+  returns `None` and the op hits the `op_name is None` fallback (`:467`) that silently aliases the node to its first
+  input `x`, dropping the entire dequant.
+- **Custom-op arg handling — a dedicated resolver branch, not the generic one.** `_resolve_inputs`
+  (`trace/torch.py:325`) walks only `fx_node.args` (ignores `kwargs`) and turns positional numeric scalars into
+  `ConstantOp` graph inputs (`:335-346`). So the generic path would (a) drop any scheme passed as kwargs and (b) leave
+  `num_bits`/`group_size`/`packed_dim`/`symmetric` as bogus graph inputs. The custom-op case must **peel the tensor
+  inputs** (`x`, `weight_packed`, `weight_scale`, `weight_zero_point`, optional `bias`) as the op's graph inputs/
+  constants from the **scalar scheme**, read `fx_node.kwargs` too, and store the scheme on `DequantLinearOp` as op
+  metadata (a `QuantScheme`) — never as graph `ConstantOp`s. **Record `has_bias`** on the op (like `LinearOp.has_bias`):
+  generic `_resolve_inputs` drops a `None`/non-tensor arg, so a `None` bias and a real bias-tensor would otherwise be
+  indistinguishable — the decomposition's "add bias when present" needs that flag to know which.
+- **New decomposition rule** `passes/frontend/decomposition/045_dequant_linear.py` (+ `dequant_decompose` in
+  `_helpers.py`, mirroring `matmul_decompose`). **Two independent unsigned-nibble unpacks** for this asymmetric model:
+  (1) `weight_packed` along `packed_dim` → `[out,in]` unsigned-nibble int; (2) `weight_zero_point`, itself int4-packed
+  **along OUT**, → `[out, in/group]` unsigned-nibble int. Then **`(nibble − zp)`** with **zp broadcast on OUT and
+  group-indexed on K** (a distinct IndexMap from the scale's) → int→fp16 cast → group-broadcast `· scale` →
+  **transpose `[out,in]`→`[in,out]`** (`matmul_decompose` expects `A[…,K] @ B[K,N]`; `LinearOp` does this same
+  `TransposeOp(axes=(-2,-1))` before the matmul, `040_linear.py:21-27` — without it the K/N axes and output features are
+  wrong) → `matmul_decompose` → **add bias** (the captured `bias`, broadcast + added *after* the matmul exactly as
+  `LinearOp` does, `040_linear.py:32`, gated on the recorded `has_bias`). **Offset gating:** `symmetric=false` subtracts the unpacked `zp`;
+  `symmetric=true` subtracts the constant `8` instead (NOT "skip the subtract" — dropping it omits the implicit
+  zero-point). Never both (see the format note).
+- **Unpack representation — 8 fixed-shift lanes (Phase 0, no IR gap).** The reference unpack is
+  `unpacked[..., i::8] = (packed >> 4i) & 0xF` for `i in 0..7`. Phase 0 emits exactly this: **eight lanes, each a
+  constant shift** `lane_i = (packed >> 4i) & 0xF` (the `4i`/`0xF` are dtype-preserving int scalar literals — no
+  coordinate-dependent operand, so it fits today's `Assign(args: tuple[str,...])` which carries SSA names, not Exprs).
+  **Assemble `[out,in]` via a multi-source `IndexMapOp`** (8 `IndexSource`s — source selected by `k%8`, coord `k//8` —
+  exactly what `150_cat.py` already lowers a cat *into*), then a copy materializes it to gmem. Do **not** use an 8-way
+  `CatOp`: only the 2-tensor cat variant is lowered (`150_cat.py:4`); a multi-source `IndexMapOp` sidesteps that (the
+  alternative is adding variadic / binary-tree cat). The zp unpacks the same way, 8 fixed-shift lanes assembled along
+  OUT (`out%8` / `out//8`). This **avoids the index-dependent shift entirely**; Phase 1 fuses the same lanes.
+- **The cast op** (today the IR has only `ElementwiseOp` + dtype-stamped `Assign`; no cast op exists). Define a
+  **tensor-IR `CastOp(target_dtype)` in `ir/tensor/ir.py`** — it's a *post-decomposition* primitive (emitted by
+  `045_dequant_linear`, consumed by loop lifting), so it belongs in tensor IR, not frontend: numpy `forward` =
+  `.astype`; serializes `target_dtype`; output `Tensor` carries the target dtype, input stays i32.
+  - **Lifting** — a loop-lifting rule for `CastOp` (the elementwise lift `010_lift_elementwise.py:45` emits
+    `Assign(op=root.op.op, ...)` with **no `dtype=`**; reuse it only if it's taught to stamp `dtype=root.output.dtype`,
+    else add a dedicated rule emitting a copy `Assign` with `dtype=F16`).
+  - **Render — an explicit copy/cast path, not the generic `Assign` path.** `Assign.render` takes the native non-f32
+    path only when *all* args are already at `result_dt` (`leaves.py:414`); a cast's i32 input never matches its f16
+    result, so it falls to the **f32-promote path** (`(float)v` → `__float2half`) — numerically fine but not the direct
+    `__int2half_rn` the codegen test asserts. Add a copy/cast render branch (keyed on `copy` with a dtype change) that
+    calls `target.convert(arg, src_dt, result_dt)` **directly** (i32→f16 = `__int2half_rn`), one conversion, no f32
+    detour.
+  - CPU correctness of the cast is checked via the numpy reference, **not** the C++ Loop runner (float-only — see the
+    Loop CPU-interpret bullet below, option (b)).
+- Wire substitution into the single tracing chokepoint `commands/compile.py::_trace_model` (which `run`/`tune` reach
+  through `load_or_trace`).
+- **Fix the blanket fp32 casts** that would destroy int weights — bind each constant at its graph-declared dtype:
+  - `compiler/loader/binder.py:96-97` (`bind_constants_from_module`, `.float().numpy()` — note it uses `state_dict()`
+    for tied weights; the `DequantLinear` buffers surface there).
+  - `commands/run.py:_bind_inputs` (~1267-1269, `.astype(np.float32)` for params/buffers). Inputs there already cast by
+    `node.output.dtype.np` — extend that per-node logic to the constant `sources` dict.
+- **Integer + cast codegen — the first mixed-int/fp graph in the pipeline** (the IR is otherwise "dtype-unified", so
+  this is more than a one-liner). All of:
+  - `compiler/ir/elementwise.py` `_NAME_TO_FN` — add `right_shift` (`np.right_shift`), `bitwise_and` (`np.bitwise_and`)
+    (deplodock-internal names, emitted by our decomposition — no aten canonicalization needed via the custom-op route).
+  - `compiler/ir/stmt/base.py` — add `>>`/`&` to `_BINARY_OP`/`op_to_expr`; integer rule in `dtype_promote`
+    (all-i32 → i32, never silently → f32).
+  - `compiler/ir/expr.py` `BinaryExpr` — add `>>`/`&` to the op set (`expr.py:274` has `+ - * / // % … ^` but not the
+    bitwise pair), with `eval` (`np.right_shift`/`np.bitwise_and`), `render`, and a precedence entry. This is the layer
+    `op_to_expr` builds on, and it powers CPU interpret, pretty output, and the Phase 1 coordinate path. Note `%` and
+    `//` already live here, so the `k%8` / `k//8` index math the shift-lookup needs is already available.
+  - `compiler/backend/cuda/render_target.py` — `type_name` `i32 → "int"` (today defaults to `"float"`, a latent bug);
+    **`convert()` gains `i32↔f16` and `i32↔f32`** (today only f16↔f32 exist — without this, `Assign.render`'s
+    f32-promote path at `leaves.py:441` silently no-ops the missing conversion); `has_native_op` returns True for the
+    native integer ops (`+ - * >> &`) so `leaves.py:415` takes the native-i32 path instead of f32-promote.
+  - **Dtype-preserving scalar-literal constants** — the unpack's immediates (shift `4`, mask `15`, offset `8`) flow as
+    scalar `ConstantOp`s, but `010_lower_kernelop.py:37` coerces every inlined scalar const via `float(t.value)` and
+    `Load.render` (`leaves.py:236-239`) / the literal-SSA substitution (`base.py:530`) stamp them `f32` — so `packed >>
+    4` would render `packed >> 4.0f` and fail to compile. Carry integer-typed scalar constants as **int** literals
+    (`int(t.value)` + `i32` ssa dtype) on all three paths.
+  - **Dtype-aware `Select`** — the lane assembly lowers to a `Select` (`030_lift_indexmap.py:43` emits one for a
+    multi-source `IndexMapOp`), but `Select.render` (`leaves.py:872`) hardcodes `float v = …` and `select_to_ternary`
+    (`base.py:240`) casts every branch to `float` — so the i32 lanes are forced to f32 *before* the `− zp` int
+    subtract. Add a result-dtype field on `Select` (like `Assign.dtype`) and render the declared type (`int` for i32),
+    the ternary casting branches to the result dtype, not unconditionally `float`. **Thread the new field through every
+    site that touches `Select`**, or fusion/simplify silently drops it: the type-stamp pass `030_stamp_types.py` (set it
+    so downstream `Write.value_dtype` is right) and the rewrite/simplify helpers that reconstruct
+    `Select(name=, branches=)` today (`ir/stmt/passes.py:161` and `:225`). Required by **both** Phase 0 (multi-source
+    IndexMap assembly) and Phase 1 (lane select).
+  - the `CastOp` `convert()` lowering (above) — the dequant's int→fp boundary must render here, not later.
+- **Loop CPU interpret dtype preservation** — bigger than the numpy arrays. `LoopOp.forward` (`ir/loop/ir.py:212`)
+  coerces every input to `np.float32`, **and** `render_loopop_cpp` (`ir/loop/runner.py:63-68`) emits `const float*`
+  inputs + a `float*` output — so even dtype-correct numpy gets reinterpreted as float by the generated C++. Two
+  acceptable resolutions, pick one explicitly: **(a)** make the runner signature + output dtype-aware (typed params per
+  `buf.dtype`, e.g. `const int*` for i32) and stop the `float32` coercion; or **(b)** — the cheaper default — **skip
+  `LoopOp.forward` CPU validation for mixed-int graphs** and validate the dequant cone with a numpy-only reference (the
+  deplodock CUDA path is still covered by the GPU accuracy check). Until (a) lands, the Phase 1 `LoopOp.forward()`
+  check is meaningless for the int unpack, so the plan assumes (b).
+- **Verify**: unit test `DequantLinearOp.forward` (numpy) + `DequantLinear.forward` (eager) against a **tiny synthetic
+  packed fixture** built in-test (network-free per `tests/ARCHITECTURE.md`: no GPU/Docker/network) — exact on the
+  integer unpack, fp16-eps on the scale multiply; an **optional, network-gated** parity test vs
+  `compressed_tensors.dequantize` (skip unless the package + a checked-in slice are present). Then (GPU-gated)
+  `deplodock run --layer 0` accuracy vs eager passes.
+
+### Phase 1 — Fusible unpack layout (refine the decomposition for Phase 3)
+The `DequantLinearOp` + its decomposition already exist (Phase 0); here the unpack is re-expressed so reading
+`unpacked[o,k]` *inside* the matmul K-loop needs no materialized `[out,in]` tensor — i.e. element `[o,k]` =
+`(packed[o, k//8] >> (4*(k%8))) & 0xF`. Two coordinate-dependent pieces, and how each is represented:
+- The **gather** `packed[o, k//8]` is a `Load` whose `Load.index` carries the `k//8` Expr — already supported (`%` and
+  `//` exist in `ir/expr.py`, `BinaryExpr` at `expr.py:274`).
+- The **index-dependent shift** `>> (4*(k%8))` is the real gap: `Assign.args` are SSA names, not Exprs, so the shift
+  amount can't be a coordinate expression on the op. **Chosen representation: Phase 0's 8 fixed-shift lanes + an 8-way
+  `Select`/`TernaryExpr` keyed on `k%8`** — all eight lanes `(packed[o,k//8] >> 4i) & 0xF` share the one `Load` of
+  `packed[o,k//8]` (the `k//8` is a `Load.index` Expr), and the select picks lane `k%8` (`Select`/ternary carry Exprs).
+  Every shift is a constant `4i`, so no `Assign` ever needs a coordinate-valued operand. **No bound tensor is needed** —
+  this matters because the obvious `[8]` shift-lookup constant has no storage path: `ConstantOp.value` is scalar-only
+  (`ir/base.py:127`) and synthetic small tensor-constants aren't materialized/bound, so a lookup tensor would require
+  new infra. (Alternatives, both heavier: add synthetic small-tensor-constant support for the shift lookup; or extend
+  `Assign` to admit expr-valued scalar operands.) This keeps the cone a strict pointwise producer of the matmul's B
+  Load (the Phase 3 precondition) rather than a materialize-then-read pair.
+- **Verify**: a **numpy-only reference** for the dequant cone matches Phase 0's `DequantLinearOp.forward` (Phase 0
+  option (b) — the float-only `LoopOp.forward` / `render_loopop_cpp` path can't carry i32, so it's skipped for the
+  mixed-int cone; if option (a) lands, use `LoopOp.forward` instead). End-to-end correctness rides the GPU accuracy
+  check.
+
+### Phase 2 — Group/zp granularity generalization
+- Group broadcast reuses the existing `gqa_broadcast` IndexMap pattern (`_helpers.py:147-157`): scale indexed by
+  `k // G` on the K/in axis. **zp is packed along OUT** → a *second, distinct* IndexMap (different axis-divide) — easy
+  to transpose-confuse, unit-test each independently. Don't hardcode G=32 (test G=128 and per-tensor/per-channel too).
+- (The int→fp16 cast op moved to Phase 0 — it's foundational, not a granularity concern.)
+
+### Phase 3 — Dequant→matmul fusion (the VRAM requirement: no full fp16 weight in gmem)
+The dequant producer chain is a strict-producer cone feeding the matmul's B Load — the same shape as
+`005_split_demoted`'s computed-B cone. The splicer (`ir/loop/splicer.py`, `passes/loop/fusion/010_merge_loop_ops.py`)
+fuses it into the matmul `LoopOp`, so gmem holds only packed int32 + scales + zp; the fp16 weight exists transiently
+per-tile.
+- Check the **stager** (`passes/lowering/tile/020_stage_inputs._classify`) admits the non-affine access (`packed[o,
+  k//8]` gather + index-dependent `(>> 4*(k%8)) & 0xF`, plus group-divide `k//G` scale). Confirm
+  `classify_matmul_operands` (`_atom.py:42-91`, structural/dtype-agnostic) still tags the cone as B.
+- **Fallback gate** `DEPLODOCK_W4A16_FUSE` (default off until this lands): if fusion bails, keep Phase 0's separate
+  dequant kernel — correct but no VRAM win — so a correctness build always exists.
+- **Verify**: `compile --ir loop|cuda` shows no `[out,in]` fp16 scratch slab; measure peak VRAM vs Phase 0.
+
+### Phase 4 — In-smem dequant via `StageBundle.compute` (scalar tier first)
+Stage packed int32 (+ scales + zp) into smem, then a hoisted **`StageBundle.compute`** phase
+(`ir/tile/ir.py:1315`, emitted by `030_hoist_invariant_compute`) unpacks/dequantizes cooperatively into an fp16 smem
+slab the matmul body Loads from. Reuses an existing phase slot — medium invasiveness, no new tier.
+- **Verify**: `compute-sanitizer` clean; accuracy vs eager; smem within `ctx.max_dynamic_smem`.
+
+### Phase 5 — MMA tier (the real W4A16 win)
+**Preferred first cut:** dequant lands in the smem slab (Phase 4) and standard `ldmatrix` reads fp16 — this already
+satisfies the goal (gmem holds only packed int4) with **medium** invasiveness and no fragment-loader rewrite.
+- Files: `passes/lowering/kernel/005_lower_atom_tile.py:82-223` (MMA fragment emission),
+  `ir/kernel/render.py:134-220` (`dpl_ldmatrix_*` / `dpl_mma_load_b_*` templates), `ir/kernel/ir.py`.
+- True register-resident dequant (skip the fp16 smem slab, assemble `__half2` fragments from nibbles in the PTX
+  m16n8k16 lane layout) is the final optimization — **high** invasiveness, not required for the VRAM goal.
+- Note: `RegEpilogue` (`ir/kernel/ir.py:358`) is POST-accumulate → NOT usable for pre-mma weight dequant.
+
+### Phase 6 — Tuning / goldens / accuracy gate
+- `tune <model>` reaches the same `load_or_trace`/`_trace_model` path (and `_bench_worker` rebuilds via `load_or_trace`
+  in-child), so it works once Phase 0 wiring lands; dequant kernels are new op identities → tuned like any kernel.
+- `S_*` structural features (`992_stamp_structural_features`: stmt/op histogram + dtypes) make a W4A16 matmul key
+  distinctly from its fp16 twin in `ShapeKey`/the prior automatically — no schema change. Optionally add a dedicated
+  `.w4a16` `GOLDEN_CONFIGS` shape via the `tune-golden` flow for a tuned prior reference.
+- Accuracy: eager == the substituted `DequantLinear`, which is the deployed reference (deplodock-kernel ↔
+  DequantLinear eager), and is **optionally cross-checked** against `compressed_tensors.dequantize` in the gated parity
+  test — so the default accuracy gate stays network/package-free. int4 round-trip is exact on the integer side (error is
+  only fp16 scale rounding) → keep a tight (~fp16-eps) tolerance, not a loose int one (`commands/run.py::_check_accuracy`).
+
+### Phase 7 — Tests (per `tests/ARCHITECTURE.md`: no GPU / Docker / network by default)
+- Unit (no GPU, no network): `right_shift`/`bitwise_and` numpy forward; `dequant_decompose` vs a numpy reference over a
+  **tiny synthetic packed fixture built in-test** (the numerics oracle). An **optional, network-gated** test asserts
+  parity vs `compressed_tensors.dequantize` (skipped unless the package + a checked-in slice are present).
+- Unit (codegen): i32 local renders as `int`, `>>`/`&` emit verbatim, the `CastOp` emits `__int2half_rn`, no spurious
+  `__half2float`.
+- e2e (GPU-gated, `cuda` xdist group): one quantized linear via `compile --code` toy `DequantLinear` (self-contained,
+  no download). A `run --layer 0` on the real HF model is a **separate GPU+network-gated** check, not part of the
+  default suite; peak-VRAM assertion once Phase 3+ lands.
+
+## Critical files
+- **new** `deplodock/compiler/trace/quantized.py` — config parse + `DequantLinear` (the `deplodock::dequant_linear`
+  `torch.library.custom_op` + `register_fake`) + pre-trace substitution (model on `trace/huggingface.py:53-123`)
+- `deplodock/compiler/trace/torch.py` — extend `_op_name` (`:398`, aten-only → recognize `deplodock::dequant_linear`
+  before the `:467` first-input-alias fallback); map it to `DequantLinearOp` (beside `linear`/`mm`/`addmm` at
+  `:526-548`); **custom-op arg branch** that peels tensor inputs from the scalar `QuantScheme` and reads `kwargs`
+  (`_resolve_inputs:325` walks only `args` and turns scalars into `ConstantOp`s) — scheme scalars become op metadata,
+  not graph inputs
+- `deplodock/compiler/ir/tensor/ir.py` `IndexMapOp` (multi-source assembly of the 8 lanes — `passes/.../150_cat.py`
+  lowers only 2-tensor `CatOp`, so use a multi-source `IndexMapOp`, not an 8-way cat) and `ir/stmt/leaves.py` `Select` /
+  `ir/expr.py` `TernaryExpr` (the `k%8` lane select — no bound lookup tensor, since `ConstantOp.value` is scalar-only)
+- **Dtype-aware `Select`** — add a result-dtype field and thread it everywhere: `ir/stmt/leaves.py:872`
+  (`Select.render` hardcodes `float`), `ir/stmt/base.py:240` (`select_to_ternary` casts branches to `float`),
+  `passes/loop/lifting/030_lift_indexmap.py:43` (emit the dtype), `030_stamp_types.py` (so `Write.value_dtype` is
+  right), and the `Select` reconstructions in `ir/stmt/passes.py:161` + `:225` (else simplify/fusion drops the field)
+- `deplodock/compiler/ir/stmt/base.py` (`_BINARY_OP`/`op_to_expr` + `dtype_promote` integer rule) and
+  `deplodock/compiler/ir/expr.py` (`BinaryExpr` `>>`/`&`: eval/render/precedence) and
+  `deplodock/compiler/backend/cuda/render_target.py` — `type_name` i32→`int`, **`convert()` i32↔f16/f32**,
+  `has_native_op` integer ops (NOT just `_TYPE_NAME`); + the int→fp16 cast (`__int2half_rn`)
+- `deplodock/compiler/ir/elementwise.py` — `right_shift`/`bitwise_and` in `_NAME_TO_FN`
+- **Integer scalar-literal lowering** — `passes/lowering/cuda/010_lower_kernelop.py:37` (`float(t.value)`),
+  `ir/stmt/leaves.py:236-239` (`Load.render` scalar-const path), `ir/stmt/base.py:~530` (literal-SSA substitution):
+  carry int-typed scalar consts as int literals, not `f32`
+- **`CastOp`** — define in `ir/tensor/ir.py` (post-decomposition primitive); **lifting** rule
+  (`passes/loop/lifting/010_lift_elementwise.py:45` emits `Assign(..., )` with no `dtype=` → stamp
+  `dtype=root.output.dtype` or a dedicated rule); **explicit copy/cast render path** in `ir/stmt/leaves.py`
+  (`Assign.render`'s native path needs all-args-at-result `:414`, which a cast fails → add a direct
+  `target.convert(arg, src, result)` branch, not the f32-promote detour)
+- **Loop CPU-interpret dtype** — `ir/loop/ir.py:212` (`np.float32` coercion) + `render_loopop_cpp`
+  (`ir/loop/runner.py:63-68`, emits `const float*`/`float*`): either make signature+output dtype-aware (option a) or
+  skip `LoopOp.forward` for mixed-int cones + use a numpy reference (option b, default)
+- `deplodock/compiler/loader/binder.py` and `deplodock/commands/run.py` (`_bind_inputs`) — bind at declared dtype, not
+  blanket fp32 (and `serving/runner.py:119-128` when serve is later in scope)
+- `deplodock/compiler/ir/frontend/ir.py` (`DequantLinearOp` + `has_bias`) (+ `passes/frontend/decomposition/
+  045_dequant_linear.py`, `decomposition/_helpers.py`) — `dequant_decompose`, weight + zp unpacks, transpose, bias add,
+  group/zp broadcasts (emits the tensor-IR `CastOp` above)
+- `deplodock/compiler/pipeline/passes/lowering/tile/020_stage_inputs.py` (+ `030_hoist_invariant_compute`,
+  `ir/tile/ir.py` `StageBundle.compute`), `deplodock/compiler/ir/kernel/render.py`,
+  `passes/lowering/kernel/005_lower_atom_tile.py` — in-smem/register dequant
+- `deplodock/commands/compile.py::_trace_model` — substitution entry point
+- docs to update on completion: `compiler/ARCHITECTURE.md`, `compiler/backend/cuda/ARCHITECTURE.md`, `CLAUDE.md`
+
+## Biggest technical risk
+**The interleaved `i::8` unpack as fusible in-kernel IR.** Numerics (Phase 0/1) are mechanical, but the VRAM goal
+demands the unpack's non-affine index math (`packed[o, k//8]` gather + index-dependent `(>> 4*(k%8)) & 0xF`, group
+`k//G` scale, OUT-axis-packed zp) survive fusion/staging without `020_stage_inputs._classify` bailing to a separate
+kernel. This is the first index shape mixing a layout gather with an index-dependent compute inside a staged slab. If
+the stager can't represent it, you fall back to Phase 0's materialized weight — correct, but forfeits the VRAM win.
+De-risk early by prototyping the `StageBundle.compute` dequant (Phase 4) on a tiny shape before the MMA tier.
+
+## Extensibility to other quantization formats
+
+The design isolates all format-specific logic in **two narrow seams**; everything below them is format-agnostic, so a
+new format reuses the whole pipeline:
+
+1. **Config parser + `DequantLinear.forward`** (`compiler/trace/quantized.py`) — *how to unpack + dequant in torch ops*.
+2. **The `045_dequant_linear` decomposition rule** — *how `DequantLinearOp` lowers to unpack → dequant → matmul*.
+
+The bitwise/integer IR ops, `dtype_promote`, the dequant→matmul fusion (Phase 3), the in-smem/register dequant
+(Phases 4–5), and tuning (Phase 6) never know it's AWQ. **Design choice that locks this in:** build `DequantLinear` /
+`DequantLinearOp` around a small **`QuantScheme` descriptor** (`num_bits`, `pack_layout` enum, `group_size`,
+`symmetric`, `scale_dtype`, `zp_packing`) and keep the dequant arithmetic *data-driven by that descriptor* — never bake
+AWQ-specific constants into the IR ops or kernel codegen. The `i::8` interleave is already expressed as an IndexMap
+coordinate function, so a different packing is just a different coordinate function feeding the same pipeline.
+
+| Tier | Formats | What changes | Effort |
+| --- | --- | --- | --- |
+| **Easy** (parametric) | other bit widths (INT8/3/2); symmetric (no zp); per-tensor / per-channel / per-group scale | `num_bits`, drop the zp node, or the scale-broadcast IndexMap divisor (`k//G` / `k//in` / const) | trivial |
+| **Easy–medium** | GPTQ / autoawq packing | new config parse + a new unpack-layout IndexMap; unpack ops + dequant chain + fusion + kernel dequant all reused | small–medium |
+| **Moderate** (different dequant *shape*, same fusion) | bitsandbytes NF4/FP4 (non-uniform → 16-entry **codebook lookup**, needs a gather-from-constant-table op); FP8 weight-only e4m3 (*simpler* — cast + scale, no bit unpack) | a new dequant primitive, but still rides the dequant-producer → matmul fusion | medium |
+| **Hard** (out of scope — separate project) | activation quantization: W8A8, FP8 W8A8 | runtime activation-quant kernel (per-token scale from input) + **integer/fp8 MMA tier** (int8→int32 dp4a/mma, or Hopper/Ada fp8 mma) + accumulator dequant — NOT the "dequant a constant operand" pattern | new kernel tiers |
+
+This W4A16 plan keeps the matmul fp16-accumulate and only dequantizes the *weight* operand. Anything that quantizes
+**activations** needs new accumulate tiers and is explicitly not covered here.
+
+## End-to-end verification
+1. `pytest tests/compiler/.../test_dequant*.py` — unit numerics over a synthetic in-test fixture, no GPU/network
+   (the `compressed_tensors` parity assertion is an optional, package-gated test).
+2. *(GPU + network gated, manual)* `deplodock run cyankiwi/Llama-3.1-8B-Instruct-AWQ-INT4 --layer 0` — accuracy vs
+   eager passes (Phase 0+).
+3. *(GPU + network gated, manual)* `deplodock run ... --layer 0 --bench` — kernel runs; peak VRAM shows only packed
+   weights resident (Phase 3+).
+4. *(GPU + network gated, manual)* `deplodock tune ... --layer 0` then `eval golden` — tuning reaches the dequant
+   kernels.
+5. `make test && make lint`.

--- a/plans/w4a16-quantization-support.md
+++ b/plans/w4a16-quantization-support.md
@@ -228,6 +228,14 @@ The `DequantLinearOp` + its decomposition already exist (Phase 0); here the unpa
   `k // G` on the K/in axis. **zp is packed along OUT** → a *second, distinct* IndexMap (different axis-divide) — easy
   to transpose-confuse, unit-test each independently. Don't hardcode G=32 (test G=128 and per-tensor/per-channel too).
 - (The int→fp16 cast op moved to Phase 0 — it's foundational, not a granularity concern.)
+- **Verified (per-group works; per-channel is a fusion gap).** `group_size` is read from the `QuantScheme` (never
+  hardcoded). Per-group GPU e2e PASSES at **G=32 and G=128** (sym + asym) and the numerics oracle covers per-tensor
+  group too. The remaining gap is the **single-group** case (`group_size >= in_features`, i.e. per-channel /
+  per-tensor-along-K, which no compressed-tensors AWQ model uses — they're all per-group): `k // G` folds to `0`, the
+  broadcast collapses, and the resulting access trips a splicer def-use scope check when it merges with the multi-lane
+  unpack (`Assign … arg not defined`). `dequant_decompose` now raises a **clear `NotImplementedError`** for that case
+  instead of the cryptic IR error (`tests/compiler/test_dequant.py::test_per_channel_single_group_raises_clear_error`);
+  fixing the splicer to support it is the open Phase-2 follow-up.
 
 ### Phase 3 — Dequant→matmul fusion (the VRAM requirement: no full fp16 weight in gmem)
 The dequant producer chain is a strict-producer cone feeding the matmul's B Load — the same shape as
@@ -240,6 +248,16 @@ per-tile.
 - **Fallback gate** `DEPLODOCK_W4A16_FUSE` (default off until this lands): if fusion bails, keep Phase 0's separate
   dequant kernel — correct but no VRAM win — so a correctness build always exists.
 - **Verify**: `compile --ir loop|cuda` shows no `[out,in]` fp16 scratch slab; measure peak VRAM vs Phase 0.
+
+> **Status: achieved by default fusion — no gate needed.** The default pipeline already fuses the dequant producer cone
+> into the matmul kernel. Verified at a realistic 4096×4096 (q_proj-sized) linear: **no materialized `[out,in]` fp16
+> weight buffer exists** (the `nibble`/`diff`/`cast`/`w` intermediates never hit gmem); the only weight buffer is the
+> packed int32 `[out, in/8]`. Measured deplodock gmem footprint **9.96 MB vs 33.82 MB** for a same-shape dense fp16
+> linear (**3.39× total reduction; 4.0× on the weight itself**); rel_err 0.00045 vs eager. So the `DEPLODOCK_W4A16_FUSE`
+> fallback gate was unnecessary for Phase 0. `tests/compiler/test_dequant.py::test_dequant_fuses_no_materialized_weight_vram`
+> guards this. (One staging fix was needed: `right_shift`/`bitwise_and` force an i32 result in `dtype_promote` so the
+> unpack stays integer when a staged-smem Load's dtype is unresolved at stamp time.) What's left here is **performance**,
+> not VRAM — the current matmul is the scalar path, not tensor-core (Phases 4–5).
 
 ### Phase 4 — In-smem dequant via `StageBundle.compute` (scalar tier first)
 Stage packed int32 (+ scales + zp) into smem, then a hoisted **`StageBundle.compute`** phase

--- a/tests/compiler/test_dequant.py
+++ b/tests/compiler/test_dequant.py
@@ -1,0 +1,323 @@
+"""W4A16 (AWQ-INT4) weight-only quantization — numerics, codegen, and e2e.
+
+Default suite is network- / GPU-free: the numerics oracle is checked against a
+tiny synthetic packed fixture built in-test, and the integer/cast codegen is
+asserted by rendering the leaf stmts directly. The ``compressed_tensors`` parity
+assertion is an optional, package-gated test. The end-to-end run (toy
+``DequantLinear`` compiled + executed vs eager) is CUDA-gated.
+
+See ``plans/w4a16-quantization-support.md``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from deplodock.compiler.ir.frontend.ir import (
+    DequantLinearOp,
+    QuantScheme,
+    dequant_weight_numpy,
+)
+
+from .conftest import requires_cuda
+
+# ---------------------------------------------------------------------------
+# Synthetic packed fixture — the numerics oracle (no network, no GPU).
+# ---------------------------------------------------------------------------
+
+
+def _pack_along(values: np.ndarray, axis: int, per: int, num_bits: int) -> np.ndarray:
+    """Pack ``per`` unsigned ``num_bits`` nibbles per int32 along ``axis``
+    (the interleaved ``i::per`` layout): out[..., j, ...] holds element
+    ``j``'s nibble at bit ``num_bits*(j % per)`` of lane ``j // per``."""
+    n = values.shape[axis]
+    packed_shape = list(values.shape)
+    packed_shape[axis] = n // per
+    out = np.zeros(packed_shape, dtype=np.int64)
+    for j in range(n):
+        src = np.take(values, j, axis=axis)
+        dst_idx = [slice(None)] * values.ndim
+        dst_idx[axis] = j // per
+        out[tuple(dst_idx)] |= src.astype(np.int64) << (num_bits * (j % per))
+    return out.astype(np.int32)
+
+
+def make_fixture(out_f=32, in_f=128, group=32, num_bits=4, symmetric=False, seed=0):
+    """Build a synthetic packed W4A16 linear + its expected fp16 weight."""
+    rng = np.random.RandomState(seed)
+    per = 32 // num_bits
+    groups = in_f // group
+    lo, hi = 0, 1 << num_bits
+
+    nib = rng.randint(lo, hi, size=(out_f, in_f)).astype(np.int64)
+    scale = (rng.rand(out_f, groups).astype(np.float32) * 0.05 + 0.01).astype(np.float16)
+    weight_packed = _pack_along(nib, axis=1, per=per, num_bits=num_bits)
+
+    if symmetric:
+        weight_zero_point = None
+        offset = 1 << (num_bits - 1)
+        deq_int = nib - offset
+    else:
+        zp = rng.randint(lo, hi, size=(out_f, groups)).astype(np.int64)
+        weight_zero_point = _pack_along(zp, axis=0, per=per, num_bits=num_bits)
+        deq_int = nib - np.repeat(zp, group, axis=1)
+
+    expected = (deq_int.astype(np.float32) * np.repeat(scale.astype(np.float32), group, axis=1)).astype(np.float16)
+    scheme = QuantScheme(num_bits=num_bits, group_size=group, packed_dim=1, symmetric=symmetric)
+    return dict(weight_packed=weight_packed, weight_scale=scale, weight_zero_point=weight_zero_point, scheme=scheme, expected=expected)
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("symmetric", [False, True])
+@pytest.mark.parametrize("group", [32, 128])
+def test_dequant_weight_numpy_oracle(symmetric, group):
+    fx = make_fixture(out_f=32, in_f=256, group=group, symmetric=symmetric, seed=1)
+    got = dequant_weight_numpy(fx["weight_packed"], fx["weight_scale"], fx["weight_zero_point"], fx["scheme"])
+    assert got.dtype == np.float16
+    assert got.shape == fx["expected"].shape
+    # Integer-exact unpack; the only error is fp16 scale rounding (already in
+    # ``expected``), so this must match bit-for-bit.
+    np.testing.assert_array_equal(got, fx["expected"])
+
+
+def test_dequant_weight_per_tensor_group():
+    """Per-tensor scale (group == in_features → one group)."""
+    fx = make_fixture(out_f=16, in_f=64, group=64, symmetric=False, seed=2)
+    got = dequant_weight_numpy(fx["weight_packed"], fx["weight_scale"], fx["weight_zero_point"], fx["scheme"])
+    np.testing.assert_array_equal(got, fx["expected"])
+
+
+def test_dequant_linear_op_forward_matches_dense_matmul():
+    fx = make_fixture(out_f=24, in_f=96, group=32, symmetric=False, seed=3)
+    x = (np.random.RandomState(4).randn(1, 5, 96) * 0.1).astype(np.float16)
+    op = DequantLinearOp(has_bias=False, num_bits=4, group_size=32, packed_dim=1, symmetric=False)
+    got = op.forward(x, fx["weight_packed"], fx["weight_scale"], fx["weight_zero_point"])
+    ref = x.astype(np.float32) @ fx["expected"].astype(np.float32).T
+    np.testing.assert_allclose(got.astype(np.float32), ref, rtol=2e-3, atol=2e-3)
+    assert op.infer_output_shape([x.shape, fx["weight_packed"].shape]) == (1, 5, 24)
+
+
+def test_torch_twin_matches_numpy_oracle():
+    torch = pytest.importorskip("torch")
+    from deplodock.compiler.trace.quantized import _dequant_weight_torch
+
+    fx = make_fixture(out_f=32, in_f=128, group=32, symmetric=False, seed=5)
+    got = dequant_weight_numpy(fx["weight_packed"], fx["weight_scale"], fx["weight_zero_point"], fx["scheme"])
+    twin = _dequant_weight_torch(
+        torch.from_numpy(fx["weight_packed"]),
+        torch.from_numpy(fx["weight_scale"]),
+        torch.from_numpy(fx["weight_zero_point"]),
+        num_bits=4,
+        group_size=32,
+        symmetric=False,
+    )
+    np.testing.assert_array_equal(twin.numpy(), got)
+
+
+def test_compressed_tensors_parity():
+    """Optional, package-gated cross-check against the upstream dequant."""
+    ct = pytest.importorskip("compressed_tensors")
+    torch = pytest.importorskip("torch")
+    try:
+        from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+        from compressed_tensors.quantization.lifecycle.forward import dequantize
+    except Exception:  # noqa: BLE001 — package layout varies across versions
+        pytest.skip(f"compressed_tensors {ct.__version__} dequantize API not found")
+
+    fx = make_fixture(out_f=32, in_f=128, group=32, symmetric=False, seed=6)
+    # Reconstruct the unpacked (signed) weight + zp the way compressed_tensors
+    # expects: it dequantizes from already-unpacked int tensors.
+    per = 8
+    nib = np.empty((32, 128), dtype=np.int64)
+    wp = fx["weight_packed"].astype(np.int64)
+    for i in range(per):
+        nib[:, i::per] = (wp >> (4 * i)) & 0xF
+    zp_unpacked = np.empty((32, 4), dtype=np.int64)
+    zpp = fx["weight_zero_point"].astype(np.int64)
+    for i in range(per):
+        zp_unpacked[i::per, :] = (zpp >> (4 * i)) & 0xF
+
+    args = QuantizationArgs(num_bits=4, group_size=32, symmetric=False, strategy=QuantizationStrategy.GROUP)
+    ref = dequantize(
+        x_q=torch.from_numpy(nib).to(torch.int8),
+        scale=torch.from_numpy(fx["weight_scale"]),
+        zero_point=torch.from_numpy(zp_unpacked).to(torch.int8),
+        args=args,
+    )
+    got = dequant_weight_numpy(fx["weight_packed"], fx["weight_scale"], fx["weight_zero_point"], fx["scheme"])
+    np.testing.assert_allclose(got.astype(np.float32), ref.numpy().astype(np.float32), rtol=2e-3, atol=2e-3)
+
+
+# ---------------------------------------------------------------------------
+# Codegen — integer unpack + int→fp16 cast render (no GPU).
+# ---------------------------------------------------------------------------
+
+
+def _render(stmt, ssa_dtypes=None, literal_ssa=None):
+    from deplodock.compiler.ir.stmt.base import RenderCtx
+
+    ctx = RenderCtx()
+    ctx.ssa_dtypes.update(ssa_dtypes or {})
+    # Mirror ``render_body``'s pre-pass: an inlined int constant is stamped
+    # i32 at its use site (so a downstream shift takes the native-int path).
+    for n, v in (literal_ssa or {}).items():
+        ctx.literal_ssa[n] = v
+        ctx.ssa_dtypes[n] = "i32" if isinstance(v, int) and not isinstance(v, bool) else "f32"
+    return "\n".join(stmt.render(ctx))
+
+
+def test_int_shift_and_mask_render_as_int():
+    from deplodock.compiler.dtype import I32
+    from deplodock.compiler.ir.stmt.leaves import Assign
+
+    shift = _render(
+        Assign(name="lane", op="right_shift", args=("packed", "c"), dtype=I32), ssa_dtypes={"packed": "i32"}, literal_ssa={"c": 4}
+    )
+    assert "int lane = packed >> 4;" in shift
+    assert ".0f" not in shift  # never a float shift amount
+
+    mask = _render(Assign(name="nib", op="bitwise_and", args=("lane", "m"), dtype=I32), ssa_dtypes={"lane": "i32"}, literal_ssa={"m": 15})
+    assert "int nib = lane & 15;" in mask
+
+
+def test_cast_renders_int2half_directly():
+    from deplodock.compiler.dtype import F16
+    from deplodock.compiler.ir.stmt.leaves import Assign
+
+    out = _render(Assign(name="v", op="copy", args=("in0",), dtype=F16), ssa_dtypes={"in0": "i32"})
+    assert "__half v = __int2half_rn(in0);" in out
+    # Direct conversion — NOT the f32-promote detour.
+    assert "__half2float" not in out
+    assert "__float2half(__int2float_rn" not in out
+
+
+def test_i32_select_renders_int():
+    from deplodock.compiler.dtype import I32
+    from deplodock.compiler.ir.expr import Literal, Var
+    from deplodock.compiler.ir.stmt.leaves import Select, SelectBranch
+
+    sel = Select(
+        name="nib",
+        branches=(SelectBranch("l0", Var("a0").lt(Literal(1, "int"))), SelectBranch("l1", Literal(1, "int"))),
+        dtype=I32,
+    )
+    out = _render(sel, ssa_dtypes={"l0": "i32", "l1": "i32"})
+    assert out.strip().startswith("int nib =")
+    assert "(int)" in out and "float" not in out
+
+
+def test_render_target_int_conversions():
+    from deplodock.compiler.backend.cuda.render_target import CudaRenderTarget
+
+    t = CudaRenderTarget()
+    assert t.type_name("i32") == "int"
+    assert t.convert("x", "i32", "f16") == "__int2half_rn(x)"
+    assert t.convert("x", "i32", "f32") == "__int2float_rn(x)"
+    assert t.has_native_op("right_shift", "i32")
+    assert t.has_native_op("subtract", "i32")
+
+
+# ---------------------------------------------------------------------------
+# Substitution walker (no GPU).
+# ---------------------------------------------------------------------------
+
+
+def test_substitution_replaces_targets_and_skips_ignore():
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn
+
+    from deplodock.compiler.trace.quantized import apply_quant_substitution
+
+    fx = make_fixture(out_f=16, in_f=64, group=32, symmetric=False, seed=7)
+
+    def _quant_linear():
+        m = nn.Module()
+        m.register_buffer("weight_packed", torch.from_numpy(fx["weight_packed"]))
+        m.register_buffer("weight_scale", torch.from_numpy(fx["weight_scale"]))
+        m.register_buffer("weight_zero_point", torch.from_numpy(fx["weight_zero_point"]))
+        m.bias = None
+        return m
+
+    model = nn.Module()
+    model.config = type("Cfg", (), {})()
+    model.config.quantization_config = {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "config_groups": {"group_0": {"targets": ["Linear"], "weights": {"num_bits": 4, "group_size": 32, "symmetric": False}}},
+        "ignore": ["lm_head"],
+    }
+    model.proj = _quant_linear()
+    model.lm_head = _quant_linear()
+
+    n = apply_quant_substitution(model)
+    assert n == 1  # proj substituted, lm_head ignored
+    assert type(model.proj).__name__ == "DequantLinear"
+    assert type(model.lm_head).__name__ != "DequantLinear"
+
+
+def test_substitution_noop_for_unquantized_model():
+    pytest.importorskip("torch")
+    import torch.nn as nn
+
+    from deplodock.compiler.trace.quantized import apply_quant_substitution
+
+    model = nn.Module()
+    model.config = type("Cfg", (), {})()
+    model.lin = nn.Linear(8, 8)
+    assert apply_quant_substitution(model) == 0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (CUDA-gated): trace → compile → run vs eager.
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+@pytest.mark.parametrize("symmetric", [False, True])
+def test_dequant_linear_e2e_cuda(symmetric):
+    import torch
+    import torch.nn as nn
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.loader.binder import bind_constants, declared_const_dtypes, source_array_at_dtype
+    from deplodock.compiler.trace.quantized import _build_dequant_linear
+    from deplodock.compiler.trace.torch import trace_module_with_constants
+
+    fx = make_fixture(out_f=32, in_f=128, group=32, symmetric=symmetric, seed=8)
+    holder = nn.Module()
+    holder.register_buffer("weight_packed", torch.from_numpy(fx["weight_packed"]))
+    holder.register_buffer("weight_scale", torch.from_numpy(fx["weight_scale"]))
+    zp = fx["weight_zero_point"]
+    holder.register_buffer("weight_zero_point", torch.from_numpy(zp if zp is not None else fx["weight_packed"][:4]))
+    holder.bias = None
+    mod = _build_dequant_linear(holder, fx["scheme"])
+
+    x = torch.randn(1, 8, 128, dtype=torch.float16)
+    ref = mod(x).detach().numpy().astype(np.float32)
+
+    graph, _ = trace_module_with_constants(mod, (x,))
+    compiled = CudaBackend().compile(graph)
+
+    # The compiled kernel must dequantize in integer math — no float-shift bug.
+    sources_cu = "\n".join(getattr(n.op, "kernel_source", "") or "" for n in compiled.nodes.values())
+    assert ">> " in sources_cu and "& 15" in sources_cu
+    import re
+
+    assert not re.search(r">> [0-9]+\.[0-9]+f", sources_cu)
+
+    in_id = list(compiled.inputs)[0]
+    input_data = {in_id: x.detach().cpu().numpy().astype(compiled.nodes[in_id].output.dtype.np, copy=False)}
+    declared = declared_const_dtypes(compiled)
+    src = {p: source_array_at_dtype(t, declared.get(p)) for p, t in mod.named_buffers(remove_duplicate=False) if t is not None}
+    input_data.update(bind_constants(compiled, src))
+
+    out = list(CudaBackend().run(compiled, input_data=input_data)[0].outputs.values())[-1]
+    out = np.asarray(out).reshape(ref.shape).astype(np.float32)
+    # fp16-eps tolerance — the int round-trip is exact, error is only fp16
+    # accumulation (the same bound a plain fp16 linear gets).
+    np.testing.assert_allclose(out, ref, rtol=6e-3, atol=6e-3)

--- a/tests/compiler/test_dequant.py
+++ b/tests/compiler/test_dequant.py
@@ -277,38 +277,30 @@ def test_substitution_noop_for_unquantized_model():
 # ---------------------------------------------------------------------------
 
 
-@requires_cuda
-@pytest.mark.parametrize("symmetric", [False, True])
-def test_dequant_linear_e2e_cuda(symmetric):
+def _build_quant_module(fx, out_f):
     import torch
     import torch.nn as nn
 
-    from deplodock.compiler.backend.cuda.backend import CudaBackend
-    from deplodock.compiler.loader.binder import bind_constants, declared_const_dtypes, source_array_at_dtype
     from deplodock.compiler.trace.quantized import _build_dequant_linear
-    from deplodock.compiler.trace.torch import trace_module_with_constants
 
-    fx = make_fixture(out_f=32, in_f=128, group=32, symmetric=symmetric, seed=8)
     holder = nn.Module()
     holder.register_buffer("weight_packed", torch.from_numpy(fx["weight_packed"]))
     holder.register_buffer("weight_scale", torch.from_numpy(fx["weight_scale"]))
     zp = fx["weight_zero_point"]
-    holder.register_buffer("weight_zero_point", torch.from_numpy(zp if zp is not None else fx["weight_packed"][:4]))
+    holder.register_buffer("weight_zero_point", torch.from_numpy(zp if zp is not None else fx["weight_packed"][: max(out_f // 8, 1)]))
     holder.bias = None
-    mod = _build_dequant_linear(holder, fx["scheme"])
+    return _build_dequant_linear(holder, fx["scheme"])
 
-    x = torch.randn(1, 8, 128, dtype=torch.float16)
+
+def _compile_and_run(mod, x):
+    """Trace → compile → bind → run a DequantLinear; return (compiled, out, ref)."""
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.loader.binder import bind_constants, declared_const_dtypes, source_array_at_dtype
+    from deplodock.compiler.trace.torch import trace_module_with_constants
+
     ref = mod(x).detach().numpy().astype(np.float32)
-
     graph, _ = trace_module_with_constants(mod, (x,))
     compiled = CudaBackend().compile(graph)
-
-    # The compiled kernel must dequantize in integer math — no float-shift bug.
-    sources_cu = "\n".join(getattr(n.op, "kernel_source", "") or "" for n in compiled.nodes.values())
-    assert ">> " in sources_cu and "& 15" in sources_cu
-    import re
-
-    assert not re.search(r">> [0-9]+\.[0-9]+f", sources_cu)
 
     in_id = list(compiled.inputs)[0]
     input_data = {in_id: x.detach().cpu().numpy().astype(compiled.nodes[in_id].output.dtype.np, copy=False)}
@@ -317,7 +309,90 @@ def test_dequant_linear_e2e_cuda(symmetric):
     input_data.update(bind_constants(compiled, src))
 
     out = list(CudaBackend().run(compiled, input_data=input_data)[0].outputs.values())[-1]
-    out = np.asarray(out).reshape(ref.shape).astype(np.float32)
+    return compiled, np.asarray(out).reshape(ref.shape).astype(np.float32), ref
+
+
+@requires_cuda
+@pytest.mark.parametrize("symmetric", [False, True])
+@pytest.mark.parametrize("group", [32, 128])  # per-group — the granularities real AWQ models use
+def test_dequant_linear_e2e_cuda(group, symmetric):
+    import torch
+
+    fx = make_fixture(out_f=64, in_f=256, group=group, symmetric=symmetric, seed=8)
+    mod = _build_quant_module(fx, out_f=64)
+    x = torch.randn(1, 8, 256, dtype=torch.float16)
+    compiled, out, ref = _compile_and_run(mod, x)
+
+    # The compiled kernel dequantizes in integer math — no float-shift bug.
+    import re
+
+    sources_cu = "\n".join(getattr(n.op, "kernel_source", "") or "" for n in compiled.nodes.values())
+    assert ">> " in sources_cu and "& 15" in sources_cu
+    assert not re.search(r">> [0-9]+\.[0-9]+f", sources_cu)
+
     # fp16-eps tolerance — the int round-trip is exact, error is only fp16
     # accumulation (the same bound a plain fp16 linear gets).
     np.testing.assert_allclose(out, ref, rtol=6e-3, atol=6e-3)
+
+
+def _gmem_buffers(compiled):
+    """``{node_id: (bytes, shape, dtype_name)}`` over a compiled graph's buffers."""
+    out = {}
+    for nid, node in compiled.nodes.items():
+        t = node.output
+        n = 1
+        for d in t.shape:
+            n *= d.as_static() if hasattr(d, "as_static") else int(d)
+        shape = tuple(d.as_static() if hasattr(d, "as_static") else int(d) for d in t.shape)
+        out[nid] = (n * t.dtype.nbytes, shape, t.dtype.name)
+    return out
+
+
+@requires_cuda
+def test_dequant_fuses_no_materialized_weight_vram():
+    """Phase 3: the dequant cone fuses into the matmul — gmem holds only packed
+    int32 + scale + zp, never a materialized [out, in] fp16 weight slab."""
+    import torch
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.trace.torch import trace_module_with_constants
+
+    out_f, in_f = 512, 512
+    fx = make_fixture(out_f=out_f, in_f=in_f, group=32, symmetric=False, seed=9)
+    qmod = _build_quant_module(fx, out_f=out_f)
+    x = torch.randn(1, 16, in_f, dtype=torch.float16)
+    qcompiled, qout, qref = _compile_and_run(qmod, x)
+    np.testing.assert_allclose(qout, qref, rtol=6e-3, atol=6e-3)
+
+    bufs = _gmem_buffers(qcompiled)
+    # No materialized dense fp16 weight (the unpack intermediates never hit gmem).
+    dense_shape = tuple(sorted((out_f, in_f)))
+    materialized = [(nid, shape) for nid, (_, shape, dt) in bufs.items() if dt == "f16" and tuple(sorted(shape)) == dense_shape]
+    assert materialized == [], f"unexpected materialized fp16 weight buffer(s): {materialized}"
+    # The largest buffer is the packed int32 weight, 4x smaller than dense fp16.
+    biggest = max(bufs.values())
+    assert biggest[2] == "i32" and biggest[1] == (out_f, in_f // 8)
+
+    # Total deplodock gmem footprint is far below a same-shape dense fp16 linear.
+    import torch.nn as nn
+
+    dcompiled = CudaBackend().compile(trace_module_with_constants(nn.Linear(in_f, out_f, bias=False).half(), (x,))[0])
+    q_bytes = sum(b for b, _, _ in bufs.values())
+    d_bytes = sum(b for b, _, _ in _gmem_buffers(dcompiled).values())
+    assert q_bytes < d_bytes / 2.5, f"expected >2.5x gmem reduction, got {d_bytes / q_bytes:.2f}x ({q_bytes} vs {d_bytes})"
+
+
+def test_per_channel_single_group_raises_clear_error():
+    """Single-group quant (per-channel / per-tensor-along-K) is a documented
+    Phase-2 gap; it must fail with a clear message, not a cryptic IR error."""
+    pytest.importorskip("torch")
+    import torch
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.trace.torch import trace_module_with_constants
+
+    fx = make_fixture(out_f=16, in_f=32, group=32, symmetric=False, seed=3)  # group == in_features → 1 group
+    mod = _build_quant_module(fx, out_f=16)
+    graph, _ = trace_module_with_constants(mod, (torch.randn(1, 4, 32, dtype=torch.float16),))
+    with pytest.raises(NotImplementedError, match="single-group"):
+        CudaBackend().compile(graph)


### PR DESCRIPTION
## Summary

Adds **W4A16 / AWQ-INT4** support: compressed-tensors quantized models now trace, compile, and run on the CUDA backend
with **in-kernel weight dequant**. Previously `compile`/`run`/`tune` on any such model hard-failed — the checkpoint's
decompress pre-hook fires mid-trace and injects a data-dependent slice `torch.export` can't specialize
(`GuardOnDataDependentSymNode`).

Verified end-to-end on `cyankiwi/Llama-3.1-8B-Instruct-AWQ-INT4 --layer 0` (224 linears substituted; accuracy vs eager
`max_diff=0.0020`, `mean_diff=8e-6` ✅) plus a hermetic `tests/compiler/test_dequant.py` suite.

## Approach

A pre-trace **submodule substitution** swaps each quantized linear for a `DequantLinear` whose forward is an opaque
`deplodock::dequant_linear` custom op — keeping the packed int32 / fp16-scale / int32-zp tensors as graph constants and
stopping the decompress hook. The tracer maps it to a new frontend `DequantLinearOp`; the `045_dequant_linear`
decomposition expands it into an 8-lane int4 unpack → `(nibble - zp)` → int→fp16 cast → group-scale → transpose →
matmul cone the rest of the pipeline lowers. **Default fusion already pulls the dequant producer into the matmul
kernel**, so gmem holds only packed int32 + scale + zp — much of the Phase 3 VRAM goal, for free.

All format-specific logic is isolated in `trace/quantized.py` + the `045` rule; everything below `DequantLinearOp` is
format-agnostic.

## New IR capability: first mixed-int codegen path

- Bitwise `>>` / `&` ops (expr/elementwise/stmt), dtype-aware `Select`, integer scalar literals, a tensor-IR `CastOp`
  (+ `015_lift_cast`), and i32 `type_name` / `convert` (`__int2half_rn` etc.) / native-op support in the CUDA render target.
- `right_shift` / `bitwise_and` force an i32 result in `dtype_promote` (integer-only; no float form) so the unpack stays
  correct when a staged-smem `Load`'s dtype is unresolved at stamp time.
- dtype-preserving constant binding so packed int32 weights aren't corrupted via a float32 round-trip; `LoopOp.forward`
  raises on mixed-int (float-only runner).

## Verification status

- **Phase 0** (in-kernel dequant) — ✅ real 8B AWQ model + hermetic suite.
- **Phase 2** (granularity) — `group_size` read from the `QuantScheme` (never hardcoded); per-group GPU e2e passes at
  **G=32 and G=128** (sym + asym). Single-group (`group_size >= in_features`, per-channel/per-tensor-along-K — which no
  compressed-tensors AWQ model uses) raises a clear `NotImplementedError`; fixing the splicer is the open Phase-2 follow-up.
- **Phase 3** (VRAM) — confirmed on RTX 4080: at a realistic 4096×4096 q_proj-sized linear, deplodock gmem **9.96 MB vs
  33.82 MB** dense fp16 = **3.39× total** (4.0× on the weight itself), `rel_err 0.00045`. Guarded by
  `test_dequant_fuses_no_materialized_weight_vram`.

## Test plan

- `make test` — 2070 passed (incl. the new `tests/compiler/test_dequant.py`: numerics oracle, compressed_tensors
  parity, integer/cast codegen, substitution walker, CUDA e2e over the G=32/128 × sym/asym matrix, VRAM guard,
  per-channel guard).
- Docs updated: `plans/w4a16-quantization-support.md`, `compiler/ARCHITECTURE.md`,
  `compiler/trace/ARCHITECTURE.md`, `compiler/backend/cuda/ARCHITECTURE.md`, `compiler/ir/ARCHITECTURE.md`, `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)