### PR TITLE
  Evaluate priors on the search-tree node store (eval prior --dataset nodes)                                                                                                         

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ same worker.
   variants it surfaces (the old `op_effort` skip-already-tuned gate, which suppressed that re-exploration, is gone).
   Persists `perf` / `lowering` / inventory rows — plus a `node` row per search-tree node (keyed/deduped,
   keep-min value-of-position latency, full feature dict + `parent_key`; written alongside the prior's reservoir,
-  no current reader) — to the SQLite cache (path from `DEPLODOCK_TUNE_DB` or `~/.cache/deplodock/autotune.db`). The inner MCTS (PUCT over the global learned `CatBoostPrior`) stops on
+  read by `eval prior --dataset nodes`) — to the SQLite cache (path from `DEPLODOCK_TUNE_DB` or `~/.cache/deplodock/autotune.db`). The inner MCTS (PUCT over the global learned `CatBoostPrior`) stops on
   patience (N consecutive measured terminals without a new best). `--clean` nukes the tuning DB + cubin/kernel caches
   first. **tune compiles kernels at `-Xcicc -O1`** (fast nvcc compile — dodges a cicc/LLVM blowup on big unrolled
   register-tile kernels, up to ~200×) — but **-O1 is NOT runtime-optimal**: reduction/attention kernels can run 1.5–3×
@@ -205,11 +205,13 @@ same worker.
   appearance), so a re-tuned kernel whose hash moved still pairs and prints as `old -> new`; one-side-only kernels are
   listed as kernel-set changes (structural fork / fusion differences). Ratios outside `--tol` color green/red. The
   before/after view for compiler changes — per-kernel rows, not the full-model total, are the stable cross-tune signal.
-The `eval` subcommands share a `--dataset {golden,db}` vocabulary (`commands/dataset_args.py`): `golden` reads the
-recorded `GOLDEN_CONFIGS`, `db` reads the tune DB's measured `perf` rows. Both flow through one read-view —
-`compiler/pipeline/search/data/` (`Sample` / `Dataset` / `ShapeKey`) — which also backs the prior `fit` featurization
-and the diagnostics grouping, so golden filtering, the DB join, and `knob_features` live in one place. Source is
-orthogonal to analysis: a degenerate combo (e.g. `eval knobs --dataset golden`) fails fast with a specific message.
+The `eval` subcommands share a `--dataset {golden,db,nodes}` vocabulary (`commands/dataset_args.py`): `golden` reads the
+recorded `GOLDEN_CONFIGS`, `db` reads the tune DB's measured `perf` rows, `nodes` reads the tune DB's search-tree `node`
+store (`eval prior` only). Both `golden`/`db` flow through one read-view — `compiler/pipeline/search/data/` (`Sample` /
+`Dataset` / `ShapeKey`) — which also backs the prior `fit` featurization and the diagnostics grouping, so golden
+filtering, the DB join, and `knob_features` live in one place (`Dataset.from_node_rows` adapts node rows into the same
+`Sample`s for the leaf metrics). Source is orthogonal to analysis: a degenerate combo (e.g. `eval knobs --dataset golden`)
+fails fast with a specific message.
 
 - `deplodock eval knobs [--dataset db] [--db PATH] [--min-variants N] [--kernel SUBSTR]` — knob-impact analysis from the
   autotune DB (`--dataset db`, the default; `--dataset golden` is rejected — goldens carry no kernel C identity): the
@@ -224,7 +226,7 @@ orthogonal to analysis: a degenerate combo (e.g. `eval knobs --dataset golden`) 
   `search/analytic.py` module is now just the golden-eval glue (`evaluate_golden` / `pick_matmul`) around the prior
   (`eval analytic` shows the matmul goldens; the prior also ranks the cooperative-reduce / pointwise goldens). Weights fit
   offline by `scripts/golden_knob_heuristics.py` (jointly over every kernel regime — matmul fp32/fp16, reduce, pointwise — tier-balanced).
-- `deplodock eval prior [--prior PATH] [--dataset {golden,db}] [--db PATH] [--kernel SUBSTR] [--features]` — evaluate the
+- `deplodock eval prior [--prior PATH] [--dataset {golden,db,nodes}] [--db PATH] [--kernel SUBSTR] [--features]` — evaluate the
   learned `CatBoostPrior`. Default `--dataset golden`: the golden's rank under the prior over the full enumeration, then
   the greedy pipeline pick vs golden (per-knob `found/golden`) with a **`vs gold`** perf column — the deployable (-O3)
   latency of the prior's predicted-best **measured** config over the golden's recorded `deplodock_us`, read from the
@@ -236,7 +238,13 @@ orthogonal to analysis: a degenerate combo (e.g. `eval knobs --dataset golden`) 
   mirrors the 992 stamp: symbolic axes are excluded from the extent products). `--dataset db` instead reports the prior's pick
   **reachability** over the tune DB's *measured* variants (does the prior recover each op's measured-best leaf?) — the
   orthogonal counterpart to the golden views, reusing `diagnostics.reachability` over `Dataset.from_db().group_by_op()`.
-  Reads the prior JSON (`DEPLODOCK_PRIOR_FILE` or `--prior`; option-0 when none loaded). `--features` (golden mode) also
+  `--dataset nodes` instead reads the tune DB's search-tree **`node` store** (the value-of-position dataset
+  `deplodock tune` records — partial branches + leaves with a `parent_key`) and reports two things
+  (`diagnostics.node_report` over `SearchDB.iter_nodes()`): the **fork sibling-ranking** — group nodes by `parent_key`
+  and ask whether the prior orders each fork's children (the partial configs it ranks during `_select`) by their
+  best-reachable latency (top-1 hit + median per-fork Spearman), the search-faithful metric no other view measures —
+  plus **leaf reachability / calibration** reused on the deduped persistent store. Reads the prior JSON
+  (`DEPLODOCK_PRIOR_FILE` or `--prior`; option-0 when none loaded). `--features` (golden mode) also
   prints the exact regressor input per golden config (`knob.knob_features`: `S_*` structural/shape + `H_*` regime +
   tuning knobs; the shape enters only as coarse `S_ext_*` products/maxes, so the occupancy/CTA/reuse terms the prior
   needs are added as engineered `D_*` features). The golden `S_*` here is the full histogram (the shape's snippet is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,9 @@ fails fast with a specific message.
   (`diagnostics.node_report` over `SearchDB.iter_nodes()`): the **fork sibling-ranking** — group nodes by `parent_key`
   and ask whether the prior orders each fork's children (the partial configs it ranks during `_select`) by their
   best-reachable latency (top-1 hit + median per-fork Spearman), the search-faithful metric no other view measures —
-  plus **leaf reachability / calibration** reused on the deduped persistent store. Reads the prior JSON
+  plus **leaf reachability / calibration** reused on the deduped persistent store. `--kernel` filters the node store
+  by **op label** (the nodes carry no kernel C-identifier; `--kernel matmul` / `reduce` / `free=512` keeps whole ops
+  atomically since all of an op's nodes share one `S_*` label). Reads the prior JSON
   (`DEPLODOCK_PRIOR_FILE` or `--prior`; option-0 when none loaded). `--features` (golden mode) also
   prints the exact regressor input per golden config (`knob.knob_features`: `S_*` structural/shape + `H_*` regime +
   tuning knobs; the shape enters only as coarse `S_ext_*` products/maxes, so the occupancy/CTA/reuse terms the prior

--- a/deplodock/commands/dataset_args.py
+++ b/deplodock/commands/dataset_args.py
@@ -31,11 +31,12 @@ def add_dataset_args(parser, *, default: str, with_min_variants: bool = False) -
     threshold."""
     parser.add_argument(
         "--dataset",
-        choices=["golden", "db"],
+        choices=["golden", "db", "nodes"],
         default=default,
-        help=f"Measurement-data source: 'golden' (recorded golden configs) or 'db' (tune DB perf rows). Default: {default}.",
+        help="Measurement-data source: 'golden' (recorded golden configs), 'db' (tune DB perf rows), or 'nodes' "
+        f"(tune DB search-tree node store, for `eval prior`). Default: {default}.",
     )
-    parser.add_argument("--db", help="Tune DB path for --dataset db. Default: DEPLODOCK_TUNE_DB or ~/.cache/deplodock/autotune.db.")
+    parser.add_argument("--db", help="Tune DB path for --dataset db/nodes. Default: DEPLODOCK_TUNE_DB or ~/.cache/deplodock/autotune.db.")
     parser.add_argument("--kernel", help="Filter by name substring (golden name, or kernel C identifier for --dataset db).")
     if with_min_variants:
         parser.add_argument(

--- a/deplodock/commands/dataset_args.py
+++ b/deplodock/commands/dataset_args.py
@@ -37,7 +37,11 @@ def add_dataset_args(parser, *, default: str, with_min_variants: bool = False) -
         f"(tune DB search-tree node store, for `eval prior`). Default: {default}.",
     )
     parser.add_argument("--db", help="Tune DB path for --dataset db/nodes. Default: DEPLODOCK_TUNE_DB or ~/.cache/deplodock/autotune.db.")
-    parser.add_argument("--kernel", help="Filter by name substring (golden name, or kernel C identifier for --dataset db).")
+    parser.add_argument(
+        "--kernel",
+        help="Filter by substring: golden name; kernel C identifier for --dataset db; op label (e.g. 'matmul', "
+        "'reduce', 'free=512') for --dataset nodes.",
+    )
     if with_min_variants:
         parser.add_argument(
             "--min-variants", type=int, default=8, help="Skip kernels with fewer than this many measured variants (default: 8)."

--- a/deplodock/commands/eval.py
+++ b/deplodock/commands/eval.py
@@ -177,10 +177,15 @@ def handle_eval_prior(args) -> None:
     """``eval prior`` — the learned prior on the golden configs: the greedy pick vs
     golden, the golden's rank under the prior, and (with ``--features``) the
     regressor input vector. With ``--dataset db`` instead reports the prior's pick
-    reachability over the tune DB's *measured* variants (the orthogonal view)."""
+    reachability over the tune DB's *measured* variants (the orthogonal view); with
+    ``--dataset nodes`` reports fork sibling-ranking + leaf reachability over the tune
+    DB's search-tree node store (the search-faithful, partial-config view)."""
     resolve_prior_arg(args)
     if args.dataset == "db":
         _emit_prior_db_reachability(args)
+        return
+    if args.dataset == "nodes":
+        _emit_prior_nodes(args)
         return
     if args.features:
         _emit_golden_features(args.kernel)
@@ -566,6 +571,31 @@ def _emit_prior_db_reachability(args) -> None:
     for label, best_us, pick_us, ratio, n in sorted(rr, key=lambda r: -r[3]):
         flag = "  <-- misses best" if ratio > 1.2 else ""
         logger.info("    %-26s  best %8.2fus  pick %8.2fus  (%.2fx, %d configs)%s", label, best_us, pick_us, ratio, n, flag)
+
+
+def _emit_prior_nodes(args) -> None:
+    """``eval prior --dataset nodes`` body: the prior over the tune DB's search-tree
+    ``node`` store (the value-of-position dataset). Reports the fork sibling-ranking
+    (does the prior order each fork's children — the partial configs it ranks during
+    search — by their best-reachable latency?) plus leaf reachability / calibration
+    on the persistent, deduped store. The search-faithful counterpart to
+    ``--dataset db`` (which only scores fully-decided leaf variants)."""
+    from deplodock.compiler.pipeline.search.db import SearchDB  # noqa: PLC0415
+    from deplodock.compiler.pipeline.search.prior import diagnostics, load_prior  # noqa: PLC0415
+
+    db_path = Path(args.db) if args.db else resolve_tune_db()
+    if not db_path.exists():
+        logger.error("no tune DB at %s — pass --db or run `deplodock tune` first.", db_path)
+        return
+    db = SearchDB.open_readonly(db_path)
+    try:
+        nodes = list(db.iter_nodes())
+    finally:
+        db.close()
+    # FallbackPrior: the learned CatBoost when fitted, else the cold AnalyticPrior — the same ranking compile/run use.
+    prior = load_prior()
+    logger.info("")
+    logger.info("%s", diagnostics.node_report(prior, nodes))
 
 
 def _mean(xs: list[float]) -> float:

--- a/deplodock/commands/eval.py
+++ b/deplodock/commands/eval.py
@@ -595,7 +595,7 @@ def _emit_prior_nodes(args) -> None:
     # FallbackPrior: the learned CatBoost when fitted, else the cold AnalyticPrior — the same ranking compile/run use.
     prior = load_prior()
     logger.info("")
-    logger.info("%s", diagnostics.node_report(prior, nodes))
+    logger.info("%s", diagnostics.node_report(prior, nodes, kernel_filter=args.kernel))
 
 
 def _mean(xs: list[float]) -> float:

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -13,7 +13,7 @@ pipeline/
 │   ├── candidate.py  # Candidate / LazyCandidate / Cursor data classes
 │   ├── policy/       # Search ABC (base.py) + TuningSearch (mcts.py, tune) + greedy_decide (greedy.py, the Run.resolve pick for compile/run); both rank via the Prior
 │   ├── db.py         # SearchDB SQLite store: op inventory + lowering edges + perf (per-variant replay cache) + node (keyed/deduped/parent-linked search-tree nodes via record_nodes); open_readonly + iter_perf_samples (perf ⋈ cuda_op) back the data layer
-│   ├── data/         # harmonized read-view over the 3 sources (golden / DB perf / prior reservoir): Sample (one normalized row + the single knob_features path; golden rows carry the config's `--dynamic` specs in `.dynamic`), Dataset (from_golden/from_db/from_prior + group_by_op/group_by_kernel_name), ShapeKey (arithmetic S_* identity AND the single golden↔measured join key: `from_matmul` / `MatmulGoldenConfig.shape_key()` build the golden side, `from_s_features` the stamped-op side — dtype flag from `S_dtype_f32`, never `S_n_mma`, which is 0 on every stamped row; `is_dyn` splits a symbolic-axis golden from its static twin, mirroring the 992 stamp's symbolic-excluded extent products + `S_ext_n_symbolic_axis` flag; all diagnostics joins + run's golden A/B kernel matching key through it)
+│   ├── data/         # harmonized read-view over the 3 sources (golden / DB perf / prior reservoir): Sample (one normalized row + the single knob_features path; golden rows carry the config's `--dynamic` specs in `.dynamic`), Dataset (from_golden/from_db/from_prior/from_node_rows + group_by_op/group_by_kernel_name), ShapeKey (arithmetic S_* identity AND the single golden↔measured join key: `from_matmul` / `MatmulGoldenConfig.shape_key()` build the golden side, `from_s_features` the stamped-op side — dtype flag from `S_dtype_f32`, never `S_n_mma`, which is 0 on every stamped row; `is_dyn` splits a symbolic-axis golden from its static twin, mirroring the 992 stamp's symbolic-excluded extent products + `S_ext_n_symbolic_axis` flag; all diagnostics joins + run's golden A/B kernel matching key through it)
 │   ├── keys.py       # op_cache_key / dialect_of / source_chain
 │   ├── slice.py      # single_node_graph: isolate one finalized kernel into a standalone graph
 │   ├── two_level.py  # two-level tuner: outer structural MCTS + inner separable per-op reward
@@ -570,8 +570,11 @@ Alongside that reservoir feed (not replacing it), the same finished tree is walk
 deduplicated, parent-linked counterpart to the unkeyed/sampled reservoir. Each node keys on
 `digest(context_key, op_sig, tunable-knob set)`, so the same position re-encountered across runs collapses to one row with a
 keep-the-minimum value-of-position latency; it carries the full `knob_features` input dict, and stores `parent_key` from the
-live `node.parent` edge so ancestry is recoverable. Persistent record only — no current consumer reads it back (the prior
-still trains from the in-memory reservoir).
+live `node.parent` edge so ancestry is recoverable. The prior still *trains* from the in-memory reservoir, but the `node`
+store is *read back* by `eval prior --dataset nodes` (`SearchDB.iter_nodes` → `diagnostics.node_report`): it groups nodes by
+`parent_key` and scores the **fork sibling-ranking** — does the prior order each fork's children (the partial configs it
+ranks during `_select`) by their best-reachable latency (top-1 hit + per-fork Spearman)? — the search-faithful evaluation
+no leaf-only view can give, alongside leaf reachability/calibration reused on the deduped store.
 
 Why CatBoost (chosen by `scripts/prior_bakeoff.py` over a multi-op tuning dataset): the model's greedy pick must not run
 off to a degenerate corner. A linear model (the former `BayesianRidgePrior`) is monotone in every knob, so its optimum is

--- a/deplodock/compiler/pipeline/search/data/dataset.py
+++ b/deplodock/compiler/pipeline/search/data/dataset.py
@@ -92,6 +92,15 @@ class Dataset:
         ``FallbackPrior`` (it delegates ``_dataset`` to the learned half)."""
         return cls([Sample.from_prior_row(k, v) for k, v in prior._dataset])
 
+    @classmethod
+    def from_node_rows(cls, rows) -> Dataset:
+        """Search-tree ``node`` rows (:meth:`SearchDB.iter_nodes`) as samples — each
+        node's full feature dict + value-of-position latency, split into
+        tunable/``H_*``/``S_*`` exactly like a reservoir row. Pure transform (no
+        I/O), so the caller reads the rows once and can also group them by
+        ``parent_key`` for the fork-ranking diagnostic."""
+        return cls([Sample.from_prior_row(r.features, r.value_us) for r in rows])
+
     # --- grouping ----------------------------------------------------------
 
     def group_by_op(self) -> dict[tuple, list[Sample]]:

--- a/deplodock/compiler/pipeline/search/db.py
+++ b/deplodock/compiler/pipeline/search/db.py
@@ -290,6 +290,11 @@ class SearchDB:
     def _has_perf_error_column(self) -> bool:
         return any(r[1] == "error" for r in self._conn.execute("PRAGMA table_info(perf)"))
 
+    def _has_node_table(self) -> bool:
+        # A read-only open of a pre-``node`` DB never ran ``CREATE TABLE IF NOT
+        # EXISTS``, so ``SELECT … FROM node`` would raise; readers gate on this.
+        return self._conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'node'").fetchone() is not None
+
     @classmethod
     def open_readonly(cls, path: Path | str) -> SearchDB:
         """Open an existing DB **read-only** — no schema creation, no version
@@ -498,6 +503,45 @@ class SearchDB:
                     "UPDATE node SET n_updates = ?, updated_at = ? WHERE node_key = ?",
                     (existing[1] + 1, now, r.node_key),
                 )
+
+    # ------------------------------------------------------------------
+    # Search-tree nodes — read
+    # ------------------------------------------------------------------
+
+    def iter_nodes(self, *, context_key: str | None = None, op_sig: str | None = None) -> Iterator[NodeRow]:
+        """Yield one :class:`NodeRow` per stored search-tree node (the value-of-position
+        dataset backing ``eval prior --dataset nodes``). Self-contained — no join.
+        A read-only open of a pre-``node`` DB has no such table, so this degrades to
+        yielding nothing instead of raising (mirrors ``iter_perf_samples``'
+        missing-column degrade). Optional ``context_key`` / ``op_sig`` scope to one
+        regime / operation."""
+        if not self._has_node_table():
+            return
+        sql = "SELECT node_key, parent_key, context_key, op_sig, features, value_us, depth FROM node"
+        clauses: list[str] = []
+        params: list = []
+        if context_key is not None:
+            clauses.append("context_key = ?")
+            params.append(context_key)
+        if op_sig is not None:
+            clauses.append("op_sig = ?")
+            params.append(op_sig)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        for node_key, parent_key, ck, sig, feats_json, value_us, depth in self._conn.execute(sql, params):
+            try:
+                features = json.loads(feats_json) if feats_json else {}
+            except (TypeError, json.JSONDecodeError):
+                continue
+            yield NodeRow(
+                node_key=node_key,
+                parent_key=parent_key,
+                context_key=ck,
+                op_sig=sig,
+                features=features,
+                value_us=value_us,
+                depth=depth,
+            )
 
     # ------------------------------------------------------------------
     # Perf — read

--- a/deplodock/compiler/pipeline/search/prior/diagnostics.py
+++ b/deplodock/compiler/pipeline/search/prior/diagnostics.py
@@ -296,14 +296,31 @@ def node_sibling_ranking(prior, nodes) -> tuple | None:
     return (n_forks, top1 / n_forks, statistics.median(rhos) if rhos else None, n_children)
 
 
-def node_report(prior, nodes) -> str:
+def _node_op_label(features: dict) -> str:
+    """The op label for a single ``node`` row — derived from its ``S_*`` features, the
+    same labels :func:`reachability` rows carry, so ``--kernel`` filters the node store
+    by op kind/shape (e.g. ``matmul`` / ``reduce`` / ``free=512``). All nodes of one op
+    share these features, so filtering keeps/drops a whole op atomically — parent and
+    children never split."""
+    return _op_label(tuple(sorted((k, v) for k, v in features.items() if k.startswith("S_"))))
+
+
+def node_report(prior, nodes, *, kernel_filter: str | None = None) -> str:
     """The ``eval prior --dataset nodes`` block: the fork sibling-ranking (the
     metric unique to this dataset) plus leaf reachability / calibration reused on the
     persistent, deduped node store. ``nodes`` is a list of :class:`db.NodeRow` from
-    :meth:`SearchDB.iter_nodes`."""
-    lines = [f"[prior] node store: {len(nodes)} nodes, fitted={prior.fitted}"]
+    :meth:`SearchDB.iter_nodes`; ``kernel_filter`` keeps only nodes whose op label
+    contains the substring (``--kernel``)."""
+    total = len(nodes)
+    if kernel_filter:
+        nodes = [n for n in nodes if kernel_filter in _node_op_label(n.features)]
+    suffix = f" matching --kernel {kernel_filter!r}" if kernel_filter else ""
+    lines = [f"[prior] node store: {len(nodes)} nodes{suffix}, fitted={prior.fitted}"]
     if not nodes:
-        lines.append("  empty — run `deplodock tune <model>` to populate the node table")
+        if kernel_filter and total:
+            lines.append(f"  no nodes match --kernel {kernel_filter!r} ({total} in store) — try an op label like 'matmul' / 'reduce'")
+        else:
+            lines.append("  empty — run `deplodock tune <model>` to populate the node table")
         return "\n".join(lines)
     if not prior.fitted:
         lines.append("  no fitted prior — the cold AnalyticPrior ranks by D_* geometry only; run `deplodock tune`")

--- a/deplodock/compiler/pipeline/search/prior/diagnostics.py
+++ b/deplodock/compiler/pipeline/search/prior/diagnostics.py
@@ -252,3 +252,83 @@ def report(prior) -> str:
     if covered == 0:
         lines.append("  none yet — tune the golden shapes (`deplodock tune --golden NAME`) to validate against them")
     return "\n".join(lines)
+
+
+def node_sibling_ranking(prior, nodes) -> tuple | None:
+    """Fork-level ranking over the autotune ``node`` store — the search-faithful
+    metric: group nodes by ``parent_key`` (each group = one fork's children, the
+    partial configs the prior actually ranks during ``_select``) and measure whether
+    the prior orders them by predicted latency the way their value-of-position labels
+    (``value_us`` = best latency reachable below) imply.
+
+    Returns ``(n_forks, top1_rate, median_spearman, n_children)`` — ``top1_rate`` is
+    the fraction of forks whose predicted-best child is a true-best child (its
+    ``value_us`` equals the fork's minimum); ``median_spearman`` is over forks with
+    ≥3 children (``None`` if none). Returns ``None`` when there are no multi-child
+    forks. Unlike :func:`reachability` it does NOT leaf-filter — siblings are already
+    one fork level (branches and leaves alike), and the prior is scored on each
+    node's full feature dict, exactly as ``mcts._select`` queries it."""
+    from collections import defaultdict  # noqa: PLC0415
+
+    from scipy.stats import spearmanr  # noqa: PLC0415
+
+    by_parent: dict = defaultdict(list)
+    for n in nodes:
+        if n.parent_key is not None:
+            by_parent[n.parent_key].append(n)
+
+    top1, rhos, n_forks, n_children = 0, [], 0, 0
+    for sibs in by_parent.values():
+        if len(sibs) < 2:
+            continue
+        n_forks += 1
+        n_children += len(sibs)
+        scored = [(prior.mean_score(s.features), s.value_us) for s in sibs]  # (predicted, measured)
+        pred_best_value = min(scored, key=lambda t: t[0])[1]  # value_us of the predicted-fastest child
+        if pred_best_value <= min(v for _, v in scored) + 1e-12:  # is it a true-best child? (measured ties OK)
+            top1 += 1
+        if len(sibs) >= 3:
+            rho = spearmanr([p for p, _ in scored], [v for _, v in scored]).statistic
+            if not math.isnan(rho):
+                rhos.append(rho)
+    if n_forks == 0:
+        return None
+    return (n_forks, top1 / n_forks, statistics.median(rhos) if rhos else None, n_children)
+
+
+def node_report(prior, nodes) -> str:
+    """The ``eval prior --dataset nodes`` block: the fork sibling-ranking (the
+    metric unique to this dataset) plus leaf reachability / calibration reused on the
+    persistent, deduped node store. ``nodes`` is a list of :class:`db.NodeRow` from
+    :meth:`SearchDB.iter_nodes`."""
+    lines = [f"[prior] node store: {len(nodes)} nodes, fitted={prior.fitted}"]
+    if not nodes:
+        lines.append("  empty — run `deplodock tune <model>` to populate the node table")
+        return "\n".join(lines)
+    if not prior.fitted:
+        lines.append("  no fitted prior — the cold AnalyticPrior ranks by D_* geometry only; run `deplodock tune`")
+
+    sib = node_sibling_ranking(prior, nodes)
+    if sib is None:
+        lines.append("[prior] fork sibling-ranking: no multi-child forks recorded")
+    else:
+        n_forks, top1, rho, n_children = sib
+        rho_txt = f"{rho:+.2f}" if rho is not None else "n/a"
+        lines.append("[prior] fork sibling-ranking — does the prior rank each fork's children by value-of-position?")
+        lines.append(f"  top-1 {top1:.2f}  (predicted-best child is a true-best child)   median per-fork Spearman {rho_txt}")
+        lines.append(f"  over {n_forks} forks ({n_children} children)")
+
+    groups = Dataset.from_node_rows(nodes).group_by_op()
+    rr = reachability(prior, groups)
+    if rr:
+        ratios = [r[3] for r in rr]
+        lines.append("[prior] leaf reachability over node store — does the prior recover each op's best leaf?")
+        agg = f"mean {statistics.mean(ratios):.2f}x  median {statistics.median(ratios):.2f}x  worst {max(ratios):.2f}x"
+        lines.append(f"  {agg}   (1.00 = optimum)")
+        for label, best_us, pick_us, ratio, n in sorted(rr, key=lambda r: -r[3]):
+            flag = "  <-- misses best" if ratio > 1.2 else ""
+            lines.append(f"    {label:26}  best {best_us:8.2f}us  pick {pick_us:8.2f}us  ({ratio:.2f}x, {n} configs){flag}")
+    calib = _calibration(prior, groups)
+    if calib is not None:
+        lines.append(f"[prior] leaf ranking calibration (median per-op Spearman): {calib:+.2f}")
+    return "\n".join(lines)

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -344,6 +344,29 @@ def test_prior_nodes_smoke(run_cli, tmp_path):
     assert "traceback" not in (stdout + stderr).lower()
 
 
+def test_prior_nodes_kernel_filter(run_cli, tmp_path):
+    """``eval prior --dataset nodes --kernel`` scopes the node store by op label."""
+    from deplodock.compiler.pipeline.search.db import NodeRow, SearchDB
+
+    db_path = tmp_path / "n.db"
+    db = SearchDB(db_path)
+    s = {"S_ext_free_prod": 1024.0, "S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0}
+    db.record_nodes(
+        [
+            NodeRow("P", None, "ctx", "mm", s, 1.0, 1),
+            NodeRow("c8", "P", "ctx", "mm", {**s, "BN": 32, "BM": 8}, 1.0, 2),
+        ]
+    )
+    db.close()
+    prior = str(tmp_path / "missing.json")
+    rc, stdout, stderr = run_cli("eval", "prior", "--dataset", "nodes", "--db", str(db_path), "--kernel", "matmul", "--prior", prior)
+    assert rc == 0, f"stderr: {stderr}"
+    assert "matching --kernel 'matmul'" in stdout
+    rc2, stdout2, _ = run_cli("eval", "prior", "--dataset", "nodes", "--db", str(db_path), "--kernel", "reduce", "--prior", prior)
+    assert rc2 == 0
+    assert "no nodes match --kernel 'reduce'" in stdout2
+
+
 def test_nodes_dataset_rejected_by_db_only_subcommand(run_cli, tmp_path):
     """Widening the ``--dataset`` vocabulary with ``nodes`` must not leak into the
     db-only subcommands — ``eval variants`` still exits 2 on it."""

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -320,6 +320,39 @@ def test_prior_db_reachability_smoke(run_cli, tmp_path):
     assert "traceback" not in (stdout + stderr).lower()
 
 
+def test_prior_nodes_smoke(run_cli, tmp_path):
+    """``eval prior --dataset nodes`` renders the fork sibling-ranking AND the leaf
+    reachability over the search-tree node store (one fork, two leaf children)."""
+    from deplodock.compiler.pipeline.search.db import NodeRow, SearchDB
+
+    db_path = tmp_path / "n.db"
+    db = SearchDB(db_path)
+    s = {"S_ext_free_prod": 1024.0, "S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0}
+    db.record_nodes(
+        [
+            NodeRow("P", None, "ctx", "mm", s, 1.0, 1),
+            NodeRow("c8", "P", "ctx", "mm", {**s, "BN": 32, "BM": 8}, 1.0, 2),
+            NodeRow("c64", "P", "ctx", "mm", {**s, "BN": 32, "BM": 64}, 3.0, 2),
+        ]
+    )
+    db.close()
+    rc, stdout, stderr = run_cli("eval", "prior", "--dataset", "nodes", "--db", str(db_path), "--prior", str(tmp_path / "missing.json"))
+    assert rc == 0, f"stderr: {stderr}"
+    assert "node store: 3 nodes" in stdout
+    assert "fork sibling-ranking" in stdout
+    assert "leaf reachability over node store" in stdout
+    assert "traceback" not in (stdout + stderr).lower()
+
+
+def test_nodes_dataset_rejected_by_db_only_subcommand(run_cli, tmp_path):
+    """Widening the ``--dataset`` vocabulary with ``nodes`` must not leak into the
+    db-only subcommands — ``eval variants`` still exits 2 on it."""
+    db = tmp_path / "n.db"
+    _make_tune_db(db, [("a", "k_mm", {"BM": 8}, 10.0)])
+    rc, _stdout, _stderr = run_cli("eval", "variants", "--dataset", "nodes", "--db", str(db))
+    assert rc == 2
+
+
 def test_failures_none_recorded(run_cli, tmp_path):
     db = tmp_path / "clean.db"
     _make_tune_db(db, [("a", "k_mm", {"BM": 8}, 10.0)])

--- a/tests/compiler/pipeline/search/test_db.py
+++ b/tests/compiler/pipeline/search/test_db.py
@@ -309,6 +309,39 @@ def test_node_survives_version_bump_that_drops_lowering(tmp_path) -> None:
     assert val == 3.0
 
 
+def test_iter_nodes_roundtrips_features_and_parent(tmp_path) -> None:
+    """``iter_nodes`` yields a NodeRow per stored node with the JSON feature dict
+    parsed back and the parent pointer intact."""
+    db = SearchDB(tmp_path / "t.db")
+    db.record_nodes(
+        [
+            _node_row("p", 2.0, op_sig="mm", features={"S_n_mma": 1.0}, depth=1),
+            _node_row("c", 4.0, parent_key="p", op_sig="mm", features={"S_n_mma": 1.0, "BM": 8}, depth=2),
+        ]
+    )
+    by_key = {n.node_key: n for n in db.iter_nodes()}
+    assert set(by_key) == {"p", "c"}
+    assert by_key["c"].parent_key == "p" and by_key["p"].parent_key is None
+    assert by_key["c"].features == {"S_n_mma": 1.0, "BM": 8}  # JSON round-trips
+    assert (by_key["c"].value_us, by_key["c"].depth, by_key["c"].op_sig) == (4.0, 2, "mm")
+    # op_sig scoping filters
+    assert [n.node_key for n in db.iter_nodes(op_sig="other")] == []
+
+
+def test_iter_nodes_missing_table_degrades(tmp_path) -> None:
+    """A read-only open of a DB that predates the ``node`` table yields nothing
+    instead of raising ``no such table`` (mirrors the perf error-column degrade)."""
+    path = tmp_path / "old.db"
+    con = sqlite3.connect(path)
+    con.executescript("CREATE TABLE perf (context_key TEXT);")  # a node-less DB
+    con.commit()
+    con.close()
+    ro = SearchDB.open_readonly(path)
+    assert not ro._has_node_table()
+    assert list(ro.iter_nodes()) == []
+    ro.close()
+
+
 # ---------------------------------------------------------------------------
 # op inventory
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/search/test_diagnostics.py
+++ b/tests/compiler/pipeline/search/test_diagnostics.py
@@ -114,3 +114,75 @@ def test_golden_prior_eval_warns_per_unjoinable_shape():
     skip_lines = [line for line in out.splitlines() if "SKIPPED" in line and "no tuned rows" in line]
     # square.512 and its .fp16 twin (one line per recorded config name, deduped by name set)
     assert {line.split()[0] for line in skip_lines} >= {"square.512", "square.512.fp16"}
+
+
+# ---------------------------------------------------------------------------
+# node-store fork sibling-ranking
+# ---------------------------------------------------------------------------
+
+
+class _BMPrior:
+    """A prior whose predicted latency is ``sign * features['BM']`` — so ``sign=+1``
+    predicts smaller BM as faster, ``sign=-1`` reverses the order."""
+
+    fitted = True
+
+    def __init__(self, sign: float = 1.0):
+        self._sign = sign
+
+    def mean_score(self, feats) -> float:
+        return self._sign * float(feats.get("BM", 0.0))
+
+
+def _child(node_key, bm, value_us, *, parent="P"):
+    from deplodock.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
+
+    return NodeRow(node_key, parent, "ctx", "mm", {"BM": bm}, value_us, 2)
+
+
+def _fork_nodes():
+    """A root P with three children whose value-of-position falls as BM falls."""
+    from deplodock.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
+
+    return [NodeRow("P", None, "ctx", "mm", {}, 1.0, 1), _child("c8", 8, 1.0), _child("c32", 32, 2.0), _child("c64", 64, 3.0)]
+
+
+def test_node_sibling_ranking_recovers_best_and_order():
+    """The prior orders the fork's children by value-of-position: top-1 hit (its
+    predicted-best child IS the true-best) and Spearman +1."""
+    n_forks, top1, rho, n_children = diagnostics.node_sibling_ranking(_BMPrior(), _fork_nodes())
+    assert (n_forks, n_children) == (1, 3)
+    assert top1 == 1.0 and rho == 1.0
+
+
+def test_node_sibling_ranking_penalizes_reversed_order():
+    """A prior that ranks the children backwards misses top-1 and scores Spearman -1."""
+    _, top1, rho, _ = diagnostics.node_sibling_ranking(_BMPrior(sign=-1.0), _fork_nodes())
+    assert top1 == 0.0  # predicted-best (BM=64) is the slowest child
+    assert rho == -1.0
+
+
+def test_node_sibling_ranking_ignores_singletons_and_top_forks():
+    """A top fork (parent None) and a single-child parent are not multi-child forks,
+    so there is nothing to rank."""
+    from deplodock.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
+
+    nodes = [NodeRow("P", None, "ctx", "mm", {}, 1.0, 1), _child("only", 8, 1.0)]
+    assert diagnostics.node_sibling_ranking(_BMPrior(), nodes) is None
+
+
+def test_node_report_combines_fork_and_leaf_sections():
+    """``node_report`` renders both the fork sibling-ranking and the leaf reachability
+    over the node store."""
+    from deplodock.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
+
+    s = {"S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0, "S_ext_free_max": 512.0}
+    nodes = [
+        NodeRow("P", None, "ctx", "mm", s, 1.0, 1),
+        NodeRow("c8", "P", "ctx", "mm", {**s, "BM": 8}, 1.0, 2),
+        NodeRow("c64", "P", "ctx", "mm", {**s, "BM": 64}, 3.0, 2),
+    ]
+    text = diagnostics.node_report(_BMPrior(), nodes)
+    assert "node store: 3 nodes" in text
+    assert "fork sibling-ranking" in text
+    assert "leaf reachability over node store" in text

--- a/tests/compiler/pipeline/search/test_diagnostics.py
+++ b/tests/compiler/pipeline/search/test_diagnostics.py
@@ -186,3 +186,25 @@ def test_node_report_combines_fork_and_leaf_sections():
     assert "node store: 3 nodes" in text
     assert "fork sibling-ranking" in text
     assert "leaf reachability over node store" in text
+
+
+def test_node_report_kernel_filter_selects_ops_by_label():
+    """``--kernel`` filters the node store by op label (derived from each node's
+    ``S_*`` features) — whole ops drop atomically, and a non-matching filter prints
+    an explanatory message, not the empty-store one."""
+    from deplodock.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
+
+    mm = {"S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0, "S_ext_free_max": 512.0}
+    rd = {"S_reduce_add": 1.0, "S_ext_reduce_max": 64.0}  # a reduce op: no pw-multiply / 2nd input
+    nodes = [
+        NodeRow("Pm", None, "ctx", "mm", mm, 1.0, 1),
+        NodeRow("m8", "Pm", "ctx", "mm", {**mm, "BM": 8}, 1.0, 2),
+        NodeRow("m64", "Pm", "ctx", "mm", {**mm, "BM": 64}, 3.0, 2),
+        NodeRow("Pr", None, "ctx", "rd", rd, 2.0, 1),
+        NodeRow("r1", "Pr", "ctx", "rd", {**rd, "FK": 1}, 2.0, 2),
+    ]
+    out = diagnostics.node_report(_BMPrior(), nodes, kernel_filter="matmul")
+    assert "3 nodes matching --kernel 'matmul'" in out  # only the matmul op's nodes survive
+    assert "fork sibling-ranking" in out
+    miss = diagnostics.node_report(_BMPrior(), nodes, kernel_filter="zzz")
+    assert "no nodes match --kernel 'zzz'" in miss


### PR DESCRIPTION
  Evaluate priors on the search-tree node store (eval prior --dataset nodes)                                                                                                         
                                                                                                                                                                                     
  Why                                                                                                                                                                                
                                                                                                                                                                                     
  PR #271 added the node table — a persistent, keyed record of every autotune search-tree node (partial branches + leaves) with a value-of-position latency and a parent_key — but   
  nothing read it back. Meanwhile the existing prior evaluations (eval prior --dataset golden / db) only score fully-decided leaf configs. That leaves the prior's hardest and most  
  consequential job unmeasured: ranking half-decided options at a fork, which is exactly what it does during MCTS selection. The node store is the one dataset that captures that    
  regime.                                                                                                                                                                            
                                                                                                                                                                                     
  What                                                                                           
  Adds eval prior --dataset nodes, which reads the node store (SearchDB.iter_nodes → diagnostics.node_report) and reports two metrics:                                               
                                                                                                                                                                                     
  - Fork sibling-ranking — the search-faithful metric unique to this dataset. Group nodes by parent_key (each group is one fork's children, i.e. the partial configs the prior ranks 
  during _select) and check whether the prior orders them by predicted latency the way their value-of-position labels imply. Reports top-1 hit rate (is the predicted-best child a   
  true-best child?) and median per-fork Spearman.                                                                                                                                    
  - Leaf reachability / calibration — the existing diagnostics.reachability / _calibration, reused on the deduped, persistent node store (a stable alternative to the in-memory      
  reservoir).                                                                                                                                                                        
                                                                                                                                                                                     
  --kernel filters the node store by op label (matmul / reduce / free=512) derived from each node's S_* features, since nodes carry no kernel C-identifier. Because all of an op's   
  nodes share one S_* label, filtering keeps/drops whole ops atomically — parent and children never split.                                                                           
                                                                                                                                                                                     
  How                                                                                                                                                      
  - db.py — iter_nodes() reader + _has_node_table() guard (degrades to empty on a read-only open of a pre-node DB, mirroring the perf error-column degrade).                         
  - data/dataset.py — Dataset.from_node_rows() adapts node rows into the existing Samples (split like a reservoir row) for the leaf metrics.                                         
  - prior/diagnostics.py — node_sibling_ranking(), node_report(), _node_op_label().                                                                                                  
  - commands/dataset_args.py + eval.py — nodes added to the --dataset vocabulary and the handle_eval_prior dispatch; db-only subcommands (variants/knobs/failures) still reject it   
  via require_source.                                                                                                                                                                
  - Docs: CLAUDE.md (eval-prior bullet, --dataset vocabulary, --kernel semantics) and pipeline/ARCHITECTURE.md (node store now read back; adapter list).                             

Testing                                                                                                                                                                                                                                                                                                                                         
  - test_db.py — iter_nodes roundtrip + missing-table degrade.                                                                                                                       
  - test_diagnostics.py — sibling-ranking correctness/penalty/skip, node_report, --kernel op-label filter + non-match message.                                                       
  - test_eval.py — CLI smoke (--dataset nodes), --kernel matmul/reduce, and rejection by a db-only subcommand.                                                                       
  - make test green; make lint clean.   