### PR TITLE
Generative (chat) inference: serve decoder-only LLMs via deplodock-compiled kernels + vLLM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,13 @@ same worker.
   (`--max-concurrency`/`--num-prompts`/`--random-input-len`/`--bench-seed`) → print results → shut down. Needs the
   `serving` extra.
 - `deplodock pull <model>` — download a HuggingFace model to local cache
+- `deplodock generate <model> [--prompt T] [--max-new-tokens N] [--temperature/--top-k/--top-p/--seed] [--chat]` —
+  **standalone naive generation oracle** (no vLLM; Phase 0 of `plans/generative-inference-support.md`). Re-runs the
+  whole growing prefix each step (O(S²)) on the deplodock fp16 CUDA backend, samples
+  (`serving/sampling.py::Sampler`), and prints the decoded text. The host loop
+  (`commands/generate.py::generate`) is pure/unit-testable; `_CompiledLM` compiles the dynamic whole-model graph (full
+  logits, last row sliced on the host — the in-graph `slice_last_logits` slice makes lm_head an M=1 demoted matmul that
+  doesn't lower cold). The token-for-token reference for the later vLLM phases.
 - `deplodock trace <model> [--layer N] [--seq-len N]` — trace a transformer layer (or the whole model if `--layer` is omitted) to Graph IR (JSON). Whole-model tracing patches HF's dynamic causal-mask construction via `trace.huggingface.build_full_model_wrapper`.
 - `deplodock trace --code "EXPR"` — trace an inline `nn.Module` expression (last stmt must be a call, e.g. `"torch.nn.RMSNorm(2048)(torch.randn(1,32,2048))"`)
 - `deplodock compile <model_or_ir> [--layer N] [--seq-len N] [--dump-dir DIR] [--target sm_NN]` — run `decomposition → optimization → fusion` and save the fused `Graph[LoopOp]` (auto-pulls + traces if given a model ID; omit `--layer` for whole-model). `--target sm_NN` (e.g. `sm_80`, `sm_90`, `sm_120`) overrides the live device's compute capability so passes that gate on hardware features (TMA, cp.async) take the target's path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ same worker.
   `serving` extra.
 - `deplodock serve <model> --generate [vllm flags...]` — serve a **generative (chat)** model via `DeplodockGenModel`
   (Phase 3 of `plans/generative-inference-support.md`): `--runner generate`, forces `--dtype float16` (seam coherence;
-  rejects an incompatible `--dtype`), keeps `--enforce-eager`. vLLM owns the API / sampler / scheduler / paged KV-cache /
-  `lm_head`; deplodock-compiled per-layer kernels (`serving/gen_runner.py::DeplodockGenRunner`) own embed + the trunk,
+  rejects an incompatible `--dtype`), keeps `--enforce-eager`. vLLM owns the API / sampler / scheduler / paged
+  KV-cache / `lm_head`; deplodock-compiled per-layer kernels (`serving/gen_runner.py::DeplodockGenRunner`) own embed + trunk,
   with vLLM's `Attention` carved into the per-layer forward. `serving/vllm_model_gen.py`.
 - `deplodock pull <model>` — download a HuggingFace model to local cache
 - `deplodock generate <model> [--prompt T] [--max-new-tokens N] [--temperature/--top-k/--top-p/--seed] [--chat]` —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ same worker.
   a one-shot benchmark: start server → wait `/health` → `vllm bench serve --backend openai-embeddings`
   (`--max-concurrency`/`--num-prompts`/`--random-input-len`/`--bench-seed`) → print results → shut down. Needs the
   `serving` extra.
+- `deplodock serve <model> --generate [vllm flags...]` — serve a **generative (chat)** model via `DeplodockGenModel`
+  (Phase 3 of `plans/generative-inference-support.md`): `--runner generate`, forces `--dtype float16` (seam coherence;
+  rejects an incompatible `--dtype`), keeps `--enforce-eager`. vLLM owns the API / sampler / scheduler / paged KV-cache /
+  `lm_head`; deplodock-compiled per-layer kernels (`serving/gen_runner.py::DeplodockGenRunner`) own embed + the trunk,
+  with vLLM's `Attention` carved into the per-layer forward. `serving/vllm_model_gen.py`.
 - `deplodock pull <model>` — download a HuggingFace model to local cache
 - `deplodock generate <model> [--prompt T] [--max-new-tokens N] [--temperature/--top-k/--top-p/--seed] [--chat]` —
   **standalone naive generation oracle** (no vLLM; Phase 0 of `plans/generative-inference-support.md`). Re-runs the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,8 @@ same worker.
 - `deplodock serve <model> --generate [vllm flags...]` — serve a **generative (chat)** model via `DeplodockGenModel`
   (Phase 3 of `plans/generative-inference-support.md`): `--runner generate`, forces `--dtype float16` (seam coherence;
   rejects an incompatible `--dtype`), keeps `--enforce-eager`. vLLM owns the API / sampler / scheduler / paged
-  KV-cache / `lm_head`; deplodock-compiled per-layer kernels (`serving/gen_runner.py::DeplodockGenRunner`) own embed + trunk,
-  with vLLM's `Attention` carved into the per-layer forward. `serving/vllm_model_gen.py`.
+  KV-cache / `lm_head`; deplodock-compiled per-layer kernels (`serving/gen_runner.py::DeplodockGenRunner`) own embed +
+  trunk, with vLLM's `Attention` carved into the per-layer forward. `serving/vllm_model_gen.py`.
 - `deplodock pull <model>` — download a HuggingFace model to local cache
 - `deplodock generate <model> [--prompt T] [--max-new-tokens N] [--temperature/--top-k/--top-p/--seed] [--chat]` —
   **standalone naive generation oracle** (no vLLM; Phase 0 of `plans/generative-inference-support.md`). Re-runs the

--- a/README.md
+++ b/README.md
@@ -189,6 +189,25 @@ deplodock serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock
 See [`deplodock/serving/ARCHITECTURE.md`](deplodock/serving/ARCHITECTURE.md); embedding recipes
 (`recipes/Qwen3-Embedding-*`) A/B this against stock vLLM via `deplodock bench`.
 
+## Generate (chat) — experimental
+
+```bash
+# Standalone generation oracle (no vLLM) — re-runs the whole prefix each step, O(S²); the
+# token-for-token reference (matches HF eager greedy, e.g. on TinyLlama-1.1B-Chat).
+deplodock generate TinyLlama/TinyLlama-1.1B-Chat-v1.0 --prompt "The capital of France is" --max-new-tokens 10
+
+# Serve a chat model through deplodock-compiled per-layer kernels (vLLM owns the OpenAI API /
+# sampler / scheduler / paged KV-cache / lm_head; deplodock owns embed + the trunk).
+deplodock serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --generate
+curl localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"TinyLlama/TinyLlama-1.1B-Chat-v1.0","messages":[{"role":"user","content":"Hi"}]}'
+```
+
+**Status:** correctness complete for decoder-only **Llama / Qwen3** (full-causal, fp16, TP=1). Perf is **not yet
+hardened** — host-sync interleave at the per-layer seam, and `serve` compiles 2× n_layers programs (startup- and
+memory-heavy → small models for now). Design + phase status:
+[`plans/generative-inference-support.md`](plans/generative-inference-support.md).
+
 ## Recipe
 
 ```yaml

--- a/deplodock/commands/generate.py
+++ b/deplodock/commands/generate.py
@@ -32,11 +32,12 @@ def register_generate_command(subparsers):
     parser.set_defaults(func=handle_generate)
 
 
-def generate(logits_fn, prompt_ids, *, max_new_tokens, eos_id, sampler):
+def generate(logits_fn, prompt_ids, *, max_new_tokens, eos_ids, sampler):
     """Pure host generate loop. ``logits_fn(ids: list[int]) -> np.ndarray`` returns the
     next-token logits ``[vocab]`` for the given prefix; ``sampler(logits) -> int`` picks a
-    token. Appends each sampled token and re-feeds the grown prefix, stopping at ``eos_id``
-    or after ``max_new_tokens``. Returns the generated token ids (excluding the prompt)."""
+    token. Appends each sampled token and re-feeds the grown prefix, stopping when the
+    sampled token is in ``eos_ids`` (a collection, or ``None`` to disable) or after
+    ``max_new_tokens``. Returns the generated token ids (excluding the prompt)."""
     ids = list(prompt_ids)
     generated: list[int] = []
     for _ in range(max_new_tokens):
@@ -44,9 +45,30 @@ def generate(logits_fn, prompt_ids, *, max_new_tokens, eos_id, sampler):
         token = sampler(logits)
         generated.append(token)
         ids.append(token)
-        if eos_id is not None and token == eos_id:
+        if eos_ids and token in eos_ids:
             break
     return generated
+
+
+def _resolve_eos_ids(tokenizer, model_id) -> set[int]:
+    """Collect every end-of-sequence id: the tokenizer's ``eos_token_id`` plus the model's
+    ``generation_config.eos_token_id`` (which may be a list — e.g. Llama-3's multiple
+    terminators). Stopping on any of them matches ``model.generate``."""
+    ids: set[int] = set()
+    tok_eos = getattr(tokenizer, "eos_token_id", None)
+    if tok_eos is not None:
+        ids.add(int(tok_eos))
+    try:
+        from transformers import GenerationConfig
+
+        eos = GenerationConfig.from_pretrained(model_id).eos_token_id
+        if isinstance(eos, int):
+            ids.add(eos)
+        elif eos:
+            ids.update(int(e) for e in eos)
+    except Exception:  # noqa: BLE001 — no generation_config is fine; tokenizer eos still applies
+        pass
+    return ids
 
 
 def handle_generate(args):
@@ -56,19 +78,31 @@ def handle_generate(args):
         logger.error("torch and transformers are required: pip install torch transformers")
         sys.exit(1)
 
+    from deplodock.compiler.trace.dynamic import DYNAMIC_DIM_MAX
     from deplodock.serving.sampling import Sampler, apply_chat_template
 
     tokenizer = AutoTokenizer.from_pretrained(args.model)
-    lm = _CompiledLM.create(args.model, seq_len=args.seq_len)
 
     prompt_ids = apply_chat_template(tokenizer, args.prompt) if args.chat else tokenizer.encode(args.prompt)
+    if not prompt_ids:
+        logger.error("empty prompt produced no tokens")
+        sys.exit(1)
+    if len(prompt_ids) >= DYNAMIC_DIM_MAX:
+        logger.error("prompt length %d exceeds DYNAMIC_DIM_MAX (%d)", len(prompt_ids), DYNAMIC_DIM_MAX)
+        sys.exit(1)
+    # Cap so the growing prefix never exceeds the dynamic-dim / RoPE-buffer limit.
+    budget = DYNAMIC_DIM_MAX - len(prompt_ids)
+    if args.max_new_tokens > budget:
+        logger.warning("clamping --max-new-tokens %d → %d (DYNAMIC_DIM_MAX=%d)", args.max_new_tokens, budget, DYNAMIC_DIM_MAX)
+
+    lm = _CompiledLM.create(args.model, seq_len=args.seq_len)
     sampler = Sampler(temperature=args.temperature, top_k=args.top_k, top_p=args.top_p, seed=args.seed)
 
     generated = generate(
         lm.logits,
         prompt_ids,
-        max_new_tokens=args.max_new_tokens,
-        eos_id=tokenizer.eos_token_id,
+        max_new_tokens=min(args.max_new_tokens, budget),
+        eos_ids=_resolve_eos_ids(tokenizer, args.model),
         sampler=sampler,
     )
     print(tokenizer.decode(generated, skip_special_tokens=True))
@@ -173,8 +207,11 @@ class _CompiledLM:
         import numpy as np
 
         from deplodock.compiler.backend.gpu_lock import gpu_lock
+        from deplodock.compiler.trace.dynamic import DYNAMIC_DIM_MAX
 
         s = len(token_ids)
+        if not 0 < s <= DYNAMIC_DIM_MAX:
+            raise ValueError(f"prefix length {s} must be in 1..{DYNAMIC_DIM_MAX} (DYNAMIC_DIM_MAX)")
         feed = _step_feed(self._ids_name, self._mask_name, self._pos_name, np.dtype("float16"), list(token_ids))
         with gpu_lock():
             self._program.rebind(feed)  # resolves seq_len from the input shapes

--- a/deplodock/commands/generate.py
+++ b/deplodock/commands/generate.py
@@ -1,0 +1,183 @@
+"""``deplodock generate`` — standalone naive generation oracle (Phase 0 of
+``plans/generative-inference-support.md``).
+
+Re-runs the whole growing prefix each step (O(S^2)) on the deplodock CUDA backend with
+**no vLLM** — deplodock controls the loop, so this is the token-for-token correctness
+reference every later (vLLM) phase verifies against, and the seed of the eventual
+standalone server. Runs the unquantized fp16 whole-model path.
+
+The host loop (:func:`generate`) is pure and unit-testable with any ``logits_fn``;
+:func:`handle_generate` wires it to a compiled fp16 program (:class:`_CompiledLM`).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def register_generate_command(subparsers):
+    parser = subparsers.add_parser("generate", help="Generate text from a model (standalone oracle; no vLLM)")
+    parser.add_argument("model", help="HuggingFace model ID")
+    parser.add_argument("--prompt", default="Hello, ", help="Prompt text")
+    parser.add_argument("--max-new-tokens", type=int, default=64, help="Max tokens to generate")
+    parser.add_argument("--temperature", type=float, default=0.0, help="Sampling temperature (0 = greedy)")
+    parser.add_argument("--top-k", type=int, default=0, help="Top-k filter (0 = off)")
+    parser.add_argument("--top-p", type=float, default=1.0, help="Top-p / nucleus filter (1.0 = off)")
+    parser.add_argument("--seed", type=int, default=0, help="Sampling RNG seed")
+    parser.add_argument("--chat", action="store_true", help="Apply the tokenizer chat template to the prompt")
+    parser.add_argument("--seq-len", type=int, default=32, help="Example seq_len for the dynamic trace")
+    parser.set_defaults(func=handle_generate)
+
+
+def generate(logits_fn, prompt_ids, *, max_new_tokens, eos_id, sampler):
+    """Pure host generate loop. ``logits_fn(ids: list[int]) -> np.ndarray`` returns the
+    next-token logits ``[vocab]`` for the given prefix; ``sampler(logits) -> int`` picks a
+    token. Appends each sampled token and re-feeds the grown prefix, stopping at ``eos_id``
+    or after ``max_new_tokens``. Returns the generated token ids (excluding the prompt)."""
+    ids = list(prompt_ids)
+    generated: list[int] = []
+    for _ in range(max_new_tokens):
+        logits = logits_fn(ids)
+        token = sampler(logits)
+        generated.append(token)
+        ids.append(token)
+        if eos_id is not None and token == eos_id:
+            break
+    return generated
+
+
+def handle_generate(args):
+    try:
+        from transformers import AutoTokenizer
+    except ImportError:
+        logger.error("torch and transformers are required: pip install torch transformers")
+        sys.exit(1)
+
+    from deplodock.serving.sampling import Sampler, apply_chat_template
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    lm = _CompiledLM.create(args.model, seq_len=args.seq_len)
+
+    prompt_ids = apply_chat_template(tokenizer, args.prompt) if args.chat else tokenizer.encode(args.prompt)
+    sampler = Sampler(temperature=args.temperature, top_k=args.top_k, top_p=args.top_p, seed=args.seed)
+
+    generated = generate(
+        lm.logits,
+        prompt_ids,
+        max_new_tokens=args.max_new_tokens,
+        eos_id=tokenizer.eos_token_id,
+        sampler=sampler,
+    )
+    print(tokenizer.decode(generated, skip_special_tokens=True))
+
+
+def _step_feed(ids_name, mask_name, pos_name, np_dtype, token_ids):
+    """Build the per-step input feed (input_ids / additive causal mask / position_ids)
+    sized to the current prefix length, keyed by the compiled graph's input names."""
+    import numpy as np
+
+    s = len(token_ids)
+    ids = np.asarray(token_ids, dtype=np.int64).reshape(1, s)
+    mask = np.triu(np.full((s, s), -np.inf, dtype=np.float32), k=1).astype(np_dtype)[None, None]
+    pos = np.arange(s, dtype=np.int64).reshape(1, s)
+    return {ids_name: ids, mask_name: mask, pos_name: pos}
+
+
+class _CompiledLM:
+    """Compiled fp16 whole-model program exposing ``logits(ids) -> np.ndarray[vocab]``.
+
+    Traces ``AutoModelForCausalLM`` through the dynamic whole-model wrapper (full logits
+    ``[1, S, vocab]``), compiles on the CUDA backend, binds fp16 constants, and re-runs the
+    whole prefix each call via the serving ``rebind`` path (one compiled dynamic-seq_len
+    program, request after request); ``logits()`` slices the final position on the host.
+    Mirrors ``DeplodockForwardRunner.create``."""
+
+    def __init__(self, program, input_names, output_name):
+        self._program = program
+        self._ids_name, self._mask_name, self._pos_name = input_names
+        self._output_name = output_name
+
+    @classmethod
+    def create(cls, model_id, *, seq_len=32):
+        import torch
+        from transformers import AutoModelForCausalLM
+
+        logger.info("[generate] loading %s (fp16, CPU trace)...", model_id)
+        with torch.device("cpu"):
+            model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.float16)
+            model.eval()
+            return cls.from_model(model, seq_len=seq_len)
+
+    @classmethod
+    def from_model(cls, model, *, seq_len=32):
+        """Build from an already-loaded fp16 CausalLM module (the network-free path used
+        by hermetic random-weight tests). ``model`` must be on CPU for the trace."""
+        import numpy as np
+        import torch
+
+        from deplodock.compiler.backend.cuda.backend import CudaBackend
+        from deplodock.compiler.backend.cuda.program import CompiledProgram
+        from deplodock.compiler.backend.gpu_lock import gpu_lock
+        from deplodock.compiler.loader.binder import bind_constants
+        from deplodock.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs
+        from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+        from deplodock.compiler.trace.torch import trace_module
+
+        dtype = torch.float16
+        np_dtype = np.dtype("float16")
+        with torch.device("cpu"):
+            # Full-logits wrapper: lm_head over all S positions, with the last row sliced
+            # on the HOST in ``logits()``. The in-graph slice (``slice_last_logits=True``)
+            # makes lm_head an M=1 *demoted* matmul that does NOT lower to CUDA on the cold
+            # path (no learned prior) — leftover LoopOp 'linear_7'. The oracle is O(S^2)
+            # regardless, so full logits + a host slice is the correct, cold-compilable cut.
+            wrapper = build_full_model_wrapper(model, seq_len, dtype, dynamic=True)
+            specs = parse_position_specs(
+                ["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"]
+            )
+            example = (
+                torch.zeros((1, seq_len), dtype=torch.long),
+                build_causal_mask(seq_len, dtype),
+                torch.arange(seq_len).unsqueeze(0),
+            )
+            graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
+
+        logger.info("[generate] compiling...")
+        compiled = CudaBackend(tune_db="auto").compile(graph)
+        if len(compiled.inputs) != 3:
+            raise RuntimeError(f"expected 3 graph inputs (input_ids, attention_mask, position_ids), got {compiled.inputs}")
+        ids_name, mask_name, pos_name = compiled.inputs
+        output_name = compiled.outputs[0]
+
+        # fp16 constant carriers (via float32 numpy — safe for bf16 checkpoints); the
+        # binder is dtype-agnostic, the graph's fp16 buffers cast at materialization.
+        sources: dict[str, np.ndarray] = {}
+        for path, t in wrapper.named_parameters(remove_duplicate=False):
+            sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+        for path, t in wrapper.named_buffers(remove_duplicate=False):
+            sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+        const_feed = bind_constants(compiled, sources)
+
+        feed = _step_feed(ids_name, mask_name, pos_name, np_dtype, [0] * seq_len)
+        with gpu_lock():
+            program = CompiledProgram.build(compiled, {**const_feed, **feed})
+        del model, wrapper, sources, const_feed
+        return cls(program, (ids_name, mask_name, pos_name), output_name)
+
+    def logits(self, token_ids):
+        """Next-token logits for the prefix ``token_ids`` (a list of ints). Re-binds the
+        whole prefix at its current length and runs the program once (the O(S^2) oracle)."""
+        import numpy as np
+
+        from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+        s = len(token_ids)
+        feed = _step_feed(self._ids_name, self._mask_name, self._pos_name, np.dtype("float16"), list(token_ids))
+        with gpu_lock():
+            self._program.rebind(feed)  # resolves seq_len from the input shapes
+            self._program.run_once()
+            out = self._program.outputs({"seq_len": s})[self._output_name]  # [1, S, vocab]
+        return out[0, -1, :].astype(np.float32)  # next-token logits [vocab]

--- a/deplodock/commands/serve.py
+++ b/deplodock/commands/serve.py
@@ -57,6 +57,12 @@ def _add_own_flags(parser, *, suppress_defaults: bool) -> None:
         "--stock", action="store_true", default=d(False), help="Serve stock vLLM kernels instead of the deplodock plugin (A/B baseline)."
     )
     parser.add_argument(
+        "--generate",
+        action="store_true",
+        default=d(False),
+        help="Serve a generative (chat) model via DeplodockGenModel (--runner generate, fp16) instead of embeddings.",
+    )
+    parser.add_argument(
         "--bench",
         action="store_true",
         default=d(False),
@@ -119,9 +125,19 @@ def _flag_value(vllm_args: list[str], flag: str, default: str) -> str:
     return default
 
 
-def build_serve_cmd(model: str, *, stock: bool, vllm_args: list[str]) -> list[str]:
-    cmd = ["vllm", "serve", model, "--runner", "pooling"]
-    if not stock:
+def build_serve_cmd(model: str, *, stock: bool, vllm_args: list[str], generate: bool = False) -> list[str]:
+    cmd = ["vllm", "serve", model, "--runner", "generate" if generate else "pooling"]
+    if not stock and generate:
+        cmd += ["--enforce-eager", "--hf-overrides", '{"architectures": ["DeplodockGenModel"]}']
+        # Force fp16 across the deplodock↔vLLM seam: vLLM defaults --dtype auto → bf16 for a
+        # bf16 checkpoint, but the deplodock trunk emits fp16. Reject an incompatible override.
+        if _has_flag(vllm_args, "--dtype"):
+            dt = _flag_value(vllm_args, "--dtype", "")
+            if dt not in ("float16", "half", "fp16"):
+                raise ValueError(f"generative serving requires fp16; --dtype {dt!r} is incompatible (use --dtype float16)")
+        else:
+            cmd += ["--dtype", "float16"]
+    elif not stock:
         cmd += _PLUGIN_ARGS
     if not _has_flag(vllm_args, "--max-model-len"):
         cmd += ["--max-model-len", _DEFAULT_MAX_MODEL_LEN]
@@ -170,7 +186,7 @@ def _vllm_bin() -> str:
 
 def handle_serve(args):
     vllm_args = _split_own_flags(args)
-    serve_cmd = build_serve_cmd(args.model, stock=args.stock, vllm_args=vllm_args)
+    serve_cmd = build_serve_cmd(args.model, stock=args.stock, vllm_args=vllm_args, generate=args.generate)
     port = _flag_value(vllm_args, "--port", "8000")
     bench_cmd = build_bench_cmd(
         args.model,

--- a/deplodock/commands/serve.py
+++ b/deplodock/commands/serve.py
@@ -137,6 +137,15 @@ def build_serve_cmd(model: str, *, stock: bool, vllm_args: list[str], generate: 
                 raise ValueError(f"generative serving requires fp16; --dtype {dt!r} is incompatible (use --dtype float16)")
         else:
             cmd += ["--dtype", "float16"]
+        # The flattened width (sum of newly-scheduled tokens per step) must stay within
+        # DYNAMIC_DIM_MAX (= _DEFAULT_MAX_MODEL_LEN). vLLM's default max_num_batched_tokens
+        # (e.g. 8192 on a big GPU) would trip the model's startup bound, so cap it here.
+        if _has_flag(vllm_args, "--max-num-batched-tokens"):
+            mnbt = _flag_value(vllm_args, "--max-num-batched-tokens", "")
+            if mnbt.isdigit() and int(mnbt) > int(_DEFAULT_MAX_MODEL_LEN):
+                raise ValueError(f"--max-num-batched-tokens {mnbt} exceeds the dynamic-dim cap ({_DEFAULT_MAX_MODEL_LEN}); use it or lower")
+        else:
+            cmd += ["--max-num-batched-tokens", _DEFAULT_MAX_MODEL_LEN]
     elif not stock:
         cmd += _PLUGIN_ARGS
     if not _has_flag(vllm_args, "--max-model-len"):
@@ -185,7 +194,10 @@ def _vllm_bin() -> str:
 
 
 def handle_serve(args):
-    vllm_args = _split_own_flags(args)
+    vllm_args = _split_own_flags(args)  # re-parses own flags placed after MODEL into args
+    if args.generate and args.bench:
+        logger.error("--bench is not supported with --generate yet (the bench client targets /v1/embeddings).")
+        sys.exit(1)
     serve_cmd = build_serve_cmd(args.model, stock=args.stock, vllm_args=vllm_args, generate=args.generate)
     port = _flag_value(vllm_args, "--port", "8000")
     bench_cmd = build_bench_cmd(

--- a/deplodock/compiler/trace/huggingface.py
+++ b/deplodock/compiler/trace/huggingface.py
@@ -234,6 +234,67 @@ def build_layer_wrapper(block, rotary_emb, hidden_size: int, dtype, *, layer_typ
     return LayerWrapper()
 
 
+def build_attention_split_wrapper(block):
+    """Carve SDPA out of one HF decoder layer (Phase 1 of
+    ``plans/generative-inference-support.md``). Returns ``(pre, post)`` ``nn.Module``s over
+    the flattened **``[num_tokens, H]``** per-token layout:
+
+    - ``pre(hidden[T, H]) -> (q, k, v)`` runs ``input_layernorm`` → separate
+      ``q_proj`` / ``k_proj`` / ``v_proj`` → reshape-into-heads → per-head ``q_norm`` /
+      ``k_norm`` (Qwen3 only), and returns **un-rotated** q,k,v in the 2-D seam ABI
+      ``q[T, Hq·D]``, ``k/v[T, Hkv·D]`` — exactly what vLLM's ``Attention.forward`` consumes.
+      RoPE is applied downstream (by vLLM, or by the test/oracle reference).
+    - ``post(attn_out[T, Hq·D], residual[T, H]) -> layer_out[T, H]`` runs ``o_proj`` →
+      ``residual +`` → ``post_attention_layernorm`` → ``mlp`` → second residual.
+
+    Reads the block's OWN submodules (not a ``self_attn`` substitution — HF
+    ``self_attn.forward`` returns ``(attn_output, weights)``, and the block adds the
+    residual after it, so swapping ``self_attn`` can't yield a clean pre-graph). NOTE: HF's
+    ``.view(B,S,-1,D).transpose(1,2)`` assumes a ``[batch, seq, hidden]`` input; on the
+    flattened ``[T, H]`` layout the reshape is ``.view(T, n_heads, D)`` with **no transpose**.
+    Qwen3 (q/k norm) and Llama (no q/k norm) are both handled; the architecture difference is
+    just the presence of ``q_norm`` / ``k_norm``."""
+    import torch.nn as nn
+
+    attn = block.self_attn
+    head_dim = attn.head_dim
+    num_heads = attn.q_proj.out_features // head_dim
+    num_kv_heads = attn.k_proj.out_features // head_dim
+    q_norm = getattr(attn, "q_norm", None)
+    k_norm = getattr(attn, "k_norm", None)
+
+    class Pre(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.input_layernorm = block.input_layernorm
+            self.q_proj, self.k_proj, self.v_proj = attn.q_proj, attn.k_proj, attn.v_proj
+            self.q_norm, self.k_norm = q_norm, k_norm
+
+        def forward(self, hidden):
+            h = self.input_layernorm(hidden)  # [T, H]
+            t = h.shape[0]
+            q = self.q_proj(h).view(t, num_heads, head_dim)  # [T, Hq, D] — NO transpose
+            k = self.k_proj(h).view(t, num_kv_heads, head_dim)
+            v = self.v_proj(h).view(t, num_kv_heads, head_dim)
+            if self.q_norm is not None:
+                q = self.q_norm(q)  # per-head RMSNorm over D
+                k = self.k_norm(k)
+            return q.reshape(t, num_heads * head_dim), k.reshape(t, num_kv_heads * head_dim), v.reshape(t, num_kv_heads * head_dim)
+
+    class Post(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.o_proj = attn.o_proj
+            self.post_attention_layernorm = block.post_attention_layernorm
+            self.mlp = block.mlp
+
+        def forward(self, attn_out, residual):
+            h = residual + self.o_proj(attn_out)  # residual1 + o_proj(SDPA)
+            return h + self.mlp(self.post_attention_layernorm(h))  # residual2 + MLP
+
+    return Pre(), Post()
+
+
 def build_causal_mask(seq_len: int, dtype) -> torch.Tensor:  # noqa: F821
     """Return the ``(1, 1, seq_len, seq_len)`` causal mask the wrapper
     uses internally — exposed so callers in dynamic mode can construct a

--- a/deplodock/compiler/trace/huggingface.py
+++ b/deplodock/compiler/trace/huggingface.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import torch.nn as nn
 
 
-def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = False) -> nn.Module:
+def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = False, slice_last_logits: bool = False) -> nn.Module:
     """Return an ``nn.Module`` with a trace-friendly forward.
 
     Static mode (``dynamic=False``, default): forward is
@@ -37,7 +37,18 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
 
     Dynamic mode replaces the rotary embedding too — with cos/sin
     precomputed for positions ``0..DYNAMIC_DIM_MAX-1`` and sliced to the
-    runtime seq_len in-graph (``_SlicedRotary``). Keeping HF's in-graph
+    runtime seq_len in-graph (``_SlicedRotary``).
+
+    ``slice_last_logits`` (dynamic only, the Phase-0 generation oracle): instead of
+    returning the whole-prefix logits ``[1, S, vocab]``, run the trunk to hidden states,
+    slice the **final** position (``hidden[:, -1:, :]``), and apply ``lm_head`` to that
+    one row → ``[1, 1, vocab]``. The generate loop only needs the next-token logits, so
+    this avoids the O(S·vocab) lm_head over every prefix position and the full-buffer host
+    copy each step. NOTE: the ``hidden[:, -1:, :]`` slice makes lm_head an **M=1 demoted
+    matmul** that the *cold* lowering path (no learned prior) does not turn into a CUDA
+    kernel — it lowers only once a prior/golden covers that shape. So the standalone
+    generation oracle currently traces full logits and slices the last row on the host;
+    this flag is the (correct, prior-dependent) optimized form. Keeping HF's in-graph
     rotary instead silently breaks: its ``inv_freq`` buffer is
     ``persistent=False`` and doesn't survive ``torch.export`` with its
     real value, so the traced cos/sin constant-fold to ``cos=1, sin=0``
@@ -49,6 +60,9 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
     """
     import torch
     import torch.nn as nn
+
+    if slice_last_logits and not dynamic:
+        raise ValueError("slice_last_logits requires dynamic=True (the generation oracle is dynamic-seq_len)")
 
     class _PassThroughRotary(nn.Module):
         """Replaces the model's ``rotary_emb`` and returns precomputed real
@@ -122,7 +136,28 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
                     cos, sin = rotary(sample, full_pos)
                 inner.rotary_emb = _SlicedRotary(cos, sin)
 
-        if dynamic:
+        if dynamic and slice_last_logits:
+
+            def forward(self, input_ids, attention_mask, position_ids):
+                # Generation oracle: run the trunk, then apply lm_head to ONLY the
+                # final position so the output is [1, 1, vocab] (next-token logits),
+                # not the whole-prefix [1, S, vocab].
+                trunk = getattr(self.model, "model", self.model)
+                out = trunk(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    use_cache=False,
+                    return_dict=False,
+                )
+                hidden = out[0]  # [1, S, H], final norm already applied by the trunk
+                last = hidden[:, -1:, :]  # [1, 1, H] — the next-token position
+                head = getattr(self.model, "lm_head", None)
+                if head is None:
+                    head = self.model.get_output_embeddings()
+                return head(last)  # [1, 1, vocab]
+
+        elif dynamic:
 
             def forward(self, input_ids, attention_mask, position_ids):
                 # The caller controls mask + position_ids so the seq_len axis can

--- a/deplodock/deplodock.py
+++ b/deplodock/deplodock.py
@@ -10,6 +10,7 @@ from deplodock.commands.deploy.cloud import register_cloud_target
 from deplodock.commands.deploy.local import register_local_target
 from deplodock.commands.deploy.ssh import register_ssh_target
 from deplodock.commands.eval import register_eval_command
+from deplodock.commands.generate import register_generate_command
 from deplodock.commands.inspect_graph import register_inspect_command
 from deplodock.commands.pull import register_pull_command
 from deplodock.commands.run import register_run_command
@@ -45,6 +46,7 @@ def main():
     register_compile_command(subparsers)
     register_tune_command(subparsers)
     register_run_command(subparsers)
+    register_generate_command(subparsers)
     register_inspect_command(subparsers)
     register_eval_command(subparsers)
     register_compare_command(subparsers)

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -63,7 +63,14 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `apply_chat_template` (delegates to the HF tokenizer). Used by the standalone **generation oracle**
   (`commands/generate.py`, Phase 0 of `plans/generative-inference-support.md`) — `deplodock generate`'s host loop
   re-runs the whole fp16 prefix each step on the CUDA backend and samples with this. The generative *vLLM plugin*
-  (`DeplodockGenModel` / `gen_runner.py`) is later-phase work tracked in that plan.
+  (`DeplodockGenModel`) is later-phase work tracked in that plan.
+- `gen_runner.py` — `DeplodockGenRunner` (Phase 2; sibling to `DeplodockForwardRunner`). Carves SDPA out of every
+  decoder layer (`build_attention_split_wrapper`), compiles **two dynamic-`num_tokens` programs per layer** (`pre` +
+  `post`) over the flattened `[num_tokens, H]` layout, and exposes `embed` / `forward_layer_pre(L,…)→(q,k,v)`
+  (un-rotated 2-D seam) / `forward_layer_post(L, attn_out, residual)→hidden` / `final_norm`. The caller stitches between
+  `pre` and `post` (a reference torch SDPA in the Phase-2 host stitch; vLLM paged `Attention` in Phase 3). Host numpy
+  `rebind` I/O for now (the device zero-copy + captured-replay path is the Phase-3/4 perf step); two capacity programs
+  per layer is the memory budget the plan flags (Top risk #9).
 
 ## Static mode (`DEPLODOCK_SERVING_STATIC=1`) — static extents for both batch and seq
 

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -59,6 +59,11 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
 - `packed.py` — `split_spans(positions, max_seq_len)`: vLLM V1 hands pooling models one packed `(num_tokens,)` tensor
   with per-request 0-based positions; spans split at `positions == 0`. Hardened for `_dummy_run`'s garbage profiling
   batches (index 0 always opens a span; overlong spans are chopped).
+- `sampling.py` — **no vLLM, no CUDA**. Pure-numpy token sampling (`Sampler`: greedy / temperature / top-k / top-p) +
+  `apply_chat_template` (delegates to the HF tokenizer). Used by the standalone **generation oracle**
+  (`commands/generate.py`, Phase 0 of `plans/generative-inference-support.md`) — `deplodock generate`'s host loop
+  re-runs the whole fp16 prefix each step on the CUDA backend and samples with this. The generative *vLLM plugin*
+  (`DeplodockGenModel` / `gen_runner.py`) is later-phase work tracked in that plan.
 
 ## Static mode (`DEPLODOCK_SERVING_STATIC=1`) — static extents for both batch and seq
 

--- a/deplodock/serving/ARCHITECTURE.md
+++ b/deplodock/serving/ARCHITECTURE.md
@@ -71,6 +71,15 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `pre` and `post` (a reference torch SDPA in the Phase-2 host stitch; vLLM paged `Attention` in Phase 3). Host numpy
   `rebind` I/O for now (the device zero-copy + captured-replay path is the Phase-3/4 perf step); two capacity programs
   per layer is the memory budget the plan flags (Top risk #9).
+- `vllm_model_gen.py` — `DeplodockGenModel` (Phase 3; the generative vLLM model class). **NOT** `IsAttentionFree`: it
+  builds real vLLM `Attention` layers (one per decoder layer, unique `prefix` → vLLM allocates a KV-cache spec and runs
+  paged attention) + a shared `get_rope` module (a bare `Attention` does no RoPE) + `ParallelLMHead` + `LogitsProcessor`.
+  The trunk compute (embed + per-layer pre/post + final norm) is the `DeplodockGenRunner`; vLLM owns only `lm_head`
+  (`load_weights` claims `lm_head.weight`, or the tied embed alias). `forward` brackets each `self.attn[L](q,k,v)` with
+  two deplodock replays (pre/post), applying RoPE in between (A2). Select via `--runner generate` +
+  `--hf-overrides '{"architectures":["DeplodockGenModel"]}'` + `--dtype float16` (the `serve --generate` branch forces
+  this for seam coherence). Registered in `__init__.py`. Decode-shaped tuning + the device-path interleave are
+  later-phase work.
 
 ## Static mode (`DEPLODOCK_SERVING_STATIC=1`) — static extents for both batch and seq
 

--- a/deplodock/serving/__init__.py
+++ b/deplodock/serving/__init__.py
@@ -12,3 +12,5 @@ def register() -> None:
 
     if "DeplodockEmbedModel" not in ModelRegistry.get_supported_archs():
         ModelRegistry.register_model("DeplodockEmbedModel", "deplodock.serving.vllm_model:DeplodockEmbedModel")
+    if "DeplodockGenModel" not in ModelRegistry.get_supported_archs():
+        ModelRegistry.register_model("DeplodockGenModel", "deplodock.serving.vllm_model_gen:DeplodockGenModel")

--- a/deplodock/serving/gen_runner.py
+++ b/deplodock/serving/gen_runner.py
@@ -1,0 +1,172 @@
+"""``DeplodockGenRunner`` — per-layer attention-split runner (Phase 2 of
+``plans/generative-inference-support.md``).
+
+Sibling to ``DeplodockForwardRunner`` (the embedding runner). Carves SDPA out of every
+decoder layer (``build_attention_split_wrapper``), compiles **two programs per layer**
+(``pre`` + ``post``) over the flattened ``[num_tokens, H]`` layout with ``num_tokens``
+symbolic, and exposes the per-token, everything-but-attention compute:
+
+- ``embed(input_ids) -> hidden[T, H]`` — token embedding lookup (the runner owns embedding).
+- ``forward_layer_pre(L, hidden, positions) -> (q, k, v)`` — un-rotated 2-D seam q[T,Hq·D],
+  k/v[T,Hkv·D] (RoPE is applied downstream by the caller / vLLM, A2 — ``positions`` unused here).
+- ``forward_layer_post(L, attn_out, residual) -> hidden`` — o_proj + residual + post-norm + MLP.
+- ``final_norm(hidden) -> hidden``.
+
+The caller stitches attention between ``pre`` and ``post`` (a reference torch SDPA in the
+Phase-2 host stitch; vLLM's paged ``Attention`` in Phase 3). I/O is host numpy (the
+serving ``rebind`` path) — correctness-first; the device zero-copy + captured-replay path
+is the Phase-3/4 optimization. NOTE: two capacity-sized ``CompiledProgram``s per layer is
+the memory budget the plan flags (Phase 2 "Memory budget" / Top risk #9).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class _Program:
+    """One compiled dynamic-``num_tokens`` split subgraph, run via the host ``rebind`` path."""
+
+    def __init__(self, program, input_names, output_names):
+        self.program = program
+        self.input_names = input_names
+        self.output_names = output_names
+
+    def run(self, arrays):
+        """arrays: numpy arrays aligned to ``input_names`` (each ``[T, …]``). Returns the
+        outputs in ``output_names`` order, sliced to the runtime ``T``."""
+        from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+        t = arrays[0].shape[0]
+        feed = dict(zip(self.input_names, arrays, strict=True))
+        with gpu_lock():
+            self.program.rebind(feed)  # resolves num_tokens from the input shapes
+            self.program.run_once()
+            out = self.program.outputs({"num_tokens": t})
+        return [out[n] for n in self.output_names]
+
+
+def _compile_split(wrapper, example_args, argnames, np_dtype):
+    """Trace ``wrapper`` with axis 0 of every arg bound to a shared ``num_tokens`` Dim,
+    compile, bind constants, build a :class:`_Program`."""
+    import torch
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.loader.binder import bind_constants
+    from deplodock.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs
+    from deplodock.compiler.trace.torch import trace_module
+
+    specs = [f"num_tokens@{name}:0" for name in argnames]  # shared NAME ties all axes
+    graph = trace_module(wrapper, tuple(example_args), dynamic_shapes=build_torch_dynamic_shapes(parse_position_specs(specs)))
+    compiled = CudaBackend(tune_db="auto").compile(graph)
+
+    sources = {}
+    for path, t in wrapper.named_parameters(remove_duplicate=False):
+        sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+    for path, t in wrapper.named_buffers(remove_duplicate=False):
+        sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+    const_feed = bind_constants(compiled, sources)
+
+    feed = {n: a.detach().cpu().to(torch.float32).numpy().astype(np_dtype) for n, a in zip(compiled.inputs, example_args, strict=True)}
+    with gpu_lock():
+        program = CompiledProgram.build(compiled, {**const_feed, **feed})
+    return _Program(program, list(compiled.inputs), list(compiled.outputs))
+
+
+class DeplodockGenRunner:
+    def __init__(self, *, embed_weight, norm, pre, post, attn_meta, np_dtype):
+        self._embed_weight = embed_weight  # numpy [vocab, H]
+        self._norm = norm  # torch module
+        self._pre = pre  # list[_Program]
+        self._post = post  # list[_Program]
+        self.head_dim, self.num_heads, self.num_kv_heads, self.scaling = attn_meta
+        self._np_dtype = np_dtype
+
+    @property
+    def num_layers(self) -> int:
+        return len(self._pre)
+
+    @classmethod
+    def create(cls, model_id, *, dtype_str="float16"):
+        import torch
+        from transformers import AutoModelForCausalLM
+
+        logger.info("[gen_runner] loading %s (%s, CPU trace)...", model_id, dtype_str)
+        with torch.device("cpu"):
+            model = AutoModelForCausalLM.from_pretrained(model_id, dtype=getattr(torch, dtype_str)).eval()
+            return cls.from_model(model, dtype_str=dtype_str)
+
+    @classmethod
+    def from_model(cls, model, *, dtype_str="float16"):
+        """Build from an already-loaded CausalLM module (the network-free path). ``model``
+        must be on CPU for the trace."""
+        import numpy as np
+        import torch
+
+        from deplodock.compiler.trace.huggingface import build_attention_split_wrapper
+
+        dtype = getattr(torch, dtype_str)
+        np_dtype = np.dtype(dtype_str)
+        trunk = getattr(model, "model", model)
+        layers = trunk.layers
+        attn0 = layers[0].self_attn
+        head_dim = attn0.head_dim
+        num_heads = attn0.q_proj.out_features // head_dim
+        num_kv = attn0.k_proj.out_features // head_dim
+        scaling = attn0.scaling
+        hidden = model.config.hidden_size
+        attn_width = num_heads * head_dim
+
+        pre_programs, post_programs = [], []
+        for i, block in enumerate(layers):
+            logger.info("[gen_runner] compiling layer %d/%d (pre + post)...", i + 1, len(layers))
+            pre_w, post_w = build_attention_split_wrapper(block)
+            with torch.device("cpu"):
+                pre_programs.append(_compile_split(pre_w, [torch.zeros(8, hidden, dtype=dtype)], ["hidden"], np_dtype))
+                post_programs.append(
+                    _compile_split(
+                        post_w,
+                        [torch.zeros(8, attn_width, dtype=dtype), torch.zeros(8, hidden, dtype=dtype)],
+                        ["attn_out", "residual"],
+                        np_dtype,
+                    )
+                )
+
+        embed_weight = trunk.embed_tokens.weight.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+        return cls(
+            embed_weight=embed_weight,
+            norm=trunk.norm,
+            pre=pre_programs,
+            post=post_programs,
+            attn_meta=(head_dim, num_heads, num_kv, scaling),
+            np_dtype=np_dtype,
+        )
+
+    def embed(self, input_ids):
+        """``input_ids``: list/1-D of ints → ``[T, H]`` numpy in the runner dtype."""
+        import numpy as np
+
+        return self._embed_weight[np.asarray(input_ids, dtype=np.int64)]
+
+    def forward_layer_pre(self, layer, hidden, positions=None):
+        """``hidden[T, H]`` numpy → un-rotated ``(q[T,Hq·D], k[T,Hkv·D], v[T,Hkv·D])``.
+        ``positions`` is unused under A2 (RoPE applied downstream); kept for signature parity."""
+        del positions
+        return tuple(self._pre[layer].run([hidden.astype(self._np_dtype, copy=False)]))
+
+    def forward_layer_post(self, layer, attn_out, residual):
+        """``(attn_out[T,Hq·D], residual[T,H])`` numpy → ``layer_out[T, H]`` numpy."""
+        return self._post[layer].run([attn_out.astype(self._np_dtype, copy=False), residual.astype(self._np_dtype, copy=False)])[0]
+
+    def final_norm(self, hidden):
+        """Apply the model's final norm (held as a torch module) to ``hidden[T, H]`` numpy."""
+        import numpy as np
+        import torch
+
+        with torch.no_grad():
+            out = self._norm(torch.from_numpy(np.ascontiguousarray(hidden)))
+        return out.numpy()

--- a/deplodock/serving/sampling.py
+++ b/deplodock/serving/sampling.py
@@ -1,0 +1,87 @@
+"""Pure-Python token sampling + chat-template helper for the standalone
+``deplodock generate`` oracle (Phase 0 of ``plans/generative-inference-support.md``).
+
+No vLLM, no CUDA: every function operates on a 1-D ``logits`` vector (numpy), so the
+whole module is unit-testable on CPU. ``Sampler`` is a callable ``logits -> token id``
+covering greedy / temperature / top-k / top-p; ``apply_chat_template`` delegates to the
+HF tokenizer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+def _softmax(logits: np.ndarray) -> np.ndarray:
+    shifted = logits - logits.max()
+    exp = np.exp(shifted)
+    return exp / exp.sum()
+
+
+def greedy(logits: np.ndarray) -> int:
+    """Argmax token id."""
+    return int(np.argmax(logits))
+
+
+def _top_k_mask(logits: np.ndarray, k: int) -> np.ndarray:
+    """Keep the ``k`` highest logits, set the rest to ``-inf``."""
+    if k <= 0 or k >= logits.shape[-1]:
+        return logits
+    kth = np.partition(logits, -k)[-k]
+    return np.where(logits < kth, -np.inf, logits)
+
+
+def _top_p_mask(logits: np.ndarray, p: float) -> np.ndarray:
+    """Nucleus filter: keep the smallest set of highest-prob tokens whose
+    cumulative probability reaches ``p`` (the top-1 token is always kept)."""
+    if not 0.0 < p < 1.0:
+        return logits
+    order = np.argsort(logits)[::-1]
+    probs = _softmax(logits[order])
+    cum_before = np.cumsum(probs) - probs  # cumulative prob strictly before each token
+    keep = cum_before < p
+    keep[0] = True  # always keep the most-likely token
+    masked = np.full_like(logits, -np.inf)
+    masked[order[keep]] = logits[order[keep]]
+    return masked
+
+
+@dataclass
+class Sampler:
+    """Callable ``logits -> token id``. ``temperature <= 0`` is greedy (the default,
+    used by the correctness oracle); otherwise temperature → top-k → top-p → multinomial,
+    seeded for reproducibility."""
+
+    temperature: float = 0.0
+    top_k: int = 0
+    top_p: float = 1.0
+    seed: int = 0
+    _rng: np.random.Generator = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._rng = np.random.default_rng(self.seed)
+
+    def __call__(self, logits: np.ndarray) -> int:
+        logits = np.asarray(logits, dtype=np.float64).reshape(-1)
+        if self.temperature <= 0.0:
+            return greedy(logits)
+        logits = logits / self.temperature
+        logits = _top_k_mask(logits, self.top_k)
+        logits = _top_p_mask(logits, self.top_p)
+        probs = _softmax(logits)
+        return int(self._rng.choice(probs.shape[0], p=probs))
+
+
+def apply_chat_template(tokenizer, prompt: str, *, system: str | None = None) -> list[int]:
+    """Render a single-turn user ``prompt`` (plus optional ``system``) through the
+    tokenizer's chat template and return token ids. Falls back to a plain encode when
+    the tokenizer carries no chat template."""
+    if not getattr(tokenizer, "chat_template", None):
+        return tokenizer.encode(prompt)
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+    return tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=True)

--- a/deplodock/serving/vllm_model_gen.py
+++ b/deplodock/serving/vllm_model_gen.py
@@ -65,6 +65,18 @@ class DeplodockGenModel(nn.Module):
         self.config = config
         self.dtype = mc.dtype
 
+        # The flattened width T = num_tokens is the SUM of newly-scheduled tokens across all
+        # requests per step (continuous batching), bounded by max_num_batched_tokens — NOT
+        # max_model_len. It must stay within the compiler's dynamic-dim / RoPE-buffer cap.
+        from deplodock.compiler.trace.dynamic import DYNAMIC_DIM_MAX
+
+        max_batched = vllm_config.scheduler_config.max_num_batched_tokens
+        if max_batched and max_batched > DYNAMIC_DIM_MAX:
+            raise ValueError(
+                f"max_num_batched_tokens={max_batched} exceeds DYNAMIC_DIM_MAX ({DYNAMIC_DIM_MAX}); "
+                f"serve with --max-num-batched-tokens {DYNAMIC_DIM_MAX} or lower"
+            )
+
         self.runner = DeplodockGenRunner.create(model_id=mc.model, dtype_str=_trunk_dtype_str(mc.dtype))
         n_layers = self.runner.num_layers
         head_dim = self.runner.head_dim

--- a/deplodock/serving/vllm_model_gen.py
+++ b/deplodock/serving/vllm_model_gen.py
@@ -65,6 +65,17 @@ class DeplodockGenModel(nn.Module):
         self.config = config
         self.dtype = mc.dtype
 
+        # The carve (pre/post + a plain causal vLLM Attention) assumes FULL causal attention.
+        # Sliding-window / per-layer-sliding / dual-chunk variants would silently miscompute
+        # (neither side here is window/chunk aware) — reject rather than mislead.
+        if getattr(config, "use_sliding_window", False) and getattr(config, "sliding_window", None):
+            raise NotImplementedError("DeplodockGenModel: sliding-window attention is not supported")
+        layer_types = getattr(config, "layer_types", None)
+        if layer_types and any(lt == "sliding_attention" for lt in layer_types):
+            raise NotImplementedError("DeplodockGenModel: per-layer sliding attention is not supported")
+        if getattr(config, "dual_chunk_attention_config", None):
+            raise NotImplementedError("DeplodockGenModel: dual-chunk attention is not supported")
+
         # The flattened width T = num_tokens is the SUM of newly-scheduled tokens across all
         # requests per step (continuous batching), bounded by max_num_batched_tokens — NOT
         # max_model_len. It must stay within the compiler's dynamic-dim / RoPE-buffer cap.

--- a/deplodock/serving/vllm_model_gen.py
+++ b/deplodock/serving/vllm_model_gen.py
@@ -1,0 +1,137 @@
+"""``DeplodockGenModel`` — the vLLM out-of-tree **generative** model class (Phase 3 of
+``plans/generative-inference-support.md``).
+
+Serve a decoder-only chat model (Qwen3 / Llama) through deplodock-compiled per-layer
+kernels with vLLM owning the API / sampler / scheduler / paged KV-cache:
+
+    vllm serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --runner generate --enforce-eager \\
+      --dtype float16 --hf-overrides '{"architectures":["DeplodockGenModel"]}'
+
+NOT ``IsAttentionFree``: it constructs real vLLM ``Attention`` layers (one per decoder
+layer, unique ``prefix``) so vLLM allocates a KV-cache spec and runs paged attention. All
+weight-bearing **trunk** compute (embed + per-layer pre/post + final norm) lives in the
+deplodock ``DeplodockGenRunner``; vLLM owns only ``lm_head`` (loaded via ``load_weights``)
+and applies RoPE through a ``get_rope`` module the model builds (a bare ``Attention`` does
+none). ``forward`` brackets each vLLM attention call with two deplodock replays (``pre`` /
+``post``); RoPE is applied between ``pre`` and ``self.attn`` (A2).
+
+Numpy host I/O at the runner boundary (the per-layer host-sync interleave — Top risk #1);
+the device zero-copy path is the Phase-4 optimization.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+import torch.nn as nn
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from deplodock.serving.gen_runner import DeplodockGenRunner
+from deplodock.serving.vllm_model import _trunk_dtype_str
+
+logger = logging.getLogger(__name__)
+
+
+def _build_rotary(config, head_dim, max_position):
+    """Construct the model's RoPE the way stock vLLM does — applying each architecture's
+    default-theta mutation first (Qwen3 → 1e6, else a missing rope_theta silently falls
+    back to 10000 → wrong logits)."""
+    try:
+        from vllm.transformers_utils.config import set_default_rope_theta
+
+        if getattr(config, "model_type", None) == "qwen3":
+            set_default_rope_theta(config, default_theta=1000000)
+    except Exception:  # noqa: BLE001 — older vLLM without the helper; config carries theta already
+        pass
+    return get_rope(
+        head_dim,
+        max_position=max_position,
+        rope_parameters=getattr(config, "rope_parameters", None),
+        is_neox_style=True,
+    )
+
+
+class DeplodockGenModel(nn.Module):
+    def __init__(self, *, vllm_config, prefix: str = ""):
+        super().__init__()
+        mc = vllm_config.model_config
+        config = mc.hf_config
+        self.config = config
+        self.dtype = mc.dtype
+
+        self.runner = DeplodockGenRunner.create(model_id=mc.model, dtype_str=_trunk_dtype_str(mc.dtype))
+        n_layers = self.runner.num_layers
+        head_dim = self.runner.head_dim
+
+        # One real vLLM Attention per layer — unique prefix (vLLM keys static_forward_context
+        # / cache-spec discovery by it and rejects duplicates). No weights.
+        self.attn = nn.ModuleList(
+            [
+                Attention(
+                    self.runner.num_heads,
+                    head_dim,
+                    self.runner.scaling,
+                    num_kv_heads=self.runner.num_kv_heads,
+                    cache_config=vllm_config.cache_config,
+                    quant_config=vllm_config.quant_config,
+                    prefix=f"{prefix}.layers.{i}.self_attn.attn",
+                )
+                for i in range(n_layers)
+            ]
+        )
+        # RoPE is NOT in Attention — one shared module (position-only, layer-independent).
+        self.rotary_emb = _build_rotary(config, head_dim, getattr(config, "max_position_embeddings", 8192))
+
+        # vLLM owns ONLY lm_head; the runner owns embed + the trunk.
+        self.lm_head = ParallelLMHead(
+            config.vocab_size, config.hidden_size, quant_config=vllm_config.quant_config, prefix=f"{prefix}.lm_head"
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size, scale=getattr(config, "logit_scale", 1.0))
+
+    def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None, **kwargs):
+        device = positions.device
+        # clamp guards vLLM's _dummy_run garbage-id profiling batches (out-of-vocab → IndexError).
+        ids_np = input_ids.clamp(0, self.config.vocab_size - 1).cpu().numpy()
+        hidden_np = self.runner.embed(ids_np)  # [T, H] numpy
+        for layer in range(self.runner.num_layers):
+            residual_np = hidden_np
+            q_np, k_np, v_np = self.runner.forward_layer_pre(layer, hidden_np, positions)
+            q = torch.from_numpy(np.ascontiguousarray(q_np)).to(device)
+            k = torch.from_numpy(np.ascontiguousarray(k_np)).to(device)
+            v = torch.from_numpy(np.ascontiguousarray(v_np)).to(device)
+            q, k = self.rotary_emb(positions, q, k)  # A2: vLLM applies RoPE
+            attn_out = self.attn[layer](q, k, v)  # vLLM paged attention (pulls attn_metadata from forward context)
+            hidden_np = self.runner.forward_layer_post(layer, attn_out.detach().cpu().numpy(), residual_np)
+        hidden_np = self.runner.final_norm(hidden_np)
+        return torch.from_numpy(np.ascontiguousarray(hidden_np)).to(device)
+
+    def compute_logits(self, hidden_states, *args):
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def embed_input_ids(self, input_ids):
+        # vLLM embedding hook → the runner owns embedding; return its lookup as a GPU tensor.
+        out = self.runner.embed(input_ids.clamp(0, self.config.vocab_size - 1).cpu().numpy())
+        return torch.from_numpy(np.ascontiguousarray(out)).to(input_ids.device)
+
+    def load_weights(self, weights):
+        """vLLM owns ONLY ``lm_head`` (the runner already loaded embed + trunk). Load
+        ``lm_head.weight`` from the checkpoint; when ``tie_word_embeddings`` the checkpoint
+        may carry only ``embed_tokens.weight``, so accept that alias for the head."""
+        param = self.lm_head.weight
+        loader = getattr(param, "weight_loader", default_weight_loader)
+        tied = getattr(self.config, "tie_word_embeddings", False)
+        loaded: set[str] = set()
+        for name, w in weights:
+            if name == "lm_head.weight":
+                loader(param, w)
+                loaded.add("lm_head.weight")
+            elif tied and name in ("model.embed_tokens.weight", "embed_tokens.weight") and "lm_head.weight" not in loaded:
+                loader(param, w)
+                loaded.add("lm_head.weight")
+        return loaded

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -111,9 +111,11 @@ First, even though the end goal is vLLM: it needs **no new SDPA-carve / attentio
 chat output now, and is the correctness reference every later phase verifies against (and is reused by the eventual
 standalone server). It uses the full-recompute strategy (re-run the whole growing prefix each step) — valid *standalone*
 (deplodock controls the loop), intentionally O(S²), an oracle not a product. Runs the **unquantized fp16 path** — the
-whole-model CLI path currently forces fp32 (`_trace_model` for `layer is None`; the runnable binder /
-`bind_constants_from_module` cast to float32), so the one fp16 change is a `dtype` param threaded through those two
-helpers (dtype plumbing, **no dependency on the W4A16 branch** — the serving runner already binds fp16). Key
+whole-model CLI path currently forces fp32 only in the **model load + trace** (`_trace_model` sets `torch.float32` for
+`layer is None`), so the one fp16 change is a `dtype` param there: the fp16 module traces an fp16 graph, and the binder
+needs **no change** — its float32 constant carriers are cast to each buffer's graph dtype at materialization
+(`program.py` `arr.set(…, dtype=buf.dtype.np)`). Dtype plumbing only, **no dependency on the W4A16 branch** (the serving
+runner already runs fp16). Key
 simplification: the recompute loop always runs at positions `0..S-1`, so the existing `_SlicedRotary` is exactly
 right — **no RoPE-runtime-positions work needed here** (that is purely a Phase-6 / incremental concern).
 
@@ -126,8 +128,8 @@ right — **no RoPE-runtime-positions work needed here** (that is purely a Phase
 - **Reuses:** `commands/compile.py::_trace_model` whole-model dynamic path, traced from `AutoModelForCausalLM` so
   `lm_head` / `logits` are in-graph — `build_full_model_wrapper(dynamic=True).forward` returns `out[0]` = logits
   `[1, S, vocab]` (Phase 0's generation wrapper slices the final position before `lm_head` → `[1, vocab]`; see Create).
-  Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs` and the constant binding (the
-  `dtype`-parameterized fp16 path).
+  Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs` and the constant binding (unchanged — float32
+  carriers cast to the graph's fp16 buffers at materialization).
 - **Create:** `deplodock/commands/generate.py` (the host generate loop: feed `input_ids[0:S]` → run dynamic program →
   read last-token `logits[1, vocab]` → sample → append id → repeat to EOS / max; the graph embeds ids internally — the
   loop never handles embeddings). A **generation wrapper** (variant of `build_full_model_wrapper`) slices the final
@@ -167,8 +169,11 @@ MLP sub-block (with its own internal second residual).
   flattened `[T, H]` layout the reshape is `.view(T, n_heads, D)` with **no batch/seq transpose**. The `[1, n_heads, T,
   D]` layout torch SDPA wants is built **only inside the oracle** (Phase 1/2 reference), never in the deplodock kernels
   or at the vLLM seam.
-- **Flattened layout:** trace the subgraph with a 2-D `[num_tokens, H]` activation, `num_tokens` symbolic (reuse
-  `parse_position_specs` / `build_torch_dynamic_shapes`, spec `seq_len@x:0`). All pre/post compute is pointwise or a
+- **Flattened layout:** trace each subgraph with 2-D `[num_tokens, H]` activations, `num_tokens` symbolic (reuse
+  `parse_position_specs` / `build_torch_dynamic_shapes`). The **pre** wrapper has one input (`num_tokens@x:0`);
+  the **post** wrapper has **two** (`attn_out`, `residual`), so both axes get the **same** `Dim` symbol —
+  `num_tokens@attn_out:0` AND `num_tokens@residual:0` (a shared NAME ties them; without the second spec `residual` stays
+  trace-sized). All pre/post compute is pointwise or a
   matmul over H, so collapsing `[1,seq,H] → [seq,H]` is layout-invariant — the property that makes Option A work; the
   q/k/v reshape-into-heads is the danger spot to test.
 - **Modify:** `commands/compile.py::_trace_model` — `--attention-split` debug branch beside the `--layer` branch.
@@ -303,15 +308,16 @@ chat template; no vLLM), `serving/gen_runner.py` (`DeplodockGenRunner`), `servin
 
 **Modify (reuse heavily):** `compiler/trace/huggingface.py` (new `build_attention_split_wrapper` + a Phase-0
 generation wrapper that slices the final position before `lm_head`; A1 rope later),
-`commands/compile.py::_trace_model` (`--attention-split` branch; thread a `dtype` param here + through the runnable
-binder so the whole-model path binds fp16), `serving/__init__.py` (register gen model), `deplodock.py` (import + call
+`commands/compile.py::_trace_model` (`--attention-split` branch; thread a `dtype` param into the whole-model load +
+trace so the graph is fp16 — binder unchanged), `serving/__init__.py` (register gen), `deplodock.py` (import + call
 `register_generate_command` in `main()`), `commands/serve.py` (generative branch).
 `passes/frontend/decomposition/010_sdpa.py` + `ir/frontend/ir.py` only if the
 Phase-1 surgery fallback is used (the explicit-wrapper path leaves them untouched).
 
 **Reuse unchanged (load-bearing machinery):** `backend/cuda/program.py` (`CompiledProgram` build / `set_sym_values` /
 capture/replay / `*_prefix_device`; unchanged **unless** the Phase-2 memory spike forces shared cross-program scratch —
-that is backend work, see Phase 2), `loader/binder.py` (`bind_constants`, fp16 constant binding),
+that is backend work, see Phase 2), `loader/binder.py` (`bind_constants` — dtype-agnostic carriers cast to each buffer's
+graph dtype at materialization),
 `trace/dynamic.py` (`parse_position_specs` / `build_torch_dynamic_shapes` / `DYNAMIC_DIM_MAX`), `trace/torch.py`
 (`trace_module`), and the entire embedding runner as the structural template (`serving/runner.py`,
 `serving/vllm_model.py`).

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -1,8 +1,12 @@
 # Generative (chat) inference for deplodock
 
-> Status: **design / scoping doc. Not yet implemented.** Companion to `plans/w4a16-quantization-support.md`. Goal: serve
-> a decoder-only chat model (Qwen3 / Llama-3 / the AWQ chat model) through deplodock-compiled kernels, with **vLLM
-> owning the API / sampler / scheduler / KV-cache / chat template** first; a deplodock-standalone server later.
+> Status: **design / scoping doc. Not yet implemented.** Goal: serve a decoder-only chat model (Qwen3 / Llama-3)
+> through deplodock-compiled kernels, with **vLLM owning the API / sampler / scheduler / KV-cache / chat template**
+> first; a deplodock-standalone server later. **Independent of the W4A16 quantization work on its own branch** — this
+> plan runs the **unquantized fp16 path** (fp16 is a dtype, not quantization: the embedding serving runner already binds
+> + runs fp16 end-to-end, `serving/runner.py`); quantized (AWQ) generation rides on the quantization branch separately,
+> once both land. (Qwen3 / Llama-3 ship bf16, and numpy has no native bf16, so the constant path runs them as **fp16** —
+> a small accuracy delta; true bf16 is separate plumbing, still not quantization.)
 >
 > Detail is front-loaded on **Phases 0–4 (to a first working vLLM chat)**; standalone serving + perf are a future-work
 > coda.
@@ -41,13 +45,19 @@ consuming vLLM's attention output; vLLM's `Attention` layer does paged-KV attent
 `Qwen3Attention.forward` — every line except `self.attn(q,k,v)` is per-token. Two refinements locked in:
 
 - **Carve via submodule substitution**, not post-trace graph surgery — the established pre-export pattern
-  (`_PassThroughRotary`, and the W4A16 `DequantLinear` swap). A thin substitute `self_attn` runs `qkv_proj` (+ q/k norm)
+  (`_PassThroughRotary`). A thin substitute `self_attn` runs `qkv_proj` (+ q/k norm)
   and **returns q,k,v directly** (no SDPA, no o_proj); a second subgraph runs o_proj + MLP + post-norm from an attn-out
   input. SDPA never enters the trace by construction.
 - **vLLM applies RoPE in the first cut (A2).** deplodock emits **un-rotated** q/k; `DeplodockGenModel.forward` calls
   vLLM's `self.rotary_emb(positions, q, k)` between the pre-attention kernel and `self.attn`. This deletes the
   runtime-arbitrary-positions trace work from the critical path. **deplodock owning RoPE with runtime positions (A1) is
   a later optimization**, not a prerequisite.
+
+**Scope (Phases 0–4): `tensor_parallel_size=1` only.** The runner loads the full checkpoint per process
+(`serving/runner.py`) with no projection sharding; vLLM's paged `Attention` and vocab-parallel `lm_head` assume
+rank-local shards, which the deplodock trunk does not produce. TP>1 (sharded q/k/v + o_proj, local head counts,
+row-parallel o_proj/MLP reductions, vocab-parallel lm_head, the matching collectives) is **future work** — Phases 0–4
+assume a single rank (fp16, so the first cut covers models that fit one GPU at fp16).
 
 ## Alternatives considered
 
@@ -72,9 +82,9 @@ and B) are not competitors but **phases of one trajectory**; the other three are
   correct so B becomes "swap the host loop", not "build it all at once".
 
 - **Option C — full-sequence recompute each step (O(S²)).** Re-run the whole growing prefix every token. *Adopted only
-  as the Phase 0 standalone oracle* — zero new compiler work, an exact token-for-token reference for every later phase.
-  Rejected as a product: quadratic, and structurally **impossible inside vLLM** (the V1 runner never re-feeds prior
-  context).
+  as the Phase 0 standalone oracle* — no new attention/cache compiler work (it reuses the existing whole-model
+  path), a correctness reference for every later phase. Rejected as a product: quadratic, and structurally **impossible
+  inside vLLM** (the V1 runner never re-feeds prior context).
 
 - **Option D — Mamba-style self-managed state (`IsAttentionFree` / `MambaSpec`).** Forced out: `MambaSpec` assumes a
   *constant-size* recurrent state, but a KV cache grows with sequence length — deplodock cannot present its cache as
@@ -93,42 +103,59 @@ substitution (chosen) vs post-trace frontend-IR graph surgery (fallback); *progr
 
 ### Phase 0 — Standalone naive `deplodock generate` (the correctness ORACLE)
 
-First, even though the end goal is vLLM: it needs **zero new compiler work**, produces real chat output now, and is the
-token-for-token correctness reference every later phase verifies against (and is reused by the eventual standalone
-server). It uses the full-recompute strategy (re-run the whole growing prefix each step) — valid *standalone* (deplodock
-controls the loop), intentionally O(S²), an oracle not a product. Key simplification: the recompute loop always runs at
-positions `0..S-1`, so the existing `_SlicedRotary` is exactly right — **no RoPE-runtime-positions work needed here**
-(that is purely a Phase-6 / incremental concern).
+First, even though the end goal is vLLM: it needs **no new SDPA-carve / attention-split compiler work**, produces real
+chat output now, and is the correctness reference every later phase verifies against (and is reused by the eventual
+standalone server). It uses the full-recompute strategy (re-run the whole growing prefix each step) — valid *standalone*
+(deplodock controls the loop), intentionally O(S²), an oracle not a product. Runs the **unquantized fp16 path** — the
+whole-model CLI path currently forces fp32 (`_trace_model` for `layer is None`; the runnable binder /
+`bind_constants_from_module` cast to float32), so the one fp16 change is a `dtype` param threaded through those two
+helpers (dtype plumbing, **no dependency on the W4A16 branch** — the serving runner already binds fp16). Key
+simplification: the recompute loop always runs at positions `0..S-1`, so the existing `_SlicedRotary` is exactly
+right — **no RoPE-runtime-positions work needed here** (that is purely a Phase-6 / incremental concern).
 
-- **Reuses (no compiler change):** `commands/compile.py::_trace_model` whole-model dynamic path, but traced from
-  `AutoModelForCausalLM` so `lm_head` / `logits` are in-graph — confirmed: `build_full_model_wrapper(dynamic=True).forward`
-  returns `out[0]` = logits `[1, S, vocab]`. Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs`, and
-  the dtype-preserving binding (incl. the W4A16 packed-int path) so the **AWQ chat model** generates too.
+- **Prerequisite spike (de-risk first):** the whole-model dynamic path is **trace-tested but not yet proven to lower and
+  execute end-to-end** — `tests/compiler/ir/test_dynamic_shapes.py::test_qwen_whole_model_dynamic_traces` asserts only
+  the trace, and its docstring flags whole-model CUDA lowering (int64 embedding-gather kernels, lm_head matmul) as
+  uncovered. Phase 0 starts with a one-shot `compile`+`run` of a small CausalLM whole-model **fp16** graph to surface
+  and fill any lowering gaps *before* the loop is built. "Reuse, no compiler change" holds only if this spike is clean —
+  budget for embedding-gather / lm_head lowering work if not.
+- **Reuses:** `commands/compile.py::_trace_model` whole-model dynamic path, traced from `AutoModelForCausalLM` so
+  `lm_head` / `logits` are in-graph — confirmed: `build_full_model_wrapper(dynamic=True).forward` returns `out[0]` =
+  logits `[1, S, vocab]`. Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs` and the constant binding
+  (the `dtype`-parameterized fp16 path).
 - **Create:** `deplodock/commands/generate.py` (the host generate loop: embed → run dynamic program at S → slice
   `logits[0,-1,:]` → sample → append → repeat to EOS / max), `deplodock/serving/sampling.py` (greedy / temperature /
   top-k / top-p — pure numpy/torch, no vLLM), a chat-template helper (delegate to `transformers.apply_chat_template`).
-- **Verify:** greedy decode matches HF `model.generate(do_sample=False)` token-for-token on an fp16 model and the AWQ
-  model (GPU+network gated, manual); fixed-seed sampling sanity; a hermetic 1-layer random-weight CausalLM test of the
+- **Verify:** greedy decode vs HF `model.generate(do_sample=False)` **run in fp16** (apples-to-apples with deplodock's
+  fp16 path — oracle matches the serving dtype, so the test isolates the carve/interleave, not a dtype gap) — gated
+  **primarily on per-step logits within tolerance + top-1 agreement when the margin is sufficient**,
+  with token-for-token kept as a short-decode smoke test (a single fp-driven argmax flip compounds, so it is not the
+  primary gate — see Top risk #7). Fixed-seed sampling sanity; a hermetic 1-layer random-weight CausalLM test of the
   loop wiring (last-token slice, append, position increment) vs an eager reference for a few steps.
 
 ### Phase 1 — Per-layer "everything-but-attention" subgraph (the deplodock enabler; no vLLM)
 
 The core compiler enabler and riskiest trace work. From one HF decoder layer, produce compiled subgraphs:
-**pre-attention** `(hidden[num_tokens,H]) → (q,k,v)` and **post-attention** `(attn_out[num_tokens,Hv]) → layer_out`,
-with `SdpaOp` excised.
+**pre-attention** `(hidden[num_tokens,H]) → (q,k,v)` and **post-attention**
+`(attn_out[num_tokens,Hv], residual[num_tokens,H]) → layer_out`, with `SdpaOp` excised. The `residual` is the
+**layer-input `hidden`** (the pre-norm residual the decoder block adds back after o_proj) — the host already holds it,
+so `pre` need not return it; `post` takes it as a second input and computes `residual + o_proj(attn_out)` then the
+MLP sub-block (with its own internal second residual).
 
 - **Create:** `build_attention_split_wrapper(block, ...)` in `trace/huggingface.py`, sibling to `build_layer_wrapper`.
   It **substitutes `block.self_attn`** with a module that runs `qkv_proj` (+ q/k norm), returns **un-rotated** q,k,v
-  (A2), and never calls SDPA / o_proj; a second wrapper runs o_proj + MLP + post-norm from an attn-out input. (Fallback
-  only if substitution can't express the post-half: post-trace cut of the `SdpaOp` node in frontend IR — promote its
-  q/k/v inputs to graph outputs, its output to a graph input.)
+  (A2), and never calls SDPA / o_proj; a second wrapper runs o_proj + residual + MLP + post-norm from an
+  `(attn_out, residual)` input pair (residual = the layer-input `hidden`). (Fallback only if substitution can't express
+  the post-half: post-trace cut of the `SdpaOp` node in frontend IR — promote its q/k/v inputs to graph outputs, its
+  output to a graph input.)
 - **Flattened layout:** trace the subgraph with a 2-D `[num_tokens, H]` activation, `num_tokens` symbolic (reuse
   `parse_position_specs` / `build_torch_dynamic_shapes`, spec `seq_len@x:0`). All pre/post compute is pointwise or a
   matmul over H, so collapsing `[1,seq,H] → [seq,H]` is layout-invariant — the property that makes Option A work; the
   q/k/v reshape-into-heads is the danger spot to test.
 - **Modify:** `commands/compile.py::_trace_model` — `--attention-split` debug branch beside the `--layer` branch.
 - **Verify (hermetic, no vLLM):** 1-layer Qwen3 (GQA), dynamic `num_tokens`. Run pre-subgraph → q/k/v → external torch
-  SDPA → post-subgraph; compare layer output to eager `block(x)`. Assert flattened-vs-`[1,seq,H]` equivalence.
+  SDPA → post-subgraph (fed `attn_out` **and** the saved layer-input `hidden` as residual); compare layer output to
+  eager `block(x)`. Assert flattened-vs-`[1,seq,H]` equivalence.
 
 ### Phase 2 — `DeplodockGenRunner` + multi-layer host stitch (still no vLLM)
 
@@ -138,11 +165,14 @@ runner, isolating the interleave / host-sync mechanics.
 
 - **Create:** `deplodock/serving/gen_runner.py` — `DeplodockGenRunner` (sibling to `DeplodockForwardRunner`): traces
   every layer's split subgraphs, compiles, binds weights (`binder.bind_constants`), exposes `embed`,
-  `forward_layer_pre(L, hidden, positions) → (q,k,v)`, `forward_layer_post(L, attn_out) → hidden`, `final_norm`. Reuses
-  the captured-graph replay machinery verbatim (`set_sym_values` / `upload_prefix_device` / `capture_program_graph` /
-  `replay_program_graph` / `output_prefix_device`) and the dlpack zero-copy device I/O.
-- **Decision settled here:** one compiled program **per layer** (simplest; layers are structurally identical so
-  capture/replay caches well) vs one all-layers program with attn boundaries (heavier surgery). Start per-layer.
+  `forward_layer_pre(L, hidden, positions) → (q,k,v)`, `forward_layer_post(L, attn_out, residual) → hidden` (residual =
+  the `hidden` fed to `forward_layer_pre`), `final_norm`. Reuses the captured-graph replay machinery verbatim
+  (`set_sym_values` / `upload_prefix_device` / `capture_program_graph` / `replay_program_graph` /
+  `output_prefix_device`) and the dlpack zero-copy device I/O.
+- **Decision settled here:** **two compiled programs per layer** (`pre` + `post`, each its own captured graph / replay /
+  buffer set — separate because vLLM attention runs between them, so a decode step is **two replays / layer**, not one)
+  at **per-layer** granularity (simplest; layers are structurally identical so capture/replay caches well) vs one
+  all-layers program with attn boundaries (heavier surgery). Start per-layer.
 - **Verify:** full forward of a small CausalLM, deplodock per-layer kernels + reference torch SDPA between, matches
   eager logits.
 
@@ -153,15 +183,22 @@ Wire Phase 2's runner into a vLLM generative model.
 - **Create:** `deplodock/serving/vllm_model_gen.py` — `DeplodockGenModel(nn.Module, …text-gen interfaces)`. **NOT**
   `IsAttentionFree`: it constructs real vLLM `Attention` layers (one per decoder layer, via `vllm.attention.Attention`
   with the model's `num_heads` / `num_kv_heads` / `head_dim` / scale / kv-dtype) so vLLM allocates a KV-cache spec and
-  runs paged attention; those layers carry no weights. All weight-bearing compute stays in the deplodock per-layer
-  programs (`DeplodockGenRunner`), so `load_weights` returns ~empty (same trick as `DeplodockEmbedModel`; lm_head / embed
-  that vLLM owns *are* loaded — get the split-ownership `load_weights` set exactly right or vLLM rejects the model).
+  runs paged attention; those layers carry no weights. **Split ownership (settled):** the **deplodock runner owns the
+  embedding + the whole trunk** (bound into its constants); **vLLM owns only `lm_head`** (loaded via `load_weights`). So
+  `load_weights` claims just `lm_head.*` and returns ~empty for the trunk (same trick as `DeplodockEmbedModel`) — get
+  this set exactly right or vLLM rejects the model on its strict all-params-initialized check. **Tied embeddings:** this
+  model ties `lm_head` to the embedding matrix; with split ownership the first cut **duplicates** it (runner binds it as
+  the embedding constant, vLLM loads it again into `lm_head`) — one extra matrix copy, simplest; sharing is a later
+  optimization.
   - `forward(input_ids, positions, …)` over flattened `[num_tokens]`: `hidden = runner.embed(ids)`; per layer:
-    `q,k,v = runner.forward_layer_pre(L, hidden, positions)`; `q,k = self.rotary_emb[L](positions, q, k)` (A2);
-    `attn_out = self.attn[L](q,k,v)` (vLLM paged attention; pulls `attn_metadata` from the forward-context global);
-    `hidden = runner.forward_layer_post(L, attn_out)`. Final norm in runner. Return `hidden[num_tokens, H]`.
+    `residual = hidden`; `q,k,v = runner.forward_layer_pre(L, hidden, positions)`;
+    `q,k = self.rotary_emb[L](positions, q, k)` (A2); `attn_out = self.attn[L](q,k,v)` (vLLM paged attention; pulls
+    `attn_metadata` from the forward-context global); `hidden = runner.forward_layer_post(L, attn_out, residual)`. Two
+    deplodock replays per layer (`pre`, `post`) bracket the vLLM attention call. Final norm in runner. Return
+    `hidden[num_tokens, H]`.
   - `compute_logits(hidden)`: `self.logits_processor(self.lm_head, hidden)` — vLLM owns lm_head + vocab-parallel (a
-    single matmul not worth compiling on the first cut). Plus `embed_input_ids`.
+    single matmul not worth compiling on the first cut). Any vLLM `get_input_embeddings` / `embed_input_ids` hook
+    **delegates to `runner.embed`** (the runner owns embedding).
 - **Register:** add `ModelRegistry.register_model("DeplodockGenModel", "deplodock.serving.vllm_model_gen:DeplodockGenModel")`
   in `serving/__init__.py::register` (the `vllm.general_plugins` entry point already exists). Select via
   `--hf-overrides '{"architectures":["DeplodockGenModel"]}'`.
@@ -179,12 +216,14 @@ Make it robust across vLLM's two regimes: **prefill** (`num_tokens` = prompt len
 (`num_tokens` = concurrently-decoding sequences, small / 1). One dynamic per-layer program serves both.
 
 - **Captured-graph reuse:** decode runs at small, recurring `num_tokens`; confirm capture is keyed on `num_tokens` and
-  steady-state decode hits the replay path (one launch / layer / step), not recapture. If decode width thrashes
-  (sequences finishing), pad to a few bucket widths (mirrors the embedding runner's per-S capture).
+  steady-state decode hits the replay path (**two replays / layer / step** — `pre` and `post`, bracketing vLLM
+  attention), not recapture. If decode width thrashes (sequences finishing), pad to a few bucket widths (mirrors the
+  embedding runner's per-S capture).
 - **GQA / head alignment** at the deplodock↔`Attention` seam (deplodock emits the right kv-head count; vLLM's
   `Attention` must be constructed to match or it misreads the layout).
-- **Verify:** long-prompt prefill + multi-step decode under concurrency; logits drift over a 100-token generation vs the
-  oracle; decode is one replay / layer / step.
+- **Verify:** long-prompt prefill + multi-step decode under concurrency; **per-step logits within tolerance** vs the
+  oracle over a 100-token generation (token-for-token a smoke check only — argmax flips compound); decode is **two
+  replays / layer / step** (`pre` + `post`).
 
 ### Future work (coda — out of this doc's detailed scope)
 
@@ -203,12 +242,13 @@ Make it robust across vLLM's two regimes: **prefill** (`num_tokens` = prompt len
 vLLM), `serving/gen_runner.py` (`DeplodockGenRunner`), `serving/vllm_model_gen.py` (`DeplodockGenModel`).
 
 **Modify (reuse heavily):** `compiler/trace/huggingface.py` (new `build_attention_split_wrapper`; A1 rope later),
-`commands/compile.py::_trace_model` (`--attention-split` branch), `serving/__init__.py` (register gen model),
+`commands/compile.py::_trace_model` (`--attention-split` branch; thread a `dtype` param here + through the runnable
+binder so the whole-model path binds fp16), `serving/__init__.py` (register gen model),
 `commands/serve.py` (generative branch). `passes/frontend/decomposition/010_sdpa.py` + `ir/frontend/ir.py` only if the
 Phase-1 surgery fallback is used (the substitution path leaves them untouched).
 
 **Reuse unchanged (load-bearing machinery):** `backend/cuda/program.py` (`CompiledProgram` build / `set_sym_values` /
-capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, the W4A16 dtype-preserving helpers),
+capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 constant binding),
 `trace/dynamic.py` (`parse_position_specs` / `build_torch_dynamic_shapes` / `DYNAMIC_DIM_MAX`), `trace/torch.py`
 (`trace_module`), and the entire embedding runner as the structural template (`serving/runner.py`,
 `serving/vllm_model.py`).
@@ -228,15 +268,29 @@ capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, the W
 4. **Captured-graph reuse across decode steps** — must be keyed on `num_tokens` and replay (not recapture) in steady
    state; bucket widths if thrash.
 5. **GQA / head-count alignment** at the deplodock↔`Attention` seam — cross-check at construction; test on Qwen3.
-6. **lm_head / `load_weights` split ownership** — vLLM owns lm_head / embed (loaded via `load_weights`), deplodock owns
-   the trunk (not loaded); the returned set must satisfy vLLM's strict all-params-initialized check exactly.
+6. **lm_head / `load_weights` split ownership** — vLLM owns **only lm_head** (loaded via `load_weights`); the deplodock
+   runner owns embed + trunk (not loaded); the returned set must satisfy vLLM's strict all-params-initialized check
+   exactly. Tied embed↔lm_head is duplicated on the first cut (runner binds embed, vLLM loads lm_head).
+7. **Oracle methodology — token-for-token is brittle.** A single fp-driven argmax flip diverges every later token, so
+   greedy token equality reads as catastrophic when logits are actually within tolerance. Gate **primarily on per-step
+   logits within tolerance + top-1 agreement when the margin is sufficient** (plus a KV-backed-logits vs eager-recompute
+   check); keep token-for-token as a short-decode smoke test only. Compare against HF run at the **same dtype as
+   deplodock (fp16)**, so the test measures the carve/interleave, not an fp16↔fp32 gap.
+8. **Whole-model lowering unproven (dtype-independent)** — only the *trace* is tested today
+   (`test_qwen_whole_model_dynamic_traces`); whole-model CUDA execution (int64 embedding-gather, lm_head matmul) is
+   uncovered. Phase 0's fp16 compile-and-run spike de-risks this before the generate loop is built; fp16 vs fp32 does
+   not change the gap.
 
 ## End-to-end verification
 
-1. Phase 0: `deplodock generate <fp16 model>` greedy == HF `model.generate(do_sample=False)` token-for-token; same on
-   the AWQ chat model. Hermetic loop-wiring unit test.
-2. Phase 1: hermetic per-layer split (pre → torch SDPA → post) == eager `block(x)`; flattened-vs-`[1,seq,H]` equivalence.
+1. Phase 0: `deplodock generate <model>` (fp16 path) greedy vs HF `model.generate(do_sample=False)` **run in fp16** —
+   per-step logits within tolerance + top-1 agreement (token-for-token a short-decode smoke test). Hermetic loop-wiring
+   unit test. Plus the whole-model fp16 compile-and-run spike up front.
+2. Phase 1: hermetic per-layer split (pre → torch SDPA → post, post fed `attn_out` + residual) == eager `block(x)`;
+   flattened-vs-`[1,seq,H]` equivalence.
 3. Phase 2: whole-model host stitch (deplodock layers + ref SDPA) == eager logits.
-4. Phase 3: `vllm serve … DeplodockGenModel` → `/v1/chat/completions` greedy == Phase 0 oracle, token-for-token; GQA ok.
-5. Phase 4: 100-token generation logits drift vs oracle; decode = one replay / layer / step under concurrency.
+4. Phase 3: `vllm serve … DeplodockGenModel` → `/v1/chat/completions` greedy vs Phase 0 oracle — per-step logits within
+   tolerance (token-for-token smoke); GQA ok.
+5. Phase 4: 100-token generation per-step logits within tolerance vs oracle; decode = **two replays / layer / step**
+   (`pre` + `post`) under concurrency.
 6. `make test && make lint` throughout.

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -1,6 +1,11 @@
 # Generative (chat) inference for deplodock
 
-> Status: **design / scoping doc. Not yet implemented.** Goal: serve a decoder-only chat model (Qwen3 / Llama-3)
+> Status: **Phases 0–4 implemented** on branch `feature/generative-inference` (this doc is the design spec they
+> followed). A chat model runs through deplodock-compiled kernels: `deplodock generate` is **token-for-token identical
+> to HF eager** on TinyLlama-1.1B, and `deplodock serve --generate` (the vLLM plugin) is **decode-validated** in-proc.
+> **Correctness is complete; perf hardening remains** — the device zero-copy interleave (the host-sync numpy I/O at the
+> seam is functional but slow) + decode-shaped tuning (Phase 5). See **Implementation status** below. Goal: serve a
+> decoder-only chat model (Qwen3 / Llama-3)
 > through deplodock-compiled kernels, with **vLLM owning the API / sampler / scheduler / KV-cache / chat template**
 > first; a deplodock-standalone server later. **Independent of the W4A16 quantization work on its own branch** — this
 > plan runs the **unquantized fp16 path** (fp16 is a dtype, not quantization: the embedding serving runner already binds
@@ -10,6 +15,27 @@
 >
 > Detail is front-loaded on **Phases 0–4 (to a first working vLLM chat)**; standalone serving + perf are a future-work
 > coda.
+
+## Implementation status
+
+**Phases 0–4 implemented and verified** (branch `feature/generative-inference`):
+
+- **Phase 0 ✅** — `deplodock generate <model>` standalone oracle (`commands/generate.py`, `serving/sampling.py`).
+  Token-for-token identical to HF eager greedy on **TinyLlama-1.1B-Chat** (real weights).
+- **Phase 1 ✅** — `build_attention_split_wrapper` carve (`trace/huggingface.py`). Eager-equivalent to `block(x)` for
+  Qwen3 (GQA + q/k norm) and Llama; dynamic-compiled and run at multiple token counts.
+- **Phase 2 ✅** — `DeplodockGenRunner` (`serving/gen_runner.py`), two per-layer programs. Multi-layer host stitch
+  (deplodock kernels + reference SDPA) == eager logits.
+- **Phase 3 ✅** — `DeplodockGenModel` vLLM plugin (`serving/vllm_model_gen.py`) + `serve --generate`. In-process vLLM
+  engine, greedy decode token-for-token vs HF eager on a tiny Llama.
+- **Phase 4 ◑** — flattened-width bound enforced (`serve` caps `--max-num-batched-tokens` at `DYNAMIC_DIM_MAX`);
+  prefill + decode exercised. **Remaining is perf**: the device zero-copy interleave (the numpy host I/O at the seam is
+  functional but slow) + Phase-5 decode-shaped golden tuning + bench vs stock vLLM.
+
+**Known limits:** full-causal attention only (sliding-window / per-layer-sliding / dual-chunk configs are **rejected**,
+not miscomputed), fp16, TP=1; `serve` compiles **2× n_layers** programs, so startup + memory scale with depth (small
+models for now). The in-graph `slice_last_logits` lm_head optimization stays **off** (cold M=1-matmul lowering gap,
+tracked by an xfail tripwire); `generate` uses full logits + a host slice.
 
 ## Context
 

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -218,7 +218,15 @@ Wire Phase 2's runner into a vLLM generative model.
   `static_forward_context` / cache-spec discovery by it and rejects duplicates (the default empty prefix collides on the
   second layer), so derive `f"{prefix}.layers.{i}.self_attn.attn"` from the model's own `prefix`, and pass the
   version-pinned config args (`cache_config` / `quant_config` off `vllm_config`). Test that vLLM discovers one KV-cache
-  spec per layer. **Split ownership (settled):** the **deplodock runner owns the
+  spec per layer. **Dtype coherence (force fp16 across the seam):** vLLM owns `Attention` / the KV cache / `lm_head`
+  and defaults to `--dtype auto` → **bf16** for a bf16 checkpoint, but the deplodock trunk emits **fp16** q/k/v + hidden
+  — a mismatch at every seam. The generative `serve` branch **forces `--dtype float16`** (so vLLM's `Attention`,
+  KV-cache dtype, and `lm_head` all init fp16) and rejects an incompatible `--dtype` override. **RoPE is NOT in
+  `Attention`:** a bare vLLM `Attention` does paged attention only (stock `Qwen3Attention` builds RoPE separately via
+  `get_rope`, then calls it before `self.attn`), so `DeplodockGenModel` constructs its own RoPE via
+  `get_rope(head_dim, rotary_dim, max_position, rope_parameters=…)` from the HF config (theta + any rope-scaling) — one
+  shared module across layers (RoPE is position-only). Test Qwen3 + Llama-3 RoPE vs stock vLLM. **Split ownership
+  (settled):** the **deplodock runner owns the
   embedding + the whole trunk** (bound into its constants); **vLLM owns only `lm_head`** (loaded via `load_weights`). So
   `load_weights` claims just `lm_head.*` and returns ~empty for the trunk (same trick as `DeplodockEmbedModel`) — get
   this set exactly right or vLLM rejects the model on its strict all-params-initialized check. **Tied embeddings
@@ -228,7 +236,7 @@ Wire Phase 2's runner into a vLLM generative model.
   trunk, so the tied case **duplicates** the matrix (one extra copy, simplest); sharing is a later optimization.
   - `forward(input_ids, positions, …)` over flattened `[num_tokens]`: `hidden = runner.embed(ids)`; per layer:
     `residual = hidden`; `q,k,v = runner.forward_layer_pre(L, hidden, positions)`;
-    `q,k = self.rotary_emb[L](positions, q, k)` (A2); `attn_out = self.attn[L](q,k,v)` (vLLM paged attention; pulls
+    `q,k = self.rotary_emb(positions, q, k)` (A2, the shared RoPE module above); `attn_out = self.attn[L](q,k,v)` (pulls
     `attn_metadata` from the forward-context global); `hidden = runner.forward_layer_post(L, attn_out, residual)`. Two
     deplodock replays per layer (`pre`, `post`) bracket the vLLM attention call. Final norm in runner. Return
     `hidden[num_tokens, H]`.
@@ -238,8 +246,9 @@ Wire Phase 2's runner into a vLLM generative model.
 - **Register:** add `ModelRegistry.register_model("DeplodockGenModel", "deplodock.serving.vllm_model_gen:DeplodockGenModel")`
   in `serving/__init__.py::register` (the `vllm.general_plugins` entry point already exists). Select via
   `--hf-overrides '{"architectures":["DeplodockGenModel"]}'`.
-- **Modify:** `commands/serve.py` — generative branch (`--runner generate` not `pooling`, gen arch override, keep
-  `--enforce-eager`), reusing the flag-split / forward plumbing.
+- **Modify:** `commands/serve.py` — generative branch (`--runner generate` not `pooling`, gen arch override, **force
+  `--dtype float16`** for coherence + reject incompatible `--dtype`, keep `--enforce-eager`), reusing the flag-split
+  / forward plumbing.
 - **Dropped (embedding-specific):** `IsAttentionFree`, `DispatchPooler`, `packed.split_spans`, `attn_type="encoder_only"`,
   the `_mask` / `_causal_mask_np` causal-mask machinery (vLLM's paged attention owns masking now).
 - **Verify (two tiers — HTTP can't expose full logits):** (1) **endpoint smoke** — `vllm serve <model> --runner
@@ -341,6 +350,12 @@ that is backend work, see Phase 2), `loader/binder.py` (`bind_constants`, fp16 c
 9. **Program-count memory blow-up** — 2 × n_layers persistent `CompiledProgram`s, each with capacity-sized buffers + a
    pinned scratch slab + a 64-entry graph cache, can cost several GB of workspace and thousands of cached graphs.
    Memory-budget spike early (Phase 2); share scratch across layer programs and/or cap the global graph cache.
+10. **Seam dtype coherence** — the deplodock trunk runs **fp16** but vLLM defaults to `--dtype auto` → **bf16** for a
+    bf16 checkpoint, so vLLM's `Attention` / KV cache / `lm_head` would mismatch the fp16 q/k/v + hidden at every seam.
+    The generative `serve` branch forces `--dtype float16` and rejects incompatible overrides.
+11. **RoPE not provided by `Attention`** — a bare vLLM `Attention` is paged-attention only; `DeplodockGenModel` must
+    build its own `get_rope(...)` module (theta + rope-scaling from the HF config) and apply it before `self.attn` (A2).
+    Test Qwen3 + Llama-3 against stock vLLM.
 
 ## End-to-end verification
 

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -49,10 +49,45 @@ consuming vLLM's attention output; vLLM's `Attention` layer does paged-KV attent
   runtime-arbitrary-positions trace work from the critical path. **deplodock owning RoPE with runtime positions (A1) is
   a later optimization**, not a prerequisite.
 
-Rejected alternatives are *forced, not chosen*: Mamba-state (KV grows ≠ constant state), full-recompute-in-vLLM (runner
-never re-feeds), one monolithic deplodock kernel that calls vLLM attention mid-graph (deplodock compiles static
-dataflow — it cannot yield to a Python `self.attn` call mid-kernel; the interleave must happen at the Python `forward`
-level, per layer).
+## Alternatives considered
+
+The end-state the user asked for is *vLLM first, deplodock-standalone later* — so the two genuinely-viable options (A
+and B) are not competitors but **phases of one trajectory**; the other three are forced out by the constraints above.
+
+- **Option A — carve SDPA out, vLLM owns paged attention (CHOSEN; this whole doc).** deplodock compiles each layer's
+  per-token everything-but-attention; vLLM's `Attention` layer owns the KV cache and attention math. *Why first:* it
+  reuses vLLM's entire serving stack for free — OpenAI API, sampler, scheduler, paged KV cache, continuous batching,
+  chat template, streaming — and needs **no new deplodock cache or incremental-attention kernel**, so a working chat
+  model lands soonest and the per-layer kernels (where deplodock's value is) get de-risked and tuned under real load.
+  *Cost:* the per-layer host-sync interleave (Top risk #1) — N deplodock↔vLLM round-trips per step, and the interleave
+  itself can't collapse into one captured graph.
+
+- **Option B — deplodock standalone: own KV cache + incremental-attention kernel (the eventual goal; Phase 7).** No
+  vLLM: deplodock manages its own KV cache and a new **incremental-attention kernel** (new q `[1,Hq]` vs cached K/V
+  `[S,Hkv]` — the inverse of today's full-sequence SDPA, the one deep new compiler capability), with Phase 0's loop +
+  `sampling.py` behind a minimal OpenAI server. *Why it wins long-term:* no Python interleave — a whole decode step can
+  be **one captured graph**, the low-latency story deplodock is built for — and no vLLM coupling. *Why deferred:*
+  it reimplements everything vLLM gives free (cache, scheduler, continuous batching, API, sampler) AND needs the hardest
+  new kernel; doing it first would gate the first chat output on the largest pile of new code. A proves the kernels
+  correct so B becomes "swap the host loop", not "build it all at once".
+
+- **Option C — full-sequence recompute each step (O(S²)).** Re-run the whole growing prefix every token. *Adopted only
+  as the Phase 0 standalone oracle* — zero new compiler work, an exact token-for-token reference for every later phase.
+  Rejected as a product: quadratic, and structurally **impossible inside vLLM** (the V1 runner never re-feeds prior
+  context).
+
+- **Option D — Mamba-style self-managed state (`IsAttentionFree` / `MambaSpec`).** Forced out: `MambaSpec` assumes a
+  *constant-size* recurrent state, but a KV cache grows with sequence length — deplodock cannot present its cache as
+  Mamba "state". (This is the embedding plugin's path; it does not generalize to generation.)
+
+- **Option E — one monolithic deplodock kernel that calls vLLM attention mid-graph.** Forced out: deplodock compiles a
+  static dataflow graph; it cannot yield to a Python `self.attn(q,k,v)` call partway through a kernel. The deplodock↔
+  attention interleave must live at the Python `forward` level, per layer — which is exactly what Option A does.
+
+**Sub-options inside A** (each resolved in the phases below, not re-litigated here): *who applies RoPE* — vLLM (**A2**,
+chosen for the first cut) vs deplodock with runtime positions (**A1**, Phase 6); *how to carve SDPA* — submodule
+substitution (chosen) vs post-trace frontend-IR graph surgery (fallback); *program granularity* — one program per layer
+(chosen) vs one all-layers program with attention boundaries (Phase 2).
 
 ## Phases (correctness-first; detail front-loaded on 0–4)
 

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -233,8 +233,10 @@ Wire Phase 2's runner into a vLLM generative model.
   `get_rope`, then calls it before `self.attn`), so `DeplodockGenModel` constructs its own RoPE via
   `get_rope(head_dim, max_position=max_position, rope_parameters=config.rope_parameters)` — the vLLM signature is
   `get_rope(head_size, max_position, …)` (no positional `rotary_dim`; rotary dim + theta + scaling derive from
-  `rope_parameters`), mirroring stock Qwen3/Llama — one
-  shared module across layers (RoPE is position-only). Test Qwen3 + Llama-3 RoPE vs stock vLLM. **Split ownership
+  `rope_parameters`). The per-architecture adapter must **apply each arch's default-theta mutation first** — Qwen3 calls
+  `set_default_rope_theta(config, 1_000_000)` before `get_rope` (else a missing `rope_theta` silently falls back to
+  10000 → wrong logits); one shared module across layers (RoPE is position-only). Test Qwen3 + Llama-3 RoPE vs stock
+  vLLM. **Split ownership
   (settled):** the **deplodock runner owns the
   embedding + the whole trunk** (bound into its constants); **vLLM owns only `lm_head`** (loaded via `load_weights`). So
   `load_weights` claims just `lm_head.*` and returns ~empty for the trunk (same trick as `DeplodockEmbedModel`) — get

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -193,12 +193,16 @@ runner, isolating the interleave / host-sync mechanics.
   buffer set — separate because vLLM attention runs between them, so a decode step is **two replays / layer**, not one)
   at **per-layer** granularity (simplest; layers are structurally identical so capture/replay caches well) vs one
   all-layers program with attn boundaries (heavier surgery). Start per-layer.
-- **Memory budget (spike early):** each `CompiledProgram` owns persistent input/output buffers **and** a pinned scratch
-  slab, plus its own 64-entry LRU CUDA-graph cache (`backend/cuda/program.py`). With **2 × n_layers** capacity-sized
-  programs the MLP-intermediate workspaces can add several GB, and the graph caches can reach thousands of entries
-  globally. Run an early memory-budget spike; plan **shared scratch workspaces** across the structurally-identical layer
-  programs (they run sequentially, so one slab can back all) and/or a **global graph-cache cap** instead of
-  64-per-program.
+- **Memory budget — an early spike that GATES this design:** each `CompiledProgram` owns persistent input/output buffers
+  **and** a pinned scratch slab, plus its own 64-entry LRU CUDA-graph cache (`backend/cuda/program.py`). With **2 ×
+  n_layers** capacity-sized programs the MLP-intermediate workspaces can add several GB, and the graph caches can reach
+  thousands of entries globally. Run the spike first; if over budget, the lightest lever is a **graph-cache cap**
+  — but `_graph_cache_max` is a **per-`CompiledProgram` field** (default 64, `program.py`), so a *global* budget across
+  the 2×n_layers programs needs the **runner to set each program's cap** (e.g. budget / program-count; small allocation
+  logic, not pure config) — plus capping capacity widths. **Shared scratch across programs is NOT free** — it needs
+  backend work (externally-supplied storage, per-program slab views, pointers stable across CUDA-graph capture), which
+  moves `program.py` out of *reuse-unchanged* (add to Critical Files if pursued). If neither suffices the spike can
+  **reject two-programs-per-layer** in favor of fewer/larger chunks.
 - **Verify:** full forward of a small CausalLM — deplodock per-layer `pre` kernels → **reconstruct RoPE on q/k at
   `positions`** → reference causal GQA torch SDPA → `post` kernels, across all layers — matches eager logits. (The
   reference stitch applies the same RoPE the vLLM forward will, since `pre` emits un-rotated q/k under A2.)
@@ -210,7 +214,11 @@ Wire Phase 2's runner into a vLLM generative model.
 - **Create:** `deplodock/serving/vllm_model_gen.py` — `DeplodockGenModel(nn.Module, …text-gen interfaces)`. **NOT**
   `IsAttentionFree`: it constructs real vLLM `Attention` layers (one per decoder layer, via `vllm.attention.Attention`
   with the model's `num_heads` / `num_kv_heads` / `head_dim` / scale / kv-dtype) so vLLM allocates a KV-cache spec and
-  runs paged attention; those layers carry no weights. **Split ownership (settled):** the **deplodock runner owns the
+  runs paged attention; those layers carry no weights. **Each `Attention` needs a unique `prefix`** — vLLM keys
+  `static_forward_context` / cache-spec discovery by it and rejects duplicates (the default empty prefix collides on the
+  second layer), so derive `f"{prefix}.layers.{i}.self_attn.attn"` from the model's own `prefix`, and pass the
+  version-pinned config args (`cache_config` / `quant_config` off `vllm_config`). Test that vLLM discovers one KV-cache
+  spec per layer. **Split ownership (settled):** the **deplodock runner owns the
   embedding + the whole trunk** (bound into its constants); **vLLM owns only `lm_head`** (loaded via `load_weights`). So
   `load_weights` claims just `lm_head.*` and returns ~empty for the trunk (same trick as `DeplodockEmbedModel`) — get
   this set exactly right or vLLM rejects the model on its strict all-params-initialized check. **Tied embeddings
@@ -236,10 +244,12 @@ Wire Phase 2's runner into a vLLM generative model.
   the `_mask` / `_causal_mask_np` causal-mask machinery (vLLM's paged attention owns masking now).
 - **Verify (two tiers — HTTP can't expose full logits):** (1) **endpoint smoke** — `vllm serve <model> --runner
   generate --hf-overrides …DeplodockGenModel…`, then a `/v1/chat/completions` greedy request matches the **Phase 0
-  oracle**'s generated **tokens** (and top-k `logprobs` where returned); (2) **in-process numerical** — a test driving
-  `DeplodockGenModel` / the runner directly (or a debug hook around `compute_logits`) gates **per-step full logits
-  within tolerance + top-1 agreement** vs the oracle (the HTTP path can't return `[vocab]` per step). GQA explicitly
-  checked (Qwen3). GPU-gated `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
+  oracle**'s generated **tokens** (and top-k `logprobs` where returned); (2) **in-process numerical** — the
+  `self.attn(q,k,v)` needs initialized KV caches **and** vLLM's forward-context attention metadata — it can't just call
+  `DeplodockGenModel.forward` in a vacuum: run an **in-process V1 engine** (`vllm.LLM(...)`) with a **logits-capture
+  hook** around `compute_logits` (or build an explicit forward-context + dummy-cache harness) and gate **per-step full
+  logits within tolerance + top-1 agreement** vs the oracle (the HTTP path can't return `[vocab]` per step). GQA
+  explicitly checked (Qwen3). GPU-gated `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
 
 ### Phase 4 — Prefill + decode hardening
 
@@ -247,6 +257,11 @@ Make it robust across vLLM's two regimes: **prefill** (`num_tokens` = prompt len
 (`num_tokens` = concurrently-decoding sequences, small / 1). The same two dynamic per-layer programs (`pre` + `post`)
 serve both.
 
+- **Bound the flattened width `T` (capacity sizing):** `T` = `num_tokens` is the **sum of newly-scheduled tokens across
+  all requests** in a step (continuous batching), **not** one request's length — so `--max-model-len` does NOT bound it.
+  The cap is vLLM's `scheduler_config.max_num_batched_tokens`; assert it `≤ DYNAMIC_DIM_MAX` (4096, `trace/dynamic.py`)
+  and **size the programs' capacity buffers from `max_num_batched_tokens`**, not max-model-len. `commands/serve.py`'s
+  generative branch sets `--max-num-batched-tokens` accordingly (and rejects a larger value).
 - **Captured-graph reuse:** decode runs at small, recurring `num_tokens`; confirm capture is keyed on `num_tokens` and
   steady-state decode hits the replay path (**two replays / layer / step** — `pre` and `post`, bracketing vLLM
   attention), not recapture. **Do NOT pad q/k/v to bucket widths the way the embedding runner does** — vLLM's
@@ -272,18 +287,22 @@ serve both.
 
 ## Critical files
 
-**Create:** `commands/generate.py` (Phase 0 loop; reused by Phase 7), `serving/sampling.py` (sampler + chat template; no
-vLLM), `serving/gen_runner.py` (`DeplodockGenRunner`), `serving/vllm_model_gen.py` (`DeplodockGenModel`).
+**Create:** `commands/generate.py` (Phase 0 loop; reused by Phase 7 — exposes `register_generate_command`, wired into
+`deplodock.py`'s imports + `main()` like every other command, with CLI-parsing tests), `serving/sampling.py` (sampler +
+chat template; no vLLM), `serving/gen_runner.py` (`DeplodockGenRunner`), `serving/vllm_model_gen.py`
+(`DeplodockGenModel`).
 
 **Modify (reuse heavily):** `compiler/trace/huggingface.py` (new `build_attention_split_wrapper` + a Phase-0
 generation wrapper that slices the final position before `lm_head`; A1 rope later),
 `commands/compile.py::_trace_model` (`--attention-split` branch; thread a `dtype` param here + through the runnable
-binder so the whole-model path binds fp16), `serving/__init__.py` (register gen model),
-`commands/serve.py` (generative branch). `passes/frontend/decomposition/010_sdpa.py` + `ir/frontend/ir.py` only if the
+binder so the whole-model path binds fp16), `serving/__init__.py` (register gen model), `deplodock.py` (import + call
+`register_generate_command` in `main()`), `commands/serve.py` (generative branch).
+`passes/frontend/decomposition/010_sdpa.py` + `ir/frontend/ir.py` only if the
 Phase-1 surgery fallback is used (the explicit-wrapper path leaves them untouched).
 
 **Reuse unchanged (load-bearing machinery):** `backend/cuda/program.py` (`CompiledProgram` build / `set_sym_values` /
-capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 constant binding),
+capture/replay / `*_prefix_device`; unchanged **unless** the Phase-2 memory spike forces shared cross-program scratch —
+that is backend work, see Phase 2), `loader/binder.py` (`bind_constants`, fp16 constant binding),
 `trace/dynamic.py` (`parse_position_specs` / `build_torch_dynamic_shapes` / `DYNAMIC_DIM_MAX`), `trace/torch.py`
 (`trace_module`), and the entire embedding runner as the structural template (`serving/runner.py`,
 `serving/vllm_model.py`).
@@ -331,8 +350,9 @@ capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 
 2. Phase 1: hermetic per-layer split (pre → **rotary(q,k)** → torch GQA SDPA → post, post fed `attn_out` + residual) ==
    eager `block(x)`; flattened-vs-`[1,seq,H]` equivalence.
 3. Phase 2: whole-model host stitch (deplodock layers + **rotary(q,k)** + ref SDPA) == eager logits.
-4. Phase 3: `vllm serve … DeplodockGenModel` → `/v1/chat/completions` greedy vs Phase 0 oracle — per-step logits within
-   tolerance (token-for-token smoke); GQA ok.
+4. Phase 3: `/v1/chat/completions` greedy matches the Phase 0 oracle's **tokens** (HTTP smoke); a separate
+   **in-process** engine test with a `compute_logits` hook gates **per-step full logits within tolerance** (HTTP can't
+   return `[vocab]`); GQA ok.
 5. Phase 4: 100-token generation per-step logits within tolerance vs oracle; decode = **two replays / layer / step**
    (`pre` + `post`) under concurrency.
 6. `make test && make lint` throughout.

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -217,8 +217,10 @@ runner, isolating the interleave / host-sync mechanics.
 Wire Phase 2's runner into a vLLM generative model.
 
 - **Create:** `deplodock/serving/vllm_model_gen.py` — `DeplodockGenModel(nn.Module, …text-gen interfaces)`. **NOT**
-  `IsAttentionFree`: it constructs real vLLM `Attention` layers (one per decoder layer, via `vllm.attention.Attention`
-  with the model's `num_heads` / `num_kv_heads` / `head_dim` / scale / kv-dtype) so vLLM allocates a KV-cache spec and
+  `IsAttentionFree`: it constructs real vLLM `Attention` layers (one per decoder layer, via
+  `vllm.model_executor.layers.attention.Attention` — NOT `vllm.attention.Attention`, which this pinned vLLM doesn't
+  export — with the model's `num_heads` / `num_kv_heads` / `head_dim` / scale / kv-dtype) so vLLM allocates a KV-cache
+  spec and
   runs paged attention; those layers carry no weights. **Each `Attention` needs a unique `prefix`** — vLLM keys
   `static_forward_context` / cache-spec discovery by it and rejects duplicates (the default empty prefix collides on the
   second layer), so derive `f"{prefix}.layers.{i}.self_attn.attn"` from the model's own `prefix`, and pass the
@@ -229,7 +231,9 @@ Wire Phase 2's runner into a vLLM generative model.
   KV-cache dtype, and `lm_head` all init fp16) and rejects an incompatible `--dtype` override. **RoPE is NOT in
   `Attention`:** a bare vLLM `Attention` does paged attention only (stock `Qwen3Attention` builds RoPE separately via
   `get_rope`, then calls it before `self.attn`), so `DeplodockGenModel` constructs its own RoPE via
-  `get_rope(head_dim, rotary_dim, max_position, rope_parameters=…)` from the HF config (theta + any rope-scaling) — one
+  `get_rope(head_dim, max_position=max_position, rope_parameters=config.rope_parameters)` — the vLLM signature is
+  `get_rope(head_size, max_position, …)` (no positional `rotary_dim`; rotary dim + theta + scaling derive from
+  `rope_parameters`), mirroring stock Qwen3/Llama — one
   shared module across layers (RoPE is position-only). Test Qwen3 + Llama-3 RoPE vs stock vLLM. **Split ownership
   (settled):** the **deplodock runner owns the
   embedding + the whole trunk** (bound into its constants); **vLLM owns only `lm_head`** (loaded via `load_weights`). So

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -1,0 +1,207 @@
+# Generative (chat) inference for deplodock
+
+> Status: **design / scoping doc. Not yet implemented.** Companion to `plans/w4a16-quantization-support.md`. Goal: serve
+> a decoder-only chat model (Qwen3 / Llama-3 / the AWQ chat model) through deplodock-compiled kernels, with **vLLM
+> owning the API / sampler / scheduler / KV-cache / chat template** first; a deplodock-standalone server later.
+>
+> Detail is front-loaded on **Phases 0–4 (to a first working vLLM chat)**; standalone serving + perf are a future-work
+> coda.
+
+## Context
+
+`deplodock serve` today serves **embeddings only** (`deplodock/serving/`): a causal trunk → hidden states, vLLM's
+pooler does last-token pooling. There is **no generation / decode / KV-cache / sampling code anywhere**. The compiler
+decomposes attention **fully and internally** (`passes/frontend/decomposition/010_sdpa.py`: QK^T → scale → mask →
+softmax → PV) over a full-sequence `[batch, heads, seq, dim]` layout, causal mask `(1,1,S,S)`, with RoPE cos/sin **baked
+as graph constants** at trace time (`trace/huggingface.py` `_SlicedRotary` / `_PassThroughRotary`). This is correct for
+*whole-sequence prefill* but structurally incompatible with how vLLM drives generation.
+
+**The hard constraint (verified against vLLM 0.22.1 source).** vLLM's V1 generative runner
+(`vllm/v1/worker/gpu_model_runner.py`) feeds the model **only the newly-scheduled tokens** per step, as a flattened
+`[num_tokens]` continuous-batched layout, passing absolute `positions`; it **never re-feeds prior context**. KV state +
+cross-token attention live in vLLM's **paged-attention backend** — a generative model only supplies q/k/v to a vLLM
+`Attention` layer (`self.attn(q,k,v)`), and vLLM owns the cache, the attention math, sampling, chat template, streaming,
+and the OpenAI API. Consequences:
+
+- **"Recompute the whole sequence each step" is impossible inside vLLM** — the runner never gives back prior tokens.
+- **Mamba-style self-managed state is invalid** — `IsAttentionFree` / `MambaSpec` assume a *constant-size* state; a KV
+  cache grows with sequence length, so deplodock cannot present its cache as Mamba "state".
+- Therefore, to ride vLLM's generation runner at all, deplodock **must** support **incremental decode** and let vLLM's
+  `Attention` layer own the KV cache. "vLLM-first" does **not** defer the hard work — it requires it.
+
+**The enabling corollary.** In a decoder layer, *everything except the SDPA core is per-token* — input norm, qkv
+projection (+ q/k norm), RoPE, o-projection, MLP, post-norms are all pointwise or matmuls over the hidden axis. So once
+SDPA is carved out, deplodock's compiled per-layer compute is **layout-invariant** to the flattened `[num_tokens, H]`
+layout, and the only cross-token coupling (attention) becomes vLLM's paged backend. This is the cut Option A makes.
+
+## Decision: Option A — carve SDPA out, vLLM does paged attention
+
+Compile the per-layer **everything-but-attention** compute over the flattened per-token layout, emitting `q/k/v` and
+consuming vLLM's attention output; vLLM's `Attention` layer does paged-KV attention. Validated directly by vLLM's own
+`Qwen3Attention.forward` — every line except `self.attn(q,k,v)` is per-token. Two refinements locked in:
+
+- **Carve via submodule substitution**, not post-trace graph surgery — the established pre-export pattern
+  (`_PassThroughRotary`, and the W4A16 `DequantLinear` swap). A thin substitute `self_attn` runs `qkv_proj` (+ q/k norm)
+  and **returns q,k,v directly** (no SDPA, no o_proj); a second subgraph runs o_proj + MLP + post-norm from an attn-out
+  input. SDPA never enters the trace by construction.
+- **vLLM applies RoPE in the first cut (A2).** deplodock emits **un-rotated** q/k; `DeplodockGenModel.forward` calls
+  vLLM's `self.rotary_emb(positions, q, k)` between the pre-attention kernel and `self.attn`. This deletes the
+  runtime-arbitrary-positions trace work from the critical path. **deplodock owning RoPE with runtime positions (A1) is
+  a later optimization**, not a prerequisite.
+
+Rejected alternatives are *forced, not chosen*: Mamba-state (KV grows ≠ constant state), full-recompute-in-vLLM (runner
+never re-feeds), one monolithic deplodock kernel that calls vLLM attention mid-graph (deplodock compiles static
+dataflow — it cannot yield to a Python `self.attn` call mid-kernel; the interleave must happen at the Python `forward`
+level, per layer).
+
+## Phases (correctness-first; detail front-loaded on 0–4)
+
+### Phase 0 — Standalone naive `deplodock generate` (the correctness ORACLE)
+
+First, even though the end goal is vLLM: it needs **zero new compiler work**, produces real chat output now, and is the
+token-for-token correctness reference every later phase verifies against (and is reused by the eventual standalone
+server). It uses the full-recompute strategy (re-run the whole growing prefix each step) — valid *standalone* (deplodock
+controls the loop), intentionally O(S²), an oracle not a product. Key simplification: the recompute loop always runs at
+positions `0..S-1`, so the existing `_SlicedRotary` is exactly right — **no RoPE-runtime-positions work needed here**
+(that is purely a Phase-6 / incremental concern).
+
+- **Reuses (no compiler change):** `commands/compile.py::_trace_model` whole-model dynamic path, but traced from
+  `AutoModelForCausalLM` so `lm_head` / `logits` are in-graph — confirmed: `build_full_model_wrapper(dynamic=True).forward`
+  returns `out[0]` = logits `[1, S, vocab]`. Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs`, and
+  the dtype-preserving binding (incl. the W4A16 packed-int path) so the **AWQ chat model** generates too.
+- **Create:** `deplodock/commands/generate.py` (the host generate loop: embed → run dynamic program at S → slice
+  `logits[0,-1,:]` → sample → append → repeat to EOS / max), `deplodock/serving/sampling.py` (greedy / temperature /
+  top-k / top-p — pure numpy/torch, no vLLM), a chat-template helper (delegate to `transformers.apply_chat_template`).
+- **Verify:** greedy decode matches HF `model.generate(do_sample=False)` token-for-token on an fp16 model and the AWQ
+  model (GPU+network gated, manual); fixed-seed sampling sanity; a hermetic 1-layer random-weight CausalLM test of the
+  loop wiring (last-token slice, append, position increment) vs an eager reference for a few steps.
+
+### Phase 1 — Per-layer "everything-but-attention" subgraph (the deplodock enabler; no vLLM)
+
+The core compiler enabler and riskiest trace work. From one HF decoder layer, produce compiled subgraphs:
+**pre-attention** `(hidden[num_tokens,H]) → (q,k,v)` and **post-attention** `(attn_out[num_tokens,Hv]) → layer_out`,
+with `SdpaOp` excised.
+
+- **Create:** `build_attention_split_wrapper(block, ...)` in `trace/huggingface.py`, sibling to `build_layer_wrapper`.
+  It **substitutes `block.self_attn`** with a module that runs `qkv_proj` (+ q/k norm), returns **un-rotated** q,k,v
+  (A2), and never calls SDPA / o_proj; a second wrapper runs o_proj + MLP + post-norm from an attn-out input. (Fallback
+  only if substitution can't express the post-half: post-trace cut of the `SdpaOp` node in frontend IR — promote its
+  q/k/v inputs to graph outputs, its output to a graph input.)
+- **Flattened layout:** trace the subgraph with a 2-D `[num_tokens, H]` activation, `num_tokens` symbolic (reuse
+  `parse_position_specs` / `build_torch_dynamic_shapes`, spec `seq_len@x:0`). All pre/post compute is pointwise or a
+  matmul over H, so collapsing `[1,seq,H] → [seq,H]` is layout-invariant — the property that makes Option A work; the
+  q/k/v reshape-into-heads is the danger spot to test.
+- **Modify:** `commands/compile.py::_trace_model` — `--attention-split` debug branch beside the `--layer` branch.
+- **Verify (hermetic, no vLLM):** 1-layer Qwen3 (GQA), dynamic `num_tokens`. Run pre-subgraph → q/k/v → external torch
+  SDPA → post-subgraph; compare layer output to eager `block(x)`. Assert flattened-vs-`[1,seq,H]` equivalence.
+
+### Phase 2 — `DeplodockGenRunner` + multi-layer host stitch (still no vLLM)
+
+Consolidate Phase 1 into a per-layer program and prove a whole-model Python stitch interleaving a **reference torch
+SDPA** between deplodock per-layer kernels across all layers — the dress rehearsal for the vLLM forward without vLLM's
+runner, isolating the interleave / host-sync mechanics.
+
+- **Create:** `deplodock/serving/gen_runner.py` — `DeplodockGenRunner` (sibling to `DeplodockForwardRunner`): traces
+  every layer's split subgraphs, compiles, binds weights (`binder.bind_constants`), exposes `embed`,
+  `forward_layer_pre(L, hidden, positions) → (q,k,v)`, `forward_layer_post(L, attn_out) → hidden`, `final_norm`. Reuses
+  the captured-graph replay machinery verbatim (`set_sym_values` / `upload_prefix_device` / `capture_program_graph` /
+  `replay_program_graph` / `output_prefix_device`) and the dlpack zero-copy device I/O.
+- **Decision settled here:** one compiled program **per layer** (simplest; layers are structurally identical so
+  capture/replay caches well) vs one all-layers program with attn boundaries (heavier surgery). Start per-layer.
+- **Verify:** full forward of a small CausalLM, deplodock per-layer kernels + reference torch SDPA between, matches
+  eager logits.
+
+### Phase 3 — `DeplodockGenModel` vLLM plugin (the integration)
+
+Wire Phase 2's runner into a vLLM generative model.
+
+- **Create:** `deplodock/serving/vllm_model_gen.py` — `DeplodockGenModel(nn.Module, …text-gen interfaces)`. **NOT**
+  `IsAttentionFree`: it constructs real vLLM `Attention` layers (one per decoder layer, via `vllm.attention.Attention`
+  with the model's `num_heads` / `num_kv_heads` / `head_dim` / scale / kv-dtype) so vLLM allocates a KV-cache spec and
+  runs paged attention; those layers carry no weights. All weight-bearing compute stays in the deplodock per-layer
+  programs (`DeplodockGenRunner`), so `load_weights` returns ~empty (same trick as `DeplodockEmbedModel`; lm_head / embed
+  that vLLM owns *are* loaded — get the split-ownership `load_weights` set exactly right or vLLM rejects the model).
+  - `forward(input_ids, positions, …)` over flattened `[num_tokens]`: `hidden = runner.embed(ids)`; per layer:
+    `q,k,v = runner.forward_layer_pre(L, hidden, positions)`; `q,k = self.rotary_emb[L](positions, q, k)` (A2);
+    `attn_out = self.attn[L](q,k,v)` (vLLM paged attention; pulls `attn_metadata` from the forward-context global);
+    `hidden = runner.forward_layer_post(L, attn_out)`. Final norm in runner. Return `hidden[num_tokens, H]`.
+  - `compute_logits(hidden)`: `self.logits_processor(self.lm_head, hidden)` — vLLM owns lm_head + vocab-parallel (a
+    single matmul not worth compiling on the first cut). Plus `embed_input_ids`.
+- **Register:** add `ModelRegistry.register_model("DeplodockGenModel", "deplodock.serving.vllm_model_gen:DeplodockGenModel")`
+  in `serving/__init__.py::register` (the `vllm.general_plugins` entry point already exists). Select via
+  `--hf-overrides '{"architectures":["DeplodockGenModel"]}'`.
+- **Modify:** `commands/serve.py` — generative branch (`--runner generate` not `pooling`, gen arch override, keep
+  `--enforce-eager`), reusing the flag-split / forward plumbing.
+- **Dropped (embedding-specific):** `IsAttentionFree`, `DispatchPooler`, `packed.split_spans`, `attn_type="encoder_only"`,
+  the `_mask` / `_causal_mask_np` causal-mask machinery (vLLM's paged attention owns masking now).
+- **Verify:** `vllm serve <model> --runner generate --hf-overrides …DeplodockGenModel…`, then a `/v1/chat/completions`
+  greedy request matches the **Phase 0 oracle** token-for-token (the reason Phase 0 came first). GQA explicitly checked
+  (Qwen3). GPU-gated `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
+
+### Phase 4 — Prefill + decode hardening
+
+Make it robust across vLLM's two regimes: **prefill** (`num_tokens` = prompt length, large) and **decode**
+(`num_tokens` = concurrently-decoding sequences, small / 1). One dynamic per-layer program serves both.
+
+- **Captured-graph reuse:** decode runs at small, recurring `num_tokens`; confirm capture is keyed on `num_tokens` and
+  steady-state decode hits the replay path (one launch / layer / step), not recapture. If decode width thrashes
+  (sequences finishing), pad to a few bucket widths (mirrors the embedding runner's per-S capture).
+- **GQA / head alignment** at the deplodock↔`Attention` seam (deplodock emits the right kv-head count; vLLM's
+  `Attention` must be constructed to match or it misreads the layout).
+- **Verify:** long-prompt prefill + multi-step decode under concurrency; logits drift over a 100-token generation vs the
+  oracle; decode is one replay / layer / step.
+
+### Future work (coda — out of this doc's detailed scope)
+
+- **Phase 5 — tuning / decode-shaped goldens:** the per-layer kernels are new op identities → tuned via the existing
+  `tune` path; decode `[small, H]` skinny matmuls likely need decode-shaped goldens (`tune-golden`). Bench vs stock vLLM
+  (`vllm bench serve`).
+- **Phase 6 — A1: fold RoPE into deplodock** with runtime positions (cos/sin table baked, index gathered by a
+  `positions[num_tokens]` runtime input via `IndexMapOp`) — drops the vLLM rope hop. Optional; A2 stays the fallback.
+- **Phase 7 — standalone serving:** deplodock's own KV cache + an **incremental-attention kernel** (new q `[1,Hq]` vs
+  cached K/V `[S,Hkv]` — the inverse of today's full-sequence SDPA, the one deep new compiler capability) + a minimal
+  OpenAI server reusing Phase 0's generate loop + `sampling.py`. Deliberately last: it duplicates what vLLM gives free.
+
+## Critical files
+
+**Create:** `commands/generate.py` (Phase 0 loop; reused by Phase 7), `serving/sampling.py` (sampler + chat template; no
+vLLM), `serving/gen_runner.py` (`DeplodockGenRunner`), `serving/vllm_model_gen.py` (`DeplodockGenModel`).
+
+**Modify (reuse heavily):** `compiler/trace/huggingface.py` (new `build_attention_split_wrapper`; A1 rope later),
+`commands/compile.py::_trace_model` (`--attention-split` branch), `serving/__init__.py` (register gen model),
+`commands/serve.py` (generative branch). `passes/frontend/decomposition/010_sdpa.py` + `ir/frontend/ir.py` only if the
+Phase-1 surgery fallback is used (the substitution path leaves them untouched).
+
+**Reuse unchanged (load-bearing machinery):** `backend/cuda/program.py` (`CompiledProgram` build / `set_sym_values` /
+capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, the W4A16 dtype-preserving helpers),
+`trace/dynamic.py` (`parse_position_specs` / `build_torch_dynamic_shapes` / `DYNAMIC_DIM_MAX`), `trace/torch.py`
+(`trace_module`), and the entire embedding runner as the structural template (`serving/runner.py`,
+`serving/vllm_model.py`).
+
+## Top risks
+
+1. **Per-layer interleave host-sync (headline).** N round-trips/step: deplodock kernel → Python → vLLM `self.attn` →
+   Python → deplodock kernel. The embedding runner proves dlpack zero-copy keeps tensors on-GPU across the boundary and
+   captured replay collapses each deplodock side to one launch — but the interleave itself can't be one captured graph.
+   Keep everything on one stream (`cp.cuda.Stream.from_external(torch.cuda.current_stream())`); measure decode-step
+   latency early (Phase 4). Fallback: fewer / larger compiled chunks.
+2. **Flattened-token compile correctness** — layout-invariance holds only because pre/post compute is pointwise +
+   matmul-over-H; the q/k/v reshape-into-heads is the danger spot. De-risk with the Phase-1 equivalence test before any
+   vLLM work.
+3. **Decode-shaped skinny matmuls** (`num_tokens` tiny) — far from the goldens' prefill-ish shapes; verify *correct* at
+   `num_tokens=1` first, tune in Phase 5.
+4. **Captured-graph reuse across decode steps** — must be keyed on `num_tokens` and replay (not recapture) in steady
+   state; bucket widths if thrash.
+5. **GQA / head-count alignment** at the deplodock↔`Attention` seam — cross-check at construction; test on Qwen3.
+6. **lm_head / `load_weights` split ownership** — vLLM owns lm_head / embed (loaded via `load_weights`), deplodock owns
+   the trunk (not loaded); the returned set must satisfy vLLM's strict all-params-initialized check exactly.
+
+## End-to-end verification
+
+1. Phase 0: `deplodock generate <fp16 model>` greedy == HF `model.generate(do_sample=False)` token-for-token; same on
+   the AWQ chat model. Hermetic loop-wiring unit test.
+2. Phase 1: hermetic per-layer split (pre → torch SDPA → post) == eager `block(x)`; flattened-vs-`[1,seq,H]` equivalence.
+3. Phase 2: whole-model host stitch (deplodock layers + ref SDPA) == eager logits.
+4. Phase 3: `vllm serve … DeplodockGenModel` → `/v1/chat/completions` greedy == Phase 0 oracle, token-for-token; GQA ok.
+5. Phase 4: 100-token generation logits drift vs oracle; decode = one replay / layer / step under concurrency.
+6. `make test && make lint` throughout.

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -47,9 +47,10 @@ consuming vLLM's attention output; vLLM's `Attention` layer does paged-KV attent
 - **Carve via explicit per-architecture pre/post wrappers** that read the block's own submodules (not post-trace graph
   surgery; substituting `self_attn` won't work — HF `self_attn.forward` returns `(attn_output, weights)`, not q/k/v).
   The **pre** wrapper runs `input_layernorm` → HF's separate `q_proj`/`k_proj`/`v_proj` (+ per-head `q_norm`/`k_norm` on
-  Qwen3) → **returns q,k,v** (no SDPA, no o_proj); the **post** wrapper runs `o_proj` + residual + MLP + post-norm from
-  an `(attn_out, residual)` input. SDPA never enters the trace by construction. (Note: the fused `qkv_proj` in vLLM's
-  `Qwen3Attention.forward` above is a vLLM detail — the HF module deplodock traces has three separate projections.)
+  Qwen3) → **returns q,k,v** (no SDPA, no o_proj); the **post** wrapper runs `o_proj` + residual + post-norm + MLP +
+  residual from an `(attn_out, residual)` input. SDPA never enters the trace by construction. (Note: the fused
+  `qkv_proj` in vLLM's `Qwen3Attention.forward` above is a vLLM detail — the HF module deplodock traces has three
+  separate projections.)
 - **vLLM applies RoPE in the first cut (A2).** deplodock emits **un-rotated** q/k; `DeplodockGenModel.forward` calls
   vLLM's `self.rotary_emb(positions, q, k)` between the pre-attention kernel and `self.attn`. This deletes the
   runtime-arbitrary-positions trace work from the critical path. **deplodock owning RoPE with runtime positions (A1) is
@@ -160,6 +161,12 @@ MLP sub-block (with its own internal second residual).
   `(attn_out, residual)` pair (residual = the layer-input `hidden`). An **architecture adapter** handles Llama next (no
   `q_norm`/`k_norm`; otherwise identical). (Fallback only if the explicit wrappers prove unworkable: post-trace cut of
   the `SdpaOp` node in frontend IR — promote its q/k/v inputs to graph outputs, its output to a graph input.)
+- **Seam q/k/v ABI (define exactly):** the pre wrapper emits **2-D** `q[T, Hq·D]`, `k[T, Hkv·D]`, `v[T, Hkv·D]` — heads
+  folded into the last dim, tokens leading — exactly what vLLM's `Attention.forward(q,k,v)` consumes (**assert** these
+  shapes at the seam). HF Qwen3's `.view(B,S,-1,D).transpose(1,2)` assumes a `[batch, seq, hidden]` input; on the
+  flattened `[T, H]` layout the reshape is `.view(T, n_heads, D)` with **no batch/seq transpose**. The `[1, n_heads, T,
+  D]` layout torch SDPA wants is built **only inside the oracle** (Phase 1/2 reference), never in the deplodock kernels
+  or at the vLLM seam.
 - **Flattened layout:** trace the subgraph with a 2-D `[num_tokens, H]` activation, `num_tokens` symbolic (reuse
   `parse_position_specs` / `build_torch_dynamic_shapes`, spec `seq_len@x:0`). All pre/post compute is pointwise or a
   matmul over H, so collapsing `[1,seq,H] → [seq,H]` is layout-invariant — the property that makes Option A work; the
@@ -186,6 +193,12 @@ runner, isolating the interleave / host-sync mechanics.
   buffer set — separate because vLLM attention runs between them, so a decode step is **two replays / layer**, not one)
   at **per-layer** granularity (simplest; layers are structurally identical so capture/replay caches well) vs one
   all-layers program with attn boundaries (heavier surgery). Start per-layer.
+- **Memory budget (spike early):** each `CompiledProgram` owns persistent input/output buffers **and** a pinned scratch
+  slab, plus its own 64-entry LRU CUDA-graph cache (`backend/cuda/program.py`). With **2 × n_layers** capacity-sized
+  programs the MLP-intermediate workspaces can add several GB, and the graph caches can reach thousands of entries
+  globally. Run an early memory-budget spike; plan **shared scratch workspaces** across the structurally-identical layer
+  programs (they run sequentially, so one slab can back all) and/or a **global graph-cache cap** instead of
+  64-per-program.
 - **Verify:** full forward of a small CausalLM — deplodock per-layer `pre` kernels → **reconstruct RoPE on q/k at
   `positions`** → reference causal GQA torch SDPA → `post` kernels, across all layers — matches eager logits. (The
   reference stitch applies the same RoPE the vLLM forward will, since `pre` emits un-rotated q/k under A2.)
@@ -221,10 +234,12 @@ Wire Phase 2's runner into a vLLM generative model.
   `--enforce-eager`), reusing the flag-split / forward plumbing.
 - **Dropped (embedding-specific):** `IsAttentionFree`, `DispatchPooler`, `packed.split_spans`, `attn_type="encoder_only"`,
   the `_mask` / `_causal_mask_np` causal-mask machinery (vLLM's paged attention owns masking now).
-- **Verify:** `vllm serve <model> --runner generate --hf-overrides …DeplodockGenModel…`, then a `/v1/chat/completions`
-  greedy request matches the **Phase 0 oracle** on **per-step logits within tolerance + top-1 agreement**
-  (token-for-token a smoke check only — the reason Phase 0 came first). GQA explicitly checked (Qwen3). GPU-gated
-  `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
+- **Verify (two tiers — HTTP can't expose full logits):** (1) **endpoint smoke** — `vllm serve <model> --runner
+  generate --hf-overrides …DeplodockGenModel…`, then a `/v1/chat/completions` greedy request matches the **Phase 0
+  oracle**'s generated **tokens** (and top-k `logprobs` where returned); (2) **in-process numerical** — a test driving
+  `DeplodockGenModel` / the runner directly (or a debug hook around `compute_logits`) gates **per-step full logits
+  within tolerance + top-1 agreement** vs the oracle (the HTTP path can't return `[vocab]` per step). GQA explicitly
+  checked (Qwen3). GPU-gated `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
 
 ### Phase 4 — Prefill + decode hardening
 
@@ -281,8 +296,10 @@ capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 
    Keep everything on one stream (`cp.cuda.Stream.from_external(torch.cuda.current_stream())`); measure decode-step
    latency early (Phase 4). Fallback: fewer / larger compiled chunks.
 2. **Flattened-token compile correctness** — layout-invariance holds only because pre/post compute is pointwise +
-   matmul-over-H; the q/k/v reshape-into-heads is the danger spot. De-risk with the Phase-1 equivalence test before any
-   vLLM work.
+   matmul-over-H; the q/k/v reshape-into-heads is the danger spot (HF's `.view(B,S,-1,D).transpose(1,2)` assumes
+   `[batch,seq,hidden]` — on `[T,H]` it must be `.view(T,n_heads,D)` with no transpose; the seam emits 2-D `q[T,Hq·D]` /
+   `k,v[T,Hkv·D]`, asserted against vLLM's `Attention` input). De-risk with the Phase-1 equivalence test before any vLLM
+   work.
 3. **Decode-shaped skinny matmuls** (`num_tokens` tiny) — far from the goldens' prefill-ish shapes; verify *correct* at
    `num_tokens=1` first, tune in Phase 5.
 4. **Captured-graph reuse across decode steps** — must be keyed on `num_tokens` and replay (not recapture) in steady
@@ -302,6 +319,9 @@ capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 
    (`test_qwen_whole_model_dynamic_traces`); whole-model CUDA execution (int64 embedding-gather, lm_head matmul) is
    uncovered. Phase 0's fp16 compile-and-run spike de-risks this before the generate loop is built; fp16 vs fp32 does
    not change the gap.
+9. **Program-count memory blow-up** — 2 × n_layers persistent `CompiledProgram`s, each with capacity-sized buffers + a
+   pinned scratch slab + a 64-entry graph cache, can cost several GB of workspace and thousands of cached graphs.
+   Memory-budget spike early (Phase 2); share scratch across layer programs and/or cap the global graph cache.
 
 ## End-to-end verification
 

--- a/plans/generative-inference-support.md
+++ b/plans/generative-inference-support.md
@@ -44,10 +44,12 @@ Compile the per-layer **everything-but-attention** compute over the flattened pe
 consuming vLLM's attention output; vLLM's `Attention` layer does paged-KV attention. Validated directly by vLLM's own
 `Qwen3Attention.forward` — every line except `self.attn(q,k,v)` is per-token. Two refinements locked in:
 
-- **Carve via submodule substitution**, not post-trace graph surgery — the established pre-export pattern
-  (`_PassThroughRotary`). A thin substitute `self_attn` runs `qkv_proj` (+ q/k norm)
-  and **returns q,k,v directly** (no SDPA, no o_proj); a second subgraph runs o_proj + MLP + post-norm from an attn-out
-  input. SDPA never enters the trace by construction.
+- **Carve via explicit per-architecture pre/post wrappers** that read the block's own submodules (not post-trace graph
+  surgery; substituting `self_attn` won't work — HF `self_attn.forward` returns `(attn_output, weights)`, not q/k/v).
+  The **pre** wrapper runs `input_layernorm` → HF's separate `q_proj`/`k_proj`/`v_proj` (+ per-head `q_norm`/`k_norm` on
+  Qwen3) → **returns q,k,v** (no SDPA, no o_proj); the **post** wrapper runs `o_proj` + residual + MLP + post-norm from
+  an `(attn_out, residual)` input. SDPA never enters the trace by construction. (Note: the fused `qkv_proj` in vLLM's
+  `Qwen3Attention.forward` above is a vLLM detail — the HF module deplodock traces has three separate projections.)
 - **vLLM applies RoPE in the first cut (A2).** deplodock emits **un-rotated** q/k; `DeplodockGenModel.forward` calls
   vLLM's `self.rotary_emb(positions, q, k)` between the pre-attention kernel and `self.attn`. This deletes the
   runtime-arbitrary-positions trace work from the critical path. **deplodock owning RoPE with runtime positions (A1) is
@@ -95,9 +97,10 @@ and B) are not competitors but **phases of one trajectory**; the other three are
   attention interleave must live at the Python `forward` level, per layer — which is exactly what Option A does.
 
 **Sub-options inside A** (each resolved in the phases below, not re-litigated here): *who applies RoPE* — vLLM (**A2**,
-chosen for the first cut) vs deplodock with runtime positions (**A1**, Phase 6); *how to carve SDPA* — submodule
-substitution (chosen) vs post-trace frontend-IR graph surgery (fallback); *program granularity* — one program per layer
-(chosen) vs one all-layers program with attention boundaries (Phase 2).
+chosen for the first cut) vs deplodock with runtime positions (**A1**, Phase 6); *how to carve SDPA* — explicit
+per-architecture pre/post wrappers reading the block's submodules (chosen) vs post-trace frontend-IR graph surgery
+(fallback); *program granularity* — two programs (pre + post) per layer (chosen) vs one all-layers program with
+attention boundaries (Phase 2).
 
 ## Phases (correctness-first; detail front-loaded on 0–4)
 
@@ -120,12 +123,17 @@ right — **no RoPE-runtime-positions work needed here** (that is purely a Phase
   and fill any lowering gaps *before* the loop is built. "Reuse, no compiler change" holds only if this spike is clean —
   budget for embedding-gather / lm_head lowering work if not.
 - **Reuses:** `commands/compile.py::_trace_model` whole-model dynamic path, traced from `AutoModelForCausalLM` so
-  `lm_head` / `logits` are in-graph — confirmed: `build_full_model_wrapper(dynamic=True).forward` returns `out[0]` =
-  logits `[1, S, vocab]`. Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs` and the constant binding
-  (the `dtype`-parameterized fp16 path).
-- **Create:** `deplodock/commands/generate.py` (the host generate loop: embed → run dynamic program at S → slice
-  `logits[0,-1,:]` → sample → append → repeat to EOS / max), `deplodock/serving/sampling.py` (greedy / temperature /
-  top-k / top-p — pure numpy/torch, no vLLM), a chat-template helper (delegate to `transformers.apply_chat_template`).
+  `lm_head` / `logits` are in-graph — `build_full_model_wrapper(dynamic=True).forward` returns `out[0]` = logits
+  `[1, S, vocab]` (Phase 0's generation wrapper slices the final position before `lm_head` → `[1, vocab]`; see Create).
+  Plus `CompiledProgram` build + `set_sym_values` + `run` + `outputs` and the constant binding (the
+  `dtype`-parameterized fp16 path).
+- **Create:** `deplodock/commands/generate.py` (the host generate loop: feed `input_ids[0:S]` → run dynamic program →
+  read last-token `logits[1, vocab]` → sample → append id → repeat to EOS / max; the graph embeds ids internally — the
+  loop never handles embeddings). A **generation wrapper** (variant of `build_full_model_wrapper`) slices the final
+  hidden state and applies `lm_head` to **that position only**, returning `[1, vocab]` — not the whole-prefix
+  `[1, S, vocab]` (`CompiledProgram.outputs` copies the full buffer to host, and lm_head over every prefix position is
+  O(S·vocab) wasted/step). Plus `deplodock/serving/sampling.py` (greedy / temperature / top-k / top-p — pure
+  numpy/torch, no vLLM), a chat-template helper (delegate to `transformers.apply_chat_template`).
 - **Verify:** greedy decode vs HF `model.generate(do_sample=False)` **run in fp16** (apples-to-apples with deplodock's
   fp16 path — oracle matches the serving dtype, so the test isolates the carve/interleave, not a dtype gap) — gated
   **primarily on per-step logits within tolerance + top-1 agreement when the margin is sufficient**,
@@ -143,19 +151,24 @@ so `pre` need not return it; `post` takes it as a second input and computes `res
 MLP sub-block (with its own internal second residual).
 
 - **Create:** `build_attention_split_wrapper(block, ...)` in `trace/huggingface.py`, sibling to `build_layer_wrapper`.
-  It **substitutes `block.self_attn`** with a module that runs `qkv_proj` (+ q/k norm), returns **un-rotated** q,k,v
-  (A2), and never calls SDPA / o_proj; a second wrapper runs o_proj + residual + MLP + post-norm from an
-  `(attn_out, residual)` input pair (residual = the layer-input `hidden`). (Fallback only if substitution can't express
-  the post-half: post-trace cut of the `SdpaOp` node in frontend IR — promote its q/k/v inputs to graph outputs, its
-  output to a graph input.)
+  Two **explicit per-architecture wrappers** that read the block's own submodules (NOT a `self_attn` substitution — HF
+  `self_attn.forward` returns `(attn_output, attn_weights)`, not q/k/v, and the block adds `residual + attn_output`
+  after it, so swapping `self_attn` can't yield a clean pre-graph). For **Qwen3**: the **pre** wrapper runs
+  `input_layernorm` → separate `q_proj` / `k_proj` / `v_proj` (HF Qwen3 has three; the fused `qkv_proj` is a vLLM
+  detail) → reshape-into-heads → per-head `q_norm` / `k_norm`, returns **un-rotated** q,k,v (A2) — no SDPA, no o_proj.
+  The **post** wrapper runs `o_proj` → `residual +` → `post_attention_layernorm` → `mlp` → `residual2 +` from an
+  `(attn_out, residual)` pair (residual = the layer-input `hidden`). An **architecture adapter** handles Llama next (no
+  `q_norm`/`k_norm`; otherwise identical). (Fallback only if the explicit wrappers prove unworkable: post-trace cut of
+  the `SdpaOp` node in frontend IR — promote its q/k/v inputs to graph outputs, its output to a graph input.)
 - **Flattened layout:** trace the subgraph with a 2-D `[num_tokens, H]` activation, `num_tokens` symbolic (reuse
   `parse_position_specs` / `build_torch_dynamic_shapes`, spec `seq_len@x:0`). All pre/post compute is pointwise or a
   matmul over H, so collapsing `[1,seq,H] → [seq,H]` is layout-invariant — the property that makes Option A work; the
   q/k/v reshape-into-heads is the danger spot to test.
 - **Modify:** `commands/compile.py::_trace_model` — `--attention-split` debug branch beside the `--layer` branch.
-- **Verify (hermetic, no vLLM):** 1-layer Qwen3 (GQA), dynamic `num_tokens`. Run pre-subgraph → q/k/v → external torch
-  SDPA → post-subgraph (fed `attn_out` **and** the saved layer-input `hidden` as residual); compare layer output to
-  eager `block(x)`. Assert flattened-vs-`[1,seq,H]` equivalence.
+- **Verify (hermetic, no vLLM):** 1-layer Qwen3 (GQA), dynamic `num_tokens`. The reference path must **reconstruct
+  RoPE** (pre emits un-rotated q/k under A2): pre-subgraph → q/k/v → **apply rotary to q,k at `positions`** → external
+  causal GQA torch SDPA → post-subgraph (fed `attn_out` **and** the saved layer-input `hidden` as residual); compare
+  layer output to eager `block(x)`. Assert flattened-vs-`[1,seq,H]` equivalence.
 
 ### Phase 2 — `DeplodockGenRunner` + multi-layer host stitch (still no vLLM)
 
@@ -173,8 +186,9 @@ runner, isolating the interleave / host-sync mechanics.
   buffer set — separate because vLLM attention runs between them, so a decode step is **two replays / layer**, not one)
   at **per-layer** granularity (simplest; layers are structurally identical so capture/replay caches well) vs one
   all-layers program with attn boundaries (heavier surgery). Start per-layer.
-- **Verify:** full forward of a small CausalLM, deplodock per-layer kernels + reference torch SDPA between, matches
-  eager logits.
+- **Verify:** full forward of a small CausalLM — deplodock per-layer `pre` kernels → **reconstruct RoPE on q/k at
+  `positions`** → reference causal GQA torch SDPA → `post` kernels, across all layers — matches eager logits. (The
+  reference stitch applies the same RoPE the vLLM forward will, since `pre` emits un-rotated q/k under A2.)
 
 ### Phase 3 — `DeplodockGenModel` vLLM plugin (the integration)
 
@@ -186,10 +200,11 @@ Wire Phase 2's runner into a vLLM generative model.
   runs paged attention; those layers carry no weights. **Split ownership (settled):** the **deplodock runner owns the
   embedding + the whole trunk** (bound into its constants); **vLLM owns only `lm_head`** (loaded via `load_weights`). So
   `load_weights` claims just `lm_head.*` and returns ~empty for the trunk (same trick as `DeplodockEmbedModel`) — get
-  this set exactly right or vLLM rejects the model on its strict all-params-initialized check. **Tied embeddings:** this
-  model ties `lm_head` to the embedding matrix; with split ownership the first cut **duplicates** it (runner binds it as
-  the embedding constant, vLLM loads it again into `lm_head`) — one extra matrix copy, simplest; sharing is a later
-  optimization.
+  this set exactly right or vLLM rejects the model on its strict all-params-initialized check. **Tied embeddings
+  (config-dependent):** when `tie_word_embeddings=True` (e.g. small Qwen3) the checkpoint may store **only**
+  `embed_tokens.weight` (no `lm_head.weight`), so `load_weights` must load the head from that embedding alias; when
+  untied (e.g. Llama-3-8B) it loads `lm_head.*` normally. Either way the runner separately binds the embedding for the
+  trunk, so the tied case **duplicates** the matrix (one extra copy, simplest); sharing is a later optimization.
   - `forward(input_ids, positions, …)` over flattened `[num_tokens]`: `hidden = runner.embed(ids)`; per layer:
     `residual = hidden`; `q,k,v = runner.forward_layer_pre(L, hidden, positions)`;
     `q,k = self.rotary_emb[L](positions, q, k)` (A2); `attn_out = self.attn[L](q,k,v)` (vLLM paged attention; pulls
@@ -207,18 +222,22 @@ Wire Phase 2's runner into a vLLM generative model.
 - **Dropped (embedding-specific):** `IsAttentionFree`, `DispatchPooler`, `packed.split_spans`, `attn_type="encoder_only"`,
   the `_mask` / `_causal_mask_np` causal-mask machinery (vLLM's paged attention owns masking now).
 - **Verify:** `vllm serve <model> --runner generate --hf-overrides …DeplodockGenModel…`, then a `/v1/chat/completions`
-  greedy request matches the **Phase 0 oracle** token-for-token (the reason Phase 0 came first). GQA explicitly checked
-  (Qwen3). GPU-gated `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
+  greedy request matches the **Phase 0 oracle** on **per-step logits within tolerance + top-1 agreement**
+  (token-for-token a smoke check only — the reason Phase 0 came first). GQA explicitly checked (Qwen3). GPU-gated
+  `tests/serving/test_vllm_plugin_gen_gpu.py` mirroring `test_vllm_plugin_gpu.py`.
 
 ### Phase 4 — Prefill + decode hardening
 
 Make it robust across vLLM's two regimes: **prefill** (`num_tokens` = prompt length, large) and **decode**
-(`num_tokens` = concurrently-decoding sequences, small / 1). One dynamic per-layer program serves both.
+(`num_tokens` = concurrently-decoding sequences, small / 1). The same two dynamic per-layer programs (`pre` + `post`)
+serve both.
 
 - **Captured-graph reuse:** decode runs at small, recurring `num_tokens`; confirm capture is keyed on `num_tokens` and
   steady-state decode hits the replay path (**two replays / layer / step** — `pre` and `post`, bracketing vLLM
-  attention), not recapture. If decode width thrashes (sequences finishing), pad to a few bucket widths (mirrors the
-  embedding runner's per-S capture).
+  attention), not recapture. **Do NOT pad q/k/v to bucket widths the way the embedding runner does** — vLLM's
+  `attn_metadata` is built for *exactly* the scheduled token count, and padded rows have no paged-attention cache slots,
+  so they'd desync the seam. With `--enforce-eager` vLLM presents exact widths, so capture **per exact `num_tokens`**
+  (steady-state decode widths recur, so the cache still hits); only pad if coordinated with vLLM's own metadata/padding.
 - **GQA / head alignment** at the deplodock↔`Attention` seam (deplodock emits the right kv-head count; vLLM's
   `Attention` must be constructed to match or it misreads the layout).
 - **Verify:** long-prompt prefill + multi-step decode under concurrency; **per-step logits within tolerance** vs the
@@ -241,11 +260,12 @@ Make it robust across vLLM's two regimes: **prefill** (`num_tokens` = prompt len
 **Create:** `commands/generate.py` (Phase 0 loop; reused by Phase 7), `serving/sampling.py` (sampler + chat template; no
 vLLM), `serving/gen_runner.py` (`DeplodockGenRunner`), `serving/vllm_model_gen.py` (`DeplodockGenModel`).
 
-**Modify (reuse heavily):** `compiler/trace/huggingface.py` (new `build_attention_split_wrapper`; A1 rope later),
+**Modify (reuse heavily):** `compiler/trace/huggingface.py` (new `build_attention_split_wrapper` + a Phase-0
+generation wrapper that slices the final position before `lm_head`; A1 rope later),
 `commands/compile.py::_trace_model` (`--attention-split` branch; thread a `dtype` param here + through the runnable
 binder so the whole-model path binds fp16), `serving/__init__.py` (register gen model),
 `commands/serve.py` (generative branch). `passes/frontend/decomposition/010_sdpa.py` + `ir/frontend/ir.py` only if the
-Phase-1 surgery fallback is used (the substitution path leaves them untouched).
+Phase-1 surgery fallback is used (the explicit-wrapper path leaves them untouched).
 
 **Reuse unchanged (load-bearing machinery):** `backend/cuda/program.py` (`CompiledProgram` build / `set_sym_values` /
 capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 constant binding),
@@ -266,11 +286,13 @@ capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 
 3. **Decode-shaped skinny matmuls** (`num_tokens` tiny) — far from the goldens' prefill-ish shapes; verify *correct* at
    `num_tokens=1` first, tune in Phase 5.
 4. **Captured-graph reuse across decode steps** — must be keyed on `num_tokens` and replay (not recapture) in steady
-   state; bucket widths if thrash.
+   state. Can't pad to bucket widths like the embedding runner (vLLM's `attn_metadata` expects the exact scheduled
+   count — padded rows have no cache slots); capture per exact width (`--enforce-eager` presents exact widths).
 5. **GQA / head-count alignment** at the deplodock↔`Attention` seam — cross-check at construction; test on Qwen3.
 6. **lm_head / `load_weights` split ownership** — vLLM owns **only lm_head** (loaded via `load_weights`); the deplodock
    runner owns embed + trunk (not loaded); the returned set must satisfy vLLM's strict all-params-initialized check
-   exactly. Tied embed↔lm_head is duplicated on the first cut (runner binds embed, vLLM loads lm_head).
+   exactly. `tie_word_embeddings` is config-dependent: when tied, the checkpoint may carry only `embed_tokens.weight`,
+   so `load_weights` loads the head from that alias (trunk duplicates the matrix); when untied, load `lm_head.*`.
 7. **Oracle methodology — token-for-token is brittle.** A single fp-driven argmax flip diverges every later token, so
    greedy token equality reads as catastrophic when logits are actually within tolerance. Gate **primarily on per-step
    logits within tolerance + top-1 agreement when the margin is sufficient** (plus a KV-backed-logits vs eager-recompute
@@ -286,9 +308,9 @@ capture/replay / `*_prefix_device`), `loader/binder.py` (`bind_constants`, fp16 
 1. Phase 0: `deplodock generate <model>` (fp16 path) greedy vs HF `model.generate(do_sample=False)` **run in fp16** —
    per-step logits within tolerance + top-1 agreement (token-for-token a short-decode smoke test). Hermetic loop-wiring
    unit test. Plus the whole-model fp16 compile-and-run spike up front.
-2. Phase 1: hermetic per-layer split (pre → torch SDPA → post, post fed `attn_out` + residual) == eager `block(x)`;
-   flattened-vs-`[1,seq,H]` equivalence.
-3. Phase 2: whole-model host stitch (deplodock layers + ref SDPA) == eager logits.
+2. Phase 1: hermetic per-layer split (pre → **rotary(q,k)** → torch GQA SDPA → post, post fed `attn_out` + residual) ==
+   eager `block(x)`; flattened-vs-`[1,seq,H]` equivalence.
+3. Phase 2: whole-model host stitch (deplodock layers + **rotary(q,k)** + ref SDPA) == eager logits.
 4. Phase 3: `vllm serve … DeplodockGenModel` → `/v1/chat/completions` greedy vs Phase 0 oracle — per-step logits within
    tolerance (token-for-token smoke); GQA ok.
 5. Phase 4: 100-token generation per-step logits within tolerance vs oracle; decode = **two replays / layer / step**

--- a/tests/serving/test_attention_split.py
+++ b/tests/serving/test_attention_split.py
@@ -1,0 +1,126 @@
+"""Hermetic equivalence test for the Phase-1 attention-split carve (no GPU/vLLM).
+
+Proves the carve is correct: for one decoder layer, running ``pre`` → reconstruct RoPE →
+external causal GQA torch SDPA → ``post`` reproduces the eager ``block(x)`` over the
+flattened ``[num_tokens, H]`` layout. Exercises GQA (num_kv_heads < num_heads) and Qwen3's
+per-head q/k norm. Pure eager, CPU, fp32 — no compile.
+"""
+
+import pytest
+
+
+def _repeat_kv(x, n_rep):
+    """[1, Hkv, T, D] -> [1, Hkv*n_rep, T, D] (GQA head expansion)."""
+    b, h, t, d = x.shape
+    if n_rep == 1:
+        return x
+    return x[:, :, None, :, :].expand(b, h, n_rep, t, d).reshape(b, h * n_rep, t, d)
+
+
+def _split_path_output(pre, post, attn, hidden2d, cos, sin, mask, apply_rotary):
+    """Reference reconstruction: pre → rope → causal GQA SDPA → post. The [1,H,T,D] layout
+    lives ONLY here (the carve's seam ABI is 2-D), per the plan."""
+    import torch.nn.functional as F
+
+    head_dim = attn.head_dim
+    num_heads = attn.q_proj.out_features // head_dim
+    num_kv = attn.k_proj.out_features // head_dim
+    t = hidden2d.shape[0]
+
+    q2d, k2d, v2d = pre(hidden2d)  # [T, Hq*D], [T, Hkv*D]
+    # 2-D seam -> [1, n_heads, T, D] (no HF-style transpose hazard; explicit here).
+    q = q2d.view(t, num_heads, head_dim).transpose(0, 1).unsqueeze(0)
+    k = k2d.view(t, num_kv, head_dim).transpose(0, 1).unsqueeze(0)
+    v = v2d.view(t, num_kv, head_dim).transpose(0, 1).unsqueeze(0)
+
+    q, k = apply_rotary(q, k, cos, sin)  # reconstruct the RoPE the eager layer applies
+    k = _repeat_kv(k, num_heads // num_kv)
+    v = _repeat_kv(v, num_heads // num_kv)
+    attn_out = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, scale=attn.scaling)  # [1, Hq, T, D]
+    attn_out = attn_out.transpose(1, 2).reshape(t, num_heads * head_dim)  # [T, Hq*D]
+    return post(attn_out, hidden2d)
+
+
+@pytest.mark.parametrize("arch", ["qwen3", "llama"])
+def test_split_matches_eager_block(arch):
+    torch = pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+
+    from deplodock.compiler.trace.huggingface import build_attention_split_wrapper, build_causal_mask
+
+    if arch == "qwen3":
+        config = transformers.Qwen3Config(
+            vocab_size=64,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            max_position_embeddings=64,
+            use_sliding_window=False,
+        )
+        model = transformers.Qwen3ForCausalLM(config)
+        from transformers.models.qwen3.modeling_qwen3 import apply_rotary_pos_emb
+    else:
+        config = transformers.LlamaConfig(
+            vocab_size=64,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            max_position_embeddings=64,
+        )
+        model = transformers.LlamaForCausalLM(config)
+        from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
+
+    torch.manual_seed(0)
+    model = model.eval()
+    trunk = model.model
+    block = trunk.layers[0]
+    attn = block.self_attn
+
+    t = 6
+    hidden3d = torch.randn(1, t, config.hidden_size)
+    position_ids = torch.arange(t).unsqueeze(0)
+    cos, sin = trunk.rotary_emb(hidden3d, position_ids)  # [1, T, D]
+    mask = build_causal_mask(t, torch.float32)  # [1, 1, T, T] additive
+
+    with torch.no_grad():
+        eager = block(hidden3d, position_embeddings=(cos, sin), attention_mask=mask)
+        eager = eager[0] if isinstance(eager, tuple) else eager  # [1, T, H]
+
+        pre, post = build_attention_split_wrapper(block)
+        out = _split_path_output(pre, post, attn, hidden3d.squeeze(0), cos, sin, mask, apply_rotary_pos_emb)
+
+    assert tuple(out.shape) == (t, config.hidden_size)
+    torch.testing.assert_close(out, eager.squeeze(0), rtol=1e-4, atol=1e-4)
+
+
+def test_pre_emits_2d_seam_shapes():
+    """The pre wrapper's seam ABI: q[T, Hq*D], k/v[T, Hkv*D] (2-D, no transpose)."""
+    torch = pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+
+    from deplodock.compiler.trace.huggingface import build_attention_split_wrapper
+
+    config = transformers.Qwen3Config(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        use_sliding_window=False,
+    )
+    torch.manual_seed(0)
+    block = transformers.Qwen3ForCausalLM(config).eval().model.layers[0]
+    pre, _ = build_attention_split_wrapper(block)
+    t = 5
+    q, k, v = pre(torch.randn(t, config.hidden_size))
+    assert tuple(q.shape) == (t, 4 * 16)  # [T, Hq*D]
+    assert tuple(k.shape) == (t, 2 * 16)  # [T, Hkv*D]
+    assert tuple(v.shape) == (t, 2 * 16)

--- a/tests/serving/test_attention_split_gpu.py
+++ b/tests/serving/test_attention_split_gpu.py
@@ -1,0 +1,122 @@
+"""GPU dynamic-compile test for the Phase-1 attention-split wrappers (the compiler enabler).
+
+``perf``-marked: needs CUDA + cupy. Traces the ``pre`` and ``post`` wrappers over the
+flattened ``[num_tokens, H]`` layout with ``num_tokens`` **symbolic**, compiles each, and
+runs at two different token counts — matching the eager wrapper output. This proves the
+carved subgraphs actually lower + run dynamically (the core of Phase 2's gen_runner), and
+that the ``post`` wrapper's two inputs share one ``Dim`` (without the second spec the
+``residual`` axis would stay trace-sized). fp32 (carve correctness is dtype-independent;
+the fp16 path is covered by the Phase-0 oracle).
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.xdist_group("cuda")]
+
+
+def _qwen3_block():
+    import torch
+    import transformers
+
+    config = transformers.Qwen3Config(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        use_sliding_window=False,
+    )
+    torch.manual_seed(0)
+    return config, transformers.Qwen3ForCausalLM(config).eval().model.layers[0]
+
+
+def _compile_wrapper(wrapper, example_args, argnames):
+    """Trace ``wrapper`` with axis 0 of every arg bound to a shared ``num_tokens`` Dim,
+    compile on the CUDA backend, bind fp32 constants. Returns (program, input_names, output_names)."""
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.loader.binder import bind_constants
+    from deplodock.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs
+    from deplodock.compiler.trace.torch import trace_module
+
+    specs = [f"num_tokens@{name}:0" for name in argnames]  # shared NAME ties all axes
+    graph = trace_module(wrapper, tuple(example_args), dynamic_shapes=build_torch_dynamic_shapes(parse_position_specs(specs)))
+    compiled = CudaBackend(tune_db="auto").compile(graph)
+
+    sources = {}
+    for path, t in wrapper.named_parameters(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    for path, t in wrapper.named_buffers(remove_duplicate=False):
+        sources[path] = t.detach().cpu().numpy().astype(np.float32, copy=False)
+    const_feed = bind_constants(compiled, sources)
+
+    feed = {n: a.detach().cpu().numpy().astype(np.float32) for n, a in zip(compiled.inputs, example_args, strict=True)}
+    with gpu_lock():
+        program = CompiledProgram.build(compiled, {**const_feed, **feed})
+    return program, list(compiled.inputs), list(compiled.outputs)
+
+
+def _run(program, input_names, output_names, arrays):
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+
+    t = arrays[0].shape[0]
+    feed = {n: a.detach().cpu().numpy().astype(np.float32) for n, a in zip(input_names, arrays, strict=True)}
+    with gpu_lock():
+        program.rebind(feed)  # resolves num_tokens from the input shapes
+        program.run_once()
+        out = program.outputs({"num_tokens": t})
+    return [out[n] for n in output_names]
+
+
+def test_pre_wrapper_compiles_and_runs_dynamic():
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from deplodock.compiler.trace.huggingface import build_attention_split_wrapper
+
+    config, block = _qwen3_block()
+    pre, _ = build_attention_split_wrapper(block)
+    h = config.hidden_size
+
+    program, in_names, out_names = _compile_wrapper(pre, [torch.randn(8, h)], ["hidden"])
+    for t in (4, 7):  # different token counts → replay at new num_tokens, not recapture
+        hidden = torch.randn(t, h)
+        got = _run(program, in_names, out_names, [hidden])
+        with torch.no_grad():
+            want = pre(hidden)  # (q, k, v)
+        assert len(got) == 3
+        for g, w in zip(got, want, strict=True):
+            np.testing.assert_allclose(g, w.numpy(), rtol=1e-3, atol=1e-3)
+
+
+def test_post_wrapper_compiles_with_shared_dim():
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from deplodock.compiler.trace.huggingface import build_attention_split_wrapper
+
+    config, block = _qwen3_block()
+    _, post = build_attention_split_wrapper(block)
+    h = config.hidden_size
+    attn_width = config.num_attention_heads * (config.head_dim or h // config.num_attention_heads)
+
+    # post(attn_out[T, Hq*D], residual[T, H]) — BOTH axis-0 share the num_tokens Dim.
+    program, in_names, out_names = _compile_wrapper(post, [torch.randn(8, attn_width), torch.randn(8, h)], ["attn_out", "residual"])
+    for t in (4, 7):
+        attn_out, residual = torch.randn(t, attn_width), torch.randn(t, h)
+        (got,) = _run(program, in_names, out_names, [attn_out, residual])
+        with torch.no_grad():
+            want = post(attn_out, residual)
+        np.testing.assert_allclose(got, want.numpy(), rtol=1e-3, atol=1e-3)

--- a/tests/serving/test_gen_runner_gpu.py
+++ b/tests/serving/test_gen_runner_gpu.py
@@ -1,0 +1,94 @@
+"""Phase-2 multi-layer host-stitch test for ``DeplodockGenRunner`` (no vLLM).
+
+``perf``-marked: needs CUDA + cupy. Builds a tiny multi-layer Qwen3, then runs a whole-model
+Python stitch — ``embed`` → per layer (deplodock ``pre`` kernels → reconstruct RoPE →
+reference causal GQA torch SDPA → deplodock ``post`` kernels) → ``final_norm`` → lm_head —
+and checks the stitched logits against eager. This is the dress rehearsal for the vLLM
+forward (Phase 3) without vLLM's runner, isolating the deplodock↔attention interleave.
+fp32 (carve correctness is dtype-independent; the fp16 path is covered by the Phase-0 oracle).
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.xdist_group("cuda")]
+
+
+def _repeat_kv(x, n_rep):
+    b, h, t, d = x.shape
+    if n_rep == 1:
+        return x
+    return x[:, :, None, :, :].expand(b, h, n_rep, t, d).reshape(b, h * n_rep, t, d)
+
+
+def _reference_attention(runner, q_np, k_np, v_np, cos, sin, mask, apply_rotary):
+    """The carve's attention seam, reconstructed for the host stitch: 2-D q/k/v → [1,H,T,D]
+    → RoPE → causal GQA SDPA → 2-D attn_out. (Phase 3 replaces this with vLLM paged attention.)"""
+    import torch
+    import torch.nn.functional as F
+
+    d, hq, hkv = runner.head_dim, runner.num_heads, runner.num_kv_heads
+    t = q_np.shape[0]
+    q = torch.from_numpy(np.ascontiguousarray(q_np)).view(t, hq, d).transpose(0, 1).unsqueeze(0)
+    k = torch.from_numpy(np.ascontiguousarray(k_np)).view(t, hkv, d).transpose(0, 1).unsqueeze(0)
+    v = torch.from_numpy(np.ascontiguousarray(v_np)).view(t, hkv, d).transpose(0, 1).unsqueeze(0)
+    q, k = apply_rotary(q, k, cos, sin)
+    k, v = _repeat_kv(k, hq // hkv), _repeat_kv(v, hq // hkv)
+    attn = F.scaled_dot_product_attention(q, k, v, attn_mask=mask, scale=runner.scaling)  # [1, Hq, T, D]
+    return attn.transpose(1, 2).reshape(t, hq * d).numpy()
+
+
+def test_gen_runner_stitch_matches_eager():
+    pytest.importorskip("cupy")
+    import torch
+    import transformers
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from transformers.models.qwen3.modeling_qwen3 import apply_rotary_pos_emb
+
+    from deplodock.compiler.trace.huggingface import build_causal_mask
+    from deplodock.serving.gen_runner import DeplodockGenRunner
+
+    config = transformers.Qwen3Config(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        use_sliding_window=False,
+    )
+    torch.manual_seed(0)
+    model = transformers.Qwen3ForCausalLM(config).eval()  # fp32; build_attention_split_wrapper does NOT mutate it
+
+    runner = DeplodockGenRunner.from_model(model, dtype_str="float32")
+    assert runner.num_layers == config.num_hidden_layers
+
+    t = 7
+    input_ids = list(range(1, t + 1))
+    position_ids = torch.arange(t).unsqueeze(0)
+    mask = build_causal_mask(t, torch.float32)  # [1, 1, T, T]
+    cos, sin = model.model.rotary_emb(torch.zeros(1, t, config.hidden_size), position_ids)
+
+    # --- deplodock host stitch ---
+    hidden = runner.embed(input_ids)  # np [T, H]
+    for layer in range(runner.num_layers):
+        residual = hidden
+        q, k, v = runner.forward_layer_pre(layer, hidden, position_ids)
+        attn_out = _reference_attention(runner, q, k, v, cos, sin, mask, apply_rotary_pos_emb)
+        hidden = runner.forward_layer_post(layer, attn_out, residual)
+    hidden = runner.final_norm(hidden)
+    with torch.no_grad():
+        logits_dep = model.lm_head(torch.from_numpy(np.ascontiguousarray(hidden))).numpy()  # [T, vocab]
+
+        # --- eager reference ---
+        eager = model(torch.tensor([input_ids], dtype=torch.long)).logits[0].numpy()  # [T, vocab]
+
+    assert logits_dep.shape == eager.shape
+    np.testing.assert_allclose(logits_dep, eager, rtol=2e-3, atol=2e-3)
+    # next-token greedy agrees too
+    assert int(np.argmax(logits_dep[-1])) == int(np.argmax(eager[-1]))

--- a/tests/serving/test_generate_gpu.py
+++ b/tests/serving/test_generate_gpu.py
@@ -43,10 +43,12 @@ def test_generate_oracle_matches_eager_fp16():
 
     from deplodock.commands.generate import _CompiledLM
 
-    model = _tiny_llama()
-    lm = _CompiledLM.from_model(model, seq_len=8)
-
-    ref = model.to("cuda").eval()
+    # IMPORTANT: build_full_model_wrapper mutates the model in place (replaces rotary_emb
+    # with _SlicedRotary, patches the causal-mask builder). Compare against an INDEPENDENT,
+    # untouched model (same seed → identical weights, but HF's real rotary) so a wrapper/RoPE
+    # bug can't hide by corrupting both sides.
+    lm = _CompiledLM.from_model(_tiny_llama(), seq_len=8)
+    ref = _tiny_llama().to("cuda").eval()
 
     prefixes = [[1, 2, 3], [1, 2, 3, 4], [5, 6, 7, 8, 9, 10]]
     for prefix in prefixes:
@@ -103,6 +105,6 @@ def test_generate_loop_runs_end_to_end():
     from deplodock.serving.sampling import Sampler
 
     lm = _CompiledLM.from_model(_tiny_llama(), seq_len=8)
-    out = generate(lm.logits, [1, 2, 3], max_new_tokens=5, eos_id=None, sampler=Sampler())
+    out = generate(lm.logits, [1, 2, 3], max_new_tokens=5, eos_ids=None, sampler=Sampler())
     assert len(out) == 5
     assert all(0 <= t < 64 for t in out)

--- a/tests/serving/test_generate_gpu.py
+++ b/tests/serving/test_generate_gpu.py
@@ -1,0 +1,108 @@
+"""GPU spike for the Phase-0 generation oracle (``plans/generative-inference-support.md``).
+
+``perf``-marked (deselected by default): needs CUDA + cupy. Builds a TINY random-weight
+Llama CausalLM (no network), compiles the whole-model fp16 dynamic path through
+``_CompiledLM`` (full logits, last row sliced on the host), and checks the compiled
+next-token logits against an eager fp16 reference across a few growing prefixes — the
+plan's "compile-and-run spike" that de-risks whole-model lowering (int64 embedding-gather,
+lm_head matmul) before the generate loop is trusted. The ``slice_last_logits`` xfail below
+tracks the cold-path M=1 lm_head lowering gap that spike surfaced.
+"""
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.xdist_group("cuda")]
+
+
+def _tiny_llama():
+    import torch
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    config = LlamaConfig(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,  # GQA
+        max_position_embeddings=64,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(config).eval().to(torch.float16)
+    return model
+
+
+def test_generate_oracle_matches_eager_fp16():
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from deplodock.commands.generate import _CompiledLM
+
+    model = _tiny_llama()
+    lm = _CompiledLM.from_model(model, seq_len=8)
+
+    ref = model.to("cuda").eval()
+
+    prefixes = [[1, 2, 3], [1, 2, 3, 4], [5, 6, 7, 8, 9, 10]]
+    for prefix in prefixes:
+        dep = lm.logits(prefix)  # [vocab] fp32
+        ids = torch.tensor([prefix], dtype=torch.long, device="cuda")
+        with torch.no_grad():
+            eager = ref(ids).logits[0, -1, :].float().cpu().numpy()
+        # fp16 path vs fp16 eager: same dtype, so the only gap is kernel numerics.
+        assert dep.shape == eager.shape
+        np.testing.assert_allclose(dep, eager, rtol=2e-2, atol=2e-2)
+        assert int(np.argmax(dep)) == int(np.argmax(eager))  # greedy token agrees
+
+
+@pytest.mark.xfail(reason="M=1 demoted lm_head (slice_last_logits) not lowered on the cold path; tracked", strict=False)
+def test_slice_last_logits_lowers_cold():
+    """Tripwire for the in-graph last-token slice optimization: compiling the
+    ``slice_last_logits=True`` whole-model graph cold (no prior) currently leaves the M=1
+    demoted lm_head as an unlowered ``LoopOp`` (``CompiledProgram.build`` rejects it). When
+    the cold lowering covers that shape this xfail flips to xpass — re-enable the slice in
+    ``_CompiledLM``."""
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from deplodock.compiler.backend.cuda.backend import CudaBackend
+    from deplodock.compiler.backend.cuda.program import CompiledProgram
+    from deplodock.compiler.backend.gpu_lock import gpu_lock
+    from deplodock.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs
+    from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+    from deplodock.compiler.trace.torch import trace_module
+
+    model = _tiny_llama()
+    s = 8
+    wrapper = build_full_model_wrapper(model, s, torch.float16, dynamic=True, slice_last_logits=True)
+    specs = parse_position_specs(["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"])
+    example = (torch.zeros((1, s), dtype=torch.long), build_causal_mask(s, torch.float16), torch.arange(s).unsqueeze(0))
+    graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
+    compiled = CudaBackend(tune_db=None).compile(graph)
+    with gpu_lock():
+        CompiledProgram.build(compiled)  # raises TypeError on the leftover LoopOp today
+
+
+def test_generate_loop_runs_end_to_end():
+    """The full host loop over the compiled program produces a fixed-length output."""
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from deplodock.commands.generate import _CompiledLM, generate
+    from deplodock.serving.sampling import Sampler
+
+    lm = _CompiledLM.from_model(_tiny_llama(), seq_len=8)
+    out = generate(lm.logits, [1, 2, 3], max_new_tokens=5, eos_id=None, sampler=Sampler())
+    assert len(out) == 5
+    assert all(0 <= t < 64 for t in out)

--- a/tests/serving/test_generate_loop.py
+++ b/tests/serving/test_generate_loop.py
@@ -1,0 +1,106 @@
+"""Hermetic loop-wiring tests for the Phase-0 ``generate`` host loop (no GPU/model).
+
+The loop is driven by a fake ``logits_fn`` so we can assert the wiring — last-token
+slice (the loop only consumes the returned logits), append, prefix growth, and the
+EOS / max-new-tokens stop conditions — without compiling anything.
+"""
+
+import argparse
+
+import numpy as np
+
+from deplodock.commands.generate import generate, register_generate_command
+from deplodock.serving.sampling import Sampler
+
+
+def _onehot(token, vocab=16):
+    logits = np.full(vocab, -10.0)
+    logits[token] = 10.0
+    return logits
+
+
+def test_generate_greedy_follows_logits_fn():
+    # logits_fn always points at the next integer after the last token → 4,5,6,...
+    def logits_fn(ids):
+        return _onehot((ids[-1] + 1) % 16)
+
+    out = generate(logits_fn, [3], max_new_tokens=4, eos_id=None, sampler=Sampler())
+    assert out == [4, 5, 6, 7]
+
+
+def test_generate_stops_at_eos():
+    def logits_fn(ids):
+        return _onehot(2)  # always emit token 2
+
+    out = generate(logits_fn, [0], max_new_tokens=10, eos_id=2, sampler=Sampler())
+    assert out == [2]  # stops immediately after emitting EOS
+
+
+def test_generate_respects_max_new_tokens():
+    def logits_fn(ids):
+        return _onehot(5)
+
+    out = generate(logits_fn, [0], max_new_tokens=3, eos_id=999, sampler=Sampler())
+    assert out == [5, 5, 5]
+
+
+def test_generate_feeds_growing_prefix():
+    seen_lengths = []
+
+    def logits_fn(ids):
+        seen_lengths.append(len(ids))
+        return _onehot(1)
+
+    generate(logits_fn, [0, 0], max_new_tokens=3, eos_id=None, sampler=Sampler())
+    # prompt len 2, then one appended token per step: 2, 3, 4
+    assert seen_lengths == [2, 3, 4]
+
+
+def test_slice_last_logits_wrapper_matches_full_logits():
+    """The generation wrapper (``slice_last_logits=True``) returns ``[1, 1, vocab]`` equal
+    to the full model's final-position logits — pure eager, CPU, no compile."""
+    import pytest
+
+    torch = pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+
+    from deplodock.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
+
+    config = transformers.LlamaConfig(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    model = transformers.LlamaForCausalLM(config).eval()  # fp32 on CPU
+    s = 6
+    wrapper = build_full_model_wrapper(model, s, torch.float32, dynamic=True, slice_last_logits=True)
+
+    ids = torch.arange(s).unsqueeze(0) % config.vocab_size
+    mask = build_causal_mask(s, torch.float32)
+    pos = torch.arange(s).unsqueeze(0)
+    with torch.no_grad():
+        sliced = wrapper(ids, mask, pos)  # [1, 1, vocab]
+        full = model(ids, attention_mask=mask, position_ids=pos, use_cache=False).logits  # [1, S, vocab]
+    assert tuple(sliced.shape) == (1, 1, config.vocab_size)
+    torch.testing.assert_close(sliced[:, 0, :], full[:, -1, :], rtol=1e-4, atol=1e-4)
+
+
+def test_register_generate_command_parses():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    register_generate_command(sub)
+
+    from deplodock.commands.generate import handle_generate
+
+    args = parser.parse_args(["generate", "some/model", "--max-new-tokens", "5", "--temperature", "0.7", "--chat"])
+    assert args.func is handle_generate
+    assert args.model == "some/model"
+    assert args.max_new_tokens == 5
+    assert args.temperature == 0.7
+    assert args.chat is True

--- a/tests/serving/test_generate_loop.py
+++ b/tests/serving/test_generate_loop.py
@@ -24,7 +24,7 @@ def test_generate_greedy_follows_logits_fn():
     def logits_fn(ids):
         return _onehot((ids[-1] + 1) % 16)
 
-    out = generate(logits_fn, [3], max_new_tokens=4, eos_id=None, sampler=Sampler())
+    out = generate(logits_fn, [3], max_new_tokens=4, eos_ids=None, sampler=Sampler())
     assert out == [4, 5, 6, 7]
 
 
@@ -32,15 +32,23 @@ def test_generate_stops_at_eos():
     def logits_fn(ids):
         return _onehot(2)  # always emit token 2
 
-    out = generate(logits_fn, [0], max_new_tokens=10, eos_id=2, sampler=Sampler())
+    out = generate(logits_fn, [0], max_new_tokens=10, eos_ids={2}, sampler=Sampler())
     assert out == [2]  # stops immediately after emitting EOS
+
+
+def test_generate_stops_at_any_eos_in_set():
+    def logits_fn(ids):
+        return _onehot(5)  # 5 is one of several terminators
+
+    out = generate(logits_fn, [0], max_new_tokens=10, eos_ids={2, 5, 7}, sampler=Sampler())
+    assert out == [5]
 
 
 def test_generate_respects_max_new_tokens():
     def logits_fn(ids):
         return _onehot(5)
 
-    out = generate(logits_fn, [0], max_new_tokens=3, eos_id=999, sampler=Sampler())
+    out = generate(logits_fn, [0], max_new_tokens=3, eos_ids={999}, sampler=Sampler())
     assert out == [5, 5, 5]
 
 
@@ -51,7 +59,7 @@ def test_generate_feeds_growing_prefix():
         seen_lengths.append(len(ids))
         return _onehot(1)
 
-    generate(logits_fn, [0, 0], max_new_tokens=3, eos_id=None, sampler=Sampler())
+    generate(logits_fn, [0, 0], max_new_tokens=3, eos_ids=None, sampler=Sampler())
     # prompt len 2, then one appended token per step: 2, 3, 4
     assert seen_lengths == [2, 3, 4]
 

--- a/tests/serving/test_sampling.py
+++ b/tests/serving/test_sampling.py
@@ -1,0 +1,61 @@
+"""Unit tests for the Phase-0 pure sampler + chat-template helper (no GPU/vLLM)."""
+
+import numpy as np
+
+from deplodock.serving.sampling import Sampler, apply_chat_template, greedy
+
+
+def test_greedy_picks_argmax():
+    logits = np.array([0.1, 3.0, 0.2, -1.0])
+    assert greedy(logits) == 1
+
+
+def test_sampler_temperature_zero_is_greedy():
+    logits = np.array([0.1, 3.0, 0.2, -1.0])
+    sampler = Sampler(temperature=0.0)
+    assert all(sampler(logits) == 1 for _ in range(5))
+
+
+def test_sampler_seed_is_reproducible():
+    logits = np.array([1.0, 1.0, 1.0, 1.0, 1.0])
+    a = [Sampler(temperature=1.0, seed=7)(logits) for _ in range(20)]
+    b = [Sampler(temperature=1.0, seed=7)(logits) for _ in range(20)]
+    assert a == b  # deterministic given the seed
+    assert 0 <= min(a) and max(a) <= 4
+
+
+def test_top_k_restricts_support():
+    # token 0 dominates, token 3 is second; with top-1 only token 0 is ever drawn.
+    logits = np.array([5.0, 0.0, 0.0, 2.0])
+    sampler = Sampler(temperature=1.0, top_k=1, seed=0)
+    assert {sampler(logits) for _ in range(50)} == {0}
+
+
+def test_top_p_restricts_support():
+    # one near-certain token: nucleus p=0.5 keeps only it.
+    logits = np.array([10.0, 0.0, 0.0, 0.0])
+    sampler = Sampler(temperature=1.0, top_p=0.5, seed=0)
+    assert {sampler(logits) for _ in range(50)} == {0}
+
+
+class _FakeTokenizer:
+    def __init__(self, chat_template):
+        self.chat_template = chat_template
+
+    def encode(self, text):
+        return [ord(c) for c in text]
+
+    def apply_chat_template(self, messages, add_generation_prompt, tokenize):
+        assert add_generation_prompt and tokenize
+        return [1, 2, 3, len(messages)]
+
+
+def test_apply_chat_template_uses_template_when_present():
+    tok = _FakeTokenizer(chat_template="{{ messages }}")
+    assert apply_chat_template(tok, "hi") == [1, 2, 3, 1]
+    assert apply_chat_template(tok, "hi", system="sys") == [1, 2, 3, 2]
+
+
+def test_apply_chat_template_falls_back_to_encode():
+    tok = _FakeTokenizer(chat_template=None)
+    assert apply_chat_template(tok, "hi") == [ord("h"), ord("i")]

--- a/tests/serving/test_serve_command.py
+++ b/tests/serving/test_serve_command.py
@@ -2,6 +2,8 @@
 
 import argparse
 
+import pytest
+
 from deplodock.commands.serve import build_bench_cmd, build_serve_cmd, handle_serve, register_serve_command
 
 MODEL = "Qwen/Qwen3-Embedding-0.6B"
@@ -101,3 +103,34 @@ def test_bench_seed_is_distinct_from_vllm_seed(capsys):
     out = capsys.readouterr().out.strip().splitlines()
     assert "--seed 1" in out[0]  # vllm serve gets --seed
     assert "--seed 9" in out[1]  # the bench client gets --bench-seed
+
+
+def test_serve_cmd_generate_branch():
+    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=[], generate=True)
+    assert cmd[cmd.index("--runner") + 1] == "generate"
+    assert '{"architectures": ["DeplodockGenModel"]}' in cmd
+    assert cmd[cmd.index("--dtype") + 1] == "float16"  # forced for seam coherence
+    assert cmd[cmd.index("--max-num-batched-tokens") + 1] == "4096"  # capped at the dynamic-dim limit
+    assert "--enforce-eager" in cmd
+
+
+def test_serve_cmd_generate_rejects_incompatible_dtype():
+    with pytest.raises(ValueError, match="fp16"):
+        build_serve_cmd(MODEL, stock=False, vllm_args=["--dtype", "bfloat16"], generate=True)
+
+
+def test_serve_cmd_generate_rejects_oversized_batched_tokens():
+    with pytest.raises(ValueError, match="dynamic-dim cap"):
+        build_serve_cmd(MODEL, stock=False, vllm_args=["--max-num-batched-tokens", "8192"], generate=True)
+
+
+def test_serve_cmd_generate_honors_explicit_batched_tokens():
+    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=["--max-num-batched-tokens", "2048"], generate=True)
+    assert cmd.count("--max-num-batched-tokens") == 1  # the user's, no added default
+    assert cmd[cmd.index("--max-num-batched-tokens") + 1] == "2048"
+
+
+def test_serve_generate_bench_is_rejected():
+    args = _parse(["serve", MODEL, "--generate", "--bench", "--dry-run"])
+    with pytest.raises(SystemExit):
+        handle_serve(args)

--- a/tests/serving/test_vllm_plugin_gen_gpu.py
+++ b/tests/serving/test_vllm_plugin_gen_gpu.py
@@ -70,6 +70,7 @@ def test_vllm_gen_plugin_matches_hf_eager(tmp_path, monkeypatch):
         enforce_eager=True,
         dtype="float16",
         max_model_len=128,
+        max_num_batched_tokens=512,  # <= DYNAMIC_DIM_MAX (the flattened-width bound)
         gpu_memory_utilization=0.4,
     )
     out = llm.generate(TokensPrompt(prompt_token_ids=prompt_ids), SamplingParams(temperature=0.0, max_tokens=max_new))

--- a/tests/serving/test_vllm_plugin_gen_gpu.py
+++ b/tests/serving/test_vllm_plugin_gen_gpu.py
@@ -1,0 +1,87 @@
+"""In-process vLLM engine test of the deplodock **generative** plugin (Phase 3).
+
+``perf``-marked (deselected by default): needs CUDA + cupy + vllm. Saves a TINY random
+Llama (vocab matches a cached Llama tokenizer, 2 layers — no network), serves it through
+``DeplodockGenModel`` in an in-process vLLM engine (real paged ``Attention`` + KV cache +
+``lm_head`` + ``get_rope``), and greedily generates — checking it runs end-to-end and that
+the generated tokens agree with HF eager greedy on the same weights. This is the Phase-3
+integration proof: vLLM accepts the model, allocates the KV-cache spec from the per-layer
+``Attention`` prefixes, and the deplodock↔attention forward interleave produces correct logits.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.xdist_group("cuda")]
+
+TOKENIZER = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"  # cached; vocab 32000
+
+
+def _save_tiny_llama(path):
+    import torch
+    import transformers
+
+    config = transformers.LlamaConfig(
+        vocab_size=32000,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=512,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    model = transformers.LlamaForCausalLM(config).eval().to(torch.float16)
+    model.save_pretrained(path)
+    return config
+
+
+def test_vllm_gen_plugin_matches_hf_eager(tmp_path, monkeypatch):
+    pytest.importorskip("cupy")
+    vllm = pytest.importorskip("vllm")
+    import torch
+    import transformers
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from vllm import SamplingParams
+    from vllm.inputs import TokensPrompt
+
+    import deplodock.serving
+
+    # The test process has CUDA initialized (conftest seeds it); vLLM's forked
+    # EngineCore would die on re-init. Run the engine in-process instead.
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+    model_dir = tmp_path / "tiny_llama"
+    _save_tiny_llama(str(model_dir))
+    deplodock.serving.register()  # ModelRegistry.register_model("DeplodockGenModel", ...)
+
+    tok = transformers.AutoTokenizer.from_pretrained(TOKENIZER)
+    prompt_ids = tok("The quick brown fox", add_special_tokens=True)["input_ids"]
+    max_new = 8
+
+    llm = vllm.LLM(
+        model=str(model_dir),
+        tokenizer=TOKENIZER,
+        runner="generate",
+        hf_overrides={"architectures": ["DeplodockGenModel"]},
+        enforce_eager=True,
+        dtype="float16",
+        max_model_len=128,
+        gpu_memory_utilization=0.4,
+    )
+    out = llm.generate(TokensPrompt(prompt_token_ids=prompt_ids), SamplingParams(temperature=0.0, max_tokens=max_new))
+    gen = list(out[0].outputs[0].token_ids)
+
+    # end-to-end gate: ran, produced max_new valid in-vocab tokens
+    assert len(gen) == max_new
+    assert all(0 <= t < 32000 for t in gen)
+
+    # correctness gate: greedy agrees with HF eager on the same weights
+    ref = transformers.LlamaForCausalLM.from_pretrained(str(model_dir), dtype=torch.float16).to("cuda").eval()
+    with torch.no_grad():
+        ref_out = ref.generate(torch.tensor([prompt_ids], device="cuda"), do_sample=False, max_new_tokens=max_new, use_cache=True)
+    ref_gen = ref_out[0, len(prompt_ids) :].tolist()
+    assert gen[0] == ref_gen[0], f"first token mismatch: deplodock {gen[0]} vs HF {ref_gen[0]}"

--- a/tests/serving/test_vllm_plugin_gen_gpu.py
+++ b/tests/serving/test_vllm_plugin_gen_gpu.py
@@ -85,4 +85,6 @@ def test_vllm_gen_plugin_matches_hf_eager(tmp_path, monkeypatch):
     with torch.no_grad():
         ref_out = ref.generate(torch.tensor([prompt_ids], device="cuda"), do_sample=False, max_new_tokens=max_new, use_cache=True)
     ref_gen = ref_out[0, len(prompt_ids) :].tolist()
-    assert gen[0] == ref_gen[0], f"first token mismatch: deplodock {gen[0]} vs HF {ref_gen[0]}"
+    # Compare the WHOLE greedy sequence: token 0 comes from prefill, tokens 1.. are KV-cache
+    # DECODE steps (num_tokens=1), so this validates the decode path, not just prefill.
+    assert gen == ref_gen, f"greedy mismatch (deplodock vs HF eager): {gen} vs {ref_gen}"


### PR DESCRIPTION
Adds **generative (chat) inference** to deplodock — a decoder-only chat model runs through deplodock-compiled per-layer
kernels, with vLLM owning the OpenAI API / sampler / scheduler / paged KV-cache. Implements
[`plans/generative-inference-support.md`](plans/generative-inference-support.md) (the design doc + its 5 review
iterations are the first commits; the implementation follows).

## Approach (Option A)
Carve SDPA out of each decoder layer and compile the per-layer **everything-but-attention** compute over a flattened
`[num_tokens, H]` layout, emitting q/k/v; vLLM's `Attention` layer owns the KV cache and runs paged attention. RoPE is
applied by vLLM between the pre-attention kernel and `self.attn` (A2).

## What's implemented (Phases 0–4, all verified)
- **Phase 0** — `deplodock generate <model>` standalone oracle (`commands/generate.py`, `serving/sampling.py`).
  **Token-for-token identical to HF eager greedy on TinyLlama-1.1B-Chat** (real weights).
- **Phase 1** — `build_attention_split_wrapper` carve (`trace/huggingface.py`): explicit per-arch pre/post wrappers.
  Eager-equivalent to `block(x)` for **Qwen3 (GQA + q/k norm) and Llama**; dynamic-compiled at multiple token counts.
- **Phase 2** — `DeplodockGenRunner` (`serving/gen_runner.py`), two dynamic programs per layer. Multi-layer host stitch
  (deplodock kernels + reference SDPA) == eager logits.
- **Phase 3** — `DeplodockGenModel` vLLM plugin (`serving/vllm_model_gen.py`) + `serve --generate`. **In-process vLLM
  engine, greedy decode token-for-token vs HF eager** (validates prefill + KV-cache decode).
- **Phase 4** — flattened-width bound (`serve` caps `--max-num-batched-tokens` at `DYNAMIC_DIM_MAX`); prefill + decode
  exercised.

## Verification
Full fast suite green (2071 passed); new GPU `perf`-marked tests for the oracle, the carve (eager + dynamic-compile),
the multi-layer stitch, and the in-process vLLM plugin. Two Codex review passes folded in (multi-EOS, dim cap, test
isolation, the out-of-the-box `max_num_batched_tokens` cap, sliding-window rejection, full-sequence decode comparison).

## Scope / known limits
- Full-causal **Llama / Qwen3**, **fp16**, **TP=1**. Sliding-window / per-layer-sliding / dual-chunk configs are
  **rejected** (not miscomputed). No quantization (AWQ rides a separate branch).
- **Perf not yet hardened** — numpy host I/O at the per-layer seam (the host-sync interleave), and `serve` compiles
  **2× n_layers** programs (startup- + memory-heavy → small models for now). The device zero-copy interleave +
  decode-shaped golden tuning (Phase 5) + bench-vs-stock-vLLM are the remaining work.
- The in-graph `slice_last_logits` lm_head optimization stays off (cold M=1-matmul lowering gap; tracked by an xfail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)