### PR TITLE
Point embedding recipes at the vllm-emmy image + EmmyEmbedModel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python virtual environment
 venv/
+venv
 
 # Python cache
 __pycache__/

--- a/recipes/Qwen3-Embedding-0.6B/recipe.yaml
+++ b/recipes/Qwen3-Embedding-0.6B/recipe.yaml
@@ -42,11 +42,11 @@ matrices:
     zip:
       engine.llm.vllm.image:
         - "vllm/vllm-openai:v0.22.1"
-        # pinned to the existing published image (registers DeplodockEmbedModel); bump to vllm-emmy + EmmyEmbedModel once rebuilt+pushed
-        - "cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b"
+        # emmy compiled-kernel serving image (registers EmmyEmbedModel)
+        - "cloudriftai/vllm-emmy:0.22.1-90c70d5e"
       engine.llm.vllm.extra_args:
         - "--runner pooling"
-        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"DeplodockEmbedModel\"]}'"
+        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"EmmyEmbedModel\"]}'"
 
 aggregate:
   run: |

--- a/recipes/Qwen3-Embedding-4B/recipe.yaml
+++ b/recipes/Qwen3-Embedding-4B/recipe.yaml
@@ -42,11 +42,11 @@ matrices:
     zip:
       engine.llm.vllm.image:
         - "vllm/vllm-openai:v0.22.1"
-        # pinned to the existing published image (registers DeplodockEmbedModel); bump to vllm-emmy + EmmyEmbedModel once rebuilt+pushed
-        - "cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b"
+        # emmy compiled-kernel serving image (registers EmmyEmbedModel)
+        - "cloudriftai/vllm-emmy:0.22.1-90c70d5e"
       engine.llm.vllm.extra_args:
         - "--runner pooling"
-        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"DeplodockEmbedModel\"]}'"
+        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"EmmyEmbedModel\"]}'"
 
 aggregate:
   run: |

--- a/recipes/Qwen3-Embedding-8B/recipe.yaml
+++ b/recipes/Qwen3-Embedding-8B/recipe.yaml
@@ -43,11 +43,11 @@ matrices:
     zip:
       engine.llm.vllm.image:
         - "vllm/vllm-openai:v0.22.1"
-        # pinned to the existing published image (registers DeplodockEmbedModel); bump to vllm-emmy + EmmyEmbedModel once rebuilt+pushed
-        - "cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b"
+        # emmy compiled-kernel serving image (registers EmmyEmbedModel)
+        - "cloudriftai/vllm-emmy:0.22.1-90c70d5e"
       engine.llm.vllm.extra_args:
         - "--runner pooling"
-        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"DeplodockEmbedModel\"]}'"
+        - "--runner pooling --enforce-eager --hf-overrides '{\"architectures\":[\"EmmyEmbedModel\"]}'"
 
 aggregate:
   run: |


### PR DESCRIPTION
## What

Following the deplodock→emmy rename (#286), the new serving image
`cloudriftai/vllm-emmy:0.22.1-90c70d5e` has been built and pushed, and the plugin
architecture is now `EmmyEmbedModel`. This updates the Qwen3-Embedding recipes to use it.

## Changes

- **recipes/Qwen3-Embedding-{0.6B,4B,8B}/recipe.yaml** — the plugin variant of the
  stock-vs-emmy `zip` now points at `cloudriftai/vllm-emmy:0.22.1-90c70d5e` (was the stale
  `cloudriftai/vllm-deplodock:0.22.1-8c7b0e9b`) and passes
  `--hf-overrides '{"architectures":["EmmyEmbedModel"]}'` (was `DeplodockEmbedModel`). Stale
  "bump once rebuilt+pushed" comment removed. The stock `vllm/vllm-openai:v0.22.1` A/B leg is
  unchanged.
- **.gitignore** — also ignore a slash-less `venv` so a `venv` symlink (pointing at a venv on
  another disk) is ignored, not just a real `venv/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)