### PR TITLE
Fix per-kernel bench attribution: pair per_launch by topo launch order, not dict order

### DIFF
--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -560,6 +560,16 @@ async def _bench_golden_variants(backend, code, golden_configs, *, warmup, iters
     return out
 
 
+def _launch_order_cuda_nodes(graph):
+    """CudaOp nodes in the backend's launch order (``graph.topological_order()`` — the order
+    ``bench.per_launch`` indexes). Graph dict order diverges from launch order after
+    node-splitting passes (a split partial lands after its consumer in dict order), which
+    cross-labels the per-kernel timings if used for pairing."""
+    from emmy.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
+
+    return [graph.nodes[nid] for nid in graph.topological_order() if isinstance(graph.nodes[nid].op, CudaOp)]
+
+
 def _print_kernel_stats(graph, bench, golden_benches=None):
     """Per-kernel breakdown. Pulls structural stats off each ``CudaOp``
     (block / grid / smem), per-launch timings from ``bench.per_launch``,
@@ -580,7 +590,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None):
     from emmy.compiler.pipeline.knob import tuning_knob_items  # noqa: PLC0415
     from emmy.compiler.pipeline.search.data import ShapeKey  # noqa: PLC0415
 
-    cuda_nodes = [node for _, node in graph.nodes.items() if isinstance(node.op, CudaOp)]
+    cuda_nodes = _launch_order_cuda_nodes(graph)
     if not cuda_nodes:
         return
 
@@ -653,7 +663,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None):
             label = f"! {label}"
         g_times = {lt.idx: (min(lt.samples) if lt.samples else lt.time_ms) * 1000 for lt in (gb.bench.per_launch or [])}
         g_attrs = _collect_kernel_attrs(gb.graph)
-        g_nodes = [n for n in gb.graph.nodes.values() if isinstance(n.op, CudaOp)]
+        g_nodes = _launch_order_cuda_nodes(gb.graph)
         for gidx, gnode in enumerate(g_nodes):
             gk = dict(tuning_knob_items(gnode.op.knobs or {}))
             records.append((label, g_times.get(gidx, 0.0), "--", _geom(gnode.op, g_attrs), gk, ref))
@@ -719,13 +729,12 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches) -> None:
     import json as _json  # noqa: PLC0415
 
     from emmy import gpu  # noqa: PLC0415
-    from emmy.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
     from emmy.compiler.pipeline.knob import tuning_knob_items  # noqa: PLC0415
 
     def _kernel_rows(g, b) -> list[dict]:
         times = {lt.idx: (min(lt.samples) if lt.samples else lt.time_ms) * 1000 for lt in (b.per_launch or [])}
         rows = []
-        for idx, node in enumerate(n for n in g.nodes.values() if isinstance(n.op, CudaOp)):
+        for idx, node in enumerate(_launch_order_cuda_nodes(g)):
             op = node.op
             rows.append(
                 {

--- a/plans/bench-attribution-by-slicing.md
+++ b/plans/bench-attribution-by-slicing.md
@@ -28,6 +28,9 @@ Why this is better:
   number (see the cuda ARCHITECTURE.md note added on the finding-6 branch).
 - **Kills the mis-attribution class.** Finding 6's `mm0`/`mm1` artifact (identical work, 5.1 vs 0.8 µs solo
   windows) can't happen when each kernel is benched as its own program with its own warmup and calibration.
+  (2026-07-07: one member of this class turned out to be a plain ordering bug — the display paired `per_launch`
+  by graph dict order vs the backend's topo launch order, cross-labeling rows 400× apart on split programs;
+  fixed minimally in run.py `_launch_order_cuda_nodes`, nsys-verified. The refactor above remains the durable fix.)
 
 ## Current state (what already exists)
 

--- a/plans/gemma-4-12b-rmsnorm-rtx4090-tune-findings.md
+++ b/plans/gemma-4-12b-rmsnorm-rtx4090-tune-findings.md
@@ -1,5 +1,13 @@
 # Gemma-4-12B RMSNorm kernel tune findings — RTX 4090 (sm_89)
 
+> **CORRECTION (2026-07-07, nsys-verified):** the per-kernel µs in this report are **cross-labeled** — `run --bench`
+> paired `per_launch` times to kernels by graph **dict** order while the backend launches in **topo** order (fixed in
+> `_launch_order_cuda_nodes`, run.py). The "626–1540 µs norm epilogues" are actually the **q/k projections running
+> scalar tiles** (the norm's f32 output feeds the f16 weights — a mixed-dtype matmul the f16 MMA tier never takes);
+> the norm kernels themselves are 4–5 µs and healthy. e4bb2c's "98 ms" is its reproducer's down-projection running
+> scalar, not the norm and not a hang; its 18 µs -O1 measurement was the true norm cost, not a wrong-bench. Findings
+> 2–3 below are superseded accordingly; the real open item is the **mixed-dtype scalar matmul fallback**.
+
 - **Scope:** targeted tune of the 7 RMSNorm-carrying kernels of `google/gemma-4-12B` layer 0 on a rented CloudRift
   RTX 4090 (24 GB, driver 580.65.06, CUDA 12.9, torch 2.12.1+cu130). Static shapes at the seq_len=512 hint. Each
   kernel tuned from its dump reproducer (`emmy tune <k>.torch.json --bench`), then greedy-benched

--- a/plans/golden-sweep-rtx4090-findings.md
+++ b/plans/golden-sweep-rtx4090-findings.md
@@ -1,5 +1,13 @@
 # Golden seeding findings — RTX 4090 (sm_89): first rms_norm entries
 
+> **CORRECTION (2026-07-07, nsys-verified):** Findings 1 and 3 were built on cross-labeled per-kernel benches
+> (`run --bench` paired times by graph dict order vs the backend's topo launch order — fixed in run.py's
+> `_launch_order_cuda_nodes`). The fused norm kernels are 4–5 µs (recognition + coop fork work fine; local variants:
+> b64 4.0 µs rank 1/11, serial 88 µs); the slow kernel in those programs is the **mixed-dtype (f32×f16) projection
+> matmul on scalar tiles**. e4bb2c's winner was never broken — its reproducer program contains the scalar
+> down-projection (~98 ms real). The seeded goldens (this file's table) are unaffected: single-kernel programs
+> can't cross-label. Finding 2 (dyn AI-floor false positive) and Finding 4 (refit skips rms_norm) stand.
+
 - **Date / GPU / box:** 2026-07-07, NVIDIA GeForce RTX 4090 24 GB (CloudRift rental, driver 580.65.06, nvcc 12.9 via
   `CUDA_HOME=/usr/local/cuda`), emmy at `main` (71bd34f3) + this branch.
 - **Scope:** NOT a full-dataset sweep — a seeding session adding the first `rms_norm` entries to `rtx4090_sm89.yaml`

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -725,3 +725,32 @@ def test_bind_inputs_preserves_int_dtype():
     assert bound["activations"].dtype == np.float32
     # Values must round-trip without precision loss.
     np.testing.assert_array_equal(bound["position_ids"], np.arange(8, dtype=np.int32)[None, :])
+
+
+def test_launch_order_cuda_nodes_pairs_by_topo_not_dict_order():
+    """The per-kernel table pairs ``bench.per_launch`` times to kernels by launch index,
+    and the backend launches in ``graph.topological_order()`` — NOT graph dict order.
+    Node-splitting passes insert a producer (the split ``__partial``) after its consumer
+    in dict order, which used to cross-label the rows: the 4 µs norm kernel printed the
+    1573 µs matmul-partial's time and vice versa (nsys-verified on the gemma-4-12B
+    QK-norm reproducer). ``_launch_order_cuda_nodes`` must return topo order regardless
+    of insertion order."""
+    from emmy.commands.run import _launch_order_cuda_nodes
+    from emmy.compiler.graph import Graph, Tensor
+    from emmy.compiler.ir.base import InputOp
+    from emmy.compiler.ir.cuda import CudaOp
+
+    def _cuda_op(name, args):
+        return CudaOp(kernel_source="", kernel_name=name, arg_order=args, grid=(1, 1, 1), block=(1, 1, 1))
+
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("A", (8,)), node_id="A")
+    g.add_node(op=_cuda_op("k_producer", ("A", "T")), inputs=["A"], output=Tensor("T", (8,)), node_id="T")
+    g.add_node(op=_cuda_op("k_consumer", ("T", "C")), inputs=["T"], output=Tensor("C", (8,)), node_id="C")
+    g.inputs = ["A"]
+    g.outputs = ["C"]
+    # Simulate the split pass's dict layout: the consumer precedes its producer in insertion order.
+    g.nodes = {nid: g.nodes[nid] for nid in ("A", "C", "T")}
+
+    names = [n.op.kernel_name for n in _launch_order_cuda_nodes(g)]
+    assert names == ["k_producer", "k_consumer"]


### PR DESCRIPTION
## Summary
- `run --bench`'s per-kernel table, `--json` kernel rows, and golden A/B rows paired `bench.per_launch` times to kernels by **graph dict order**, while the backend launches in **`graph.topological_order()`** (which `LaunchTime.idx` indexes). After node-splitting passes the orders diverge and rows cross-label.
- nsys-verified reproducer (gemma-4-12B QK-norm program): the table claimed norm=1573µs / matmul-partial=4.2µs; hardware truth is norm=**5.2µs** / partial=**1573µs** — a 400× label swap that mis-directed an entire tuning session's findings ("thread-serial norm prison", "e4bb2c 98ms broken winner" — corrections prepended to both reports in `plans/`).
- Fix: `_launch_order_cuda_nodes` (topo-ordered CudaOp nodes, mirroring `pipeline.py`'s already-correct `cuda_nodes`) used at all three run.py sites + a regression test with scrambled dict order.
- Not affected: tune DB/prior rows (pipeline.py was topo-correct), recorded goldens (single-kernel programs can't cross-label), `compare.py` (pairs by kernel_name).
- Real perf item this unblocks (follow-up): mixed-dtype f32×f16 projection matmuls (norm output → f16 weights) fall to scalar tiles — the actual source of the 626µs/98ms latencies previously blamed on the norm kernels.

## Validation
- New regression test passes; before/after on the reproducer now matches nsys exactly.
- `make lint` clean; `make test` 2070 passed, same 9 pre-existing failures on this box as main (2× `--golden` CLI tests needing h4096 seeds on the live card, 7× staged-flash TMA post-#321).

🤖 Generated with [Claude Code](https://claude.com/claude-code)