### PR TITLE
Projection linears onto tensor cores: analytic tier gates + a deployable-evidence lane for mma

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -95,7 +95,10 @@ Ranking is always the policy's job over a single `Prior` — Forks carry NO scor
 `Prior` featurizes the row knobs directly (`features.knob_features`). There is ONE ranking path: the hand-coded
 `AnalyticPrior` cold (a real heuristic *score* over the engineered `D_*` geometry / occupancy features, not emission
 order; a separate `_W_A_DYN` weight set ranks symbolic-axis masked-tile kernels, selected on the stamped
-`S_ext_n_symbolic_axis`) and the learned `CatBoostPrior` once trained, composed behind `FallbackPrior`. `TuningSearch`
+`S_ext_n_symbolic_axis`; two hard-coded interaction gates ride outside the linear weights — the atomic-free split-K
+term, and the tensor-core preference pair `D_scalar_on_warp_eligible` / `D_splitk_roundtrip` off the scheduler's
+per-kernel `S_warp_eligible` row stamp, which stops a warp-eligible f16 contraction deploying a scalar split tile)
+and the learned `CatBoostPrior` once trained, composed behind `FallbackPrior`. `TuningSearch`
 (`tune`) ranks the PUCT frontier; `greedy_decide` (`compile` / `run`, via `Run.resolve`) picks via `Prior.pick` —
 measured -O3 reservoir evidence first (`evidence_pick`: the candidate prefix-consistent with the fastest `H_opt=3` row of
 the same op), the `mean_score` argmin otherwise.

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -452,11 +452,21 @@ def _tile_rows(kernel, place, ctx=None) -> tuple[list[dict], str]:
     if probe is not None and probe.a_computed:
         return _computed_a_rows(kernel, place, probe, kaxis, _smem_budget(ctx)), kaxis
     tiles = scalar_tile_moves() if probe is not None else [""]
+    warp_offered = False
     if probe is not None:
         atoms = _warp_atoms(kernel, probe)
         if atoms:
-            tiles += [s for s in warp_tile_moves(atoms) if _warp_move_ok(kernel, s)]
+            warp_moves = [s for s in warp_tile_moves(atoms) if _warp_move_ok(kernel, s)]
+            tiles += warp_moves
+            warp_offered = bool(warp_moves)
     tiles = list(TILE.narrow(tiles))
+    # Warp-eligibility is a structural fact about the KERNEL: when the enumeration offers any
+    # tensor-core row, EVERY row (scalar and warp alike) carries ``S_warp_eligible`` so the
+    # priors can price "a scalar tile where tensor cores were on offer"
+    # (``features.D_scalar_on_warp_eligible``). ``S_``-prefixed — rides ``knob_features``'
+    # structural pass-through; not a schedule family, so tile identity / prefix-consistency
+    # and ``tile_signature`` are untouched.
+    stamp: dict = {"S_warp_eligible": 1.0} if warp_offered else {}
     rows: list[dict] = []
     for spec in tiles:
         plan = TilePlan.parse(spec)
@@ -478,7 +488,7 @@ def _tile_rows(kernel, place, ctx=None) -> tuple[list[dict], str]:
                 # evidence pick's prefix-consistency depends on it: an absent key reads as
                 # "free" and would let a gmem-direct leaf inherit a staged row's measurement.
                 for wspec in _wspec_candidates(plan, stage, red):
-                    rows.append({_at(TILE, kaxis): spec, _at(STAGE, kaxis): stage, _at(REDUCE, kaxis): red, WSPEC.name: wspec})
+                    rows.append({_at(TILE, kaxis): spec, _at(STAGE, kaxis): stage, _at(REDUCE, kaxis): red, WSPEC.name: wspec, **stamp})
     return rows, kaxis
 
 

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -455,6 +455,11 @@ def _geom_feats(
         "D_finalize_kernel": 1.0 if (splitk > 1 and finalize == "kernel") else 0.0,
         "D_tilen_clean": 1.0 if tile_n in (32, 64, 128) else 0.0,
         "D_near_tilen": -abs(l2(tile_n) - 6.0),
+        # A scalar tile on a warp-ELIGIBLE contraction (16-bit operands, atoms offered — the
+        # scheduler's ``S_warp_eligible`` kernel stamp) competes against tensor cores: the
+        # roofline bar none of the flat geometry terms can see. 0 on warp rows and on kernels
+        # with no warp offer, so fp32 / non-contraction ranking is untouched.
+        "D_scalar_on_warp_eligible": 1.0 if (not warp and float(knobs.get("S_warp_eligible", 0.0) or 0.0) > 0) else 0.0,
     }
     if free_prod:
         ctas = float(free_prod) / area * splitk
@@ -475,6 +480,11 @@ def _geom_feats(
         free_ctas = float(free_prod) / area
         needed = max(2.0 * sm / max(free_ctas, 1.0), 1.0)
         out["D_splitk_excess"] = math.log2(max(splitk / needed, 1.0))
+        # The deferred split-K finalize (``g<w>k``) writes + re-reads a full free-size partial
+        # workspace and launches the combine kernel — the same round-trip volume axis
+        # ``D_cut_roundtrip`` prices for the demoted-cone cut, un-priced here until now (the
+        # in-place atomic ``g<w>a`` finalize pays no workspace).
+        out["D_splitk_roundtrip"] = l2(free_prod) if out["D_finalize_kernel"] else 0.0
         # Register-tile intensity × occupancy interaction: a wide per-thread
         # register tile (big FM·FN) is a win only while the grid still covers
         # the SMs — the flat D_cells* terms can't express that, so the big-FM

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -44,22 +44,16 @@ if TYPE_CHECKING:
     from emmy.compiler.pipeline.search.prior import Prior
 
 # Re-bench at -O3 any config whose -O1 latency is within this fraction of the best
-# -O1 so far (not just a strict new best). -O1 is the fast ranking compile but
-# ties configs that diverge at -O3 (deployable) — e.g. a warp-tier WARPSPEC /
-# occupancy split where the -O1 latencies are within ~1% but -O3 differs ~15%.
-# Widening the deployable-sample net to this band feeds the prior -O3 truth for
-# every near-best contender, so it can rank by -O3 cost. Env-overridable via
-# ``EMMY_O3_TOL`` (a fraction, e.g. ``0.15`` for 15%).
-O3_REBENCH_TOL = 0.15
-
-# Warp (mma) rows get a wider -O3-worthiness band: the -O1 ranking lane systematically
-# overprices register-tile mma kernels (1.5–3× vs -O3 — the cicc unroll blowup the -O1
-# ranking compile dodges), so an mma config that loses the 15% -O1 band can still be the
-# -O3 deploy winner. Without a deployable sample the evidence-first deploy hierarchy only
-# ever sees scalar -O3 rows and keeps deploying them (the qwen3-emb layer-0 projections:
-# scalar g2a evidence at 394 µs deployed over the 70 µs-class mma picks). Cost is
-# bounded: ``_o3_done`` dedups per config, one -O3 compile + short bench each.
-O3_WARP_REBENCH_TOL = 2.0
+# -O1 so far (not just a strict new best). -O1 is the fast ranking compile but its
+# ranking diverges at -O3 (deployable): register-tile mma kernels run 1.5–3× slower at
+# -O1 (the cicc unroll blowup the ranking compile dodges), so an mma config outside a
+# narrow -O1 band can still be the -O3 deploy winner — and without a deployable sample
+# the evidence-first deploy hierarchy only ever sees scalar -O3 rows and keeps deploying
+# them (the qwen3-emb layer-0 projections: scalar g2a evidence at 394 µs deployed over
+# the 70 µs-class mma picks). The band covers that skew (within 3× of best -O1); cost is
+# bounded by ``_o3_done``'s per-config dedup — one -O3 compile + short bench each.
+# Env-overridable via ``EMMY_O3_TOL`` (a fraction, e.g. ``0.15`` for 15%).
+O3_REBENCH_TOL = 2.0
 
 # The nvcc flags of that deployable re-bench (``pipeline._rebench_o3_async``) — also
 # the regime the re-bench's node rows are keyed under (``two_level`` derives their
@@ -213,12 +207,8 @@ class TuningSearch(Search):
         # winner. Dedup via ``_o3_done`` so each config is -O3'd at most once.
         self.last_o3_worthy = False
         if status == "ok" and stats.median > 0 and self.tree.best_reward > 0:
-            from emmy.compiler.pipeline.search.features import is_warp  # noqa: PLC0415
-
             best_lat = 1.0 / self.tree.best_reward
             tol = config.o3_tol(O3_REBENCH_TOL)
-            if is_warp(token.realized_knobs or {}):
-                tol = max(tol, O3_WARP_REBENCH_TOL)  # the -O1 lane overprices mma — see O3_WARP_REBENCH_TOL
             sig = self._o3_sig(token.realized_knobs)
             if stats.median <= best_lat * (1.0 + tol) and sig not in self._o3_done:
                 self._o3_done.add(sig)

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -52,6 +52,15 @@ if TYPE_CHECKING:
 # ``EMMY_O3_TOL`` (a fraction, e.g. ``0.15`` for 15%).
 O3_REBENCH_TOL = 0.15
 
+# Warp (mma) rows get a wider -O3-worthiness band: the -O1 ranking lane systematically
+# overprices register-tile mma kernels (1.5–3× vs -O3 — the cicc unroll blowup the -O1
+# ranking compile dodges), so an mma config that loses the 15% -O1 band can still be the
+# -O3 deploy winner. Without a deployable sample the evidence-first deploy hierarchy only
+# ever sees scalar -O3 rows and keeps deploying them (the qwen3-emb layer-0 projections:
+# scalar g2a evidence at 394 µs deployed over the 70 µs-class mma picks). Cost is
+# bounded: ``_o3_done`` dedups per config, one -O3 compile + short bench each.
+O3_WARP_REBENCH_TOL = 2.0
+
 # The nvcc flags of that deployable re-bench (``pipeline._rebench_o3_async``) — also
 # the regime the re-bench's node rows are keyed under (``two_level`` derives their
 # ``context_key`` from the tune context with these flags substituted).
@@ -204,8 +213,12 @@ class TuningSearch(Search):
         # winner. Dedup via ``_o3_done`` so each config is -O3'd at most once.
         self.last_o3_worthy = False
         if status == "ok" and stats.median > 0 and self.tree.best_reward > 0:
+            from emmy.compiler.pipeline.search.features import is_warp  # noqa: PLC0415
+
             best_lat = 1.0 / self.tree.best_reward
             tol = config.o3_tol(O3_REBENCH_TOL)
+            if is_warp(token.realized_knobs or {}):
+                tol = max(tol, O3_WARP_REBENCH_TOL)  # the -O1 lane overprices mma — see O3_WARP_REBENCH_TOL
             sig = self._o3_sig(token.realized_knobs)
             if stats.median <= best_lat * (1.0 + tol) and sig not in self._o3_done:
                 self._o3_done.add(sig)

--- a/emmy/compiler/pipeline/search/prior/analytic.py
+++ b/emmy/compiler/pipeline/search/prior/analytic.py
@@ -177,6 +177,8 @@ class AnalyticPrior(Prior):
         scale: float = 0.1,
         atomic_free_split_threshold: float = 4.0,
         atomic_free_weight: float = 5.0,
+        scalar_on_warp_weight: float = 40.0,
+        splitk_roundtrip_weight: float = 0.25,
     ) -> None:
         super().__init__()
         self._w = weights if weights is not None else _W_A
@@ -190,6 +192,17 @@ class AnalyticPrior(Prior):
         # CatBoostPrior takes over once real atomic-vs-free ``H_opt=3`` rows exist.
         self._atomic_free_split_threshold = atomic_free_split_threshold
         self._atomic_free_weight = atomic_free_weight
+        # Scalar-on-warp-eligible penalty + split-K workspace round-trip price.
+        # Hardcoded like the atomic-free term — no training rows carry the new stamps yet,
+        # and a plain linear weight can't express "only bad when the alternative exists".
+        # ``scalar_on_warp_weight`` must outweigh the scalar tile's accumulated geometry
+        # bonuses under BOTH weight sets (the dyn set hands scalar rows ~+30 quality via
+        # ``D_bn_ge_bm`` / band features a warp row structurally cannot earn — the qwen3-emb
+        # projection deploys landed scalar at 5-20× the -O3 cost of their enumerated mma
+        # siblings). ``splitk_roundtrip_weight`` is a mild price (~5 quality at free_prod
+        # ≈ 512·1024): the deferred finalize IS the right shape for wide mma splits.
+        self._scalar_on_warp_weight = scalar_on_warp_weight
+        self._splitk_roundtrip_weight = splitk_roundtrip_weight
 
     @property
     def fitted(self) -> bool:
@@ -228,6 +241,11 @@ class AnalyticPrior(Prior):
             splitk = feats.get("D_splitk", 1.0)  # the split-K count (REDUCE@<k>.cta)
             many_splits = splitk >= self._atomic_free_split_threshold
             quality += self._atomic_free_weight * af_on * (1.0 if many_splits else -1.0)
+        # Tensor-core preference gates (see __init__): a scalar tile on a warp-eligible
+        # contraction eats the roofline penalty; a deferred split-K finalize pays its
+        # workspace round-trip. Both features are 0 wherever the stamps don't apply.
+        quality -= self._scalar_on_warp_weight * feats.get("D_scalar_on_warp_eligible", 0.0)
+        quality -= self._splitk_roundtrip_weight * feats.get("D_splitk_roundtrip", 0.0)
         return math.exp(-self._scale * max(min(quality, 80.0), -80.0))
 
     def mean_score(self, knobs: dict) -> float:

--- a/tests/compiler/pipeline/search/test_analytic_tier_preference.py
+++ b/tests/compiler/pipeline/search/test_analytic_tier_preference.py
@@ -1,0 +1,71 @@
+"""The analytic prior's tensor-core preference gates.
+
+A warp-eligible f16 contraction enumerates scalar AND mma rows; the deploy pick must not
+land on a scalar tile when tensor cores are on offer. Historically the DYNAMIC (masked-tier)
+weight set ranked scalar split-K rows first — the qwen3-emb / gemma-4-e2b layer-0 projection
+deploys landed scalar at 5-20x the -O3 cost of their enumerated mma siblings — because no
+feature told the prior the alternative existed. The ``S_warp_eligible`` kernel stamp
+(``_schedule._tile_rows``) + ``D_scalar_on_warp_eligible`` / ``D_splitk_roundtrip``
+(``features._geom_feats``) + the hard-coded ``AnalyticPrior`` gates close that. No GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from emmy.compiler.context import Context
+from emmy.compiler.pipeline.search.analytic import _enumerate
+from emmy.compiler.pipeline.search.features import knob_features
+from emmy.compiler.pipeline.search.prior import AnalyticPrior
+
+CTX = Context.from_target((8, 9))
+
+
+def _tile_of(row: dict) -> str:
+    return row[next(k for k in row if k.startswith("TILE"))]
+
+
+def _base(M: int, N: int, K: int, *, dynamic: bool) -> dict:
+    free = float(N) if dynamic else float(M * N)
+    b = {**CTX.features(), "S_ext_free_prod": free, "S_ext_reduce_prod": float(K), "S_ext_reduce_max": float(K)}
+    if dynamic:
+        b["S_ext_n_symbolic_axis"] = 1.0
+    return b
+
+
+def test_warp_eligible_stamp_fp16_present_fp32_absent():
+    """Every row of a warp-eligible f16 contraction (scalar rows included) carries the
+    ``S_warp_eligible`` kernel stamp; an fp32 contraction (no atoms) carries none."""
+    rows16, _ = _enumerate(512, 1024, 1024, "fp16", CTX)
+    assert rows16, "f16 matmul must enumerate"
+    assert all(r.get("S_warp_eligible") == 1.0 for r in rows16)
+    assert any("a:mma" in _tile_of(r) for r in rows16), "warp rows must be offered"
+    rows32, _ = _enumerate(512, 1024, 1024, "fp32", CTX)
+    assert rows32 and all("S_warp_eligible" not in r for r in rows32)
+
+
+def test_scalar_on_warp_eligible_feature_fires_on_scalar_rows_only():
+    rows, _ = _enumerate(512, 1024, 1024, "fp16", CTX)
+    base = _base(512, 1024, 1024, dynamic=False)
+    for r in rows[:200]:
+        tile = _tile_of(r)
+        if not tile:
+            continue  # the per-cell serial row has no tile geometry — no D_* features at all
+        feat = knob_features({**base, **r}).get("D_scalar_on_warp_eligible", 0.0)
+        assert feat == (0.0 if "a:mma" in tile else 1.0), tile
+
+
+@pytest.mark.parametrize("dynamic", [False, True], ids=["static", "dynamic"])
+def test_analytic_ranks_mma_above_every_scalar_split(dynamic):
+    """The deploy-critical property: some mma row outranks EVERY scalar row (g?a / g?k
+    splits included) on a warp-eligible f16 projection shape — in BOTH weight regimes.
+    The dynamic (symbolic-M) regime is the one that historically ranked all-scalar."""
+    rows, _ = _enumerate(512, 1024, 1024, "fp16", CTX)
+    ap = AnalyticPrior()
+    base = _base(512, 1024, 1024, dynamic=dynamic)
+    scored = sorted(rows, key=lambda r: ap.score({**base, **r}))
+    assert "a:mma" in _tile_of(scored[0]), f"top pick must be a warp row, got {_tile_of(scored[0])!r}"
+    best_scalar = next((i for i, r in enumerate(scored) if "a:mma" not in _tile_of(r)), None)
+    assert best_scalar is None or best_scalar > 0, "a scalar row must not outrank every mma row"
+    # Stronger: no scalar row inside the tuner's first-page patience window.
+    assert all("a:mma" in _tile_of(r) for r in scored[:25]), "scalar rows must not crowd the top-25"


### PR DESCRIPTION
## Summary
Independent of #310 (restacked onto main). The qwen3-emb / gemma-4-e2b layer-0 reports found every projection linear (q/k/v/o_proj, PLE) deploying scalar split-K tiles at 5–20× the -O3 cost of their enumerated mma siblings. Two fixes, complementary to #317's golden refit:

**1. Analytic tier gates — the structural invariant behind #317's data-side fix.** The dynamic weight set ranked scalar rows first on warp-eligible f16 contractions because no feature told the prior the alternative existed. #317's `_W_A_DYN` refit fixes the ranking for the current golden distribution; these gates encode the interaction a linear weight can't express — "a scalar tile where tensor cores were on offer must clear the roofline bar" — so the property holds independent of future refits and off-distribution shapes, and the new stamp feeds the learned prior the same signal.
- `_schedule._tile_rows` stamps `S_warp_eligible` onto every enumerated row when the kernel offers any tensor-core row (an `S_` structural fact; row identity / `tile_signature` untouched).
- `features._geom_feats` adds `D_scalar_on_warp_eligible` and `D_splitk_roundtrip` (the `g<w>k` deferred finalize's workspace round-trip — the un-priced `D_cut_roundtrip` analogue).
- `AnalyticPrior` gains two hard-coded gates (the `atomic_free_weight` precedent).
- Verified vs the refit weights on main: identical golden ranks (no over-rotation), identical dynamic-regime top picks; `tests/compiler/pipeline/search/test_analytic_tier_preference.py` pins mma-above-every-scalar in both weight regimes.

**2. A deployable-evidence lane for mma rows (load-bearing; #317 hit this exact failure — "deployed greedy kept picking scalar until retrained").** The -O3 rebench sampled only configs within 15% of the best **-O1**, and -O1 overprices register-tile mma kernels 1.5–3× (the reports' finding 4) — so mma configs never earned `H_opt=3` evidence rows and the evidence-first deploy hierarchy kept deploying the scalar rows that had them. Per review, the common `O3_REBENCH_TOL` is raised to 2.0 (within 3× of best -O1, bounded by the per-config dedup; `EMMY_O3_TOL` overrides), so a fresh tune produces mma -O3 evidence instead of requiring a golden-dataset retrain to displace stale scalar rows.

## Measured effect (RTX 4080, qwen3-emb layer-0, dynamic seq_len, 512 hint — with #310 in the tree)
| Deploy path | before | after |
|---|---|---|
| Cold analytic prior | 6.6–7.4 ms (scalar splits, one 5.4 ms partial = 82%) | **1.46 ms** — all projections `a:mma` `g2k` partials |
| Freshly tuned (learned prior) | 7.4 ms | 5.9–6.1 ms (healthy per-kernel picks: q/v_proj 51/29 µs at 0.5× eager, down_proj 80 µs — minus one anomalous launch, below) |

Without #310, attention stays on the un-fused ~9.4 ms path and dominates the layer number, but the projection-pick improvements stand alone.

## Known issues documented (follow-ups, not addressed here)
- **A constant ~5.4–5.5 ms cost attaches to ONE kernel launch in layer benches on this box** — position-stable per run, moves across kernels/configs between runs, appears in standalone reproducer benches — while the same variant benched via `emmy run --code` at the same shape/symbolic-M runs 26 µs. Likely related to the gemma k_proj ">1 s hang" class and possibly #317's "attention golden re-bench pathology"; needs its own investigation.
- **gemma-4-E2B layer-0 fails accuracy (`output mul_ contains NaN`) pre-existing** — reproduced on a baseline without these changes; blocks re-validating that layer end-to-end. The historical g4a hang pick is dodged by the mma routing.
- The tune's 4 s per-variant compile budget and reproducer coverage flags (reports' findings 3/5) remain open tune-infra items.

## Test plan
- `tests/compiler/pipeline/search/` + move-catalog + goldens permanence: 184 passed on this base; full `make test` green minus the 4 pre-existing sm_89 failures (`test_contraction_emits_matmul`, 3× TMA staging).
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
