### PR TITLE
Document the PyPI release procedure in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,23 @@ make format    # auto-fix
 4. `make test && make lint` (use `make format` to auto-fix).
 5. Open a PR against `main`.
 
+## Releasing
+
+Publishes to [PyPI as `emmy-llm`](https://pypi.org/project/emmy-llm/) via GitHub Actions
+([publish.yml](.github/workflows/publish.yml)) when a GitHub Release is published — trusted publishing
+(OIDC), no API token. The distribution is `emmy-llm` (the name `emmy` was taken); the import package and CLI
+stay `emmy` (`pip install emmy-llm` → `import emmy`).
+
+```bash
+# 1. Bump `version` in pyproject.toml to a NEW value (PyPI versions and git tags are immutable).
+# 2. Merge to main, then cut a Release whose tag is v<version> — CI hard-checks tag == pyproject version:
+gh release create v0.1.2 --target main --title "emmy-llm 0.1.2" --generate-notes
+```
+
+CI runs `make test` → build → publish. A brand-new distribution name first needs a one-time
+[PyPI trusted publisher](https://docs.pypi.org/trusted-publishers/) registered (owner `cloudrift-ai`, repo
+`emmy`, workflow `publish.yml`, environment `pypi`).
+
 ## License
 
 Licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
Adds a terse, example-driven **Releasing** section to the README (between Contributing and License) so the
trusted-publishing flow is written down:

- Bump `version` in `pyproject.toml` (new value — PyPI versions and git tags are immutable).
- Cut a GitHub Release tagged `v<version>`; CI (`publish.yml`) hard-checks tag == version, then runs
  `make test` → build → publish to [PyPI as `emmy-llm`](https://pypi.org/project/emmy-llm/) via OIDC (no token).
- Notes the `emmy-llm` distribution vs `emmy` import/CLI split, and the one-time trusted-publisher setup for
  a new distribution name.

Captures the workflow established by #288 / #289 / #290 and the 0.1.1 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)