### PR TITLE
reduce IR: ReduceCarrier protocol + algebraic op traits

### DIFF
--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -113,15 +113,21 @@ it replaces the frontend layout ops via `coord_map` expressions.
 | `GatherOp`, `ScatterOp`              | Data-dependent reads / writes.                                 |
 | `IndexMapOp` + `IndexSource`         | Unified layout-only op over `Expr`.                            |
 
-Op metadata (arity / commutative / reduce identity) lives on
-`ElementwiseImpl` in `ir/elementwise.py` — the single source of truth
-shared across elementwise, reduce, scan, and accumulator use sites.
+Op metadata (arity / `commutative` / `associative` / `identity` /
+`has_identity`) lives on `ElementwiseImpl` in `ir/elementwise.py` — the single
+source of truth shared across elementwise, reduce, scan, and accumulator use
+sites. The algebraic traits are what reassociation gates (split-K, cooperative
+tree-combine) query instead of matching op names.
 
 ## `loop/`
 
 One `LoopOp` = one GPU kernel described as an SSA program over named
 iteration axes. Free vs reduce is inferred from body structure — a
-`Loop` is a reduce Loop iff its body contains an `Accum`.
+`Loop` is a reduce Loop iff its body contains a `ReduceCarrier` (the shared
+base of `Accum` and its tensor-core form `Mma`; `is_reduce`, axis threading,
+and the other carrier-agnostic checks key off the base, not an
+`isinstance(s, (Accum, Mma))` ladder). Rules that need the combine's algebra
+read `carrier.combine_op()` and query its traits.
 
 ### `loop/ir.py` — LoopOp types
 
@@ -307,8 +313,10 @@ itself** (`AtomTile.atom`) — the structural "this matmul factorizes through
 tensor cores" signal, carried in the IR rather than re-derived from a knob.
 Right after, `tile/011_lower_atom_cell` reads `.atom` off the tile and
 collapses the cell's `Assign(multiply) + Accum` into a single `Mma` op
-(`c += a @ b`, a reduce-accumulate sibling of `Accum` — it makes its loop
-`is_reduce`) that carries that `Atom` and names its A/B operand `Load`s by SSA
+(`c += a @ b`, a reduce-accumulate sibling of `Accum` — both subclass
+`ReduceCarrier`, so the `Mma` makes its loop `is_reduce` with no special-casing,
+and its `combine_op()` reports `add`) that carries that `Atom` and names its A/B
+operand `Load`s by SSA
 value. The operand loads stay **plain** — the `Mma` is the sole tensor-core
 marker downstream. Both are ordinary IR the staging passes carry through (the
 loads stage like any `Load`); `kernel/005_lower_atom_tile` recovers each

--- a/deplodock/compiler/ir/elementwise.py
+++ b/deplodock/compiler/ir/elementwise.py
@@ -48,12 +48,20 @@ class ElementwiseImpl:
     Construction resolves the callable from ``_NAME_TO_FN`` (non-numpy
     intrinsics) or ``getattr(np, name)`` for numpy-aligned names, and
     reads arity from the ufunc's ``nin`` (non-ufunc intrinsics are
-    unary). Unknown names raise. ``commutative`` / ``identity`` are
-    computed properties reading from class-level tables keyed by name.
+    unary). Unknown names raise. ``commutative`` / ``associative`` /
+    ``identity`` / ``has_identity`` are computed properties reading from
+    class-level tables keyed by name — the algebraic traits reassociation
+    gates (split-K, cooperative tree-combine) query instead of matching op
+    names.
     """
 
     # Commutative ops — binary combines where ``op(a, b) == op(b, a)``.
     _COMMUTATIVE: frozenset[str] = frozenset({"add", "multiply", "maximum", "minimum", "amax", "sum", "prod"})
+    # Associative ops — binary combines where ``op(op(a, b), c) == op(a, op(b, c))``.
+    # The reassociable reduce combines: a reduction over one of these may be
+    # split / reordered (split-K, cooperative tree-combine) without changing
+    # the result. ``subtract`` / ``divide`` are deliberately absent.
+    _ASSOCIATIVE: frozenset[str] = frozenset({"add", "multiply", "maximum", "minimum", "amax", "sum", "prod"})
     # Reducer neutral elements — only meaningful when used as an Accum
     # combine or a ReduceOp.
     _IDENTITY: dict[str, float] = {
@@ -90,8 +98,19 @@ class ElementwiseImpl:
         return self.name in self._COMMUTATIVE
 
     @property
+    def associative(self) -> bool:
+        return self.name in self._ASSOCIATIVE
+
+    @property
     def identity(self) -> float | None:
         return self._IDENTITY.get(self.name)
+
+    @property
+    def has_identity(self) -> bool:
+        """True iff this op has a neutral element — i.e. it can seed an
+        accumulator. The reassociation gates pair this with ``associative``
+        / ``commutative`` to admit a reduce for split-K / tree-combine."""
+        return self.identity is not None
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, ElementwiseImpl) and self.name == other.name

--- a/deplodock/compiler/ir/stmt/__init__.py
+++ b/deplodock/compiler/ir/stmt/__init__.py
@@ -41,6 +41,7 @@ and produce Loop-IR's canonical form.
 
 from deplodock.compiler.ir.stmt.base import (
     INDENT,
+    ReduceCarrier,
     RenderCtx,
     Stmt,
     op_to_expr,
@@ -83,6 +84,7 @@ __all__ = [
     "Loop",
     "Mma",
     "Pack",
+    "ReduceCarrier",
     "RenderCtx",
     "Select",
     "SelectBranch",

--- a/deplodock/compiler/ir/stmt/base.py
+++ b/deplodock/compiler/ir/stmt/base.py
@@ -17,6 +17,7 @@ from deplodock.compiler.ir.expr import BinaryExpr, CastExpr, Expr, FuncCallExpr,
 from deplodock.compiler.ir.sigma import Sigma
 
 if TYPE_CHECKING:
+    from deplodock.compiler.ir.elementwise import ElementwiseImpl
     from deplodock.compiler.ir.stmt.body import Body
     from deplodock.compiler.ir.stmt.leaves import Select
     from deplodock.compiler.render_target import RenderTarget
@@ -493,6 +494,45 @@ class Stmt:
         for index flattening. Subclasses override.
         """
         raise NotImplementedError(f"{type(self).__name__}.render not implemented")
+
+
+class ReduceCarrier(Stmt):
+    """A loop-carried reduce accumulator — the shared structural role behind
+    ``Accum`` (scalar monoid fold), ``Mma`` (tensor-core ``c += a @ b``), and
+    the future flash/LSE combine.
+
+    A ``Loop`` / ``StridedLoop`` / serial tile is a *reduce* loop iff its
+    immediate body holds a ``ReduceCarrier`` — that is the one predicate the
+    trait-agnostic machinery (``is_reduce``, axis threading, topo-sort)
+    keys off, so a new carrier kind is recognized everywhere by subclassing
+    this rather than being threaded through an ``isinstance(s, (Accum, Mma))``
+    ladder at every site.
+
+    Rules that *do* care about the combine's algebra don't switch on the
+    carrier type either — they read :meth:`combine_op` and query its traits
+    (``associative`` / ``commutative`` / ``has_identity``) to decide whether a
+    reduction may be split / reordered (split-K, cooperative tree-combine).
+
+    Three methods name the carrier's reduce surface, distinct from the generic
+    SSA def-use surface (:meth:`deps` / :meth:`defines`):
+
+    - :meth:`carried_names` — the accumulator name(s) read-and-written across
+      the reduce axis (the carried read is *implicit*, so it is absent from
+      :meth:`deps`).
+    - :meth:`partial_deps` — the SSA names read to form this iteration's
+      contribution, excluding the carried accumulator. Defaults to
+      :meth:`deps`, which ``Accum`` / ``Mma`` already define to exclude it.
+    - :meth:`combine_op` — the accumulation's combine op, for its traits.
+    """
+
+    def carried_names(self) -> tuple[str, ...]:
+        raise NotImplementedError(f"{type(self).__name__}.carried_names")
+
+    def partial_deps(self) -> tuple[str, ...]:
+        return self.deps()
+
+    def combine_op(self) -> ElementwiseImpl:
+        raise NotImplementedError(f"{type(self).__name__}.combine_op")
 
 
 def pretty_body(body: Body, indent: str = "") -> list[str]:

--- a/deplodock/compiler/ir/stmt/blocks.py
+++ b/deplodock/compiler/ir/stmt/blocks.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from deplodock.compiler.dtype import F32 as _F32
 from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import Expr, Var
-from deplodock.compiler.ir.stmt.base import INDENT, RenderCtx, Stmt, _pad, pretty_body, render_body
+from deplodock.compiler.ir.stmt.base import INDENT, ReduceCarrier, RenderCtx, Stmt, _pad, pretty_body, render_body
 from deplodock.compiler.ir.stmt.body import Body
 from deplodock.compiler.ir.stmt.leaves import Accum
 
@@ -79,8 +79,9 @@ class Loop(Stmt):
 
     @property
     def is_reduce(self) -> bool:
-        """A loop is a reduce-loop iff its immediate body contains an ``Accum``."""
-        return any(isinstance(s, Accum) for s in self.body)
+        """A loop is a reduce-loop iff its immediate body contains a
+        ``ReduceCarrier`` (``Accum``, or its tensor-core form ``Mma``)."""
+        return any(isinstance(s, ReduceCarrier) for s in self.body)
 
     def pretty(self, indent: str = "") -> list[str]:
         head = f"{indent}for {self.axis.name} in 0..{self.axis.extent}{_source_suffix(self.axis)}"
@@ -292,8 +293,9 @@ class StridedLoop(Stmt):
 
     @property
     def is_reduce(self) -> bool:
-        """A strided loop is a reduce-loop iff its immediate body contains an ``Accum``."""
-        return any(isinstance(s, Accum) for s in self.body)
+        """A strided loop is a reduce-loop iff its immediate body contains a
+        ``ReduceCarrier`` (``Accum``, or its tensor-core form ``Mma``)."""
+        return any(isinstance(s, ReduceCarrier) for s in self.body)
 
     def pretty(self, indent: str = "") -> list[str]:
         start = self.start.pretty()

--- a/deplodock/compiler/ir/stmt/leaves.py
+++ b/deplodock/compiler/ir/stmt/leaves.py
@@ -13,7 +13,16 @@ from typing import TYPE_CHECKING
 from deplodock.compiler.dtype import F32, DataType
 from deplodock.compiler.ir.elementwise import ElementwiseImpl
 from deplodock.compiler.ir.expr import BinaryExpr, Expr, Literal, Var, _float_lit
-from deplodock.compiler.ir.stmt.base import RenderCtx, Stmt, _pad, dtype_promote, op_to_expr, render_index, select_to_ternary
+from deplodock.compiler.ir.stmt.base import (
+    ReduceCarrier,
+    RenderCtx,
+    Stmt,
+    _pad,
+    dtype_promote,
+    op_to_expr,
+    render_index,
+    select_to_ternary,
+)
 
 if TYPE_CHECKING:
     # ``Mma.atom`` holds an ``Atom`` (defined in the tile-IR layer, which builds
@@ -448,7 +457,7 @@ class Assign(Stmt):
 
 
 @dataclass(frozen=True)
-class Accum(Stmt):
+class Accum(ReduceCarrier):
     """Reduce accumulator — declares-and-folds in one statement.
 
     Semantics: ``name = op(name, value)`` inside the enclosing reduce
@@ -502,6 +511,12 @@ class Accum(Stmt):
     def defines(self) -> tuple[str, ...]:
         return (self.name,)
 
+    def carried_names(self) -> tuple[str, ...]:
+        return (self.name,)
+
+    def combine_op(self) -> ElementwiseImpl:
+        return self.op
+
     def pretty(self, indent: str = "") -> list[str]:
         prefix = f"{self.dtype.name} " if self.dtype is not None else ""
         return [f"{indent}{prefix}{self.name} <- {self.op.name}({self.name}, {self.value})"]
@@ -526,7 +541,7 @@ class Accum(Stmt):
 
 
 @dataclass(frozen=True)
-class Mma(Stmt):
+class Mma(ReduceCarrier):
     """Tensor-core multiply-accumulate over one atom cell — ``c += a @ b``.
 
     The fused replacement for the scalar ``Assign(multiply) + Accum`` matmul
@@ -571,6 +586,16 @@ class Mma(Stmt):
 
     def defines(self) -> tuple[str, ...]:
         return (self.c,)
+
+    def carried_names(self) -> tuple[str, ...]:
+        return (self.c,)
+
+    def combine_op(self) -> ElementwiseImpl:
+        # The tensor-core accumulation is ``c += a @ b`` — an additive fold.
+        # Reporting ``add`` (associative + commutative + identity 0) is what
+        # tells reassociation gates that split-K over the matmul's K axis is
+        # legal, exactly as for a scalar sum Accum.
+        return ElementwiseImpl("add")
 
     def pretty(self, indent: str = "") -> list[str]:
         return [f"{indent}{self.c} <- mma[{self.atom.name}]({self.a} @ {self.b})"]

--- a/deplodock/compiler/ir/tile/ir.py
+++ b/deplodock/compiler/ir/tile/ir.py
@@ -71,7 +71,7 @@ from deplodock.compiler.ir.stmt import (
     Cond,
     Load,
     Loop,
-    Mma,
+    ReduceCarrier,
     Select,
     SelectBranch,
     Stmt,
@@ -1124,9 +1124,10 @@ class SerialTileBase(Stmt):
 
     @property
     def is_reduce(self) -> bool:
-        """A serial tile is a reduce iff its immediate body contains an ``Accum``
-        (or its tensor-core fused form ``Mma``, which accumulates ``c += a @ b``)."""
-        return any(isinstance(s, (Accum, Mma)) for s in self.body)
+        """A serial tile is a reduce iff its immediate body contains a
+        ``ReduceCarrier`` — an ``Accum`` or its tensor-core fused form ``Mma``
+        (which accumulates ``c += a @ b``)."""
+        return any(isinstance(s, ReduceCarrier) for s in self.body)
 
 
 @dataclass(frozen=True)

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import logging
 
-from deplodock.compiler.ir.stmt import Accum, Body, Load, Loop, Mma, Stmt, StridedLoop
+from deplodock.compiler.ir.stmt import Accum, Body, Load, Loop, ReduceCarrier, Stmt, StridedLoop
 from deplodock.compiler.ir.tile.ir import GridTile, ParallelTile, SerialTile, StridedTile, ThreadTile, WarpTile
 from deplodock.compiler.pipeline import RuleSkipped
 
@@ -165,7 +165,7 @@ def is_matmul_reduce(loop) -> bool:
     bufs = {ld.input for ld in loop.body.of_type(Load) if K_name in {v for e in ld.index for v in e.free_vars()}}
     if len(bufs) < 2:
         return False
-    return any(isinstance(s, (Accum, Mma)) for s in loop.body)
+    return any(isinstance(s, ReduceCarrier) for s in loop.body)
 
 
 def segmentable_k_extent(load: Load, k_name: str) -> int | None:

--- a/deplodock/compiler/provenance.py
+++ b/deplodock/compiler/provenance.py
@@ -226,11 +226,11 @@ def name_for(loop: LoopOp, base_name: str, node_prov: dict, all_totals: dict[str
     never makes one launch reuse another's code). The node-id fallback is
     already unique, so it needs no hash.
 
-    Local import for ``Accum`` avoids a top-of-module cycle through
+    Local import for ``ReduceCarrier`` avoids a top-of-module cycle through
     ``ir.loop`` (which imports ``provenance`` for graph utilities)."""
-    from deplodock.compiler.ir.stmt import Accum
+    from deplodock.compiler.ir.stmt import ReduceCarrier
 
-    suffix = "reduce" if any(isinstance(s, Accum) for s in loop) else "pointwise"
+    suffix = "reduce" if any(isinstance(s, ReduceCarrier) for s in loop) else "pointwise"
     strong = [oid for oid, e in node_prov.items() if e["kind"] not in _GENERIC_KINDS | _WEAK_KINDS]
     meaningful = strong or [oid for oid, e in node_prov.items() if e["kind"] in _WEAK_KINDS]
     if not meaningful:

--- a/tests/compiler/ir/stmt/test_reduce_carrier.py
+++ b/tests/compiler/ir/stmt/test_reduce_carrier.py
@@ -1,0 +1,107 @@
+"""``ReduceCarrier`` protocol + ``ElementwiseImpl`` algebraic traits.
+
+The trait-agnostic machinery keys off ``isinstance(s, ReduceCarrier)`` instead
+of an ``isinstance(s, (Accum, Mma))`` ladder, and rules that care about the
+combine query ``combine_op()``'s traits rather than matching op names. These
+tests pin both halves of that contract.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.dim import Dim
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.stmt import Accum, Loop, Mma, ReduceCarrier, StridedLoop
+from deplodock.compiler.ir.tile.ir import ATOM_REGISTRY
+
+# --------------------------------------------------------------------------- #
+# ElementwiseImpl traits
+# --------------------------------------------------------------------------- #
+
+
+def test_associative_and_identity_traits():
+    for name in ("add", "sum", "multiply", "prod", "maximum", "minimum", "amax"):
+        op = ElementwiseImpl(name)
+        assert op.associative, name
+        assert op.has_identity, name
+        assert op.identity is not None, name
+
+
+def test_non_reassociable_ops_lack_traits():
+    for name in ("subtract", "divide"):
+        op = ElementwiseImpl(name)
+        assert not op.associative, name
+        assert not op.has_identity, name
+        assert op.identity is None, name
+
+
+def test_max_is_associative_but_existing_commutative_unchanged():
+    mx = ElementwiseImpl("maximum")
+    assert mx.commutative and mx.associative
+    assert ElementwiseImpl("maximum").identity == -1e30
+
+
+# --------------------------------------------------------------------------- #
+# ReduceCarrier protocol — Accum
+# --------------------------------------------------------------------------- #
+
+
+def test_accum_is_reduce_carrier():
+    a = Accum(name="acc", value="v", op=ElementwiseImpl("maximum"))
+    assert isinstance(a, ReduceCarrier)
+    assert a.carried_names() == ("acc",)
+    assert a.partial_deps() == ("v",)  # excludes the implicit carried read
+    assert a.combine_op().name == "maximum"
+    assert a.combine_op().associative
+
+
+# --------------------------------------------------------------------------- #
+# ReduceCarrier protocol — Mma
+# --------------------------------------------------------------------------- #
+
+
+def _mma() -> Mma:
+    return Mma(a="a0", b="b0", c="acc", atom=ATOM_REGISTRY["mma_m16n8k16_f16"])
+
+
+def test_mma_is_reduce_carrier():
+    m = _mma()
+    assert isinstance(m, ReduceCarrier)
+    assert m.carried_names() == ("acc",)
+    assert m.partial_deps() == ("a0", "b0")  # operands, not the carried c
+    # The tensor-core accumulation is an additive fold — reported so split-K
+    # reassociation gates see the same algebra as a scalar sum Accum.
+    op = m.combine_op()
+    assert op.name == "add"
+    assert op.associative and op.commutative and op.has_identity
+
+
+# --------------------------------------------------------------------------- #
+# is_reduce keys off the protocol — Accum AND Mma make a loop a reduce loop
+# --------------------------------------------------------------------------- #
+
+
+def _kloop(stmt):
+    return Loop(axis=Axis(name="k", extent=Dim(16)), body=(stmt,))
+
+
+def test_loop_is_reduce_for_accum():
+    assert _kloop(Accum(name="acc", value="v")).is_reduce
+
+
+def test_loop_is_reduce_for_mma():
+    # Before the protocol, Loop.is_reduce checked Accum only — an Mma-bearing
+    # loop read as non-reduce. The protocol unifies the two.
+    assert _kloop(_mma()).is_reduce
+
+
+def test_strided_loop_is_reduce_for_mma():
+    sl = StridedLoop(axis=Axis(name="k", extent=Dim(16)), start=Var("t"), step=Literal(32, "int"), body=(_mma(),))
+    assert sl.is_reduce
+
+
+def test_non_carrier_loop_is_not_reduce():
+    from deplodock.compiler.ir.stmt import Load
+
+    assert not _kloop(Load(name="x", input="buf", index=(Var("k"),))).is_reduce


### PR DESCRIPTION
## What

Unifies the loop-carried reduce statements (`Accum`, `Mma`) behind a shared `ReduceCarrier(Stmt)` base, and promotes the combine's algebra to first-class op traits. Foundation for the flash-attention work (the future flash/LSE combine subclasses `ReduceCarrier`).

## Why

Two warts motivated this:

1. **`Mma` was a bolt-on.** `Loop.is_reduce` / `StridedLoop.is_reduce` checked `isinstance(s, Accum)` only — so an `Mma`-bearing loop read as *non-reduce*, while `SerialTile.is_reduce` and `is_matmul_reduce` had to spell out `(Accum, Mma)` by hand. Adding a third carrier (flash) would mean a third thread-through.
2. **Reassociation gates matched op *names*.** Whether a reduction may be split (split-K, cooperative tree-combine) is an algebraic property, but it was expressed as `op.name in {"add", ...}` allowlists.

## Changes

- **Traits on the op** (`ir/elementwise.py`): `associative` + `has_identity` join the existing `commutative` / `identity`. `subtract`/`divide` correctly report `False`.
- **`ReduceCarrier(Stmt)`** (`ir/stmt/base.py`): `carried_names()`, `partial_deps()` (defaults to `deps()`), `combine_op()`.
- **`Accum` / `Mma` subclass it** (`ir/stmt/leaves.py`): `Mma.combine_op()` reports `add` — the additive tensor-core fold — which is exactly what tells a split-K gate the matmul's K axis splits.
- **Reduce-role checks migrated**: `Loop` / `StridedLoop` / `SerialTile` `is_reduce`, `is_matmul_reduce`, and the provenance reduce/pointwise suffix now key off `ReduceCarrier`. Fixes the `Loop.is_reduce` inconsistency.

**Deliberately left alone:** the ~50 `Accum`-*field*-specific sites (init emission, dtype freeze, mma-folding, fp16 packing, `accums_independent`). Those read concrete fields and aren't reduce-role checks — migrating them would be behavior change, not refactor.

## Boundary

Traits capture the combine's *algebra*, not the *dataflow coupling* that blocks softmax's two K-loops from merging — that stays `accums_independent`, untouched.

## Tests

- New `tests/compiler/ir/stmt/test_reduce_carrier.py` (9 tests): traits, carrier membership, the three methods on both, and `is_reduce` now true for an `Mma`-bearing `Loop`/`StridedLoop`.
- Full compiler suite: **1640 passed, 6 skipped**. Lint + format clean. `ir/ARCHITECTURE.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)