### PR TITLE
Add vercel rewrite to serve /emmy route

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,7 +1,12 @@
 {
   "redirects": [
-    { "source": "/", "destination": "/emmy/" },
+    { "source": "/", "destination": "/emmy/getting_started" },
+    { "source": "/emmy", "destination": "/emmy/getting_started" },
+    { "source": "/emmy/", "destination": "/emmy/getting_started" },
     { "source": "/cloudrift", "destination": "https://docs.cloudrift.ai/" },
     { "source": "/cloudrift/:path*", "destination": "https://docs.cloudrift.ai/:path*" }
+  ],
+  "rewrites": [
+    { "source": "/emmy/:path*", "destination": "/:path*" }
   ]
 }


### PR DESCRIPTION
This makes the site to be served on /emmy/:path routes correctly. The CSS assets were not showing on the website and rewrites solves it.