### PR TITLE
RTX 4080 (sm_89) GpuSpec + golden matmul configs

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx4080_sm89.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4080_sm89.yaml
@@ -1,0 +1,191 @@
+gpu_name: NVIDIA GeForce RTX 4080
+compute_cap: [8, 9]
+configs:
+  - kernel: matmul
+    name: square.512
+    M: 512
+    N: 512
+    K: 512
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 17.9
+    cublas_us: 18.0
+  - kernel: matmul
+    name: square.1024
+    M: 1024
+    N: 1024
+    K: 1024
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 101.8
+    cublas_us: 77.0
+  - kernel: matmul
+    name: square.2048
+    M: 2048
+    N: 2048
+    K: 2048
+    knobs: {TILE: 'n16x8/f4x8', STAGE: 'd1/cp'}
+    emmy_us: 595.5
+    cublas_us: 499.0
+  - kernel: matmul
+    name: square.4096
+    M: 4096
+    N: 4096
+    K: 4096
+    knobs: {TILE: 'n32x16/f4x10', STAGE: 'd1/cp'}
+    emmy_us: 4854.8
+    cublas_us: 3922.0
+  - kernel: matmul
+    name: square.512.fp16
+    M: 512
+    N: 512
+    K: 512
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16/w2x1/f1x4/k2', STAGE: 'd4/cp/ring'}
+    emmy_us: 8.3
+    cublas_us: 6.0
+  - kernel: matmul
+    name: square.1024.fp16
+    M: 1024
+    N: 1024
+    K: 1024
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16/w2x1/f4x4/k2', STAGE: 'd1/cp'}
+    emmy_us: 35.7
+    cublas_us: 27.0
+  - kernel: matmul
+    name: square.2048.fp16
+    M: 2048
+    N: 2048
+    K: 2048
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16/w2x1/f4x4/k2', STAGE: 'd1/cp'}
+    emmy_us: 207.1
+    cublas_us: 197.0
+  - kernel: matmul
+    name: square.4096.fp16
+    M: 4096
+    N: 4096
+    K: 4096
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16/w4x1/f2x4/k2', STAGE: 'd1/cp'}
+    emmy_us: 1580.0
+    cublas_us: 1350.0
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s32
+    M: 32
+    N: 2048
+    K: 1024
+    knobs: {TILE: 'n16x8/f4x2', REDUCE: 'g4a'}
+    emmy_us: 16.1
+    cublas_us: 10.0
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s32
+    M: 32
+    N: 1024
+    K: 1024
+    knobs: {TILE: 'n16x8/f2x2', STAGE: 'd1/cp'}
+    emmy_us: 12.3
+    cublas_us: 8.0
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s32
+    M: 32
+    N: 1024
+    K: 2048
+    knobs: {TILE: 'n32x8/f2x2', REDUCE: 'g4a'}
+    emmy_us: 21.9
+    cublas_us: 11.0
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s32
+    M: 32
+    N: 3072
+    K: 1024
+    knobs: {TILE: 'n32x8/f4x2', REDUCE: 'g4a'}
+    emmy_us: 21.7
+    cublas_us: 15.0
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s32
+    M: 32
+    N: 1024
+    K: 3072
+    knobs: {TILE: 'n32x8/f4x2', REDUCE: 'g8a'}
+    emmy_us: 26.1
+    cublas_us: 15.0
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s128
+    M: 128
+    N: 2048
+    K: 1024
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 32.8
+    cublas_us: 28.0
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s128
+    M: 128
+    N: 1024
+    K: 1024
+    knobs: {TILE: 'n16x8/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 24.4
+    cublas_us: 18.0
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s128
+    M: 128
+    N: 1024
+    K: 2048
+    knobs: {TILE: 'n16x8/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 40.7
+    cublas_us: 24.0
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s128
+    M: 128
+    N: 3072
+    K: 1024
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 53.5
+    cublas_us: 33.0
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s128
+    M: 128
+    N: 1024
+    K: 3072
+    knobs: {TILE: 'n32x16/f4x4', REDUCE: 'g8a'}
+    emmy_us: 59.3
+    cublas_us: 32.0
+  - kernel: matmul
+    name: qwen3_06b.q_proj.s512
+    M: 512
+    N: 2048
+    K: 1024
+    knobs: {TILE: 'n16x8/f4x8', STAGE: 'd1/cp'}
+    emmy_us: 92.5
+    cublas_us: 76.0
+  - kernel: matmul
+    name: qwen3_06b.kv_proj.s512
+    M: 512
+    N: 1024
+    K: 1024
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 54.6
+    cublas_us: 41.0
+  - kernel: matmul
+    name: qwen3_06b.o_proj.s512
+    M: 512
+    N: 1024
+    K: 2048
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 117.8
+    cublas_us: 84.0
+  - kernel: matmul
+    name: qwen3_06b.gate_up_proj.s512
+    M: 512
+    N: 3072
+    K: 1024
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 146.8
+    cublas_us: 123.0
+  - kernel: matmul
+    name: qwen3_06b.down_proj.s512
+    M: 512
+    N: 1024
+    K: 3072
+    knobs: {TILE: 'n16x16/f4x4', STAGE: 'd1/cp'}
+    emmy_us: 157.9
+    cublas_us: 120.0

--- a/emmy/gpu.py
+++ b/emmy/gpu.py
@@ -153,6 +153,15 @@ KNOWN_GPUS: tuple[GpuSpec, ...] = (
         peak_fp16_tflops=330.3,
     ),  # measured
     GpuSpec(
+        name="NVIDIA GeForce RTX 4080",
+        pci_device_ids=("2704",),
+        short_name="rtx4080",
+        compute_capability=(8, 9),
+        sm_count=76,
+        smem_per_sm=102400,
+        vram_mib=15946,
+    ),  # measured
+    GpuSpec(
         name="NVIDIA GeForce RTX 5090",
         pci_device_ids=("2b85",),
         short_name="rtx5090",


### PR DESCRIPTION
## Summary

Add RTX 4080 (sm_89) support: a `GpuSpec` for the card (pci 2704, 76 SMs, cc 8.9) and a 23-shape golden
matmul config set (`rtx4080_sm89.yaml`), so emmy recognizes and deploys on the 4080 — an sm_89 sibling of
the 4090.

## Notes

- Schema matches the existing per-GPU golden yamls (4090 / 5090 / pro6000); the 23 configs load and parse
  cleanly, and `tests/compiler/test_golden_configs.py` passes (30 tests).
- The golden knobs are a **pre-ring baseline** — recorded before main's scalar cp.async ring landed — so
  they can be re-tuned on the 4080 to pick up the ring.

## History

This branch previously also carried a scalar cp.async prefetch ring, but main independently shipped an
equivalent (more complete) ring via #293 / #296 / #302, so that work was dropped as redundant. Two
correctness deltas main still lacks — a bk-degrade fix and a masked-N staging gate — are being re-verified
against main for a separate focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
