### PR TITLE
Flash dispatch: a STAGE pin no longer bypasses the axis-keyed TILE narrowing

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1293,6 +1293,11 @@ def schedule(tile: TileOp, name: str, knobs: dict, ctx=None) -> Fork | list[Tile
             stage_pinned = STAGE.raw() is not None and bool(STAGE.narrow([""])[0])
             warp_pinned = TILE.raw() is not None and is_warp_codec(TILE.raw())
             if warps and (warp_pinned or stage_pinned):
+                # The axis-keyed ``TILE@<dd>``/``TILE@<pj>`` pins (a static attention golden's
+                # spelling) must still select their geometry among the kept mma rows — this early
+                # return used to skip the narrowing entirely, so a golden that also pins ``STAGE``
+                # benched the prior's tile under the pinned stage (the findings-5 F2 coercion).
+                warps = _narrow_flash_forms(warps, head, pv, keyed_only=True)
                 return warps if len(warps) > 1 else warps[0]
             chain = _twisted_chain_option(tile, place, name, knobs)
             forms = [*warps, *([chain] if chain is not None else [])]
@@ -1330,16 +1335,21 @@ def _canon_tile_spec(spec: str) -> str:
         return spec
 
 
-def _narrow_flash_forms(forms: list[TileOp], head: Contraction, pv: Contraction) -> list[TileOp]:
+def _narrow_flash_forms(forms: list[TileOp], head: Contraction, pv: Contraction, *, keyed_only: bool = False) -> list[TileOp]:
     """Narrow the flash fork's leaf rows by the live per-node ``TILE`` pins. Every flash row spells
     the same key set (``TILE@<qk_k>`` / ``TILE@<pv_k>``), so a pin selects rows by their stamped
     spelling: ``f<d>`` on the PV k-axis keeps the CHAIN row, ``""`` / ``a:scalar`` the per-cell
     rows, a warp codec the mma rows (the bare-warp-pin fast path returns before this). A pin that
     matches NO row keeps the full fork — the same graceful degrade as a warp pin that doesn't fit
-    the flash form (warned, greedy picks by prior)."""
+    the flash form (warned, greedy picks by prior). ``keyed_only`` reads the explicit
+    ``TILE@<axis>`` pins alone, skipping ``narrow_at``'s bare-``TILE`` fallback — the warp-rows
+    caller has already consumed a bare pin in ``_twisted_warp_options``, and matching it against
+    the *derived* pj spelling would spuriously miss every row."""
+    from emmy import config  # noqa: PLC0415
+
     live: dict[str, str] = {}
     for ax in (head.k_axis.name, pv.k_axis.name):
-        pin = TILE.narrow_at(ax)
+        pin = config.knob_raw(f"{TILE.name}@{ax}") if keyed_only else TILE.narrow_at(ax)
         if pin is not None:
             live[ax] = _canon_tile_spec(pin)
     if not live:

--- a/tests/compiler/pipeline/test_flash_form_narrowing.py
+++ b/tests/compiler/pipeline/test_flash_form_narrowing.py
@@ -61,3 +61,58 @@ def test_alias_spelling_canonicalizes(monkeypatch):
 def test_unmatched_pin_keeps_the_full_fork(monkeypatch):
     monkeypatch.setenv("EMMY_TILE@PJ", "f32")  # no row stamps f32
     assert _tags(_narrow_flash_forms(_forms(), _HEAD, _PV)) == ["warp", "chain", "cell"]
+
+
+def test_keyed_only_ignores_the_bare_pin(monkeypatch):
+    # ``keyed_only`` is the warp-rows caller's mode: a bare warp pin was already consumed by
+    # ``_twisted_warp_options`` and must not be re-matched against the DERIVED pj spelling
+    # (it can never equal both axes' spellings — their ``k<bk>`` differ).
+    monkeypatch.setenv("EMMY_TILE", _WARP_SPEC)
+    assert _tags(_narrow_flash_forms(_forms(), _HEAD, _PV, keyed_only=True)) == ["warp", "chain", "cell"]
+
+
+def test_keyed_only_still_selects_by_axis_pins(monkeypatch):
+    monkeypatch.setenv("EMMY_TILE@DD", _WARP_SPEC)
+    monkeypatch.setenv("EMMY_TILE@PJ", _WARP_SPEC)
+    assert _tags(_narrow_flash_forms(_forms(), _HEAD, _PV, keyed_only=True)) == ["warp"]
+
+
+def test_stage_pin_does_not_bypass_keyed_tile_pins(monkeypatch):
+    """The findings-5 F2 regression: a static attention golden pins ``TILE@dd``/``TILE@pj`` AND
+    ``STAGE``; the dispatch's stage-pinned early return (mma rows alone) used to skip the
+    narrowing, so the golden A/B benched the prior's tile under the pinned stage. The full
+    trace→resolve path must stamp exactly the pinned pair."""
+    import pytest
+
+    torch = pytest.importorskip("torch")  # noqa: F841
+
+    from emmy.commands.run import _pinned_knobs
+    from emmy.commands.trace import trace_inline_code
+    from emmy.compiler.context import Context
+    from emmy.compiler.pipeline import TILE_PASSES, Pipeline
+    from emmy.compiler.pipeline.fork import Fork
+    from emmy.compiler.pipeline.pipeline import Run
+
+    d = trace_inline_code(
+        "F.scaled_dot_product_attention(torch.randn(1,2,128,64,dtype=torch.float16), "
+        "torch.randn(1,2,128,64,dtype=torch.float16), torch.randn(1,2,128,64,dtype=torch.float16), is_causal=False)"
+    )
+    g = d["graph"] if isinstance(d, dict) else d
+    pins = {
+        "PLACE": "fuse",
+        "TILE@dd": "a:mma_m16n8k16_f16/w2x1/f1x8/k4",
+        "TILE@pj": "a:mma_m16n8k16_f16/w2x1/f1x8/k4",
+        "STAGE": "d2/cp/ring",
+    }
+
+    def decide(fp):
+        o = fp.options[0]
+        while isinstance(o, Fork) and not o.is_leaf:
+            o = o.expand()[0]
+        return o
+
+    with _pinned_knobs(pins):
+        out, _ = Run(pipeline=Pipeline.build(TILE_PASSES), ctx=Context(compute_capability=(8, 9))).resolve(g, decide)
+    stamped = next(k for _, n in out.nodes.items() if (k := getattr(n.op, "knobs", None)) and "TILE@dd" in k)
+    assert stamped["TILE@dd"] == pins["TILE@dd"], stamped
+    assert stamped["TILE@pj"] == pins["TILE@pj"], stamped

--- a/tests/compiler/pipeline/test_golden_attention_pins.py
+++ b/tests/compiler/pipeline/test_golden_attention_pins.py
@@ -1,0 +1,48 @@
+"""Every recorded STATIC attention golden's pins must still bind — resolve the golden's own
+snippet under its recorded knobs and assert the stamped ``TILE@*`` spellings match the record.
+
+The findings-5 F2 guard: a moveset / pin-routing change that silently stops a recorded config
+from binding turns every golden A/B for that shape into a lie (the "golden" row benches some
+other config). CPU-only — the pins bind (or not) at fork-build time, no kernel is compiled.
+Dynamic (``.dynM``) attention goldens record a bare ``TILE`` whose binding is exercised by the
+masked-flash e2e tests; the static axis-keyed pins are the spelling this guard pins down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from emmy.compiler.pipeline.search.golden import GOLDEN_CONFIGS, AttentionGoldenConfig  # noqa: E402
+
+_STATIC_ATTENTION = [g for g in GOLDEN_CONFIGS if isinstance(g, AttentionGoldenConfig) and not g.dynamic]
+
+
+@pytest.mark.parametrize("golden", _STATIC_ATTENTION, ids=lambda g: f"{g.name}@{g.gpu_name.split()[-1]}")
+def test_static_attention_golden_pins_bind(golden, monkeypatch):
+    from emmy.commands.run import _pinned_knobs
+    from emmy.commands.trace import trace_inline_code
+    from emmy.compiler.context import Context
+    from emmy.compiler.pipeline import TILE_PASSES, Pipeline
+    from emmy.compiler.pipeline.fork import Fork
+    from emmy.compiler.pipeline.pipeline import Run
+
+    d = trace_inline_code(golden.snippet())
+    g = d["graph"] if isinstance(d, dict) else d
+
+    def decide(fp):
+        o = fp.options[0]
+        while isinstance(o, Fork) and not o.is_leaf:
+            o = o.expand()[0]
+        return o
+
+    ctx = Context(compute_capability=tuple(golden.compute_cap))
+    with _pinned_knobs(golden.knobs):
+        out, _ = Run(pipeline=Pipeline.build(TILE_PASSES), ctx=ctx).resolve(g, decide)
+    tile_pins = {k: v for k, v in golden.knobs.items() if k.startswith("TILE@")}
+    assert tile_pins, f"{golden.name}: static attention golden should record axis-keyed TILE pins"
+    stamped = next((k for _, n in out.nodes.items() if (k := getattr(n.op, "knobs", None)) and set(tile_pins) <= set(k)), None)
+    assert stamped is not None, f"{golden.name}: no node stamps the recorded TILE keys {sorted(tile_pins)}"
+    for key, want in tile_pins.items():
+        assert stamped[key] == want, f"{golden.name}: recorded {key}={want!r} resolved to {stamped[key]!r}"


### PR DESCRIPTION
Fixes findings-5 **F2** (the "attention static golden pin coercion") — and corrects its diagnosis. Based on main, independent of #331/#336.

## What was actually broken

The twisted-flash dispatch early-returns the warp rows whenever a `STAGE` pin is live (by design: a staging pin must not be buried under a higher-occupancy scalar form). But that early return **skipped `_narrow_flash_forms` entirely**, so the axis-keyed `TILE@dd`/`TILE@pj` pins — exactly how a static attention golden records its config — were never consulted. The golden A/B then benched the *prior's* tile under the pinned stage and reported it as the golden row. Both static attention goldens on the 4090 (and, it turns out, the 5090's too) were replaying wrong.

Findings-5 F2 blamed #332's flash-form narrowing for making the recorded forms unenumerable — wrong: the forms were in the move grid all along (`(um=4, nt=16, fm=1)` etc.); the pins just never reached the match. The early return predates #332.

## The fix

One call in the early-return branch: narrow the kept warp rows by the **explicit axis-keyed** pins (`keyed_only=True` — `narrow_at`'s bare-`TILE` fallback must not re-match a bare pin already consumed by `_twisted_warp_options` against the *derived* pj spelling, which can never equal both axes' `k<bk>`).

## Validation (RTX 4080, sm_89 — same pin plumbing on every sm)

| golden (static) | recorded (4090) | pinned A/B before fix | pinned A/B after fix |
|---|--:|--:|--:|
| attention.hd64 | 10.6 µs | coerced tile, 13.9 µs | **binds exactly, 10.8 µs** |
| attention.hd128 | 19.9 µs | coerced config, 26.0 µs | **binds exactly, 19.7 µs** |

No YAML change — the recorded goldens were right; only their replay was broken.

## Tests

- `test_flash_form_narrowing.py`: `keyed_only` unit tests + a full trace→resolve dispatch test (STAGE pin + keyed TILE pins → stamped knobs equal the pins).
- **`test_golden_attention_pins.py` (new guard)**: resolves every recorded static attention golden under its own pins and asserts the stamped `TILE@*` spellings match the record — CPU-only, and it **fails 4/4 without the fix** (both 4090 and 5090 entries), passes with it. A future moveset/pin-routing change can no longer silently un-bind a golden.
- Full suite: 2126 passed, failure set byte-identical to the pre-existing baseline on this box (sm_89 TMA + CLI golden-substring), zero new.

Follow-up (not this PR): greedy still deploys its own pick on these shapes (hd64 15.0 µs vs the now-reachable 10.6) — a search/prior matter for the next attention re-tune, not a pin matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)