### PR TITLE
Masked flash stages K/V under cp.async: sm_89 .dynM attention reaches SDPA parity

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -113,12 +113,12 @@ the full prior-ranked fork. Each warp geometry row crosses with its **K/V operan
 batched K/V operands encode as rank-N TMA boxes with leading extent-1 dims, the load's own batch/head index exprs
 riding as origin coords; cp.async slabs take the +16 B row pad, TMA slabs stay dense under the hardware swizzle; the
 resolved `Stage` rides the `TileOp` and the streaming step becomes the `staged_kloop` drain, K/V slabs kept in each
-operand's own layout so staging stays bit-identical to gmem-direct). cp.async stages a **static, block-divisible** kv
-only; **TMA also stages a symbolic (dynamic-`seq_len`) kv** — the descriptor rides the runtime globalDim and zero-fills
-the box overhang past the last key, and the streaming drain's tail masks (the same clamp the gmem-direct symbolic path
-makes) zero those keys' contribution, so the masked-flash `.dynM` kernel stages at bit-identity to gmem-direct (the
-`staged_kloop` ring allocates the full depth and the last-chunk clamp / loop bound ride the symbolic `Dim`; WSPEC over a
-symbolic kv is not built). A resolved TMA row additionally offers the `WSPEC` producer-band splits (the matmul tier's
+operand's own layout so staging stays bit-identical to gmem-direct). **Both transports also stage a symbolic
+(dynamic-`seq_len`) kv**: TMA rides the runtime globalDim and zero-fills the box overhang past the last key; cp.async
+(which has no OOB zero-fill) clamp-reads the tail chunk's key rows to the last valid key. Either way the streaming
+drain's tail masks (the same clamp the gmem-direct symbolic path makes) zero those keys' P columns exactly, so the
+masked-flash `.dynM` kernel stages at bit-identity to gmem-direct on any sm (the `staged_kloop` ring allocates the
+full depth and the last-chunk clamp / loop bound ride the symbolic `Dim`; WSPEC over a symbolic kv is not built). A resolved TMA row additionally offers the `WSPEC` producer-band splits (the matmul tier's
 legality, `32·aux ≤ 32·um`; measured occupancy-negative at flash's CTA scale — offered, honest, not the default). The
 chain / coop / serial escapes stamp the decided-empty `STAGE@<kv>: ""`. The causal tile-skip is the remaining flash
 follow-up.

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -679,8 +679,9 @@ def staged_kloop(
     chunk base by name (the warp-flash stream's absolute score columns) passes its own axis name."""
     # A symbolic ``k_extent`` (warp-flash over a runtime seq_len) is a ``Dim``: the chunk count is a
     # runtime value, so allocate the full ``depth`` ring (the tuned hint has ≥ depth chunks) and let
-    # the TMA box zero-fill any over-primed tail chunk — the drain masks those keys to the fold
-    # identity, so it stays bit-identical to gmem-direct. Static callers pass plain ``int``s.
+    # the transport absorb any over-primed tail chunk (TMA zero-fills its box; cp.async clamp-reads
+    # the last valid key rows) — the drain masks those keys to the fold identity, so it stays
+    # bit-identical to gmem-direct. Static callers pass plain ``int``s.
     symbolic = isinstance(k_extent, Dim)
     ring = depth if symbolic else (min(depth, n_chunks) if n_chunks >= 2 else 1)
     if workers is not None:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -67,7 +67,7 @@ from emmy.compiler.ir.schedule import Fold, Level, ReduceStage
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body, Init, Load, Select, Stmt, StridedLoop, Write
 from emmy.compiler.ir.tile.ir import Contraction, Map, Reduction
-from emmy.compiler.pipeline.passes.lowering.kernel._atom import unroll_ok
+from emmy.compiler.pipeline.passes.lowering.kernel._atom import _clamp_last, unroll_ok
 from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
     CpAsyncTransport,
     CtaTile,
@@ -511,21 +511,29 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
         # cp.async fills cooperatively into padded rows; TMA box-copies the batched operands via
         # rank-N descriptors (leading extent-1 box dims, the load's own batch/head index exprs as
         # origin coords — GQA's ``h // group`` rides through) into dense hardware-swizzled slabs.
-        # A symbolic kv reaches here under TMA only (``_resolve_twisted_stage`` — cp.async stays
-        # static): the streaming loop bound / last-chunk clamp ride the symbolic ``Dim`` and the box
-        # zero-fills the overhang, so the drain's tail masks keep it bit-identical to gmem-direct.
-        assert not symbolic_k or is_tma, "symbolic-kv staging is TMA-only (no OOB zero-fill on cp.async)"
+        # A symbolic kv stages under both: the streaming loop bound / last-chunk clamp ride the
+        # symbolic ``Dim``; TMA zero-fills the box overhang, cp.async clamp-reads the tail's key
+        # rows to the last valid key (``_key_row``). Either way the drain's tail masks zero the
+        # overhanging P columns, so the staged kernel stays bit-identical to gmem-direct.
         kv_ext = kv_axis.extent if symbolic_k else kv_axis.extent.as_static()
         n_chunks = kv_axis.extent.ceil_div(bn) if symbolic_k else kv_axis.extent.as_static() // bn
         head_dim = qk.k_axis.extent.as_static()
         k_load, v_load = qk.b_load, pv.b_load
         kn, kk, vn = qk.n_axis.name, qk.k_axis.name, pv.n_axis.name
 
+        def _key_row(k0: Expr, row) -> Expr:
+            # cp.async has no OOB zero-fill — clamp a symbolic tail's key rows to the last valid
+            # key. The drain's tail masks zero the overhanging P columns, so the duplicated rows
+            # contribute exactly 0 (the cp.async counterpart of TMA's box zero-fill, which needs
+            # no clamp).
+            key = BinaryExpr("+", k0, row)
+            return _clamp_last(key, seq) if symbolic_k and not is_tma else key
+
         def _k_index(k0: Expr):
-            return lambda row, col: _idx(k_load, {kn: BinaryExpr("+", k0, row), kk: col})
+            return lambda row, col: _idx(k_load, {kn: _key_row(k0, row), kk: col})
 
         def _v_index(k0: Expr):
-            return lambda row, col: _idx(v_load, {kv_axis.name: BinaryExpr("+", k0, row), vn: col})
+            return lambda row, col: _idx(v_load, {kv_axis.name: _key_row(k0, row), vn: col})
 
         k_batch, v_batch = tuple(k_load.index[:-2]), tuple(v_load.index[:-2])
         k_op = Operand(

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1494,18 +1494,22 @@ def _resolve_twisted_stage(stage: Stage, kv_extent, bn: int, head_dim: int, d_v:
     ``(1, 1, bn, head_dim)`` — the load's own batch/head index exprs supplying the origin coords;
     the slabs stay dense and take the hardware swizzle + drain XOR instead of padding; box dims
     cap at the 256 hardware limit). ``sync`` has nothing to overlap. A **symbolic** kv stages
-    under TMA only — the descriptor rides the runtime globalDim and zero-fills the box overhang, so
-    the streaming drain's tail-key masks (the same clamp the gmem-direct symbolic path makes) keep
-    it bit-identical; cp.async has no such zero-fill and a static, non-block-divisible kv has no
-    tail mask, so both stay gmem-direct. ``depth`` clamps so the ring's K+V slot pairs fit the smem
+    under both transports — TMA rides the runtime globalDim and zero-fills the box overhang;
+    cp.async clamp-reads the tail's key rows to the last valid key — and the streaming drain's
+    tail-key masks (the same clamp the gmem-direct symbolic path makes) keep either bit-identical.
+    A static, non-block-divisible kv has no tail mask, so it stays gmem-direct on both.
+    ``depth`` clamps so the ring's K+V slot pairs fit the smem
     ``budget``; ``reg_depth`` clamps to 1 (no ldmatrix ping-pong on the streaming drain yet);
     ``bk_elems`` records the streamed keys per step."""
     if stage.transport not in ("cp.async", "tma"):
         return None
     if stage.transport == "cp.async":
-        # cp.async has no OOB zero-fill — a symbolic / non-block-divisible kv would read the
-        # overhanging tail chunk out of bounds, so it stays static + block-divisible only.
-        if not kv_extent.is_static or kv_extent.as_static() % bn != 0:
+        # A symbolic kv stages: the fill clamp-reads the overhanging tail rows to the last valid
+        # key (cp.async has no OOB zero-fill) and the drain's tail masks zero their P columns, so
+        # the duplicates contribute exactly 0 — bit-identical to gmem-direct, the cp.async
+        # counterpart of TMA's box zero-fill. The static non-divisible guard below is defensive:
+        # the warp form's own divisibility gate rejects that geometry before any stage resolves.
+        if kv_extent.is_static and kv_extent.as_static() % bn != 0:
             return None
     elif kv_extent.is_static and kv_extent.as_static() % bn != 0:
         # TMA + a STATIC non-block-divisible kv has no tail mask (masking is symbolic-only) —

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
@@ -378,8 +378,8 @@ configs:
     dtype: 'fp16'
     causal: false
     dynamic: true
-    knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16/w1x1/f1x16/k4'}
-    emmy_us: 20.6
+    knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16/w4x1/f1x16/k4', STAGE: 'd2/cp/ring'}
+    emmy_us: 10.7
     cublas_us: 11.0
   - kernel: attention
     name: attention.hd128.dynM
@@ -389,8 +389,8 @@ configs:
     dtype: 'fp16'
     causal: false
     dynamic: true
-    knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16/w2x1/f1x16/k8'}
-    emmy_us: 27.3
+    knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16/w4x1/f1x8/k8', STAGE: 'd2/cp/ring'}
+    emmy_us: 20.3
     cublas_us: 19.0
   - kernel: rms_norm
     name: rms_norm.k3840

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -611,11 +611,12 @@ def test_staged_warp_flash_causal_and_gqa_match_torch(monkeypatch, stage):
 
 
 @requires_cuda
-def test_staged_flash_symbolic_declines_to_gmem_direct(monkeypatch):
-    """A **cp.async** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash declines (cp.async has no OOB
-    zero-fill, so the resolver stages a static, block-divisible kv only — the masked gmem-direct
-    fragment loads keep the symbolic path correct) and the kernel still compiles and matches torch —
-    the standard pin-validity degrade. TMA stages the symbolic stream instead (see the TMA twins)."""
+def test_staged_flash_symbolic_cp_stages_and_matches_torch(monkeypatch):
+    """A **cp.async** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash STAGES the K/V stream: the fill
+    clamp-reads the tail chunk's key rows to the last valid key (cp.async has no OOB zero-fill) and
+    the drain's tail masks zero their P columns, so the duplicated rows contribute exactly 0. One
+    cached kernel carries ``int seq_len``; accurate vs torch at seq ∈ {37, 64, 100} (37/100
+    overhang the KV block)."""
     monkeypatch.setenv("EMMY_STAGE", "d2/cp/ring")
     B, H, D = 1, 2, 32
     sd = torch.export.Dim("seq_len", min=4, max=4096)
@@ -623,19 +624,47 @@ def test_staged_flash_symbolic_declines_to_gmem_direct(monkeypatch):
     backend, compiled, graph, kernels = _trace(_Sdpa(), seed, dynamic_shapes={"q": {2: sd}, "k": {2: sd}, "v": {2: sd}})
     src = compiled.nodes[kernels[0]].op.kernel_source
     assert "emmy_c_to_a" in src, "must still be the fused warp form"
-    assert "_k_smem" not in src and "_v_smem" not in src, "a symbolic stream must decline the K/V stage"
+    assert "int seq_len" in src, "dynamic kernel must carry the runtime seq_len arg"
+    assert "_k_smem" in src and "_v_smem" in src, "cp.async must stage the symbolic K/V stream"
+    assert "cp.async" in src and "cp_async_bulk_tensor" not in src, "the fill must be cp.async, not TMA"
 
-    torch.manual_seed(37)
-    q, k, v = (torch.randn(B, H, 37, D, dtype=torch.float16) for _ in range(3))
+    for s in (37, 64, 100):
+        torch.manual_seed(s)
+        q, k, v = (torch.randn(B, H, s, D, dtype=torch.float16) for _ in range(3))
 
-    def ref():
-        with torch.no_grad():
-            return torch.nn.functional.scaled_dot_product_attention(q.cuda(), k.cuda(), v.cuda()).cpu().flatten().float().numpy()
+        def ref(q=q, k=k, v=v):
+            with torch.no_grad():
+                return F.scaled_dot_product_attention(q.cuda(), k.cuda(), v.cuda()).cpu().flatten().float().numpy()
 
-    data = {n: t for n, t in zip(graph.inputs, (q.numpy(), k.numpy(), v.numpy()), strict=True)}
-    run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
-    got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
-    assert float(np.max(np.abs(got - eager))) < 5e-3, "declined-stage symbolic flash drifted from torch"
+        data = {n: t for n, t in zip(graph.inputs, (q.numpy(), k.numpy(), v.numpy()), strict=True)}
+        run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
+        got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
+        assert float(np.max(np.abs(got - eager))) < 5e-3, f"staged symbolic cp flash seq={s} drifted from torch"
+
+
+@requires_cuda
+@pytest.mark.parametrize("s", [64, 100])
+def test_staged_flash_symbolic_cp_bit_identical_to_gmem_direct(monkeypatch, s):
+    """The symbolic cp.async-staged stream is a pure perf transform: verbatim K/V row copies, and
+    the tail chunk's clamped (duplicated) key rows land on P columns the drain masks to exactly 0 —
+    so the staged output is BIT-identical to gmem-direct at both a block-divisible (64) and an
+    overhanging (100) seq. The cp.async counterpart of the TMA twin above."""
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16/w2x1/f1x4/k4")
+    B, H, D = 1, 4, 64
+    sd = torch.export.Dim("seq_len", min=4, max=4096)
+    seed = tuple(torch.randn(B, H, 16, D, dtype=torch.float16) for _ in range(3))
+    ds = {"q": {2: sd}, "k": {2: sd}, "v": {2: sd}}
+    torch.manual_seed(s)
+    q, k, v = (torch.randn(B, H, s, D, dtype=torch.float16) for _ in range(3))
+
+    backend, compiled, graph, _ = _trace(_Sdpa(), seed, dynamic_shapes=ds)
+    base = _run_flash(backend, compiled, graph, (q, k, v))
+    monkeypatch.setenv("EMMY_STAGE", "d2/cp/ring")
+    backend2, compiled2, graph2, kernels2 = _trace(_Sdpa(), seed, dynamic_shapes=ds)
+    src2 = compiled2.nodes[kernels2[0]].op.kernel_source
+    assert "_k_smem" in src2 and "cp.async" in src2, "cp.async must stage the symbolic stream"
+    staged = _run_flash(backend2, compiled2, graph2, (q, k, v))
+    assert np.array_equal(base, staged), f"staged symbolic cp (seq={s}) differs from gmem-direct sibling"
 
 
 @requires_cuda
@@ -657,11 +686,11 @@ def test_staged_flash_stage_pin_keeps_warp_not_scalar(monkeypatch):
 
 @requires_cuda
 def test_staged_flash_symbolic_tma_stages_and_matches_torch(monkeypatch):
-    """A **TMA** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash STAGES the K/V stream (unlike
-    cp.async, which declines): the descriptor rides the runtime globalDim and zero-fills the box
-    overhang past the last key, so the tail chunk of a non-block-divisible seq is safe and the
-    drain's tail masks keep it correct. One cached kernel carries ``int seq_len``; accurate vs torch
-    at seq ∈ {64, 100} (100 overhangs the KV block)."""
+    """A **TMA** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash STAGES the K/V stream: the
+    descriptor rides the runtime globalDim and zero-fills the box overhang past the last key, so
+    the tail chunk of a non-block-divisible seq is safe and the drain's tail masks keep it correct
+    (the cp.async twin clamp-reads instead of zero-filling). One cached kernel carries
+    ``int seq_len``; accurate vs torch at seq ∈ {64, 100} (100 overhangs the KV block)."""
     monkeypatch.setenv("EMMY_STAGE", "d2/tma/ring")
     B, H, D = 1, 4, 64
     sd = torch.export.Dim("seq_len", min=4, max=4096)


### PR DESCRIPTION
**Independent of the goldens PRs — based on main.** Closes the masked-flash gap findings-4 F3 flagged: every `.dynM` (symbolic seq_len) flash kernel below sm_90 ran **gmem-direct** — `_resolve_twisted_stage` declined a symbolic kv under cp.async ("no OOB zero-fill"), so only TMA (sm_90+) could stage the K/V stream, and sm_89 masked attention trailed torch SDPA 1.4–1.9×.

## The fix

The cp.async counterpart of TMA's box zero-fill: the fill **clamp-reads the tail chunk's key rows to the last valid key** (`_key_row` in `_twist.py`, the same `_clamp_last` idiom the matmul tier's masked-M A-slab fill uses), and the drain's existing tail masks zero the overhanging P columns *exactly* — so 0 × (finite duplicated row) = 0 and the staged kernel stays **bit-identical to gmem-direct**. `staged_kloop` and the tail-mask machinery were already transport-independent; only the fill's OOB semantics differed. ~10 lines of lowering change:

- `_schedule._resolve_twisted_stage`: accept a symbolic kv under cp.async (static non-divisible stays declined — defensively; the warp form's divisibility gate already rejects that geometry upstream)
- `_twist`: drop the TMA-only assert, clamp the K/V fill rows
- `passes/ARCHITECTURE.md`: staging paragraph updated

## Results (RTX 4090, hint 512, pinned -O3 A/B, 3 stable runs)

| shape | before (gmem-direct golden on main) | after (staged) | torch SDPA | vs SDPA |
|---|--:|--:|--:|--:|
| attention.hd128.dynM | 27.3 µs (this week's sweep deploy: 33.9) | **20.3 µs** | 20 µs | ~1.5× → **1.02×** |
| attention.hd64.dynM | 20.6 µs | **10.7 µs** | 10 µs | ~1.9× → **1.08×** |

Goldens replaced in `rtx4090_sm89.yaml`; both replay exactly from the recorded pins (bare `TILE` + `STAGE`, pj fold derives). RTX 4080 (sm_89) shows the same shape: hd128.dynM 40.6 → 20.4 µs vs SDPA ~25.5.

Note for #336 (the golden-sweep PR): its `attention.hd64.dynM` entry (17.2 µs, gmem-direct) is superseded by this PR's 10.7 µs staged entry — whichever merges second resolves that one YAML hunk by keeping 10.7.

## Tests

- `test_staged_flash_symbolic_declines_to_gmem_direct` inverts into `test_staged_flash_symbolic_cp_stages_and_matches_torch` (accurate at seq 37/64/100 — 37/100 overhang the KV block) + `test_staged_flash_symbolic_cp_bit_identical_to_gmem_direct[64,100]`, mirroring the TMA twins. These run on sm_89 (unlike the TMA ones), so the local lane covers them.
- Full suite on an sm_89 box: 2122 passed; the same 9 pre-existing failures as pristine main there (sm_89 TMA tests + CLI golden-substring), zero new.

Follow-up (not this PR): greedy on a cold prior now *explores* the staged fork (a fresh box's pick was a staged config with a worse tile) — a routine `tune --dataset golden --kernel attention` re-tune will let deploy find the recorded configs; the goldens pin the target either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)