### PR TITLE
Persist autotune search-tree nodes to a keyed SearchDB `node` table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,9 @@ same worker.
   per-variant `perf` cache, so an identical re-run (same prior) replays every variant with no GPU bench, while the
   ever-changing global prior can steer the same-patience search down a new trajectory and bench only the genuinely-new
   variants it surfaces (the old `op_effort` skip-already-tuned gate, which suppressed that re-exploration, is gone).
-  Persists `perf` / `lowering` / inventory rows to the SQLite cache (path from `DEPLODOCK_TUNE_DB` or
-  `~/.cache/deplodock/autotune.db`). The inner MCTS (PUCT over the global learned `CatBoostPrior`) stops on
+  Persists `perf` / `lowering` / inventory rows — plus a `node` row per search-tree node (keyed/deduped,
+  keep-min value-of-position latency, full feature dict + `parent_key`; written alongside the prior's reservoir,
+  no current reader) — to the SQLite cache (path from `DEPLODOCK_TUNE_DB` or `~/.cache/deplodock/autotune.db`). The inner MCTS (PUCT over the global learned `CatBoostPrior`) stops on
   patience (N consecutive measured terminals without a new best). `--clean` nukes the tuning DB + cubin/kernel caches
   first. **tune compiles kernels at `-Xcicc -O1`** (fast nvcc compile — dodges a cicc/LLVM blowup on big unrolled
   register-tile kernels, up to ~200×) — but **-O1 is NOT runtime-optimal**: reduction/attention kernels can run 1.5–3×

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -12,7 +12,7 @@ pipeline/
 ├── search/        # Autotune state: Candidate, Search policies, SearchDB + SearchTree
 │   ├── candidate.py  # Candidate / LazyCandidate / Cursor data classes
 │   ├── policy/       # Search ABC (base.py) + TuningSearch (mcts.py, tune) + greedy_decide (greedy.py, the Run.resolve pick for compile/run); both rank via the Prior
-│   ├── db.py         # SearchDB SQLite store: op inventory + lowering edges + perf (per-variant replay cache); open_readonly + iter_perf_samples (perf ⋈ cuda_op) back the data layer
+│   ├── db.py         # SearchDB SQLite store: op inventory + lowering edges + perf (per-variant replay cache) + node (keyed/deduped/parent-linked search-tree nodes via record_nodes); open_readonly + iter_perf_samples (perf ⋈ cuda_op) back the data layer
 │   ├── data/         # harmonized read-view over the 3 sources (golden / DB perf / prior reservoir): Sample (one normalized row + the single knob_features path; golden rows carry the config's `--dynamic` specs in `.dynamic`), Dataset (from_golden/from_db/from_prior + group_by_op/group_by_kernel_name), ShapeKey (arithmetic S_* identity AND the single golden↔measured join key: `from_matmul` / `MatmulGoldenConfig.shape_key()` build the golden side, `from_s_features` the stamped-op side — dtype flag from `S_dtype_f32`, never `S_n_mma`, which is 0 on every stamped row; `is_dyn` splits a symbolic-axis golden from its static twin, mirroring the 992 stamp's symbolic-excluded extent products + `S_ext_n_symbolic_axis` flag; all diagnostics joins + run's golden A/B kernel matching key through it)
 │   ├── keys.py       # op_cache_key / dialect_of / source_chain
 │   ├── slice.py      # single_node_graph: isolate one finalized kernel into a standalone graph
@@ -478,7 +478,7 @@ table, pick one; don't invent a third:
 
 The autotune state is split across two cooperating modules:
 
-- **`SearchDB`** (`search/db.py`) — SQLite store partitioned into six
+- **`SearchDB`** (`search/db.py`) — SQLite store partitioned into seven
   tables: `loop_op`, `tile_op`, `kernel_op`, `cuda_op` (one row per op
   encountered along any lowering chain, keyed by `op_cache_key`), a
   `lowering` edge table (one row per rewrite hop carrying the knob
@@ -487,10 +487,18 @@ The autotune state is split across two cooperating modules:
   cost — loop→loop source hops are skipped: those are
   structural/decision hops, and a one-best-child row would let a
   multi-kernel decomposition's parent resolve through ONE fragment
-  kernel's median), and a backend-partitioned `perf` table carrying
+  kernel's median), a backend-partitioned `perf` table carrying
   full stats (`latency_us_{median,min,max,mean,variance}`,
-  `n_samples`, `backend`, `status`, `knobs`). Selection statistic is
-  the median.
+  `n_samples`, `backend`, `status`, `knobs`), and a `node` table — one
+  row per **search-tree node** (every partial branch + leaf of a per-kernel
+  search), keyed by `digest(context_key, op_sig, tunable-knob set)`, carrying
+  the full feature dict the prior sees (`H_*` + `S_*` + knobs), a keep-the-minimum
+  value-of-position latency (`1/best_reward`), a `parent_key` pointer (ancestry
+  is the live tree edge, not knob-subset inference), and `depth`/`n_updates`
+  bookkeeping (written by `record_nodes`, fed by `TuningSearch._collect_node_records`).
+  `node` is content-keyed like `perf` (parent-tree-independent) and survives a
+  `_SCHEMA_VERSION` bump; only the topology-keyed `lowering` table is dropped on
+  mismatch. Selection statistic is the median.
 - **`SearchTree`** (`search/policy/mcts.py`) — pure-Python in-memory
   MCTS state, colocated with `TuningSearch` because MCTS is the only
   policy that reads it. Each tree node wraps a `LazyCandidate`; nodes
@@ -669,6 +677,14 @@ has no realized knobs of its own, so it falls back to `_node_knobs` (its partial
 `S_*`/`H_*` base), carrying the value-of-position label. `knob.knob_features` vectorizes. (Before this, `_collect_rows`
 used only the fork prefix for every node, so the prior was blind to every deterministically-stamped knob — e.g. it never
 saw `FK`, the dominant knob for a reduction, and greedy stayed on `FK=1`.)
+
+Alongside that reservoir feed (not replacing it), the same finished tree is walked once by
+`TuningSearch._collect_node_records` and persisted to the `node` SQLite table via `SearchDB.record_nodes` — the keyed,
+deduplicated, parent-linked counterpart to the unkeyed/sampled reservoir. Each node keys on
+`digest(context_key, op_sig, tunable-knob set)`, so the same position re-encountered across runs collapses to one row with a
+keep-the-minimum value-of-position latency; it carries the full `knob_features` input dict, and stores `parent_key` from the
+live `node.parent` edge so ancestry is recoverable. Persistent record only — no current consumer reads it back (the prior
+still trains from the in-memory reservoir).
 
 Why CatBoost (chosen by `scripts/prior_bakeoff.py` over a multi-op tuning dataset): the model's greedy pick must not run
 off to a degenerate corner. A linear model (the former `BayesianRidgePrior`) is monotone in every knob, so its optimum is

--- a/deplodock/compiler/pipeline/search/db.py
+++ b/deplodock/compiler/pipeline/search/db.py
@@ -21,6 +21,16 @@ Pure persistence layer — no MCTS state, no propagation walks. Tables:
   terminal op the backend measured (today: a CudaOp; tomorrow whatever
   other backends lower to). ``backend`` partitions the table so the
   loop interpreter and the CUDA backend can coexist in the same DB.
+- ``node`` — one row per search-tree node (every partial branch + leaf of a
+  per-kernel autotune search), keyed by ``digest(context_key, op_sig,
+  tunable-knob set)``. Each row carries the full feature dict passed to the
+  prior (``H_*`` + ``S_*`` + knobs), a keep-the-minimum value-of-position
+  latency (``1/best_reward`` — the best latency reachable below the node), and
+  a ``parent_key`` pointer so ancestry between rows is recoverable. Content-keyed
+  (parent-tree-independent), so it survives schema-version drops like ``perf``.
+  Written once per finished search by :meth:`SearchDB.record_nodes`, fed by the
+  post-order tree walk ``TuningSearch._collect_node_records`` — alongside (not
+  replacing) the learned prior's reservoir feed.
 
 Concurrency: opened in WAL mode so parallel benches can read while one
 writes. The connection is kept open for the DB's lifetime; callers can
@@ -119,6 +129,27 @@ class LoweringRow:
     best_median_us: float | None
 
 
+@dataclass(frozen=True)
+class NodeRow:
+    """One ``node`` row — a single node of a per-kernel autotune search tree.
+
+    ``node_key`` is ``digest(context_key, op_sig, tunable-knob set)`` — the node's
+    identity within its operation; ``parent_key`` is the parent node's ``node_key``
+    (``None`` at the operation's top forks). ``features`` is the full feature dict
+    the prior sees (``H_*`` regime + ``S_*`` structure + tunable knobs).
+    ``value_us`` is the value-of-position latency (best reachable below the node);
+    :meth:`SearchDB.record_nodes` keeps the minimum on re-encounter. ``depth`` is
+    the node's distance from the sentinel root (top forks = 1)."""
+
+    node_key: str
+    parent_key: str | None
+    context_key: str
+    op_sig: str
+    features: dict
+    value_us: float
+    depth: int
+
+
 # The ``perf`` SELECT column list — order must match ``_row_to_perf``.
 _PERF_COLS = (
     "context_key, op_key, backend, status, latency_us_median, latency_us_min, latency_us_max, "
@@ -213,6 +244,25 @@ class SearchDB:
             PRIMARY KEY (context_key, op_key, backend)
         )
         """,
+        # Content-keyed (``node_key`` folds context + op_sig + knob set), so —
+        # unlike ``lowering`` — it is parent-tree-independent and survives a
+        # ``_SCHEMA_VERSION`` bump. ``CREATE … IF NOT EXISTS`` auto-creates it on
+        # the next open of a pre-``node`` DB; no version bump / ALTER needed.
+        """
+        CREATE TABLE IF NOT EXISTS node (
+            node_key     TEXT PRIMARY KEY,
+            parent_key   TEXT,
+            context_key  TEXT NOT NULL,
+            op_sig       TEXT NOT NULL,
+            features     TEXT NOT NULL DEFAULT '{}',
+            value_us     REAL NOT NULL,
+            depth        INTEGER NOT NULL,
+            n_updates    INTEGER NOT NULL DEFAULT 1,
+            updated_at   TEXT NOT NULL
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS node_parent ON node (parent_key)",
+        "CREATE INDEX IF NOT EXISTS node_op ON node (context_key, op_sig)",
     ]
 
     def __init__(self, path: Path | str | None = None) -> None:
@@ -410,6 +460,44 @@ class SearchDB:
                 error,
             ),
         )
+
+    # ------------------------------------------------------------------
+    # Search-tree nodes — write
+    # ------------------------------------------------------------------
+
+    def record_nodes(self, rows: list[NodeRow]) -> None:
+        """Keep-the-minimum upsert a batch of search-tree node rows (one finished
+        per-kernel search's worth). ``value_us`` is a value-of-position label that
+        only falls on re-encounter, so a worse-or-equal value never overwrites a
+        known one; ``context_key`` / ``op_sig`` / ``parent_key`` are functions of
+        ``node_key`` and re-stamp identically. ``n_updates`` counts writes (incl.
+        non-improving re-encounters) and ``updated_at`` refreshes each time.
+
+        Manual lookup-guard + INSERT/UPDATE (the ``record_perf`` / ``record_lowering``
+        idiom) rather than ``INSERT OR REPLACE`` — the latter would reset
+        ``n_updates`` and drop the old value. Row-at-a-time autocommit like the rest
+        of the file; a finished search is a few-hundred-row batch at most."""
+        now = datetime.now(UTC).isoformat()
+        for r in rows:
+            feats_json = json.dumps(r.features, sort_keys=True, default=str)
+            existing = self._conn.execute("SELECT value_us, n_updates FROM node WHERE node_key = ?", (r.node_key,)).fetchone()
+            if existing is None:
+                self._conn.execute(
+                    "INSERT INTO node "
+                    "(node_key, parent_key, context_key, op_sig, features, value_us, depth, n_updates, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (r.node_key, r.parent_key, r.context_key, r.op_sig, feats_json, r.value_us, r.depth, 1, now),
+                )
+            elif r.value_us < existing[0]:
+                self._conn.execute(
+                    "UPDATE node SET value_us = ?, features = ?, parent_key = ?, n_updates = ?, updated_at = ? WHERE node_key = ?",
+                    (r.value_us, feats_json, r.parent_key, existing[1] + 1, now, r.node_key),
+                )
+            else:
+                self._conn.execute(
+                    "UPDATE node SET n_updates = ?, updated_at = ? WHERE node_key = ?",
+                    (existing[1] + 1, now, r.node_key),
+                )
 
     # ------------------------------------------------------------------
     # Perf — read

--- a/deplodock/compiler/pipeline/search/policy/mcts.py
+++ b/deplodock/compiler/pipeline/search/policy/mcts.py
@@ -38,6 +38,7 @@ from deplodock import config
 from deplodock.compiler.pipeline.search.candidate import LazyCandidate
 from deplodock.compiler.pipeline.search.db import PerfStats
 from deplodock.compiler.pipeline.search.policy.base import Search
+from deplodock.compiler.structural import digest
 
 if TYPE_CHECKING:
     from deplodock.compiler.pipeline.search.prior import Prior
@@ -361,6 +362,54 @@ class TuningSearch(Search):
             knobs = node.realized_knobs if node.realized_knobs is not None else self._node_knobs(node)
             rows.append((knobs, 1.0 / node.best_reward))
         return rows
+
+    def _node_key(self, feats: dict, op_sig: str, context_key: str) -> str:
+        """Identity of a node within its operation: a digest over the deploy
+        regime (``context_key``), the op's ``S_*`` signature (``op_sig``), and the
+        canonical tunable-knob set. ``S_*`` / ``H_*`` features are excluded from the
+        set — they are already folded via ``op_sig`` / ``context_key`` — so the key
+        is the "within-op node identity". ``str()``-ified values mirror
+        :meth:`_o3_sig` so list-valued knobs (``OVERHANG``) stay stable, and the
+        sorted tuple keeps :func:`digest` (order-sensitive) deterministic."""
+        tun = tuple(sorted((k, str(v)) for k, v in feats.items() if not k.startswith(("S_", "H_"))))
+        return digest(context_key, op_sig, tun)
+
+    def _collect_node_records(self, *, context_key: str, op_sig: str) -> list[tuple]:
+        """Post-search tree walk producing keyed, parent-linked node records for
+        :meth:`SearchDB.record_nodes` — the persistent/keyed/deduped sibling of
+        :meth:`_collect_rows` (which feeds the prior's in-memory reservoir).
+
+        Pre-order descent from the top forks (the sentinel root is skipped); each
+        node passing the same ``visits > 0 and best_reward > 0`` guard as
+        ``_collect_rows`` emits ``(node_key, parent_key, features, value_us, depth)``:
+        ``features`` is the full dict the prior sees (``realized_knobs`` on a benched
+        leaf — incl. deterministically-stamped knobs — else the partial fork-prefix
+        from ``_node_knobs``), ``value_us`` is the value-of-position ``1/best_reward``.
+
+        ``parent_key`` is the *nearest emitted ancestor*'s ``node_key`` (a skipped
+        intermediate node passes its own inherited parent down), so it always
+        references a recorded row — true ancestry from the live ``parent`` edge,
+        not knob-subset inference (which a leaf's extra stamped knobs would break).
+        Asserts the monotone ``parent.value_us <= child.value_us`` invariant — it
+        holds because ``record_terminal`` max-propagates ``best_reward`` up the
+        chain, transitively across skipped nodes."""
+        out: list[tuple] = []
+
+        def visit(node: SearchNode, parent_key: str | None, parent_value: float | None, depth: int) -> None:
+            nk = parent_key
+            if node.candidate is not None and node.visits > 0 and node.best_reward > 0:
+                feats = node.realized_knobs if node.realized_knobs is not None else self._node_knobs(node)
+                value_us = 1.0 / node.best_reward
+                assert parent_value is None or value_us >= parent_value - 1e-9, "value-of-position not monotone up the tree"
+                nk = self._node_key(feats, op_sig, context_key)
+                out.append((nk, parent_key, feats, value_us, depth))
+                parent_value = value_us
+            for child in node.children:
+                visit(child, nk, parent_value, depth + 1)
+
+        for child in self.tree.root.children:
+            visit(child, None, None, 1)
+        return out
 
     def _should_stop(self) -> bool:
         if self.stop_reason is not None:

--- a/deplodock/compiler/pipeline/search/two_level.py
+++ b/deplodock/compiler/pipeline/search/two_level.py
@@ -62,10 +62,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from deplodock.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pass, Pipeline, TuningSearch
-from deplodock.compiler.pipeline.search.db import PerfStats, SearchDB
+from deplodock.compiler.pipeline.search.db import NodeRow, PerfStats, SearchDB
 from deplodock.compiler.pipeline.search.keys import op_cache_key
 from deplodock.compiler.pipeline.search.policy.greedy import PARTITION_RULE
 from deplodock.compiler.pipeline.search.slice import single_node_graph
+from deplodock.compiler.structural import digest
 
 if TYPE_CHECKING:
     from deplodock.compiler.context import Context
@@ -338,6 +339,17 @@ async def _inner_reward_async(fused_graph, *, ctx, db, pool, patience, ucb_c, ex
                 prior.add_rows(inner._collect_rows() + inner.o3_rows)
                 if prior.maybe_refit():
                     prior.checkpoint()
+            # Persist every search-tree node (partial branches + leaves) to the
+            # keyed/deduped ``node`` table — alongside the reservoir feed above, and
+            # independent of whether a prior is attached. ``op_sig`` is the op's
+            # ``S_*`` structural signature; the walk threads parent_key/value/depth.
+            op_sig = digest(*sorted((k, v) for k, v in op.knobs.items() if k.startswith("S_")))
+            db.record_nodes(
+                [
+                    NodeRow(node_key=nk, parent_key=pk, context_key=ctx_key, op_sig=op_sig, features=feats, value_us=v, depth=d)
+                    for nk, pk, feats, v, d in inner._collect_node_records(context_key=ctx_key, op_sig=op_sig)
+                ]
+            )
             best = db.best_per_op_time(ctx_key, key, backend=backend_name)
             results[op_idx] = OpResult(name=name, op_key=key, best_us=best, multiplicity=count)
             if progress is not None:

--- a/tests/compiler/pipeline/search/test_db.py
+++ b/tests/compiler/pipeline/search/test_db.py
@@ -7,11 +7,12 @@ Loop→Tile), and a backend-partitioned generic ``perf`` table.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
 import pytest
 
-from deplodock.compiler.pipeline.search.db import PerfStats, SearchDB
+from deplodock.compiler.pipeline.search.db import NodeRow, PerfStats, SearchDB
 
 
 def _stats(median: float) -> PerfStats:
@@ -216,6 +217,96 @@ def test_open_readonly_reads_without_mutating(tmp_path) -> None:
 def test_open_readonly_missing_file_raises(tmp_path) -> None:
     with pytest.raises(sqlite3.OperationalError):
         SearchDB.open_readonly(tmp_path / "nope.db")
+
+
+# ---------------------------------------------------------------------------
+# node — search-tree node store
+# ---------------------------------------------------------------------------
+
+
+def _node_row(node_key: str, value_us: float, *, parent_key=None, op_sig="sig", features=None, depth=1) -> NodeRow:
+    return NodeRow(
+        node_key=node_key,
+        parent_key=parent_key,
+        context_key="ctx",
+        op_sig=op_sig,
+        features=features or {},
+        value_us=value_us,
+        depth=depth,
+    )
+
+
+def test_record_nodes_then_read() -> None:
+    db = SearchDB()
+    db.record_nodes([_node_row("n1", 5.0, features={"BM": 8, "S_n_mma": 1.0}, depth=2)])
+    row = db._conn.execute(
+        "SELECT parent_key, context_key, op_sig, features, value_us, depth, n_updates FROM node WHERE node_key = ?",
+        ("n1",),
+    ).fetchone()
+    assert row[0] is None
+    assert (row[1], row[2]) == ("ctx", "sig")
+    assert json.loads(row[3]) == {"BM": 8, "S_n_mma": 1.0}  # full feature dict round-trips
+    assert (row[4], row[5], row[6]) == (5.0, 2, 1)
+
+
+def test_record_nodes_keeps_min() -> None:
+    db = SearchDB()
+    db.record_nodes([_node_row("n1", 5.0)])
+    db.record_nodes([_node_row("n1", 2.0)])  # improves → kept
+    db.record_nodes([_node_row("n1", 9.0)])  # worse → value untouched, n_updates still bumps
+    val, n = db._conn.execute("SELECT value_us, n_updates FROM node WHERE node_key = ?", ("n1",)).fetchone()
+    assert val == 2.0
+    assert n == 3
+
+
+def test_record_nodes_parent_link() -> None:
+    db = SearchDB()
+    db.record_nodes([_node_row("parent", 2.0, depth=1), _node_row("child", 4.0, parent_key="parent", depth=2)])
+    (parent_value,) = db._conn.execute(
+        "SELECT p.value_us FROM node c JOIN node p ON c.parent_key = p.node_key WHERE c.node_key = ?",
+        ("child",),
+    ).fetchone()
+    assert parent_value == 2.0
+
+
+def test_node_table_autocreated_on_pre_node_db(tmp_path) -> None:
+    """A DB written before the ``node`` table existed gains it on the next writer
+    open — ``CREATE TABLE IF NOT EXISTS`` auto-creates it, no ALTER needed."""
+    path = tmp_path / "old.db"
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        CREATE TABLE perf (context_key TEXT NOT NULL, op_key TEXT NOT NULL, backend TEXT NOT NULL,
+            status TEXT NOT NULL, latency_us_median REAL NOT NULL, latency_us_min REAL NOT NULL,
+            latency_us_max REAL NOT NULL, latency_us_mean REAL NOT NULL, latency_us_variance REAL NOT NULL,
+            n_samples INTEGER NOT NULL, measured_at TEXT NOT NULL, knobs TEXT NOT NULL DEFAULT '{}',
+            captured INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (context_key, op_key, backend));
+        """
+    )
+    con.commit()
+    con.close()
+
+    db = SearchDB(path)  # writer open creates the absent ``node`` table
+    db.record_nodes([_node_row("n1", 3.0)])
+    (val,) = db._conn.execute("SELECT value_us FROM node WHERE node_key = 'n1'").fetchone()
+    assert val == 3.0
+
+
+def test_node_survives_version_bump_that_drops_lowering(tmp_path) -> None:
+    """``node`` is content-keyed like ``perf`` (not topology-keyed like
+    ``lowering``), so a schema-version mismatch — which wipes ``lowering`` — leaves
+    ``node`` rows intact."""
+    path = tmp_path / "t.db"
+    db = SearchDB(path)
+    db.record_lowering("p", "loop", "c", "tile", knobs={"BN": 64}, measured_median_us=1.0)
+    db.record_nodes([_node_row("n1", 3.0)])
+    db._conn.execute("PRAGMA user_version = 0")  # simulate an older on-disk schema
+    db.close()
+
+    reopened = SearchDB(path)  # version mismatch → drops+recreates ``lowering``; ``node`` survives
+    assert reopened.lookup_lowering("p") is None
+    (val,) = reopened._conn.execute("SELECT value_us FROM node WHERE node_key = 'n1'").fetchone()
+    assert val == 3.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/search/test_online_prior.py
+++ b/tests/compiler/pipeline/search/test_online_prior.py
@@ -239,6 +239,76 @@ def test_collect_rows_skips_unbenched_nodes():
     assert (("BM", 64), ("BR", 2)) not in knob_sets
 
 
+# --- node store extraction (_collect_node_records) -------------------------
+
+
+def test_collect_node_records_parent_linkage():
+    """A leaf points at its branch via parent_key (the real tree edge), and the
+    leaf's full ``realized_knobs`` — incl. a deterministically-stamped knob the
+    branch never saw — is what gets stored, proving parentage is taken from the
+    ``parent`` pointer, not inferred from knob-subset containment."""
+    tree = SearchTree()
+    branch = _node({"BR": 1}, tree.root)
+    leaf = _node({"BR": 1, "BM": 64}, branch)
+    leaf.realized_knobs = {"S_n_mma": 1.0, "H_opt": 1.0, "BR": 1, "BM": 64, "FK": 2}
+    tree.root.children = [branch]
+    branch.children = [leaf]
+    tree.record_terminal(leaf, 2.0)
+    recs = TuningSearch(tree=tree)._collect_node_records(context_key="ctx", op_sig="sig")
+    by_depth = {d: (nk, pk, feats) for nk, pk, feats, _, d in recs}
+    branch_key, branch_parent, branch_feats = by_depth[1]
+    leaf_key, leaf_parent, leaf_feats = by_depth[2]
+    assert branch_parent is None  # top fork → no recorded parent
+    assert leaf_parent == branch_key  # leaf → branch edge from node.parent
+    assert "FK" in leaf_feats and "FK" not in branch_feats  # stamped knob only on the leaf
+
+
+def test_collect_node_records_value_min_invariant():
+    """Each node's value-of-position (1/best_reward) is >= its parent's — the
+    max-propagation invariant the walk asserts."""
+    tree = SearchTree()
+    branch = _node({"BR": 1}, tree.root)
+    leaf_slow = _node({"BR": 1, "BM": 32}, branch)
+    leaf_fast = _node({"BR": 1, "BM": 64}, branch)
+    tree.root.children = [branch]
+    branch.children = [leaf_slow, leaf_fast]
+    tree.record_terminal(leaf_slow, 1.0)
+    tree.record_terminal(leaf_fast, 2.0)
+    recs = TuningSearch(tree=tree)._collect_node_records(context_key="ctx", op_sig="sig")
+    by_key = {nk: (pk, v) for nk, pk, _, v, _ in recs}
+    assert any(pk is not None for pk, _ in by_key.values())  # at least one real edge exercised
+    for pk, v in by_key.values():
+        if pk is not None:
+            assert v >= by_key[pk][1] - 1e-12  # child never labeled faster than its parent
+
+
+def test_collect_node_records_skips_unbenched_and_sentinel():
+    """An unbenched frontier yields no row, and the sentinel root is never emitted
+    (its benched child is depth 1 with ``parent_key`` None)."""
+    tree = SearchTree()
+    visited = _node({"BR": 1, "BM": 64}, tree.root)
+    frontier = _node({"BR": 2, "BM": 64}, tree.root)
+    tree.root.children = [visited, frontier]
+    tree.record_terminal(visited, 1.5)
+    recs = TuningSearch(tree=tree)._collect_node_records(context_key="ctx", op_sig="sig")
+    assert len(recs) == 1
+    nk, pk, _, v, d = recs[0]
+    assert pk is None and d == 1
+    assert abs(v - 1 / 1.5) < 1e-12
+
+
+def test_node_key_excludes_s_and_h():
+    """Within one op (op_sig) + regime (context_key), node identity is the tunable
+    knob set only — two nodes differing solely in ``S_*``/``H_*`` collide, and a
+    differing tunable knob splits them."""
+    s = TuningSearch(tree=SearchTree())
+    base = s._node_key({"BM": 64, "S_n_mma": 1.0, "H_opt": 1.0}, "sig", "ctx")
+    s_h_perturbed = s._node_key({"BM": 64, "S_n_mma": 9.0, "H_opt": 3.0}, "sig", "ctx")
+    tunable_perturbed = s._node_key({"BM": 32, "S_n_mma": 1.0, "H_opt": 1.0}, "sig", "ctx")
+    assert base == s_h_perturbed
+    assert base != tunable_perturbed
+
+
 def _stats(median: float):
     from deplodock.compiler.pipeline.search.db import PerfStats  # noqa: PLC0415
 

--- a/tests/compiler/pipeline/search/test_two_level.py
+++ b/tests/compiler/pipeline/search/test_two_level.py
@@ -171,6 +171,24 @@ def test_inner_reward_is_separable_not_a_product() -> None:
     assert reward.total_us == pytest.approx(sum(r.best_us for r in reward.per_op))
 
 
+def test_inner_reward_records_nodes() -> None:
+    """The post-search walk persists tree nodes to the ``node`` table — keyed by
+    the run's context, one op_sig group per distinct kernel, with every non-null
+    parent_key referencing a recorded node (valid ancestry edges)."""
+    fused = _fuse(_two_distinct_matmuls())
+    ctx = Context.from_target((8, 0))
+    db = SearchDB()
+    run_inner_reward(fused, ctx=ctx, db=db, backend=_CountingBackend(), patience=_PATIENCE)
+
+    rows = db._conn.execute("SELECT node_key, parent_key, context_key, op_sig, value_us FROM node").fetchall()
+    assert rows, "expected node rows recorded from the finished search trees"
+    assert {r[2] for r in rows} == {ctx.structural_key()}  # all under the run's regime
+    assert all(r[4] > 0 for r in rows)  # positive value-of-position
+    assert len({r[3] for r in rows}) >= 2  # two distinct matmuls → ≥2 op_sig groups
+    keys = {r[0] for r in rows}
+    assert all(r[1] in keys for r in rows if r[1] is not None)  # parents reference recorded nodes
+
+
 def test_inner_reward_rerun_is_replay_dominated() -> None:
     """A second pass at the same patience is replay-dominated and never regresses:
     the warm perf cache serves almost every terminal, so the rerun benches far


### PR DESCRIPTION
Each per-kernel autotune search builds an MCTS tree whose nodes are partial knob choices (branches) and fully-decided kernels (leaves). Today every node is dumped into the learned prior's in-memory reservoir — a bounded, uniform sample with no key, no dedup, and no parent/child structure: the same node re-encountered across runs piles up as duplicates with stale value-of-position labels, and nodes are evicted once the 100k cap fills.

Add a persistent, content-keyed `node` table to SearchDB capturing every search-tree node with the full feature dict the prior sees (H_* + S_* + knobs), a keep-the-minimum value-of-position latency (1/best_reward), and a parent pointer so ancestry between rows is recoverable. It runs alongside the reservoir feed (prior training unchanged) and is storage-only (no reader yet; queryable via raw SQL).

- db.py: `node` table + indexes in _SCHEMA (content-keyed → survives version bumps like perf, no _SCHEMA_VERSION bump); NodeRow dataclass; record_nodes() keep-min batch writer using the existing manual lookup-guard idiom.
- mcts.py: _node_key() (digest of context_key + op_sig + tunable-knob set, excluding S_*/H_*) and _collect_node_records(), a pre-order tree walk yielding parent-linked records via the real node.parent edge (so a leaf's extra deterministically-stamped knobs don't break ancestry), asserting the parent.value_us <= child.value_us max-propagation invariant.
- two_level.py: extraction call site beside the reservoir feed, computing op_sig from the op's S_* knobs.
- Tests: write/read + keep-min + parent link + autocreate + survives-version-bump (test_db.py); parent linkage, value invariant, skip unbenched/sentinel, node_key excludes S_*/H_* (test_online_prior.py); e2e wiring (test_two_level.py).
- Docs: pipeline/ARCHITECTURE.md (SearchDB seven tables + node, prior-section note) and CLAUDE.md tune persisted-rows line.