### PR TITLE
Gate TMA staging to sm_90+ (fixes a non-compilable deploy on Ada/Ampere)

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -134,8 +134,12 @@ verbatim. The `Stage` spells two buffering levels:
 `p<reg_depth>` is the smem→register double-buffer (the `ldmatrix` ping-pong over the inner atom-K steps). Staging is a
 **pure perf transform** — an ineligible kernel (transposed-B, masked N, symbolic / non-divisible K, or a computed-A
 flash operand) silently falls back to gmem-direct, and a staged kernel is
-**bit-identical** to its gmem-direct baseline. Unpinned, the schedule fork enumerates the resolver-gated stage grid
-(`search/space.stage_moves`) alongside the tile / reduce moves; a `EMMY_STAGE` pin stays authoritative.
+**bit-identical** to its gmem-direct baseline. The **TMA** transport additionally requires **sm_90+**
+(Hopper/Blackwell): below it (`_schedule._tma_allowed`, mirroring the frontend TMA-fold gate) the `d*/tma*` moves are
+never offered and a `tma` pin declines to cp.async / gmem-direct — Ada/Ampere have no `cp.async.bulk.tensor` and nvcc
+has no `sm_89a` target, so a TMA kernel there would fail to compile. Unpinned, the schedule fork enumerates the
+resolver-gated stage grid (`search/space.stage_moves`) alongside the tile / reduce moves; a `EMMY_STAGE` pin stays
+authoritative.
 
 **The warp-flash stream stages too** (`STAGE@<kv>`, resolved by `_schedule._resolve_twisted_stage`): the K and V
 operands of the TWISTED streaming pair fill per-block smem slabs through the same `CpAsyncTransport` seam, the whole

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -84,6 +84,16 @@ def _smem_budget(ctx) -> int:
     return ctx.max_dynamic_smem if ctx is not None else STATIC_SMEM_CAP
 
 
+def _tma_allowed(ctx) -> bool:
+    """Whether ``TMA`` (``cp.async.bulk.tensor``) stage moves may be offered for this target. TMA is
+    a Hopper (sm_90) feature — Ada / Ampere and older have no TMA, and nvcc has no ``sm_89a`` target,
+    so a TMA stage there fails to compile (``nvcc fatal: Unsupported gpu architecture 'sm_89a'``).
+    Gate the ``d*/tma*`` moves off below sm_90, mirroring the frontend TMA-fold gate in
+    :mod:`~emmy.compiler.pipeline.passes.frontend.decomposition._fold_constant` (``cc < (9, 0)``).
+    ``ctx is None`` (direct unit-test drive, no target) allows it — those paths never reach nvcc."""
+    return ctx is None or ctx.compute_capability >= (9, 0)
+
+
 def _at(knob, axis_name: str) -> str:
     """The axis-named knob key ``FAMILY@<axis>`` (e.g. ``TILE@d``) — the per-node schedule codec keyed
     by the reduce/contraction axis it schedules, so a multi-node kernel addresses each node."""
@@ -339,18 +349,22 @@ def _tile_area(plan: TilePlan) -> int:
     return max(plan.units_m * plan.reg_m * am * plan.units_n * plan.reg_n * an, 1)
 
 
-def _stage_candidates(kernel, probe, plan: TilePlan, budget: int = STATIC_SMEM_CAP) -> list[str]:
+def _stage_candidates(kernel, probe, plan: TilePlan, budget: int = STATIC_SMEM_CAP, tma_ok: bool = True) -> list[str]:
     """The RESOLVED operand-stage spellings for one tile candidate — gmem-direct ``""`` first, then
     every grid move that resolves against the node with this ``plan`` (:func:`_resolve_warp_stage` /
     :func:`_resolve_scalar_stage`); the row carries the resolved spelling so the leaf identity, the
     stamped knobs, and the kernel agree. A pinned ``STAGE`` is authoritative: the resolved pin
-    alone, or gmem-direct when it declines (the standard pin-validity degrade)."""
+    alone, or gmem-direct when it declines (the standard pin-validity degrade). ``tma_ok`` is the
+    target's TMA availability (:func:`_tma_allowed`): below sm_90 a ``d*/tma*`` move / pin declines
+    here (stays gmem-direct) rather than being offered and failing to compile."""
     if probe is None or not plan.is_tiled:
         return [""]  # per-cell / unbindable — no operand slab to stage
     node = replace(probe, tile=plan)
 
     def resolve(spec: str) -> str | None:
         st = Stage.parse(spec)
+        if st.transport == "tma" and not tma_ok:
+            return None  # TMA is Hopper+ (sm_90); nvcc has no sm_89a — decline below it
         r = _resolve_warp_stage(node, st, budget) if plan.is_warp else _resolve_scalar_stage(node, st, kernel.inputs, budget)
         return r.spell() if r is not None else None
 
@@ -454,7 +468,7 @@ def _tile_rows(kernel, place, ctx=None) -> tuple[list[dict], str]:
                     "load (a data-dependent index) — the fragment epilogue cannot thread it; "
                     "drop the a:<atom> token to use the scalar tier."
                 )
-        for stage in _stage_candidates(kernel, probe, plan, _smem_budget(ctx)):
+        for stage in _stage_candidates(kernel, probe, plan, _smem_budget(ctx), _tma_allowed(ctx)):
             for red in _reduce_candidates(kernel, place, plan, probe):
                 # A staged split row is legal: ``_splitk_option`` re-resolves the stage against the
                 # SLICED inner node (the warp slice divisibility already held in
@@ -1102,7 +1116,7 @@ def schedule(tile: TileOp, name: str, knobs: dict, ctx=None) -> Fork | list[Tile
         pair = _twisted_pair(tile.op)
         if pair is not None:
             red, head, pv = pair
-            warps = _twisted_warp_options(tile, name, knobs, _smem_budget(ctx))
+            warps = _twisted_warp_options(tile, name, knobs, _smem_budget(ctx), _tma_allowed(ctx))
             if warps and TILE.raw() is not None:  # a live warp pin — the mma rows alone (the pin contract)
                 return warps if len(warps) > 1 else warps[0]
             chain = _twisted_chain_option(tile, place, name, knobs)
@@ -1300,16 +1314,23 @@ def _resolve_twisted_stage(stage: Stage, kv_extent, bn: int, head_dim: int, d_v:
     return replace(stage, depth=depth, ring=stage.ring and depth >= 2, reg_depth=min(stage.reg_depth, 2), bk_elems=bn)
 
 
-def _twisted_stage_candidates(kv_extent, bn: int, head_dim: int, d_v: int, elem_bytes: int, budget: int) -> list[Stage | None]:
+def _twisted_stage_candidates(
+    kv_extent, bn: int, head_dim: int, d_v: int, elem_bytes: int, budget: int, tma_ok: bool = True
+) -> list[Stage | None]:
     """The K/V operand-stage candidates for one warp-flash geometry row — gmem-direct ``None``
     first (the conservative option-0), then every ``stage_moves`` entry that RESOLVES against the
     stream (:func:`_resolve_twisted_stage`), deduped on the resolved spelling (a ``p2`` move clamps
     to the same pipeline as its ``p1`` sibling and drops; an over-budget depth clamps down the same
     way). A pinned ``STAGE`` is authoritative: the resolved pin alone, or gmem-direct with a log
-    line when it declines — the same pin-validity degrade as the warp ``TILE`` pin."""
+    line when it declines — the same pin-validity degrade as the warp ``TILE`` pin. ``tma_ok`` is
+    the target's TMA availability (:func:`_tma_allowed`): below sm_90 a ``d*/tma*`` move / pin
+    declines here rather than being offered and failing to compile."""
 
     def resolve(spec: str) -> Stage | None:
-        return _resolve_twisted_stage(Stage.parse(spec), kv_extent, bn, head_dim, d_v, elem_bytes, budget)
+        st = Stage.parse(spec)
+        if st.transport == "tma" and not tma_ok:
+            return None  # TMA is Hopper+ (sm_90); nvcc has no sm_89a — decline below it
+        return _resolve_twisted_stage(st, kv_extent, bn, head_dim, d_v, elem_bytes, budget)
 
     if STAGE.raw() is not None:
         pinned = STAGE.narrow([""])[0]
@@ -1339,7 +1360,7 @@ def _twisted_stage_candidates(kv_extent, bn: int, head_dim: int, d_v: int, elem_
     return out
 
 
-def _twisted_warp_options(tile: TileOp, name: str, knobs: dict, budget: int = STATIC_SMEM_CAP) -> list[TileOp]:
+def _twisted_warp_options(tile: TileOp, name: str, knobs: dict, budget: int = STATIC_SMEM_CAP, tma_ok: bool = True) -> list[TileOp]:
     """The fragment-resident (tensor-core) candidates for a ``TWISTED`` streaming reduce — the
     warp-flash MOVE GRID over :func:`~emmy.compiler.pipeline.search.space.twisted_warp_moves`'s
     ``(warps_m, key_atoms)`` geometry — or ``[]`` (not eligible: the scalar options stand alone).
@@ -1444,7 +1465,7 @@ def _twisted_warp_options(tile: TileOp, name: str, knobs: dict, budget: int = ST
         # ``_wspec_workers`` gates the thread budgets — the aux band must not exceed the
         # ``32·um`` compute band); a degraded candidate is skipped rather than duplicating the
         # uniform row.
-        for stage in _twisted_stage_candidates(kv_ext, bn, head_dim.as_static(), d_v.as_static(), elem_bytes, budget):
+        for stage in _twisted_stage_candidates(kv_ext, bn, head_dim.as_static(), d_v.as_static(), elem_bytes, budget, tma_ok):
             wspecs = list(WSPEC.narrow(wspec_moves())) if (stage is not None and stage.transport == "tma") else [""]
             for wspec_cand in wspecs:
                 workers, wspec_spec = _wspec_workers(wspec_cand, stage, 32 * um)

--- a/tests/compiler/e2e/test_matmul_coverage.py
+++ b/tests/compiler/e2e/test_matmul_coverage.py
@@ -312,6 +312,43 @@ def test_scalar_masked_n_stage_declines(monkeypatch) -> None:
         assert family_value(tile_op.knobs, "STAGE") == "", (stage, tile_op.knobs)  # OFF-stamped (gmem-direct)
 
 
+def test_tma_allowed_cc_floor() -> None:
+    """TMA (``cp.async.bulk.tensor``) is a Hopper (sm_90) feature — Ada / Ampere have no TMA and nvcc
+    has no ``sm_89a`` target. :func:`_tma_allowed` (the floor both the matmul and warp-flash stage
+    enumerations gate on) admits TMA at sm_90+ only, mirroring the frontend TMA-fold gate."""
+    from emmy.compiler.pipeline.passes.lowering.tile._schedule import _tma_allowed  # noqa: PLC0415
+
+    assert not _tma_allowed(Context.from_target((8, 0)))  # Ampere — no TMA
+    assert not _tma_allowed(Context.from_target((8, 9)))  # Ada — no TMA (this repo's RTX 4080)
+    assert _tma_allowed(Context.from_target((9, 0)))  # Hopper — TMA
+    assert _tma_allowed(Context.from_target((12, 0)))  # Blackwell — TMA
+    assert _tma_allowed(None)  # no target (direct unit-test drive) — allow; never reaches nvcc
+
+
+def test_tma_stage_declines_below_sm90(monkeypatch) -> None:
+    """A ``d*/tma*`` STAGE pin below sm_90 DECLINES to gmem-direct rather than being resolved into a
+    kernel the backend cannot compile (``nvcc fatal: Unsupported gpu architecture 'sm_89a'``). The
+    same pin at sm_90 resolves (:func:`test_scalar_matmul_stages_through_pipeline`), and cp.async
+    staging still rings below sm_90 — the gate is TMA-specific, not a staging disable."""
+    from emmy.compiler.ir.tile import TileOp  # noqa: PLC0415
+
+    monkeypatch.setenv("EMMY_TILE", "n16x16/f2x2")
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    monkeypatch.setenv("EMMY_STAGE", "d2/tma")
+    # sm_89 (Ada) is below the TMA floor: the pin declines, stamping the OFF ``""`` (gmem-direct).
+    out = Pipeline.build(TILE_PASSES).run(_scalar_stage_graph(), ctx=Context.from_target((8, 9)))
+    tile_op = next(n.op for n in out.nodes.values() if isinstance(n.op, TileOp))
+    assert family_value(tile_op.knobs, "STAGE") == "", tile_op.knobs  # tma declined below sm_90
+    assert tile_op.stage is None, tile_op.stage
+
+    # Control: cp.async is unaffected by the gate — a d2/cp/ring pin still rings at sm_89.
+    monkeypatch.setenv("EMMY_STAGE", "d2/cp/ring")
+    out = Pipeline.build(TILE_PASSES).run(_scalar_stage_graph(), ctx=Context.from_target((8, 9)))
+    tile_op = next(n.op for n in out.nodes.values() if isinstance(n.op, TileOp))
+    stage = tile_op.stage
+    assert stage is not None and stage.transport == "cp.async", stage
+
+
 @requires_cuda
 @pytest.mark.parametrize("stage", ["d2/cp/ring", "d3/cp/ring"])
 def test_scalar_ring_matches_gmem_direct_bit_for_bit(monkeypatch, stage):


### PR DESCRIPTION
## Problem

The tile scheduler's stage-move enumeration offers TMA (`d*/tma*`) stages regardless of compute
capability. TMA (`cp.async.bulk.tensor`) is a **Hopper (sm_90) feature** — Ada (sm_89) / Ampere have no TMA, and
nvcc has no `sm_89a` target. So on any pre-Hopper GPU the analytic / learned prior can rank a TMA config first and
greedy deploys a kernel that **cannot compile**:

```
nvcc fatal : Unsupported gpu architecture 'sm_89a'
```

Reproduced on an RTX 4080 (sm_89): a plain `emmy run -c "<matmul>"` (greedy, no pin) aborts at the accuracy check
with that error; forcing any cp.async stage compiles and runs clean. This breaks the **default deploy** for these
shapes on every Ada / consumer GPU.

The codebase already knows TMA is sm_90+ — `passes/frontend/decomposition/_fold_constant.py` skips the TMA fold when
`compute_capability() < (9, 0)` — but the tile scheduler's stage enumeration never consulted it.

## Fix

Add `_tma_allowed(ctx)` (`ctx.compute_capability >= (9, 0)`, mirroring `_fold_constant`) and thread it into the two
stage-move enumerations — the matmul tier (`_stage_candidates`) and the warp-flash tier
(`_twisted_stage_candidates`). Below sm_90 a `d*/tma*` move is never offered and a `tma` pin declines to
cp.async / gmem-direct. **cp.async staging is unaffected** — the gate is TMA-specific.

Both enumerations resolve pins internally and feed every downstream re-resolve via the fork rows, so gating them
covers the greedy, prior, and explicit-pin paths uniformly (no TMA stage_spec can reach the option builders below
sm_90).

## Result

- On sm_89 the greedy pick now compiles — it falls back to cp.async instead of a non-compilable `sm_89a` TMA kernel.
- At sm_90+ TMA is offered exactly as before (the gate is inactive; `_fold_constant`'s existing gate uses the same
  floor).

## Tests

- `test_tma_allowed_cc_floor` — the cc floor: TMA admitted at sm_90 / sm_120, denied at sm_80 / sm_89, allowed for a
  null (direct test-drive) target.
- `test_tma_stage_declines_below_sm90` — a `d2/tma` pin at sm_89 declines to gmem-direct (OFF-stamped); a
  `d2/cp/ring` pin at sm_89 still rings (the gate is TMA-specific, not a staging disable).
- Existing `test_scalar_matmul_stages_through_pipeline` (a `d2/tma` pin at sm_90 resolves) is unchanged — the floor
  admits sm_90.

## Not in this PR

On Ada the deployed prior was trained with TMA available, so after this gate greedy falls back to cp.async but to a
shallow / gmem-direct pick, not the optimal `d2/cp/ring`. Deploying the staging sweet spot is a separate tuning /
prior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
