### PR TITLE
Recognize the fused norm→linear / gate-up composition as a computed-A multi-fold Contraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,15 @@ The `README.md` is intentionally short — example-driven, no narrative. For det
   a tree of **structural nodes** (all in `ir/tile/ir.py`): a `PLANAR`/`TWISTED` reduce lifts to a typed `Reduction`
   (its `Carrier` + reduce `axis` + `partial` split out, the fold `Loop` synthesized on demand, holding no
   projection); EVERY recognized contraction — per-cell scalar included — is a `Contraction` node (nodified at
-  recognize time with a deferred `TilePlan()`; an unbindable one demotes to `PLANAR`); the lift / projection wrapper
-  is a `Map` (`body` + an optional `source: Reduction | Contraction | None` — `project ∘ reduce`). A bare reduce is
-  the root `Reduction`; softmax/RMSNorm is a `Map(body=sweep, source=Reduction)`; a pure pointwise cell is a
-  `Map(source=None)`; the only annotated `Loop`s still riding a flat `Map.body` are `030_split`'s sliced partials.
+  recognize time with a deferred `TilePlan()`; an unbindable one demotes to `PLANAR`), carrying its ⊗-folds as
+  `folds` **channels** — `(B, acc)` pairs sharing one A operand (the product-monoid fold: one channel is a plain
+  matmul, N channels the fused gate/up MLP edge); the lift / projection wrapper is a `Map` (`body` + an optional
+  `source: Reduction | Contraction | None` — `project ∘ reduce`). A bare reduce is the root `Reduction`;
+  softmax/RMSNorm is a `Map(body=sweep, source=Reduction)`; the fused norm→linear / gate-up composition is a
+  `Map(body=combine, source=Contraction)` whose computed A cone carries the statistic prologue (a fork sibling of
+  its coop-reduce form — option-0 stays coop; the warp mma rows ride the sync compute-fill); a pure pointwise cell
+  is a `Map(source=None)`; the only annotated `Loop`s still riding a flat `Map.body` are `030_split`'s sliced
+  partials.
   Dispatch reads the role/carrier off the node (`ops.axis_role`/`reduce_loop` recurse through `Map.source`), and
   `ops.lower` flattens any node back to the same loop nest — there is no stored `Monoid`/`Semiring` node kind (those
   wrappers were retired). Flash attention is the `TWISTED` reduce on the streaming schedule, a twisted monoid is a

--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1286,6 +1286,10 @@ class RegEpilogue:
     # carries ``__M__`` / ``__N__`` placeholder Vars the store substitutes with
     # the fragment element's own (row, col); the last branch is the else.
     selects: tuple[tuple[str, tuple[tuple[Expr | None, str], ...]], ...] = ()
+    # Additional ``(acc_name, frag_name)`` accumulator bindings — a multi-fold contraction's
+    # extra C fragments (the fused gate/up edge): each name substitutes to its fragment's
+    # element alongside ``acc``, so the chain combines the folds per cell (SwiGLU et al).
+    extra_accs: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -1329,7 +1333,8 @@ class RegStore(Stmt):
     n_guard: tuple[Expr, Expr] | None = None
 
     def deps(self) -> tuple[str, ...]:
-        return (self.frag,)
+        extra = () if self.epilogue is None else tuple(fr for _, fr in self.epilogue.extra_accs)
+        return (self.frag, *extra)
 
     def external_reads(self) -> tuple[str, ...]:
         # The fused epilogue's leaf loads are gmem reads this stmt performs
@@ -1397,7 +1402,7 @@ class RegStore(Stmt):
             row = "_g" if i < 2 else "(_g + 8)"
             col = f"(_t * 2 + {i & 1})"
             lines: list[str] = []
-            env = {epi.acc: f"{self.frag}[{i}]"}
+            env = {epi.acc: f"{self.frag}[{i}]", **{a: f"{fr}[{i}]" for a, fr in epi.extra_accs}}
             for ld in epi.loads:
                 temp = f"{ld.name}_e{i}"
                 if ld.buffer in ctx.literal_constants:

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -47,7 +47,7 @@ from emmy.compiler.ir.axis import Axis, AxisRole
 from emmy.compiler.ir.base import Op
 from emmy.compiler.ir.expr import Expr, Literal
 from emmy.compiler.ir.schedule import Placement, ReducePlan, Stage, TilePlan, WarpSpec
-from emmy.compiler.ir.stmt import INDENT, Accum, Body, Carrier, Load, Loop, RenderCtx, Stmt, pretty_body
+from emmy.compiler.ir.stmt import INDENT, Accum, Assign, Body, Carrier, Load, Loop, RenderCtx, Stmt, pretty_body
 
 if TYPE_CHECKING:
     from emmy.compiler.ir.atom import Atom
@@ -192,6 +192,33 @@ class Side:
         return _ext_expr(self.axis)
 
 
+def _deep_defines(s: Stmt) -> set[str]:
+    """Every SSA name defined in ``s`` (deep — a stat reduce ``Loop``'s ``Accum`` counts)."""
+    out = set(s.defines())
+    for b in s.nested():
+        for child in b:
+            out |= _deep_defines(child)
+    return out
+
+
+def _deep_reads(stmts: list[Stmt]) -> set[str]:
+    """Every SSA name read anywhere in ``stmts`` (deep)."""
+    out: set[str] = set()
+    for s in stmts:
+        out |= set(s.deps())
+        for b in s.nested():
+            out |= _deep_reads(list(b))
+    return out
+
+
+def _refs_axis(s: Stmt, name: str) -> bool:
+    """``s`` references axis ``name`` in any index expr (deep)."""
+    idx = getattr(s, "index", None)
+    if idx and any(name in e.free_vars() for e in idx):
+        return True
+    return any(_refs_axis(child, name) for b in s.nested() for child in b)
+
+
 @dataclass(frozen=True)
 class Contraction(Stmt):
     """A contraction **before** atom factorization — built **recognize-side** at fork-emit
@@ -202,8 +229,8 @@ class Contraction(Stmt):
     register-tiles through the shared ``_contract_kloop`` skeleton. **ONE
     flat node** that cleanly splits the **algebra params** (what to contract) from the **schedule**
     (how to tile it): the params are the tiled output ``axes`` ``(m, n)``, the contraction ``k_axis``,
-    the leading batch ``lead_axes``, the structured A/B operand ``Load``\\ s, the fold accumulator
-    ``acc``, and the projection ``epilogue`` (which carries the output ``Write``); the schedule is the
+    the leading batch ``lead_axes``, the A operand, the ``folds`` fold channels (``(b_load, acc)``
+    pairs), and the projection ``epilogue`` (which carries the output ``Write``); the schedule is the
     one ``tile`` field — a resolved :class:`~emmy.compiler.ir.schedule.TilePlan` carrying the
     leaf ``atom`` (tensor-core :class:`AtomKind` or the ``1×1`` :class:`ScalarAtom`), the per-CTA
     **UNIT** grid + per-unit **REGISTER** sub-tile, and the K-chunk. Keeping the schedule a single
@@ -223,8 +250,14 @@ class Contraction(Stmt):
     axes: tuple[Axis, Axis]  # the tiled output (m_axis, n_axis) — params
     k_axis: Axis  # the contraction axis — params
     a_operand: Load | Body  # A: a gmem ``Load`` OR a computed register-resident ``Body`` (flash PV's ``P = exp(S − M)``) — params
-    b_load: Load  # params
-    acc: str  # params
+    # The fold CHANNELS — ``(b_load, acc)`` per channel, every channel folding the SAME lifted A
+    # value over the same ``(m, n, k)`` space: the product-monoid carrier specialized to
+    # contractions. One channel is the ordinary matmul; N channels is the fused gate/up MLP edge
+    # (``swiglu(x̂@Wg, x̂@Wu)`` — the combine is projection, riding the wrapping ``Map.body``, never
+    # per-step state). A multi-channel node is computed-A only and lowers through the warp ``sync``
+    # compute-fill tier alone: one A fragment reused across the per-channel mma chains, one C
+    # fragment per channel.
+    folds: tuple[tuple[Load, str], ...]
     tile: TilePlan  # the schedule: leaf atom + unit/register widths + K-chunk (the only schedule field)
     lead_axes: tuple[Axis, ...] = ()  # params
     epilogue: Body = field(default_factory=Body)  # params
@@ -232,11 +265,26 @@ class Contraction(Stmt):
     def __post_init__(self) -> None:
         if not isinstance(self.epilogue, Body):
             object.__setattr__(self, "epilogue", Body(self.epilogue))
+        assert self.folds, "a Contraction needs at least one fold channel"
+        k = self.k_axis.name
+        assert len({k in bl.index[-1].free_vars() for bl, _ in self.folds}) == 1, (
+            "every fold channel's B layout must agree (one b_trans per node)"
+        )
+
+    # ---- the primary fold channel unpacked (the single-fold common case; every multi-channel
+    # consumer iterates ``folds`` itself) ---------- #
+    @property
+    def b_load(self) -> Load:
+        return self.folds[0][0]
+
+    @property
+    def acc(self) -> str:
+        return self.folds[0][1]
 
     @property
     def out(self) -> str:
-        """The bound output name — the fold accumulator (a bare contraction's grid ``Write`` stores
-        ``acc`` at the cell; a fused-epilogue contraction carries its own ``Write`` in ``epilogue``)."""
+        """The bound output name — the primary fold accumulator (a bare contraction's grid ``Write``
+        stores it at the cell; a fused-projection contraction carries its own ``Write``)."""
         return self.acc
 
     @property
@@ -257,6 +305,23 @@ class Contraction(Stmt):
         """The A operand's bound SSA name (its producing body's last def)."""
         return self.a_body[-1].defines()[-1]
 
+    def stat_prologue(self) -> tuple[tuple[Stmt, ...], tuple[Stmt, ...], tuple[str, ...]]:
+        """Split the computed-A body at the contraction-axis seam: the maximal leading run of stmts
+        that never index the K axis is the **per-row statistic prologue** (the fused norm→linear
+        cone's stat reduce ``Loop`` + scalar epilogue — or a broadcast row scale), the remainder the
+        **per-cell** cone. Returns ``(prologue, cell, stats)`` — ``stats`` are the prologue defs the
+        cell reads, the values bridged through the stat smem rows (a prologue whose defs go unread
+        is dropped). The ONE seam both sides read: the scheduler sizes the stat rows into the sync
+        stage's smem budget, the materializer fills them (``sync_stat_fill``)."""
+        body = list(self.a_body)
+        pro: list[Stmt] = []
+        while body and not _refs_axis(body[0], self.k_axis.name):
+            pro.append(body.pop(0))
+        if not pro:
+            return (), tuple(body), ()
+        stats = tuple(sorted({nm for s in pro for nm in _deep_defines(s)} & _deep_reads(body)))
+        return (tuple(pro), tuple(body), stats) if stats else ((), tuple(body), ())
+
     @property
     def loop(self) -> Loop:
         """The synthesized ``CONTRACTION`` reduce ``Loop`` — the canonical ``for k: v = a*b; acc += v``
@@ -266,12 +331,22 @@ class Contraction(Stmt):
         from emmy.compiler.ir.elementwise import ElementwiseImpl  # noqa: PLC0415
         from emmy.compiler.ir.tile.ops import contraction_loop  # noqa: PLC0415 — avoid an import cycle
 
-        return contraction_loop(
+        base = contraction_loop(
             lift=ElementwiseImpl("multiply"),
             fold=Accum(name=self.acc, value=f"{self.acc}__v", op=ElementwiseImpl("add"), axes=(self.k_axis.name,)),
             operand_bodies=([self.b_load], self.a_body),  # B[k, n], A[m, k] (or A's computed body) — keep B-then-A load reuse
             reduce_axis=self.k_axis,
         )
+        if len(self.folds) == 1:
+            return base
+        # Each extra fold channel splices its ``b_load → lift → accum`` triple after the primary's,
+        # reusing the shared A value (the carrier stays the primary channel's — a multi-channel node
+        # never rides the coop / split tiers, so the carrier only serves role/axis reads).
+        extra: list[Stmt] = []
+        for bl, acc in self.folds[1:]:
+            lift = Assign(name=f"{acc}__v", op=ElementwiseImpl("multiply"), args=(self.a_name, bl.names[0]))
+            extra += [bl, lift, Accum(name=acc, value=lift.name, op=ElementwiseImpl("add"), axes=(self.k_axis.name,))]
+        return Loop(axis=base.axis, body=Body((*base.body, *extra)), unroll=base.unroll, role=base.role, carrier=base.carrier)
 
     def lower(self) -> list[Stmt]:
         """Flatten to the loop-IR body — the synthesized reduce ``Loop`` followed by the projection
@@ -337,7 +412,7 @@ class Contraction(Stmt):
         return replace(self, epilogue=epilogue)
 
     def defines(self) -> tuple[str, ...]:
-        return (self.acc,)
+        return tuple(acc for _, acc in self.folds)
 
     def external_reads(self) -> tuple[str, ...]:
         def loads(stmts):
@@ -349,12 +424,14 @@ class Contraction(Stmt):
 
         # Deep over the A body — a computed cone may nest its loads (the fused norm→linear cone's
         # per-row statistic reduce ``Loop``).
-        return (*dict.fromkeys(loads(self.a_body)), self.b_load.input)
+        return (*dict.fromkeys(loads(self.a_body)), *(bl.input for bl, _ in self.folds))
 
     def pretty(self, indent: str = "") -> list[str]:
         t = " trans" if self.b_trans else ""
         a_src = self.a_operand.input if isinstance(self.a_operand, Load) else self.a_name
-        ops = f"{a_src} @ {self.b_load.input}{t} -> {self.acc} ({self.atom.name})"
+        bs = " + ".join(bl.input for bl, _ in self.folds)
+        accs = ", ".join(acc for _, acc in self.folds)
+        ops = f"{a_src} @ {bs}{t} -> {accs} ({self.atom.name})"
         return [f"{indent}Contraction [{self.m_axis.name}, {self.n_axis.name}] {ops}", *pretty_body(self.epilogue, indent + INDENT)]
 
     def render(self, ctx: RenderCtx) -> list[str]:
@@ -380,8 +457,7 @@ def _(s: Contraction, rename, sigma, axis_fn):
         axes=tuple(axis_fn(a) for a in s.axes),
         k_axis=axis_fn(s.k_axis),
         a_operand=a_operand,
-        b_load=_rewrite(s.b_load, rename, sigma, axis_fn),
-        acc=rename(s.acc),
+        folds=tuple((_rewrite(bl, rename, sigma, axis_fn), rename(acc)) for bl, acc in s.folds),
         tile=s.tile,
         lead_axes=tuple(axis_fn(a) for a in s.lead_axes),
         epilogue=Body(tuple(_rewrite(c, rename, sigma, axis_fn) for c in s.epilogue)),

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -18,11 +18,11 @@ layout rules that drift apart) and silently narrows coverage to the shapes someo
 
 How to comply:
 
-- **Write the rule per element, not per shape.** Example: `lowering/tile/split/010_split_demoted.try_split_demoted`
-  classifies each multiply operand independently (plain `Load` stays put; computed cone becomes a producer
-  materialized over exactly the axes it reads). Norm→linear, scale→matmul, SDPA P@V, and rotary QK^T are
-  *instances* of that one rule, not branches — and a shape nobody designed for (a weight-side dequant cone) is
-  covered for free.
+- **Write the rule per element, not per shape.** Example: `lowering/tile/_atomize.map_cone` /
+  `bind_prologue_contraction` classify each ⊗-fold operand independently (plain `Load` stays put; a computed cone is
+  bound as the shared A value by value-tree equality, however many fold channels read it). Norm→linear, gate/up +
+  SwiGLU, scale→matmul, SDPA P@V, and rotary QK^T are *instances* of that one rule, not branches — and a shape
+  nobody designed for (a weight-side dequant cone) is covered for free.
 - **Gate in the negative.** Enumerating admissible shapes is shape matching by another name. Walk the body and
   report the first thing the transform *fundamentally cannot do*, like `lowering/_predicates.classify_fragment_epilogue`
   (the epilogue folds unless it has an ineligible op/dependency) — the eligible set then grows with the renderer
@@ -58,6 +58,15 @@ bound (e.g. a non-`Load` operand — a computed-cone / demoted matmul) is reject
   option builders resolve it against the built node ONCE (`_resolve_warp_stage` / `_resolve_scalar_stage` — transport
   eligibility, the slab K-chunk `bk_elems`, the depth clamps) and stamp the resolved `Stage` (or `None`, gmem-direct)
   on the `TileOp`, so the materializer's one staged driver applies it verbatim, deciding nothing.
+- the **MONOID-producer composition** — the fused norm→linear edge and its N-channel form, the gate/up MLP edge —
+  binds at recognize time too (`_atomize.bind_prologue_contraction`, structure-only): a projecting `Map` over a
+  per-row `PLANAR` statistic whose tail is one or more ⊗-folds of one shared A value nodifies to
+  `Map(body=projection, source=Contraction)` — the computed-A `Contraction` carrying the statistic prologue in its A
+  cone and the `(B, acc)` channels on `folds` (a product-monoid fold: channels never interact per step; the combine
+  — SwiGLU — is projection, riding the wrapping `Map.body`). `010_recognize` schedules it as a fork SIBLING of the
+  cooperative reduce form (option-0 stays the coop row; the warp mma rows ride the mandatory `sync` compute-fill;
+  dtype / geometry legality stays schedule-side in `_computed_a_rows`). This retired the pin-only
+  `_prologue_warp_option` rescue.
 - a cooperative / ILP reduce (`PLANAR` / `TWISTED`, or a non-output-tiled `CONTRACTION`) needs **no** binding here — its
   accumulator dtype + the shuffle/tree fold mechanism are **derived** at materialize time (`emit_combine` off the carrier
   + `ReduceStage.combine`), never stored. Its one schedule-time staging decision follows the same
@@ -71,9 +80,10 @@ reuse it on flash's nested QK^T / PV; flash's inner score IS now a structural `C
 `TilePlan()` today, `source` of the streaming `Reduction` — the `Reduction ⊃ Contraction` composition), so warp-flash is
 just that node gaining a warp `TilePlan` — no new path.
 
-**The move catalog** (`lowering/tile/_catalog.py`) is the permitted-move enumeration the schedule emit forks over, keyed
-on `AxisRole`: `scalar_tile_moves()` is the legality-guarded scalar register-tile product (`par × reg`, `block_threads ≤
-1024`) with per-cell `""` as the conservative option-0, returned by `_schedule._tile_specs` for an unpinned contraction
-so `compile` / `tune` explores the tile space (each spec → a structural `Contraction`-node leaf under `TILE@<k_axis>`; an
-env pin wins via `Knob.narrow`). Warp / reduce / stage move families and the hierarchical `build_fork_tree` levels (the
-MCTS laziness + multi-node flash bundling) fold in next; a flat list suffices for today's single-node scalar product.
+**The move catalog** (`search/space.py`) is the permitted-move enumeration the schedule emit forks over, keyed on
+`AxisRole`: `scalar_tile_moves()` is the legality-guarded scalar register-tile product (`par × reg`, `block_threads ≤
+1024`) with per-cell `""` as the conservative option-0, crossed with the warp / reduce / stage move families by
+`_schedule._tile_rows` for an unpinned contraction so `compile` / `tune` explores the space (each row → a structural
+`Contraction`-node leaf keyed `TILE@<k_axis>` in a hierarchical `build_fork_tree`; an env pin wins via `Knob.narrow`).
+A computed-A (fused-cone) contraction enumerates its own warp-only rows (`_schedule._computed_a_rows` — the mandatory
+resolved `sync` compute-fill stage, no scalar / gmem-direct / split-K rows).

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -138,14 +138,18 @@ flash operand) silently falls back to gmem-direct, and a staged kernel is
 under a warp `TILE` pin: `_schedule._demoted_warp_option` nodifies the PLANAR ⊗-fold to a computed-A `Contraction`
 (the same `a_operand = Body` flash P@V rides) and stamps a `sync` `Stage`; `_staged` then builds a `SyncTransport`
 whose A fill is the producer CONE evaluated per slab cell (compute-fill) and whose B fill is a plain copy — the same
-`fill`/`commit`/`wait` seam, single-buffer, one CTA barrier, feeding the unchanged `ldmatrix` drain. Pin-driven,
-exact-cover geometry (static M/N/K divisible; masks are a follow-on). A **reduce-bearing (MONOID) cone** — the fused
-norm→linear edge (`_schedule._prologue_warp_option`) — fuses too: the A cone carries its k-invariant prefix (the
-per-row statistic reduce `Loop` + scalar epilogue), split off at the K seam by `_sync_operands`
+`fill`/`commit`/`wait` seam, single-buffer, one CTA barrier, feeding the unchanged `ldmatrix` drain. A
+**reduce-bearing (MONOID) cone** — the fused norm→linear edge — is nodified at RECOGNIZE time
+(`_atomize.bind_prologue_contraction`; real fork rows, not a pin rescue): the A cone carries its k-invariant prefix
+(the per-row statistic reduce `Loop` + scalar epilogue), split off at the K seam by `_sync_operands`
 (`_split_stat_prologue`) and run ONCE per tile row as the transport prologue (`_stage.sync_stat_fill` — threads
 stripe the tile's rows, each folds its row's statistic into a stat smem row, one barrier); the per-cell compute-fill
 reads the bridged values back from the stat rows. The prologue is a one-shot `SyncTransport.prologue`, ahead of the
-staged K-loop.
+staged K-loop. Geometry: exact cover on N/K only — a masked / symbolic **M** clamp-reads (the A / stat-prologue σ
+ride `_clamp_last`; the overhang store is discarded by the `RegStore` guard). A **multi-fold** node (the gate/up MLP
+edge — N `(B, acc)` channels folding one shared A value, `Contraction.folds`) fills one B slab per channel, drains N
+mma chains off the ONE ldmatrix'd A fragment into per-channel C fragments (`_fold_frag`), and the projection
+(SwiGLU) combines the channels per element in the store's `RegEpilogue` (`extra_accs`).
 
 The **scalar** contraction tier stages too, under the same `STAGE` codec, through the **same** `_staged` driver — the
 scheduler's `_resolve_scalar_stage` sizes the slab (the depth-aware fit-to-smem K-chunk `bk_elems`, not a codec field;

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -111,9 +111,12 @@ def _warp_roles(index, m_name: str, n_name: str) -> tuple[str, ...]:
     return tuple(roles)
 
 
-def _warp_epilogue(tail: list[Stmt], acc: str, m_name: str, n_name: str, sigma: Sigma) -> RegEpilogue | None:
+def _warp_epilogue(
+    tail: list[Stmt], acc: str, m_name: str, n_name: str, sigma: Sigma, extra_accs: tuple[tuple[str, str], ...] = ()
+) -> RegEpilogue | None:
     """Fold the projection ``Map`` into a :class:`RegEpilogue` for cell ``sigma``. ``None`` when
-    there is no projection (a bare ``Write`` of the accumulator).
+    there is no projection (a bare ``Write`` of the accumulator). ``extra_accs`` binds a multi-fold
+    node's additional ``(acc, C-fragment)`` pairs so the chain combines the channels per element.
 
     The projection is the post-reduce ``tail`` stmts: the leaf ``Load``s + pointwise ``Assign``s +
     an optional causal ``Select``. Each leaf ``Load`` becomes an :class:`EpilogueLoad` at the
@@ -142,7 +145,7 @@ def _warp_epilogue(tail: list[Stmt], acc: str, m_name: str, n_name: str, sigma: 
             write = s
     if write is None or (not ops and not selects):
         return None
-    return RegEpilogue(acc=acc, loads=tuple(loads), ops=tuple(ops), result=write.value, selects=tuple(selects))
+    return RegEpilogue(acc=acc, loads=tuple(loads), ops=tuple(ops), result=write.value, selects=tuple(selects), extra_accs=extra_accs)
 
 
 # ---- operand staging (smem slab + ldmatrix drain) ---------------------------------------------- #
@@ -153,13 +156,22 @@ def _warp_epilogue(tail: list[Stmt], acc: str, m_name: str, n_name: str, sigma: 
 # bit-identical to its gmem-direct baseline. The transport primitives (the fill loops + the
 # commit/wait / mbarrier handshakes) live in ``_stage.py``; these functions schedule them onto the
 # K-loop off the :class:`Contraction` geometry.
+def _fold_frag(base: str, fold: int) -> str:
+    """The per-fold-channel fragment name — the primary channel keeps the historic bare spelling
+    (``_b0`` / ``_c0_0``), extra channels suffix ``_x<f>`` (the multi-B gate/up node)."""
+    return base if fold == 0 else f"{base}_x{fold}"
+
+
 def _staged_inner_atom_loop(
-    *, slabs: tuple[str, str], mn: tuple[Side, Side], atom, bk_elems, ki, reg_depth: int = 1, offs=(None, None)
+    *, slabs: tuple[str, ...], mn: tuple[Side, Side], atom, bk_elems, ki, reg_depth: int = 1, offs=None
 ) -> list[Stmt]:
     """The inner atom-K drain shared by the cp.async and TMA staged paths: read the A/B ``slabs`` via
-    ``LdmatrixLoad(staged=True)`` + ``MmaSyncPtx``. Slab-local indices — A[tile_m][bk_elems]
-    (ldm=bk_elems), B[bk_elems][tile_n] (ldm=tile_n) — independent of which producer filled the (plain
-    row-major, NONE-swizzle) slab; ``mn`` is the ``(m, n)`` :class:`Side` pair.
+    ``LdmatrixLoad(staged=True)`` + ``MmaSyncPtx``. ``slabs`` is ``(A, B…)`` — one B slab per fold
+    channel (one for the ordinary matmul; N for the multi-B gate/up node, whose ONE ldmatrix'd A
+    fragment feeds a per-channel mma chain into a per-channel C fragment). Slab-local indices —
+    A[tile_m][bk_elems] (ldm=bk_elems), B[bk_elems][tile_n] (ldm=tile_n) — independent of which
+    producer filled the (plain row-major, NONE-swizzle) slab; ``mn`` is the ``(m, n)`` :class:`Side`
+    pair.
 
     ``reg_depth == 1`` (default): one ``StridedLoop`` over the ``bk`` atom-K steps, ldmatrix-then-mma
     inline (the operand fragments ``_a{i}``/``_b{j}`` reused every step). ``reg_depth >= 2`` (the
@@ -168,34 +180,42 @@ def _staged_inner_atom_loop(
     ``reg_depth-1`` steps ahead while the mma consumes the current slot — breaking the per-step WAR
     hazard on the operand fragments. Numerically identical to the inline form.
 
-    ``offs`` (the gmem→smem ring, ``STAGE`` depth>1): the ``(a, b)`` read SLOT row offsets — added to
+    ``offs`` (the gmem→smem ring, ``STAGE`` depth>1): the per-slab read SLOT row offsets — added to
     each slab's ROW (A's tile row / B's K row) so the drain reads the ring slot the producer already
     filled, while a later chunk prefetches into another slot."""
-    (a_slab, b_slab), (m, n) = slabs, mn
+    (a_slab, *b_slabs), (m, n) = slabs, mn
+    offs = offs if offs is not None else (None,) * len(slabs)
     atom_m, atom_n, atom_k = atom.shape
     n_steps = bk_elems // atom_k
-    # Per-operand drain spec: (tag, slab, ldm, tile-is-slab-row, reg count, warp-unit var, atom dim, slot row off).
-    # A stacks the tile axis on the slab row (K the col); B swaps (K the row, tile the col); the slot
-    # offset always lands on the ROW. The two share ONE emission loop.
-    specs = (
-        ("a", a_slab, bk_elems, True, m.reg, m.unit, atom_m, offs[0]),
-        ("b", b_slab, n.tile, False, n.reg, n.unit, atom_n, offs[1]),
-    )
+    # Per-operand drain spec: (frag base fn, slab, ldm, tile-is-slab-row, reg count, warp-unit var,
+    # atom dim, slot row off). A stacks the tile axis on the slab row (K the col); B swaps (K the
+    # row, tile the col); the slot offset always lands on the ROW. All share ONE emission loop.
+    specs = [(lambda x: f"_a{x}", "a", a_slab, bk_elems, True, m.reg, m.unit, atom_m, offs[0])]
+    for f, bs in enumerate(b_slabs):
+        specs.append(((lambda ff: lambda x: _fold_frag(f"_b{x}", ff))(f), "b", bs, n.tile, False, n.reg, n.unit, atom_n, offs[1 + f]))
 
-    def ldms(kexpr, suffix):  # both operands' ldmatrix reads at K position `kexpr`, into fragment slot `suffix`
+    def ldms(kexpr, suffix):  # every operand's ldmatrix reads at K position `kexpr`, into fragment slot `suffix`
         reads: list[Stmt] = []
-        for tag, slab, ldm, is_row, reg, unit, adim, off in specs:
+        for frag_of, role, slab, ldm, is_row, reg, unit, adim, off in specs:
             for x in range(reg):  # within-tile coord for register cell x: warp·(reg·adim) + x·adim
                 prim = BinaryExpr("+", BinaryExpr("*", Var(unit), Literal(reg * adim, "int")), Literal(x * adim, "int"))
                 row, col = (prim, kexpr) if is_row else (kexpr, prim)
                 if off is not None:
                     row = BinaryExpr("+", off, row)
-                reads.append(LdmatrixLoad(frag=f"_{tag}{x}{suffix}", src_buffer=slab, src_index=(row, col), role=tag, staged=True, ldm=ldm))
+                frag = f"{frag_of(x)}{suffix}"
+                reads.append(LdmatrixLoad(frag=frag, src_buffer=slab, src_index=(row, col), role=role, staged=True, ldm=ldm))
         return reads
 
-    def mmas(suffix):  # every (i, j) cell's mma.sync over the `suffix`-slotted operand fragments
+    def mmas(suffix):  # every fold channel × (i, j) cell's mma.sync over the `suffix`-slotted operand fragments
         return [
-            MmaSyncPtx(c_frag=f"_c{i}_{j}", a_frag=f"_a{i}{suffix}", b_frag=f"_b{j}{suffix}", shape=atom.shape, ab_dtype=atom.ab_dtype)
+            MmaSyncPtx(
+                c_frag=_fold_frag(f"_c{i}_{j}", f),
+                a_frag=f"_a{i}{suffix}",
+                b_frag=f"{_fold_frag(f'_b{j}', f)}{suffix}",
+                shape=atom.shape,
+                ab_dtype=atom.ab_dtype,
+            )
+            for f in range(len(b_slabs))
             for i in range(m.reg)
             for j in range(n.reg)
         ]
@@ -306,49 +326,6 @@ def _cta(mn: tuple[Side, Side], lanes: int, n_threads: int) -> CtaTile:
     return CtaTile(linear_tid=tid, n_threads=n_threads)
 
 
-def _deep_defines(s: Stmt) -> set[str]:
-    """Every SSA name defined in ``s`` (deep — a stat reduce ``Loop``'s ``Accum`` counts)."""
-    out = set(s.defines())
-    for b in s.nested():
-        for child in b:
-            out |= _deep_defines(child)
-    return out
-
-
-def _deep_reads(stmts: list[Stmt]) -> set[str]:
-    """Every SSA name read anywhere in ``stmts`` (deep)."""
-    out: set[str] = set()
-    for s in stmts:
-        out |= set(s.deps())
-        for b in s.nested():
-            out |= _deep_reads(list(b))
-    return out
-
-
-def _refs_axis(s: Stmt, name: str) -> bool:
-    """``s`` references axis ``name`` in any index expr (deep)."""
-    idx = getattr(s, "index", None)
-    if idx and any(name in e.free_vars() for e in idx):
-        return True
-    return any(_refs_axis(child, name) for b in s.nested() for child in b)
-
-
-def _split_stat_prologue(a_body: tuple[Stmt, ...], k_name: str) -> tuple[tuple[Stmt, ...], tuple[Stmt, ...], tuple[str, ...]]:
-    """Split a computed-A body at the contraction-axis seam: the maximal leading run of stmts that
-    never index the K axis is the **per-row statistic prologue** (the fused norm→linear cone's stat
-    reduce ``Loop`` + scalar epilogue — or a broadcast row scale), the remainder the **per-cell**
-    cone. Returns ``(prologue, cell, stats)`` — ``stats`` are the prologue defs the cell reads, the
-    values bridged through the stat smem rows (a prologue whose defs go unread is dropped)."""
-    body = list(a_body)
-    pro: list[Stmt] = []
-    while body and not _refs_axis(body[0], k_name):
-        pro.append(body.pop(0))
-    if not pro:
-        return (), tuple(body), ()
-    stats = tuple(sorted({nm for s in pro for nm in _deep_defines(s)} & _deep_reads(body)))
-    return (tuple(pro), tuple(body), stats) if stats else ((), tuple(body), ())
-
-
 def _stat_slab(name: str) -> str:
     """The smem row buffer bridging per-row statistic ``name`` from the sync prologue to the fill."""
     return f"_a_stat_{name}"
@@ -362,7 +339,8 @@ def _sync_operands(
     evaluates the cone at the slab cell's absolute ``(m, k)`` coords and writes the result), B
     copy-filled from its gmem ``Load``. A cone with a k-invariant prefix (the fused norm→linear
     per-row statistic — its reduce ``Loop`` + scalar epilogue) is split at the K seam
-    (:func:`_split_stat_prologue`): the prefix runs ONCE per tile row (:func:`sync_stat_fill`,
+    (``Contraction.stat_prologue`` — the node-owned seam the scheduler also sizes the stat rows
+    off): the prefix runs ONCE per tile row (:func:`sync_stat_fill`,
     returned as the transport prologue) and the per-cell fill reads the bridged values back from
     the stat smem rows. The schedule's eligibility guarantees exact cover on N and K only; a
     masked / symbolic **M** clamp-reads the overhanging rows in-bounds (the A fill σ and the stat
@@ -370,7 +348,7 @@ def _sync_operands(
     ``RegStore`` guard, the same contract the copy transports follow)."""
     m_name, n_name, k_name = c.m_axis.name, c.n_axis.name, c.k_axis.name
     row_base, col_base = _tile_base(mn)
-    pro, cell, stats = _split_stat_prologue(c.a_body, k_name)
+    pro, cell, stats = c.stat_prologue()
 
     def m_coord(row) -> Expr:
         t = BinaryExpr("+", row_base, row)
@@ -382,10 +360,13 @@ def _sync_operands(
         stmts += [s.rewrite(lambda nm: nm, sigma) for s in cell]
         return stmts, c.a_name
 
-    def b_value(k0, row, col):
-        sigma = Sigma({k_name: BinaryExpr("+", k0, row), n_name: BinaryExpr("+", col_base, col)})
-        name = f"{c.b_load.names[0]}__f"
-        return [Load(name=name, input=c.b_load.input, index=tuple(sigma.apply(e) for e in c.b_load.index))], name
+    def b_value_of(bl: Load):
+        def b_value(k0, row, col):
+            sigma = Sigma({k_name: BinaryExpr("+", k0, row), n_name: BinaryExpr("+", col_base, col)})
+            name = f"{bl.names[0]}__f"
+            return [Load(name=name, input=bl.input, index=tuple(sigma.apply(e) for e in bl.index))], name
+
+        return b_value
 
     prologue: list[Stmt] = []
     if stats:
@@ -393,9 +374,14 @@ def _sync_operands(
         sigma = Sigma({m_name: m_coord(Var(row_axis.name))})
         row_body = [s.rewrite(lambda nm: nm, sigma) for s in pro]
         prologue = sync_stat_fill(stats=stats, slab_of=_stat_slab, row_axis=row_axis, row_body=row_body, cta=cta)
+    # One B slab per fold channel (the multi-B node copy-fills each projection's weights alongside
+    # the one compute-filled A slab).
     operands = (
         SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value),
-        SyncOperand(tag="b", shape=(bk_elems, mn[1].tile), value=b_value),
+        *(
+            SyncOperand(tag="b" if f == 0 else f"b_x{f}", shape=(bk_elems, mn[1].tile), value=b_value_of(bl))
+            for f, (bl, _) in enumerate(c.folds)
+        ),
     )
     return operands, prologue
 
@@ -425,6 +411,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
         operands, stat_pro = _sync_operands(c, stage.bk_elems, mn, cta)
         transport = SyncTransport(operands=operands, slab_dtype=cuda_name(elem), cta=cta, prologue_stmts=tuple(stat_pro))
     else:
+        assert len(c.folds) == 1, "cp.async / TMA staging is single-fold — a multi-B node rides the sync compute-fill"
         operands = _slab_operands(
             index_srcs=(c.a_operand.index, c.b_load.index),
             bufs=(c.a_operand.input, c.b_load.input),
@@ -630,18 +617,24 @@ class _MmaOps(_AtomOps):
         atom, m, n = c.atom, c.m, c.n
         reg_depth = self.stage.reg_depth if self.stage is not None else 1
 
-        def frags(tag, reg):  # reg-tile operand fragment names (slotted ``_s{s}`` when double-buffered)
-            return (
-                [f"_{tag}{i}_s{s}" for i in range(reg) for s in range(reg_depth)] if reg_depth >= 2 else [f"_{tag}{i}" for i in range(reg)]
-            )
+        def frags(base_of, reg):  # reg-tile operand fragment names (slotted ``_s{s}`` when double-buffered)
+            names = [base_of(i) for i in range(reg)]
+            return [f"{nm}_s{s}" for nm in names for s in range(reg_depth)] if reg_depth >= 2 else names
 
+        # One A fragment set; one B and one C fragment set PER fold channel (the multi-B node's
+        # shared-A / per-channel-accumulate drain).
+        n_folds = len(c.folds)
         decls: list[Stmt] = [
-            RegFragment(name=nm, role=tag, shape=atom.shape, dtype=atom.operand_dtype(tag))
-            for tag, reg in (("a", m.reg), ("b", n.reg))
-            for nm in frags(tag, reg)
+            RegFragment(name=nm, role="a", shape=atom.shape, dtype=atom.operand_dtype("a")) for nm in frags(lambda i: f"_a{i}", m.reg)
         ]
+        for f in range(n_folds):
+            decls += [
+                RegFragment(name=nm, role="b", shape=atom.shape, dtype=atom.operand_dtype("b"))
+                for nm in frags(lambda i, ff=f: _fold_frag(f"_b{i}", ff), n.reg)
+            ]
         decls += [
-            RegFragment(name=f"_c{i}_{j}", role="c", shape=atom.shape, dtype=atom.operand_dtype("c"))
+            RegFragment(name=_fold_frag(f"_c{i}_{j}", f), role="c", shape=atom.shape, dtype=atom.operand_dtype("c"))
+            for f in range(n_folds)
             for i in range(m.reg)
             for j in range(n.reg)
         ]
@@ -658,6 +651,7 @@ class _MmaOps(_AtomOps):
         assert not c.a_computed, (
             "mma matmul arm: a register-resident (computed) A operand lowers through the fragment realizer (_twist), not here"
         )
+        assert len(c.folds) == 1, "gmem-direct mma is single-fold — a multi-B node rides the sync compute-fill"
         a_load, b_load, b_trans = c.a_operand, c.b_load, c.b_trans
         k_static = k_axis.extent.is_static
         k_zero = None if k_static else (Var(k_axis.name), k_axis.extent_expr())
@@ -699,7 +693,8 @@ class _MmaOps(_AtomOps):
 
     def store(self, i, j, offset, mn):
         """Store cell ``(i, j)``'s ``_c`` fragment to the output, folding the projection ``tail`` into a
-        :class:`RegEpilogue` and guarding overhanging M/N rows."""
+        :class:`RegEpilogue` and guarding overhanging M/N rows. A multi-fold node binds its extra C
+        fragments as additional epilogue accumulators (the combine — SwiGLU — reads them per cell)."""
         c = self.c
         atom = c.atom
         m, n = mn
@@ -707,13 +702,16 @@ class _MmaOps(_AtomOps):
         tail = list(c.epilogue)
         write = next(s for s in tail if isinstance(s, Write))
         sigma = Sigma({m.axis.name: mcell, n.axis.name: ncell})
+        extra = tuple((acc, _fold_frag(f"_c{i}_{j}", f)) for f, (_, acc) in enumerate(c.folds[1:], 1))
+        epi = _warp_epilogue(tail, c.acc, m.axis.name, n.axis.name, sigma, extra_accs=extra)
+        assert len(c.folds) == 1 or epi is not None, "a multi-fold contraction's projection must combine the accumulators"
         return [
             RegStore(
                 dst_buffer=write.output,
                 dst_index=tuple(sigma.apply(e) for e in write.index),
                 frag=f"_c{i}_{j}",
                 shape=atom.shape,
-                epilogue=_warp_epilogue(tail, c.acc, m.axis.name, n.axis.name, sigma),
+                epilogue=epi,
                 m_guard=_guard(m, mcell),
                 n_guard=_guard(n, ncell),
             )
@@ -754,6 +752,7 @@ class _ScalarOps(_AtomOps):
         ``Loop`` (``Loop.render`` seeds the accumulators; the store reads them). A masked axis wraps
         its read in-bounds (``% extent``) and the overhanging store is guarded (:meth:`store`)."""
         c = self.c
+        assert len(c.folds) == 1, "the scalar tier is single-fold — a multi-B node rides the warp sync compute-fill"
         k_axis = c.k_axis
         m, n = mn
         prot = _scalar_protected(c)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -364,14 +364,20 @@ def _sync_operands(
     per-row statistic — its reduce ``Loop`` + scalar epilogue) is split at the K seam
     (:func:`_split_stat_prologue`): the prefix runs ONCE per tile row (:func:`sync_stat_fill`,
     returned as the transport prologue) and the per-cell fill reads the bridged values back from
-    the stat smem rows. The schedule's eligibility guarantees exact-cover geometry (no masked
-    overhang), so the σ needs no clamps."""
+    the stat smem rows. The schedule's eligibility guarantees exact cover on N and K only; a
+    masked / symbolic **M** clamp-reads the overhanging rows in-bounds (the A fill σ and the stat
+    prologue σ — a duplicate of the last valid row is computed and its store discarded by the
+    ``RegStore`` guard, the same contract the copy transports follow)."""
     m_name, n_name, k_name = c.m_axis.name, c.n_axis.name, c.k_axis.name
     row_base, col_base = _tile_base(mn)
     pro, cell, stats = _split_stat_prologue(c.a_body, k_name)
 
+    def m_coord(row) -> Expr:
+        t = BinaryExpr("+", row_base, row)
+        return _clamp_last(t, mn[0].ext) if mn[0].mask else t
+
     def a_value(k0, row, col):
-        sigma = Sigma({m_name: BinaryExpr("+", row_base, row), k_name: BinaryExpr("+", k0, col)})
+        sigma = Sigma({m_name: m_coord(row), k_name: BinaryExpr("+", k0, col)})
         stmts: list[Stmt] = [Load(names=(nm,), input=_stat_slab(nm), index=(row,)) for nm in stats]
         stmts += [s.rewrite(lambda nm: nm, sigma) for s in cell]
         return stmts, c.a_name
@@ -384,7 +390,7 @@ def _sync_operands(
     prologue: list[Stmt] = []
     if stats:
         row_axis = Axis(name="_sr", extent=mn[0].tile)
-        sigma = Sigma({m_name: BinaryExpr("+", row_base, Var(row_axis.name))})
+        sigma = Sigma({m_name: m_coord(Var(row_axis.name))})
         row_body = [s.rewrite(lambda nm: nm, sigma) for s in pro]
         prologue = sync_stat_fill(stats=stats, slab_of=_stat_slab, row_axis=row_axis, row_body=row_body, cta=cta)
     operands = (

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -36,6 +36,14 @@ step unconditional — no knobs):
    the ``TileOp``'s schedule (the root's concern); ``_schedule`` maps them onto the grid. A cell
    the lift can't cleanly factor (no reduce, several reduces, or a nested non-flash reduce) stays a
    flat un-annotated ``Map`` (→ the scalar tier).
+4. **The MONOID-producer composition** — a lifted ``Map(source=Reduction)`` whose body is the
+   statistic's scalar epilogue + a fresh free (column) ``Loop`` over an ⊗-fold contraction reading
+   the statistic (the fused norm→linear edge, ``rmsnorm(x)·nw @ w``) ALSO nodifies to a computed-A
+   :class:`Contraction` whose A cone carries the per-row statistic prologue
+   (``_atomize.bind_prologue_contraction``, structure-only), its column axis joining the grid. Both
+   forms are scheduled and merged into ONE fork — the ``Map`` rows first (option-0 stays the
+   conservative coop pick), then the Contraction form's warp (mma) rows over the ``sync``
+   compute-fill stage; a warp ``TILE`` pin keeps the Contraction rows alone.
 
 Flash must precede online-softmax which must precede the lift: each later step consumes the
 ``Accum``\\ s an earlier one matches. A **symbolic** axis (dynamic ``seq_len``) is left
@@ -57,9 +65,13 @@ from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.tile import Contraction, Map, Placement, Reduction, TileOp, TilePlan
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
 from emmy.compiler.pipeline.fork import Fork
-from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_contraction
+
+# NOTE: no ``Knob`` objects (``TILE`` / ``REDUCE`` / ``STAGE``) may be imported here — ``Pass.load``
+# scans rule modules for ``Knob`` attrs and OFF-fills any it finds bare onto every variant of the
+# pass. Pin reads / knob-key spelling ride the ``_schedule`` helpers instead.
+from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_contraction, bind_prologue_contraction
 from emmy.compiler.pipeline.passes.lowering.tile._flash import is_flash_score_producer, is_fold_offer_site, try_flash
-from emmy.compiler.pipeline.passes.lowering.tile._schedule import schedule
+from emmy.compiler.pipeline.passes.lowering.tile._schedule import prologue_knob_bases, schedule, warp_tile_pinned
 from emmy.compiler.pipeline.passes.lowering.tile._softmax import _fuse
 from emmy.compiler.pipeline.pipeline import LoweringError
 from emmy.compiler.pipeline.search.space import place_decision
@@ -280,6 +292,12 @@ def _order_free_by_output(node: Map | Reduction, free: list) -> tuple:
     return tuple(sorted(free, key=lambda ax: pos[ax.name]))
 
 
+def _as_list(scheduled) -> list:
+    """Normalize a ``schedule()`` result (a single ``TileOp``, a branch ``Fork``, or a candidate
+    list — possibly empty) into a flat options list for the recognizer's structural merge."""
+    return scheduled if isinstance(scheduled, list) else [scheduled]
+
+
 def rewrite(match: Match, root: Node) -> Fork | list[TileOp] | TileOp | Graph | None:
     # (0) Schedule an UNMAPPED ``TileOp`` — a kernel that recognition emitted as a *graph
     # rewrite* (flash's fused fragment, ``try_flash``) rather than scheduling inline, because a
@@ -330,4 +348,27 @@ def rewrite(match: Match, root: Node) -> Fork | list[TileOp] | TileOp | Graph | 
     # ``inputs`` is seeded from the matched ``LoopOp`` (the matcher populated its real Tensors) so
     # the scheduler can read operand shapes (the shared-row stage detection); the matcher refreshes
     # it from the graph again when a later pass matches the scheduled op.
-    return schedule(TileOp(op=node, place=Placement(free=free), inputs=dict(loop.inputs)), loop.name, knob_base)
+    map_tile = TileOp(op=node, place=Placement(free=free), inputs=dict(loop.inputs))
+    pro = bind_prologue_contraction(node, free) if place_decision("cone") == "fuse" else None
+    if pro is None:
+        return schedule(map_tile, loop.name, knob_base)
+    # (4) The MONOID-producer composition — the fused norm→linear edge (``rmsnorm(x)·nw @ w``):
+    # the tail contraction ALSO nodifies to a computed-A :class:`Contraction` whose A cone carries
+    # the per-row statistic prologue (:func:`bind_prologue_contraction`), its column axis joining
+    # the grid. Both forms are scheduled and their candidates merged into ONE fork: the ``Map``
+    # rows first (the cooperative / serial reduce tiers — option-0 stays the conservative coop
+    # pick, lowerable everywhere), then the Contraction form's warp (mma) rows (the sync
+    # compute-fill tier — zero rows on fp32 / no atoms / bad geometry). A warp ``TILE`` pin is
+    # authoritative: the Contraction rows alone (the pin demands the mma tier; offering the Map
+    # sibling would let cold greedy pick past the pin). Each form's rows carry the OTHER form's
+    # family keys as decided-empty stamps, so every leaf row spells the same key set (the
+    # evidence pick's prefix-consistency: an absent key reads as "free").
+    c_node, n_ax = pro
+    con_base, map_base = prologue_knob_bases(c_node.k_axis.name, c_node.a_operand[0].axis.name)
+    con_tile = TileOp(op=c_node, place=Placement(free=(*free, n_ax)), inputs=dict(loop.inputs))
+    con = _as_list(schedule(con_tile, loop.name, {**knob_base, **con_base}))
+    if con and warp_tile_pinned():
+        return con if len(con) > 1 else con[0]
+    maps = _as_list(schedule(map_tile, loop.name, {**knob_base, **map_base}))
+    merged = [*maps, *con]
+    return merged if len(merged) > 1 else merged[0]

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -37,12 +37,14 @@ step unconditional — no knobs):
    the lift can't cleanly factor (no reduce, several reduces, or a nested non-flash reduce) stays a
    flat un-annotated ``Map`` (→ the scalar tier).
 4. **The MONOID-producer composition** — a lifted ``Map(source=Reduction)`` whose body is the
-   statistic's scalar epilogue + a fresh free (column) ``Loop`` over an ⊗-fold contraction reading
-   the statistic (the fused norm→linear edge, ``rmsnorm(x)·nw @ w``) ALSO nodifies to a computed-A
-   :class:`Contraction` whose A cone carries the per-row statistic prologue
-   (``_atomize.bind_prologue_contraction``, structure-only), its column axis joining the grid. Both
-   forms are scheduled and merged into ONE fork — the ``Map`` rows first (option-0 stays the
-   conservative coop pick), then the Contraction form's warp (mma) rows over the ``sync``
+   statistic's scalar epilogue + a fresh free (column) ``Loop`` over one or more ⊗-folds of ONE
+   shared A value reading the statistic (the fused norm→linear edge ``rmsnorm(x)·nw @ w``; its
+   N-channel form the gate/up MLP edge ``swiglu(x̂@Wg, x̂@Wu)`` — a product-monoid fold) ALSO
+   nodifies to ``Map(body=projection, source=Contraction)``: a computed-A :class:`Contraction`
+   whose A cone carries the per-row statistic prologue and whose ``folds`` are the ``(B, acc)``
+   channels (``_atomize.bind_prologue_contraction``, structure-only), its column axis joining the
+   grid. Both forms are scheduled and merged into ONE fork — the reduce rows first (option-0 stays
+   the conservative coop pick), then the Contraction form's warp (mma) rows over the ``sync``
    compute-fill stage; a warp ``TILE`` pin keeps the Contraction rows alone.
 
 Flash must precede online-softmax which must precede the lift: each later step consumes the
@@ -251,8 +253,7 @@ def _nodify_contraction(node, free: tuple):
                 axes=(free[-2], free[-1]),
                 k_axis=rloop.axis,
                 a_operand=a_load,
-                b_load=b_load,
-                acc=acc,
+                folds=((b_load, acc),),
                 tile=TilePlan(),
                 lead_axes=tuple(free[:-2]),
                 epilogue=epi,
@@ -352,20 +353,23 @@ def rewrite(match: Match, root: Node) -> Fork | list[TileOp] | TileOp | Graph | 
     pro = bind_prologue_contraction(node, free) if place_decision("cone") == "fuse" else None
     if pro is None:
         return schedule(map_tile, loop.name, knob_base)
-    # (4) The MONOID-producer composition — the fused norm→linear edge (``rmsnorm(x)·nw @ w``):
-    # the tail contraction ALSO nodifies to a computed-A :class:`Contraction` whose A cone carries
-    # the per-row statistic prologue (:func:`bind_prologue_contraction`), its column axis joining
-    # the grid. Both forms are scheduled and their candidates merged into ONE fork: the ``Map``
-    # rows first (the cooperative / serial reduce tiers — option-0 stays the conservative coop
-    # pick, lowerable everywhere), then the Contraction form's warp (mma) rows (the sync
-    # compute-fill tier — zero rows on fp32 / no atoms / bad geometry). A warp ``TILE`` pin is
-    # authoritative: the Contraction rows alone (the pin demands the mma tier; offering the Map
-    # sibling would let cold greedy pick past the pin). Each form's rows carry the OTHER form's
-    # family keys as decided-empty stamps, so every leaf row spells the same key set (the
-    # evidence pick's prefix-consistency: an absent key reads as "free").
-    c_node, n_ax = pro
-    con_base, map_base = prologue_knob_bases(c_node.k_axis.name, c_node.a_operand[0].axis.name)
-    con_tile = TileOp(op=c_node, place=Placement(free=(*free, n_ax)), inputs=dict(loop.inputs))
+    # (4) The MONOID-producer composition — the fused norm→linear edge (``rmsnorm(x)·nw @ w``, and
+    # its N-channel form, the gate/up MLP edge): the tail fold(s) ALSO nodify to
+    # ``Map(body=projection, source=Contraction)`` — a computed-A :class:`Contraction` whose A cone
+    # carries the per-row statistic prologue and whose ``folds`` are the ``(B, acc)`` channels
+    # (:func:`bind_prologue_contraction`), its column axis joining the grid. Both forms are
+    # scheduled and their candidates merged into ONE fork: the reduce-``Map`` rows first (the
+    # cooperative / serial tiers — option-0 stays the conservative coop pick, lowerable
+    # everywhere), then the Contraction form's warp (mma) rows (the sync compute-fill tier — zero
+    # rows on fp32 / no atoms / bad geometry). A warp ``TILE`` pin is authoritative: the
+    # Contraction rows alone (the pin demands the mma tier; offering the reduce sibling would let
+    # cold greedy pick past the pin). Each form's rows carry the OTHER form's family keys as
+    # decided-empty stamps, so every leaf row spells the same key set (the evidence pick's
+    # prefix-consistency: an absent key reads as "free").
+    c_map, n_ax = pro
+    src = c_map.source
+    con_base, map_base = prologue_knob_bases(src.k_axis.name, src.a_operand[0].axis.name)
+    con_tile = TileOp(op=c_map, place=Placement(free=(*free, n_ax)), inputs=dict(loop.inputs))
     con = _as_list(schedule(con_tile, loop.name, {**knob_base, **con_base}))
     if con and warp_tile_pinned():
         return con if len(con) > 1 else con[0]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
@@ -29,15 +29,56 @@ geometry."""
 
 from __future__ import annotations
 
-from emmy.compiler.ir.axis import AxisRole
-from emmy.compiler.ir.stmt import Accum, Load, Loop
+from emmy.compiler.ir.axis import Axis, AxisRole
+from emmy.compiler.ir.stmt import Accum, Assign, Load, Loop, Write
+from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.stmt.body import Body
+from emmy.compiler.ir.tile import Contraction, Map, Reduction, TilePlan
 from emmy.compiler.pipeline.pipeline import LoweringError
 
 
 def _idx_vars(index) -> set[str]:
     """Every free Var name across an index tuple's exprs (the materializer's helper)."""
     return {v for e in index for v in e.free_vars()}
+
+
+def _idx_vars_deep(stmts) -> set:
+    """Every free Var name across the index exprs reachable in ``stmts`` (deep)."""
+    out: set = set()
+    for s in stmts:
+        idx = getattr(s, "index", None)
+        if idx:
+            out |= {v for e in idx for v in e.free_vars()}
+        for b in s.nested():
+            out |= _idx_vars_deep(list(b))
+    return out
+
+
+def map_cone(body: list, root: str) -> list | None:
+    """The backward cone of SSA ``root`` within ``body`` — the fused producer's compute, in body
+    order. ``None`` unless every cone stmt is a scalar ``Load`` or a pointwise ``Assign`` (a pure
+    MAP cone — a reduce-bearing cone, e.g. an rmsnorm scale, is not compute-fillable per cell)."""
+    defs: dict[str, Stmt] = {}
+    for st in body:
+        for d in st.defines():
+            defs[d] = st
+    need, cone, seen = [root], [], set()
+    while need:
+        nm = need.pop()
+        st = defs.get(nm)
+        if st is None or id(st) in seen:
+            continue
+        seen.add(id(st))
+        if isinstance(st, Load):
+            cone.append(st)
+            continue
+        if isinstance(st, Assign):
+            cone.append(st)
+            need.extend(st.args)
+            continue
+        return None  # an Accum / Loop / Select in the cone — not a pure MAP producer
+    order = {id(st): i for i, st in enumerate(body)}
+    return sorted(cone, key=lambda st: order[id(st)])
 
 
 def bind_contraction(loop: Loop, m_name: str, n_name: str, epilogue: Body) -> tuple[Load, Load, str, Body]:
@@ -81,4 +122,88 @@ def semiring_binding(node, grid) -> tuple[Load, Load, str, Body]:
     return bind_contraction(stmts[ridx], grid[-2].name, grid[-1].name, epilogue)
 
 
-__all__ = ["bind_contraction", "semiring_binding"]
+def bind_prologue_contraction(op, free: tuple) -> tuple[Contraction, Axis] | None:
+    """Nodify the **reduce-bearing (MONOID) producer cone** composition — the fused norm→linear
+    edge (``rmsnorm(x)·nw @ w``): a projecting ``Map`` whose ``source`` is a per-row ``PLANAR``
+    statistic reduce and whose body is that statistic's scalar epilogue followed by a fresh free
+    (column) ``Loop`` over an ⊗-fold contraction whose A cone reads the statistic. Returns the
+    computed-A :class:`Contraction` — its A cone **carries the statistic prologue** (the annotated
+    stat reduce ``Loop`` + its scalar epilogue ahead of the per-cell map stmts, the k-invariant
+    prefix) with a **deferred** ``TilePlan()`` — plus the column axis (the scheduler adds it to the
+    grid), or ``None`` (not this shape; the ``Map`` form stands alone).
+
+    STRUCTURE-ONLY: no dtype / geometry / pin legality here — those are per-move scheduling guards
+    (``_schedule``), so the same node offers whatever tiers the target legally supports."""
+    if not isinstance(op, Map) or not isinstance(op.source, Reduction):
+        return None
+    red = op.source
+    if red.role is not AxisRole.PLANAR or red.source is not None or red.carrier.twist.family != "id":
+        return None
+    body = list(op.body)
+    if not body or not isinstance(body[-1], Loop) or body[-1].is_reduce:
+        return None
+    stat_epi, nloop = body[:-1], body[-1]
+    if not all(isinstance(s, (Load, Assign)) for s in stat_epi):
+        return None
+    n_ax = nloop.axis
+    inner = list(nloop.body)
+    if len(inner) != 2 or not isinstance(inner[0], Loop) or not inner[0].is_reduce or not isinstance(inner[1], Write):
+        return None
+    kloop, write = inner
+    k_ax = kloop.axis
+    grid = list(free)
+    if not grid:
+        return None
+    m_ax = grid[-1]
+    kbody = list(kloop.body)
+    accums = [st for st in kbody if isinstance(st, Accum)]
+    if len(accums) != 1 or accums[0].op.name != "add":
+        return None
+    acc = accums[0]
+    if write.values != (acc.name,) or not write.is_scalar:
+        return None
+    defs = {st.name: st for st in kbody if isinstance(st, Assign)}
+    lift = defs.get(acc.value)
+    if lift is None or lift.op.name != "multiply" or len(lift.args) != 2:
+        return None
+    loads = {st.names[0]: st for st in kbody if isinstance(st, Load)}
+
+    def _load_vars(nm: str) -> set | None:
+        ld = loads.get(nm)
+        return {v for e in ld.index for v in e.free_vars()} if ld is not None else None
+
+    b_name = next((a for a in lift.args if (vs := _load_vars(a)) and n_ax.name in vs and k_ax.name in vs), None)
+    if b_name is None:
+        return None
+    a_name = next(a for a in lift.args if a != b_name)
+    cone = map_cone(kbody, a_name)
+    if cone is None or not cone:
+        return None
+    for st in cone:
+        if isinstance(st, Load) and n_ax.name in {v for e in st.index for v in e.free_vars()}:
+            return None  # the cone must be (m, k)-indexed — an n-dependent producer isn't the A tile
+    # Every free SSA name the cone reads must be a statistic (the source reduce's carried state or
+    # its scalar epilogue) — anything else is a shape this binding doesn't understand.
+    stat_defs = {red.out} | {nm for s in stat_epi for nm in s.defines()}
+    cone_defs = {nm for st in cone for nm in st.defines()}
+    free_refs = {a for st in cone if isinstance(st, Assign) for a in st.args if a not in cone_defs}
+    if not free_refs or not free_refs <= stat_defs:
+        return None  # a stat-free cone is the demoted option's shape, not ours
+    # The statistic prologue must be row-local: its gmem reads may index (m, its own reduce axis)
+    # but never the column / contraction axes.
+    if _idx_vars_deep([*red.partial, *stat_epi]) & {n_ax.name, k_ax.name}:
+        return None
+    node = Contraction(
+        axes=(m_ax, n_ax),
+        k_axis=k_ax,
+        a_operand=Body((red.loop, *stat_epi, *cone)),
+        b_load=loads[b_name],
+        acc=acc.name,
+        tile=TilePlan(),
+        lead_axes=tuple(grid[:-1]),
+        epilogue=Body((write,)),
+    )
+    return node, n_ax
+
+
+__all__ = ["bind_contraction", "bind_prologue_contraction", "map_cone", "semiring_binding"]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
@@ -89,10 +89,11 @@ def bind_contraction(loop: Loop, m_name: str, n_name: str, epilogue: Body) -> tu
     Reads the facts straight off the loop body — no op-tree node: the contraction operands are the
     ``Load``\\ s in the loop indexed over the reduce (K) axis; A/B are bound by which output axis
     each one's index carries; the fold accumulator is the loop body's ``Accum`` target. A clean
-    gmem-direct contraction has plain-``Load`` operands (a computed-cone / demoted matmul never
-    reaches CONTRACTION — recognition leaves it a flat reduce), so an unbindable body (no m/n-bearing
-    K-load) raises, matching the warp gmem-direct guard. ``b_trans`` is not returned — the
-    ``Contraction`` node re-derives it off ``b_load``."""
+    gmem-direct contraction has plain-``Load`` operands (a computed-cone matmul binds elsewhere:
+    the MONOID-producer composition via :func:`bind_prologue_contraction`, flash's PV at fusion; the
+    stat-free demoted cone stays a flat reduce), so an unbindable body (no m/n-bearing K-load)
+    raises, matching the warp gmem-direct guard. ``b_trans`` is not returned — the ``Contraction``
+    node re-derives it off its fold's ``b_load``."""
     k_name = loop.axis.name
     loads = [s for s in loop.body if isinstance(s, Load) and k_name in _idx_vars(s.index)]
     a_leaf = next((ld for ld in loads if m_name in _idx_vars(ld.index)), None)
@@ -122,15 +123,35 @@ def semiring_binding(node, grid) -> tuple[Load, Load, str, Body]:
     return bind_contraction(stmts[ridx], grid[-2].name, grid[-1].name, epilogue)
 
 
-def bind_prologue_contraction(op, free: tuple) -> tuple[Contraction, Axis] | None:
+def _cone_value_key(name: str, defs: dict) -> tuple:
+    """The canonical value tree of SSA ``name`` within a k-loop body — Loads keyed by (buffer,
+    index), Assigns by (op, child keys), a name defined outside the body by itself. Two folds
+    share one A operand iff their lift values have EQUAL keys: fusion duplicates the producer
+    cone per consumer (fresh SSA names, interleaved body order), so name/order equality is too
+    strict but value-tree equality is exact."""
+    st = defs.get(name)
+    if st is None:
+        return ("free", name)
+    if isinstance(st, Load):
+        return ("load", st.input, tuple(e.pretty() for e in st.index))
+    return ("op", st.op.name, tuple(_cone_value_key(a, defs) for a in st.args))
+
+
+def bind_prologue_contraction(op, free: tuple) -> tuple[Map, Axis] | None:
     """Nodify the **reduce-bearing (MONOID) producer cone** composition — the fused norm→linear
-    edge (``rmsnorm(x)·nw @ w``): a projecting ``Map`` whose ``source`` is a per-row ``PLANAR``
-    statistic reduce and whose body is that statistic's scalar epilogue followed by a fresh free
-    (column) ``Loop`` over an ⊗-fold contraction whose A cone reads the statistic. Returns the
-    computed-A :class:`Contraction` — its A cone **carries the statistic prologue** (the annotated
-    stat reduce ``Loop`` + its scalar epilogue ahead of the per-cell map stmts, the k-invariant
-    prefix) with a **deferred** ``TilePlan()`` — plus the column axis (the scheduler adds it to the
-    grid), or ``None`` (not this shape; the ``Map`` form stands alone).
+    edge: a projecting ``Map`` whose ``source`` is a per-row ``PLANAR`` statistic reduce and whose
+    body is that statistic's scalar epilogue followed by a fresh free (column) ``Loop`` over one or
+    more ⊗-folds whose shared A cone reads the statistic. One fold channel is the plain norm→linear
+    (``rmsnorm(x)·nw @ w``); N channels sharing ONE A value with a pointwise combine tail is the
+    fused gate/up MLP edge (``swiglu(x̂@Wg, x̂@Wu)`` — a product-monoid fold; fusion duplicates the
+    cone SSA per channel, deduped by value-tree equality). Returns the same
+    ``Map(body=projection, source=node)`` factorization the ``Reduction`` spelling uses: the
+    ``source`` is the computed-A :class:`Contraction` — its A cone **carries the statistic
+    prologue** (the annotated stat reduce ``Loop`` + its scalar epilogue ahead of the per-cell map
+    stmts, the k-invariant prefix), its ``folds`` the ``(B, acc)`` channels, a **deferred**
+    ``TilePlan()`` — and the ``body`` is the projection (the combine tail + any stat-free prefix
+    defs it reads + the ``Write``). Plus the column axis (the scheduler adds it to the grid), or
+    ``None`` (not this shape; the reduce ``Map`` form stands alone).
 
     STRUCTURE-ONLY: no dtype / geometry / pin legality here — those are per-move scheduling guards
     (``_schedule``), so the same node offers whatever tiers the target legally supports."""
@@ -147,9 +168,11 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Contraction, Axis] | Non
         return None
     n_ax = nloop.axis
     inner = list(nloop.body)
-    if len(inner) != 2 or not isinstance(inner[0], Loop) or not inner[0].is_reduce or not isinstance(inner[1], Write):
+    if len(inner) < 2 or not isinstance(inner[0], Loop) or not inner[0].is_reduce or not isinstance(inner[-1], Write):
         return None
-    kloop, write = inner
+    kloop, tail_ops, write = inner[0], inner[1:-1], inner[-1]
+    if not all(isinstance(s, Assign) for s in tail_ops):
+        return None  # the combine tail is a pure pointwise chain (Loads ride the stat-free prefix)
     k_ax = kloop.axis
     grid = list(free)
     if not grid:
@@ -157,26 +180,32 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Contraction, Axis] | Non
     m_ax = grid[-1]
     kbody = list(kloop.body)
     accums = [st for st in kbody if isinstance(st, Accum)]
-    if len(accums) != 1 or accums[0].op.name != "add":
-        return None
-    acc = accums[0]
-    if write.values != (acc.name,) or not write.is_scalar:
+    if not accums or any(a.op.name != "add" for a in accums):
         return None
     defs = {st.name: st for st in kbody if isinstance(st, Assign)}
-    lift = defs.get(acc.value)
-    if lift is None or lift.op.name != "multiply" or len(lift.args) != 2:
-        return None
     loads = {st.names[0]: st for st in kbody if isinstance(st, Load)}
+    kdefs = {**loads, **defs}
 
     def _load_vars(nm: str) -> set | None:
         ld = loads.get(nm)
         return {v for e in ld.index for v in e.free_vars()} if ld is not None else None
 
-    b_name = next((a for a in lift.args if (vs := _load_vars(a)) and n_ax.name in vs and k_ax.name in vs), None)
-    if b_name is None:
-        return None
-    a_name = next(a for a in lift.args if a != b_name)
-    cone = map_cone(kbody, a_name)
+    # Bind each fold's (B, acc, A-value): the B operand is the (n, k)-indexed load of the ⊗ lift;
+    # the other arg is the fold's A value. Every fold must share ONE A value (key equality).
+    folds: list[tuple[Load, str]] = []
+    a_names: list[str] = []
+    for acc in accums:
+        lift = defs.get(acc.value)
+        if lift is None or lift.op.name != "multiply" or len(lift.args) != 2:
+            return None
+        b_name = next((a for a in lift.args if (vs := _load_vars(a)) and n_ax.name in vs and k_ax.name in vs), None)
+        if b_name is None:
+            return None
+        a_names.append(next(a for a in lift.args if a != b_name))
+        folds.append((loads[b_name], acc.name))
+    if len({_cone_value_key(nm, kdefs) for nm in a_names}) != 1:
+        return None  # per-fold A values differ — not a shared-operand multi-fold
+    cone = map_cone(kbody, a_names[0])
     if cone is None or not cone:
         return None
     for st in cone:
@@ -193,17 +222,44 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Contraction, Axis] | Non
     # but never the column / contraction axes.
     if _idx_vars_deep([*red.partial, *stat_epi]) & {n_ax.name, k_ax.name}:
         return None
+    # The combine tail: its reads must be the fold accumulators, its own defs, or STAT-FREE prefix
+    # defs (a k/n-invariant value like SiLU's ``1.0`` scalar — its backward cone within the prefix
+    # is prepended to the node epilogue so the store-side fragment epilogue can re-evaluate it; a
+    # stat-DERIVED read would need the reduce's state at the store, which the fragment path has no
+    # channel for). The Write stores one scalar from the tail chain (or the bare primary acc).
+    derived = {red.out}
+    for s in stat_epi:
+        if set(s.deps()) & derived:
+            derived |= set(s.defines())
+    acc_names = {a.name for a in accums}
+    tail_defs = {s.name for s in tail_ops}
+    prefix_needs: list[str] = []
+    for s in tail_ops:
+        for a in s.args:
+            if a in acc_names or a in tail_defs:
+                continue
+            if a in stat_defs - derived:
+                prefix_needs.append(a)
+                continue
+            return None
+    prefix: list[Stmt] = []
+    seen: set[int] = set()
+    for nm in prefix_needs:
+        for st in map_cone(list(stat_epi), nm) or ():
+            if id(st) not in seen:
+                seen.add(id(st))
+                prefix.append(st)
+    if not write.is_scalar or write.values != ((tail_ops[-1].name,) if tail_ops else (folds[0][1],)):
+        return None
     node = Contraction(
         axes=(m_ax, n_ax),
         k_axis=k_ax,
         a_operand=Body((red.loop, *stat_epi, *cone)),
-        b_load=loads[b_name],
-        acc=acc.name,
+        folds=tuple(folds),
         tile=TilePlan(),
         lead_axes=tuple(grid[:-1]),
-        epilogue=Body((write,)),
     )
-    return node, n_ax
+    return Map(body=Body((*prefix, *tail_ops, write)), source=node), n_ax
 
 
 __all__ = ["bind_contraction", "bind_prologue_contraction", "map_cone", "semiring_binding"]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_flash.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_flash.py
@@ -260,8 +260,7 @@ def _split_pv(merge: list, o: str, v: str, v_buf: str, v_idx: tuple, m_axis: Axi
         axes=(m_axis, d_axis),
         k_axis=Axis(name="pj", extent=Dim(1)),  # block=1: a singleton intra-block reduce
         a_operand=Body((Assign(name=f"{o}__p", op="copy", args=(p_name,)),)),  # A = P, register-resident
-        b_load=Load(name=v, input=v_buf, index=v_idx),  # B = V (the value tile)
-        acc=f"{o}__pv",
+        folds=((Load(name=v, input=v_buf, index=v_idx), f"{o}__pv"),),  # B = V (the value tile)
         tile=TilePlan(),
     )
     out: list = []
@@ -323,8 +322,7 @@ def _flash_op(
         axes=(Axis(name="m", extent=s_q), Axis(name="kv", extent=s_k)),
         k_axis=Axis(name="dd", extent=Dim(head_dim)),
         a_operand=Load(name="q_e", input=q_buf, index=q_idx),
-        b_load=Load(name="k_e", input=k_buf, index=k_idx),
-        acc="sacc",
+        folds=((Load(name="k_e", input=k_buf, index=k_idx), "sacc"),),
         tile=TilePlan(),
     )
     score_post = [

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -45,11 +45,11 @@ from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.schedule import Stage, WarpSpec, is_warp_codec
 from emmy.compiler.ir.sigma import Sigma
-from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Stmt, Write
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Stmt
 from emmy.compiler.ir.tile import Contraction, Map, Placement, ReducePlan, Reduction, TileOp, TilePlan
 from emmy.compiler.ir.tile.ops import axis_role, nodify_reduce, reduce_loop
 from emmy.compiler.pipeline.fork import Fork, Level, build_fork_tree
-from emmy.compiler.pipeline.passes.lowering.tile._atomize import semiring_binding
+from emmy.compiler.pipeline.passes.lowering.tile._atomize import map_cone, semiring_binding
 from emmy.compiler.pipeline.passes.lowering.tile._carrier import projection_distributes
 from emmy.compiler.pipeline.pipeline import LoweringError
 from emmy.compiler.pipeline.search.space import (
@@ -285,13 +285,19 @@ def _fragment_epilogue_ok(epilogue: Body) -> bool:
 
 def _warp_atoms(kernel, probe) -> tuple[str, ...]:
     """The dtype-eligible tensor-core atom names for this contraction, ``()`` when the warp tier
-    doesn't apply (unbindable / computed-A node, a non-16-bit operand dtype, or a fragment-
-    unrealizable gather epilogue)."""
-    if probe is None or probe.a_computed or not kernel.inputs:
+    doesn't apply (unbindable node, a non-16-bit operand dtype, or a fragment-unrealizable gather
+    epilogue). A computed-A (fused-cone) node reads its operand dtype off the cone's K-indexed
+    ``Load`` — the value the sync compute-fill stores to the A slab."""
+    if probe is None or not kernel.inputs:
         return ()
     if not _fragment_epilogue_ok(probe.epilogue):
         return ()
-    t = kernel.inputs.get(probe.a_operand.input)
+    if isinstance(probe.a_operand, Load):
+        ld = probe.a_operand
+    else:
+        kname = probe.k_axis.name
+        ld = next((st for st in probe.a_body if isinstance(st, Load) and kname in {v for e in st.index for v in e.free_vars()}), None)
+    t = kernel.inputs.get(ld.input) if ld is not None else None
     return _ATOMS_BY_DTYPE.get(getattr(getattr(t, "dtype", None), "name", None), ())
 
 
@@ -367,7 +373,9 @@ def _reduce_candidates(kernel, place, plan: TilePlan, probe: Contraction | None 
             if p.coop <= k and p.reg <= k:
                 out.append(move)
     free = prod(_hint_extent(a) for a in place.free) if place.free else 1
-    if k is not None and free // _tile_area(plan) <= _SPLITK_MAX_CTAS:
+    # A computed-A (fused-cone) contraction offers no split-K: the split σ-reindexes the operand
+    # Loads, and a producer-cone A cannot be sliced over K (its statistic prologue spans the row).
+    if k is not None and free // _tile_area(plan) <= _SPLITK_MAX_CTAS and (probe is None or not probe.a_computed):
         step = plan.atom.atom_k * plan.bk if plan.is_warp else 1
         atomic_ok = probe is not None and (len(probe.epilogue) == 0 or projection_distributes(probe.epilogue, (probe.acc,)))
         for move in splitk_moves(warp=plan.is_warp):
@@ -389,6 +397,8 @@ def _tile_rows(kernel, place) -> tuple[list[dict], str]:
         probe = _contraction_node(kernel.op, place, TilePlan())
     except LoweringError:
         probe = None
+    if probe is not None and probe.a_computed:
+        return _computed_a_rows(kernel, place, probe, kaxis), kaxis
     tiles = scalar_tile_moves() if probe is not None else [""]
     if probe is not None:
         atoms = _warp_atoms(kernel, probe)
@@ -590,6 +600,90 @@ def _resolve_scalar_stage(c: Contraction, stage: Stage, inputs) -> Stage | None:
     return replace(stage, depth=depth, ring=stage.ring and depth >= 2, reg_depth=1, bk_elems=bk_elems)
 
 
+def warp_tile_pinned() -> bool:
+    """A live warp (``a:<atom>``) ``TILE`` env pin. Exposed as a function so ``010_recognize`` never
+    imports the ``Knob`` objects themselves — ``Pass.load`` scans rule modules for ``Knob`` attrs and
+    OFF-fills any it finds onto every variant of the pass (bare ``TILE: ""`` stamps on every kernel)."""
+    return is_warp_codec(TILE.narrow([""])[0])
+
+
+def prologue_knob_bases(k2: str, stat_axis: str) -> tuple[dict, dict]:
+    """The recognizer merge's two knob bases — ``(contraction-form, map-form)``. Each form carries
+    the OTHER form's family keys as decided-empty stamps so every leaf row of the merged fork spells
+    the same key set (the evidence pick's prefix-consistency: an absent key reads as "free"). Lives
+    here (not the rule module) for the same ``Knob``-import reason as :func:`warp_tile_pinned`."""
+    con = {"PLACE@cone": "fuse", _at(REDUCE, stat_axis): ""}
+    map_ = {_at(TILE, k2): "", _at(STAGE, k2): "", _at(REDUCE, k2): ""}
+    return con, map_
+
+
+def _resolve_sync_stage(c: Contraction) -> Stage | None:
+    """The ``sync`` compute-fill :class:`Stage` for a **computed-A** warp contraction with tile plan
+    ``c.tile`` — MANDATORY for this form (the gmem-direct mma leaf refuses a computed A; cp.async /
+    TMA are copy transports that cannot evaluate a producer cone), so there is no gmem-direct ``""``
+    sibling and a ``STAGE`` pin degrades to this resolved row. ``None`` when the slabs don't fit the
+    48 KiB smem budget: the A/B operand slabs (single-buffer — ``SyncTransport`` has no ring) plus
+    one fp32 row per bridged statistic (``sync_stat_fill``'s decls — the same
+    ``_split_stat_prologue`` seam the materializer fills through)."""
+    from emmy.compiler.pipeline.passes.lowering.kernel._atom import _split_stat_prologue  # noqa: PLC0415 — avoid an import cycle
+
+    atom = c.atom
+    bk_elems = c.tile.bk * atom.atom_k
+    a_nbytes = atom.operand_dtype("a").nbytes
+    _, _, stats = _split_stat_prologue(c.a_body, c.k_axis.name)
+    slab_bytes = (c.m.tile + c.n.tile) * bk_elems * a_nbytes + len(stats) * c.m.tile * 4
+    if slab_bytes > 48 * 1024:
+        return None
+    return Stage(transport="sync", smem=(c.a_name,), bk_elems=bk_elems)
+
+
+def _computed_a_rows(kernel, place, probe: Contraction, kaxis: str) -> list[dict]:
+    """The knob rows for a **computed-A (fused-cone)** contraction — warp (mma) rows only, each
+    riding the mandatory resolved ``sync`` stage. No scalar / per-cell ``""`` row: a per-cell
+    expansion would re-run the embedded producer cone (the norm→linear statistic reduce) on every
+    K step, and the serial / cooperative coverage already rides the ``Map``-form fork siblings the
+    recognizer emits alongside this node. Geometry: K must be static and tile-divisible
+    (``_warp_move_ok`` — the ``_staged`` driver reads a static K) and N exactly covered (the sync
+    B fill has no N clamp); a masked / symbolic M is fine (the fill σ clamps, the store guards).
+    Zero rows (fp32, no atoms, bad geometry, over-budget slabs) is the graceful fallback — the
+    ``Map`` rows stand alone. Pins: a warp ``TILE`` pin is checked loudly (the pin contract); a
+    scalar / empty ``TILE`` pin asks for a tier this form doesn't offer (zero rows — the ``Map``
+    sibling's business); ``REDUCE`` rides :func:`_reduce_candidates` (split-K is excluded unpinned;
+    a ``g<w>`` pin raises in :func:`_splitk_option`); a ``STAGE`` pin is ignored in favor of the
+    resolved sync row."""
+    if TILE.raw() is not None:
+        spec = TILE.narrow([""])[0]
+        if not is_warp_codec(spec):
+            return []
+        wt = TilePlan.parse(spec)
+        _check_warp_static_k(kernel, wt)
+        if not probe.k_axis.extent.is_static:
+            raise ValueError("warp TILE pin on a fused-cone contraction: K must be static (the sync compute-fill has no K mask).")
+        if replace(probe, tile=wt).n.mask:
+            raise ValueError(
+                f"warp TILE pin on a fused-cone contraction: the tile's N width must exactly cover the static "
+                f"output columns (N={probe.axes[1].extent}, no N mask in the sync compute-fill); pick a dividing tile."
+            )
+        tiles = [spec]
+    else:
+        atoms = _warp_atoms(kernel, probe)
+        tiles = [
+            s
+            for s in warp_tile_moves(atoms)
+            if _warp_move_ok(kernel, s) and probe.k_axis.extent.is_static and not replace(probe, tile=TilePlan.parse(s)).n.mask
+        ]
+    rows: list[dict] = []
+    for spec in tiles:
+        stage = _resolve_sync_stage(replace(probe, tile=TilePlan.parse(spec)))
+        if stage is None:
+            if TILE.raw() is not None:
+                raise ValueError(f"warp TILE pin {spec!r} on a fused-cone contraction: the sync slabs exceed the 48 KiB smem budget.")
+            continue
+        for red in _reduce_candidates(kernel, place, TilePlan.parse(spec), probe):
+            rows.append({_at(TILE, kaxis): spec, _at(STAGE, kaxis): stage.spell(), _at(REDUCE, kaxis): red})
+    return rows
+
+
 def _wspec_workers(stage) -> tuple[WarpSpec | None, str]:
     """The pinned ``WSPEC`` worker split for a pipeline with the given ``stage``, or ``(None, "")`` —
     uniform SIMT. A pin that doesn't parse, names no role, or whose roles are illegal (a producer needs
@@ -702,6 +796,11 @@ def _splitk_option(tile, place, tile_spec: str, split_spec: str, name: str, knob
     prior featurizer stay invariant vs the residual/golden spelling."""
     wt = TilePlan.parse(tile_spec)
     inner = _contraction_node(tile.op, place, wt)
+    if inner.a_computed:
+        raise ValueError(
+            "split-K REDUCE pin on a fused-cone (computed-A) contraction: the producer cone cannot be "
+            "sliced over K (its per-row statistic prologue spans the whole row); drop the g<w> pin."
+        )
     w = ReducePlan.parse(split_spec).cta
     # A warp (mma) slice must keep the inner K-step dividing K/w — the warp K-loop has no static-K
     # tail masking (same guard as ``_check_warp_static_k``, but on the post-split slice).
@@ -744,7 +843,14 @@ def _warp_option(tile, place, spec: str, name: str, knobs: dict, stage_spec: str
     # unbindable atom (a non-Load operand: a computed-cone / demoted matmul) raises and is rejected
     # at fork construction, like the static-K check.
     op = _contraction_node(tile.op, place, wt)
-    stage = _resolve_warp_stage(op, Stage.parse(stage_spec)) if stage_spec else None
+    # A computed-A node's stage is the mandatory resolved ``sync`` compute-fill (its ``smem`` /
+    # ``bk_elems`` are derived, not codec-spelled, so the row's ``"d1/sync"`` re-resolves here);
+    # a Load-operand node resolves the copy transports as usual.
+    if op.a_computed:
+        stage = _resolve_sync_stage(op)
+        assert stage is not None, "computed-A row enumerated past its smem budget"  # _computed_a_rows resolved this
+    else:
+        stage = _resolve_warp_stage(op, Stage.parse(stage_spec)) if stage_spec else None
     # Warp specialization rides ORTHOGONAL to the tile/stage just resolved: an optional WSPEC pin
     # splits the warps into roles over this fixed pipeline (gated on the RESOLVED ``stage`` — an
     # ineligible pin leaves no pipeline for a producer to drive, so WSPEC degrades to uniform).
@@ -847,6 +953,11 @@ def schedule(tile: TileOp, name: str, knobs: dict) -> Fork | list[TileOp] | Tile
         # (:func:`_splitk_option`, consumed by ``030_split``); a warp row through
         # :func:`_warp_option`; the rest through :func:`_tile_option`.
         rows, kaxis = _tile_rows(tile, place)
+        if not rows:
+            # A computed-A (fused-cone) contraction with no legal warp row (fp32, no atoms, bad
+            # geometry, over-budget slabs) contributes nothing — the recognizer's ``Map``-form
+            # fork siblings stand alone. Never a raising row: the guardrail contract.
+            return []
 
         def _materialize(row: dict) -> TileOp:
             spec = row.get(_at(TILE, kaxis), "")
@@ -889,41 +1000,11 @@ def schedule(tile: TileOp, name: str, knobs: dict) -> Fork | list[TileOp] | Tile
         demoted = _demoted_warp_option(tile, place, name, knobs)
         if demoted is not None:
             return demoted
-        # A MONOID (reduce-bearing) producer cone — the fused norm→linear edge — honors the same
-        # warp pin: the tail contraction nodifies with a computed A whose cone CARRIES the per-row
-        # statistic prologue (run once cooperatively by the sync transport's stat fill).
-        prologue = _prologue_warp_option(tile, name, knobs)
-        if prologue is not None:
-            return prologue
+        # (The MONOID-producer cone — the fused norm→linear edge — no longer needs a rescue here:
+        # recognition nodifies it to a computed-A Contraction fork sibling, ``010_recognize``'s
+        # ``bind_prologue_contraction`` merge, so it arrives at this dispatch as CONTRACTION.)
     specs = _reduce_specs(tile, place)
     return [_option(tile, place, spec, name, knobs) for spec in specs]
-
-
-def _map_cone(body: list, root: str) -> list | None:
-    """The backward cone of SSA ``root`` within ``body`` — the fused producer's compute, in body
-    order. ``None`` unless every cone stmt is a scalar ``Load`` or a pointwise ``Assign`` (a pure
-    MAP cone — a reduce-bearing cone, e.g. an rmsnorm scale, is not compute-fillable per cell)."""
-    defs: dict[str, Stmt] = {}
-    for st in body:
-        for d in st.defines():
-            defs[d] = st
-    need, cone, seen = [root], [], set()
-    while need:
-        nm = need.pop()
-        st = defs.get(nm)
-        if st is None or id(st) in seen:
-            continue
-        seen.add(id(st))
-        if isinstance(st, Load):
-            cone.append(st)
-            continue
-        if isinstance(st, Assign):
-            cone.append(st)
-            need.extend(st.args)
-            continue
-        return None  # an Accum / Loop / Select in the cone — not a pure MAP producer
-    order = {id(st): i for i, st in enumerate(body)}
-    return sorted(cone, key=lambda st: order[id(st)])
 
 
 _CHAIN_MAX_D = 64  # register-vector budget: the chain holds the whole output row per thread
@@ -1005,7 +1086,7 @@ def _demoted_warp_option(tile: TileOp, place, name: str, knobs: dict) -> TileOp 
     if b_name is None:
         return None
     a_name = next(a for a in lift.args if a != b_name)
-    cone = _map_cone(body, a_name)
+    cone = map_cone(body, a_name)
     if cone is None or not cone:
         return None
     for st in cone:
@@ -1042,123 +1123,6 @@ def _demoted_warp_option(tile: TileOp, place, name: str, knobs: dict) -> TileOp 
     # compute-fills the A slab instead of round-tripping a gmem intermediate. The one live producer
     # of the cone element (the cut side — materialize the producer as its own kernel — has no
     # emitter in the rebuilt tree, so only ``fuse`` is ever stamped today).
-    stamped = {**knobs, _at(TILE, k_ax.name): spec, "PLACE@cone": "fuse"}
-    return TileOp(op=node, name=name, place=place, tier=wt, stage=stage, knobs=stamped)
-
-
-def _idx_vars_deep(stmts) -> set:
-    """Every free Var name across the index exprs reachable in ``stmts`` (deep)."""
-    out: set = set()
-    for s in stmts:
-        idx = getattr(s, "index", None)
-        if idx:
-            out |= {v for e in idx for v in e.free_vars()}
-        for b in s.nested():
-            out |= _idx_vars_deep(list(b))
-    return out
-
-
-def _prologue_warp_option(tile: TileOp, name: str, knobs: dict) -> TileOp | None:
-    """The warp (mma) candidate for a **reduce-bearing (MONOID) producer cone** — the fused
-    norm→linear edge (``rmsnorm(x)·nw @ w``): a projecting ``Map`` whose ``source`` is a per-row
-    ``PLANAR`` statistic reduce and whose body is that statistic's scalar epilogue followed by a
-    fresh free (column) ``Loop`` over an ⊗-fold contraction whose A cone reads the statistic.
-    PIN-DRIVEN like the matmul warp tier. Nodifies the tail fold to a computed-A
-    :class:`Contraction` whose A cone **carries the statistic prologue** (the annotated stat
-    reduce ``Loop`` + its scalar epilogue ahead of the per-cell map stmts — the k-invariant
-    prefix) and stamps the ``sync`` compute-fill :class:`Stage`; the materializer runs that
-    prefix ONCE per tile row into a stat smem row (``_stage.sync_stat_fill``, the shared-row
-    seam) and the per-cell remainder per A-slab cell. The column axis joins the grid. First cut:
-    exact-cover geometry only (static M/N/K divisible), like the demoted-cone option."""
-    spec = TILE.narrow([""])[0]
-    if not is_warp_codec(spec):
-        return None
-    op = tile.op
-    if not isinstance(op, Map) or not isinstance(op.source, Reduction):
-        return None
-    red = op.source
-    if red.role is not AxisRole.PLANAR or red.source is not None or red.carrier.twist.family != "id":
-        return None
-    body = list(op.body)
-    if not body or not isinstance(body[-1], Loop) or body[-1].is_reduce:
-        return None
-    stat_epi, nloop = body[:-1], body[-1]
-    if not all(isinstance(s, (Load, Assign)) for s in stat_epi):
-        return None
-    n_ax = nloop.axis
-    inner = list(nloop.body)
-    if len(inner) != 2 or not isinstance(inner[0], Loop) or not inner[0].is_reduce or not isinstance(inner[1], Write):
-        return None
-    kloop, write = inner
-    k_ax = kloop.axis
-    grid = list(tile.place.free)
-    if not grid:
-        return None
-    m_ax = grid[-1]
-    kbody = list(kloop.body)
-    accums = [st for st in kbody if isinstance(st, Accum)]
-    if len(accums) != 1 or accums[0].op.name != "add":
-        return None
-    acc = accums[0]
-    if write.values != (acc.name,) or not write.is_scalar:
-        return None
-    defs = {st.name: st for st in kbody if isinstance(st, Assign)}
-    lift = defs.get(acc.value)
-    if lift is None or lift.op.name != "multiply" or len(lift.args) != 2:
-        return None
-    loads = {st.names[0]: st for st in kbody if isinstance(st, Load)}
-
-    def _load_vars(nm: str) -> set | None:
-        ld = loads.get(nm)
-        return {v for e in ld.index for v in e.free_vars()} if ld is not None else None
-
-    b_name = next((a for a in lift.args if (vs := _load_vars(a)) and n_ax.name in vs and k_ax.name in vs), None)
-    if b_name is None:
-        return None
-    a_name = next(a for a in lift.args if a != b_name)
-    cone = _map_cone(kbody, a_name)
-    if cone is None or not cone:
-        return None
-    for st in cone:
-        if isinstance(st, Load) and n_ax.name in {v for e in st.index for v in e.free_vars()}:
-            return None  # the cone must be (m, k)-indexed — an n-dependent producer isn't the A tile
-    # Every free SSA name the cone reads must be a statistic (the source reduce's carried state or
-    # its scalar epilogue) — anything else is a shape this option doesn't understand.
-    stat_defs = {red.out} | {nm for s in stat_epi for nm in s.defines()}
-    cone_defs = {nm for st in cone for nm in st.defines()}
-    free_refs = {a for st in cone if isinstance(st, Assign) for a in st.args if a not in cone_defs}
-    if not free_refs or not free_refs <= stat_defs:
-        return None  # a stat-free cone is the demoted option's shape, not ours
-    # The statistic prologue must be row-local: its gmem reads may index (m, its own reduce axis)
-    # but never the column / contraction axes.
-    if _idx_vars_deep([*red.partial, *stat_epi]) & {n_ax.name, k_ax.name}:
-        return None
-    wt = TilePlan.parse(spec)
-    atom = wt.atom
-    atom_m, atom_n, atom_k = atom.shape
-    first_load = next((st for st in cone if isinstance(st, Load)), None)
-    t = tile.inputs.get(first_load.input) if (first_load is not None and tile.inputs) else None
-    if getattr(getattr(t, "dtype", None), "name", None) != atom.ab_dtype:
-        return None
-    exts = (m_ax.extent, n_ax.extent, k_ax.extent)
-    if not all(e.is_static for e in exts):
-        return None
-    M, N, K = (e.as_static() for e in exts)
-    bk_elems = wt.bk * atom_k
-    if K % bk_elems or M % (wt.units_m * wt.reg_m * atom_m) or N % (wt.units_n * wt.reg_n * atom_n):
-        return None
-    place = Placement(free=(*tile.place.free, n_ax)).on_grid()
-    node = Contraction(
-        axes=(m_ax, n_ax),
-        k_axis=k_ax,
-        a_operand=Body((red.loop, *stat_epi, *cone)),
-        b_load=loads[b_name],
-        acc=acc.name,
-        tile=wt,
-        lead_axes=tuple(grid[:-1]),
-        epilogue=Body((write,)),
-    )
-    stage = Stage(transport="sync", smem=(node.a_name,), bk_elems=bk_elems)
     stamped = {**knobs, _at(TILE, k_ax.name): spec, "PLACE@cone": "fuse"}
     return TileOp(op=node, name=name, place=place, tier=wt, stage=stage, knobs=stamped)
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -624,14 +624,14 @@ def _resolve_sync_stage(c: Contraction) -> Stage | None:
     sibling and a ``STAGE`` pin degrades to this resolved row. ``None`` when the slabs don't fit the
     48 KiB smem budget: the A/B operand slabs (single-buffer — ``SyncTransport`` has no ring) plus
     one fp32 row per bridged statistic (``sync_stat_fill``'s decls — the same
-    ``_split_stat_prologue`` seam the materializer fills through)."""
-    from emmy.compiler.pipeline.passes.lowering.kernel._atom import _split_stat_prologue  # noqa: PLC0415 — avoid an import cycle
-
+    ``Contraction.stat_prologue`` seam the materializer fills through)."""
     atom = c.atom
     bk_elems = c.tile.bk * atom.atom_k
     a_nbytes = atom.operand_dtype("a").nbytes
-    _, _, stats = _split_stat_prologue(c.a_body, c.k_axis.name)
-    slab_bytes = (c.m.tile + c.n.tile) * bk_elems * a_nbytes + len(stats) * c.m.tile * 4
+    _, _, stats = c.stat_prologue()
+    # One A slab + one B slab per fold channel (the multi-channel gate/up node fills a B slab per
+    # projection) + one fp32 stat row per bridged statistic.
+    slab_bytes = (c.m.tile + len(c.folds) * c.n.tile) * bk_elems * a_nbytes + len(stats) * c.m.tile * 4
     if slab_bytes > 48 * 1024:
         return None
     return Stage(transport="sync", smem=(c.a_name,), bk_elems=bk_elems)
@@ -651,10 +651,15 @@ def _computed_a_rows(kernel, place, probe: Contraction, kaxis: str) -> list[dict
     sibling's business); ``REDUCE`` rides :func:`_reduce_candidates` (split-K is excluded unpinned;
     a ``g<w>`` pin raises in :func:`_splitk_option`); a ``STAGE`` pin is ignored in favor of the
     resolved sync row."""
+    # The projection rides the recognizer's ``Map`` wrapper (plus any node epilogue) — the store
+    # folds it into the fragment epilogue, so it must be fragment-realizable (no gather chains).
+    tail = (*probe.epilogue, *kernel.op.body) if isinstance(kernel.op, Map) else tuple(probe.epilogue)
+    if not _fragment_epilogue_ok(Body(tail)):
+        return []
     if TILE.raw() is not None:
         spec = TILE.narrow([""])[0]
-        if not is_warp_codec(spec):
-            return []
+        if not is_warp_codec(spec) or not _warp_atoms(kernel, probe):
+            return []  # a scalar/empty pin, or no dtype-eligible atom (fp32) — the reduce sibling's business
         wt = TilePlan.parse(spec)
         _check_warp_static_k(kernel, wt)
         if not probe.k_axis.extent.is_static:
@@ -739,6 +744,11 @@ def _contraction_node(node, place, tile_plan: TilePlan) -> Contraction:
     binding's body verbatim — the synthesized grid-``Write`` for a bare contraction stays a
     materialize concern (it needs ``root.output``), appended there when the epilogue carries no
     ``Write``."""
+    if isinstance(node, Map) and isinstance(node.source, Contraction):
+        # The recognizer's ``Map(body=projection, source=Contraction)`` spelling — the node under
+        # the wrapper is the schedulable contraction; the projection stays on the ``Map`` (the
+        # option builders re-wrap, materialize peels it into the store tail).
+        return replace(node.source, tile=tile_plan)
     if isinstance(node, Contraction):
         return replace(node, tile=tile_plan)
     grid = list(place.grid)
@@ -747,8 +757,7 @@ def _contraction_node(node, place, tile_plan: TilePlan) -> Contraction:
         axes=(grid[-2], grid[-1]),
         k_axis=reduce_loop(node).axis,
         a_operand=a_load,
-        b_load=b_load,
-        acc=acc,
+        folds=((b_load, acc),),
         tile=tile_plan,
         lead_axes=tuple(grid[:-2]),
         epilogue=epilogue,
@@ -817,7 +826,7 @@ def _splitk_option(tile, place, tile_spec: str, split_spec: str, name: str, knob
         inner,
         k_axis=kslice,
         a_operand=replace(inner.a_operand, index=tuple(sigma.apply(e) for e in inner.a_operand.index)),
-        b_load=replace(inner.b_load, index=tuple(sigma.apply(e) for e in inner.b_load.index)),
+        folds=tuple((replace(bl, index=tuple(sigma.apply(e) for e in bl.index)), acc) for bl, acc in inner.folds),
     )
     stage = None
     if stage_spec:
@@ -851,6 +860,9 @@ def _warp_option(tile, place, spec: str, name: str, knobs: dict, stage_spec: str
         assert stage is not None, "computed-A row enumerated past its smem budget"  # _computed_a_rows resolved this
     else:
         stage = _resolve_warp_stage(op, Stage.parse(stage_spec)) if stage_spec else None
+    # Re-wrap the recognizer's projecting ``Map`` around the tiled node (materialize peels it into
+    # the store tail — the same ``project ∘ contract`` spelling the Reduction tiers use).
+    emitted = replace(tile.op, source=op) if isinstance(tile.op, Map) and isinstance(tile.op.source, Contraction) else op
     # Warp specialization rides ORTHOGONAL to the tile/stage just resolved: an optional WSPEC pin
     # splits the warps into roles over this fixed pipeline (gated on the RESOLVED ``stage`` — an
     # ineligible pin leaves no pipeline for a producer to drive, so WSPEC degrades to uniform).
@@ -867,7 +879,7 @@ def _warp_option(tile, place, spec: str, name: str, knobs: dict, stage_spec: str
     stamped[_at(STAGE, kaxis)] = stage.spell() if stage is not None else ""
     if wspec_spec:
         stamped[WSPEC.name] = wspec_spec
-    return TileOp(op=op, name=name, place=place, tier=wt, stage=stage, workers=workers, knobs=stamped)
+    return TileOp(op=emitted, name=name, place=place, tier=wt, stage=stage, workers=workers, knobs=stamped)
 
 
 def _tile_option(tile, place, spec: str, name: str, knobs: dict, reduce_spec: str = "", stage_spec: str = "") -> TileOp:
@@ -1112,8 +1124,7 @@ def _demoted_warp_option(tile: TileOp, place, name: str, knobs: dict) -> TileOp 
         axes=(m_ax, n_ax),
         k_axis=k_ax,
         a_operand=Body(tuple(cone)),
-        b_load=loads[b_name],
-        acc=acc.name,
+        folds=((loads[b_name], acc.name),),
         tile=wt,
         lead_axes=tuple(grid[:-2]),
         epilogue=epilogue,

--- a/tests/compiler/e2e/test_fused_edge.py
+++ b/tests/compiler/e2e/test_fused_edge.py
@@ -195,3 +195,44 @@ def test_fused_rmsnorm_linear_unpinned():
     the fork-integrity e2e (runs on any CUDA device; option-0 stays the coop row)."""
     S, H, inter = 32, 256, 512
     _rmsnorm_linear_check(_rmsnorm_linear_graph(S, H, inter), S, H, inter, want_mma=False)
+
+
+@requires_cuda
+@requires_sm90
+@pytest.mark.parametrize("runtime_s", [31, 130])
+def test_fused_gate_up_swiglu_symbolic_m(runtime_s, monkeypatch):
+    """The MULTI-FOLD (product-monoid) fused edge — ``swiglu(rmsnorm(x)·nw @ Wg, rmsnorm(x)·nw @
+    Wu)`` in ONE mma kernel: the two folds share the compute-filled A slab (one ldmatrix'd A
+    fragment feeding per-fold B slabs / C fragments) and the SwiGLU combine rides the store's
+    fragment epilogue; the seq axis is symbolic with a masked M tail (31 under / 130 over the
+    64-row tile)."""
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16/w2x2/f2x2/k2")
+    S, H, inter = runtime_s, 256, 512
+    Sd = Dim("seq_len", hint=64)
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, Sd, H), F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("nw", (H,), F16), node_id="nw")
+    g.add_node(InputOp(), [], Tensor("wg", (inter, H), F16), node_id="wg")
+    g.add_node(InputOp(), [], Tensor("wu", (inter, H), F16), node_id="wu")
+    g.add_node(RmsNormOp(eps=1e-6), ["x", "nw"], Tensor("xn", (1, Sd, H), F16), node_id="xn")
+    g.add_node(LinearOp(), ["xn", "wg"], Tensor("gate", (1, Sd, inter), F16), node_id="gate")
+    g.add_node(LinearOp(), ["xn", "wu"], Tensor("up", (1, Sd, inter), F16), node_id="up")
+    g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("sg", (1, Sd, inter), F16), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, Sd, inter), F16), node_id="o")
+    g.inputs, g.outputs = ["x", "nw", "wg", "wu"], ["o"]
+
+    rng = np.random.default_rng(0)
+    ins = {
+        "x": (rng.standard_normal((1, S, H)) * 0.3).astype(np.float16),
+        "nw": (rng.standard_normal((H,)) * 0.3).astype(np.float16),
+        "wg": (rng.standard_normal((inter, H)) * 0.1).astype(np.float16),
+        "wu": (rng.standard_normal((inter, H)) * 0.1).astype(np.float16),
+    }
+    got, srcs = _compile_run(g, ins)
+    assert len(srcs) == 1, f"the fused gate/up edge must be ONE kernel, got {len(srcs)}"
+    assert "dpl_mma" in srcs[0], "the pinned mma tier must engage on the multi-fold contraction"
+    x, nw, wg, wu = (ins[k].astype(np.float32) for k in ("x", "nw", "wg", "wu"))
+    rms = x[0] * (1.0 / np.sqrt((x[0] ** 2).mean(axis=-1, keepdims=True) + 1e-6)) * nw
+    gate, up = rms @ wg.T, rms @ wu.T
+    ref = gate * _sigmoid(gate) * up
+    np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), ref, atol=0.5, rtol=0.1)

--- a/tests/compiler/e2e/test_fused_edge.py
+++ b/tests/compiler/e2e/test_fused_edge.py
@@ -8,9 +8,10 @@ structural pin lives with ``test_fused_prologue_compiles_in_budget``).
 
 The **warp tier** engages under a warp ``TILE`` pin: the demoted cone nodifies to a computed-A
 ``Contraction`` (``_schedule._demoted_warp_option``) and the producer COMPUTE-FILLS the A slab the
-``ldmatrix`` drain reads (the mma tier's ``sync`` transport). Two cells stay xfailed via the
-registry: the broadcast producer recognizes as a flat un-annotated ``Map`` (a recognition gap), and
-the MONOID (rmsnorm) cone carries a reduce — not compute-fillable per cell.
+``ldmatrix`` drain reads (the mma tier's ``sync`` transport). The MONOID (rmsnorm) cone is
+recognize-nodified (``010_recognize``'s ``bind_prologue_contraction`` merge): its statistic reduce
+rides the A cone as a per-row prologue (``sync_stat_fill``), the warp rows are real fork siblings
+of the coop ``Map`` form (exercised unpinned below), and a masked / symbolic M clamp-reads.
 """
 
 from __future__ import annotations
@@ -19,11 +20,12 @@ import numpy as np
 import pytest
 
 from emmy.compiler import dtype as _dt
+from emmy.compiler.dim import Dim
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import LinearOp, MatmulOp, RmsNormOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
-from tests.compiler.conftest import requires_cuda
+from tests.compiler.conftest import requires_cuda, requires_sm90
 
 F16 = _dt.get("f16")
 _M, _K, _N = 32, 64, 32  # M != K so the row / col broadcasts are unambiguous
@@ -112,7 +114,8 @@ def test_fused_rmsnorm_linear(tier, monkeypatch):
     numpy reference (whether the linear's N axis rides the grid or a tail sweep is the schedule's
     choice — the staged-shared-row structural pin lives with `test_fused_prologue_compiles_in_budget`,
     whose shape keeps the sweep in-tail). The ``warp`` cell demands the mma tier on the fused
-    matmul (xfailed — the MONOID-producer warp fused edge is not rebuilt)."""
+    matmul — the recognize-nodified computed-A ``Contraction`` (the statistic prologue rides the
+    A cone, run once per tile row by the sync stat fill)."""
     if tier == "warp":
         monkeypatch.setenv("EMMY_TILE", _WARP_TILE)
     S, H, inter = 32, 1024, 3072
@@ -140,3 +143,55 @@ def test_fused_rmsnorm_linear(tier, monkeypatch):
     # rms-scale reduce + fp16 matmul accumulate at K=1024) — rtol=0.1 catches a regression without
     # flaking; atol absorbs near-zero elements where relative error is meaningless.
     np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), rms @ wg.T, atol=0.5, rtol=0.1)
+
+
+def _rmsnorm_linear_graph(S, H: int, inter: int) -> Graph:
+    """``rmsnorm(x)·nw @ wg`` — ``S`` is an int (static) or a ``Dim`` (symbolic seq)."""
+    Sd = S if isinstance(S, Dim) else S
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, Sd, H), F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("nw", (H,), F16), node_id="nw")
+    g.add_node(InputOp(), [], Tensor("wg", (inter, H), F16), node_id="wg")
+    g.add_node(RmsNormOp(eps=1e-6), ["x", "nw"], Tensor("xn", (1, Sd, H), F16), node_id="xn")
+    g.add_node(LinearOp(), ["xn", "wg"], Tensor("o", (1, Sd, inter), F16), node_id="o")
+    g.inputs, g.outputs = ["x", "nw", "wg"], ["o"]
+    return g
+
+
+def _rmsnorm_linear_check(g: Graph, S: int, H: int, inter: int, *, want_mma: bool) -> None:
+    rng = np.random.default_rng(0)
+    ins = {
+        "x": (rng.standard_normal((1, S, H)) * 0.3).astype(np.float16),
+        "nw": (rng.standard_normal((H,)) * 0.3).astype(np.float16),
+        "wg": (rng.standard_normal((inter, H)) * 0.1).astype(np.float16),
+    }
+    got, srcs = _compile_run(g, ins)
+    assert len(srcs) == 1, f"the fused norm→linear must be ONE kernel, got {len(srcs)}"
+    if want_mma:
+        assert "dpl_mma" in srcs[0], "the pinned mma tier must engage on the fused matmul"
+    x, nw, wg = (ins[k].astype(np.float32) for k in ("x", "nw", "wg"))
+    rms = x[0] * (1.0 / np.sqrt((x[0] ** 2).mean(axis=-1, keepdims=True) + 1e-6)) * nw
+    np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), rms @ wg.T, atol=0.5, rtol=0.1)
+
+
+@requires_cuda
+@requires_sm90
+@pytest.mark.parametrize("runtime_s", [31, 130])
+def test_fused_rmsnorm_linear_symbolic_m(runtime_s, monkeypatch):
+    """The MONOID warp fused edge over a **symbolic seq axis** — ONE masked-M mma kernel deployed
+    at the hint and run at off-hint sizes straddling the 64-row tile (31 under, 130 over + tail):
+    the sync compute-fill / stat-prologue σ clamp the overhanging rows and the ``RegStore`` guard
+    discards their store."""
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16/w2x2/f2x2/k2")  # tile 64×32 — every runtime S is masked
+    H, inter = 256, 512
+    g = _rmsnorm_linear_graph(Dim("seq_len", hint=64), H, inter)
+    _rmsnorm_linear_check(g, runtime_s, H, inter, want_mma=True)
+
+
+@requires_cuda
+def test_fused_rmsnorm_linear_unpinned():
+    """UNPINNED greedy on the fused norm→linear: the merged fork (coop ``Map`` rows + the
+    computed-A Contraction's warp rows) lowers and matches numpy whichever row the prior picks —
+    the fork-integrity e2e (runs on any CUDA device; option-0 stays the coop row)."""
+    S, H, inter = 32, 256, 512
+    _rmsnorm_linear_check(_rmsnorm_linear_graph(S, H, inter), S, H, inter, want_mma=False)

--- a/tests/compiler/e2e/test_knob_pinning.py
+++ b/tests/compiler/e2e/test_knob_pinning.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from ..conftest import dyn_M, requires_cuda
+from ..conftest import dyn_M, requires_cuda, requires_sm90
 
 
 def _format_knobs(knobs: dict) -> str:
@@ -149,6 +149,30 @@ def test_norm_linear_fp16_scalar_reduce_tma_alignment(shape_mode, monkeypatch):
     ref = _reference(static_graph, inputs, out_name)
     forced = _run_with_knobs(forced_graph, inputs, out_name, _NORM_REDUCE_WEDGE_KNOBS, monkeypatch)
     # fp16 reduction drift over H=128 — same looser bound the other fp16 tests use.
+    peak = float(np.max(np.abs(ref.astype(np.float32))))
+    atol = max(5e-1, 0.1 * peak)
+    np.testing.assert_allclose(forced.astype(np.float32), ref.astype(np.float32), atol=atol, rtol=0.1)
+
+
+# The recognize-nodified MONOID fused edge (norm→linear as a computed-A ``Contraction``) pinned to
+# the warp mma tier at a 64-row tile: S=32 overhangs it, so the STATIC mode exercises the masked
+# static-M sync compute-fill (clamped A/stat σ + guarded ``RegStore``) and the DYNAMIC mode the
+# symbolic-M form of the same clamps. K=128 / N=512 exactly cover (the sync fill's N/K contract).
+_NORM_WARP_FUSED_KNOBS = {"TILE": "a:mma_m16n8k16_f16/w2x2/f2x2/k2"}
+
+
+@requires_cuda
+@requires_sm90
+def test_norm_linear_warp_fused_masked_m(shape_mode, monkeypatch):
+    """fp16 ``RmsNorm(x) @ W.T`` pinned to the warp mma tier — the fused edge is ONE mma kernel
+    whose statistic prologue rides the A cone (no separate norm-reduce producer), with the M tail
+    masked in both shape modes."""
+    static_graph, input_shapes, (out_name, _) = _build_norm_linear_graph(_NORM_DIMS)
+    forced_graph, _, _ = _build_norm_linear_graph(_NORM_DIMS, mode=shape_mode)
+    rng = np.random.default_rng(0)
+    inputs = {name: (rng.standard_normal(shape, dtype=np.float32) * 0.1).astype(np.float16) for name, shape in input_shapes.items()}
+    ref = _reference(static_graph, inputs, out_name)
+    forced = _run_with_knobs(forced_graph, inputs, out_name, _NORM_WARP_FUSED_KNOBS, monkeypatch)
     peak = float(np.max(np.abs(ref.astype(np.float32))))
     atol = max(5e-1, 0.1 * peak)
     np.testing.assert_allclose(forced.astype(np.float32), ref.astype(np.float32), atol=atol, rtol=0.1)

--- a/tests/compiler/ir/tile/test_structural_reduction.py
+++ b/tests/compiler/ir/tile/test_structural_reduction.py
@@ -119,8 +119,7 @@ def _contraction(epilogue: Body | None = None) -> Contraction:
         axes=(Axis("m", 128), Axis("n", 128)),
         k_axis=Axis("k", 256),
         a_operand=a,
-        b_load=b,
-        acc="acc",
+        folds=((b, "acc"),),
         tile=TilePlan.parse("n2/f2"),
         epilogue=epilogue or Body(()),
     )
@@ -211,7 +210,7 @@ def test_splitk_reduction_over_contraction_is_no_double_reduce() -> None:
         c,
         k_axis=kslice,
         a_operand=replace(c.a_operand, index=tuple(sigma.apply(e) for e in c.a_operand.index)),
-        b_load=replace(c.b_load, index=tuple(sigma.apply(e) for e in c.b_load.index)),
+        folds=tuple((replace(bl, index=tuple(sigma.apply(e) for e in bl.index)), acc) for bl, acc in c.folds),
     )
     carrier = Accum(name="acc", value="acc__v", op=ElementwiseImpl("add")).as_carrier()
     red = Reduction(carrier=carrier, axis=ksplit, role=AxisRole.CONTRACTION, source=inner, reduce=ReducePlan.of(cta=2, finalize="atomic"))
@@ -234,7 +233,8 @@ def test_reduce_partial_flattens_a_nested_pv_contraction() -> None:
     loop in place — one recursion rule, so the scalar tier expands ``for kv:[QK loop; P; PV loop;
     fold]``. This is the structural seam warp-flash rides."""
     qk = _contraction()  # Σ_k A·B -> acc (the score S)
-    pv = replace(_contraction(), axes=(Axis("m", 128), Axis("d", 64)), k_axis=Axis("j", 32), acc="oblk")
+    pv = replace(_contraction(), axes=(Axis("m", 128), Axis("d", 64)), k_axis=Axis("j", 32))
+    pv = replace(pv, folds=((pv.b_load, "oblk"),))
     prob = Assign(name="p", op="exp", args=("acc",))  # softmax weight between the two contractions
     fold = Accum(name="O_i", value="oblk", op="add")
     red = Reduction(carrier=fold.as_carrier(), axis=Axis("kv", 128), partial=Body((prob, pv, fold)), role=AxisRole.TWISTED, source=qk)
@@ -287,8 +287,7 @@ def _pv_contraction(tile: str = "") -> Contraction:
         axes=(Axis("m", 8), Axis("d", 8)),
         k_axis=Axis("j", 8),
         a_operand=a_body,
-        b_load=Load(name="v_e", input="V", index=(Var("j"), Var("d"))),
-        acc="oblk",
+        folds=((Load(name="v_e", input="V", index=(Var("j"), Var("d"))), "oblk"),),
         tile=TilePlan.parse(tile) if tile else TilePlan(),
         epilogue=Body((Write(output="out", index=(Var("m"), Var("d")), value="oblk"),)),
     )

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -4,15 +4,26 @@
 ``LoopOp`` into the tile IR (a ``Map`` / ``Reduction`` / ``Contraction``
 node). These assert it fires on the two simplest kinds — pointwise and
 reduce — transitively proving the axes got lifted and the kernel entered
-the tile dialect (no planner / launch-geometry fallback needed).
+the tile dialect (no planner / launch-geometry fallback needed), and that
+the MONOID-producer composition (the fused norm→linear edge) nodifies to
+a computed-A ``Contraction`` fork sibling of the ``Map`` form.
 """
 
 from __future__ import annotations
 
+from emmy.compiler.context import Context
+from emmy.compiler.dim import Dim
+from emmy.compiler.dtype import F16, F32
 from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.axis import AxisRole
 from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.frontend.ir import LinearOp, RmsNormOp
+from emmy.compiler.ir.stmt import Loop, Write
 from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
+from emmy.compiler.ir.tile import Contraction, Map, TileOp
 from emmy.compiler.pipeline import TILE_PASSES, Pipeline
+from emmy.compiler.pipeline.fork import flatten_leaves
+from emmy.compiler.pipeline.pipeline import Run
 
 
 def _input(g: Graph, name: str, shape: tuple) -> str:
@@ -39,3 +50,121 @@ def test_recognize_fires_on_reduction(recording_dump):
 
     Pipeline.build(TILE_PASSES).run(g, dump=recording_dump)
     assert "recognize" in recording_dump.fired_rules("lowering/tile")
+
+
+# --------------------------------------------------------------------------- #
+# The MONOID-producer composition — ``rmsnorm(x)·nw @ w`` nodifies to a computed-A
+# ``Contraction`` fork sibling of the ``Map(source=Reduction)`` form (``010_recognize``'s
+# ``bind_prologue_contraction`` merge). Pipeline-only (no CUDA): resolve the tile passes with a
+# capturing ``decide`` and assert the fork rows / the picked node's structure.
+# --------------------------------------------------------------------------- #
+
+
+def _norm_linear_graph(dt=F16, S: int | Dim = 32, H: int = 1024, inter: int = 3072) -> Graph:
+    g = Graph()
+    Sd = S if isinstance(S, Dim) else Dim(S)
+    g.add_node(InputOp(), [], Tensor("x", (1, Sd, Dim(H)), dtype=dt), node_id="x")
+    g.add_node(InputOp(), [], Tensor("wn", (Dim(H),), dtype=dt), node_id="wn")
+    g.add_node(InputOp(), [], Tensor("w", (Dim(inter), Dim(H)), dtype=dt), node_id="w")
+    g.add_node(RmsNormOp(), ["x", "wn"], Tensor("xn", (1, Sd, Dim(H)), dtype=dt), node_id="xn")
+    g.add_node(LinearOp(), ["xn", "w"], Tensor("y", (1, Sd, Dim(inter)), dtype=dt), node_id="y")
+    g.inputs, g.outputs = ["x", "wn", "w"], ["y"]
+    return g
+
+
+def _resolve(g: Graph, pick=None) -> tuple[list[dict], TileOp]:
+    """Run the tile passes, capturing every fork leaf's knob row; ``pick`` selects the applied
+    leaf (default: option-0, the emission-order head). Returns ``(rows, the one TileOp)``."""
+    rows: list[dict] = []
+
+    def decide(fp):
+        leaves = flatten_leaves(fp.options)
+        rows.extend(dict(getattr(leaf, "knobs", {}) or {}) for leaf in leaves)
+        if pick is not None:
+            for leaf in leaves:
+                if pick(dict(getattr(leaf, "knobs", {}) or {})):
+                    return leaf
+        return leaves[0]
+
+    rg, _ = Run(pipeline=Pipeline.build(TILE_PASSES), ctx=Context.from_target((12, 0))).resolve(g, decide)
+    tiles = [n.op for n in rg.nodes.values() if isinstance(n.op, TileOp)]
+    assert len(tiles) == 1, f"expected the fused norm→linear to be ONE kernel, got {len(tiles)}"
+    return rows, tiles[0]
+
+
+def _is_warp_row(row: dict) -> bool:
+    return any("a:" in str(v) for v in row.values())
+
+
+def test_norm_linear_offers_map_rows_then_warp_contraction_rows():
+    """The merged fork: the ``Map``-form reduce rows lead (option-0 = the conservative coop pick,
+    lowerable everywhere), then the computed-A Contraction form's warp rows, each riding the
+    mandatory resolved ``sync`` compute-fill stage with the contraction K partition decided-empty."""
+    rows, _ = _resolve(_norm_linear_graph())
+    assert rows, "no fork was offered for the fused norm→linear"
+    assert not _is_warp_row(rows[0]), "option-0 must be the Map-form coop row, not a warp row"
+    assert any(v.startswith("b") for v in rows[0].values() if isinstance(v, str)), "option-0 must cooperate on the stat reduce"
+    warp = [r for r in rows if _is_warp_row(r)]
+    assert warp, "the Contraction form contributed no warp rows"
+    for r in warp:
+        stage = [v for k, v in r.items() if k.startswith("STAGE@")]
+        red = [v for k, v in r.items() if k.startswith("REDUCE@")]
+        assert stage == ["d1/sync"], f"warp rows must ride the resolved sync compute-fill: {r}"
+        assert all(v == "" for v in red), f"the computed-A form has no reduce partition: {r}"
+
+
+def test_norm_linear_warp_pick_is_computed_a_contraction():
+    """Picking a warp row materializes the recognize-built node: a computed-A :class:`Contraction`
+    whose A cone is headed by the annotated PLANAR statistic reduce ``Loop``, its (m, n) output on
+    the grid (the column axis joined), the bare ``Write`` epilogue, and the knob stamps the DB rows
+    key on (``PLACE@cone`` + the decided-empty stat ``REDUCE``)."""
+    _, tile = _resolve(_norm_linear_graph(), pick=_is_warp_row)
+    c = tile.op
+    assert isinstance(c, Contraction) and c.a_computed
+    stat_loop = c.a_operand[0]
+    assert isinstance(stat_loop, Loop) and stat_loop.is_reduce and stat_loop.role is AxisRole.PLANAR
+    assert [a.extent.as_static() for a in c.axes] == [32, 3072]
+    assert c.axes[0].name == tile.place.grid[-2].name and c.axes[1].name == tile.place.grid[-1].name
+    assert [type(s) for s in c.epilogue] == [Write]
+    assert {"x", "wn", "w"} <= set(c.external_reads())
+    assert tile.stage is not None and tile.stage.transport == "sync" and tile.stage.bk_elems > 0
+    assert tile.knobs.get("PLACE@cone") == "fuse"
+    assert tile.knobs.get(f"REDUCE@{stat_loop.axis.name}") == ""
+    assert tile.knobs.get(f"TILE@{c.k_axis.name}", "").startswith("a:")
+    assert tile.knobs.get(f"STAGE@{c.k_axis.name}") == "d1/sync"
+
+
+def test_norm_linear_fp32_keeps_map_rows_only():
+    """No 16-bit mma atom ⇒ the Contraction form contributes ZERO rows (never a raising row) and
+    the fork is exactly the Map-form reduce rows — the graceful fallback."""
+    rows, tile = _resolve(_norm_linear_graph(dt=F32))
+    assert rows and not any(_is_warp_row(r) for r in rows)
+    assert isinstance(tile.op, Map)
+
+
+def test_norm_linear_symbolic_m_offers_warp_rows():
+    """A symbolic seq axis (masked M) stays eligible — the sync fill clamps the row coordinate, so
+    only N/K demand exact cover."""
+    rows, _ = _resolve(_norm_linear_graph(S=Dim("seq_len")))
+    assert any(_is_warp_row(r) for r in rows)
+
+
+def test_mlp_two_linear_tail_stays_map_form():
+    """The gate/up MLP fusion (TWO column loops behind the statistic) is not the composition —
+    the matcher declines and the kernel keeps today's ``Map`` form with no sync rows."""
+    S, H, inter = 32, 1024, 3072
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, Dim(S), Dim(H)), dtype=F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("wn", (Dim(H),), dtype=F16), node_id="wn")
+    g.add_node(InputOp(), [], Tensor("wg", (Dim(inter), Dim(H)), dtype=F16), node_id="wg")
+    g.add_node(InputOp(), [], Tensor("wu", (Dim(inter), Dim(H)), dtype=F16), node_id="wu")
+    g.add_node(RmsNormOp(), ["x", "wn"], Tensor("xn", (1, Dim(S), Dim(H)), dtype=F16), node_id="xn")
+    g.add_node(LinearOp(), ["xn", "wg"], Tensor("gate", (1, Dim(S), Dim(inter)), dtype=F16), node_id="gate")
+    g.add_node(LinearOp(), ["xn", "wu"], Tensor("up", (1, Dim(S), Dim(inter)), dtype=F16), node_id="up")
+    g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("sg", (1, Dim(S), Dim(inter)), dtype=F16), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, Dim(S), Dim(inter)), dtype=F16), node_id="o")
+    g.inputs, g.outputs = ["x", "wn", "wg", "wu"], ["o"]
+
+    rows, tile = _resolve(g)
+    assert isinstance(tile.op, Map)
+    assert not any("d1/sync" in str(v) for r in rows for v in r.values())

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -114,18 +114,21 @@ def test_norm_linear_offers_map_rows_then_warp_contraction_rows():
 
 
 def test_norm_linear_warp_pick_is_computed_a_contraction():
-    """Picking a warp row materializes the recognize-built node: a computed-A :class:`Contraction`
-    whose A cone is headed by the annotated PLANAR statistic reduce ``Loop``, its (m, n) output on
-    the grid (the column axis joined), the bare ``Write`` epilogue, and the knob stamps the DB rows
-    key on (``PLACE@cone`` + the decided-empty stat ``REDUCE``)."""
+    """Picking a warp row materializes the recognize-built ``Map(body=projection, source=node)``
+    tree — the same ``project ∘ contract`` spelling the Reduction tiers use: the source is a
+    computed-A :class:`Contraction` whose A cone is headed by the annotated PLANAR statistic reduce
+    ``Loop``, one fold channel, its (m, n) output on the grid (the column axis joined); the ``Map``
+    body carries the ``Write``; and the knob stamps the DB rows key on (``PLACE@cone`` + the
+    decided-empty stat ``REDUCE``)."""
     _, tile = _resolve(_norm_linear_graph(), pick=_is_warp_row)
-    c = tile.op
-    assert isinstance(c, Contraction) and c.a_computed
+    assert isinstance(tile.op, Map)
+    c = tile.op.source
+    assert isinstance(c, Contraction) and c.a_computed and len(c.folds) == 1
     stat_loop = c.a_operand[0]
     assert isinstance(stat_loop, Loop) and stat_loop.is_reduce and stat_loop.role is AxisRole.PLANAR
     assert [a.extent.as_static() for a in c.axes] == [32, 3072]
     assert c.axes[0].name == tile.place.grid[-2].name and c.axes[1].name == tile.place.grid[-1].name
-    assert [type(s) for s in c.epilogue] == [Write]
+    assert len(c.epilogue) == 0 and [type(s) for s in tile.op.body] == [Write]
     assert {"x", "wn", "w"} <= set(c.external_reads())
     assert tile.stage is not None and tile.stage.transport == "sync" and tile.stage.bk_elems > 0
     assert tile.knobs.get("PLACE@cone") == "fuse"
@@ -149,9 +152,7 @@ def test_norm_linear_symbolic_m_offers_warp_rows():
     assert any(_is_warp_row(r) for r in rows)
 
 
-def test_mlp_two_linear_tail_stays_map_form():
-    """The gate/up MLP fusion (TWO column loops behind the statistic) is not the composition —
-    the matcher declines and the kernel keeps today's ``Map`` form with no sync rows."""
+def _mlp_gate_up_graph() -> Graph:
     S, H, inter = 32, 1024, 3072
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (1, Dim(S), Dim(H)), dtype=F16), node_id="x")
@@ -164,7 +165,19 @@ def test_mlp_two_linear_tail_stays_map_form():
     g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("sg", (1, Dim(S), Dim(inter)), dtype=F16), node_id="sg")
     g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, Dim(S), Dim(inter)), dtype=F16), node_id="o")
     g.inputs, g.outputs = ["x", "wn", "wg", "wu"], ["o"]
+    return g
 
-    rows, tile = _resolve(g)
-    assert isinstance(tile.op, Map)
-    assert not any("d1/sync" in str(v) for r in rows for v in r.values())
+
+def test_mlp_gate_up_nodifies_as_two_fold_contraction():
+    """The fused gate/up MLP edge — TWO ⊗-folds sharing one normalized-row A value (fusion
+    duplicates the cone SSA per fold; the matcher dedupes by value-tree equality) with the SwiGLU
+    combine as projection — nodifies to ``Map(body=combine…Write, source=Contraction(folds=2))``,
+    the product-monoid fold, and offers warp sync rows."""
+    rows, tile = _resolve(_mlp_gate_up_graph(), pick=_is_warp_row)
+    assert isinstance(tile.op, Map) and isinstance(tile.op.source, Contraction)
+    c = tile.op.source
+    assert len(c.folds) == 2 and c.a_computed
+    assert {bl.input for bl, _ in c.folds} == {"wg", "wu"}
+    assert isinstance(tile.op.body[-1], Write)
+    assert any(_is_warp_row(r) for r in rows)
+    assert not _is_warp_row(rows[0]), "option-0 stays the coop reduce row"


### PR DESCRIPTION
## What

Teaches the tile recognizer the **MONOID-producer composition** — the fused `rmsnorm → linear(s)` chains that own
~97% of Qwen3-Embedding's forward (finding 1 of `plans/qwen3-embedding-06b-tune-findings.md`) — as first-class
structural nodes, so the warp MMA tiers apply as real search fork candidates instead of the kernel being stuck on
the cooperative-reduce schedule with the matmul as unanalyzed `Map.body` cargo.

Two commits:

**1. Single-fold recognition + masked/symbolic-M sync fill.** `bind_prologue_contraction` (`_atomize.py`,
structure-only) nodifies `rmsnorm(x)·nw @ W` to a computed-A `Contraction` whose A cone carries the per-row
statistic prologue. `010_recognize` merges both forms into ONE fork: the coop/serial reduce rows first (option-0
stays the conservative pick, lowerable everywhere), then warp mma rows riding the mandatory resolved `sync`
compute-fill stage (`_computed_a_rows` — exact-cover N/K, no scalar/split-K rows). The sync fill's A/stat σ now
clamp a masked/symbolic M (the `RegStore` guard discards overhang stores), so the dynamic-`seq_len` serving shape
is warp-eligible. The pin-only `_prologue_warp_option` rescue is retired. Also fixed en route: rule modules must
not import `Knob` objects (`Pass.load` OFF-fills any it finds bare onto every variant of the pass).

**2. Multi-fold channels (the gate/up MLP edge).** `Contraction`'s fold spelling becomes symmetric channels —
`folds: tuple[(b_load, acc), ...]` — the product-monoid carrier specialized to contractions (one iteration space,
one A, one `TilePlan`, N channels; no new twist — the channels never interact per step). The SwiGLU combine is
projection, riding `Map(body=combine, source=Contraction)`, mirroring the Reduction spelling. The matcher binds N
add-folds whose lift values share one A cone by value-tree equality (fusion duplicates the cone SSA per consumer);
the materializer fills one A slab + per-channel B slabs and drains N mma chains off the ONE `ldmatrix`'d A fragment
into per-channel C fragments, combined per element in the store's `RegEpilogue`. The stat-prologue split lives on
the node (`Contraction.stat_prologue`) — one seam for both the scheduler's smem budget and the materializer's fill.

## Numbers (RTX 5090, fp16 `rmsnorm → gate/up → SwiGLU`, seq 512 / H 1024 / I 3072)

| schedule | latency |
|---|---|
| cooperative reduce (the only option before) | ~4.6 ms |
| **fused mma kernel (this PR, unpinned greedy pick)** | **~290 µs (16×)** |
| eager (two cuBLAS matmuls + pointwise) | 57 µs |

Accuracy verified on GPU vs numpy at static exact-cover, static masked-M, and symbolic-M (runtime seq 1–512), for
both the single-fold and gate/up forms. The remaining eager gap is sync-fill transport quality (single-buffer, per
n-block stat recompute) — now explorable by the search. Note: the committed `_tune` fp32 reproducers stay on the
coop schedule by design (no fp32 mma atom; a warp pin degrades gracefully) — the win applies to the fp16 serving
trace.

## Out of scope / follow-ups

Masked-N sync fill (the lm_head shape), split-K for computed-A, a scalar computed-A tier, first-classing the
stat-free demoted cone, and the structural un-fuse CUT for the SDPA mega-chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)