### PR TITLE
Fix three model-onboarding gaps: dropout trace, square codegen, trust_remote_code fallback

### DIFF
--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -434,7 +434,16 @@ def _trace_model(model_id: str, layer: int | None, seq_len: int, *, dynamic_shap
 
     logger.info("Pulling %s...", model_id)
     dtype = torch.float32 if layer is None else torch.float16
-    model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype)
+    try:
+        model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype)
+    except ValueError as e:
+        # Only fall back to executing the repo's custom modeling code when
+        # transformers explicitly requires it (e.g. MiniCPM3). Models that ship
+        # remote code but also have a built-in class (e.g. Phi-4-mini) must use
+        # the built-in path — their remote code may not match this transformers.
+        if "trust_remote_code" not in str(e):
+            raise
+        model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype, trust_remote_code=True)
     model.eval()
 
     if layer is None:

--- a/emmy/compiler/ir/stmt/base.py
+++ b/emmy/compiler/ir/stmt/base.py
@@ -192,6 +192,8 @@ def op_to_expr(fn: str, inputs: list[Expr]) -> Expr:
         return BinaryExpr("-", Literal(0.0, "float"), inputs[0])
     if fn == "copy":
         return inputs[0]
+    if fn == "square":
+        return BinaryExpr("*", inputs[0], inputs[0])
     if fn == "reciprocal":
         return BinaryExpr("/", Literal(1.0, "float"), inputs[0])
     if fn == "relu":

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -800,6 +800,12 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, str], *, s
         node_map[name] = nid
         return
 
+    if op_name == "dropout":
+        # Inference-time dropout is the identity. Drop the p / training args and
+        # lower it as a `copy` passthrough so it becomes a no-op in the graph.
+        input_ids = input_ids[:1]
+        op_name = "copy"
+
     # --- Fallback: unknown op becomes ElementwiseOp by torch-aten name ---
     logger.debug("Fallback elementwise for %s (%s)", op_name, fx_node.target)
     if input_ids:

--- a/tests/compiler/ir/stmt/test_op_to_expr.py
+++ b/tests/compiler/ir/stmt/test_op_to_expr.py
@@ -1,0 +1,23 @@
+"""Unit tests for ``op_to_expr`` — elementwise op-name → Expr translation."""
+
+from emmy.compiler.ir.expr import BinaryExpr, Literal
+from emmy.compiler.ir.stmt.base import op_to_expr
+
+
+def test_square_renders_to_self_multiply():
+    """``square`` lowers to ``x * x``.
+
+    ReLU²/squared-ReLU MLPs (e.g. AFM-4.5B) emit a ``square`` elementwise op; the CUDA
+    renderer previously had no case for it and raised ``NotImplementedError``.
+    """
+    x = Literal(3.0, "float")
+    e = op_to_expr("square", [x])
+    assert isinstance(e, BinaryExpr)
+    assert e.op == "*"
+    assert e.left is x and e.right is x
+
+
+def test_copy_is_identity_passthrough():
+    """``copy`` returns its input unchanged (dropout lowers through this path)."""
+    x = Literal(1.0, "float")
+    assert op_to_expr("copy", [x]) is x

--- a/tests/compiler/trace/test_torch.py
+++ b/tests/compiler/trace/test_torch.py
@@ -396,3 +396,29 @@ def test_trace_repeat_kv_correct():
     be = LoopBackend()
     out = list(be.run(be.compile(g), input_data={g.inputs[0]: k.numpy()})[0].outputs.values())[0]
     np.testing.assert_allclose(np.asarray(out).reshape(ref.shape), ref, rtol=1e-5, atol=1e-5)
+
+
+def test_dropout_traces_as_copy_passthrough():
+    """Inference dropout must trace as a ``copy`` no-op, not crash on an unknown op.
+
+    Phi3-family layers (Phi-4-mini) emit a ``dropout`` node; before the fix the trace
+    raised ``unknown elementwise op name: 'dropout'``.
+    """
+    import torch
+    import torch.nn as nn
+
+    from emmy.compiler.trace.torch import trace_module
+
+    class M(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.lin = nn.Linear(8, 8)
+            self.drop = nn.Dropout(0.5)
+
+        def forward(self, x):
+            return self.drop(self.lin(x))
+
+    g = trace_module(M().eval(), (torch.randn(2, 8),))
+    ew_names = [n.op.op.name for n in g.nodes.values() if type(n.op).__name__ == "ElementwiseOp"]
+    assert "dropout" not in ew_names
+    assert "copy" in ew_names


### PR DESCRIPTION
## What

Three small, independent fixes that each unblock a model class from `emmy compile` / `emmy tune`. Found while
tuning a 13-model architecture sweep on an RTX 5090 and an RTX Pro 6000 — 3 of the failing models were emmy bugs
(the rest were gated/OOM/encoder-path limitations).

| Fix | File | Symptom | Unblocks |
|---|---|---|---|
| `dropout` → `copy` passthrough | `emmy/compiler/trace/torch.py` | trace crash `unknown elementwise op name: 'dropout'` | **Phi-4-mini** (Phi3) |
| `square` → `x*x` render case | `emmy/compiler/ir/stmt/base.py` | codegen crash `render: elementwise fn='square' not supported` | **AFM-4.5B** (ReLU² MLP) |
| `trust_remote_code` fallback | `emmy/commands/compile.py` | `ValueError: ... pass trust_remote_code=True` | **MiniCPM3** |

## Details

- **dropout**: inference dropout is the identity, but it reached the elementwise fallback (which rejects it).
  Now special-cased to drop the `p`/`training` args and lower as a `copy` no-op.
- **square**: `op_to_expr` had no `square` case even though `np.square` let it pass tracing, so ReLU²/squared-ReLU
  MLPs died at CUDA render. Now renders `square(x)` as `x * x`.
- **trust_remote_code**: load **without** `trust_remote_code` first, falling back to `trust_remote_code=True` only
  when transformers explicitly demands it. This fixes MiniCPM3 (needs remote code) **without** regressing Phi-4-mini,
  which ships remote code that imports a symbol absent from the installed transformers but also has a built-in class.

## Tests

- `tests/compiler/ir/stmt/test_op_to_expr.py` — `op_to_expr('square')` → `x*x` (and `copy` passthrough).
- `tests/compiler/trace/test_torch.py::test_dropout_traces_as_copy_passthrough` — a dropout module traces to a
  `copy` no-op instead of raising.
- The `trust_remote_code` fallback is control-flow around a network model load; validated end-to-end in the sweep
  (Phi-4-mini loads built-in, MiniCPM3 takes the fallback) rather than with a brittle mock.

`make test`: 2167 passed, 39 skipped. `make lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)