### PR TITLE
Tile lowering: decline over-budget warp stages; bench_fail un-lowered terminals (#327)

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -201,7 +201,10 @@ engine loops (`drive` for exploration, `resolve` for deterministic resolution):
   `TuningSearch(patience=, ucb_c=)`; the async generator yields one terminal `Candidate` per fully-explored rollout, and
   `tune_async` benches each via `await _bench_terminal_async` (writes per-kernel `perf` / `lowering` / inventory rows,
   returns the aggregate `PerfStats`), then calls `search.observe(stats, status)`. With `backend=None` the bench is
-  stubbed to `latency_us=1.0` and nothing is persisted, so a backend-less sweep never overwrites tuned rows.
+  stubbed to `latency_us=1.0` and nothing is persisted, so a backend-less sweep never overwrites tuned rows. A terminal
+  still carrying an un-lowered kernel-bearing node (a validation-filtered rewrite) is a `bench_fail` decided before any
+  bench or cache lookup — the bench sums `CudaOp`s only, so without that guard the un-lowered kernel priced at zero and
+  a cached residual kernel's µs could stand in for the whole graph as an `ok` measurement (issue #327).
 - `Run.drive(graph) -> Iterator[(token, Candidate)]` — the exploration engine loop (`tune`). `Run` is the per-run state
   object (`pipeline` + `ctx` + `search` + `db` + `backend` + `dump` + `rejections`): `Pipeline` stays a frozen,
   shareable pass layout while every run-scoped sink lives on the Run, reached through the candidate (`cand.run.dump`,

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -57,7 +57,11 @@ bound (e.g. a non-`Load` operand — a computed-cone / demoted matmul) is reject
   instead of `lower()`-ing the contraction and pattern-matching the result. A `STAGE` pin follows the same rule: the
   option builders resolve it against the built node ONCE (`_resolve_warp_stage` / `_resolve_scalar_stage` — transport
   eligibility, the slab K-chunk `bk_elems`, the depth clamps) and stamp the resolved `Stage` (or `None`, gmem-direct)
-  on the `TileOp`, so the materializer's one staged driver applies it verbatim, deciding nothing. One staging fact
+  on the `TileOp`, so the materializer's one staged driver applies it verbatim, deciding nothing. Fitting the smem
+  budget is part of resolving: a tile whose single depth-1 slot already exceeds it declines to gmem-direct (the warp
+  slab is codec-sized and cannot shrink; the scalar resolver steps `bk_elems` / depth down first), so every offered
+  stage row materializes within budget — a resolved-but-unfittable row would only die at `validate(ctx)`, leaving an
+  un-lowered `TileOp` in the tune's terminal (issue #327). One staging fact
   is derived at materialization rather than resolved here because it is layout, not eligibility: a TMA slab feeding an
   mma drain is **swizzled** (`_stage.pick_swizzle_atom` picks B32/B64/B128 per operand from the slab's inner row span;
   the hardware permutes 16 B chunks in-copy, each staged `LdmatrixLoad` XORs the address back, and the kernel stays

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -600,7 +600,11 @@ def _resolve_warp_stage(c: Contraction, stage: Stage, budget: int = STATIC_SMEM_
     in elements), ``depth`` clamped so the ring's slots fit the smem ``budget`` (the device's dynamic
     opt-in cap when a ``Context`` reaches the schedule, else the 48 KiB static floor; dropping
     ``ring`` when the clamp leaves nothing to cycle), and ``reg_depth`` clamped to ``bk`` (nothing to
-    ping-pong past the resident chunk)."""
+    ping-pong past the resident chunk). A tile whose single depth-1 slot already exceeds ``budget``
+    DECLINES (``None``, gmem-direct) — unlike the scalar resolver it cannot shrink the slab
+    (``bk_elems`` is codec-spelled here, not derived), and a resolved-but-unfittable stage would
+    sail through the fork only to be rejected at materialize (the issue-#327 unlowered-``TileOp``
+    bench fails)."""
     atom = c.atom
     a_nbytes = atom.operand_dtype("a").nbytes
     bk = c.tile.bk
@@ -622,7 +626,9 @@ def _resolve_warp_stage(c: Contraction, stage: Stage, budget: int = STATIC_SMEM_
         return None
     bk_elems = bk * atom.atom_k
     slot_bytes = (m.tile + n.tile) * bk_elems * a_nbytes
-    depth = min(stage.depth, max(1, budget // slot_bytes))
+    if slot_bytes > budget:
+        return None
+    depth = min(stage.depth, budget // slot_bytes)
     return replace(stage, depth=depth, ring=stage.ring and depth >= 2, reg_depth=min(stage.reg_depth, bk), bk_elems=bk_elems)
 
 

--- a/emmy/compiler/pipeline/pipeline.py
+++ b/emmy/compiler/pipeline/pipeline.py
@@ -1129,13 +1129,23 @@ class _TerminalBench:
     :meth:`finalize_exc`) live here, so the only awaited step is the device bench."""
 
     def __init__(self, cand, *, backend, db) -> None:
+        from emmy.compiler.ir.base import ConstantOp, InputOp  # noqa: PLC0415
         from emmy.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
 
         self.backend = backend
         self.db = db
         self.graph = cand.graph
         self.context_key = cand.ctx.structural_key()
-        self.cuda_nodes = [self.graph.nodes[nid] for nid in self.graph.topological_order() if isinstance(self.graph.nodes[nid].op, CudaOp)]
+        order = self.graph.topological_order()
+        self.cuda_nodes = [self.graph.nodes[nid] for nid in order if isinstance(self.graph.nodes[nid].op, CudaOp)]
+        # Kernel-bearing nodes a rewrite left un-lowered (a validation-filtered rewrite under
+        # tune — see ``Candidate.try_rewrite``). The same membership test as the backend's
+        # ``_launches`` walk, so anything the backend would refuse is known BEFORE the bench:
+        # summing only ``cuda_nodes`` prices the un-lowered kernel at zero, and the cache-hit
+        # path would then report the residual kernels' Σ as an ``ok`` terminal measurement (the
+        # issue-#327 "impossibly fast" split-K rows — a finalize kernel's cached µs standing in
+        # for the whole matmul).
+        self.unlowered = [nid for nid in order if not isinstance(self.graph.nodes[nid].op, (CudaOp, InputOp, ConstantOp))]
         self.backend_name = getattr(backend, "name", "stub")
 
     @staticmethod
@@ -1280,6 +1290,20 @@ class _TerminalBench:
         stub backend), else ``("bench", None)`` — the caller obtains a
         ``BenchmarkResult`` and calls :meth:`finalize_result` / :meth:`finalize_exc`."""
         from emmy.compiler.pipeline.search.keys import op_cache_key  # noqa: PLC0415
+
+        # An un-lowered kernel-bearing node is a bench_fail terminal, decided here — never a
+        # backend call (it would raise the opaque ``non-CudaOp`` TypeError) and never the
+        # cache-hit / no-CudaOp paths below (they see only the RESIDUAL kernels and would report
+        # a partial Σ as ``ok``). Nothing is persisted: the residual kernels' own perf rows are
+        # honest, and the fail is the terminal's, not theirs.
+        if self.unlowered:
+            logger.warning(
+                "[tune] %d node(s) left un-lowered (%s) — bench_fail without benching",
+                len(self.unlowered),
+                ", ".join(f"{nid}: {type(self.graph.nodes[nid].op).__name__}" for nid in self.unlowered),
+            )
+            fail_s = self.backend.bench_run_timeout_s if self.backend is not None else 1.0
+            return "done", (self._point_stats(float(fail_s) * 1_000_000.0), "bench_fail")
 
         if not self.cuda_nodes:
             return "done", (self._point_stats(0.0), "ok")

--- a/tests/compiler/passes/test_move_catalog.py
+++ b/tests/compiler/passes/test_move_catalog.py
@@ -140,6 +140,50 @@ def test_schedule_leaves_key_tile_by_contraction_axis():
     assert len(axes) == 1  # one contraction → one eligible k-axis
 
 
+def _fp16_matmul_graph() -> Graph:
+    """A static fp16 square matmul (K=512, tile-divisible for every ``bk``) — warp (mma) moves
+    are eligible, and the big 256×256 warp tiles fit unmasked."""
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("a", (Dim(512), Dim(512)), "f16"), node_id="a")
+    g.add_node(InputOp(), [], Tensor("b", (Dim(512), Dim(512)), "f16"), node_id="b")
+    g.add_node(MatmulOp(), ["a", "b"], Tensor("c", (Dim(512), Dim(512)), "f16"), node_id="c")
+    g.inputs, g.outputs = ["a", "b"], ["c"]
+    return g
+
+
+def test_warp_staged_rows_fit_the_smem_budget():
+    """Every enumerated warp row with a non-empty ``STAGE`` fits its depth-1 operand slot in the
+    ctx smem budget, and an over-budget tile still rides gmem-direct. The 256×256 ``w4x4/f4x8``
+    tile at ``k8`` needs a 128 KiB slot — over any current cap — and ``_resolve_warp_stage`` used
+    to floor the depth clamp at 1 instead of declining, so the row sailed through the fork and
+    died at materialize (`validate(ctx)`), leaving an un-lowered ``TileOp`` in the tune's terminal
+    (issue #327)."""
+    ctx = Context.from_target((8, 9))  # the issue's sm_89 cap (101376 B)
+    rows: list[dict] = []
+
+    def decide(fp):
+        leaves = flatten_leaves(fp.options)
+        for leaf in leaves:
+            row = dict(getattr(leaf, "knobs", {}) or {})
+            if any("TILE" in family_of(k) for k in row):
+                rows.append(row)
+        return leaves[0]
+
+    Run(pipeline=Pipeline.build(TILE_PASSES), ctx=ctx).resolve(_fp16_matmul_graph(), decide)
+    staged = [r for r in rows if str(family_value(r, "TILE")).startswith("a:") and family_value(r, "STAGE")]
+    assert staged, "no staged warp rows were enumerated"
+    for r in staged:
+        plan = TilePlan.parse(str(family_value(r, "TILE")))
+        slot = (plan.tile_m + plan.tile_n) * plan.bk * plan.atom.atom_k * plan.atom.operand_dtype("a").nbytes
+        assert slot <= ctx.max_dynamic_smem, f"{family_value(r, 'TILE')} / {family_value(r, 'STAGE')}: slot {slot} over budget"
+    # The over-budget tile itself stays enumerable — gmem-direct only (its every staged sibling
+    # resolver-declines), split-K rows included.
+    big = [r for r in rows if family_value(r, "TILE") == "a:mma_m16n8k16_f16/w4x4/f4x8/k8"]
+    assert big, "the 256x256 warp tile dropped out of the enumeration"
+    assert all(family_value(r, "STAGE") == "" for r in big)
+    assert any(family_value(r, "REDUCE") for r in big), "split-K must still ride the gmem-direct rows"
+
+
 def _reduce_graph() -> Graph:
     """A bare full-row sum reduce (the ``reduce.2048x2048`` golden shape) — a lifted
     :class:`Reduction` with a 2048-cell free grid, well past the coop heuristic's free cap."""

--- a/tests/compiler/pipeline/test_lowering_error_guardrail.py
+++ b/tests/compiler/pipeline/test_lowering_error_guardrail.py
@@ -138,6 +138,58 @@ def test_tuning_does_not_raise_and_prunes_branch():
 
 
 # ---------------------------------------------------------------------------
+# Tune-side bench guard: a terminal still carrying an un-lowered node is a
+# bench_fail decided in ``_TerminalBench.prelude`` — never an ``ok``. Without
+# the guard the un-lowered node is invisible to the bench (it sums CudaOps
+# only): a no-CudaOp terminal reported ok @ 0 µs, and a cached residual kernel
+# (a split's finalize) reported its own µs as the terminal's — the issue-#327
+# "impossibly fast" ok rows that poisoned the tune DB.
+# ---------------------------------------------------------------------------
+
+
+def _terminal_bench(graph, *, backend, db):
+    from types import SimpleNamespace
+
+    from emmy.compiler.pipeline.pipeline import _TerminalBench
+
+    return _TerminalBench(SimpleNamespace(graph=graph, ctx=_small_smem_ctx()), backend=backend, db=db)
+
+
+def test_unlowered_terminal_is_bench_fail_without_cuda_nodes():
+    from emmy.compiler.pipeline.search.db import SearchDB
+
+    b = _terminal_bench(_graph_with_tile(), backend=None, db=SearchDB())
+    assert b.unlowered == ["y"]
+    kind, (_stats, status) = b.prelude()
+    assert kind == "done"
+    assert status == "bench_fail"
+
+
+def test_unlowered_terminal_is_bench_fail_despite_cached_residual_kernel():
+    from emmy.compiler.ir.cuda.ir import CudaOp
+    from emmy.compiler.pipeline.search.db import SearchDB
+    from emmy.compiler.pipeline.search.keys import op_cache_key
+
+    class _StubBackend:
+        name = "cuda"
+        bench_run_timeout_s = 1.0
+
+    # ``x -> y (TileOp) -> z (CudaOp)`` — the split shape: an un-lowered partial
+    # feeding a lowered finalize whose perf row is already cached.
+    g = _graph_with_tile()
+    cuda = CudaOp(kernel_source="__global__ void k_fin() {}", kernel_name="k_fin")
+    g.add_node(op=cuda, inputs=["y"], output=Tensor("z", (4,), "f32"), node_id="z")
+    g.outputs = ["z"]
+    db = SearchDB()
+    b = _terminal_bench(g, backend=_StubBackend(), db=db)
+    db.record_perf(b.context_key, op_cache_key(cuda), backend="cuda", status="ok", stats=b._point_stats(104.0))
+    kind, (stats, status) = b.prelude()
+    assert kind == "done"
+    assert status == "bench_fail"
+    assert stats.median > 104.0  # the pinned fail latency, not the residual kernel's cached µs
+
+
+# ---------------------------------------------------------------------------
 # Option-0 fallback: a prior that over-extrapolates large (over-budget) tiles
 # onto a small shape must not abort the greedy compile. The retry blocklist
 # exhausts on the prior-ranked over-budget tiles, then the conservative


### PR DESCRIPTION
Fixes #327 — the `w4x4/f4x8/k8` warp tile's broken programs (unlowered `TileOp` with `g4k/d1/cp`; the physically-impossible ~104 µs "ok" rows with `g2k/d1/cp`).

## Root cause

Both modes are one bug with two symptoms. That tile is a 256×256 CTA tile with a 128-element K-chunk, so a single operand-staging slot is 131072 B — over the RTX 4090's 101376 B dynamic-smem cap. `_resolve_warp_stage` clamped the ring depth with `max(1, budget // slot_bytes)`: the floor of 1 made an unfittable slot **resolve at d1 instead of declining**, so the fork offered a row that could only die at `010_materialize`'s `validate(ctx)`. Under tune a validation-filtered rewrite leaves the node un-lowered, silently.

- **Mode 1** (`g4k`): the un-lowered `matmul__partial` `TileOp` reached the CUDA backend → the `TypeError` bench_fails, one full compile wasted per row.
- **Mode 2** (`g2k`): `_TerminalBench` collects only `CudaOp` nodes, so the un-lowered partial was invisible to the bench; the graph's only visible kernel was the cheap split **finalize**, whose cached perf row made `prelude()` take the full-cache-hit path and report finalize-only time as an `ok` terminal measurement. The finalize benches at ~92 µs on the 4090 — the issue's ~104 µs "1.15 PFLOPS matmul". Which sibling got the garbage-ok vs. the TypeError was just cache order during the ε-tune.

## Fix

- **`_schedule._resolve_warp_stage`** declines (`None` → gmem-direct) when even a depth-1 slot exceeds the budget. The warp slab is codec-sized (`bk` is spelled, not derived) so unlike the scalar resolver it cannot shrink — declining is the only honest resolution. Unfittable stage rows are no longer offered by the fork, and a `STAGE` pin degrades to gmem-direct, restoring the resolver contract the scalar/sync resolvers already keep: everything offered materializes within budget.
- **`_TerminalBench`** now detects kernel-bearing nodes a rewrite left un-lowered (same membership test as the backend's `_launches` walk) and returns `bench_fail` from `prelude()` before any bench or cache lookup. A partial kernel sum can never be recorded as `ok` again, whatever leaves a node un-lowered in the future — this half is defense in depth beyond #327's specific trigger (numeric validation of benches stays #328).

## Verification

- Both issue repro commands now lower and bench honestly on the 4090: the ab rows run gmem-direct (~29 ms partial + finalize, `STAGE=""` stamped per the honest-stamping rule) — no un-lowered node, no TypeError, no impossible timing.
- New regression tests: every enumerated warp row with a non-empty `STAGE` fits its depth-1 slot in the ctx budget and the over-budget tile stays enumerable gmem-direct with its split-K rows (`test_move_catalog.py`); an un-lowered terminal is `bench_fail` both with no CudaOps at all and with a cached residual kernel — the exact mode-2 scenario (`test_lowering_error_guardrail.py`).
- `make test` on the 4090: 2074 passed; the 8 failures (7 TMA-flash, 1 bench_block dry-run) reproduce identically on unmodified HEAD in the same environment (sm_89 has no TMA) — zero new failures. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)