### PR TITLE
Post-rebase analytic refit + second fast-math golden sweep (RTX 5090)

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -17,7 +17,7 @@ configs:
     N: 512
     K: 512
     dtype: 'fp16'
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g2k', STAGE: 'd3/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f4x1/k4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g2k', STAGE: 'd3/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f4x1/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 4.2
     cublas_us: 6.14
   - kernel: matmul
@@ -26,7 +26,7 @@ configs:
     N: 1024
     K: 1024
     dtype: 'fp16'
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f1x4/k8', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f1x4/k8', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 15.59
     cublas_us: 14.51
   - kernel: matmul
@@ -35,7 +35,7 @@ configs:
     N: 2048
     K: 2048
     dtype: 'fp16'
-    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x2/k4', STAGE: 'd2/tma/ring'}
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x2/k4', STAGE: 'd2/tma/ring', WSPEC: ''}
     emmy_us: 88.5
     cublas_us: 98.36
   - kernel: matmul
@@ -44,8 +44,21 @@ configs:
     N: 4096
     K: 4096
     dtype: 'fp16'
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 640.83
+    cublas_us: 640.93
+  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): the deep-bk region the 07-09 cold
+  # sweep missed — 491.9 us vs the standard golden's live 678 (0.73x) and 0.77x vs cuBLAS HGEMM
+  # (~279 TFLOP/s; the f32-accumulate hardware ceiling is ~210). 2026-07-10 fm2 sweep, 3x
+  # reproduced. Kept beside the standard entry — gate-off compiles can't reach it.
+  - kernel: matmul
+    name: matmul.square.4096
+    M: 4096
+    N: 4096
+    K: 4096
+    dtype: 'fp16'
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd1/tma', TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k4', VECTORIZE_LOADS: true, WSPEC: ''}
+    emmy_us: 491.9
     cublas_us: 640.93
   - kernel: matmul
     name: matmul.square.512.dynM
@@ -54,7 +67,7 @@ configs:
     K: 512
     dtype: 'fp16'
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g2k', STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x2/k4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g2k', STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x2/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 6.14
     cublas_us: 6.14
   # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): 3.6 µs vs the standard golden's live
@@ -66,7 +79,7 @@ configs:
     K: 512
     dtype: 'fp16'
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f2x2/k8', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f2x2/k8', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 3.6
     cublas_us: 6.14
   - kernel: matmul
@@ -75,7 +88,7 @@ configs:
     N: 12288
     K: 4096
     dtype: 'fp16'
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 258.47
     cublas_us: 250.54
   # Fast-math sibling (f16-accumulate atom, FAST_MATH lane — torch-default fp16 numerics): kept
@@ -87,7 +100,7 @@ configs:
     N: 12288
     K: 4096
     dtype: 'fp16'
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd1/tma', TILE: 'a:mma_m16n8k16_f16_f16/w2x4/f2x4/k8', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd1/tma', TILE: 'a:mma_m16n8k16_f16_f16/w2x4/f2x4/k8', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 238.5
     cublas_us: 250.54
   - kernel: matmul
@@ -96,7 +109,7 @@ configs:
     N: 4096
     K: 4096
     dtype: 'fp16'
-    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: 'g4k', STAGE: 'd2/tma/ring'}
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: 'g4k', STAGE: 'd2/tma/ring', WSPEC: ''}
     emmy_us: 90.1
     cublas_us: 95.22
   - kernel: matmul
@@ -108,7 +121,7 @@ configs:
     # 2026-07-09 sweep: replaced w2x2/f4x4/k4 d1/tma (recorded 605.5) — that pin benches ~638 even at
     # its own recording commit (8ab967cf, bisect-verified; cuBLAS steady), so the old 605.5 was a
     # recording-fidelity miss, not codegen drift. This config runs 608-612 live (6x reproduced).
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f4x4/k2', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd4/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f4x4/k2', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 610.6
     cublas_us: 557.94
   - kernel: matmul
@@ -117,7 +130,7 @@ configs:
     N: 4096
     K: 14336
     dtype: 'fp16'
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g8k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f2x2/k4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g8k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f2x2/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 303.0
     cublas_us: 296.95
   - kernel: matmul
@@ -127,7 +140,7 @@ configs:
     K: 4096
     dtype: 'fp16'
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x4/k2', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x4/k2', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 250.8
     cublas_us: 249.82
   - kernel: matmul
@@ -137,8 +150,10 @@ configs:
     K: 4096
     dtype: 'fp16'
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g2k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f2x2/k4', VECTORIZE_LOADS: true}
-    emmy_us: 97.7
+    # 2026-07-10 fm2 sweep: replaced w2x4/f2x2/k4 g2k d2/tma/ring (97.7; live 95.2) with the
+    # greedy pick, 0.96x reproduced in both lanes (91.4/91.5/91.8).
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g4k', STAGE: 'd1/tma', TILE: 'a:mma_m16n8k16_f16_f32/w1x4/f4x2/k4', VECTORIZE_LOADS: true, WSPEC: ''}
+    emmy_us: 91.4
     cublas_us: 95.08
   - kernel: matmul
     name: matmul.mlp_gate_up.h4096.dynM
@@ -150,7 +165,7 @@ configs:
     # 2026-07-09 sweep: replaced w8x2/f2x8/k4 d2/tma/ring (recorded 596.3) — that entry's knob set
     # left REDUCE unpinned and today's greedy fill adds g2k, re-benching at 641.0 live (613.6 + 27.4
     # finalize), while this config runs 608-611 live. See the sweep findings.
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 610.6
     cublas_us: 553.70
   - kernel: matmul
@@ -160,7 +175,7 @@ configs:
     K: 14336
     dtype: 'fp16'
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g8k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f2x2/k4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, REDUCE: 'g8k', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x4/f2x2/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 304.0
     cublas_us: 295.03
   - kernel: softmax
@@ -305,7 +320,7 @@ configs:
     head_dim: 64
     dtype: 'fp16'
     causal: false
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x16/k4', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k8', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x16/k4', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k8', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 8.6
     cublas_us: 10.24
   - kernel: attention
@@ -315,7 +330,7 @@ configs:
     head_dim: 128
     dtype: 'fp16'
     causal: false
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w2x1/f1x16/k4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w2x1/f1x16/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 16.5
     cublas_us: 18.42
   - kernel: attention
@@ -326,7 +341,7 @@ configs:
     dtype: 'fp16'
     causal: false
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f1x16/k4', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f1x16/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 8.6
     cublas_us: 10.23
   - kernel: attention
@@ -337,6 +352,6 @@ configs:
     dtype: 'fp16'
     causal: false
     dynamic: true
-    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', VECTORIZE_LOADS: true}
+    knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 16.4
     cublas_us: 18.4

--- a/plans/golden-sweep-rtx5090-fm2-findings.md
+++ b/plans/golden-sweep-rtx5090-fm2-findings.md
@@ -1,0 +1,69 @@
+# Golden sweep findings — RTX 5090, fast-math lane, second run (2026-07-10)
+
+- **GPU**: NVIDIA GeForce RTX 5090 (sm_120), branch `feature/refit-analytic-fm-golden-retune`
+- **Sweep**: `EMMY_FAST_MATH=1 EMMY_O3_TOL=0.10 emmy tune --dataset golden --clean` — 36 shapes, ≈2.6 h (vs 3.6 h
+  on 07-09; the refit ranking converges faster). First sweep with all three 07-09/#343 improvements active: the
+  post-rebase analytic refit (this branch — 15/16 golden matmuls rank #1 cold), #339's per-regime -O3 band, and
+  #343's node plausibility gate. Delta-report against `golden-sweep-rtx5090-fm-findings.md` (the 07-09 sweep).
+- **Tally (36 shapes)**: 1 fast-math `[fm]` entry added (square.4096 — the big one) / 1 standard replace
+  (o_proj.h4096.dynM) / 13 WSPEC-underspecification stamps / 22 same / ~11 worse / **0 bench failures** (07-09: 1
+  pathological gate-off deploy — the per-regime band fix held in the wild).
+- Logs: `_tune/golden-sweep-rtx5090-fm2/` (tune.log, `ab/*.log`, ab_table.txt).
+
+## Headline — square.4096 reaches the deep-bk f16-accumulate region: 0.77× vs cuBLAS
+
+The 07-09 sweep's cold ranking never reached the `k4+` deep-bk f16acc rows on the big square (the PR #339 hand A/B
+had found them at 1.35×). The refit weights reached them cold: the fm-lane greedy picked
+`a:mma_m16n8k16_f16_f16/w2x2/f4x8/k4 d1/tma` at **491.9 µs** — 0.73× vs the standard golden's live 678, **0.77× vs
+cuBLAS HGEMM** (≈279 TFLOP/s; the f32-accumulate hardware ceiling is ≈210). Reproduced 3× at <0.5% spread; recorded
+as the shape's `[fm]` entry beside the standard one. This is now the fastest kernel emmy has ever produced on this
+card for any golden shape relative to cuBLAS.
+
+Also recorded: **o_proj.h4096.dynM** replaced (`w1x4/f4x2/k4 g4k d1/tma`, 91.4 µs, 0.96× vs the old golden's live
+95.2 — reproduced in both lanes). The qkv/square.512.dynM `[fm]` entries from 07-09 re-verified (see Finding 2).
+
+## Finding 1 — the per-regime -O3 band fix held; one NEW gate-off deploy miss (square.4096 std → scalar)
+
+The 07-09 sweep's pathological gate-off deploy (qkv → per-cell scalar, bench_fail) did **not** recur — qkv's
+gate-off greedy deploys a warp row at 278.7 µs (1.03× vs its golden; every lane benched clean). But the standard
+lane's greedy for **square.4096** deploys a SCALAR register tile (`n32x8/f4x10 d1/tma`, 2919 µs, 4.3×) while the
+fm lane's greedy on the same shape picks the f16acc row at 491.9. Same mechanism family as 07-09's qkv miss —
+the gate-off enumeration lacks the fm winner and the deploy falls to model/evidence over the remainder — but this
+time the standard best DID get its -O3 rebench (the band fix); the miss is in the deploy-side pick, not evidence
+starvation. `matmul.square.512.dynM`'s gate-off greedy similarly regressed to a stage-less warp row (17.8 µs vs
+the 4.2 golden; it picked `w1x4/f2x2/k4` with no STAGE). Both are `eval variants` / deploy-hierarchy follow-ups
+on main, not this branch: the recorded goldens are unaffected (they replay by pin), and both shapes' goldens
+re-bench true.
+
+## Finding 2 — WSPEC is the third unpinned-family drift; every warp+TMA golden now stamps it
+
+The recorded qkv `[fm]` entry re-benched at 309 µs (was 238) in the A/B. Root cause: the recorded knob set never
+pinned `WSPEC`, and the refit weights flipped the greedy fill for the unpinned family from uniform to `p1` (a
+producer-warp split) — worth −30% on this kernel. Pin-replay with `WSPEC=` (uniform) restored 235.9 µs exactly.
+This is the same under-specification class as Finding 4's dynM `REDUCE` (07-09) — the third occurrence
+(`REDUCE`, then the fill-order drift on gate_up, now `WSPEC`) — so the fix went wide: **every warp-TILE + TMA-stage
+golden in the 5090 file now records `WSPEC: ''` explicitly** (13 entries stamped; WSPEC is only offered on that
+combination, so the stamp set is exactly the eligible set). Post-stamp, both qkv entries replay at their recorded
+speeds (258.6 std / 240.0 fm) gate-off. The durable recommendation stands and is now urgent for the other card
+files: the recorder should stamp every resolved schedule family, and a post-record `--golden` re-bench should
+gate the YAML edit (the 07-09 workflow-notes item).
+
+## Deltas vs the 07-09 sweep (standard lane, live A/B)
+
+Unchanged-within-noise: attention.hd128/hd128.dynM/hd64.dynM (0.98–1.02), all pointwise/rms_norm/softmax/reduce
+kinds (1.00–1.05, the k2048 reduce pair still shows the flagged impossible golden row → `(*)` unreliable), the
+mlp family (1.03–1.16 worse — the greedy still trails its goldens there), square.512 fp32 (1.06) and
+square.512.fp16 (2.6× — unchanged; its `g2k` split golden stays unreachable cold, same as 07-09 Finding 3).
+attention.hd64 static improved 1.29 → 1.13–1.15 (the refit helped, still a miss). The fm lane picked f32-acc
+everywhere except square.4096 — including attention (PV stays f32-acc, latency-bound) and the small squares —
+i.e. the tuner continues to adopt f16acc only where it measures a win, which is the intended shape of the fork.
+
+## Workflow notes
+
+- The two-regime golden A/B parse needed per-config grouping (a knob-less golden row = the preceding config's
+  split-K finalize; the `_f16_f16` atom token = the fm regime) — the `golden NAME (total)`-row proposal from the
+  07-09 notes would have made this trivial; it stands.
+- The fm-lane categorization now compares against the shape's own `[fm]` entry when one exists (`[vs-fm]` rows) —
+  the within-regime rule works end-to-end with recorded fm entries for the first time.
+- Sweep wall time 2.6 h under the refit (down from 3.6 h): better cold ranking = fewer wasted deep benches.
+  The `EMMY_O3_TOL=0.10` lever is now safe under gates (per-regime band).


### PR DESCRIPTION
## Summary

Two stages, sequenced so the sweep ran under the corrected prior:

**1. Analytic re-fit (post-#339-rebase).** The #339 rebase landed on top of #343's arch-aware featurizer, whose weights were fit before the fast-math sweep's golden updates. Re-fit per the #343 methodology — incumbent-seeded coordinate descent only (`--samples 0`, no random restart). Script fix folded in: the dyn fit seeded from the *static result*, discarding an already-good incumbent `_W_A_DYN` (measured: incumbent median 105 vs the static-seeded descent's 190) — it now seeds from its own incumbent. Live 5090 `eval analytic`: **15/16 golden matmuls rank #1** (both `[fm]` entries, every `.dynM` shape).

**2. Fast-math golden sweep under the new weights** (`EMMY_FAST_MATH=1`, 36 shapes, 2.6h, **0 bench failures** — the per-regime -O3 band fix held; no pathological gate-off deploy this time):

- **`matmul.square.4096` `[fm]`**: `a:mma_m16n8k16_f16_f16/w2x2/f4x8/k4 d1/tma` at **491.9µs — 0.73× vs the standard golden and 0.77× vs cuBLAS HGEMM** (≈279 TFLOP/s vs the ≈210 f32-accumulate ceiling), 3× reproduced. The deep-bk region the 07-09 cold sweep missed; the refit reached it cold.
- **`matmul.o_proj.h4096.dynM`**: replaced (91.4µs, 0.96×, reproduced in both lanes).
- **WSPEC under-specification closed**: the recorded qkv `[fm]` entry re-benched 30% slow because the refit flipped the unpinned `WSPEC` greedy fill to `p1`. Third unpinned-family drift — every warp-TILE + TMA-stage 5090 golden now records `WSPEC: ''` explicitly (13 entries = exactly the eligible set). Both qkv entries replay true post-stamp.

Findings: `plans/golden-sweep-rtx5090-fm2-findings.md`. Two main-side follow-ups noted (gate-off deploy picks a scalar tile on square.4096 std at 4.3×— evidence exists, deploy-side; square.512.dynM stage-less pick); recorded goldens unaffected.

Full suite: 2294 passed, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)