### PR TITLE
Gemma-4 text support for EmmyGenModel generative serving

### DIFF
--- a/emmy/compiler/trace/huggingface.py
+++ b/emmy/compiler/trace/huggingface.py
@@ -273,7 +273,11 @@ def build_attention_split_wrapper(block):
     ``.view(B,S,-1,D).transpose(1,2)`` assumes a ``[batch, seq, hidden]`` input; on the
     flattened ``[T, H]`` layout the reshape is ``.view(T, n_heads, D)`` with **no transpose**.
     Qwen3 (q/k norm) and Llama (no q/k norm) are both handled; the architecture difference is
-    just the presence of ``q_norm`` / ``k_norm``."""
+    just the presence of ``q_norm`` / ``k_norm``. Gemma-4 blocks are also handled: a missing
+    ``v_proj`` (``attention_k_eq_v`` — V is the raw ``k_proj`` output, taken BEFORE ``k_norm``),
+    the unscaled ``v_norm``, the sandwich norms (``post_attention_layernorm`` applied to the attn
+    OUTPUT, ``pre/post_feedforward_layernorm`` around the MLP — keyed on the presence of
+    ``pre_feedforward_layernorm``), and the trailing ``layer_scalar`` buffer."""
     import torch.nn as nn
 
     attn = block.self_attn
@@ -282,23 +286,28 @@ def build_attention_split_wrapper(block):
     num_kv_heads = attn.k_proj.out_features // head_dim
     q_norm = getattr(attn, "q_norm", None)
     k_norm = getattr(attn, "k_norm", None)
+    v_norm = getattr(attn, "v_norm", None)
+    v_proj = getattr(attn, "v_proj", None)  # None on gemma-4 k_eq_v (global) layers — V rides k_proj
+    pre_ff_norm = getattr(block, "pre_feedforward_layernorm", None)  # gemma sandwich-norm marker
 
     class Pre(nn.Module):
         def __init__(self) -> None:
             super().__init__()
             self.input_layernorm = block.input_layernorm
-            self.q_proj, self.k_proj, self.v_proj = attn.q_proj, attn.k_proj, attn.v_proj
-            self.q_norm, self.k_norm = q_norm, k_norm
+            self.q_proj, self.k_proj, self.v_proj = attn.q_proj, attn.k_proj, v_proj
+            self.q_norm, self.k_norm, self.v_norm = q_norm, k_norm, v_norm
 
         def forward(self, hidden):
             h = self.input_layernorm(hidden)  # [T, H]
             t = h.shape[0]
             q = self.q_proj(h).view(t, num_heads, head_dim)  # [T, Hq, D] — NO transpose
             k = self.k_proj(h).view(t, num_kv_heads, head_dim)
-            v = self.v_proj(h).view(t, num_kv_heads, head_dim)
+            v = self.v_proj(h).view(t, num_kv_heads, head_dim) if self.v_proj is not None else k  # k_eq_v: raw k, pre-k_norm
             if self.q_norm is not None:
                 q = self.q_norm(q)  # per-head RMSNorm over D
                 k = self.k_norm(k)
+            if self.v_norm is not None:
+                v = self.v_norm(v)
             return q.reshape(t, num_heads * head_dim), k.reshape(t, num_kv_heads * head_dim), v.reshape(t, num_kv_heads * head_dim)
 
     class Post(nn.Module):
@@ -307,8 +316,19 @@ def build_attention_split_wrapper(block):
             self.o_proj = attn.o_proj
             self.post_attention_layernorm = block.post_attention_layernorm
             self.mlp = block.mlp
+            self.pre_feedforward_layernorm = pre_ff_norm
+            self.post_feedforward_layernorm = getattr(block, "post_feedforward_layernorm", None)
+            scalar = getattr(block, "layer_scalar", None)
+            if scalar is not None:  # register as a buffer so the trace binds it as a constant, not a free input
+                self.register_buffer("layer_scalar", scalar)
+            else:
+                self.layer_scalar = None
 
         def forward(self, attn_out, residual):
+            if self.pre_feedforward_layernorm is not None:  # gemma sandwich norms
+                h = residual + self.post_attention_layernorm(self.o_proj(attn_out))
+                out = h + self.post_feedforward_layernorm(self.mlp(self.pre_feedforward_layernorm(h)))
+                return out * self.layer_scalar if self.layer_scalar is not None else out
             h = residual + self.o_proj(attn_out)  # residual1 + o_proj(SDPA)
             return h + self.mlp(self.post_attention_layernorm(h))  # residual2 + MLP
 

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -75,18 +75,29 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   also compiles a **static M=`decode_bucket` (default 16)** `pre`/`post` twin per layer and uses it when
   `num_tokens ≤ bucket` (pad → run → slice the real rows) — the symbolic hint-512 M-tile is ~66× too slow at decode
   M=1; falls back to symbolic above the bucket or if a static compile fails. So
-  up to 4 capacity programs/layer — a real memory-budget risk.
+  up to 4 capacity programs/layer — a real memory-budget risk. Architecture handling: the trunk is unwrapped through a
+  multimodal wrapper's `language_model` (gemma-4 unified) and config fields read via `text_config`; attention geometry
+  is **per layer** (`attn_metas` — gemma-4 global layers have a wider `global_head_dim` + fewer KV heads); a gemma
+  scaled embedding (×√H) is baked into the embed table; pre outputs are **cast to the runner dtype at the seam** (a
+  norm-ended pre graph — gemma's fp32-internal RMSNorm — can widen the compiled outputs to fp32; the cast is the eager
+  module's trailing `type_as`). When `rope_parameters` is keyed by layer type, the trunk's own rotary module rides the
+  runner (`rotary_emb`) for the vLLM side to apply.
 - `vllm_model_gen.py` — `EmmyGenModel` (Phase 3; the generative vLLM model class). **NOT** `IsAttentionFree`: it
   builds real vLLM `Attention` layers (one per decoder layer, unique `prefix` → vLLM allocates a KV-cache spec and runs
-  paged attention) + a shared `get_rope` module (a bare `Attention` does no RoPE) + `ParallelLMHead` + `LogitsProcessor`.
+  paged attention; per-layer geometry from `runner.attn_metas`, sliding layers pass `per_layer_sliding_window`) + RoPE
+  (a shared `get_rope` module, or the runner's HF rotary applied per layer_type) + `ParallelLMHead` + `LogitsProcessor`
+  (with `soft_cap` when the config carries `final_logit_softcapping`).
   The trunk compute (embed + per-layer pre/post + final norm) is the `EmmyGenRunner`; vLLM owns only `lm_head`
-  (`load_weights` claims `lm_head.weight`, or the tied embed alias). `forward` brackets each `self.attn[L](q,k,v)` with
+  (`load_weights` claims `lm_head.weight`, or the tied embed alias — including the nested `language_model.embed_tokens`
+  names). `forward` brackets each `self.attn[L](q,k,v)` with
   two emmy replays (pre/post), applying RoPE in between (A2). `forward` branches on `num_tokens`: the decode hot
   path (`≤ bucket`) runs `_forward_device` (q/k/v + attn_out stay CUDA tensors through RoPE + attention, no host
   hop); prefill keeps the numpy path. Select via `--runner generate` +
   `--hf-overrides '{"architectures":["EmmyGenModel"]}'` + `--dtype float16` (the `serve --generate` branch forces
-  this for seam coherence). Registered in `__init__.py`. Whole-step CUDA-graph capture (drop `--enforce-eager`) is
-  future work.
+  this for seam coherence). Registered in `__init__.py`. Supported: Qwen3 / Llama / gemma-4 text (sandwich norms,
+  k_eq_v, per-type rope — validated token-exact vs HF eager on a tiny random gemma-4). Rejected: legacy
+  `use_sliding_window` without `layer_types`, dual-chunk attention, cross-layer KV sharing
+  (`num_kv_shared_layers > 0`). Whole-step CUDA-graph capture (drop `--enforce-eager`) is future work.
 
 ## Static mode (`EMMY_SERVING_STATIC=1`) — static extents for both batch and seq
 

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -118,8 +118,28 @@ def _compile_split(wrapper, example_args, argnames, np_dtype):
     return _Program(program, list(compiled.inputs), list(compiled.outputs))
 
 
+def _per_type_rope(cfg) -> bool:
+    """True when ``rope_parameters`` is keyed by layer type (gemma-4) rather than a flat single-rope dict."""
+    rp = getattr(cfg, "rope_parameters", None)
+    return isinstance(rp, dict) and any(k in rp for k in ("full_attention", "sliding_attention"))
+
+
 class EmmyGenRunner:
-    def __init__(self, *, embed_weight, norm, pre, post, attn_meta, np_dtype, pre_decode=None, post_decode=None, decode_bucket=16):
+    def __init__(
+        self,
+        *,
+        embed_weight,
+        norm,
+        pre,
+        post,
+        attn_meta,
+        np_dtype,
+        pre_decode=None,
+        post_decode=None,
+        decode_bucket=16,
+        attn_metas=None,
+        rotary_emb=None,
+    ):
         self._embed_weight = embed_weight  # numpy [vocab, H]
         self._norm = norm  # torch module
         self._pre = pre  # list[_Program] — symbolic (prefill / any width)
@@ -128,6 +148,8 @@ class EmmyGenRunner:
         self._post_decode = post_decode
         self._decode_bucket = decode_bucket
         self.head_dim, self.num_heads, self.num_kv_heads, self.scaling = attn_meta
+        self.attn_metas = attn_metas or [attn_meta] * len(pre)  # per-layer (head_dim, nh, nkv, scaling) — heterogeneous (gemma-4)
+        self.rotary_emb = rotary_emb  # the trunk's own rotary module when per-layer-type (gemma-4); None → caller builds vLLM get_rope
         self._np_dtype = np_dtype
 
     @property
@@ -166,20 +188,23 @@ class EmmyGenRunner:
         dtype = getattr(torch, dtype_str)
         np_dtype = np.dtype(dtype_str)
         trunk = getattr(model, "model", model)
+        if not hasattr(trunk, "layers"):  # multimodal wrapper (gemma-4 unified) — the text decoder is a submodule
+            trunk = trunk.language_model
         layers = trunk.layers
-        attn0 = layers[0].self_attn
-        head_dim = attn0.head_dim
-        num_heads = attn0.q_proj.out_features // head_dim
-        num_kv = attn0.k_proj.out_features // head_dim
-        scaling = attn0.scaling
-        hidden = model.config.hidden_size
-        attn_width = num_heads * head_dim
+        cfg = getattr(model.config, "text_config", None) or model.config
+        attn_metas = []  # per-layer (head_dim, num_heads, num_kv, scaling) — heterogeneous on gemma-4
+        for block in layers:
+            attn = block.self_attn
+            d = attn.head_dim
+            attn_metas.append((d, attn.q_proj.out_features // d, attn.k_proj.out_features // d, attn.scaling))
+        hidden = cfg.hidden_size
 
         pre_programs, post_programs = [], []
         pre_decode, post_decode = [], []
         decode_ok = decode_bucket and decode_bucket > 0
         for i, block in enumerate(layers):
             logger.info("[gen_runner] compiling layer %d/%d (pre + post%s)...", i + 1, len(layers), " + decode" if decode_ok else "")
+            attn_width = attn_metas[i][1] * attn_metas[i][0]  # nh · head_dim for THIS layer
             pre_w, post_w = build_attention_split_wrapper(block)
             with torch.device("cpu"):
                 pre_programs.append(_compile_split(pre_w, [torch.zeros(8, hidden, dtype=dtype)], ["hidden"], np_dtype))
@@ -209,18 +234,27 @@ class EmmyGenRunner:
                         logger.warning("[gen_runner] decode-bucket compile failed at layer %d (%s); decode falls back to symbolic", i, ex)
                         decode_ok = False
 
-        embed_weight = trunk.embed_tokens.weight.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
+        embed_weight = trunk.embed_tokens.weight.detach().cpu().to(torch.float32).numpy()
+        embed_scale = getattr(trunk.embed_tokens, "embed_scale", None)  # gemma scaled embedding (×√H) — baked into the table
+        if embed_scale is not None:
+            embed_weight = embed_weight * float(embed_scale)
+        embed_weight = embed_weight.astype(np_dtype, copy=False)
         use_decode = decode_ok and len(pre_decode) == len(layers)
         return cls(
             embed_weight=embed_weight,
             norm=trunk.norm,
             pre=pre_programs,
             post=post_programs,
-            attn_meta=(head_dim, num_heads, num_kv, scaling),
+            attn_meta=attn_metas[0],
             np_dtype=np_dtype,
             pre_decode=pre_decode if use_decode else None,
             post_decode=post_decode if use_decode else None,
             decode_bucket=decode_bucket,
+            attn_metas=attn_metas,
+            # Per-layer-type rope (gemma-4): hand the trunk's own rotary module through, the vLLM
+            # side applies it per layer_type instead of a single get_rope. Keyed on rope_parameters
+            # being a PER-TYPE dict ({'full_attention': {...}, ...}), not the flat single-rope dict.
+            rotary_emb=trunk.rotary_emb if _per_type_rope(cfg) else None,
         )
 
     def embed(self, input_ids):
@@ -238,8 +272,13 @@ class EmmyGenRunner:
         t = h.shape[0]
         if self._pre_decode is not None and t <= self._decode_bucket:
             q, k, v = self._pre_decode[layer].run([_pad_rows(h, self._decode_bucket)])
-            return q[:t], k[:t], v[:t]
-        return tuple(self._pre[layer].run([h]))
+            q, k, v = q[:t], k[:t], v[:t]
+        else:
+            q, k, v = self._pre[layer].run([h])
+        # Cast to the runner dtype at the seam: a per-head norm ending the pre graph (gemma's
+        # fp32-internal RMSNorm) can widen the program outputs to fp32; the eager module's
+        # trailing ``type_as`` does exactly this cast.
+        return q.astype(self._np_dtype, copy=False), k.astype(self._np_dtype, copy=False), v.astype(self._np_dtype, copy=False)
 
     def forward_layer_post(self, layer, attn_out, residual):
         """``(attn_out[T,Hq·D], residual[T,H])`` numpy → ``layer_out[T, H]`` numpy. Decode-bucketed
@@ -286,8 +325,13 @@ class EmmyGenRunner:
 
     def forward_layer_pre_device(self, layer, hidden):
         """Device twin of :meth:`forward_layer_pre` (decode path, ``T <= decode_bucket``):
-        ``hidden[T,H]`` CUDA → un-rotated ``(q, k, v)`` CUDA tensors."""
-        return tuple(self._pre_decode[layer].run_device([hidden]))
+        ``hidden[T,H]`` CUDA → un-rotated ``(q, k, v)`` CUDA tensors. Cast to the runner dtype
+        at the seam (same reason as the host path — a norm-ended pre graph widens to fp32)."""
+        import torch
+
+        dt = getattr(torch, str(self._np_dtype))
+        q, k, v = self._pre_decode[layer].run_device([hidden])
+        return q.to(dt), k.to(dt), v.to(dt)
 
     def forward_layer_post_device(self, layer, attn_out, residual):
         """Device twin of :meth:`forward_layer_post`: ``(attn_out, residual)`` CUDA → ``[T,H]`` CUDA."""

--- a/emmy/serving/vllm_model_gen.py
+++ b/emmy/serving/vllm_model_gen.py
@@ -1,6 +1,6 @@
 """``EmmyGenModel`` — the vLLM out-of-tree **generative** model class (Phase 3).
 
-Serve a decoder-only chat model (Qwen3 / Llama) through emmy-compiled per-layer
+Serve a decoder-only chat model (Qwen3 / Llama / gemma-4 text) through emmy-compiled per-layer
 kernels with vLLM owning the API / sampler / scheduler / paged KV-cache:
 
     vllm serve TinyLlama/TinyLlama-1.1B-Chat-v1.0 --runner generate --enforce-eager \\
@@ -37,6 +37,12 @@ from emmy.serving.vllm_model import _trunk_dtype_str
 logger = logging.getLogger(__name__)
 
 
+def _rotate_half(x):
+    """HF neox-style rotate-half (transformers' ``rotate_half``) on ``[..., D]``."""
+    half = x.shape[-1] // 2
+    return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+
 def _build_rotary(config, head_dim, max_position):
     """Construct the model's RoPE the way stock vLLM does — applying each architecture's
     default-theta mutation first (Qwen3 → 1e6, else a missing rope_theta silently falls
@@ -63,17 +69,21 @@ class EmmyGenModel(nn.Module):
         config = mc.hf_config
         self.config = config
         self.dtype = mc.dtype
+        # Multimodal wrappers (gemma-4 unified) nest the decoder config; all attention/geometry
+        # fields read from the text config. Text-only models: text_cfg IS config.
+        text_cfg = getattr(config, "text_config", None) or config
+        self.text_config = text_cfg
 
-        # The carve (pre/post + a plain causal vLLM Attention) assumes FULL causal attention.
-        # Sliding-window / per-layer-sliding / dual-chunk variants would silently miscompute
-        # (neither side here is window/chunk aware) — reject rather than mislead.
-        if getattr(config, "use_sliding_window", False) and getattr(config, "sliding_window", None):
-            raise NotImplementedError("EmmyGenModel: sliding-window attention is not supported")
-        layer_types = getattr(config, "layer_types", None)
-        if layer_types and any(lt == "sliding_attention" for lt in layer_types):
-            raise NotImplementedError("EmmyGenModel: per-layer sliding attention is not supported")
-        if getattr(config, "dual_chunk_attention_config", None):
+        # Per-layer sliding attention is supported via vLLM's ``per_layer_sliding_window``
+        # (keyed off ``layer_types``). The legacy flag without layer_types, dual-chunk, and
+        # cross-layer KV sharing are not — reject rather than silently miscompute.
+        layer_types = getattr(text_cfg, "layer_types", None)
+        if getattr(text_cfg, "use_sliding_window", False) and getattr(text_cfg, "sliding_window", None) and not layer_types:
+            raise NotImplementedError("EmmyGenModel: legacy use_sliding_window without layer_types is not supported")
+        if getattr(text_cfg, "dual_chunk_attention_config", None):
             raise NotImplementedError("EmmyGenModel: dual-chunk attention is not supported")
+        if getattr(text_cfg, "num_kv_shared_layers", 0):
+            raise NotImplementedError("EmmyGenModel: cross-layer KV sharing (num_kv_shared_layers > 0) is not supported")
 
         # The flattened width T = num_tokens is the SUM of newly-scheduled tokens across all
         # requests per step (continuous batching), bounded by max_num_batched_tokens — NOT
@@ -90,36 +100,72 @@ class EmmyGenModel(nn.Module):
         self.runner = EmmyGenRunner.create(model_id=mc.model, dtype_str=_trunk_dtype_str(mc.dtype))
         n_layers = self.runner.num_layers
         head_dim = self.runner.head_dim
+        self.layer_types = list(layer_types) if layer_types else ["full_attention"] * n_layers
+        sliding_window = getattr(text_cfg, "sliding_window", None)
 
         # One real vLLM Attention per layer — unique prefix (vLLM keys static_forward_context
-        # / cache-spec discovery by it and rejects duplicates). No weights.
+        # / cache-spec discovery by it and rejects duplicates). No weights. Geometry is
+        # PER LAYER (gemma-4 global layers: wider head_dim, fewer KV heads), and sliding
+        # layers carry their window so vLLM's paged attention masks them.
         self.attn = nn.ModuleList(
             [
                 Attention(
-                    self.runner.num_heads,
-                    head_dim,
-                    self.runner.scaling,
-                    num_kv_heads=self.runner.num_kv_heads,
+                    nh,
+                    d,
+                    scaling,
+                    num_kv_heads=nkv,
+                    per_layer_sliding_window=(sliding_window if self.layer_types[i] == "sliding_attention" else None),
                     cache_config=vllm_config.cache_config,
                     quant_config=vllm_config.quant_config,
                     prefix=f"{prefix}.layers.{i}.self_attn.attn",
                 )
-                for i in range(n_layers)
+                for i, (d, nh, nkv, scaling) in enumerate(self.runner.attn_metas)
             ]
         )
-        # RoPE is NOT in Attention — one shared module (position-only, layer-independent).
-        self.rotary_emb = _build_rotary(config, head_dim, getattr(config, "max_position_embeddings", 8192))
+        # RoPE is NOT in Attention. Uniform models: one shared vLLM get_rope. Per-layer-type
+        # rope (gemma-4): the trunk's OWN HF rotary module (handed through the runner) applied
+        # per layer_type in forward — faithful to partial/proportional rope by construction.
+        if self.runner.rotary_emb is not None:
+            import copy
+
+            self.hf_rotary = copy.deepcopy(self.runner.rotary_emb).float()
+            self.rotary_emb = None
+        else:
+            self.hf_rotary = None
+            self.rotary_emb = _build_rotary(config, head_dim, getattr(text_cfg, "max_position_embeddings", 8192))
 
         # vLLM owns ONLY lm_head; the runner owns embed + the trunk.
         self.lm_head = ParallelLMHead(
-            config.vocab_size, config.hidden_size, quant_config=vllm_config.quant_config, prefix=f"{prefix}.lm_head"
+            text_cfg.vocab_size, text_cfg.hidden_size, quant_config=vllm_config.quant_config, prefix=f"{prefix}.lm_head"
         )
-        self.logits_processor = LogitsProcessor(config.vocab_size, scale=getattr(config, "logit_scale", 1.0))
+        self.logits_processor = LogitsProcessor(
+            text_cfg.vocab_size,
+            scale=getattr(text_cfg, "logit_scale", 1.0),
+            soft_cap=getattr(text_cfg, "final_logit_softcapping", None),
+        )
+
+    def _apply_rope(self, layer, positions, q, k):
+        """Rotate flat ``q[T, nh·D]`` / ``k[T, nkv·D]`` for ``layer``. Uniform models ride the
+        shared vLLM ``get_rope``; per-layer-type models (gemma-4) apply the trunk's own HF
+        rotary per layer_type (HF semantics: cos/sin computed fp32, cast to q dtype, full-width
+        multiply with rotate-half)."""
+        if self.hf_rotary is None:
+            return self.rotary_emb(positions, q, k)
+        d, nh, nkv, _ = self.runner.attn_metas[layer]
+        t = q.shape[0]
+        cos, sin = self.hf_rotary(q, positions.view(1, -1), self.layer_types[layer])  # [1, T, D] in q dtype
+        cos = cos.squeeze(0).unsqueeze(1)  # [T, 1, D] — broadcast over heads
+        sin = sin.squeeze(0).unsqueeze(1)
+        q3 = q.view(t, nh, d)
+        k3 = k.view(t, nkv, d)
+        q3 = q3 * cos + _rotate_half(q3) * sin
+        k3 = k3 * cos + _rotate_half(k3) * sin
+        return q3.view(t, nh * d), k3.view(t, nkv * d)
 
     def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None, **kwargs):
         device = positions.device
         # clamp guards vLLM's _dummy_run garbage-id profiling batches (out-of-vocab → IndexError).
-        ids = input_ids.clamp(0, self.config.vocab_size - 1)
+        ids = input_ids.clamp(0, self.text_config.vocab_size - 1)
         t = int(ids.shape[0])
         # Decode hot path (T <= bucket): device-resident, no host numpy round-trip (Phase A).
         # Prefill / larger T keeps the host path.
@@ -133,7 +179,7 @@ class EmmyGenModel(nn.Module):
             q = torch.from_numpy(np.ascontiguousarray(q_np)).to(device)
             k = torch.from_numpy(np.ascontiguousarray(k_np)).to(device)
             v = torch.from_numpy(np.ascontiguousarray(v_np)).to(device)
-            q, k = self.rotary_emb(positions, q, k)  # A2: vLLM applies RoPE
+            q, k = self._apply_rope(layer, positions, q, k)  # A2: RoPE applied at the seam
             attn_out = self.attn[layer](q, k, v)  # vLLM paged attention (pulls attn_metadata from forward context)
             hidden_np = self.runner.forward_layer_post(layer, attn_out.detach().cpu().numpy(), residual_np)
         hidden_np = self.runner.final_norm(hidden_np)
@@ -146,7 +192,7 @@ class EmmyGenModel(nn.Module):
         for layer in range(self.runner.num_layers):
             residual = hidden
             q, k, v = self.runner.forward_layer_pre_device(layer, hidden)
-            q, k = self.rotary_emb(positions, q, k)  # A2: vLLM applies RoPE
+            q, k = self._apply_rope(layer, positions, q, k)  # A2: RoPE applied at the seam
             attn_out = self.attn[layer](q, k, v)  # vLLM paged attention
             hidden = self.runner.forward_layer_post_device(layer, attn_out, residual)
         return self.runner.final_norm_device(hidden)
@@ -156,7 +202,7 @@ class EmmyGenModel(nn.Module):
 
     def embed_input_ids(self, input_ids):
         # vLLM embedding hook → the runner owns embedding; on-device gather (no host hop).
-        return self.runner.embed_device(input_ids.clamp(0, self.config.vocab_size - 1))
+        return self.runner.embed_device(input_ids.clamp(0, self.text_config.vocab_size - 1))
 
     def load_weights(self, weights):
         """vLLM owns ONLY ``lm_head`` (the runner already loaded embed + trunk). Load
@@ -164,13 +210,20 @@ class EmmyGenModel(nn.Module):
         may carry only ``embed_tokens.weight``, so accept that alias for the head."""
         param = self.lm_head.weight
         loader = getattr(param, "weight_loader", default_weight_loader)
-        tied = getattr(self.config, "tie_word_embeddings", False)
+        tied = getattr(self.config, "tie_word_embeddings", False) or getattr(self.text_config, "tie_word_embeddings", False)
+        embed_aliases = (
+            "model.embed_tokens.weight",
+            "embed_tokens.weight",
+            # multimodal wrappers (gemma-4 unified) nest the text embedding
+            "model.language_model.embed_tokens.weight",
+            "language_model.embed_tokens.weight",
+        )
         loaded: set[str] = set()
         for name, w in weights:
             if name == "lm_head.weight":
                 loader(param, w)
                 loaded.add("lm_head.weight")
-            elif tied and name in ("model.embed_tokens.weight", "embed_tokens.weight") and "lm_head.weight" not in loaded:
+            elif tied and name in embed_aliases and "lm_head.weight" not in loaded:
                 loader(param, w)
                 loaded.add("lm_head.weight")
         return loaded

--- a/tests/serving/test_attention_split.py
+++ b/tests/serving/test_attention_split.py
@@ -98,6 +98,60 @@ def test_split_matches_eager_block(arch):
     torch.testing.assert_close(out, eager.squeeze(0), rtol=1e-4, atol=1e-4)
 
 
+@pytest.mark.parametrize("layer_idx", [0, 1], ids=["sliding", "global_k_eq_v"])
+def test_split_matches_eager_block_gemma4(layer_idx):
+    """Gemma-4 carve equivalence: sandwich norms + layer_scalar (both layers), and on the
+    global layer the k_eq_v missing ``v_proj`` (V = raw k_proj output), ``v_norm``, the wider
+    ``global_head_dim``, and single KV head. RoPE differs per layer type (partial/proportional
+    on global), reconstructed via the trunk's own rotary module."""
+    torch = pytest.importorskip("torch")
+    transformers = pytest.importorskip("transformers")
+
+    from emmy.compiler.trace.huggingface import build_attention_split_wrapper, build_causal_mask
+
+    config = transformers.Gemma4UnifiedTextConfig(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_global_key_value_heads=1,
+        head_dim=16,
+        global_head_dim=32,
+        attention_k_eq_v=True,
+        layer_types=["sliding_attention", "full_attention"],
+        sliding_window=8,
+        max_position_embeddings=64,
+        num_kv_shared_layers=0,
+    )
+    from transformers.models.gemma4_unified.modeling_gemma4_unified import apply_rotary_pos_emb
+
+    torch.manual_seed(0)
+    model = transformers.Gemma4UnifiedForCausalLM(config).eval()
+    trunk = model.model
+    block = trunk.layers[layer_idx]
+    attn = block.self_attn
+    layer_type = config.layer_types[layer_idx]
+
+    t = 6  # within the sliding window — one causal mask serves both layer types
+    hidden3d = torch.randn(1, t, config.hidden_size)
+    position_ids = torch.arange(t).unsqueeze(0)
+    cos, sin = trunk.rotary_emb(hidden3d, position_ids, layer_type)  # [1, T, D_rot]
+    mask = build_causal_mask(t, torch.float32)
+
+    with torch.no_grad():
+        eager = block(hidden3d, shared_kv_states={}, position_embeddings=(cos, sin), attention_mask=mask)
+        eager = eager[0] if isinstance(eager, tuple) else eager
+
+        pre, post = build_attention_split_wrapper(block)
+        rotary = lambda q, k, c, s: (apply_rotary_pos_emb(q, c, s), apply_rotary_pos_emb(k, c, s))  # noqa: E731
+        out = _split_path_output(pre, post, attn, hidden3d.squeeze(0), cos, sin, mask, rotary)
+
+    assert tuple(out.shape) == (t, config.hidden_size)
+    torch.testing.assert_close(out, eager.squeeze(0), rtol=1e-4, atol=1e-4)
+
+
 def test_pre_emits_2d_seam_shapes():
     """The pre wrapper's seam ABI: q[T, Hq*D], k/v[T, Hkv*D] (2-D, no transpose)."""
     torch = pytest.importorskip("torch")


### PR DESCRIPTION
The attention-split carve handles gemma blocks: missing v_proj (attention_k_eq_v — V is the raw k_proj output taken before k_norm), the unscaled v_norm, sandwich norms (post-attn norm on the attention output, pre/post-feedforward norms around the MLP), and the layer_scalar buffer (registered as a buffer so the trace binds it as a constant). The gen runner unwraps the text decoder from a multimodal wrapper (language_model), reads text_config, extracts per-layer attention geometry (attn_metas — global layers have wider global_head_dim + fewer KV heads), bakes the gemma scaled embedding (×√H) into the embed table, casts pre outputs to the runner dtype at the seam (a norm-ended pre graph widens the compiled outputs to fp32), and hands the trunk's own rotary module through when rope_parameters is keyed by layer type. EmmyGenModel builds per-layer vLLM Attention (sliding layers pass per_layer_sliding_window), applies the HF rotary per layer_type, adds soft_cap logits, and accepts the nested tied-embed weight names.

Validated on a tiny random gemma-4 (mixed sliding/global layers, k_eq_v): served greedy output is deterministic and token-exact vs HF eager. Qwen3/Llama carve tests unregressed; remote GPU serving suite green.