### PR TITLE
Bump version to 0.1.1 for first emmy-llm PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emmy-llm"
-version = "0.1.0"
+version = "0.1.1"
 description = "Deploy and benchmark LLM inference on GPU servers using vLLM"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bumps `pyproject.toml` version `0.1.0` → `0.1.1` so the first PyPI release under the new **`emmy-llm`**
name can be cut.

**Why not 0.1.0:** the `v0.1.0` git tag is already used by the historical **deplodock 0.1.0** release
(2026-03-04, published to PyPI). `.github/workflows/publish.yml` hard-checks `tag == pyproject version`,
so publishing `emmy-llm` needs a fresh tag — `v0.1.1`. `emmy-llm` is a brand-new PyPI project (no existing
releases).

After merge: create a GitHub Release tagged **`v0.1.1`** to trigger test → build → publish (trusted
publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)