### PR TITLE
Algebraic carrier analysis (A/B/C1a): trait-carrying ops + bottom-up analyzer + tag-driven planner

### DIFF
--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -114,10 +114,19 @@ it replaces the frontend layout ops via `coord_map` expressions.
 | `IndexMapOp` + `IndexSource`         | Unified layout-only op over `Expr`.                            |
 
 Op metadata (arity / `commutative` / `associative` / `identity` /
-`has_identity`) lives on `ElementwiseImpl` in `ir/elementwise.py` — the single
-source of truth shared across elementwise, reduce, scan, and accumulator use
-sites. The algebraic traits are what reassociation gates (split-K, cooperative
-tree-combine) query instead of matching op names.
+`has_identity` / `selecting`) lives on `ElementwiseImpl` in `ir/elementwise.py` —
+the single source of truth shared across elementwise, reduce, scan, and
+accumulator use sites. The algebraic traits are what reassociation gates
+(split-K, cooperative tree-combine) query instead of matching op names. Beyond
+the per-op trait properties, the module exposes the op-name-free **role
+queries** the planner / atom-cell matchers / flash recognizer ask:
+`reduce_canon` (alias → base combine, `sum` → `add` …), `distributes_over(⊗, ⊕)`
+and `is_semiring_product(⊗)` (the `_SEMIRING` table — only `(+, ×)` today), and
+the `_REDUCE_SPELLING` registry (`reduce_spelling`) — the single op-keyed table
+behind the four sites that used to switch on the reduce op name (`Accum.render`'s
+`+=` / `*=` / `fmax` / `fmin`, `kernel/ir._binary_combine_expr`, and
+`ReduceOp.forward` / `ScanOp.forward`'s numpy reductions). `op.selecting` (the
+max/min family) drives the init-placement dtype choice.
 
 ## `loop/`
 
@@ -131,6 +140,20 @@ algebra read the carrier's `associative` / `commutative` / `has_identity` traits
 directly (`Accum` forwards to its scalar `op`; `Mma` reports the additive-fold
 constants; `Monoid` reports `associative` / `has_identity` `True` by construction
 with a per-instance `commutative` field).
+
+**Bottom-up algebra analysis** (`ir/algebra.py`). `Loop.algebra_kind` derives
+each reduce loop's `AlgebraKind` — `MAP` (non-reduce) / `MONOID` (a plain
+associative `Accum`) / `SEMIRING` (a matmul-shaped reduce whose product
+distributes over its reduce — `Mma`, or an `Accum` fed by a distributing
+product) / `TWISTED_MONOID` (a recognized `Monoid`, e.g. flash's online softmax)
+— by *reading back* the carrier already in the body. It is a **derived cache,
+not a second source of truth**: computed on demand, so it can never contradict
+the carrier's traits and never enters equality / `op_cache_key`. The expensive
+match (raw coupled-accumulator → verified twisted monoid) is done once by
+`loop/recognize` (which emits the `Monoid`); this is a cheap read of that
+carrier. The structural matmul predicate `matmul_reduce` lives here too — the
+single source `lowering/tile/_helpers.is_matmul_reduce` delegates to (adding only
+its tile-layer type guard).
 
 `Monoid` is the general loop-carried **monoid** carrier — *(identity element,
 associative operation, internal state)* made explicit: `state` (the carried SSA

--- a/deplodock/compiler/ir/ARCHITECTURE.md
+++ b/deplodock/compiler/ir/ARCHITECTURE.md
@@ -114,15 +114,17 @@ it replaces the frontend layout ops via `coord_map` expressions.
 | `IndexMapOp` + `IndexSource`         | Unified layout-only op over `Expr`.                            |
 
 Op metadata (arity / `commutative` / `associative` / `identity` /
-`has_identity` / `selecting`) lives on `ElementwiseImpl` in `ir/elementwise.py` —
-the single source of truth shared across elementwise, reduce, scan, and
-accumulator use sites. The algebraic traits are what reassociation gates
-(split-K, cooperative tree-combine) query instead of matching op names. Beyond
-the per-op trait properties, the module exposes the op-name-free **role
-queries** the planner / atom-cell matchers / flash recognizer ask:
-`reduce_canon` (alias → base combine, `sum` → `add` …), `distributes_over(⊗, ⊕)`
-and `is_semiring_product(⊗)` (the `_SEMIRING` table — only `(+, ×)` today), and
-the `_REDUCE_SPELLING` registry (`reduce_spelling`) — the single op-keyed table
+`has_identity` / `selecting` / `semiring_product`) lives on `ElementwiseImpl` in
+`ir/elementwise.py` — the single source of truth shared across elementwise,
+reduce, scan, and accumulator use sites. The algebraic traits are what
+reassociation gates (split-K, cooperative tree-combine) query instead of matching
+op names. The per-op trait *properties* (`op.semiring_product` — is this op a `⊗`
+in some semiring) and the binary method `⊗.distributes_over(⊕)` (does this product
+distribute over that reduce — the `_SEMIRING` table, only `(+, ×)` today) live on
+`ElementwiseImpl`; the module's op-name-free **role queries** the planner /
+atom-cell matchers / flash recognizer ask round them out: `reduce_canon` (alias →
+base combine, `sum` → `add` …) and the `_REDUCE_SPELLING` registry
+(`reduce_spelling`) — the single op-keyed table
 behind the four sites that used to switch on the reduce op name (`Accum.render`'s
 `+=` / `*=` / `fmax` / `fmin`, `kernel/ir._binary_combine_expr`, and
 `ReduceOp.forward` / `ScanOp.forward`'s numpy reductions). `op.selecting` (the

--- a/deplodock/compiler/ir/algebra.py
+++ b/deplodock/compiler/ir/algebra.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 from enum import Enum
 
-from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.stmt.base import ReduceCarrier
 from deplodock.compiler.ir.stmt.blocks import Loop
 from deplodock.compiler.ir.stmt.leaves import Accum, Assign, Load, Mma, Monoid
@@ -90,7 +89,7 @@ def _is_semiring_contraction(loop) -> bool:
     for acc in body:
         if isinstance(acc, Accum):
             prod = assigns.get(acc.value)
-            if prod is not None and distributes_over(prod.op, acc.op):
+            if prod is not None and prod.op.distributes_over(acc.op):
                 return True
     return False
 

--- a/deplodock/compiler/ir/algebra.py
+++ b/deplodock/compiler/ir/algebra.py
@@ -28,6 +28,7 @@ from enum import Enum
 
 from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.stmt.base import ReduceCarrier
+from deplodock.compiler.ir.stmt.blocks import Loop
 from deplodock.compiler.ir.stmt.leaves import Accum, Assign, Load, Mma, Monoid
 
 
@@ -61,6 +62,16 @@ def matmul_reduce(loop) -> bool:
     if len(bufs) < 2:
         return False
     return any(isinstance(s, ReduceCarrier) for s in loop.body)
+
+
+def contains_matmul_reduce(stmt) -> bool:
+    """True iff ``stmt`` is or transitively contains a matmul-shape reduce
+    ``Loop`` (``matmul_reduce``). Recurses through every nested body — the
+    shared core behind the planner's fused-prologue probe and the
+    demoted-split cut's K-loop search."""
+    if isinstance(stmt, Loop) and matmul_reduce(stmt):
+        return True
+    return any(contains_matmul_reduce(c) for body in stmt.nested() for c in body)
 
 
 def _is_semiring_contraction(loop) -> bool:

--- a/deplodock/compiler/ir/algebra.py
+++ b/deplodock/compiler/ir/algebra.py
@@ -1,0 +1,110 @@
+"""Bottom-up algebra analysis — derive each reduce loop's algebraic *kind*
+from its carrier and loads (Part B of ``plans/algebraic-carrier-analysis.md``).
+
+This is the inverse of the bespoke top-down recognizers (``loop/recognize``):
+rather than hand-match a known pattern, *read back* the algebra that already
+lives in the loop body and expose a uniform tag the scheduler can dispatch on.
+
+The tag is a **derived cache, not a second source of truth**: it is computed
+from the loop body on demand (`classify_algebra` / the `Loop.algebra_kind`
+property), so it can never contradict the carrier's own traits — the
+`MonoidNode(associative=False)` class of bug is unrepresentable. Because it is
+computed, not stored, it never enters equality / `op_cache_key`, and it is
+always consistent with the current body (re-derived after every rewrite). The
+*expensive* match — turning a raw coupled-accumulator cluster into a verified
+twisted monoid — is done ONCE by the recognizer (``loop/recognize``, which
+emits a `Monoid` carrier); this classification is then a cheap read of that
+carrier.
+
+The kind is well-defined where the **carrier is present** — i.e. on a `LoopOp`
+body's reduce loops, before the partition planner tiles the carrier away (a
+matmul becomes `Mma`/`ldmatrix` fragments; a `Monoid` combine becomes an
+explicit rescale + `Accum`). Post-partition nothing re-derives it.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from deplodock.compiler.ir.elementwise import distributes_over
+from deplodock.compiler.ir.stmt.base import ReduceCarrier
+from deplodock.compiler.ir.stmt.leaves import Accum, Assign, Load, Mma, Monoid
+
+
+class AlgebraKind(Enum):
+    """The algebraic kind of a loop scope, derived bottom-up from its carrier.
+
+    A non-reduce scope is ``MAP`` (the default — a pointwise functor); a reduce
+    loop is one of the fold kinds below.
+    """
+
+    MAP = "map"  # pointwise / functor — a non-reduce scope (the default)
+    MONOID = "monoid"  # a plain associative reduce        (carrier: Accum)
+    SEMIRING = "semiring"  # a contraction / matmul           (carrier: Mma, or matmul-shaped Accum)
+    TWISTED_MONOID = "twisted_monoid"  # an online / coupled reduce        (carrier: Monoid — flash, Welford, …)
+    SCAN = "scan"  # prefix / causal — reserved, out of scope v1
+
+
+def matmul_reduce(loop) -> bool:
+    """True iff ``loop`` is a reduce loop whose body matches the matmul
+    signature: ≥ 2 distinct buffers with K-indexed Loads (K = ``loop.axis.name``)
+    plus at least one :class:`ReduceCarrier` (`Accum`, or its fused `Mma`).
+
+    The ir-level structural core of ``lowering/tile/_helpers.is_matmul_reduce``;
+    duck-typed on ``.is_reduce`` / ``.axis`` / ``.body`` so it serves Loop-IR
+    ``Loop`` / ``StridedLoop`` and Tile-IR ``SerialTile`` / ``StridedTile``
+    alike (the caller restricts the type)."""
+    if not getattr(loop, "is_reduce", False):
+        return False
+    k_name = loop.axis.name
+    bufs = {ld.input for ld in loop.body.of_type(Load) if k_name in {v for e in ld.index for v in e.free_vars()}}
+    if len(bufs) < 2:
+        return False
+    return any(isinstance(s, ReduceCarrier) for s in loop.body)
+
+
+def _is_semiring_contraction(loop) -> bool:
+    """A matmul-shaped reduce whose product ``⊗`` distributes over the reduce
+    combine ``⊕`` — a genuine semiring contraction, not just any 2-load reduce.
+
+    The fused `Mma` carrier *is* the ``(×, +)`` tensor-core fold (the product is
+    folded into the instruction); a scalar matmul cell is an `Accum` fed by a
+    distributing product `Assign`."""
+    if not matmul_reduce(loop):
+        return False
+    body = loop.body
+    if any(isinstance(s, Mma) for s in body):
+        return True
+    assigns = {s.name: s for s in body if isinstance(s, Assign)}
+    for acc in body:
+        if isinstance(acc, Accum):
+            prod = assigns.get(acc.value)
+            if prod is not None and distributes_over(prod.op, acc.op):
+                return True
+    return False
+
+
+def classify_algebra(loop) -> AlgebraKind:
+    """Classify a loop scope by its carrier — the cheap bottom-up read.
+
+    - ``MAP`` — a non-reduce scope (no `ReduceCarrier` in the immediate body).
+    - ``TWISTED_MONOID`` — a recognized `Monoid` carrier (flash's online softmax
+      and any future Welford / argmax catalog entry); its catalog identity is the
+      carrier's own (`FlashCombine` ⟺ ``lse``).
+    - ``SEMIRING`` — a matmul-shaped reduce whose product distributes over its
+      reduce (`Mma`, or an `Accum` fed by a distributing product).
+    - ``MONOID`` — a plain associative reduce (an `Accum` whose combine is
+      associative — `has_identity` makes it maskable).
+    - ``MAP`` (fallback) — a reduce the analysis doesn't recognize (no
+      regression: callers keep their current path)."""
+    if not getattr(loop, "is_reduce", False):
+        return AlgebraKind.MAP
+    body = loop.body
+    if any(isinstance(s, Monoid) for s in body):
+        return AlgebraKind.TWISTED_MONOID
+    if _is_semiring_contraction(loop):
+        return AlgebraKind.SEMIRING
+    carriers = [s for s in body if isinstance(s, ReduceCarrier)]
+    if carriers and all(c.associative for c in carriers):
+        return AlgebraKind.MONOID
+    return AlgebraKind.MAP

--- a/deplodock/compiler/ir/elementwise.py
+++ b/deplodock/compiler/ir/elementwise.py
@@ -135,6 +135,19 @@ class ElementwiseImpl:
         return self.name in self._SELECTING
 
     @property
+    def semiring_product(self) -> bool:
+        """True iff this op is a ``⊗`` in some semiring (today only
+        ``multiply``) — the op-name-free 'is this a matmul / square product'
+        query. The unary counterpart of the binary ``distributes_over``."""
+        return any(self.name in prods for prods in self._SEMIRING.values())
+
+    def distributes_over(self, reduce) -> bool:
+        """True iff this op (``⊗``) distributes over the reduce combine
+        ``reduce`` (``⊕``) — i.e. ``Σ_k a⊗b`` is a contraction / matmul over
+        ``⊕``. ``reduce`` may be an op name or ``ElementwiseImpl``."""
+        return self.name in self._SEMIRING.get(reduce_canon(_op_name(reduce)), frozenset())
+
+    @property
     def reduce_canon(self) -> str:
         """This op's canonical reduce-combine identity (``sum`` → ``add``,
         ``prod`` → ``multiply``, ``amax`` → ``maximum`` …); aliasless names map
@@ -182,21 +195,6 @@ def reduce_canon(name: str) -> str:
 
 def _op_name(op) -> str:
     return op.name if isinstance(op, ElementwiseImpl) else op
-
-
-def distributes_over(product, reduce) -> bool:
-    """True iff op ``product`` (``⊗``) distributes over the reduce combine
-    ``reduce`` (``⊕``) — i.e. ``Σ_k a⊗b`` is a contraction/matmul over ``⊕``.
-    Accepts op names or ``ElementwiseImpl``."""
-    return _op_name(product) in ElementwiseImpl._SEMIRING.get(reduce_canon(_op_name(reduce)), frozenset())
-
-
-def is_semiring_product(op) -> bool:
-    """True iff ``op`` is a ``⊗`` in some semiring (today only ``multiply``) —
-    the op-name-free 'is this a matmul / square product' query. Accepts an op
-    name or ``ElementwiseImpl``."""
-    name = _op_name(op)
-    return any(name in prods for prods in ElementwiseImpl._SEMIRING.values())
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/ir/elementwise.py
+++ b/deplodock/compiler/ir/elementwise.py
@@ -18,6 +18,9 @@ indices, a separate layer.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import NamedTuple
+
 import numpy as np
 
 
@@ -73,6 +76,18 @@ class ElementwiseImpl:
         "amax": -1e30,
         "minimum": 1e30,
     }
+    # Selecting ops *choose* an existing input value (max/min family) rather
+    # than accumulate magnitude — so an Accum over one may stay in the input
+    # dtype, and the flash recognizer's rowmax keys off it. The single source
+    # for the per-op ``selecting`` trait (was a ``_SELECTING_OPS`` frozenset in
+    # ``020_place_inits``).
+    _SELECTING: frozenset[str] = frozenset({"maximum", "amax", "minimum", "max", "min"})
+    # Semiring pairing — a reduce combine ``⊕`` mapped to the products ``⊗``
+    # that distribute over it (``a·(b⊕c) == a·b ⊕ a·c``), so a contraction
+    # ``Σ_k a⊗b`` is a matmul over ``⊕``. Only ``(+, ×)`` is exercised today;
+    # the table is *data* so tropical ``(min, +)`` etc. is a one-line add when a
+    # consumer exists — but DO NOT add unused semirings (simplicity-first).
+    _SEMIRING: dict[str, frozenset[str]] = {"add": frozenset({"multiply"})}
 
     def __init__(self, name: str) -> None:
         fn = _NAME_TO_FN.get(name)
@@ -112,6 +127,21 @@ class ElementwiseImpl:
         / ``commutative`` to admit a reduce for split-K / tree-combine."""
         return self.identity is not None
 
+    @property
+    def selecting(self) -> bool:
+        """True for ops that *select* an existing input value (the max/min
+        family) instead of accumulating magnitude — an Accum over one may keep
+        the input dtype rather than promote to the accumulating dtype."""
+        return self.name in self._SELECTING
+
+    @property
+    def reduce_canon(self) -> str:
+        """This op's canonical reduce-combine identity (``sum`` → ``add``,
+        ``prod`` → ``multiply``, ``amax`` → ``maximum`` …); aliasless names map
+        to themselves. The op-name-free key the reduce/scan render + numpy
+        sites share."""
+        return reduce_canon(self.name)
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, ElementwiseImpl) and self.name == other.name
 
@@ -120,6 +150,85 @@ class ElementwiseImpl:
 
     def __repr__(self) -> str:
         return f"ElementwiseImpl({self.name!r})"
+
+
+# ---------------------------------------------------------------------------
+# Algebraic-role queries — the op-name-free helpers the partition planner,
+# atom-cell matchers, and flash recognizer ask instead of string-matching
+# ``"multiply"`` / ``"add"`` / ``"maximum"``.
+# ---------------------------------------------------------------------------
+
+# Reduce/scan op aliases → their canonical combine identity. The single map
+# behind ``ElementwiseImpl.reduce_canon`` and the lift-reduce tensor→loop
+# alias; an unlisted name canonicalizes to itself.
+_REDUCE_CANON: dict[str, str] = {
+    "add": "add",
+    "sum": "add",
+    "multiply": "multiply",
+    "prod": "multiply",
+    "maximum": "maximum",
+    "amax": "maximum",
+    "fmax": "maximum",
+    "minimum": "minimum",
+    "fmin": "minimum",
+}
+
+
+def reduce_canon(name: str) -> str:
+    """Canonicalize a reduce/scan op name to its base combine identity
+    (``sum`` → ``add`` …). Names without an alias map to themselves."""
+    return _REDUCE_CANON.get(name, name)
+
+
+def _op_name(op) -> str:
+    return op.name if isinstance(op, ElementwiseImpl) else op
+
+
+def distributes_over(product, reduce) -> bool:
+    """True iff op ``product`` (``⊗``) distributes over the reduce combine
+    ``reduce`` (``⊕``) — i.e. ``Σ_k a⊗b`` is a contraction/matmul over ``⊕``.
+    Accepts op names or ``ElementwiseImpl``."""
+    return _op_name(product) in ElementwiseImpl._SEMIRING.get(reduce_canon(_op_name(reduce)), frozenset())
+
+
+def is_semiring_product(op) -> bool:
+    """True iff ``op`` is a ``⊗`` in some semiring (today only ``multiply``) —
+    the op-name-free 'is this a matmul / square product' query. Accepts an op
+    name or ``ElementwiseImpl``."""
+    name = _op_name(op)
+    return any(name in prods for prods in ElementwiseImpl._SEMIRING.values())
+
+
+# ---------------------------------------------------------------------------
+# Reduce render-spelling registry — the single op-keyed table behind the four
+# sites that used to switch on the reduce op name: ``Accum.render`` (CUDA
+# ``+=`` / ``*=`` / ``fmax`` / ``fmin``), ``kernel/ir._binary_combine_expr``
+# (the tree-combine binary expr), and ``ReduceOp.forward`` / ``ScanOp.forward``
+# (the numpy interpreter reductions). Keyed by canonical combine name.
+# ---------------------------------------------------------------------------
+
+
+class ReduceSpelling(NamedTuple):
+    infix: str | None  # binary-expr operator (``a + b``), or None for a call form
+    compound: str | None  # compound assignment (``name += rhs``), or None
+    intrinsic: str | None  # CUDA/abstract intrinsic (``fmax`` / ``fmin``), or None
+    np_reduce: Callable  # numpy axis reduction (keepdims)
+    np_scan: Callable | None  # numpy cumulative (scan), or None if scan is undefined
+
+
+_REDUCE_SPELLING: dict[str, ReduceSpelling] = {
+    "add": ReduceSpelling("+", "+=", None, np.sum, np.cumsum),
+    "multiply": ReduceSpelling("*", "*=", None, np.prod, np.cumprod),
+    "maximum": ReduceSpelling(None, None, "fmax", np.max, np.maximum.accumulate),
+    "minimum": ReduceSpelling(None, None, "fmin", np.min, np.minimum.accumulate),
+}
+
+
+def reduce_spelling(op) -> ReduceSpelling:
+    """The render data for a reduce combine, defaulting to additive (``+=``)
+    for non-reduce / unknown ops — matches ``Accum.render``'s legacy fallback.
+    Accepts an op name or ``ElementwiseImpl``."""
+    return _REDUCE_SPELLING.get(reduce_canon(_op_name(op)), _REDUCE_SPELLING["add"])
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/ir/kernel/ir.py
+++ b/deplodock/compiler/ir/kernel/ir.py
@@ -28,7 +28,7 @@ from functools import cached_property
 
 from deplodock.compiler.dtype import F32, DataType
 from deplodock.compiler.ir.axis import Axis
-from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.elementwise import _REDUCE_SPELLING, ElementwiseImpl
 from deplodock.compiler.ir.expr import (
     BinaryExpr,
     Builtin,
@@ -1241,18 +1241,13 @@ def _binary_combine_expr(op: ElementwiseImpl, a: str, b: str, target=None, dt: s
     ``None`` keeps the legacy f32 spellings for callers that haven't
     plumbed a target through yet.
     """
-    name = op.name
-    if name in ("add", "sum"):
-        return f"{a} + {b}"
-    if name in ("multiply", "prod"):
-        return f"{a} * {b}"
-    if name in ("maximum", "amax"):
-        spelling = target.intrinsic("fmax", dt) if target is not None else "fmaxf"
-        return f"{spelling}({a}, {b})"
-    if name == "minimum":
-        spelling = target.intrinsic("fmin", dt) if target is not None else "fminf"
-        return f"{spelling}({a}, {b})"
-    raise ValueError(f"TreeHalve: unsupported op {name!r}")
+    spelling = _REDUCE_SPELLING.get(op.reduce_canon)
+    if spelling is None:
+        raise ValueError(f"TreeHalve: unsupported op {op.name!r}")
+    if spelling.infix is not None:
+        return f"{a} {spelling.infix} {b}"
+    fn = target.intrinsic(spelling.intrinsic, dt) if target is not None else f"{spelling.intrinsic}f"
+    return f"{fn}({a}, {b})"
 
 
 # ``StridedLoop`` is shared infrastructure — defined in ``ir/stmt.py``

--- a/deplodock/compiler/ir/stmt/blocks.py
+++ b/deplodock/compiler/ir/stmt/blocks.py
@@ -83,6 +83,17 @@ class Loop(Stmt):
         ``ReduceCarrier`` (``Accum``, or its tensor-core form ``Mma``)."""
         return any(isinstance(s, ReduceCarrier) for s in self.body)
 
+    @property
+    def algebra_kind(self):
+        """The loop's algebraic kind (``AlgebraKind``), derived bottom-up from
+        its carrier — ``MAP`` (non-reduce) / ``MONOID`` / ``SEMIRING`` /
+        ``TWISTED_MONOID``. A computed read (never stored, never in
+        ``op_cache_key``), so it can never contradict the body's algebra. See
+        ``ir/algebra.py``."""
+        from deplodock.compiler.ir.algebra import classify_algebra  # noqa: PLC0415 — break blocks↔algebra cycle
+
+        return classify_algebra(self)
+
     def pretty(self, indent: str = "") -> list[str]:
         head = f"{indent}for {self.axis.name} in 0..{self.axis.extent}{_source_suffix(self.axis)}"
         return [head, *pretty_body(self.body, indent + INDENT)]

--- a/deplodock/compiler/ir/stmt/leaves.py
+++ b/deplodock/compiler/ir/stmt/leaves.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from deplodock.compiler.dtype import F32, DataType
-from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.elementwise import ElementwiseImpl, reduce_spelling
 from deplodock.compiler.ir.expr import BinaryExpr, Expr, Literal, Var, _float_lit
 from deplodock.compiler.ir.stmt.base import (
     ReduceCarrier,
@@ -535,21 +535,19 @@ class Accum(ReduceCarrier):
 
     def render(self, ctx: RenderCtx) -> list[str]:
         pad = _pad(ctx.indent)
-        op_name = self.op.name
         # Accumulator dtype — explicit on Accum once the Init-placement pass
         # has frozen it; otherwise default to fp32 (legacy behavior).
         acc_dt = (self.dtype or F32).name
         ctx.ssa_dtypes[self.name] = acc_dt
         value_dt = ctx.ssa_dtypes.get(self.value, "f32")
         rhs = ctx.target.convert(self.value, value_dt, acc_dt)
-        if op_name in ("maximum", "amax"):
-            spelling = ctx.target.intrinsic("fmax", acc_dt)
-            return [f"{pad}{self.name} = {spelling}({self.name}, {rhs});"]
-        if op_name == "minimum":
-            spelling = ctx.target.intrinsic("fmin", acc_dt)
-            return [f"{pad}{self.name} = {spelling}({self.name}, {rhs});"]
-        op = {"add": "+=", "sum": "+=", "multiply": "*=", "prod": "*="}.get(op_name, "+=")
-        return [f"{pad}{self.name} {op} {rhs};"]
+        # Spelling (``+=`` / ``*=`` / ``fmax`` / ``fmin``) from the shared reduce
+        # registry; defaults to additive for non-reduce ops.
+        spelling = reduce_spelling(self.op)
+        if spelling.intrinsic is not None:
+            fn = ctx.target.intrinsic(spelling.intrinsic, acc_dt)
+            return [f"{pad}{self.name} = {fn}({self.name}, {rhs});"]
+        return [f"{pad}{self.name} {spelling.compound} {rhs};"]
 
 
 @dataclass(frozen=True)

--- a/deplodock/compiler/ir/tensor/ir.py
+++ b/deplodock/compiler/ir/tensor/ir.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from deplodock.compiler.dim import Dim, to_dim
 from deplodock.compiler.ir.base import Op, _keepdim_axis
-from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.elementwise import _REDUCE_SPELLING, ElementwiseImpl
 
 # ---------------------------------------------------------------------------
 # Elementwise / reduce / scan
@@ -127,18 +127,10 @@ class ReduceOp(Op):
         return _keepdim_axis(input_shapes[0], self.axis)
 
     def forward(self, *inputs):
-
-        a = inputs[0]
-        name = self.op.name
-        if name in ("sum", "add"):
-            return np.sum(a, axis=self.axis, keepdims=True)
-        if name in ("prod", "multiply"):
-            return np.prod(a, axis=self.axis, keepdims=True)
-        if name in ("maximum", "amax", "fmax"):
-            return np.max(a, axis=self.axis, keepdims=True)
-        if name in ("minimum", "fmin"):
-            return np.min(a, axis=self.axis, keepdims=True)
-        raise NotImplementedError(f"ReduceOp.forward: unknown fn {name!r}")
+        spelling = _REDUCE_SPELLING.get(self.op.reduce_canon)
+        if spelling is None:
+            raise NotImplementedError(f"ReduceOp.forward: unknown fn {self.op.name!r}")
+        return spelling.np_reduce(inputs[0], axis=self.axis, keepdims=True)
 
 
 @dataclass
@@ -164,16 +156,10 @@ class ScanOp(Op):
         return tuple(input_shapes[0])  # scan preserves shape
 
     def forward(self, *inputs):
-
-        a = inputs[0]
-        name = self.op.name
-        if name in ("sum", "add"):
-            return np.cumsum(a, axis=self.axis)
-        if name in ("maximum", "fmax"):
-            return np.maximum.accumulate(a, axis=self.axis)
-        if name in ("prod", "multiply"):
-            return np.cumprod(a, axis=self.axis)
-        raise NotImplementedError(f"ScanOp.forward: unknown fn {name!r}")
+        spelling = _REDUCE_SPELLING.get(self.op.reduce_canon)
+        if spelling is None or spelling.np_scan is None:
+            raise NotImplementedError(f"ScanOp.forward: unknown fn {self.op.name!r}")
+        return spelling.np_scan(inputs[0], axis=self.axis)
 
 
 # ---------------------------------------------------------------------------

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -106,8 +106,12 @@ Implementations hold their producer's state as data: `OptionFork` (a concrete `O
 own knob delta, so siblings share one function instead of per-instance capture lambdas; used by
 `085_warp_specialize`), and the tree builder's branch / leaf node classes.
 
-The partition planner (`lowering/tile/010_partition_loops`) emits one
-hierarchical Fork tree over both tiers:
+The partition planner (`lowering/tile/010_partition_loops`) routes each reduce loop by its bottom-up **algebra
+tag** (`Loop.algebra_kind`, `ir/algebra.py`) rather than re-deriving the archetype: `SEMIRING` → matmul-output
+tiling; a static `TWISTED_MONOID` (flash's online-softmax `Monoid`) → the cooperative-reduce KV split; any other
+reduce → cooperative-K / pointwise. The tag reads the carrier already in the body, so the routing inputs come
+from the analyzer, not a fresh structural match (Part C1a of `plans/algebraic-carrier-analysis.md`). It then emits
+one hierarchical Fork tree over both tiers:
 `MMA → BR → (BM,BN) → (WM,WN) → (FM,FN) → TileOp` leaf — each leaf carrying its COMPLETE knob row
 (incl. `BK` / `SPLITK` / `FK` / `OVERHANG`, which live in no level), the DB-matchable variant identity. The root
 `MMA` level keys warp rows by atom kind; scalar rows return an empty key and skip the level (their subtree

--- a/deplodock/compiler/pipeline/passes/loop/lifting/020_lift_reduce.py
+++ b/deplodock/compiler/pipeline/passes/loop/lifting/020_lift_reduce.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from deplodock.compiler.graph import Graph, Node, Tensor
 from deplodock.compiler.ir.base import InputOp
-from deplodock.compiler.ir.elementwise import ElementwiseImpl
+from deplodock.compiler.ir.elementwise import ElementwiseImpl, reduce_canon
 from deplodock.compiler.ir.expr import Expr, Literal, Var
 from deplodock.compiler.ir.loop import Accum, Axis, Load, Loop, LoopOp, Write
 from deplodock.compiler.ir.stmt import Body
@@ -18,11 +18,6 @@ from deplodock.compiler.ir.tensor.ir import ReduceOp
 from deplodock.compiler.pipeline import Match, Pattern, RuleSkipped
 
 PATTERN = [Pattern("root", ReduceOp)]
-
-# Map ReduceOp.fn ("sum"/"maximum"/"minimum"/"prod") to the combine op name that
-# ``Accum`` carries. Accum init is derived from this op by the Loop IR
-# identity table (``ACCUM_IDENTITY``), so no separate init lookup is needed.
-_COMBINE: dict[str, str] = {"sum": "add", "maximum": "maximum", "prod": "multiply", "minimum": "minimum"}
 
 
 def rewrite(match: Match, root: Node) -> Graph | None:
@@ -51,7 +46,10 @@ def rewrite(match: Match, root: Node) -> Graph | None:
     reduce_axis_name = f"a{axis}"
     load_index = tuple(Var(a.name) for a in axes)
 
-    combine = ElementwiseImpl(_COMBINE.get(root.op.name, root.op.name))
+    # ReduceOp.fn ("sum"/"maximum"/"minimum"/"prod") canonicalizes to the combine
+    # op ``Accum`` carries (sum→add, prod→multiply). Accum init is derived from
+    # this op by the Loop IR identity table, so no separate init lookup is needed.
+    combine = ElementwiseImpl(reduce_canon(root.op.name))
     write_index = _build_write_index(axes, reduce_axis_name, tuple(root.output.shape))
 
     # Nested body: Loop(reduce_axis, [Load + Accum]) + Write wrapped in

--- a/deplodock/compiler/pipeline/passes/loop/recognize/010_recognize_flash.py
+++ b/deplodock/compiler/pipeline/passes/loop/recognize/010_recognize_flash.py
@@ -47,6 +47,7 @@ heads) fails a check and the score-matrix path stands.
 from __future__ import annotations
 
 from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.elementwise import is_semiring_product
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop.ir import LoopOp
 from deplodock.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Stmt, Write
@@ -61,8 +62,15 @@ from deplodock.compiler.pipeline.passes.loop.recognize._flash import (
 
 PATTERN = [Pattern("root", LoopOp)]
 
-_SUM = ("add", "sum")
-_MAX = ("maximum", "amax")
+
+def _is_sum(accum: Accum) -> bool:
+    """The accum is the semiring additive reduce ``⊕`` (``add`` / ``sum``)."""
+    return accum.op.reduce_canon == "add"
+
+
+def _is_rowmax(accum: Accum) -> bool:
+    """The accum is the softmax rowmax reduce (``maximum`` / ``amax``)."""
+    return accum.op.reduce_canon == "maximum"
 
 
 def _reduce_loops(op: LoopOp) -> list[Loop]:
@@ -95,8 +103,8 @@ def _extract_qk(xnode: Node) -> tuple[str, str, object] | None:
     for lp in _reduce_loops(op):
         loads = [s for s in lp.body if isinstance(s, Load)]
         accs = [s for s in lp.body if isinstance(s, Accum)]
-        muls = [s for s in lp.body if isinstance(s, Assign) and s.op.name == "multiply"]
-        if len(loads) == 2 and len(accs) == 1 and accs[0].op.name in _SUM and muls:
+        muls = [s for s in lp.body if isinstance(s, Assign) and is_semiring_product(s.op)]
+        if len(loads) == 2 and len(accs) == 1 and _is_sum(accs[0]) and muls:
             q_id = k_id = None
             for ld in loads:
                 if _var_at(ld.index, -2) == m_var:
@@ -126,7 +134,7 @@ def _classify_rowmax(graph: Graph, lp: Loop) -> tuple[str, str, str | None] | No
     ``add(score, mask)`` — the mask being a coord ``Select`` (causal) or a buffer
     ``Load`` (the additive bias). The score side is the operand whose buffer is a
     ``LoopOp`` (the scaled-QK producer); the mask side is the other."""
-    max_accs = [s for s in lp.body if isinstance(s, Accum) and s.op.name in _MAX]
+    max_accs = [s for s in lp.body if isinstance(s, Accum) and _is_rowmax(s)]
     if len(max_accs) != 1:
         return None
     feed = _def(lp.body, max_accs[0].value)
@@ -180,7 +188,7 @@ def _recognize(graph: Graph, node: Node) -> tuple[str, str, str, str | None] | N
     # P@V: the reduce whose sum-Accum feeds the output; V = its non-X/-mask operand.
     v_buf: str | None = None
     for lp in _reduce_loops(op):
-        if not any(isinstance(s, Accum) and s.name == out_write.value and s.op.name in _SUM for s in lp.body):
+        if not any(isinstance(s, Accum) and s.name == out_write.value and _is_sum(s) for s in lp.body):
             continue
         others = {s.input for s in lp.body if isinstance(s, Load)} - {x_buf, mask_buf}
         if len(others) == 1:

--- a/deplodock/compiler/pipeline/passes/loop/recognize/010_recognize_flash.py
+++ b/deplodock/compiler/pipeline/passes/loop/recognize/010_recognize_flash.py
@@ -47,7 +47,6 @@ heads) fails a check and the score-matrix path stands.
 from __future__ import annotations
 
 from deplodock.compiler.graph import Graph, Node
-from deplodock.compiler.ir.elementwise import is_semiring_product
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop.ir import LoopOp
 from deplodock.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Stmt, Write
@@ -103,7 +102,7 @@ def _extract_qk(xnode: Node) -> tuple[str, str, object] | None:
     for lp in _reduce_loops(op):
         loads = [s for s in lp.body if isinstance(s, Load)]
         accs = [s for s in lp.body if isinstance(s, Accum)]
-        muls = [s for s in lp.body if isinstance(s, Assign) and is_semiring_product(s.op)]
+        muls = [s for s in lp.body if isinstance(s, Assign) and s.op.semiring_product]
         if len(loads) == 2 and len(accs) == 1 and _is_sum(accs[0]) and muls:
             q_id = k_id = None
             for ld in loads:

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/010_split_register_axes.py
@@ -39,12 +39,6 @@ from deplodock.compiler.ir.tile.ir import RegisterTile, SerialTile, StageBundle,
 from deplodock.compiler.pipeline import Pattern, RuleSkipped
 from deplodock.compiler.pipeline.passes.lowering.tile._helpers import parallel_tile_of, replace_parallel_tile_body, single_tile
 
-# Reduce ops the cross-accumulator fold may reorder. The FK strip-mine reorders
-# the per-thread reduction (independent partial sums folded at the end), so the
-# op must be associative + commutative — the same fp-reassociation the existing
-# BR cross-thread warp-shuffle combine already relies on (within eager tolerance).
-_ASSOCIATIVE_REDUCE_OPS = frozenset({"add", "sum", "maximum", "amax", "minimum", "amin", "multiply", "prod"})
-
 PATTERN = [Pattern("root", TileOp)]
 
 
@@ -170,9 +164,11 @@ def _build_accum_fold(tile: RegisterTile) -> list[Stmt]:
     fk = k_f.extent.as_static()
     folds: list[Stmt] = []
     for accum in _iter_accums(tile.body):
-        op_name = accum.op.name
-        if op_name not in _ASSOCIATIVE_REDUCE_OPS:
-            raise RuleSkipped(f"FK fold requires an associative reduce op; got {op_name!r} on accumulator {accum.name!r}")
+        # The FK strip-mine reorders the per-thread reduction (independent partial
+        # sums folded at the end), so the combine must be associative — the same
+        # fp-reassociation the BR cross-thread warp-shuffle combine relies on.
+        if not accum.op.associative:
+            raise RuleSkipped(f"FK fold requires an associative reduce op; got {accum.op.name!r} on accumulator {accum.name!r}")
         folds.extend(_fold_tree(accum.name, fk, accum.op))
     return folds
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/015_pack_fk_window.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/015_pack_fk_window.py
@@ -145,7 +145,7 @@ def _pack_window(loop: SerialTile, counter: list[int]) -> list[Stmt]:
             pn = f"{x}__p{cid}"
             new_body.append(Pack(name=pn, low=lo, high=hi, dtype=F16x2))
             packed[x] = pn
-        elif isinstance(st, Assign) and st.op.name == "multiply":
+        elif isinstance(st, Assign) and is_semiring_product(st.op):
             args = tuple(packed.get(a, a) for a in st.args)
             pn = f"{st.name}__p{cid}"
             new_body.append(Assign(name=pn, op=st.op, args=args, dtype=F16x2))

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/015_pack_fk_window.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/015_pack_fk_window.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 from deplodock.compiler.dtype import F16, F32, F16x2
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.axis import Axis
-from deplodock.compiler.ir.elementwise import is_semiring_product
 from deplodock.compiler.ir.expr import Literal, Var
 from deplodock.compiler.ir.sigma import Sigma
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Cond, Init, Load, Pack, Stmt, Unpack
@@ -100,7 +99,7 @@ def _is_window_loop(s: SerialTile) -> bool:
     accums = [x for x in s.body if isinstance(x, Accum)]
     if not accums or not s.axis.extent.is_static or s.axis.extent.as_static() % 2 != 0:
         return False
-    muls = {x.name: x for x in s.body if isinstance(x, Assign) and is_semiring_product(x.op)}
+    muls = {x.name: x for x in s.body if isinstance(x, Assign) and x.op.semiring_product}
     loads = {x.name: x for x in s.body if isinstance(x, Load)}
     for acc in accums:
         mul = muls.get(acc.value)
@@ -145,7 +144,7 @@ def _pack_window(loop: SerialTile, counter: list[int]) -> list[Stmt]:
             pn = f"{x}__p{cid}"
             new_body.append(Pack(name=pn, low=lo, high=hi, dtype=F16x2))
             packed[x] = pn
-        elif isinstance(st, Assign) and is_semiring_product(st.op):
+        elif isinstance(st, Assign) and st.op.semiring_product:
             args = tuple(packed.get(a, a) for a in st.args)
             pn = f"{st.name}__p{cid}"
             new_body.append(Assign(name=pn, op=st.op, args=args, dtype=F16x2))

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/015_pack_fk_window.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/015_pack_fk_window.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 from deplodock.compiler.dtype import F16, F32, F16x2
 from deplodock.compiler.graph import Graph, Node
 from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.elementwise import is_semiring_product
 from deplodock.compiler.ir.expr import Literal, Var
 from deplodock.compiler.ir.sigma import Sigma
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Cond, Init, Load, Pack, Stmt, Unpack
@@ -99,7 +100,7 @@ def _is_window_loop(s: SerialTile) -> bool:
     accums = [x for x in s.body if isinstance(x, Accum)]
     if not accums or not s.axis.extent.is_static or s.axis.extent.as_static() % 2 != 0:
         return False
-    muls = {x.name: x for x in s.body if isinstance(x, Assign) and x.op.name == "multiply"}
+    muls = {x.name: x for x in s.body if isinstance(x, Assign) and is_semiring_product(x.op)}
     loads = {x.name: x for x in s.body if isinstance(x, Load)}
     for acc in accums:
         mul = muls.get(acc.value)

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/020_place_inits.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/020_place_inits.py
@@ -73,17 +73,15 @@ def rewrite(match: Match, root: Node) -> Graph | None:
     return TileOp(body=new_body, name=root.op.name)
 
 
-# Reduction ops that select one input value (no magnitude accumulation)
-# and can therefore stay in the input dtype. Everything else (sum, prod)
-# uses the accumulating dtype.
-_SELECTING_OPS: frozenset[str] = frozenset({"maximum", "amax", "minimum", "max", "min"})
-
-
 def _decide_dtype(accum: Accum, accumulating_dtype: DataType, selecting_dtype: DataType) -> DataType:
-    """Per-Accum dtype choice. Already-stamped Accums keep their dtype."""
+    """Per-Accum dtype choice. Already-stamped Accums keep their dtype.
+
+    A *selecting* combine (the max/min family — ``op.selecting``) picks an
+    existing input value rather than accumulating magnitude, so it can stay in
+    the input dtype; everything else (sum, prod) uses the accumulating dtype."""
     if accum.dtype is not None:
         return accum.dtype
-    if accum.op.name in _SELECTING_OPS:
+    if accum.op.selecting:
         return selecting_dtype
     return accumulating_dtype
 

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/030_stamp_types.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/030_stamp_types.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass, field, replace
 
 from deplodock.compiler.dtype import F16, F32, DataType
 from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.elementwise import is_semiring_product
 from deplodock.compiler.ir.stmt import (
     Accum,
     Assign,
@@ -200,7 +201,7 @@ def _is_overflow_prone(s: Assign) -> bool:
     mean-of-squares). Distinct-arg ``multiply`` (matmul) is excluded."""
     if s.op.name == "pow":
         return True
-    return s.op.name == "multiply" and len(s.args) == 2 and s.args[0] == s.args[1]
+    return is_semiring_product(s.op) and len(s.args) == 2 and s.args[0] == s.args[1]
 
 
 def _stamp_write(s: Write, ctx: _StampCtx) -> Write:

--- a/deplodock/compiler/pipeline/passes/lowering/kernel/030_stamp_types.py
+++ b/deplodock/compiler/pipeline/passes/lowering/kernel/030_stamp_types.py
@@ -39,7 +39,6 @@ from dataclasses import dataclass, field, replace
 
 from deplodock.compiler.dtype import F16, F32, DataType
 from deplodock.compiler.graph import Graph, Node
-from deplodock.compiler.ir.elementwise import is_semiring_product
 from deplodock.compiler.ir.stmt import (
     Accum,
     Assign,
@@ -201,7 +200,7 @@ def _is_overflow_prone(s: Assign) -> bool:
     mean-of-squares). Distinct-arg ``multiply`` (matmul) is excluded."""
     if s.op.name == "pow":
         return True
-    return is_semiring_product(s.op) and len(s.args) == 2 and s.args[0] == s.args[1]
+    return s.op.semiring_product and len(s.args) == 2 and s.args[0] == s.args[1]
 
 
 def _stamp_write(s: Write, ctx: _StampCtx) -> Write:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -138,7 +138,7 @@ from deplodock.compiler.context import Context
 from deplodock.compiler.dim import Dim
 from deplodock.compiler.dtype import F16, F32
 from deplodock.compiler.graph import Graph, Node
-from deplodock.compiler.ir.algebra import AlgebraKind
+from deplodock.compiler.ir.algebra import AlgebraKind, contains_matmul_reduce
 from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import BinaryExpr, Literal, SimplifyCtx, TernaryExpr, Var
 from deplodock.compiler.ir.loop import LoopOp
@@ -363,7 +363,7 @@ def _classify_fused_prologue(stmts: tuple[Stmt, ...]) -> tuple[tuple[Stmt, ...],
     for s in stmts:
         if isinstance(s, Loop) and s.is_reduce:
             prologue.append(s)
-        elif isinstance(s, Loop) and not s.is_reduce and inner is None and _contains_matmul_reduce(s):
+        elif isinstance(s, Loop) and not s.is_reduce and inner is None and contains_matmul_reduce(s):
             inner = s
         elif isinstance(s, (Loop, StridedLoop)):
             return (), None
@@ -372,19 +372,6 @@ def _classify_fused_prologue(stmts: tuple[Stmt, ...]) -> tuple[tuple[Stmt, ...],
         else:
             prologue.append(s)
     return (tuple(prologue), inner) if inner is not None else ((), None)
-
-
-def _contains_matmul_reduce(stmt: Stmt) -> bool:
-    """True if ``stmt`` is or transitively contains a matmul-shape reduce
-    Loop (``is_matmul_reduce``: reduce body has ≥ 2 K-indexed Loads + an
-    Accum)."""
-    if isinstance(stmt, Loop) and stmt.is_reduce and is_matmul_reduce(stmt):
-        return True
-    for sub in stmt.nested():
-        for c in sub:
-            if _contains_matmul_reduce(c):
-                return True
-    return False
 
 
 def _identity_rename(name: str) -> str:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/010_partition_loops.py
@@ -138,11 +138,12 @@ from deplodock.compiler.context import Context
 from deplodock.compiler.dim import Dim
 from deplodock.compiler.dtype import F16, F32
 from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.algebra import AlgebraKind
 from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import BinaryExpr, Literal, SimplifyCtx, TernaryExpr, Var
 from deplodock.compiler.ir.loop import LoopOp
 from deplodock.compiler.ir.sigma import Sigma
-from deplodock.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Monoid, Select, SelectBranch, Stmt, StridedLoop, Write
+from deplodock.compiler.ir.stmt import Accum, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
 from deplodock.compiler.ir.tile.ir import (
     ATOM_REGISTRY,
     Atom,
@@ -596,20 +597,25 @@ def _plan_kernel(loop_op: LoopOp, ctx: Context, *, kernel_name: str = "", graph:
     # should rewrite. ``target_names`` survives σ_outer (only axis NAMES are
     # used downstream, not Loop identity — names don't change under σ).
     all_loops: tuple[Loop, ...] = outer_n.body.iter_of_type(Loop)
-    matmul_reduces = [lp for lp in all_loops if lp.is_reduce and is_matmul_reduce(lp)]
-    nonmatmul_reduces = [lp for lp in all_loops if lp.is_reduce and not is_matmul_reduce(lp)]
-    # Flash-style kernel (online-softmax ``Monoid`` reduce): the KV reduce is the
-    # cooperative-parallelization axis (Step 4 of plans/atomic-free-monoid-combine.md),
-    # NOT the nested score dot-product (a matmul-reduce over head_dim that stays serial
-    # inside each KV step). When a Monoid reduce is present, route to the
-    # cooperative-reduce path so the KV axis splits across the CTA's threads
-    # (Step 2's monoid combine) instead of the matmul-output tiling that leaves KV
-    # serial. ``commutative`` (split-KV legality) is True for the LSE monoid.
-    # Restricted to a STATIC KV extent: a SYMBOLIC (masked) KV needs the overhang
-    # keys folded to the monoid identity (score → −inf so exp → 0), which the
-    # ``Accum``-only ``_mask_reduce_accums`` doesn't do for a Monoid — masked
-    # symbolic flash stays on its existing serial-KV path (a follow-up).
-    combine_reduces = [lp for lp in nonmatmul_reduces if lp.axis.extent.is_static and any(isinstance(s, Monoid) for s in lp.body)]
+    # Route on each reduce loop's bottom-up algebra tag (Part C1a of
+    # plans/algebraic-carrier-analysis.md) instead of re-deriving the archetype:
+    # ``SEMIRING`` → matmul-output tiling; everything else → cooperative-reduce.
+    reduce_loops = [lp for lp in all_loops if lp.is_reduce]
+    matmul_reduces = [lp for lp in reduce_loops if lp.algebra_kind is AlgebraKind.SEMIRING]
+    nonmatmul_reduces = [lp for lp in reduce_loops if lp.algebra_kind is not AlgebraKind.SEMIRING]
+    # Flash-style kernel (online-softmax ``TWISTED_MONOID`` reduce): the KV reduce
+    # is the cooperative-parallelization axis (Step 4 of
+    # plans/atomic-free-monoid-combine.md), NOT the nested score dot-product (a
+    # matmul-reduce over head_dim that stays serial inside each KV step). When a
+    # twisted monoid is present, route to the cooperative-reduce path so the KV
+    # axis splits across the CTA's threads (Step 2's monoid combine) instead of
+    # the matmul-output tiling that leaves KV serial. ``commutative`` (split-KV
+    # legality) is True for the LSE monoid. Restricted to a STATIC KV extent: a
+    # SYMBOLIC (masked) KV needs the overhang keys folded to the monoid identity
+    # (score → −inf so exp → 0), which the ``Accum``-only ``_mask_reduce_accums``
+    # doesn't do for a Monoid — masked symbolic flash stays on its existing
+    # serial-KV path (a follow-up).
+    combine_reduces = [lp for lp in nonmatmul_reduces if lp.axis.extent.is_static and lp.algebra_kind is AlgebraKind.TWISTED_MONOID]
 
     k_loop: Loop | None
     target_names: frozenset[str]

--- a/deplodock/compiler/pipeline/passes/lowering/tile/011_lower_atom_cell.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/011_lower_atom_cell.py
@@ -26,6 +26,7 @@ visit rewrites nothing and the pass skips.
 from __future__ import annotations
 
 from deplodock.compiler.graph import Graph, Node
+from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Load, Mma, Stmt, Write
 from deplodock.compiler.ir.tile.ir import Atom, AtomTile, SerialTile, TileOp
 from deplodock.compiler.pipeline import Match, Pattern, RuleSkipped
@@ -114,7 +115,9 @@ def _try_tag_here(body: Body, *, atom: Atom, k_name: str | None, write: Write | 
     if not (len(loads) == 2 and len(assigns) == 1 and len(accums) == 1):
         return None
     mul, accum = assigns[0], accums[0]
-    if mul.op.name != "multiply" or accum.value != mul.name or set(mul.args) != {ld.names[0] for ld in loads if ld.names}:
+    # The cell is a semiring contraction: its product ``⊗`` must distribute over
+    # the accumulator's reduce ``⊕`` (today the ``(×, +)`` matmul semiring).
+    if not distributes_over(mul.op, accum.op) or accum.value != mul.name or set(mul.args) != {ld.names[0] for ld in loads if ld.names}:
         return None
     a_load, b_load = _classify_ab(loads, k_name=k_name, write=write)
     if a_load is None or b_load is None:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/011_lower_atom_cell.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/011_lower_atom_cell.py
@@ -26,7 +26,6 @@ visit rewrites nothing and the pass skips.
 from __future__ import annotations
 
 from deplodock.compiler.graph import Graph, Node
-from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Load, Mma, Stmt, Write
 from deplodock.compiler.ir.tile.ir import Atom, AtomTile, SerialTile, TileOp
 from deplodock.compiler.pipeline import Match, Pattern, RuleSkipped
@@ -117,7 +116,7 @@ def _try_tag_here(body: Body, *, atom: Atom, k_name: str | None, write: Write | 
     mul, accum = assigns[0], accums[0]
     # The cell is a semiring contraction: its product ``⊗`` must distribute over
     # the accumulator's reduce ``⊕`` (today the ``(×, +)`` matmul semiring).
-    if not distributes_over(mul.op, accum.op) or accum.value != mul.name or set(mul.args) != {ld.names[0] for ld in loads if ld.names}:
+    if not mul.op.distributes_over(accum.op) or accum.value != mul.name or set(mul.args) != {ld.names[0] for ld in loads if ld.names}:
         return None
     a_load, b_load = _classify_ab(loads, k_name=k_name, write=write)
     if a_load is None or b_load is None:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/040_use_ring_buffers.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/040_use_ring_buffers.py
@@ -31,10 +31,11 @@ import importlib
 from deplodock.compiler.context import Context
 from deplodock.compiler.graph import Node
 from deplodock.compiler.ir.expr import Literal, Var
-from deplodock.compiler.ir.stmt import Accum, Body, Load, Stmt
+from deplodock.compiler.ir.stmt import Body, Load, Stmt
 from deplodock.compiler.ir.tile.ir import SerialTile, StageBundle, StagePolicy, TileOp
 from deplodock.compiler.pipeline import Match, Pattern, RuleSkipped
 from deplodock.compiler.pipeline.knob import Knob, KnobType, is_warp
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import reduce_body_has_coupled_accum
 
 PATTERN = [Pattern("root", TileOp)]
 
@@ -316,14 +317,9 @@ def _has_stage_inner_reduce(body: Body) -> bool:
 def _accums_independent_in(body: Body) -> bool:
     """For each reduce SerialTile inside ``body``, reject if any non-Accum
     stmt reads a sibling Accum's running value (online-softmax merge shape)."""
-    for nested in body.iter():
-        if isinstance(nested, SerialTile) and nested.is_reduce:
-            for c in nested.body:
-                if isinstance(c, Accum):
-                    continue
-                if any(isinstance(d, Accum) for d in nested.body.deps_of(c) if d is not None):
-                    return False
-    return True
+    return not any(
+        reduce_body_has_coupled_accum(nested.body) for nested in body.iter() if isinstance(nested, SerialTile) and nested.is_reduce
+    )
 
 
 def _make_phase_load_rewriter(staged_names: set[str], phase):

--- a/deplodock/compiler/pipeline/passes/lowering/tile/080_pipeline_stages.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/080_pipeline_stages.py
@@ -85,6 +85,7 @@ from deplodock.compiler.ir.tile.ir import (
 )
 from deplodock.compiler.pipeline import Pattern, RuleSkipped
 from deplodock.compiler.pipeline.knob import Knob, KnobType
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import reduce_body_has_coupled_accum
 
 PATTERN = [Pattern("root", TileOp)]
 
@@ -173,14 +174,8 @@ def _try_pipeline(kouter: SerialTile) -> list[Stmt] | None:
     # softmax (running max / sum read mid-iter) and similar shapes
     # compound fp32 drift under the prologue/main/epilogue peel and
     # produce wrong output.
-    from deplodock.compiler.ir.stmt import Accum  # noqa: PLC0415
-
-    for k_inner in reduces:
-        for c in k_inner.body:
-            if isinstance(c, Accum):
-                continue
-            if any(isinstance(d, Accum) for d in k_inner.body.deps_of(c) if d is not None):
-                return None
+    if any(reduce_body_has_coupled_accum(k_inner.body) for k_inner in reduces):
+        return None
 
     n = kouter.axis.extent.as_static()
     k_var = kouter.axis.name

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_atom.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_atom.py
@@ -233,6 +233,13 @@ def _mma_eligible_factory(atom: Atom, *, min_cc: tuple[int, int] = (8, 0)) -> Ca
                 return False
             if accum.value != multiply.name:
                 return False
+            # The cell must be a semiring contraction — the product distributes
+            # over the Accum's reduce (the matmul ``(×, +)``). This matches the
+            # check the lowering it feeds enforces (``011_lower_atom_cell`` /
+            # ``_split_demoted``: ``mul.op.distributes_over(acc.op)``), so the
+            # eligibility gate and the tagger agree on what reaches the mma tier.
+            if not multiply.op.distributes_over(accum.op):
+                return False
             # Operand layout: the gate and the tagger share ONE classifier
             # (:func:`classify_matmul_operands`), so a cell the tagger can't
             # recover A/B for is never offered the mma tier (an untagged

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
@@ -51,6 +51,17 @@ def accums_independent(body: Body) -> bool:
     return not any(body.depends_on(s.value, accum_names - {s.name}) for s in body if isinstance(s, Accum))
 
 
+def reduce_body_has_coupled_accum(body: Body) -> bool:
+    """True iff a non-Accum stmt in ``body`` reads a sibling Accum's running
+    value — the online / coupled-reduction shape (online softmax, Welford)
+    whose cross-Accum dependency the ring-buffer / pipeline-stage peels can't
+    preserve. The per-reduce-scope counterpart of :func:`accums_independent`
+    (which tests Accum-value coupling over a flat body); shared by
+    ``040_use_ring_buffers`` and ``080_pipeline_stages``."""
+    body = Body.coerce(body)
+    return any(any(isinstance(d, Accum) for d in body.deps_of(c) if d is not None) for c in body if not isinstance(c, Accum))
+
+
 from deplodock.compiler.target import compute_capability  # noqa: E402,F401
 
 

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_helpers.py
@@ -33,7 +33,8 @@ from __future__ import annotations
 
 import logging
 
-from deplodock.compiler.ir.stmt import Accum, Body, Load, Loop, ReduceCarrier, Stmt, StridedLoop
+from deplodock.compiler.ir.algebra import matmul_reduce
+from deplodock.compiler.ir.stmt import Accum, Body, Load, Loop, Stmt, StridedLoop
 from deplodock.compiler.ir.tile.ir import GridTile, ParallelTile, SerialTile, StridedTile, ThreadTile, WarpTile
 from deplodock.compiler.pipeline import RuleSkipped
 
@@ -158,14 +159,12 @@ def is_matmul_reduce(loop) -> bool:
     ``010_partition_loops`` to locate the matmul K reduce inside a LoopOp
     body, and by downstream tile passes to confirm a matmul-shaped reduce
     survived.
+
+    The structural core lives in ``ir/algebra.matmul_reduce`` (the single
+    source the bottom-up `AlgebraKind` classifier shares); this wrapper adds
+    the tile-layer type guard.
     """
-    if not (isinstance(loop, (Loop, StridedLoop, SerialTile, StridedTile)) and loop.is_reduce):
-        return False
-    K_name = loop.axis.name
-    bufs = {ld.input for ld in loop.body.of_type(Load) if K_name in {v for e in ld.index for v in e.free_vars()}}
-    if len(bufs) < 2:
-        return False
-    return any(isinstance(s, ReduceCarrier) for s in loop.body)
+    return isinstance(loop, (Loop, StridedLoop, SerialTile, StridedTile)) and matmul_reduce(loop)
 
 
 def segmentable_k_extent(load: Load, k_name: str) -> int | None:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
@@ -96,6 +96,7 @@ from deplodock.compiler import dtype as dtype_mod
 from deplodock.compiler.dim import DEFAULT_SEQ_HINT, Dim
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.base import InputOp
+from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import LoopOp
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Stmt, Write
@@ -172,7 +173,8 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
     per_acc: list[tuple[Accum, Assign, tuple[str, ...]]] = []
     for acc in accums:
         mul = cell_def.get(acc.value)
-        if not isinstance(mul, Assign) or mul.op.name != "multiply" or len(mul.args) != 2:
+        # Matmul cell: the product must distribute over the accumulator's reduce.
+        if not isinstance(mul, Assign) or not distributes_over(mul.op, acc.op) or len(mul.args) != 2:
             return None
         cone_args: dict[str, None] = {}  # ordered de-dup (a squared cone appears twice)
         for a in mul.args:

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
@@ -95,6 +95,7 @@ from typing import TYPE_CHECKING
 from deplodock.compiler import dtype as dtype_mod
 from deplodock.compiler.dim import DEFAULT_SEQ_HINT, Dim
 from deplodock.compiler.graph import Graph, Tensor
+from deplodock.compiler.ir.algebra import contains_matmul_reduce
 from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.expr import Var
@@ -495,7 +496,7 @@ def _classify_cut(loop_op: LoopOp):
         cur = tuple(cur[0].body)
 
     inner = [s for s in cur if isinstance(s, Loop) and not s.is_reduce]
-    if len(inner) == 1 and _contains_matmul_reduce_loop(inner[0]):
+    if len(inner) == 1 and contains_matmul_reduce(inner[0]):
         outer_n = inner[0]
         prologue_level = cur
     elif rows and not inner:
@@ -523,12 +524,6 @@ def _classify_cut(loop_op: LoopOp):
     # that reaches the tensor-core tier, matching its static twin — the search
     # prices the split against the fused-scalar form.
     return tuple(leading), rows, prologue_level, outer_n, k_loop
-
-
-def _contains_matmul_reduce_loop(stmt: Stmt) -> bool:
-    if isinstance(stmt, Loop) and stmt.is_reduce and is_matmul_reduce(stmt):
-        return True
-    return any(_contains_matmul_reduce_loop(c) for body in stmt.nested() for c in body)
 
 
 def _matmul_operand_dtype(root: str, per_acc, cell_def, graph: Graph):

--- a/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
+++ b/deplodock/compiler/pipeline/passes/lowering/tile/_split_demoted.py
@@ -97,7 +97,6 @@ from deplodock.compiler.dim import DEFAULT_SEQ_HINT, Dim
 from deplodock.compiler.graph import Graph, Tensor
 from deplodock.compiler.ir.algebra import contains_matmul_reduce
 from deplodock.compiler.ir.base import InputOp
-from deplodock.compiler.ir.elementwise import distributes_over
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import LoopOp
 from deplodock.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Stmt, Write
@@ -175,7 +174,7 @@ def try_split_demoted(loop_op: LoopOp, ctx: Context, *, graph: Graph, node_id: s
     for acc in accums:
         mul = cell_def.get(acc.value)
         # Matmul cell: the product must distribute over the accumulator's reduce.
-        if not isinstance(mul, Assign) or not distributes_over(mul.op, acc.op) or len(mul.args) != 2:
+        if not isinstance(mul, Assign) or not mul.op.distributes_over(acc.op) or len(mul.args) != 2:
             return None
         cone_args: dict[str, None] = {}  # ordered de-dup (a squared cone appears twice)
         for a in mul.args:

--- a/plans/algebraic-carrier-analysis.md
+++ b/plans/algebraic-carrier-analysis.md
@@ -1,0 +1,343 @@
+# Algebraic carrier analysis — trait-carrying ops, a bottom-up algebra analyzer, and a trait-driven planner
+
+> **Status (implemented).** Parts **A**, **B**, and **C1a** are landed and byte-identical (verified by `deplodock
+> compile` per-kernel compare on Qwen3-Embedding-0.6B layer 0 under a fixed `PYTHONHASHSEED` — both the default and
+> `DEPLODOCK_FLASH=1` paths — and a green `make test`):
+> - **A** — `ir/elementwise.py` is the complete algebraic registry; the ~10 string-match sites are op-name-free trait
+>   queries (`selecting`, `distributes_over` / `is_semiring_product`, `reduce_canon`, the `_REDUCE_SPELLING` registry).
+> - **B** — `ir/algebra.py`'s `AlgebraKind` + `classify_algebra` / `Loop.algebra_kind` tags each reduce loop bottom-up
+>   from its carrier (implemented as a **derived property**, not a normalize-stamped field — the plan's "derived cache,
+>   read back from the carrier" framing, with zero serialization/codegen risk). `matmul_reduce` moved to `ir/algebra`;
+>   `lowering/tile/_helpers.is_matmul_reduce` delegates.
+> - **C1a** — `010_partition_loops` routes on the tag (`SEMIRING` → matmul tiling; static `TWISTED_MONOID` →
+>   cooperative-reduce; else cooperative-K / pointwise).
+> - **C6** — effectively satisfied: after A no op-name string-match gates remain (the cooperative combine / split-KV
+>   legality already read `carrier.associative` / `commutative`; dtype reads `op.selecting`).
+>
+> **Deferred (C1b / C2 / C3 / C4 / C5 — the generic MMA twisted-monoid carry).** These supersede the bespoke flash
+> rule by giving the MMA tensor-core tier a `(init, action, fold)` carrier interface. They are **blocked on a consumer
+> that does not yet exist**: twisted monoids today route to the cooperative *scalar* path, and the MMA tensor-core
+> flash tier is itself future work (the landed flash is the *scalar* tier — see `plans/masked-gqa-mma-flash-attention.md`
+> Part C / `plans/masked-gqa-mma-flash-attention.md` sub-step C1). Adding the `action`/`fold` protocol + the MMA
+> fragment-carry generalization now would be machinery with no live consumer; they should land *with* the MMA-flash tier
+> work, behind the `action = identity` byte-identical gate the plan describes below. The analyzer (B) and the tag-driven
+> planner (C1a) are the groundwork that makes them reachable.
+
+Derive each kernel's **algebra** bottom-up from its loops, carry it as a first-class structure, and let the partition
+planner + downstream passes dispatch on it instead of re-deriving the archetype from syntactic shape. This is the
+inverse of the bespoke top-down recognizers (`loop/recognize/010_recognize_flash`): rather than hand-match a known
+pattern and stamp a carrier, *analyze* the carrier that's already there and expose a uniform interface the scheduler
+consumes.
+
+The north-star payoff: the MMA tensor-core tier for flash (and any other twisted monoid — Welford, argmax) deploys
+through a **generic `(init, action, fold)` carrier interface** rather than a bespoke per-carrier lowering rule. This
+supersedes the "bespoke `FlashCombine`-keyed rule" decision in `plans/masked-gqa-mma-flash-attention.md` (Part C) once
+the action hook lands — see Part C5 below.
+
+## The framing (why this is mostly consolidation, not new machinery)
+
+Three facts about the current tree make this tractable:
+
+1. **The op trait tables already exist.** `ir/elementwise.py::ElementwiseImpl` is the single source of truth:
+   `_COMMUTATIVE` / `_ASSOCIATIVE` (lines 59–64), `_IDENTITY` (lines 67–75), and the `commutative` / `associative` /
+   `identity` / `has_identity` properties (lines 96–113). The docstring already says these exist so "the reassociation
+   gates query instead of matching op names."
+2. **The carrier already *is* the algebra.** `ir/stmt/base.py::ReduceCarrier` (lines 562–578) exposes
+   `associative` / `commutative` / `has_identity` + `carried_names` / `partial_deps`; `Accum` forwards to its scalar
+   `op`, `Mma` reports the additive-fold constants, `Monoid` (FlashCombine) reports a monoid with a per-instance
+   `commutative` flag (`ir/stmt/leaves.py:461–780`). The base docstring already states rules "don't switch on the
+   carrier type — they read the algebraic traits."
+3. **The planner already classifies by predicate, not by op-name string.** `lowering/tile/010_partition_loops.py`
+   routes on `is_matmul_reduce` / `Loop.is_reduce` / presence of a `Monoid` in the body (lines 599–617), not on
+   `"add"` / `"maximum"`.
+
+So the infrastructure is half-built. What's missing — and what this plan delivers — is (A) **finishing** the op trait
+system so the ~15 remaining string-match sites become trait queries, (B) a **bottom-up classifier** (run in `LoopOp`
+normalize) that tags each reduce loop with its algebraic kind, and (C) **rewiring** the planner + downstream to consume
+those tags, including the `(init, action, fold)` generalization that unlocks generic MMA-tier twisted monoids.
+
+## Hard constraints
+
+- **Behavior-preserving through Parts A–B.** The trait system must give byte-identical answers to the current
+  hardcoded sets for every known op; the analyzer is additive (it produces a structure; nothing yet *requires* it).
+  Validate with `deplodock compare` per-kernel on a real model (Qwen3-Embedding-0.6B layer 0) — the three existing
+  regimes (matmul / pointwise / cooperative-reduce) must not move.
+- **`action = identity` is byte-identical (Part C).** Generalizing the MMA fragment-carry to call a carrier-supplied
+  action between K-steps must reduce to today's zero-init + store-at-end for plain `Accum` / `Mma` (the action is the
+  no-op). Plain matmul codegen does not change.
+- **Traits are algebraic over the reals; fp reordering is the accepted relaxation.** float32 `add` is not
+  bit-associative; `associative` means "the schedule may reorder, accepting rounding drift," which the pipeline already
+  tolerates (accuracy is checked with tolerances, not bit-equality). Do NOT try to prove fp associativity — prove over
+  exact algebra, keep the existing tolerance-based validation.
+- **No frontend / decomposition changes.** All work lands in `ir/` (the classifier in `LoopOp` normalize), `loop/` (the
+  reframed `loop/recognize/`), and `lowering/` (`tile` / `kernel`). Recognizers are reframed, not deleted.
+
+## Part A — finish the op trait system (the "stop switching on names" layer)
+
+`ElementwiseImpl` becomes the complete algebraic registry, and every site that string-matches op identity queries a
+trait instead.
+
+### A1 — extend the trait tables
+
+Add to `ElementwiseImpl` (data, not code — adding an op is editing a table):
+
+- **`selecting`** — True for ops that *select* an existing value rather than accumulate magnitude (`maximum` / `amax` /
+  `minimum` / `max` / `min`). Replaces `_SELECTING_OPS` in `lowering/kernel/020_place_inits.py:79`.
+- **Semiring pairing** — `_SEMIRING: dict[str, frozenset[str]]` mapping a reduce `⊕` to the products `⊗` that
+  distribute over it: `{"add": {"multiply"}, ...}`. A `distributes_over(mul, add)` helper lets matmul detection ask
+  "does `⊗` distribute over `⊗`'s reduce?" instead of hardcoding `"multiply"` + `"add"`
+  (`recognize/010_recognize_flash.py`, `011_lower_atom_cell.py:117`, `_splitk_residual.py:111`, `_split_demoted.py:175`,
+  `015_pack_fk_window.py:102`). Start minimal — only `(+, ×)` is exercised today; the table is structured so tropical
+  `(min, +)` etc. are *data* if ever needed, but DO NOT add unused semirings (simplicity-first).
+- **One render-spelling registry.** Consolidate the per-op CUDA/numpy spelling currently scattered across
+  `Accum.render` (`leaves.py:545–552`), `kernel/ir.py::_tree_halve_op` (1245–1254), `stmt/base.py::op_to_expr`
+  (206–237), and `tensor/ir.py::ReduceOp.forward` / `ScanOp.forward` (133–176) into one op-keyed table (`+=` / `*=` /
+  `fmax` / `fmin`, and the numpy reduce callable). These four sites are the same dispatch written four times.
+
+### A2 — convert the string-check sites to trait queries
+
+The audited call sites (file:line → trait):
+
+| site                                                                                     | today                                  | becomes                                                                     |
+|------------------------------------------------------------------------------------------|----------------------------------------|-----------------------------------------------------------------------------|
+| `lowering/kernel/020_place_inits.py:79,82`                                               | `_SELECTING_OPS` frozenset             | `op.selecting`                                                              |
+| `lowering/kernel/010_split_register_axes.py:46,174`                                      | `_ASSOCIATIVE_REDUCE_OPS` frozenset    | `op.associative` (already a trait!)                                         |
+| `loop/lifting/020_lift_reduce.py:25,54`                                                  | `_COMBINE` name map                    | keep as a tensor→loop alias, but key off the op, not a literal dict         |
+| `loop/recognize/010_recognize_flash.py` (`_SUM`/`_MAX` tuples + `"multiply"`)            | `_SUM` / `_MAX` tuples + `"multiply"`  | semiring-role + `selecting` helpers (the recognizer survives — see Part B3) |
+| `tensor/ir.py:133–176`, `kernel/ir.py:1245–1254`, `leaves.py:545–552`, `base.py:206–237` | per-op spelling switches               | the A1 render registry                                                      |
+| `lowering/kernel/030_stamp_types.py:203`                                                 | `"multiply" and args[0]==args[1]`      | `op.name`-free square detection via semiring role                           |
+| `ir/loop/ir.py:414`, `ir/stmt/blocks.py:108,320`, `ir/tile/ir.py:1179,1248`              | identity-presence / op-conflict checks | `op.has_identity` / carrier-trait checks (mostly already trait-shaped)      |
+
+`010_split_register_axes` is the cleanest example of the win: it carries its *own* `_ASSOCIATIVE_REDUCE_OPS` set that
+duplicates `ElementwiseImpl._ASSOCIATIVE` — pure redundancy, delete it and read `op.associative`.
+
+### A3 — tests
+
+A trait-table test asserting every known op's `(associative, commutative, identity, selecting, semiring-role)` matches
+the pre-refactor hardcoded sets exactly (behavior-preservation). Lint + `make test` green; `deplodock compare` on a
+model dump unchanged.
+
+## Part B — the bottom-up algebra analyzer (computed in `LoopOp` normalize)
+
+Rather than a one-shot stamp pass, the classification is computed in **`LoopOp` normalize** (`loop/ir.py:102`
+`__post_init__` → `normalize_body`, which already runs on every (re)construction — i.e. after every rewrite). Each
+reduce loop is tagged with its **algebraic kind** as a derived field. It does NOT build a separate tree: the loop nest
+already carries the nesting and the carrier already lives in the loop body, so the classification is just a cheap
+function of the body, re-run whenever the body changes. The scheduler then walks the loop nest it already walks,
+dispatching on each reduce loop's tag.
+
+Computing it in normalize (vs. a stamp pass) is **only safe because the tag is excluded from `op_cache_key`** (B1): a
+knob re-stamped on every reconstruction would give one logical kernel many identities — which is exactly why
+`020_stamp_structural_features` must run once at the end. Our tag dodges that by being out of the key, so continuous
+maintenance is free and there is no "must run after recognize" ordering hazard: the tag is always consistent with the
+current body.
+
+**Why this stays cheap (the expensive match is elsewhere).** Normalize must not re-run an expensive analysis on every
+rewrite — and it doesn't. The costly part — the **catalog match** that turns a raw coupled-accumulator cluster into a
+verified twisted monoid (eventually SMT-backed) — is done ONCE by the recognizer (`loop/recognize`, B3), which produces
+a tagged carrier (`FlashCombine` ⟺ `lse`). Normalize's classification is then a cheap read: `Accum` → `MONOID` (or
+`SEMIRING` if matmul-shaped), `Mma` → `SEMIRING`, a recognized `Monoid` → `TWISTED_MONOID` by the carrier's id; an
+unrecognized coupled accumulator stays `MAP` (no regression). For this the classifier must be **ir-level** (it reads
+carriers, an ir concept) — an `is_matmul_reduce`-style structural check may have to move from `lowering/tile/_helpers`
+down to `ir`.
+
+**Axis assignment — why it lives on `LoopOp`, not `TileOp`.** The tag is well-defined on the `LoopOp` because the
+carrier is present there. It is NOT recomputed in `TileOp` normalize: the partition planner's axis assignment **lowers
+the carrier structure away** (a matmul becomes `Mma`/`ldmatrix` register fragments; a `Monoid` combine becomes an
+explicit rescale + `Accum`), so the bottom-up signals don't survive in the same form. The planner (the first
+`lowering/tile` pass) reads the tag from its `LoopOp` *input*, before tiling; the C6 legality gates run during that
+pass, on the same pre-tile form. Post-partition nothing re-derives it — the schedule embodies the decision; if a later
+tile pass ever needs it, it carries the tag forward via provenance (`Op.source`) rather than re-classifying the tiled
+body.
+
+**Why no separate structure.** Everything a richer node object would store is already recoverable:
+
+- **Nesting → the loop nest.** Kernels are compositions of algebras (flash is `twisted-monoid { semiring(QK^T) ;
+  map(scale,mask) ; <P@V inside the combine> }`), but that composition IS the loop nest. A decomposable kernel's
+  sub-algebras are its inner loops / surrounding stmts; walking the nest recovers them, so a `children` field would only
+  duplicate the IR.
+- **Carrier → the loop body.** The `Accum` / `Mma` / `Monoid` is a stmt in the body, found by scanning, and stays the
+  single source of truth: traits read from it (`carrier.associative` …, the `ReduceCarrier` surface at
+  `base.py:562–572`), operand roles recompute from its loads (`classify_matmul_operands`), and the twisted catalog
+  identity is the carrier's own identity (`FlashCombine` ⟺ `lse`).
+- **The twist is NOT loop-isomorphic — and that's the point.** Flash's two matmuls aren't both loops: QK^T is an inner
+  reduce loop, but P@V lives *inside* the `combine` carrier, not as a loop, so children-as-loops couldn't capture it
+  anyway. What defines that internal structure is the **catalog entry** (`lse` ⇒ "two matmuls + a rescale"), read off
+  the carrier — not a `children` list. The catalog absorbs exactly the non-loop structure, so the loop-nest-as-tree view
+  loses nothing.
+
+**The tag is a derived cache, not a second source of truth.** Because traits and structure are always read back from the
+carrier, the tag can never contradict the algebra — the `MonoidNode(associative=False)` class of bug is unrepresentable,
+there is no trait field to set.
+
+### B1 — the analysis output
+
+A single enum assigned to each reduce loop (non-reduce loops are `MAP` by default and need no tag):
+
+```python
+class AlgebraKind(Enum):
+    MAP             # pointwise / functor — a non-reduce scope (the default; not stamped)
+    MONOID          # a plain associative reduce      (carrier: Accum)
+    SEMIRING        # a contraction / matmul          (carrier: Mma, or a matmul-shaped Accum)
+    TWISTED_MONOID  # an online / coupled reduce       (carrier: Monoid — flash, Welford, …)
+    SCAN            # prefix / causal — reserved, out of scope v1
+```
+
+The kind is a derived field on the reduce `Loop`, set during `LoopOp` normalize, and — like `Axis.source_axis` — is
+**excluded from equality / `op_cache_key`**, which is what makes normalize-maintenance safe. Everything else the
+scheduler needs is fetched from the loop on demand:
+
+- **traits** — `carrier.associative` / `commutative` / `has_identity` (the existing `ReduceCarrier` surface);
+  `distributive` is the A1 semiring-pairing query on the loop's `(⊕, ⊗)`. Read from the carrier, so the tag can never
+  contradict them.
+- **operands** (SEMIRING) — `classify_matmul_operands` over the loop's loads (cache if it proves hot).
+- **catalog_id** (TWISTED_MONOID) — the carrier's identity (`FlashCombine` ⟺ `lse`); a future coupled-accumulator match
+  that isn't yet a `Monoid` carrier records its id on the carrier it constructs.
+
+This subsumes the current prologue/epilogue machinery without a tree: plain matmul is a SEMIRING reduce loop wrapped by
+non-reduce (MAP) loops/stmts for its prologue/epilogue, so `_classify_fused_prologue` /
+`has_nonlinear_post_reduce_epilogue` become "is the surrounding scope a non-reduce loop," read straight off the nest.
+The kernel's top-level kind (for routing-only consumers, Part C1) is its outermost reduce loop's tag.
+
+### B2 — the classifier
+
+The per-reduce-loop classification (a cheap function of the loop body, run in normalize):
+
+- **`MONOID`** — a single `Accum` whose `op.associative` (and `has_identity` for maskability). Traits from the op.
+- **`SEMIRING`** — `is_matmul_reduce` (≥2 distinctly-indexed K-Loads feeding a reduce) **and** the body's `⊗`
+  `distributes_over` the reduce `⊕` (A1 helper). Operand roles come from `classify_matmul_operands` on demand. Replaces
+  the planner's inline `is_matmul_reduce` + the `"multiply"`/`"add"` checks with one trait-verified classification.
+- **`TWISTED_MONOID`** — a recognized `Monoid` carrier (its catalog id is the carrier's own identity). The raw
+  coupled-accumulator → catalog match that *creates* that carrier is the recognizer's job (B3), not normalize's — the
+  key inversion is that `lowering/tile/_helpers.py::accums_independent` currently *rejects* cross-`Accum` reads
+  (`l_i`/`O_i` read `m_i`) as un-fusable, and `_atom.py::classify_fragment_epilogue` bails on "accumulator consumed
+  inside the reduce loop"; the recognizer treats that coupling as the **signal** of a twisted monoid, not a failure.
+- **`MAP`** — any non-reduce loop (the default; not tagged).
+
+Tiering for the recognizer establishing a novel combine's laws (B3): (1) registry/catalog lookup (cheap, covers
+everything today); (2) a randomized associativity/commutativity probe as a filter for a novel combine; (3) SMT
+verification of the survivor — (2)/(3) are future (catalog-only to start), noted in Scope.
+
+### B3 — recognizers become catalog matchers feeding the analyzer
+
+`loop/recognize/010_recognize_flash` + `loop/fusion/_flash.py` are **not deleted** — they are reframed as the **`lse`
+catalog entry**: a verified matcher that recognizes the softmax-P@V shape and emits a `FlashCombine` `Monoid` carrying
+its `lse` identity. Normalize's classifier then tags the loop `TWISTED_MONOID` by reading that carrier, instead of the
+planner re-deriving `combine_reduces` from `isinstance(s, Monoid)` (`010_partition_loops.py:612`). New twisted monoids
+(Welford, argmax) are added as new catalog matchers in the same shape — each ships its pre-verified combine + identity
+(the way `_flash.py:91` hardcodes the LSE identity `(−1e30, 0, 0)`).
+
+### B4 — tests
+
+The classifier tags the known kernels from the dump set correctly: `k_linear_*` reduce loop → `SEMIRING` (its epilogue a
+surrounding non-reduce loop); RMSNorm / `k_mul_*_reduce` → `MONOID`; flash `k_sdpa_*` → `TWISTED_MONOID` with the
+carrier's id `lse`; gated-MLP prologue and SDPA P@V keep their current routing. Assert each reduce loop's tag (plus, for
+`SEMIRING`, its `classify_matmul_operands` roles, and for `TWISTED_MONOID`, the carrier's catalog id) matches an
+expected fixture. A separate check asserts the tag survives idempotently across a normalize round-trip but does NOT
+enter `op_cache_key`.
+
+## Part C — planner + downstream consume the analysis
+
+### C1 — planner dispatches on the per-loop tags (staged)
+
+The planner already walks the loop nest; now it reads each reduce loop's tag instead of re-deriving the archetype. Stage
+it:
+
+- **C1a — top-level routing first (behavior-preserving).** Replace the inline classification at
+  `010_partition_loops.py:599–617` (`matmul_reduces` / `nonmatmul_reduces` / `combine_reduces`) with a dispatch on the
+  outermost reduce loop's tag: `SEMIRING` → matmul-output tiling; `MONOID`/`TWISTED_MONOID` → cooperative-reduce; no
+  reduce (`MAP`) → pointwise. The routing decisions stay; their *inputs* come from the tag, not re-derivation.
+  Byte-identical.
+- **C1b — use the nested tags where it unlocks something.** Only for the cases that need the nesting — first a
+  `TWISTED_MONOID` loop whose inner `SEMIRING` loops must be tensorized as MMA cells while the carrier holds the
+  rescaled fragment (C2–C4). Each reduce loop consults its carrier traits to certify its axis transform (assoc→tile,
+  distributive→split-K, identity→mask). Plain matmul / pointwise stay on the C1a routing path until there's a reason to
+  go deeper, so the blast radius is confined to the twisted-monoid case it enables.
+
+### C2 — promote `(init, action, fold)` onto `ReduceCarrier`
+
+The carrier interface gains three methods naming its reduce surface for a *tiled* schedule:
+
+- **`init`** — seed the accumulator (today: zero-init `c` for `Mma`, `op.identity` for `Accum`).
+- **`action(acc, partial_stats)`** — the **twist**: transform the carry given a new partial. For `Accum` / `Mma` this
+  is the **identity** (no rescale) — which is *why* the plain monoid is already MMA-transparent. For `Monoid` /
+  `FlashCombine` it is the per-step rescale (`O *= alpha`, `l *= alpha`), the content of `FlashCombine.combine_states`.
+- **`fold(acc, partial)`** — accumulate the contribution (today: `+=` / `mma.sync`).
+
+### C3 — generalize the MMA fragment-carry to call `action`
+
+Today the `Mma` `c` fragment is zero-init-at-declaration + store-at-end (`ir/kernel/ir.py:705–707`). Generalize the
+fragment lifecycle across a serial-outer (`K_o`) loop to: `init → (fold ; action)* → finalize`. For plain matmul,
+`action` is identity → the emitted CUDA is byte-identical to today (the hard-constraint gate). For a twisted monoid,
+`action` is a `RegScale` on the fragment regs → the loop-carried, per-step-rescaled accumulator the MMA flash kernel
+needs.
+
+This is exactly sub-step **C1 of `plans/masked-gqa-mma-flash-attention.md`** ("loop-carried, per-step-scaled `Mma`
+fragment"), generalized: instead of a flash-only carry, *any* carrier supplies its action.
+
+### C4 — generic twisted-monoid MMA path
+
+With C2 + C3, the MMA-tier flash kernel (two chained MMAs — QK^T score fragment feeding P@V, with the rescale between
+them) falls out of the generic path keyed on a `TWISTED_MONOID` loop with inner `SEMIRING` loops, reusing the
+existing
+`Mma` / `RegFragment` / `ldmatrix` staging for the two cells. The cross-cell fragment routing (`c:f32` score →
+`a:f16` P operand) and the softmax-stat reduction over the `c`-fragment row layout remain the flash-specific pieces,
+but they hang off the catalog entry's `action` / finalize, not a standalone lowering rule.
+
+### C5 — supersede the bespoke flash rule
+
+`plans/masked-gqa-mma-flash-attention.md` Part C recommends a **bespoke `FlashCombine`-keyed lowering rule** explicitly
+to dodge blast radius ("generalizing `010_partition_loops` to model a reduced-N matmul-reduce is invasive"). This plan's
+C2/C3 is the *general* version it set aside — and it is now justified because the generalization is **gated on
+`action = identity` being byte-identical**, so plain matmul is provably untouched. The decision flips: land the action
+hook (small, test-guarded, additive to the carrier protocol) and the flash MMA tier is a catalog client, not a bespoke
+rule. If C3 proves to move plain-matmul codegen at all, fall back to the masked-gqa plan's bespoke rule for flash and
+keep the generic interface for the scalar tier only.
+
+### C6 — downstream gates read the analysis
+
+Consolidate the remaining schedule-legality gates onto the nodes' derived trait properties: SPLITK legality
+(`010_partition_loops.py` `force_splitk_one` reasoning) reads the reduce loop's `distributive` (A1 semiring query);
+cooperative tree-combine reads `carrier.associative` / `carrier.commutative` (split-KV legality); dtype selection
+(`020_place_inits`) reads `op.selecting`. These already *want* traits (A2); the tag + carrier are the one source.
+
+## Risks / open questions
+
+- **Blast radius of C3** (touches the shared MMA lowering every matmul uses). Mitigate: the `action = identity`
+  byte-identical check, compare-tests on existing kernels before merge, and the C5 fallback to the bespoke flash rule if
+  it isn't clean.
+- **Coupled-accumulator detection vs the `accums_independent` / `classify_fragment_epilogue` bail.** The recognizer must
+  run *before* (or those gates must defer to) the twisted-monoid verdict — the dependency they reject is the dependency
+  it needs. Concretely: `accums_independent` should consult the loop's tag and allow a coupling already classified as a
+  known twisted monoid.
+- **fp associativity** — algebraic-over-reals only; keep tolerance-based validation (hard constraint).
+- **SMT / verified lifting of *novel* carriers is out of scope** — catalog-only v1. A loop matching no catalog entry
+  stays on its current path (no regression), and `log()`s that it was unclassified so the gap is visible.
+- **Semiring-table generality** — resist adding tropical/boolean semirings until a consumer exists; structure it as
+  data so it's a one-line add when one does.
+
+## Scope
+
+**In:** complete the op trait system + delete the duplicated string-match sets (A); a bottom-up classifier in `LoopOp`
+normalize that tags each reduce loop with its algebraic kind, with the recognizers reframed as catalog matchers (B);
+planner dispatch on the tags + the `(init, action, fold)` carrier interface + the generic MMA twisted-monoid carry that
+supersedes the bespoke flash rule (C). Static + dynamic seq at existing test parity.
+
+**Out (future):** SMT / verified-lifting synthesis of novel coupled carriers (catalog-only for now); semirings beyond
+`(+, ×)` and the LSE log-semiring; `SCAN` / segmented-scan (causal attention as a prefix, not a fold) — the algebra
+makes it reachable but it is its own work.
+
+## Sequencing
+
+A (pure refactor, zero behavior change — safe to land alone) → B (additive analysis, nothing depends on it yet) → C
+(consume it; the flash MMA payoff and the only real blast radius live here). A and B are low-risk and independently
+mergeable; C is the one to land behind the byte-identical gate + compare-tests.
+
+## Test strategy
+
+- **Behavior-preservation:** full `make test` green; `deplodock compare <before> <after>` per-kernel unchanged on
+  Qwen3-Embedding-0.6B layer 0 through Parts A–B and for the three existing regimes through C.
+- **New:** the A3 trait-table test; the B4 analyzer-classification fixtures; MMA-flash parity reusing
+  `tests/compiler/e2e/test_flash_attention.py` extended with the masked-gqa plan's GQA / masked / MMA-tier cases.
+- **Integration:** re-run the `plans/masked-gqa-mma-flash-attention.md` validation commands and confirm the flash MMA
+  kernel deploys via the generic twisted-monoid path (one fused `k_sdpa…` kernel with `MMA=mma_m16n8k16_f16`).

--- a/tests/compiler/ir/test_algebra_kind.py
+++ b/tests/compiler/ir/test_algebra_kind.py
@@ -1,0 +1,149 @@
+"""Bottom-up algebra classifier tests (Part B of
+``plans/algebraic-carrier-analysis.md``).
+
+`classify_algebra` / `Loop.algebra_kind` tags each reduce loop by reading its
+carrier: a matmul cell → ``SEMIRING``, a plain associative `Accum` → ``MONOID``,
+a recognized `Monoid` → ``TWISTED_MONOID``, a non-reduce scope → ``MAP``. The
+tag is a derived read — it never enters equality / `op_cache_key` and stays
+consistent across a normalize round-trip.
+"""
+
+from __future__ import annotations
+
+from deplodock.compiler.ir.algebra import AlgebraKind, classify_algebra
+from deplodock.compiler.ir.axis import Axis
+from deplodock.compiler.ir.expr import Literal, Var
+from deplodock.compiler.ir.loop import Accum, Load, Loop, LoopOp, Write
+from deplodock.compiler.ir.stmt import Assign, Mma, Monoid
+from deplodock.compiler.ir.tile.ir import ATOM_REGISTRY
+
+
+def _matmul_loop(k_ext: int = 8) -> Loop:
+    """``acc += a[m,k] * b[k,n]`` — a scalar matmul cell (Accum + multiply)."""
+    return Loop(
+        axis=Axis("k", k_ext),
+        body=(
+            Load(name="a", input="A", index=(Var("m"), Var("k"))),
+            Load(name="b", input="B", index=(Var("k"), Var("n"))),
+            Assign(name="p", op="multiply", args=("a", "b")),
+            Accum(name="acc", value="p", op="add"),
+        ),
+    )
+
+
+def _mma_loop() -> Loop:
+    """The tensor-core fused form of the same cell (Mma carrier)."""
+    return Loop(
+        axis=Axis("k", 16),
+        body=(
+            Load(name="a0", input="A", index=(Var("m"), Var("k"))),
+            Load(name="b0", input="B", index=(Var("k"), Var("n"))),
+            Mma(a="a0", b="b0", c="acc", atom=ATOM_REGISTRY["mma_m16n8k16_f16"]),
+        ),
+    )
+
+
+def _reduce_loop(op: str) -> Loop:
+    return Loop(
+        axis=Axis("k", 8),
+        body=(Load(name="x", input="X", index=(Var("k"),)), Accum(name="s", value="x", op=op)),
+    )
+
+
+def _monoid_loop() -> Loop:
+    combine = Monoid(
+        state=("m_i", "l_i"),
+        partial=("s",),
+        merge=(
+            Assign("mx", "maximum", ("m_i", "s")),
+            Assign("l_i", "add", ("l_i", "mx")),
+            Assign("m_i", "copy", ("mx",)),
+        ),
+        identity=(Literal(-1e30), Literal(0.0)),
+        axes=("kv",),
+    )
+    return Loop(
+        axis=Axis("kv", 8),
+        body=(Load(name="s", input="S", index=(Var("kv"),)), combine),
+    )
+
+
+# --- the four kinds ----------------------------------------------------------
+
+
+def test_matmul_cell_is_semiring():
+    assert _matmul_loop().algebra_kind is AlgebraKind.SEMIRING
+
+
+def test_mma_cell_is_semiring():
+    assert _mma_loop().algebra_kind is AlgebraKind.SEMIRING
+
+
+def test_sum_reduce_is_monoid():
+    assert _reduce_loop("add").algebra_kind is AlgebraKind.MONOID
+
+
+def test_max_reduce_is_monoid():
+    assert _reduce_loop("maximum").algebra_kind is AlgebraKind.MONOID
+
+
+def test_monoid_carrier_is_twisted_monoid():
+    assert _monoid_loop().algebra_kind is AlgebraKind.TWISTED_MONOID
+
+
+def test_non_reduce_loop_is_map():
+    free = Loop(
+        axis=Axis("n", 8),
+        body=(Load(name="x", input="X", index=(Var("n"),)), Write(output="O", index=(Var("n"),), value="x")),
+    )
+    assert free.algebra_kind is AlgebraKind.MAP
+
+
+def test_two_load_max_reduce_is_not_semiring():
+    # Two K-indexed loads but a max combine (no distributing product) — a monoid,
+    # not a contraction. Guards against is_matmul_reduce over-firing.
+    loop = Loop(
+        axis=Axis("k", 8),
+        body=(
+            Load(name="a", input="A", index=(Var("m"), Var("k"))),
+            Load(name="b", input="B", index=(Var("k"), Var("n"))),
+            Assign(name="p", op="add", args=("a", "b")),  # add, not multiply → no semiring
+            Accum(name="acc", value="p", op="maximum"),
+        ),
+    )
+    assert loop.algebra_kind is AlgebraKind.MONOID
+
+
+# --- derived-cache invariants ------------------------------------------------
+
+
+def test_kind_survives_loopop_normalize_roundtrip():
+    # Wrap the matmul cell in a LoopOp (runs normalize_body) and confirm the
+    # classification of its reduce loop is unchanged — a derived read stays
+    # consistent with the (re)normalized body.
+    cell = _matmul_loop()
+    op = LoopOp(
+        body=(
+            Loop(
+                axis=Axis("m", 4),
+                body=(Loop(axis=Axis("n", 4), body=(cell, Write(output="O", index=(Var("m"), Var("n")), value="acc"))),),
+            ),
+        )
+    )
+    reduce_loops = [s for s in op.body.iter() if isinstance(s, Loop) and s.is_reduce]
+    assert len(reduce_loops) == 1
+    assert reduce_loops[0].algebra_kind is AlgebraKind.SEMIRING
+    # Reconstructing the same LoopOp re-normalizes; the classification holds.
+    op2 = LoopOp(body=op.body)
+    reduce_loops2 = [s for s in op2.body.iter() if isinstance(s, Loop) and s.is_reduce]
+    assert reduce_loops2[0].algebra_kind is AlgebraKind.SEMIRING
+
+
+def test_kind_not_in_equality_or_op_cache_key():
+    # The kind is computed, never stored — two structurally identical reduce
+    # loops are equal and the tag adds no field to compare/hash.
+    a, b = _matmul_loop(), _matmul_loop()
+    assert a == b and hash(a) == hash(b)
+    # classify is a pure function of the body, not a stored attribute.
+    assert classify_algebra(a) is classify_algebra(b)
+    assert "algebra" not in {f for f in a.__dataclass_fields__}

--- a/tests/compiler/ir/test_algebra_kind.py
+++ b/tests/compiler/ir/test_algebra_kind.py
@@ -10,7 +10,7 @@ consistent across a normalize round-trip.
 
 from __future__ import annotations
 
-from deplodock.compiler.ir.algebra import AlgebraKind, classify_algebra
+from deplodock.compiler.ir.algebra import AlgebraKind, classify_algebra, contains_matmul_reduce
 from deplodock.compiler.ir.axis import Axis
 from deplodock.compiler.ir.expr import Literal, Var
 from deplodock.compiler.ir.loop import Accum, Load, Loop, LoopOp, Write
@@ -137,6 +137,19 @@ def test_kind_survives_loopop_normalize_roundtrip():
     op2 = LoopOp(body=op.body)
     reduce_loops2 = [s for s in op2.body.iter() if isinstance(s, Loop) and s.is_reduce]
     assert reduce_loops2[0].algebra_kind is AlgebraKind.SEMIRING
+
+
+def test_contains_matmul_reduce_recurses():
+    # The shared helper finds a matmul reduce transitively nested under a
+    # non-reduce loop (the fused-prologue / demoted-split probe shape).
+    nest = Loop(
+        axis=Axis("n", 4),
+        body=(Loop(axis=Axis("m", 4), body=(_matmul_loop(),)), Write(output="O", index=(Var("n"),), value="x")),
+    )
+    assert contains_matmul_reduce(nest)
+    # A pure pointwise / monoid nest has none.
+    monoid_nest = Loop(axis=Axis("n", 4), body=(_reduce_loop("add"),))
+    assert not contains_matmul_reduce(monoid_nest)
 
 
 def test_kind_not_in_equality_or_op_cache_key():

--- a/tests/compiler/ir/test_algebra_traits.py
+++ b/tests/compiler/ir/test_algebra_traits.py
@@ -1,0 +1,164 @@
+"""Behavior-preservation tests for the op algebra traits (Part A of
+``plans/algebraic-carrier-analysis.md``).
+
+These pin the trait queries (``selecting`` / ``associative`` / ``commutative``
+/ ``has_identity`` / semiring role / reduce render-spelling) to the values the
+pre-refactor hardcoded sets gave, so the "stop switching on op names" refactor
+is provably byte-identical. The hardcoded sets they replaced, verbatim:
+
+- ``020_place_inits._SELECTING_OPS`` = {maximum, amax, minimum, max, min}
+- ``010_split_register_axes._ASSOCIATIVE_REDUCE_OPS`` =
+  {add, sum, maximum, amax, minimum, amin, multiply, prod}  (amin / min / max
+  are numpy-reduce aliases that never appear as an ``Accum`` combine)
+- ``recognize_flash._SUM`` = (add, sum), ``_MAX`` = (maximum, amax), plus the
+  literal ``"multiply"`` product check
+- the per-op CUDA / numpy reduce spellings (Accum.render, _binary_combine_expr,
+  ReduceOp.forward / ScanOp.forward)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from deplodock.compiler.ir.elementwise import (
+    _REDUCE_SPELLING,
+    ElementwiseImpl,
+    distributes_over,
+    is_semiring_product,
+    reduce_canon,
+    reduce_spelling,
+)
+
+# Every op name the trait queries are asked about in the pipeline.
+_REDUCE_OPS = ["add", "sum", "multiply", "prod", "maximum", "amax", "minimum"]
+
+# --- selecting (was _SELECTING_OPS) -----------------------------------------
+
+_OLD_SELECTING = frozenset({"maximum", "amax", "minimum", "max", "min"})
+
+
+@pytest.mark.parametrize("name", sorted(_OLD_SELECTING | set(_REDUCE_OPS)))
+def test_selecting_matches_old_set(name: str) -> None:
+    assert ElementwiseImpl(name).selecting == (name in _OLD_SELECTING)
+
+
+# --- associative / commutative (was duplicated _ASSOCIATIVE_REDUCE_OPS) ------
+
+
+@pytest.mark.parametrize("name", _REDUCE_OPS)
+def test_reduce_ops_are_associative_and_commutative(name: str) -> None:
+    # Every op that the FK strip-mine / cross-thread combine reorders was in the
+    # old _ASSOCIATIVE_REDUCE_OPS set — and stays reorderable via op.associative.
+    op = ElementwiseImpl(name)
+    assert op.associative
+    assert op.commutative
+
+
+@pytest.mark.parametrize("name", ["subtract", "divide"])
+def test_non_associative_ops(name: str) -> None:
+    assert not ElementwiseImpl(name).associative
+
+
+# --- has_identity ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", _REDUCE_OPS)
+def test_reduce_ops_have_identity(name: str) -> None:
+    assert ElementwiseImpl(name).has_identity
+
+
+# --- semiring role (was the literal "multiply" / "add" checks) ---------------
+
+
+def test_semiring_product_is_multiply_only() -> None:
+    assert is_semiring_product("multiply")
+    for name in ["add", "sum", "maximum", "minimum", "subtract"]:
+        assert not is_semiring_product(name)
+
+
+def test_distributes_over_plus_times_only() -> None:
+    assert distributes_over("multiply", "add")
+    assert distributes_over("multiply", "sum")  # alias of add
+    assert not distributes_over("multiply", "maximum")
+    assert not distributes_over("add", "add")
+
+
+# --- reduce canonicalization (was _COMBINE / the alias tuples) ---------------
+
+
+@pytest.mark.parametrize(
+    ("name", "canon"),
+    [
+        ("add", "add"),
+        ("sum", "add"),
+        ("multiply", "multiply"),
+        ("prod", "multiply"),
+        ("maximum", "maximum"),
+        ("amax", "maximum"),
+        ("fmax", "maximum"),
+        ("minimum", "minimum"),
+        ("fmin", "minimum"),
+        ("copy", "copy"),  # aliasless → itself
+    ],
+)
+def test_reduce_canon(name: str, canon: str) -> None:
+    assert reduce_canon(name) == canon
+
+
+# --- render spellings (was four duplicated dispatch tables) ------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "compound", "intrinsic"),
+    [
+        ("add", "+=", None),
+        ("sum", "+=", None),
+        ("multiply", "*=", None),
+        ("prod", "*=", None),
+        ("maximum", None, "fmax"),
+        ("amax", None, "fmax"),
+        ("minimum", None, "fmin"),
+    ],
+)
+def test_reduce_spelling_render(name: str, compound: str | None, intrinsic: str | None) -> None:
+    sp = reduce_spelling(name)
+    assert sp.compound == compound
+    assert sp.intrinsic == intrinsic
+
+
+def test_reduce_spelling_defaults_to_add() -> None:
+    # Accum.render's legacy fallback: an unknown / non-reduce op renders as +=.
+    assert reduce_spelling("copy").compound == "+="
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("add", np.array([6.0])),
+        ("sum", np.array([6.0])),
+        ("multiply", np.array([6.0])),
+        ("prod", np.array([6.0])),
+        ("maximum", np.array([3.0])),
+        ("amax", np.array([3.0])),
+        ("minimum", np.array([1.0])),
+    ],
+)
+def test_np_reduce_matches(name: str, expected) -> None:
+    a = np.array([1.0, 2.0, 3.0])
+    out = _REDUCE_SPELLING[reduce_canon(name)].np_reduce(a, axis=0, keepdims=True)
+    np.testing.assert_allclose(out, expected)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("add", np.array([1.0, 3.0, 6.0])),
+        ("multiply", np.array([1.0, 2.0, 6.0])),
+        ("maximum", np.array([1.0, 2.0, 3.0])),
+    ],
+)
+def test_np_scan_matches(name: str, expected) -> None:
+    a = np.array([1.0, 2.0, 3.0])
+    np_scan = _REDUCE_SPELLING[reduce_canon(name)].np_scan
+    np.testing.assert_allclose(np_scan(a, axis=0), expected)

--- a/tests/compiler/ir/test_algebra_traits.py
+++ b/tests/compiler/ir/test_algebra_traits.py
@@ -24,8 +24,6 @@ import pytest
 from deplodock.compiler.ir.elementwise import (
     _REDUCE_SPELLING,
     ElementwiseImpl,
-    distributes_over,
-    is_semiring_product,
     reduce_canon,
     reduce_spelling,
 )
@@ -72,16 +70,17 @@ def test_reduce_ops_have_identity(name: str) -> None:
 
 
 def test_semiring_product_is_multiply_only() -> None:
-    assert is_semiring_product("multiply")
+    assert ElementwiseImpl("multiply").semiring_product
     for name in ["add", "sum", "maximum", "minimum", "subtract"]:
-        assert not is_semiring_product(name)
+        assert not ElementwiseImpl(name).semiring_product
 
 
 def test_distributes_over_plus_times_only() -> None:
-    assert distributes_over("multiply", "add")
-    assert distributes_over("multiply", "sum")  # alias of add
-    assert not distributes_over("multiply", "maximum")
-    assert not distributes_over("add", "add")
+    mul, add = ElementwiseImpl("multiply"), ElementwiseImpl("add")
+    assert mul.distributes_over(add)
+    assert mul.distributes_over("sum")  # alias of add; reduce arg accepts a name
+    assert not mul.distributes_over("maximum")
+    assert not add.distributes_over(add)
 
 
 # --- reduce canonicalization (was _COMBINE / the alias tuples) ---------------

--- a/tests/compiler/passes/test_partition_planner_rules.py
+++ b/tests/compiler/passes/test_partition_planner_rules.py
@@ -16,7 +16,7 @@ from deplodock.compiler.ir.base import InputOp
 from deplodock.compiler.ir.elementwise import ElementwiseImpl
 from deplodock.compiler.ir.expr import Var
 from deplodock.compiler.ir.loop import Axis, Load, Loop, LoopOp, Write
-from deplodock.compiler.ir.stmt import Accum
+from deplodock.compiler.ir.stmt import Accum, Assign
 from deplodock.compiler.ir.tile.ir import RegisterTile, ThreadTile, TileOp
 from deplodock.compiler.pipeline import KERNEL_PASSES, TILE_PASSES, Pipeline
 
@@ -158,7 +158,13 @@ def test_replicator_keeps_n_invariant_loads_once():
                                 body=(
                                     Load(name="a", input="a", index=(Var("m"), Var("k"))),
                                     Load(name="b", input="b", index=(Var("k"), Var("n"))),
-                                    Accum(name="acc", value="b", op=ElementwiseImpl("add")),
+                                    # A genuine matmul cell — ``acc += a·b`` — so the planner's
+                                    # SEMIRING classification (trait-verified is_matmul_reduce ∧
+                                    # product-distributes-over) routes it to the matmul path.
+                                    # ``a[m,k]`` stays N-invariant, ``b[k,n]`` N-dependent — what
+                                    # the replicator splits.
+                                    Assign(name="p", op=ElementwiseImpl("multiply"), args=("a", "b")),
+                                    Accum(name="acc", value="p", op=ElementwiseImpl("add")),
                                 ),
                             ),
                             Write(output="o", index=(Var("m"), Var("n")), value="acc"),

--- a/tests/compiler/passes/test_reduction_rules.py
+++ b/tests/compiler/passes/test_reduction_rules.py
@@ -19,6 +19,7 @@ from deplodock.compiler.ir.tensor.ir import ReduceOp
 from deplodock.compiler.ir.tile.ir import StageBundle, ThreadTile
 from deplodock.compiler.pipeline import KERNEL_PASSES, TILE_PASSES, Pipeline
 from deplodock.compiler.pipeline.passes.lowering.tile._helpers import accums_independent as _accums_independent
+from deplodock.compiler.pipeline.passes.lowering.tile._helpers import reduce_body_has_coupled_accum
 
 
 def _input(g: Graph, name: str, shape: tuple) -> str:
@@ -278,3 +279,44 @@ def test_accums_dependent_via_assign_chain():
         Accum(name="acc_sum", value="e", op="add"),
     )
     assert _accums_independent(body) is False
+
+
+# --- reduce_body_has_coupled_accum: the per-reduce-scope counterpart shared by
+#     040_use_ring_buffers / 080_pipeline_stages (a NON-Accum stmt reads a
+#     sibling Accum's running value).
+
+
+def test_coupled_accum_false_when_independent():
+    body = (
+        _load("v", "x"),
+        Assign(name="vv", op="multiply", args=("v", "v")),
+        Accum(name="s", value="v", op="add"),
+        Accum(name="s2", value="vv", op="add"),
+    )
+    assert reduce_body_has_coupled_accum(body) is False
+
+
+def test_coupled_accum_true_for_online_softmax():
+    # The rescale ``d = subtract(v, acc_max)`` is a non-Accum stmt reading the
+    # running max — the coupled-reduction shape the ring/pipeline peels reject.
+    body = (
+        _load("v", "x"),
+        Accum(name="acc_max", value="v", op="max"),
+        Assign(name="d", op="subtract", args=("v", "acc_max")),
+        Assign(name="e", op="exp", args=("d",)),
+        Accum(name="acc_sum", value="e", op="add"),
+    )
+    assert reduce_body_has_coupled_accum(body) is True
+
+
+def test_coupled_accum_only_inspects_non_accum_stmts():
+    # An Accum reading another Accum directly is the *accums_independent*
+    # concern; this predicate inspects only non-Accum stmts, so the bare
+    # Accum→Accum read (no intermediate non-Accum) is not coupled here.
+    body = (
+        _load("v", "x"),
+        Accum(name="acc_max", value="v", op="max"),
+        Accum(name="acc_sum", value="acc_max", op="add"),
+    )
+    assert reduce_body_has_coupled_accum(body) is False
+    assert _accums_independent(body) is False  # the other predicate does catch it


### PR DESCRIPTION
Executes Parts **A**, **B**, and **C1a** of `plans/algebraic-carrier-analysis.md`. Derives each kernel's algebra
bottom-up from its carrier and lets the planner dispatch on it instead of re-deriving the archetype from syntactic
shape. **Byte-identical** through every part (verified by `deplodock compile` per-kernel compare on
Qwen3-Embedding-0.6B layer 0 under a fixed `PYTHONHASHSEED` — default **and** `DEPLODOCK_FLASH=1` paths); `make test`
green (2288 passed), `make lint` clean.

## Part A — finish the op trait system (stop switching on op names)
`ir/elementwise.py` becomes the complete algebraic registry; ~10 string-match sites become op-name-free trait queries.
- New: `selecting` trait; `_SEMIRING` + `distributes_over` / `is_semiring_product`; `reduce_canon` (alias → base
  combine); the `_REDUCE_SPELLING` registry (`reduce_spelling`) — one op-keyed table behind `Accum.render`,
  `kernel/ir._binary_combine_expr`, and `ReduceOp/ScanOp.forward` (the same dispatch previously written four times).
- Converted: `020_place_inits` (selecting), `010_split_register_axes` (deletes the duplicate `_ASSOCIATIVE_REDUCE_OPS`
  → `op.associative`), `020_lift_reduce` (reduce_canon), `010_recognize_flash` (`_SUM`/`_MAX`/multiply → `reduce_canon`
  / `is_semiring_product`), `030_stamp_types` + `011_lower_atom_cell` + `_split_demoted` + `015_pack_fk_window`
  (semiring product / distributes_over).

## Part B — bottom-up algebra analyzer
New `ir/algebra.py`: `AlgebraKind` (MAP / MONOID / SEMIRING / TWISTED_MONOID / SCAN) + `classify_algebra(loop)`,
surfaced as the `Loop.algebra_kind` property. Implemented as a **derived cache read back from the carrier** (the plan's
own framing) rather than a normalize-stamped field — same guarantees (always consistent with the body, never in
`op_cache_key`, cheap) with zero serialization/codegen risk. The expensive coupled-accumulator → twisted-monoid match
stays in `loop/recognize` (which emits the `Monoid`); this is a cheap read of it. The structural `matmul_reduce` moves
to `ir/algebra`; `lowering/tile/_helpers.is_matmul_reduce` delegates (single source).

Verified on real kernels: linear projections → SEMIRING, RMSNorm reduces → MONOID, SDPA softmax stats → MONOID, the
real FlashCombine LSE monoid → TWISTED_MONOID.

## Part C1a — planner dispatches on the tag
`010_partition_loops` routes each reduce loop by `Loop.algebra_kind` (SEMIRING → matmul tiling; static TWISTED_MONOID →
cooperative-reduce KV split; else cooperative-K / pointwise) instead of re-deriving the archetype. SEMIRING is the
trait-verified matmul (`is_matmul_reduce` ∧ product distributes over the reduce), so it correctly rejects a degenerate
2-K-load reduce whose `Accum` value is a bare Load; one synthetic fixture relied on the looser check (`acc += b`, no
multiply, despite its "plain matmul" docstring) and was corrected to a genuine `acc += a·b` cell.

**C6** is effectively satisfied: after A no op-name string-match gates remain (cooperative combine / split-KV legality
already read `carrier.associative`/`commutative`; dtype reads `op.selecting`).

## Deferred (recorded in the plan's status block)
**C1b / C2 / C3 / C4 / C5** — the generic MMA `(init, action, fold)` twisted-monoid carry that supersedes the bespoke
flash rule. **No live consumer exists today**: twisted monoids route to the cooperative *scalar* path, and the MMA
tensor-core flash tier is itself future work (the landed flash is the scalar tier). Building the protocol + MMA-lowering
generalization now would be speculative machinery; they should land *with* the MMA-flash tier work, behind the
`action = identity` byte-identical gate the plan describes. The analyzer (B) + tag-driven planner (C1a) are the
groundwork that makes them reachable.

## Tests
- `tests/compiler/ir/test_algebra_traits.py` — behavior-preservation for the trait queries vs the pre-refactor sets.
- `tests/compiler/ir/test_algebra_kind.py` — the classifier tags each kernel archetype + derived-cache invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)