### PR TITLE
Dynamic-flash TMA staging + split-K feature + reduce-family golden fixes (21→29/36 at parity)

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -106,14 +106,19 @@ leaf row spelling the same `TILE@<qk_k>` / `TILE@<pv_k>` / `REDUCE@<kv>` key set
 tile). A non-empty `REDUCE` pin remains the scalar escape; a warp `TILE` pin keeps the mma rows alone (loud on a
 divisibility violation, declining with a log line when the pin doesn't fit the flash form — a bare warp pin may target
 another kernel). Each warp geometry row crosses with its **K/V operand-stage** candidates (`STAGE@<kv>` —
-`_schedule._twisted_stage_candidates`: gmem-direct option-0, then the resolver-gated cp.async AND TMA ring depths over
-a static, block-divisible kv — the batched K/V operands encode as rank-N TMA boxes with leading extent-1 dims, the
-load's own batch/head index exprs riding as origin coords; cp.async slabs take the +16 B row pad, TMA slabs stay dense
-under the hardware swizzle; the resolved `Stage` rides the `TileOp` and the streaming step becomes the `staged_kloop`
-drain, K/V slabs kept in each operand's own layout so staging stays bit-identical to gmem-direct). A resolved TMA row
-additionally offers the `WSPEC` producer-band splits (the matmul tier's legality, `32·aux ≤ 32·um`; measured
-occupancy-negative at flash's CTA scale — offered, honest, not the default). The chain / coop / serial escapes stamp
-the decided-empty `STAGE@<kv>: ""`. The causal tile-skip is the remaining flash follow-up.
+`_schedule._twisted_stage_candidates`: gmem-direct option-0, then the resolver-gated cp.async AND TMA ring depths — the
+batched K/V operands encode as rank-N TMA boxes with leading extent-1 dims, the load's own batch/head index exprs
+riding as origin coords; cp.async slabs take the +16 B row pad, TMA slabs stay dense under the hardware swizzle; the
+resolved `Stage` rides the `TileOp` and the streaming step becomes the `staged_kloop` drain, K/V slabs kept in each
+operand's own layout so staging stays bit-identical to gmem-direct). cp.async stages a **static, block-divisible** kv
+only; **TMA also stages a symbolic (dynamic-`seq_len`) kv** — the descriptor rides the runtime globalDim and zero-fills
+the box overhang past the last key, and the streaming drain's tail masks (the same clamp the gmem-direct symbolic path
+makes) zero those keys' contribution, so the masked-flash `.dynM` kernel stages at bit-identity to gmem-direct (the
+`staged_kloop` ring allocates the full depth and the last-chunk clamp / loop bound ride the symbolic `Dim`; WSPEC over a
+symbolic kv is not built). A resolved TMA row additionally offers the `WSPEC` producer-band splits (the matmul tier's
+legality, `32·aux ≤ 32·um`; measured occupancy-negative at flash's CTA scale — offered, honest, not the default). The
+chain / coop / serial escapes stamp the decided-empty `STAGE@<kv>: ""`. The causal tile-skip is the remaining flash
+follow-up.
 Two catalog invariants hold: every recorded golden's `TILE`/`STAGE`/`REDUCE` stays a **member** of the enumerated
 grids (the permanence test in `tests/compiler/test_golden_configs.py` — a space edit can never silently orphan a
 golden into unreachability again, the sixth sweep's `.s512` regression class; the scalar reg grid carries the

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -33,6 +33,7 @@ import math
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from emmy.compiler.dim import Dim
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import BinaryExpr, Builtin, Expr, Literal, TernaryExpr, Var
 from emmy.compiler.ir.kernel.ir import (
@@ -648,8 +649,8 @@ def staged_kloop(
     drain: Callable[[Expr], list[Stmt]],
     depth: int,
     bk_elems: int,
-    n_chunks: int,
-    k_extent: int,
+    n_chunks: int | Dim,
+    k_extent: int | Dim,
     workers=None,
     block_threads: int | None = None,
     k0: str = "_ks",
@@ -676,8 +677,14 @@ def staged_kloop(
 
     ``k0`` names the chunk loop variable (default ``"_ks"``) — a drain whose body references the
     chunk base by name (the warp-flash stream's absolute score columns) passes its own axis name."""
-    ring = min(depth, n_chunks) if n_chunks >= 2 else 1
+    # A symbolic ``k_extent`` (warp-flash over a runtime seq_len) is a ``Dim``: the chunk count is a
+    # runtime value, so allocate the full ``depth`` ring (the tuned hint has ≥ depth chunks) and let
+    # the TMA box zero-fill any over-primed tail chunk — the drain masks those keys to the fold
+    # identity, so it stays bit-identical to gmem-direct. Static callers pass plain ``int``s.
+    symbolic = isinstance(k_extent, Dim)
+    ring = depth if symbolic else (min(depth, n_chunks) if n_chunks >= 2 else 1)
     if workers is not None:
+        assert not symbolic, "warp-spec + symbolic-kv staging is not built (WSPEC drives static-kv TMA only)"
         assert isinstance(transport, TmaTransport), "warp specialization drives the TMA transport only (scheduler legality)"
         assert block_threads is not None, "warp specialization needs the compute-band thread count"
         return _wspec_kloop(
@@ -711,9 +718,12 @@ def staged_kloop(
         pref_slot = BinaryExpr("%", pref_chunk, _lit(ring))
         read_slot = BinaryExpr("%", i_expr, _lit(ring))
         read_phase = BinaryExpr("%", BinaryExpr("/", i_expr, _lit(ring)), _lit(2))
-        last_k0 = (n_chunks - 1) * bk_elems
+        # The last chunk's base and the loop bound are runtime Exprs when kv is symbolic (``Dim``),
+        # else folded literals — the clamp pins an overhanging prefetch back onto the last chunk.
+        last_k0 = BinaryExpr("*", BinaryExpr("-", n_chunks.expr, _lit(1)), _lit(bk_elems)) if symbolic else _lit((n_chunks - 1) * bk_elems)
+        k_bound = k_extent.expr if symbolic else _lit(k_extent)
         k0_next = BinaryExpr("+", Var(k0), _lit((ring - 1) * bk_elems))
-        k0_pref = TernaryExpr(cond=BinaryExpr("<", k0_next, _lit(K)), if_true=k0_next, if_false=_lit(last_k0))
+        k0_pref = TernaryExpr(cond=BinaryExpr("<", k0_next, k_bound), if_true=k0_next, if_false=last_k0)
         body += transport.fill(k0=k0_pref, slot=pref_slot)
         body += transport.commit()
         body += transport.wait(in_flight=ring - 1, slot=read_slot, phase=read_phase)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -510,7 +510,12 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
         # cp.async fills cooperatively into padded rows; TMA box-copies the batched operands via
         # rank-N descriptors (leading extent-1 box dims, the load's own batch/head index exprs as
         # origin coords — GQA's ``h // group`` rides through) into dense hardware-swizzled slabs.
-        K = kv_axis.extent.as_static()
+        # A symbolic kv reaches here under TMA only (``_resolve_twisted_stage`` — cp.async stays
+        # static): the streaming loop bound / last-chunk clamp ride the symbolic ``Dim`` and the box
+        # zero-fills the overhang, so the drain's tail masks keep it bit-identical to gmem-direct.
+        assert not symbolic_k or is_tma, "symbolic-kv staging is TMA-only (no OOB zero-fill on cp.async)"
+        kv_ext = kv_axis.extent if symbolic_k else kv_axis.extent.as_static()
+        n_chunks = kv_axis.extent.ceil_div(bn) if symbolic_k else kv_axis.extent.as_static() // bn
         head_dim = qk.k_axis.extent.as_static()
         k_load, v_load = qk.b_load, pv.b_load
         kn, kk, vn = qk.n_axis.name, qk.k_axis.name, pv.n_axis.name
@@ -562,8 +567,8 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             drain=lambda slot: _stream_step(k_op.slot_row(slot), v_op.slot_row(slot), staged=True),
             depth=stage.depth,
             bk_elems=bn,
-            n_chunks=K // bn,
-            k_extent=K,
+            n_chunks=n_chunks,
+            k_extent=kv_ext,
             k0=kv0.name,
             workers=ctx.workers,
             block_threads=block_threads,

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1375,14 +1375,23 @@ def _resolve_twisted_stage(stage: Stage, kv_extent, bn: int, head_dim: int, d_v:
     break) and **TMA** (the batched K/V encode as rank-N boxes with leading extent-1 dims —
     ``(1, 1, bn, head_dim)`` — the load's own batch/head index exprs supplying the origin coords;
     the slabs stay dense and take the hardware swizzle + drain XOR instead of padding; box dims
-    cap at the 256 hardware limit). ``sync`` has nothing to overlap. A symbolic or
-    non-block-divisible kv stays gmem-direct (its masked fragment loads already clamp; slab
-    zero-fill is a follow-up). ``depth`` clamps so the ring's K+V slot pairs fit the smem
+    cap at the 256 hardware limit). ``sync`` has nothing to overlap. A **symbolic** kv stages
+    under TMA only — the descriptor rides the runtime globalDim and zero-fills the box overhang, so
+    the streaming drain's tail-key masks (the same clamp the gmem-direct symbolic path makes) keep
+    it bit-identical; cp.async has no such zero-fill and a static, non-block-divisible kv has no
+    tail mask, so both stay gmem-direct. ``depth`` clamps so the ring's K+V slot pairs fit the smem
     ``budget``; ``reg_depth`` clamps to 1 (no ldmatrix ping-pong on the streaming drain yet);
     ``bk_elems`` records the streamed keys per step."""
     if stage.transport not in ("cp.async", "tma"):
         return None
-    if not kv_extent.is_static or kv_extent.as_static() % bn != 0:
+    if stage.transport == "cp.async":
+        # cp.async has no OOB zero-fill — a symbolic / non-block-divisible kv would read the
+        # overhanging tail chunk out of bounds, so it stays static + block-divisible only.
+        if not kv_extent.is_static or kv_extent.as_static() % bn != 0:
+            return None
+    elif kv_extent.is_static and kv_extent.as_static() % bn != 0:
+        # TMA + a STATIC non-block-divisible kv has no tail mask (masking is symbolic-only) —
+        # stay gmem-direct. A symbolic kv falls through: TMA zero-fills its box overhang.
         return None
     if stage.transport == "tma":
         # Box dims must fit the 1..256 hardware range, and the inner (contiguous) row spans must

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1206,7 +1206,15 @@ def schedule(tile: TileOp, name: str, knobs: dict, ctx=None) -> Fork | list[Tile
         if pair is not None:
             red, head, pv = pair
             warps = _twisted_warp_options(tile, name, knobs, _smem_budget(ctx), _tma_allowed(ctx))
-            if warps and TILE.raw() is not None:  # a live warp pin — the mma rows alone (the pin contract)
+            # A live warp ``TILE`` pin OR a non-empty ``STAGE`` pin keeps the mma rows alone: ONLY the
+            # warp tier stages, so a staging pin (the ``--ab STAGE=…`` / ``emmy tune`` staging probe,
+            # or ``EMMY_STAGE``) must not fall through to the chain / scalar reduce-partition siblings
+            # and let the prior bury the (necessarily lower-occupancy) staged warp form under a
+            # higher-occupancy scalar form — the scalar-fallback that made a staged-flash A/B row read
+            # as a 100× regression. ``warps == []`` (a non-warp-eligible flash) still degrades to
+            # scalar below, so a stage pin on such a shape stays a graceful no-op.
+            stage_pinned = STAGE.raw() is not None and bool(STAGE.narrow([""])[0])
+            if warps and (TILE.raw() is not None or stage_pinned):
                 return warps if len(warps) > 1 else warps[0]
             chain = _twisted_chain_option(tile, place, name, knobs)
             forms = [*warps, *([chain] if chain is not None else [])]

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -478,8 +478,24 @@ def _geom_feats(
         # prior needs to separate the SPLITK=1/2 goldens from the SPLITK=8/16 tiles
         # the -O1 sweep over-ranks (the analytic prior already gets it via D_splitk_le2).
         free_ctas = float(free_prod) / area
-        needed = max(2.0 * sm / max(free_ctas, 1.0), 1.0)
+        # Split-K is justified to (a) lift occupancy toward ~2 waves AND (b) hide the K-streaming
+        # latency of a K-HEAVY GEMM — a long reduction per output tile parallelizes across the split
+        # CTAs even when the free dims already fill the machine. The occupancy-only ``needed`` mispriced
+        # exactly (b): mlp_down (M=512, N=4096, K=14336) has ``free_ctas`` alone saturating the SMs, so
+        # it credited ZERO split and ranked the winning ``g8k`` golden ~9000-deep. ``k_ext /
+        # sqrt(free_prod)`` is the K-per-output-linear-dim heaviness (config-independent; ≈1 for a
+        # square / balanced GEMM, large only when K ≫ √(M·N)) — a second floor on the split the shape
+        # justifies.
+        occ_need = 2.0 * sm / max(free_ctas, 1.0)
+        kheavy_need = k_ext / math.sqrt(max(float(free_prod), 1.0)) if k_ext > 0 else 1.0
+        needed = max(occ_need, kheavy_need, 1.0)
         out["D_splitk_excess"] = math.log2(max(splitk / needed, 1.0))
+        # The deficit side: UNDER-splitting a shape that justifies a wide split (``splitk < needed``)
+        # is the K-heavy miss — the penalty that lifts the ``g<w>k`` golden over the ``g1`` tile the
+        # occupancy terms alone rank as safe. Zero once ``splitk ≥ needed`` (and for every shape with
+        # ``needed == 1``, so the well-tuned non-split geometries are untouched). Was absent: split-K
+        # had only penalties (``D_splitk_le2`` / ``D_splitk_excess``), never a reward when justified.
+        out["D_splitk_deficit"] = math.log2(max(needed / max(float(splitk), 1.0), 1.0))
         # The deferred split-K finalize (``g<w>k``) writes + re-reads a full free-size partial
         # workspace and launches the combine kernel — the same round-trip volume axis
         # ``D_cut_roundtrip`` prices for the demoted-cone cut, un-priced here until now (the

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -91,7 +91,7 @@ configs:
     K: 14336
     dtype: 'fp16'
     knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g8k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16/w4x4/f2x2/k4', VECTORIZE_LOADS: true}
-    emmy_us: 303.6
+    emmy_us: 303.0
     cublas_us: 296.95
   - kernel: matmul
     name: matmul.qkv.h4096.dynM
@@ -152,7 +152,7 @@ configs:
     M: 512
     K: 8192
     knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'b256', VECTORIZE_LOADS: true}
-    emmy_us: 10.3
+    emmy_us: 10.2
     cublas_us: 14.29
   - kernel: reduce
     name: reduce.k8192
@@ -172,8 +172,8 @@ configs:
     name: rms_norm.k4096
     M: 512
     K: 4096
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'b256', VECTORIZE_LOADS: true}
-    emmy_us: 6.7
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'b512', VECTORIZE_LOADS: true}
+    emmy_us: 6.4
     cublas_us: 6.14
   - kernel: rms_norm
     name: rms_norm.k8192
@@ -241,8 +241,8 @@ configs:
     M: 512
     K: 4096
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'b256', VECTORIZE_LOADS: true}
-    emmy_us: 6.7
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'b512', VECTORIZE_LOADS: true}
+    emmy_us: 6.4
     cublas_us: 6.14
   - kernel: rms_norm
     name: rms_norm.k8192.dynM
@@ -250,7 +250,7 @@ configs:
     K: 8192
     dynamic: true
     knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'b256', VECTORIZE_LOADS: true}
-    emmy_us: 10.4
+    emmy_us: 10.3
     cublas_us: 10.25
   - kernel: pointwise
     name: pointwise.n4096.dynM

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -131,7 +131,7 @@ configs:
     dtype: 'fp16'
     dynamic: true
     knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g8k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16/w4x4/f2x2/k4', VECTORIZE_LOADS: true}
-    emmy_us: 305.1
+    emmy_us: 304.0
     cublas_us: 295.03
   - kernel: softmax
     name: softmax.k2048
@@ -296,8 +296,8 @@ configs:
     dtype: 'fp16'
     causal: false
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16/w1x1/f1x16/k4', VECTORIZE_LOADS: true}
-    emmy_us: 19.5
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16/w4x1/f1x8/k4', VECTORIZE_LOADS: true}
+    emmy_us: 9.1
     cublas_us: 10.23
   - kernel: attention
     name: attention.hd128.dynM
@@ -307,6 +307,6 @@ configs:
     dtype: 'fp16'
     causal: false
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16/w2x1/f1x16/k8', VECTORIZE_LOADS: true}
-    emmy_us: 29.6
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16/w2x1/f1x8/k8', VECTORIZE_LOADS: true}
+    emmy_us: 16.4
     cublas_us: 18.4

--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -353,13 +353,10 @@ def splitk_moves(*, warp: bool) -> list[str]:
 def coop_reduce_moves() -> list[str]:
     """The cooperative / ILP K-partition ``REDUCE`` codec candidates for a NON-output-tiled
     contraction (``_coop_reduce_spec``'s contract — the per-cell tier folds K across ``b`` coop
-    threads / ``r`` ILP register chains). These EXTEND the serial ``""`` option-0.
-
-    The ``b`` ladder runs to ``b512`` because the wide-row memory-bound norms (``rms_norm`` /
-    ``softmax`` over K=2048–8192) are bandwidth-bound and need MANY warps folding each row to
-    saturate DRAM: at ``b32`` (one warp/row) they hit ~9% of peak DRAM throughput (~0.25× torch's
-    fused norm); ``b256``/``b512`` (8–16 warps/row) reach ~40%+ and close the gap. ``_reduce_candidates``
-    legality-gates each move on ``coop <= K``, so the wide folds are offered only on rows wide enough
-    to use them; ``b1024`` is left off — it trips the ``block_threads + 32·aux <= 1024`` budget and
-    lost to ``b256``/``b512`` in the sweep anyway."""
+    threads / ``r`` ILP register chains). These EXTEND the serial ``""`` option-0. ``b16`` /
+    ``b32`` are recorded reduce-golden winners (the wide-row coop folds) — kept enumerable so
+    the reduce goldens stay reachable. The wide ``b64``–``b512`` folds are the memory-bound
+    normalizer band: a wide-K softmax / rms_norm saturates bandwidth only with a full-block coop
+    row (``softmax.k2048`` wants ``b512`` — 2.6× over ``b32``). The scheduler's ``_coop_reduce_spec``
+    declines a ``b<n>`` wider than the row has work for, so enumerating them is safe on small K."""
     return ["b4", "b8", "b16", "b32", "b64", "b128", "b256", "b512", "r2", "r4", "r2/b4"]

--- a/plans/golden-sweep-rtx5090-findings.md
+++ b/plans/golden-sweep-rtx5090-findings.md
@@ -108,12 +108,22 @@ GEMMs") — it is *unfixed*: the golden still holds because neither the analytic
 feature on `K / max(M,N)`), then refit the analytic weights over it — a 9116-deep analytic rank is a heuristic
 mispricing, not a search-patience problem, so patience bumps alone won't reach it.
 
-**UPDATE — softmax coop-reduce ladder extended to `b512`; golden re-recorded.** `softmax.k2048` had regressed to
-`REDUCE=b32` (9.5 µs) because `space.coop_reduce_moves` capped the ladder at `b32`, so `b512` (3.7 µs — **2.6×**, 0.9×
-cuBLAS) was unreachable by the search. Restored the wide folds `b64`–`b512` (the scheduler's `_coop_reduce_spec`
-already gates per-shape legality, so it's safe on small K); re-recorded `softmax.k2048`(.dynM) at `b512`. **Greedy now
-DEPLOYS `b256` (3.9 µs)** — a 2.4× deploy win over the `b32` it shipped before — with `b512` the golden. (`rms_norm`'s
-bandwidth gap at wide K is untouched — a separate codegen lead.)
+**RESOLVED — it was the capped fold ladder, NOT bandwidth.** The whole family was stuck at `REDUCE=b32` because
+`space.coop_reduce_moves` capped the ladder at `b32`, so the wide folds a memory-bound normalizer needs were
+unreachable by the search. Restored `b64`–`b512` (the scheduler's `_coop_reduce_spec` gates per-shape legality, safe on
+small K). Greedy now **auto-deploys** the right fold and all eight kernels jump to at/above parity — re-recorded:
+
+| kernel | old `b32` | new fold | vs cuBLAS |
+|---|--:|--:|--:|
+| `softmax.k2048`(.dynM) | 9.5 µs | `b512` 3.7 | 1.11 |
+| `softmax.k8192`(.dynM) | 44.2 µs | `b256` 10.2 | **1.40** |
+| `rms_norm.k2048`(.dynM) | 11.0 µs | `b512` 3.9 | 1.05 |
+| `rms_norm.k4096`(.dynM) | 20.9 µs | `b512` 6.4 | 0.96 |
+| `rms_norm.k8192`(.dynM) | 41.0 µs | `b256` 10.2 | 1.00 |
+
+Optimum fold rises with K then backs off (`b512` at K≤4096, `b256` at K=8192 — wider drops occupancy). The finding's
+"memory-bound / bandwidth / vectorization" framing was **wrong**: these were never saturating a narrow fold, and no
+codegen change was needed — only the ladder cap. This is the single biggest parity swing of the sweep (up to 4×).
 
 ## 4 — attention golden re-benches are pathological on the current build
 

--- a/plans/golden-sweep-rtx5090-findings.md
+++ b/plans/golden-sweep-rtx5090-findings.md
@@ -119,7 +119,22 @@ static twin (NCU) to attack the 2–3× residual; separately, the `hd128.dynM` K
 enumeration to prefer the uniform-k form — but that can't be diagnosed until `eval analytic`/`variants` learn to
 enumerate attention shapes (see Workflow notes).
 
-## Finding 3 — greedy picks `b256` over the faster `b512` on `softmax.k2048`
+Non-causal flash is *faster* than torch SDPA static (hd64/hd128 ~1.11–1.12×), but the `.dynM` masked flash is
+0.52–0.60× (golden), 1.7–1.9× behind static. `hd128.dynM` greedy (59.49) is a further 1.96× behind its own
+golden (30.43) — a prior shortfall on top of the masked-flash residual. Unlike the matmuls this is not a tier
+fallback (the flash goldens already use MMA); it is genuine masked-streaming-flash work.
+
+**Part A (the residual) — ADDRESSED, branch `feature/dynamic-flash-staging`.** The residual was *not* intrinsic
+masked-flash cost — it was the missing K/V staging. `_resolve_twisted_stage` only staged a static, block-divisible
+kv; TMA rides the runtime globalDim and zero-fills the box overhang, and the streaming drain already masks the tail
+keys, so the zero-filled tail contributes nothing — bit-identical to gmem-direct. Admitting a symbolic kv under **TMA**
+(cp.async stays static-only: no OOB zero-fill) + threading the symbolic `Dim` through `staged_kloop` makes `.dynM`
+flash stageable. 5090 `-O3`, `hd64.dynM` snippet, same warp tile, gmem→+TMA: `w1x1` 19.2→16.9, `w2x1` 22.2→9.2,
+**`w4x1` 26.3→9.1 µs** — best staged **0.89× cuBLAS** (torch SDPA 10.2), ~at the static hd64 8.6. Bit-identity
+test-enforced at a divisible (64) and overhanging (100) seq. **Part B (the pick, still open):** greedy does not yet
+*select* it — STAGE-free it deploys the unstaged `w2x1` (19.7), STAGE-pinned + TILE-free the flash fork falls to
+scalar. The fast config is now reachable; teaching the masked-tier prior to prefer a wider warp tile + TMA stage (and
+re-recording the `.dynM` goldens) is the lever. **Next:** Part B — the prior/fork selection, then re-record.
 
 Small but reproducible: `softmax.k2048` (static + `.dynM`) golden is `REDUCE=b512` at 3.7 µs; the greedy prior deploys
 `b256` at 3.8–3.9 µs (**~5%** slower, 3/3 re-benches: 3.9 / 3.8 / 3.9). This is a mild prior shortfall — the fold

--- a/plans/golden-sweep-rtx5090-findings.md
+++ b/plans/golden-sweep-rtx5090-findings.md
@@ -78,10 +78,19 @@ eager; reduce → `torch.sum` (unfused, **weak**); pointwise → torch `relu`.
 
 ## Finding 1 — greedy still misses `g8k` split-K on the K-heavy `mlp_down` GEMM
 
-The K-heavy `mlp_down` (M=512, N=4096, **K=14336**) is the biggest matmul shortfall, static and dynamic alike. The
-golden deploys `w4x4/f2x2/k4` + **`REDUCE=g8k`** (8-way split-K, 2048-CTA grid, 67% occ) at 303.6 / 305.1 µs. The
-greedy pick reaches the MMA tier but **no split-K**: `w8x2/f2x4/k4` with `REDUCE=-` at 346.7 µs (static, **1.14×**
-slower) and a *different-but-still-not-g8k* `w2x4/f2x2/k2` + `g2k` at 375.6 µs (dynamic, **1.23×** slower).
+**UPDATE — split-K candidacy feature + golden re-recorded (branch `feature/dynamic-flash-staging`).** The winning
+`mlp_down` config (`w4x4/f2x2/k4 + g8k`, ~303 µs) had been lost from the golden — re-recorded to the unstaged greedy
+tile at 346 µs; restored for static + `.dynM`. Root cause of the prior miss: split-K carried ONLY penalties in the
+feature space (`D_splitk_le2` / `D_splitk_excess`), never a reward when justified, and the occupancy-only `needed`
+credited zero split for K-heavy shapes whose free dims already fill the SMs. Added `D_splitk_deficit`: K-heaviness
+`K/√(M·N)` folds a second floor into `needed`, and under-splitting past it is a penalty (verified: `mlp_down` g8 in the
+sweet spot, balanced GEMMs still prefer g1). Masked-tier cold rank `mlp_down.dynM` 3833→1351 at no aggregate-median
+cost. **Static cold-prior limit:** the LINEAR `_W_A` cannot isolate the `g8k` geometry among the many balanced GEMMs
+(rank stays ~10k; any stronger deficit trades the aggregate median for a modest gain) — the static split-K deploy is a
+CatBoost lever (the refit's `build_cases` is matmul-only, and the nonlinear prior is the model that can price the
+interaction). The feature is in place for that retrain.
+
+## 2 — deployed greedy picks a suboptimal MMA tile for `square.512.dynM`
 
 Evidence:
 
@@ -99,7 +108,14 @@ GEMMs") — it is *unfixed*: the golden still holds because neither the analytic
 feature on `K / max(M,N)`), then refit the analytic weights over it — a 9116-deep analytic rank is a heuristic
 mispricing, not a search-patience problem, so patience bumps alone won't reach it.
 
-## Finding 2 — dynamic flash trails static badly; `hd128.dynM` greedy is 2× off its own golden
+**UPDATE — softmax coop-reduce ladder extended to `b512`; golden re-recorded.** `softmax.k2048` had regressed to
+`REDUCE=b32` (9.5 µs) because `space.coop_reduce_moves` capped the ladder at `b32`, so `b512` (3.7 µs — **2.6×**, 0.9×
+cuBLAS) was unreachable by the search. Restored the wide folds `b64`–`b512` (the scheduler's `_coop_reduce_spec`
+already gates per-shape legality, so it's safe on small K); re-recorded `softmax.k2048`(.dynM) at `b512`. **Greedy now
+DEPLOYS `b256` (3.9 µs)** — a 2.4× deploy win over the `b32` it shipped before — with `b512` the golden. (`rms_norm`'s
+bandwidth gap at wide K is untouched — a separate codegen lead.)
+
+## 4 — attention golden re-benches are pathological on the current build
 
 Non-causal static flash is *faster* than torch SDPA (`hd64` 0.84×, `hd128` 0.90× vs cuBLAS — both now at/above
 parity). The masked `.dynM` twins are far behind: `hd64.dynM` sits at **1.93× cuBLAS** (19.5 µs golden vs 10.2 µs
@@ -131,10 +147,19 @@ keys, so the zero-filled tail contributes nothing — bit-identical to gmem-dire
 (cp.async stays static-only: no OOB zero-fill) + threading the symbolic `Dim` through `staged_kloop` makes `.dynM`
 flash stageable. 5090 `-O3`, `hd64.dynM` snippet, same warp tile, gmem→+TMA: `w1x1` 19.2→16.9, `w2x1` 22.2→9.2,
 **`w4x1` 26.3→9.1 µs** — best staged **0.89× cuBLAS** (torch SDPA 10.2), ~at the static hd64 8.6. Bit-identity
-test-enforced at a divisible (64) and overhanging (100) seq. **Part B (the pick, still open):** greedy does not yet
-*select* it — STAGE-free it deploys the unstaged `w2x1` (19.7), STAGE-pinned + TILE-free the flash fork falls to
-scalar. The fast config is now reachable; teaching the masked-tier prior to prefer a wider warp tile + TMA stage (and
-re-recording the `.dynM` goldens) is the lever. **Next:** Part B — the prior/fork selection, then re-record.
+test-enforced at a divisible (64) and overhanging (100) seq.
+
+**Part B — golden re-recorded + scalar fallback fixed; greedy DEPLOY still open.** Re-recorded `hd64.dynM` (9.1 µs, was
+19.6; bare `w4x1/f1x8/k4` + `STAGE=d2/tma/ring`) and `hd128.dynM` (16.4 µs, was 30.8; `w2x1/f1x8/k8` + stage). Fixed the
+flash-form-fork **scalar fallback**: a `STAGE` pin now keeps the warp rows alone (only the warp tier stages), so the
+`--ab STAGE=…` / `emmy tune` staging probe and `EMMY_STAGE` no longer collapse to a ~100× scalar row (regression-tested
+at H=8/seq=512). Result: **static** flash greedy-deploys the staged form (8.5 µs); **dynamic** flash greedy still
+deploys the unstaged warp (19.6 µs) — the masked-tier LINEAR prior underprices the low-occupancy staged form, and the
+analytic refit can't learn it because `build_cases`/`eval analytic` are matmul-only (attention isn't enumerated).
+Boosting the dyn `D_stage_*` weights was inert (the flash gmem-vs-staged decision rides features the matmul-only eval
+can't surface). The staged config is reachable (golden / pin / `--ab`), so a served model that tunes deploys it;
+greedy-by-default staged `.dynM` flash is the remaining **CatBoost lever** (train over attention shapes). **Next:**
+retrain the CatBoost prior over the goldens (incl. attention) so greedy deploys the staged flash + `g8k` split-K.
 
 Small but reproducible: `softmax.k2048` (static + `.dynM`) golden is `REDUCE=b512` at 3.7 µs; the greedy prior deploys
 `b256` at 3.8–3.9 µs (**~5%** slower, 3/3 re-benches: 3.9 / 3.8 / 3.9). This is a mild prior shortfall — the fold

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -505,9 +505,10 @@ def test_staged_warp_flash_causal_and_gqa_match_torch(monkeypatch, stage):
 
 @requires_cuda
 def test_staged_flash_symbolic_declines_to_gmem_direct(monkeypatch):
-    """A ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash declines (the resolver stages a static,
-    block-divisible kv only — the masked gmem-direct fragment loads keep the symbolic path correct)
-    and the kernel still compiles and matches torch — the standard pin-validity degrade."""
+    """A **cp.async** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash declines (cp.async has no OOB
+    zero-fill, so the resolver stages a static, block-divisible kv only — the masked gmem-direct
+    fragment loads keep the symbolic path correct) and the kernel still compiles and matches torch —
+    the standard pin-validity degrade. TMA stages the symbolic stream instead (see the TMA twins)."""
     monkeypatch.setenv("EMMY_STAGE", "d2/cp/ring")
     B, H, D = 1, 2, 32
     sd = torch.export.Dim("seq_len", min=4, max=4096)
@@ -528,6 +529,62 @@ def test_staged_flash_symbolic_declines_to_gmem_direct(monkeypatch):
     run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
     got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
     assert float(np.max(np.abs(got - eager))) < 5e-3, "declined-stage symbolic flash drifted from torch"
+
+
+@requires_cuda
+def test_staged_flash_symbolic_tma_stages_and_matches_torch(monkeypatch):
+    """A **TMA** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash STAGES the K/V stream (unlike
+    cp.async, which declines): the descriptor rides the runtime globalDim and zero-fills the box
+    overhang past the last key, so the tail chunk of a non-block-divisible seq is safe and the
+    drain's tail masks keep it correct. One cached kernel carries ``int seq_len``; accurate vs torch
+    at seq ∈ {64, 100} (100 overhangs the KV block)."""
+    monkeypatch.setenv("EMMY_STAGE", "d2/tma/ring")
+    B, H, D = 1, 4, 64
+    sd = torch.export.Dim("seq_len", min=4, max=4096)
+    seed = tuple(torch.randn(B, H, 16, D, dtype=torch.float16) for _ in range(3))
+    backend, compiled, graph, kernels = _trace(_Sdpa(), seed, dynamic_shapes={"q": {2: sd}, "k": {2: sd}, "v": {2: sd}})
+    src = compiled.nodes[kernels[0]].op.kernel_source
+    assert "int seq_len" in src, "dynamic kernel must carry the runtime seq_len arg"
+    assert "_k_smem" in src and "_v_smem" in src, "TMA must stage the symbolic K/V stream"
+    assert "cp_async_bulk_tensor" in src, "the symbolic K/V must box-copy via the TMA descriptor"
+
+    for s in (64, 100):
+        torch.manual_seed(s)
+        q, k, v = (torch.randn(B, H, s, D, dtype=torch.float16) for _ in range(3))
+
+        def ref(q=q, k=k, v=v):
+            with torch.no_grad():
+                return F.scaled_dot_product_attention(q.cuda(), k.cuda(), v.cuda()).cpu().flatten().float().numpy()
+
+        data = {n: t for n, t in zip(graph.inputs, (q.numpy(), k.numpy(), v.numpy()), strict=True)}
+        run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
+        got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
+        assert float(np.max(np.abs(got - eager))) < 5e-3, f"staged symbolic tma flash seq={s} drifted from torch"
+
+
+@requires_cuda
+@pytest.mark.parametrize("s", [64, 100])
+def test_staged_flash_symbolic_tma_bit_identical_to_gmem_direct(monkeypatch, s):
+    """The symbolic TMA-staged stream is a pure perf transform: verbatim K/V row copies, and the
+    box zero-fill of the overhang lands on keys the drain masks to the fold identity — the same
+    clamp the gmem-direct symbolic path makes — so the staged output is BIT-identical to gmem-direct
+    at both a block-divisible (64) and an overhanging (100) seq."""
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16/w2x1/f1x4/k4")
+    B, H, D = 1, 4, 64
+    sd = torch.export.Dim("seq_len", min=4, max=4096)
+    seed = tuple(torch.randn(B, H, 16, D, dtype=torch.float16) for _ in range(3))
+    ds = {"q": {2: sd}, "k": {2: sd}, "v": {2: sd}}
+    torch.manual_seed(s)
+    q, k, v = (torch.randn(B, H, s, D, dtype=torch.float16) for _ in range(3))
+
+    backend, compiled, graph, _ = _trace(_Sdpa(), seed, dynamic_shapes=ds)
+    base = _run_flash(backend, compiled, graph, (q, k, v))
+    monkeypatch.setenv("EMMY_STAGE", "d2/tma/ring")
+    backend2, compiled2, graph2, kernels2 = _trace(_Sdpa(), seed, dynamic_shapes=ds)
+    src2 = compiled2.nodes[kernels2[0]].op.kernel_source
+    assert "_k_smem" in src2 and "cp_async_bulk_tensor" in src2, "TMA must stage the symbolic stream"
+    staged = _run_flash(backend2, compiled2, graph2, (q, k, v))
+    assert np.array_equal(base, staged), f"staged symbolic tma (seq={s}) differs from gmem-direct sibling"
 
 
 @requires_cuda

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -532,6 +532,23 @@ def test_staged_flash_symbolic_declines_to_gmem_direct(monkeypatch):
 
 
 @requires_cuda
+def test_staged_flash_stage_pin_keeps_warp_not_scalar(monkeypatch):
+    """A ``STAGE`` pin keeps the flash fork on the WARP (mma) tier — only the warp tier stages, so
+    the pin must not fall through to the chain / scalar reduce-partition siblings and let the prior
+    bury the (lower-occupancy) staged warp form under a higher-occupancy scalar form. At H=8/seq=512
+    the pre-fix prior did exactly that (a staged-flash A/B row read as a ~100× regression). The
+    kernel must be the fused warp form (`dpl_c_to_a`) with a live TMA-staged K/V slab, NOT scalar."""
+    monkeypatch.setenv("EMMY_STAGE", "d2/tma/ring")
+    B, H, D = 1, 8, 64  # H=8 is the scale where the pre-fix prior buried the staged form under scalar
+    sd = torch.export.Dim("seq_len", min=4, max=4096)
+    seed = tuple(torch.randn(B, H, 16, D, dtype=torch.float16) for _ in range(3))
+    _backend, compiled, _graph, kernels = _trace(_Sdpa(), seed, dynamic_shapes={"q": {2: sd}, "k": {2: sd}, "v": {2: sd}})
+    src = compiled.nodes[kernels[0]].op.kernel_source
+    assert "dpl_c_to_a" in src, "STAGE pin must keep the fused WARP flash form, not fall to scalar"
+    assert "_k_smem" in src and "cp_async_bulk_tensor" in src, "the warp form must carry the pinned TMA K/V stage"
+
+
+@requires_cuda
 def test_staged_flash_symbolic_tma_stages_and_matches_torch(monkeypatch):
     """A **TMA** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash STAGES the K/V stream (unlike
     cp.async, which declines): the descriptor rides the runtime globalDim and zero-fills the box

--- a/tests/compiler/passes/test_move_catalog.py
+++ b/tests/compiler/passes/test_move_catalog.py
@@ -16,7 +16,7 @@ from emmy.compiler.dim import Dim
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
-from emmy.compiler.ir.schedule import TilePlan
+from emmy.compiler.ir.schedule import ReducePlan, TilePlan
 from emmy.compiler.pipeline import TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
 from emmy.compiler.pipeline.knob import axis_of, family_of, family_value
@@ -90,11 +90,10 @@ def test_schedule_leaf_set_equals_catalog():
     for r in rows:
         by_tile.setdefault(str(family_value(r, "TILE")), []).append(r)
     percell = by_tile[""]
-    # The coop ladder is legality-gated on ``coop <= K`` (``_reduce_candidates``): this matmul's
-    # K=64 keeps the narrow folds and filters the wide ``b128``/``b256``/``b512`` rows.
-    from emmy.compiler.ir.tile import ReducePlan  # noqa: PLC0415
-
-    legal_coop = [m for m in coop_reduce_moves() if ReducePlan.parse(m).coop <= 64 and ReducePlan.parse(m).reg <= 64]
+    # The per-cell tier offers serial + every coop/ILP move whose fold fits the reduce extent
+    # (``_reduce_specs``'s ``coop <= extent and reg <= extent`` gate) — so the wide ``b64``–``b512``
+    # folds drop out on this K=64 matmul, exactly as they would on any reduce narrower than the fold.
+    legal_coop = {m for m in coop_reduce_moves() if (p := ReducePlan.parse(m)).coop <= 64 and p.reg <= 64}
     assert {str(family_value(r, "REDUCE")) for r in percell} == {"", *legal_coop}
     assert all(family_value(r, "STAGE") == "" for r in percell), "per-cell has no operand slab to stage (decided-empty)"
     # Every tiled tile is the full (resolved stages) × (serial + split widths) product, the split


### PR DESCRIPTION
Closes the reachability half of the RTX 5090 golden findings: makes several winning kernel configs **reachable and (mostly) auto-deployed**, taking the golden set from **21/36 → 29/36 at/above cuBLAS parity**.

## What's in it

**1. Dynamic flash — stageable under TMA (`_schedule.py`, `_twist.py`, `_stage.py`).**
`.dynM` (symbolic `seq_len`) flash trailed its static twin ~2–3×; the cause was the *missing* K/V staging, not intrinsic masked-flash cost. `_resolve_twisted_stage` only staged a static, block-divisible kv. TMA rides the runtime `globalDim` and zero-fills the box overhang, and the streaming drain already masks the tail keys — so the zero-filled tail contributes nothing and staging stays **bit-identical to gmem-direct**. Admitted symbolic kv under TMA (cp.async stays static-only: no OOB zero-fill) and threaded the symbolic `Dim` through `staged_kloop`. `hd64.dynM` `w4x1` 26.3→**9.1 µs** (0.89× cuBLAS, ~at the static hd64). Bit-identity is test-enforced at a block-divisible (64) and an **overhanging (100)** seq.

**2. Flash-form-fork scalar fallback — fixed.** A `STAGE` pin now keeps the warp rows alone (only the warp tier stages), so `--ab STAGE=…` / `EMMY_STAGE` / a tune staging-probe no longer collapse to a ~100× scalar sibling. Regression-tested at H=8/seq=512.

**3. Split-K K-heaviness feature (`features.py`, `analytic.py`).** Split-K carried only *penalties* and the occupancy-only `needed` credited zero split for K-heavy GEMMs whose free dims already fill the SMs (mlp_down K=14336). Folded `K/√(M·N)` into `needed` and added `D_splitk_deficit` — a symmetric penalty for under-splitting a shape that justifies a wide split. Added to the analytic weights as a targeted, non-regressing change (golden median rank held at 357; masked-tier `mlp_down.dynM` 3833→1351).

**4. Coop-reduce ladder `b64`–`b512` (`space.py`) — the single biggest parity swing.** The ladder capped at `b32`, so the entire `rms_norm` family + `softmax.k8192` were stuck at 0.25–0.37× cuBLAS (Finding #3 had misdiagnosed this as "bandwidth"). Extending the ladder lets greedy **auto-deploy** the right fold — up to **4×**, all at/above parity.

**5. Goldens re-recorded (14 shapes, all verified reproducing):** mlp_down(.dynM) `g8k` (~303 µs, was 346); softmax/rms_norm family to the wide-fold optimum; flash hd64.dynM 9.1 µs (was 19.6) + hd128.dynM 16.4 µs (was 30.8), staged.

## Honest limits (documented in `plans/golden-sweep-rtx5090-findings.md`)

Two wins are **reachable but not greedy-deployed by default** — static mlp_down `g8k` and greedy-default staged `.dynM` flash. Both are blocked by the **linear** analytic cold prior + the **matmul-only** refit enumeration (`build_cases` / `eval analytic` don't cover attention). The feature and goldens are in place; the lever is a **CatBoost** retrain over all shapes (incl. attention). The remaining 7 sub-parity goldens are genuine floors: `pointwise.n16384` (0.78×, memory-bandwidth vs torch relu) and a few HGEMMs at 0.93–0.94× (cuBLAS wall).

## Testing

- Full `make test` green (2170 passed, 39 skipped); `make lint` clean.
- New tests: symbolic-kv TMA staging + bit-identity (divisible + overhanging seq), `STAGE`-pin-keeps-warp regression, move-catalog updated for the wider ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)