### PR TITLE
Key the autotune node store by GPU so it collects cross-hardware data                                                                                                              

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,14 +239,17 @@ fails fast with a specific message.
   **reachability** over the tune DB's *measured* variants (does the prior recover each op's measured-best leaf?) — the
   orthogonal counterpart to the golden views, reusing `diagnostics.reachability` over `Dataset.from_db().group_by_op()`.
   `--dataset nodes` instead reads the tune DB's search-tree **`node` store** (the value-of-position dataset
-  `deplodock tune` records — partial branches + leaves with a `parent_key`) and reports two things
-  (`diagnostics.node_report` over `SearchDB.iter_nodes()`): the **fork sibling-ranking** — group nodes by `parent_key`
-  and ask whether the prior orders each fork's children (the partial configs it ranks during `_select`) by their
-  best-reachable latency (top-1 hit + median per-fork Spearman), the search-faithful metric no other view measures —
-  plus **leaf reachability / calibration** reused on the deduped persistent store. `--kernel` filters the node store
-  by **op label** (the nodes carry no kernel C-identifier; `--kernel matmul` / `reduce` / `free=512` keeps whole ops
-  atomically since all of an op's nodes share one `S_*` label). Reads the prior JSON
-  (`DEPLODOCK_PRIOR_FILE` or `--prior`; option-0 when none loaded). `--features` (golden mode) also
+  `deplodock tune` records — partial branches + leaves with a `parent_key`, keyed/grouped by GPU) and reports, **per
+  card** (`diagnostics.node_report` over `SearchDB.iter_nodes()`): the **fork sibling-ranking** — group nodes by
+  `parent_key` and ask whether the prior orders each fork's children (the partial configs it ranks during `_select`) by
+  their best-reachable latency (top-1 hit + median per-fork Spearman), the search-faithful metric no other view
+  measures — plus **leaf reachability / calibration** reused on the deduped persistent store. The node store keys on
+  the **GPU product name** (`Context.hardware_id`) so a cross-hardware dataset (H100, H200, …) never collides — same-die
+  SKUs share cc + SM features but differ in VRAM, captured as the `H_total_mem` feature so the prior can model them —
+  and the report blocks per card so same-die SKUs are never compared against each other. `--kernel` filters by **op
+  label** (the nodes carry no kernel C-identifier; `--kernel matmul` / `reduce` / `free=512` keeps whole ops atomically
+  since all of an op's nodes share one `S_*` label). Reads the prior JSON (`DEPLODOCK_PRIOR_FILE` or `--prior`;
+  option-0 when none loaded). `--features` (golden mode) also
   prints the exact regressor input per golden config (`knob.knob_features`: `S_*` structural/shape + `H_*` regime +
   tuning knobs; the shape enters only as coarse `S_ext_*` products/maxes, so the occupancy/CTA/reuse terms the prior
   needs are added as engineered `D_*` features). The golden `S_*` here is the full histogram (the shape's snippet is

--- a/deplodock/compiler/context.py
+++ b/deplodock/compiler/context.py
@@ -243,7 +243,6 @@ class Context:
         the launch. Without this distinction, ``--target sm_90`` on an
         sm_86 box would request 227 KB on a 99 KB device.
         """
-        from deplodock import gpu  # noqa: PLC0415
         from deplodock.compiler.target import compute_capability, live_compute_capability  # noqa: PLC0415
 
         cap = compute_capability()

--- a/deplodock/compiler/context.py
+++ b/deplodock/compiler/context.py
@@ -113,6 +113,13 @@ class Context:
     # which would mis-model an RTX PRO 6000 golden ranked on an RTX 5090 (both
     # cc 12.0 but 188 vs 170 SMs). NOT in ``structural_key`` (device-physical).
     device_props: dict = field(default_factory=dict)
+    # PCIe product name of the card this context is for (e.g. "NVIDIA H200 141GB"),
+    # set by ``from_target(gpu_name=…)`` or probed live (``gpu.live_name``). The one
+    # identity that separates same-die SKUs (H100 vs H200: identical cc + SM features,
+    # different VRAM) — used by the node-store key + ``gpu`` column so cross-hardware
+    # tuning data never collides. NOT in ``structural_key`` (the perf cache stays
+    # SKU-coarse on purpose; only the node *dataset* keys on it). ``None`` ⇒ unknown.
+    gpu_name: str | None = None
     # Identifies which backend's perf rows this compile reads/writes — the
     # tune DB keys ``perf`` by ``(context_key, op_key, backend)``. Defaults to
     # ``"cuda"`` — the canonical autotune target. ``run_autotune`` replaces
@@ -152,6 +159,7 @@ class Context:
             max_dynamic_smem=_max_dynamic_smem_for(cap),
             sm_count=sm,
             device_props=props,
+            gpu_name=spec.name if spec else gpu_name,
             compile_flags=_env_compile_flags(),
         )
 
@@ -171,6 +179,19 @@ class Context:
 
         return digest("Context", self.compute_capability, self.compile_flags)
 
+    def hardware_id(self) -> str:
+        """A stable per-card identity for the node-store key + ``gpu`` column: the PCIe
+        product name when known, else a digest of the device-physical regime (``H_*``
+        features + capability). Separates same-die SKUs (H100 vs H200) that
+        ``structural_key`` (cc + opt only) and the SM-only ``H_*`` features can't, so a
+        cross-hardware node dataset never collides."""
+        if self.gpu_name:
+            return self.gpu_name
+        from deplodock.compiler.structural import digest  # noqa: PLC0415
+
+        regime = sorted((k, v) for k, v in self.features().items() if k.startswith("H_"))
+        return digest("hw", self.compute_capability, regime)
+
     def features(self) -> dict[str, float]:
         """Host/hardware regime as ``H_*`` features for the learned prior, so a
         SINGLE global prior spans every GPU and nvcc opt level (these are
@@ -185,8 +206,10 @@ class Context:
         - ``H_opt`` — nvcc cicc opt level from ``compile_flags`` (tune's
           ``-Xcicc -O1`` → 1; compile/run's default → 3)
         - ``H_sm_count`` / ``H_smem_per_sm`` / ``H_smem_per_block`` /
-          ``H_regs_per_block`` / ``H_warp_size`` — live device props
-          (:func:`target.live_device_features`; absent on GPU-less hosts)
+          ``H_regs_per_block`` / ``H_warp_size`` / ``H_total_mem`` — live device props
+          (:func:`target.live_device_features`; absent on GPU-less hosts). ``H_total_mem``
+          (VRAM bytes) is the one feature that distinguishes same-die SKUs the SM-only
+          features can't — H100 80GB vs H200 141GB share cc + SM count.
         """
         import re  # noqa: PLC0415
 
@@ -220,6 +243,7 @@ class Context:
         the launch. Without this distinction, ``--target sm_90`` on an
         sm_86 box would request 227 KB on a 99 KB device.
         """
+        from deplodock import gpu  # noqa: PLC0415
         from deplodock.compiler.target import compute_capability, live_compute_capability  # noqa: PLC0415
 
         cap = compute_capability()
@@ -230,4 +254,10 @@ class Context:
             smem = _max_dynamic_smem_for(cap)
         else:
             smem = min(_max_dynamic_smem_for(cap), _max_dynamic_smem_for(live))
-        return cls(compute_capability=cap, max_dynamic_smem=smem, sm_count=_live_sm_count(), compile_flags=_env_compile_flags())
+        return cls(
+            compute_capability=cap,
+            max_dynamic_smem=smem,
+            sm_count=_live_sm_count(),
+            gpu_name=gpu.live_name(),
+            compile_flags=_env_compile_flags(),
+        )

--- a/deplodock/compiler/pipeline/ARCHITECTURE.md
+++ b/deplodock/compiler/pipeline/ARCHITECTURE.md
@@ -378,11 +378,17 @@ The autotune state is split across two cooperating modules:
   full stats (`latency_us_{median,min,max,mean,variance}`,
   `n_samples`, `backend`, `status`, `knobs`), and a `node` table — one
   row per **search-tree node** (every partial branch + leaf of a per-kernel
-  search), keyed by `digest(context_key, op_sig, tunable-knob set)`, carrying
+  search), keyed by `digest(context_key, gpu, op_sig, tunable-knob set)`, carrying
   the full feature dict the prior sees (`H_*` + `S_*` + knobs), a keep-the-minimum
   value-of-position latency (`1/best_reward`), a `parent_key` pointer (ancestry
-  is the live tree edge, not knob-subset inference), and `depth`/`n_updates`
-  bookkeeping (written by `record_nodes`, fed by `TuningSearch._collect_node_records`).
+  is the live tree edge, not knob-subset inference), a `gpu` column, and
+  `depth`/`n_updates` bookkeeping (written by `record_nodes`, fed by
+  `TuningSearch._collect_node_records`). The `gpu` identity (`Context.hardware_id` —
+  the PCIe product name) is folded into the key so a **cross-hardware** dataset
+  never collides: `context_key` (cc + opt only) can't separate same-die SKUs (H100
+  vs H200 share cc + SM count), so without `gpu` their rows would merge and keep-min
+  would silently drop one card's data (the `H_total_mem` VRAM feature is what then
+  lets the prior model the difference).
   `node` is content-keyed like `perf` (parent-tree-independent) and survives a
   `_SCHEMA_VERSION` bump; only the topology-keyed `lowering` table is dropped on
   mismatch. Selection statistic is the median.
@@ -571,10 +577,13 @@ deduplicated, parent-linked counterpart to the unkeyed/sampled reservoir. Each n
 `digest(context_key, op_sig, tunable-knob set)`, so the same position re-encountered across runs collapses to one row with a
 keep-the-minimum value-of-position latency; it carries the full `knob_features` input dict, and stores `parent_key` from the
 live `node.parent` edge so ancestry is recoverable. The prior still *trains* from the in-memory reservoir, but the `node`
-store is *read back* by `eval prior --dataset nodes` (`SearchDB.iter_nodes` → `diagnostics.node_report`): it groups nodes by
-`parent_key` and scores the **fork sibling-ranking** — does the prior order each fork's children (the partial configs it
-ranks during `_select`) by their best-reachable latency (top-1 hit + per-fork Spearman)? — the search-faithful evaluation
-no leaf-only view can give, alongside leaf reachability/calibration reused on the deduped store.
+store is *read back* by `eval prior --dataset nodes` (`SearchDB.iter_nodes` → `diagnostics.node_report`): **per card**,
+it groups nodes by `parent_key` and scores the **fork sibling-ranking** — does the prior order each fork's children (the
+partial configs it ranks during `_select`) by their best-reachable latency (top-1 hit + per-fork Spearman)? — the
+search-faithful evaluation no leaf-only view can give, alongside leaf reachability/calibration reused on the deduped
+store. The per-card grouping matters for a cross-hardware dataset: same-die SKUs (H100/H200) share an `S_*` op signature
+(the leaf-reachability group key) but not their latencies, so mixing them would corrupt both metrics — the `gpu` key
+keeps their rows distinct and `node_report` reports them in separate blocks.
 
 Why CatBoost (chosen by `scripts/prior_bakeoff.py` over a multi-op tuning dataset): the model's greedy pick must not run
 off to a degenerate corner. A linear model (the former `BayesianRidgePrior`) is monotone in every knob, so its optimum is

--- a/deplodock/compiler/pipeline/search/db.py
+++ b/deplodock/compiler/pipeline/search/db.py
@@ -133,13 +133,17 @@ class LoweringRow:
 class NodeRow:
     """One ``node`` row — a single node of a per-kernel autotune search tree.
 
-    ``node_key`` is ``digest(context_key, op_sig, tunable-knob set)`` — the node's
-    identity within its operation; ``parent_key`` is the parent node's ``node_key``
-    (``None`` at the operation's top forks). ``features`` is the full feature dict
-    the prior sees (``H_*`` regime + ``S_*`` structure + tunable knobs).
-    ``value_us`` is the value-of-position latency (best reachable below the node);
-    :meth:`SearchDB.record_nodes` keeps the minimum on re-encounter. ``depth`` is
-    the node's distance from the sentinel root (top forks = 1)."""
+    ``node_key`` is ``digest(context_key, gpu, op_sig, tunable-knob set)`` — the
+    node's identity within its operation *on its hardware*; ``parent_key`` is the
+    parent node's ``node_key`` (``None`` at the operation's top forks). ``gpu`` is the
+    card's identity (``Context.hardware_id`` — the PCIe product name, or a device
+    digest when unknown): folded into the key so same-die SKUs (H100 vs H200) never
+    collide, and kept as a column so the dataset groups/filters by hardware.
+    ``features`` is the full feature dict the prior sees (``H_*`` regime + ``S_*``
+    structure + tunable knobs). ``value_us`` is the value-of-position latency (best
+    reachable below the node); :meth:`SearchDB.record_nodes` keeps the minimum on
+    re-encounter. ``depth`` is the node's distance from the sentinel root (top
+    forks = 1)."""
 
     node_key: str
     parent_key: str | None
@@ -148,6 +152,7 @@ class NodeRow:
     features: dict
     value_us: float
     depth: int
+    gpu: str = ""
 
 
 # The ``perf`` SELECT column list — order must match ``_row_to_perf``.
@@ -254,6 +259,7 @@ class SearchDB:
             parent_key   TEXT,
             context_key  TEXT NOT NULL,
             op_sig       TEXT NOT NULL,
+            gpu          TEXT NOT NULL DEFAULT '',
             features     TEXT NOT NULL DEFAULT '{}',
             value_us     REAL NOT NULL,
             depth        INTEGER NOT NULL,
@@ -263,6 +269,7 @@ class SearchDB:
         """,
         "CREATE INDEX IF NOT EXISTS node_parent ON node (parent_key)",
         "CREATE INDEX IF NOT EXISTS node_op ON node (context_key, op_sig)",
+        "CREATE INDEX IF NOT EXISTS node_gpu ON node (gpu)",
     ]
 
     def __init__(self, path: Path | str | None = None) -> None:
@@ -279,16 +286,27 @@ class SearchDB:
         if cur_version != self._SCHEMA_VERSION:
             self._conn.execute("DROP TABLE IF EXISTS lowering")
             self._conn.execute(f"PRAGMA user_version = {self._SCHEMA_VERSION}")
+        # Additive ``node.gpu`` migration must run BEFORE the schema loop — the
+        # ``node_gpu`` index in ``_SCHEMA`` references the column, so it has to exist
+        # first. A brand-new DB has no ``node`` table yet (the loop's CREATE includes
+        # ``gpu``), so this only fires for a pre-``gpu``-column table; old rows default
+        # to '' (unknown card).
+        if self._has_node_table() and not self._has_node_gpu_column():
+            self._conn.execute("ALTER TABLE node ADD COLUMN gpu TEXT NOT NULL DEFAULT ''")
         for stmt in self._SCHEMA:
             self._conn.execute(stmt)
         # Additive migration: pre-existing DBs lack the ``error`` column
         # (``CREATE TABLE IF NOT EXISTS`` never alters). Writer-side only —
-        # read-only consumers tolerate its absence instead.
+        # read-only consumers tolerate its absence instead. (``perf`` has no index on
+        # ``error``, so unlike ``node.gpu`` this can run after the schema loop.)
         if not self._has_perf_error_column():
             self._conn.execute("ALTER TABLE perf ADD COLUMN error TEXT")
 
     def _has_perf_error_column(self) -> bool:
         return any(r[1] == "error" for r in self._conn.execute("PRAGMA table_info(perf)"))
+
+    def _has_node_gpu_column(self) -> bool:
+        return any(r[1] == "gpu" for r in self._conn.execute("PRAGMA table_info(node)"))
 
     def _has_node_table(self) -> bool:
         # A read-only open of a pre-``node`` DB never ran ``CREATE TABLE IF NOT
@@ -489,9 +507,9 @@ class SearchDB:
             if existing is None:
                 self._conn.execute(
                     "INSERT INTO node "
-                    "(node_key, parent_key, context_key, op_sig, features, value_us, depth, n_updates, updated_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (r.node_key, r.parent_key, r.context_key, r.op_sig, feats_json, r.value_us, r.depth, 1, now),
+                    "(node_key, parent_key, context_key, op_sig, gpu, features, value_us, depth, n_updates, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (r.node_key, r.parent_key, r.context_key, r.op_sig, r.gpu, feats_json, r.value_us, r.depth, 1, now),
                 )
             elif r.value_us < existing[0]:
                 self._conn.execute(
@@ -517,7 +535,10 @@ class SearchDB:
         regime / operation."""
         if not self._has_node_table():
             return
-        sql = "SELECT node_key, parent_key, context_key, op_sig, features, value_us, depth FROM node"
+        # ``gpu`` degrades to '' on a pre-``gpu``-column DB opened read-only (the
+        # additive migration runs writer-side only) — same pattern as perf.error.
+        gpu_col = "gpu" if self._has_node_gpu_column() else "''"
+        sql = f"SELECT node_key, parent_key, context_key, op_sig, {gpu_col}, features, value_us, depth FROM node"  # noqa: S608
         clauses: list[str] = []
         params: list = []
         if context_key is not None:
@@ -528,7 +549,7 @@ class SearchDB:
             params.append(op_sig)
         if clauses:
             sql += " WHERE " + " AND ".join(clauses)
-        for node_key, parent_key, ck, sig, feats_json, value_us, depth in self._conn.execute(sql, params):
+        for node_key, parent_key, ck, sig, gpu, feats_json, value_us, depth in self._conn.execute(sql, params):
             try:
                 features = json.loads(feats_json) if feats_json else {}
             except (TypeError, json.JSONDecodeError):
@@ -541,6 +562,7 @@ class SearchDB:
                 features=features,
                 value_us=value_us,
                 depth=depth,
+                gpu=gpu,
             )
 
     # ------------------------------------------------------------------

--- a/deplodock/compiler/pipeline/search/policy/mcts.py
+++ b/deplodock/compiler/pipeline/search/policy/mcts.py
@@ -362,18 +362,22 @@ class TuningSearch(Search):
             rows.append((knobs, 1.0 / node.best_reward))
         return rows
 
-    def _node_key(self, feats: dict, op_sig: str, context_key: str) -> str:
-        """Identity of a node within its operation: a digest over the deploy
-        regime (``context_key``), the op's ``S_*`` signature (``op_sig``), and the
-        canonical tunable-knob set. ``S_*`` / ``H_*`` features are excluded from the
-        set — they are already folded via ``op_sig`` / ``context_key`` — so the key
-        is the "within-op node identity". ``str()``-ified values mirror
-        :meth:`_o3_sig` so list-valued knobs (``OVERHANG``) stay stable, and the
-        sorted tuple keeps :func:`digest` (order-sensitive) deterministic."""
+    def _node_key(self, feats: dict, op_sig: str, context_key: str, gpu: str) -> str:
+        """Identity of a node within its operation *on its hardware*: a digest over the
+        deploy regime (``context_key``), the card identity (``gpu`` —
+        ``Context.hardware_id``), the op's ``S_*`` signature (``op_sig``), and the
+        canonical tunable-knob set. ``gpu`` is folded in because ``context_key`` (cc +
+        opt only) can't tell same-die SKUs apart (H100 vs H200), so without it their
+        rows would collide and keep-min would silently drop one card's data. ``S_*`` /
+        ``H_*`` features are excluded from the set — already folded via ``op_sig`` /
+        ``context_key`` (and ``gpu``) — so the key is the within-op node identity.
+        ``str()``-ified values mirror :meth:`_o3_sig` so list-valued knobs
+        (``OVERHANG``) stay stable, and the sorted tuple keeps :func:`digest`
+        (order-sensitive) deterministic."""
         tun = tuple(sorted((k, str(v)) for k, v in feats.items() if not k.startswith(("S_", "H_"))))
-        return digest(context_key, op_sig, tun)
+        return digest(context_key, gpu, op_sig, tun)
 
-    def _collect_node_records(self, *, context_key: str, op_sig: str) -> list[tuple]:
+    def _collect_node_records(self, *, context_key: str, op_sig: str, gpu: str = "") -> list[tuple]:
         """Post-search tree walk producing keyed, parent-linked node records for
         :meth:`SearchDB.record_nodes` — the persistent/keyed/deduped sibling of
         :meth:`_collect_rows` (which feeds the prior's in-memory reservoir).
@@ -400,7 +404,7 @@ class TuningSearch(Search):
                 feats = node.realized_knobs if node.realized_knobs is not None else self._node_knobs(node)
                 value_us = 1.0 / node.best_reward
                 assert parent_value is None or value_us >= parent_value - 1e-9, "value-of-position not monotone up the tree"
-                nk = self._node_key(feats, op_sig, context_key)
+                nk = self._node_key(feats, op_sig, context_key, gpu)
                 out.append((nk, parent_key, feats, value_us, depth))
                 parent_value = value_us
             for child in node.children:

--- a/deplodock/compiler/pipeline/search/prior/diagnostics.py
+++ b/deplodock/compiler/pipeline/search/prior/diagnostics.py
@@ -305,17 +305,57 @@ def _node_op_label(features: dict) -> str:
     return _op_label(tuple(sorted((k, v) for k, v in features.items() if k.startswith("S_"))))
 
 
+def _node_gpu_block(prior, gpu: str, gnodes: list) -> list[str]:
+    """Per-card metrics: fork sibling-ranking + leaf reachability/calibration over ONE
+    GPU's nodes. Grouping by card is what keeps same-die SKUs (H100 vs H200) from being
+    compared against each other — their latencies differ but their ``S_*`` op signature
+    (the leaf-reachability group key) is identical."""
+    lines = [f"  [{gpu}] {len(gnodes)} nodes"]
+    sib = node_sibling_ranking(prior, gnodes)
+    if sib is None:
+        lines.append("    fork sibling-ranking: no multi-child forks")
+    else:
+        n_forks, top1, rho, n_children = sib
+        rho_txt = f"{rho:+.2f}" if rho is not None else "n/a"
+        lines.append(
+            f"    fork sibling-ranking: top-1 {top1:.2f}  median per-fork Spearman {rho_txt}  ({n_forks} forks, {n_children} children)"
+        )
+    groups = Dataset.from_node_rows(gnodes).group_by_op()
+    rr = reachability(prior, groups)
+    if rr:
+        ratios = [r[3] for r in rr]
+        agg = f"mean {statistics.mean(ratios):.2f}x  median {statistics.median(ratios):.2f}x  worst {max(ratios):.2f}x"
+        lines.append(f"    leaf reachability: {agg}  ({len(rr)} ops, 1.00 = optimum)")
+        for label, best_us, pick_us, ratio, n in sorted(rr, key=lambda r: -r[3]):
+            if ratio > 1.2:
+                lines.append(
+                    f"      {label:26}  best {best_us:8.2f}us  pick {pick_us:8.2f}us  ({ratio:.2f}x, {n} configs)  <-- misses best"
+                )
+    calib = _calibration(prior, groups)
+    if calib is not None:
+        lines.append(f"    leaf calibration (median per-op Spearman): {calib:+.2f}")
+    return lines
+
+
 def node_report(prior, nodes, *, kernel_filter: str | None = None) -> str:
-    """The ``eval prior --dataset nodes`` block: the fork sibling-ranking (the
-    metric unique to this dataset) plus leaf reachability / calibration reused on the
-    persistent, deduped node store. ``nodes`` is a list of :class:`db.NodeRow` from
+    """The ``eval prior --dataset nodes`` block. Groups the node store **by card**
+    (``NodeRow.gpu``) and, per card, reports the fork sibling-ranking (the metric unique
+    to this dataset) plus leaf reachability / calibration. Per-card grouping is what
+    makes a cross-hardware dataset (H100, H200, …) evaluate correctly — same-die SKUs
+    share an ``S_*`` op signature but not their latencies, so mixing them would corrupt
+    both metrics. ``nodes`` is a list of :class:`db.NodeRow` from
     :meth:`SearchDB.iter_nodes`; ``kernel_filter`` keeps only nodes whose op label
     contains the substring (``--kernel``)."""
+    from collections import defaultdict  # noqa: PLC0415
+
     total = len(nodes)
     if kernel_filter:
         nodes = [n for n in nodes if kernel_filter in _node_op_label(n.features)]
+    by_gpu: dict[str, list] = defaultdict(list)
+    for n in nodes:
+        by_gpu[n.gpu or "(unknown card)"].append(n)
     suffix = f" matching --kernel {kernel_filter!r}" if kernel_filter else ""
-    lines = [f"[prior] node store: {len(nodes)} nodes{suffix}, fitted={prior.fitted}"]
+    lines = [f"[prior] node store: {len(nodes)} nodes{suffix} across {len(by_gpu)} card(s), fitted={prior.fitted}"]
     if not nodes:
         if kernel_filter and total:
             lines.append(f"  no nodes match --kernel {kernel_filter!r} ({total} in store) — try an op label like 'matmul' / 'reduce'")
@@ -324,28 +364,6 @@ def node_report(prior, nodes, *, kernel_filter: str | None = None) -> str:
         return "\n".join(lines)
     if not prior.fitted:
         lines.append("  no fitted prior — the cold AnalyticPrior ranks by D_* geometry only; run `deplodock tune`")
-
-    sib = node_sibling_ranking(prior, nodes)
-    if sib is None:
-        lines.append("[prior] fork sibling-ranking: no multi-child forks recorded")
-    else:
-        n_forks, top1, rho, n_children = sib
-        rho_txt = f"{rho:+.2f}" if rho is not None else "n/a"
-        lines.append("[prior] fork sibling-ranking — does the prior rank each fork's children by value-of-position?")
-        lines.append(f"  top-1 {top1:.2f}  (predicted-best child is a true-best child)   median per-fork Spearman {rho_txt}")
-        lines.append(f"  over {n_forks} forks ({n_children} children)")
-
-    groups = Dataset.from_node_rows(nodes).group_by_op()
-    rr = reachability(prior, groups)
-    if rr:
-        ratios = [r[3] for r in rr]
-        lines.append("[prior] leaf reachability over node store — does the prior recover each op's best leaf?")
-        agg = f"mean {statistics.mean(ratios):.2f}x  median {statistics.median(ratios):.2f}x  worst {max(ratios):.2f}x"
-        lines.append(f"  {agg}   (1.00 = optimum)")
-        for label, best_us, pick_us, ratio, n in sorted(rr, key=lambda r: -r[3]):
-            flag = "  <-- misses best" if ratio > 1.2 else ""
-            lines.append(f"    {label:26}  best {best_us:8.2f}us  pick {pick_us:8.2f}us  ({ratio:.2f}x, {n} configs){flag}")
-    calib = _calibration(prior, groups)
-    if calib is not None:
-        lines.append(f"[prior] leaf ranking calibration (median per-op Spearman): {calib:+.2f}")
+    for gpu in sorted(by_gpu):
+        lines.extend(_node_gpu_block(prior, gpu, by_gpu[gpu]))
     return "\n".join(lines)

--- a/deplodock/compiler/pipeline/search/two_level.py
+++ b/deplodock/compiler/pipeline/search/two_level.py
@@ -348,12 +348,15 @@ async def _inner_reward_async(fused_graph, *, ctx, db, pool, patience, ucb_c, ex
             # Persist every search-tree node (partial branches + leaves) to the
             # keyed/deduped ``node`` table — alongside the reservoir feed above, and
             # independent of whether a prior is attached. ``op_sig`` is the op's
-            # ``S_*`` structural signature; the walk threads parent_key/value/depth.
+            # ``S_*`` structural signature; ``gpu`` is the card identity (folded into
+            # the key so same-die SKUs don't collide); the walk threads
+            # parent_key/value/depth.
             op_sig = digest(*sorted((k, v) for k, v in op.knobs.items() if k.startswith("S_")))
+            gpu = ctx.hardware_id()
             db.record_nodes(
                 [
-                    NodeRow(node_key=nk, parent_key=pk, context_key=ctx_key, op_sig=op_sig, features=feats, value_us=v, depth=d)
-                    for nk, pk, feats, v, d in inner._collect_node_records(context_key=ctx_key, op_sig=op_sig)
+                    NodeRow(node_key=nk, parent_key=pk, context_key=ctx_key, op_sig=op_sig, features=feats, value_us=v, depth=d, gpu=gpu)
+                    for nk, pk, feats, v, d in inner._collect_node_records(context_key=ctx_key, op_sig=op_sig, gpu=gpu)
                 ]
             )
             best = db.best_per_op_time(ctx_key, key, backend=backend_name)

--- a/deplodock/gpu.py
+++ b/deplodock/gpu.py
@@ -108,19 +108,19 @@ class GpuSpec:
         memorized fallback. ``total_mem`` (VRAM bytes) is the one feature that
         distinguishes same-die SKUs the prior otherwise can't tell apart (H100 80GB vs
         H200 141GB share cc + SM count). Empty when ``sm_count`` is unknown (degrades
-        like a GPU-less host); ``total_mem`` is omitted when VRAM is unknown."""
+        like a GPU-less host); ``total_mem`` is always present (``0.0`` when VRAM is
+        unknown) so the feature SET matches the live probe — a card featurizes the same
+        whether probed or memorized."""
         if self.sm_count is None or self.smem_per_sm is None:
             return {}
-        feats = {
+        return {
             "sm_count": float(self.sm_count),
             "smem_per_sm": float(self.smem_per_sm),
             "smem_per_block": float(self.smem_per_block),
             "regs_per_block": float(self.regs_per_block),
             "warp_size": float(self.warp_size),
+            "total_mem": float(self.vram_bytes or 0),
         }
-        if self.vram_bytes is not None:
-            feats["total_mem"] = float(self.vram_bytes)
-        return feats
 
 
 # Specs marked "measured" are exact values probed off the live card (recorded in

--- a/deplodock/gpu.py
+++ b/deplodock/gpu.py
@@ -21,6 +21,7 @@ properties of the silicon; this module owns only the hardware itself.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, field
 
 _MIB = 1024 * 1024
@@ -102,18 +103,24 @@ class GpuSpec:
         return TENSOR_CORE_GEN.get(self.compute_capability, self.compute_capability[0])
 
     def device_features(self) -> dict[str, float]:
-        """The ``sm_count`` / ``smem_*`` / ``regs`` / ``warp`` subset, matching the
-        keys :func:`probe_live_features` reads from a live device — the memorized
-        fallback. Empty when ``sm_count`` is unknown (degrades like a GPU-less host)."""
+        """The ``sm_count`` / ``smem_*`` / ``regs`` / ``warp`` / ``total_mem`` subset,
+        matching the keys :func:`probe_live_features` reads from a live device — the
+        memorized fallback. ``total_mem`` (VRAM bytes) is the one feature that
+        distinguishes same-die SKUs the prior otherwise can't tell apart (H100 80GB vs
+        H200 141GB share cc + SM count). Empty when ``sm_count`` is unknown (degrades
+        like a GPU-less host); ``total_mem`` is omitted when VRAM is unknown."""
         if self.sm_count is None or self.smem_per_sm is None:
             return {}
-        return {
+        feats = {
             "sm_count": float(self.sm_count),
             "smem_per_sm": float(self.smem_per_sm),
             "smem_per_block": float(self.smem_per_block),
             "regs_per_block": float(self.regs_per_block),
             "warp_size": float(self.warp_size),
         }
+        if self.vram_bytes is not None:
+            feats["total_mem"] = float(self.vram_bytes)
+        return feats
 
 
 # Specs marked "measured" are exact values probed off the live card (recorded in
@@ -286,7 +293,26 @@ def probe_live_features(fallback_name: str | None = None) -> dict[str, float]:
             "smem_per_block": float(props["sharedMemPerBlock"]),
             "regs_per_block": float(props["regsPerBlock"]),
             "warp_size": float(props["warpSize"]),
+            "total_mem": float(props["totalGlobalMem"]),
         }
     except Exception:  # noqa: BLE001 — no live device ⇒ memorized fallback
         spec = (by_name(fallback_name) if fallback_name else None) or DEFAULT_GPU
         return spec.device_features()
+
+
+@functools.cache
+def live_name() -> str | None:
+    """The live CUDA device's PCIe product name (``cudaDeviceProp.name``), canonicalized
+    through the registry (:func:`by_name`) when recognized, else the raw reported name;
+    ``None`` when no device is visible. The hardware identity that distinguishes same-die
+    SKUs (H100 vs H200) — ``compute_capability`` + SM features alone can't. Cached:
+    physical, target-independent."""
+    try:
+        import cupy as cp  # noqa: PLC0415
+
+        raw = cp.cuda.runtime.getDeviceProperties(cp.cuda.Device().id)["name"]
+    except Exception:  # noqa: BLE001 — no live device
+        return None
+    name = raw.decode() if isinstance(raw, (bytes, bytearray)) else str(raw)
+    spec = by_name(name)
+    return spec.name if spec else name

--- a/deplodock/gpu.py
+++ b/deplodock/gpu.py
@@ -193,6 +193,9 @@ KNOWN_GPUS: tuple[GpuSpec, ...] = (
         sm_count=132,
         smem_per_sm=233472,
         vram_mib=81559,
+        # ``cudaDeviceProp.name`` reports the SXM5 form, not the capacity-suffixed
+        # registry name — so a live card canonicalizes via the alias (see ``live_name``).
+        aliases=("NVIDIA H100 80GB HBM3",),
     ),
     GpuSpec(
         name="NVIDIA H200 141GB",
@@ -202,6 +205,7 @@ KNOWN_GPUS: tuple[GpuSpec, ...] = (
         sm_count=132,
         smem_per_sm=233472,
         vram_mib=143771,
+        aliases=("NVIDIA H200",),  # bare reported name (SXM); registry name carries the capacity
     ),
     GpuSpec(
         name="NVIDIA B200",
@@ -220,6 +224,9 @@ KNOWN_GPUS: tuple[GpuSpec, ...] = (
         sm_count=108,
         smem_per_sm=167936,
         vram_mib=40960,
+        # SXM4 / PCIe report distinct ``cudaDeviceProp.name`` forms; both 40GB A100s
+        # share this spec's SM count + VRAM, so canonicalize them to one identity.
+        aliases=("NVIDIA A100-SXM4-40GB", "NVIDIA A100-PCIE-40GB"),
     ),
     GpuSpec(
         name="NVIDIA A100 80GB",
@@ -229,6 +236,7 @@ KNOWN_GPUS: tuple[GpuSpec, ...] = (
         sm_count=108,
         smem_per_sm=167936,
         vram_mib=81920,
+        aliases=("NVIDIA A100-SXM4-80GB", "NVIDIA A100 80GB PCIe"),
     ),
     GpuSpec(
         name="NVIDIA Tesla V100 SXM3 32GB",
@@ -303,10 +311,13 @@ def probe_live_features(fallback_name: str | None = None) -> dict[str, float]:
 @functools.cache
 def live_name() -> str | None:
     """The live CUDA device's PCIe product name (``cudaDeviceProp.name``), canonicalized
-    through the registry (:func:`by_name`) when recognized, else the raw reported name;
-    ``None`` when no device is visible. The hardware identity that distinguishes same-die
-    SKUs (H100 vs H200) — ``compute_capability`` + SM features alone can't. Cached:
-    physical, target-independent."""
+    to the registry name via :func:`by_name` (datacenter cards report a bare name —
+    ``"NVIDIA H200"`` — that the registry carries as an alias of the capacity-suffixed
+    ``"NVIDIA H200 141GB"``); the raw reported name when unrecognized, ``None`` when no
+    device is visible. The hardware identity that distinguishes same-die SKUs (H100 vs
+    H200) — ``compute_capability`` + SM features alone can't. Canonicalizing matters so a
+    live node-store row and a golden reconstructed from the canonical name share one
+    ``gpu`` string. Cached: physical, target-independent."""
     try:
         import cupy as cp  # noqa: PLC0415
 

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -340,7 +340,7 @@ def test_prior_nodes_smoke(run_cli, tmp_path):
     assert rc == 0, f"stderr: {stderr}"
     assert "node store: 3 nodes" in stdout
     assert "fork sibling-ranking" in stdout
-    assert "leaf reachability over node store" in stdout
+    assert "leaf reachability" in stdout
     assert "traceback" not in (stdout + stderr).lower()
 
 

--- a/tests/compiler/pipeline/search/test_db.py
+++ b/tests/compiler/pipeline/search/test_db.py
@@ -224,7 +224,7 @@ def test_open_readonly_missing_file_raises(tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _node_row(node_key: str, value_us: float, *, parent_key=None, op_sig="sig", features=None, depth=1) -> NodeRow:
+def _node_row(node_key: str, value_us: float, *, parent_key=None, op_sig="sig", features=None, depth=1, gpu="") -> NodeRow:
     return NodeRow(
         node_key=node_key,
         parent_key=parent_key,
@@ -233,6 +233,7 @@ def _node_row(node_key: str, value_us: float, *, parent_key=None, op_sig="sig", 
         features=features or {},
         value_us=value_us,
         depth=depth,
+        gpu=gpu,
     )
 
 
@@ -339,6 +340,51 @@ def test_iter_nodes_missing_table_degrades(tmp_path) -> None:
     ro = SearchDB.open_readonly(path)
     assert not ro._has_node_table()
     assert list(ro.iter_nodes()) == []
+    ro.close()
+
+
+def test_record_nodes_gpu_column_roundtrips(tmp_path) -> None:
+    db = SearchDB(tmp_path / "t.db")
+    db.record_nodes([_node_row("n1", 5.0, features={"BM": 8}, gpu="NVIDIA H200 141GB")])
+    (n,) = list(db.iter_nodes())
+    assert n.gpu == "NVIDIA H200 141GB"
+
+
+_PRE_GPU_NODE_SCHEMA = (
+    "CREATE TABLE node (node_key TEXT PRIMARY KEY, parent_key TEXT, context_key TEXT NOT NULL, "
+    "op_sig TEXT NOT NULL, features TEXT NOT NULL DEFAULT '{}', value_us REAL NOT NULL, "
+    "depth INTEGER NOT NULL, n_updates INTEGER NOT NULL DEFAULT 1, updated_at TEXT NOT NULL); "
+    "INSERT INTO node VALUES ('old', NULL, 'ctx', 'mm', '{}', 3.0, 1, 1, 'now');"
+)
+
+
+def test_node_gpu_column_added_to_pre_gpu_db(tmp_path) -> None:
+    """A ``node`` table from the first node-store version (no ``gpu`` column) gains it
+    on the next writer open — the ALTER runs *before* the schema loop so the
+    ``node_gpu`` index builds; old rows default to ''."""
+    path = tmp_path / "old.db"
+    con = sqlite3.connect(path)
+    con.executescript(_PRE_GPU_NODE_SCHEMA)
+    con.commit()
+    con.close()
+    db = SearchDB(path)  # writer migrates: ALTER adds gpu, then node_gpu index builds
+    assert db._has_node_gpu_column()
+    assert list(db.iter_nodes())[0].gpu == ""  # pre-existing row defaults
+    db.record_nodes([_node_row("new", 2.0, gpu="NVIDIA H100 80GB")])
+    assert {n.node_key: n.gpu for n in db.iter_nodes()}["new"] == "NVIDIA H100 80GB"
+
+
+def test_iter_nodes_pre_gpu_column_readonly_degrades(tmp_path) -> None:
+    """A read-only open of a pre-``gpu``-column DB degrades ``gpu`` to '' rather than
+    raising (the additive ALTER is writer-side only)."""
+    path = tmp_path / "ro.db"
+    con = sqlite3.connect(path)
+    con.executescript(_PRE_GPU_NODE_SCHEMA)
+    con.commit()
+    con.close()
+    ro = SearchDB.open_readonly(path)
+    assert not ro._has_node_gpu_column()
+    assert list(ro.iter_nodes())[0].gpu == ""
     ro.close()
 
 

--- a/tests/compiler/pipeline/search/test_diagnostics.py
+++ b/tests/compiler/pipeline/search/test_diagnostics.py
@@ -185,7 +185,26 @@ def test_node_report_combines_fork_and_leaf_sections():
     text = diagnostics.node_report(_BMPrior(), nodes)
     assert "node store: 3 nodes" in text
     assert "fork sibling-ranking" in text
-    assert "leaf reachability over node store" in text
+    assert "leaf reachability" in text
+
+
+def test_node_report_separates_hardware():
+    """The report groups by card, so an H100 op and a same-die H200 op (identical S_*
+    signature, different latencies) are evaluated as separate blocks — never mixed."""
+    from deplodock.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
+
+    mm = {"S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0, "S_ext_free_max": 512.0}
+    nodes = [
+        NodeRow("Ph", None, "ctx", "mm", mm, 5.0, 1, gpu="NVIDIA H100 80GB"),
+        NodeRow("h8", "Ph", "ctx", "mm", {**mm, "BM": 8}, 5.0, 2, gpu="NVIDIA H100 80GB"),
+        NodeRow("h64", "Ph", "ctx", "mm", {**mm, "BM": 64}, 7.0, 2, gpu="NVIDIA H100 80GB"),
+        NodeRow("Pn", None, "ctx", "mm", mm, 3.0, 1, gpu="NVIDIA H200 141GB"),
+        NodeRow("n8", "Pn", "ctx", "mm", {**mm, "BM": 8}, 3.0, 2, gpu="NVIDIA H200 141GB"),
+        NodeRow("n64", "Pn", "ctx", "mm", {**mm, "BM": 64}, 4.0, 2, gpu="NVIDIA H200 141GB"),
+    ]
+    text = diagnostics.node_report(_BMPrior(), nodes)
+    assert "across 2 card(s)" in text
+    assert "[NVIDIA H100 80GB]" in text and "[NVIDIA H200 141GB]" in text
 
 
 def test_node_report_kernel_filter_selects_ops_by_label():

--- a/tests/compiler/pipeline/search/test_online_prior.py
+++ b/tests/compiler/pipeline/search/test_online_prior.py
@@ -298,15 +298,27 @@ def test_collect_node_records_skips_unbenched_and_sentinel():
 
 
 def test_node_key_excludes_s_and_h():
-    """Within one op (op_sig) + regime (context_key), node identity is the tunable
-    knob set only — two nodes differing solely in ``S_*``/``H_*`` collide, and a
+    """Within one op (op_sig) + regime (context_key) + card (gpu), node identity is the
+    tunable knob set only — two nodes differing solely in ``S_*``/``H_*`` collide, and a
     differing tunable knob splits them."""
     s = TuningSearch(tree=SearchTree())
-    base = s._node_key({"BM": 64, "S_n_mma": 1.0, "H_opt": 1.0}, "sig", "ctx")
-    s_h_perturbed = s._node_key({"BM": 64, "S_n_mma": 9.0, "H_opt": 3.0}, "sig", "ctx")
-    tunable_perturbed = s._node_key({"BM": 32, "S_n_mma": 1.0, "H_opt": 1.0}, "sig", "ctx")
+    base = s._node_key({"BM": 64, "S_n_mma": 1.0, "H_opt": 1.0}, "sig", "ctx", "gpu")
+    s_h_perturbed = s._node_key({"BM": 64, "S_n_mma": 9.0, "H_opt": 3.0}, "sig", "ctx", "gpu")
+    tunable_perturbed = s._node_key({"BM": 32, "S_n_mma": 1.0, "H_opt": 1.0}, "sig", "ctx", "gpu")
     assert base == s_h_perturbed
     assert base != tunable_perturbed
+
+
+def test_node_key_folds_gpu():
+    """Same op + knobs + regime on different cards get distinct node_keys — so same-die
+    SKUs (identical context_key) never collide and keep-min can't drop one card's data;
+    the same card is stable."""
+    s = TuningSearch(tree=SearchTree())
+    feats = {"BM": 64, "S_n_mma": 1.0, "H_opt": 1.0}
+    h100 = s._node_key(feats, "sig", "ctx", "NVIDIA H100 80GB HBM3")
+    h200 = s._node_key(feats, "sig", "ctx", "NVIDIA H200 141GB")
+    assert h100 != h200
+    assert h100 == s._node_key(feats, "sig", "ctx", "NVIDIA H100 80GB HBM3")
 
 
 def _stats(median: float):

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -56,6 +56,30 @@ def test_probe_falls_back_to_memorized(monkeypatch):
     assert gpu.probe_live_features("NVIDIA GeForce RTX 4090")["total_mem"] == gpu.by_name("NVIDIA GeForce RTX 4090").vram_bytes
 
 
+def test_by_name_canonicalizes_reported_aliases():
+    """Live datacenter cards report bare ``cudaDeviceProp.name`` strings that differ from
+    the capacity-suffixed registry names; the registry aliases canonicalize them (so a
+    live node-store row and a golden built from the canonical name share one gpu string).
+    Without these, ``live_name`` canonicalization was a no-op for the exact cards it
+    targets."""
+    assert gpu.by_name("NVIDIA H200").name == "NVIDIA H200 141GB"
+    assert gpu.by_name("NVIDIA H100 80GB HBM3").name == "NVIDIA H100 80GB"
+    assert gpu.by_name("NVIDIA A100-SXM4-80GB").name == "NVIDIA A100 80GB"
+    assert gpu.by_name("NVIDIA H200 141GB").name == "NVIDIA H200 141GB"  # canonical resolves to itself
+    assert gpu.by_name("NVIDIA Totally Made Up") is None  # unknown → None (live_name keeps the raw string)
+
+
+def test_registry_names_and_aliases_are_unique():
+    """No string maps to two specs — every canonical name / alias is unique across the
+    registry, so a typo'd alias is caught here instead of being silently shadowed by the
+    ``setdefault`` in the ``_BY_NAME`` build (or mis-canonicalizing a card)."""
+    seen: dict[str, str] = {}
+    for g in gpu.KNOWN_GPUS:
+        for label in (g.name, *g.aliases):
+            assert label not in seen, f"{label!r} claimed by both {seen[label]!r} and {g.name!r}"
+            seen[label] = g.name
+
+
 def test_hardware_id_distinguishes_same_die_skus(monkeypatch):
     """``Context.hardware_id`` keys on the product name when known — so H100 and H200
     (identical cc + SM features) get distinct identities; an unnamed context falls back

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -38,6 +38,15 @@ def test_device_features_shape():
     assert gpu.by_name("AMD Instinct MI350X").device_features() == {}
 
 
+def test_device_features_total_mem_present_when_vram_unknown():
+    """``total_mem`` is always emitted (``0.0`` when VRAM is unknown) so a card's feature
+    SET matches the live probe — it featurizes the same whether probed or memorized."""
+    spec = gpu.GpuSpec(name="Synthetic SM-known/VRAM-unknown", compute_capability=(9, 0), sm_count=132, smem_per_sm=233472)
+    feats = spec.device_features()
+    assert "total_mem" in feats and feats["total_mem"] == 0.0
+    assert set(feats) == {"sm_count", "smem_per_sm", "smem_per_block", "regs_per_block", "warp_size", "total_mem"}
+
+
 def test_probe_falls_back_to_memorized(monkeypatch):
     # Force the cupy probe to fail → memorized fallback of the named card / default.
     import builtins

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -31,8 +31,9 @@ def test_derived_cc_facts():
 
 def test_device_features_shape():
     feats = gpu.by_name("NVIDIA GeForce RTX 5090").device_features()
-    assert set(feats) == {"sm_count", "smem_per_sm", "smem_per_block", "regs_per_block", "warp_size"}
+    assert set(feats) == {"sm_count", "smem_per_sm", "smem_per_block", "regs_per_block", "warp_size", "total_mem"}
     assert feats["sm_count"] == 170.0
+    assert feats["total_mem"] == gpu.by_name("NVIDIA GeForce RTX 5090").vram_bytes  # distinguishes same-die SKUs
     # AMD card has no CUDA specs → empty feature dict (degrades like a GPU-less host).
     assert gpu.by_name("AMD Instinct MI350X").device_features() == {}
 
@@ -51,6 +52,23 @@ def test_probe_falls_back_to_memorized(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", no_cupy)
     assert gpu.probe_live_features() == gpu.DEFAULT_GPU.device_features()
     assert gpu.probe_live_features("NVIDIA GeForce RTX 4090")["sm_count"] == 128.0
+    # total_mem (the same-die SKU discriminator) rides the fallback too.
+    assert gpu.probe_live_features("NVIDIA GeForce RTX 4090")["total_mem"] == gpu.by_name("NVIDIA GeForce RTX 4090").vram_bytes
+
+
+def test_hardware_id_distinguishes_same_die_skus(monkeypatch):
+    """``Context.hardware_id`` keys on the product name when known — so H100 and H200
+    (identical cc + SM features) get distinct identities; an unnamed context falls back
+    to a device-regime digest. And ``features()`` carries ``H_total_mem``."""
+    from deplodock.compiler.context import Context
+
+    h100 = Context.from_target((9, 0), gpu_name="NVIDIA H100 80GB")
+    h200 = Context.from_target((9, 0), gpu_name="NVIDIA H200 141GB")
+    assert h100.hardware_id() != h200.hardware_id()  # same cc, distinct product → distinct id
+    assert h100.features()["H_total_mem"] != h200.features()["H_total_mem"]  # the distinguishing feature
+    # No product name → a stable digest, not a crash.
+    anon = Context(compute_capability=(9, 0))
+    assert isinstance(anon.hardware_id(), str) and anon.hardware_id()
 
 
 def test_back_compat_maps_match_registry():


### PR DESCRIPTION
 Key the autotune node store by GPU (cross-hardware dataset)                                                                                                                        
                                                                                                                                                                                     
  Why                                                                                                                                                                                
                                                                                                                                                                                     
  The node store (#271, read by eval prior --dataset nodes in #278) is meant to collect value-of-position data across hardware. But node_key folded only context_key (cc + opt), and 
  the H_* features are SM-die properties — identical for H100/H200 (same GH100 die). So tuning both into one DB collided on node_key and keep-min silently dropped one card's data;  
  even kept, they were indistinguishable to a fitted prior.                                                                                                                          
                                                                                                                                                                                     
  What                                                                                                                                                                               
                                                                                                                                                                                     
  Fix both layers, keyed on the GPU product name:                                                                                                                                    
  - No collision: Context gains gpu_name + hardware_id(); node_key becomes digest(context_key, gpu, op_sig, knobs) and the table gains a gpu column (additive migration; read-only   
  degrade). H100/H200 rows now stay distinct.                                                                                                                                        
  - Fit-readiness: device_features/probe_live_features emit total_mem (VRAM) → Context.features() carries H_total_mem, the one feature that distinguishes same-die SKUs.             
  - Canonicalization: populated the registry aliases so live_name maps bare cudaDeviceProp.name ("NVIDIA H200") → canonical ("NVIDIA H200 141GB"), so live node rows and goldens     
  share one gpu string.                                                                                                                                                              
  - Eval: node_report groups per card, so same-die ops (identical S_*, different latencies) are never mixed.                                                                         
                                                                                                                                                                                     
  Testing                                                                                                                                                                            
                                                                                                                                                                                     
  GPU-folded key, gpu column round-trip + migration + degrade, hardware_id, total_mem symmetry, alias canonicalization + uniqueness guard, per-card report. make test green (1919    
  passed); make lint clean.