### PR TITLE
Publish to PyPI as emmy-llm (name emmy is taken)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 *.cubin
 
 # Python egg-info
-emmy.egg-info/
+*.egg-info/
 
 # Build and run artifacts
 dist/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://pypi.org/project/emmy/"><img src="https://img.shields.io/pypi/v/emmy" alt="PyPI"></a>
+  <a href="https://pypi.org/project/emmy-llm/"><img src="https://img.shields.io/pypi/v/emmy-llm" alt="PyPI"></a>
   <a href="https://github.com/cloudrift-ai/emmy/actions/workflows/tests.yml"><img src="https://github.com/cloudrift-ai/emmy/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
   <a href="https://discord.gg/cloudrift"><img src="https://img.shields.io/discord/1150997934113030174?label=Discord" alt="Discord"></a>
 </p>

--- a/docker/vllm-emmy/Dockerfile
+++ b/docker/vllm-emmy/Dockerfile
@@ -18,8 +18,8 @@ FROM vllm/vllm-openai:${VLLM_VERSION}
 # The cupy wheel must match the image's CUDA major (vllm-openai:v0.22.1
 # ships CUDA 13.0 + nvcc; transformers 5.10.2 satisfies the compile pin).
 ARG CUPY_PACKAGE=cupy-cuda13x
-COPY dist/emmy-*.whl /tmp/wheels/
-RUN pip install --no-cache-dir --no-deps /tmp/wheels/emmy-*.whl \
+COPY dist/emmy_llm-*.whl /tmp/wheels/
+RUN pip install --no-cache-dir --no-deps /tmp/wheels/emmy_llm-*.whl \
     && pip install --no-cache-dir "${CUPY_PACKAGE}" catboost pyyaml httpx "huggingface_hub[hf_transfer]" safetensors \
     && rm -rf /tmp/wheels
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "emmy"
+name = "emmy-llm"
 version = "0.1.0"
 description = "Deploy and benchmark LLM inference on GPU servers using vLLM"
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "huggingface_hub[cli,hf_transfer]",


### PR DESCRIPTION
## Why

The deplodock→emmy rename (#286) can't publish to PyPI as `emmy` — that name is already owned by an
unrelated project (`pypi.org/project/emmy`, user *Joyoforigami*). So the **distribution** is published
as **`emmy-llm`** while the **import package / CLI stay `emmy`** (`pip install emmy-llm` → `import emmy`,
`emmy …` CLI). Version stays `0.1.0` — a valid first release under the new name.

## Changes

- **pyproject.toml** — `name = "emmy-llm"`; add `readme = "README.md"` so the PyPI page renders
  (`twine check` went from PASSED-with-warnings to clean).
- **docker/vllm-emmy/Dockerfile** — the wheel is now `emmy_llm-*.whl`, so the `COPY` / `pip install`
  globs move `emmy-*.whl` → `emmy_llm-*.whl`. Without this the serving-image build (`make vllm-emmy-image`)
  matches no wheel and fails.
- **README.md** — PyPI badge repointed `emmy` → `emmy-llm`.
- **.gitignore** — generalize `emmy.egg-info/` → `*.egg-info/` (build now emits `emmy_llm.egg-info/`;
  also sweeps the stale `deplodock`/`emmy` egg-infos).

## Publishing

`.github/workflows/publish.yml` is **name-agnostic** (reads version/name from `pyproject.toml` + the built
dist, trusted-publishing via OIDC) and needs no edits. After merge, publish by creating a GitHub Release
tagged **`v0.1.0`** — CI runs tests → build → publish.

⚠️ **One-time PyPI setup required:** because `emmy-llm` is a brand-new project, a **pending trusted
publisher** must be registered on PyPI first, matching the GitHub repo as it is **now renamed to
`cloudrift-ai/emmy`**:
- PyPI project: `emmy-llm`
- Owner: `cloudrift-ai`
- Repository: `emmy`  *(not `deplodock` — the OIDC claim carries the current repo name)*
- Workflow: `publish.yml`
- Environment: `pypi`

Otherwise the publish job's OIDC exchange is rejected on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)