### PR TITLE
Fix publish workflow test job to match the maintained CI lane

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: make setup
+        run: make setup-ci
 
       - name: Ruff check
         run: ./venv/bin/ruff check
@@ -23,8 +23,20 @@ jobs:
       - name: Ruff format check
         run: ./venv/bin/ruff format --check
 
+      # Cache the HuggingFace hub downloads (TinyLlama-1.1B-Chat-v1.0 +
+      # Qwen/Qwen3-Embedding-0.6B). The anonymous HF CDN rate-limits the
+      # shared runner egress IPs — 429s on config.json have killed multiple
+      # runs — and with a populated cache ``from_pretrained`` falls back to
+      # the cached files when the hub is unreachable. Bump the key suffix
+      # when tests start needing new models.
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-models-v1
+
       - name: Run tests
-        run: ./venv/bin/pytest tests/ -v
+        run: make test
 
   build:
     needs: test


### PR DESCRIPTION
## Problem

Cutting the `v0.1.1` release (first release since deplodock 0.1.0 in March) failed: the `publish.yml`
**test** job errored, so **build/publish were skipped** and nothing published. Root cause is workflow
drift, not the code — `publish.yml`'s test job diverged from the maintained `tests.yml` lane:

| | `tests.yml` (PR check — **green**) | `publish.yml` (release — **failed**) |
|---|---|---|
| setup | `make setup-ci` (CPU torch, `.[compile,test]`, no cupy) | `make setup` (`.[dev]` — cupy + CUDA torch) |
| run | `make test` (`EMMY_NVCC_FLAGS=-O1`, xdist) | raw `./venv/bin/pytest tests/ -v` |

With cupy/CUDA-torch installed, the `tests/compiler/ir/test_dynamic_shapes.py` tests slip past their
cupy skip-guard and then hit `RuntimeError: nvcc unavailable` on the GPU-less runner (plus two
`test_tune_devices.py` CLI tests exiting `2`). Under `make setup-ci` (no cupy) they skip cleanly.

## Fix

Align the `test` job with `tests.yml`: `make setup-ci` + HF-model cache + `make test`. These are the exact
commands the PR `test` check already passes on this commit, so the release run will pass too. The ruff
gate is kept ahead of the tests.

## After merge

The failed `v0.1.1` tag/release will be recreated on this fixed `main` to re-trigger publish (nothing was
published, so it's safe to recreate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)