### PR TITLE
RTX 4080: golden re-validation (#339) + gemma-4-12B layer-0 tune + FAST_MATH exploration

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx4080_sm89.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4080_sm89.yaml
@@ -66,8 +66,8 @@ configs:
     N: 2048
     K: 2048
     dtype: fp16
-    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x1/f4x4/k2', STAGE: 'd1/cp'}
-    emmy_us: 207.1
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x4/f4x4', STAGE: 'd2/cp/ring'}
+    emmy_us: 188.4
     cublas_us: 197.0
   - kernel: matmul
     name: matmul.square.4096.fp16

--- a/plans/gemma-4-12b-layer0-rtx4080-tune-findings.md
+++ b/plans/gemma-4-12b-layer0-rtx4080-tune-findings.md
@@ -1,0 +1,192 @@
+# gemma-4-12B layer-0 tune findings — NVIDIA GeForce RTX 4080 (sm_89)
+
+**Status:** emmy is **≥2.4× slower than eager** on this layer, dominated by ONE kernel — the fused
+RMSNorm→gate_up MLP megakernel (~7.4 ms, ~65 % of the layer), which is **locked out of cp.async pipelining**
+(`d1/sync`, A/B-proven). The headline e2e ratio and most of the per-kernel table are **unreliable on this card**
+(bench artifact + degenerate-fast tune rows); the megakernel is the one number that survives cross-checking and it
+is the finding that matters.
+
+**Run command (cold, one invocation):**
+
+```
+EMMY_O3_TOL=0.10 emmy tune google/gemma-4-12B --layer 0 --dynamic seq_len@x:1 --clean --bench \
+    --dump-dir _tune/gemma4-12b-layer0-4080/dump
+```
+
+**Date:** 2026-07-10  **GPU:** RTX 4080 16 GB (sm_89)  **Base:** latest `main` `f7f35a38` (#339 f16-accumulate mma
+atom) — deliberately, since gemma-4-12B is fp16 and #339 changes the mma atom the projections ride.
+**Scope:** single layer, **dynamic** (`--dynamic seq_len@x:1`), benched at **seq_len=512** (symbolic `Dim` hint).
+Single-layer scope ⇒ no servable artifact (no vLLM serving A/B) — not applicable here.
+**Run stats:** wall ~39 min (trace/front-end ~10, autotune 1565 s / 774 benches, -O3 rebench ~3); **7 bench_fail
+clusters** — the fused megakernel (`k_linear_mean_reduce`, 8 rows: hang >1 s / >2 s GPU-time) and wide attention
+(`k_scaled_dot_product_attention_reduce`, 3 rows), isolated in the bench-worker subprocess.
+
+**-O1 vs -O3 disclaimer:** the `--bench` tables below are the **-O3** deployable re-bench; any tune-DB latency
+quoted for ranking context is `-Xcicc -O1` and labeled as such. The two families are never compared directly.
+
+## Bench results
+
+**Layer end-to-end** (`--bench`, benched at seq_len=512 symbolic hint; torch inputs tiled to match):
+
+| Backend | Latency (µs) | vs Eager |
+| --- | --- | --- |
+| Eager PyTorch | 3110 | 1.00× |
+| torch.compile | 2827 | 1.10× |
+| **Emmy** | **11657** | **0.27×** |
+
+**The 0.27× is a lower bound polluted upward** — see Finding 3. The single trustworthy dominant term is the
+megakernel at ~7.4 ms, which alone puts the layer at ≥2.4× eager.
+
+**Per-kernel** (`--bench` -O3 reproducer table, sorted by emmy µs; **Layer op** from each `.torch.json` provenance;
+**tune-DB -O3** = the same kernel's best -O3 row in the tune DB, for the cross-check in Finding 3):
+
+| Kernel | Layer op | eager | tcompile | emmy (repro) | tune-DB -O3 | agree? |
+| --- | --- | --- | --- | --- | --- | --- |
+| `k_linear_mean_reduce` | **fused RMSNorm→gate_proj+up_proj→GeLU-gate** (~120 GFLOP) | — | — | **7582** | 7451 | ✅ real |
+| `k_mean_linear_reduce` ×5 | post-FFN norm / scale + linear fragments | 1078 / 465 / — | 747 / 186 | 2189…338 | **3–7** | ❌ 100–600× |
+| `k_linear_reduce` (f1b366) | **mlp.down_proj** (15360→3840) | 732 | 727 | 2165 | 2158 | ✅ real |
+| `k_linear_reduce` (eb26a6) | self_attn.q_proj (→4096) | — | — | 515 | 461 | ✅ real |
+| `k_linear_reduce` (cdc109) | self_attn.k_proj (→2048) | — | — | 335 | 311 | ✅ real |
+| `k_linear_sdpa_reduce` | attention QK·V reduce | 223 | 219 | 458 | — | — |
+| `k_scaled_dot_product_attention_reduce` | flash attention | 52 | 52 | 73 | — | 0.70× |
+| `k_linear_pointwise`, `k_mean`, `k_*_slice_unsqueeze_pointwise` | rope / mean / slice epilogues | 54–262 | 3–20 | 3–8 | — | ✅ wins (12–44×) |
+
+Dominating term: **`k_linear_mean_reduce` alone is ~65 %** of the emmy total. The small pointwise/mean kernels
+already beat eager 12–44× (memory-bound epilogues emmy fuses well) — one line, no drill-down.
+
+## Finding 1 — fused gate_up megakernel locked to `d1/sync`: cp.async pipelining is refused (~7.4 ms, 65 % of layer)
+
+**Symptom.** `k_linear_mean_reduce_02ef41` benches **7454 µs standalone** (reproducer) and **7451 µs** in the tune
+DB (-O3) — they agree, and 7.4 ms is physically consistent for a 120-GFLOP kernel running at ~16 TFLOP/s (~13 % of
+the 4080's f16 tensor-core peak). So it is a **genuinely slow kernel**, not the bench artifact of Finding 3.
+
+**What it is.** The `.torch.json` provenance shows the whole MLP up-path fused into one kernel: `add_7` (residual
+[1,seq,3840] f16) → `pow²`→`mean`→`+eps`→`rsqrt`→`×`→`× pre_ffn_norm.weight` (**RMSNorm, computed in f32**) →
+**`gate_proj` [3840→15360]** and **`up_proj` [3840→15360]** matmuls → `gelu_tanh` → `× up` gate → out
+[1,seq,15360] f16. The normalized activations feeding the two matmuls are **f32 computed on-chip**, then cast to
+f16 for the `mma_m16n8k16_f16_f32` atom (hence the "float != Half" torch-ref skip on every repro of this kernel).
+
+**Root cause — a class-2 tier lockout, proven.** The `eval variants` leaderboard has **54 configs, every one
+`STAGE d1/sync`** — synchronous, single-buffered, no cp.async ring. The pipelined `d2/cp/ring` tier (what the golden
+squares use to hit cuBLAS parity) is **never enumerated** for this kernel. And it is not merely un-enumerated: an
+explicit `--ab "STAGE=d2/cp/ring"` / `"STAGE=d2/cp"` pin **realizes `STAGE@a3=d1/sync` anyway** (flagged
+"unreproducible pin") — the lowering *forces* sync for the matmul stage-group. The reason is correct-by-design: the
+matmul's **A-operand is the on-chip-computed normalized row**, and you cannot `cp.async`-copy a value that does not
+live in global memory. The fused-prologue staging lives in the `PLACE@cone=fuse` path
+([`tile/010_recognize.py`](emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py) `bind_prologue_contraction`
++ [`kernel/_factor.py:767`](emmy/compiler/pipeline/passes/lowering/kernel/_factor.py#L767) "shared-row staging").
+
+**The over-broad part (the actionable gap).** For gate/up the A-operand (normalized activations [512,3840]) is
+small and computed, but the **B-operand — the weights [3840,15360] — is a large plain-global load**, and it is the
+bandwidth-dominant operand of a 3840→15360 projection. Forcing the *whole* kernel to `d1/sync` because the A-side
+is computed throws away the B-side cp.async pipelining that would hide the weight-load latency. The pick
+(`w2x1/f4x4/k2`, 163 regs, 25 % occ) is the fastest of the 54 sync configs (its -O3 7451 < rank-1's 7785 — the
+search did find the sync-tier optimum), so **the ceiling is the tier gate, not the prior**.
+
+**Fix (high priority — this is 65 % of the layer).** Two options, either recovers most of the ~4–7× headroom:
+(a) **stage the plain-global B-operand via cp.async even when the A-operand is a computed prologue** — split the
+transport decision per operand instead of one `d1/sync` for the whole stage-group; (b) offer a **de-fused
+`PLACE@cone=split` variant** (RMSNorm as its own kernel; gate_up then reads plain-global activations and can
+pipeline `d2/cp/ring`) and let the search A/B fuse-vs-split. This matches the prior gemma theme
+([[gemma4-12b-rmsnorm-rtx4090-tuning]]: "f32 flash-tail view blocks warp tier") — the fused f32 prologue blocking
+the pipelined tier is now confirmed as a *staging* refusal, not just an enumeration gap.
+
+## Finding 2 — the `k_linear_reduce` projections land on a smem-LESS schedule (no tiling, no cp.async) — 3× off cuBLAS
+
+**Symptom.** The standalone projections `down_proj` (f1b366, -O3 2158 µs, `w8x2/f2x8`), `q_proj` (eb26a6, 461),
+`k_proj` (cdc109, 311) are all ~2–4× off their FLOP roofline (`down_proj` 60 GFLOP / 2158 µs ≈ 28 TFLOP/s vs
+eager's 732 µs ≈ 82 TFLOP/s — **emmy `down_proj` is 3× slower than cuBLAS**).
+
+**Root cause — a smem-less schedule, not `d1/sync` (A/B-refined).** I first read these as sync-tier; the A/B
+corrected it. `--ab "STAGE=d2/cp/ring"` on `down_proj` realizes **`STAGE (off)`**, and the deployed kernel uses
+**0.0 K shared memory** (grid 60 × 512 threads, 128 regs, 33 % occ). So the `k_linear_reduce` (matmul-as-K-reduction)
+form deploys a **register-only, smem-less matmul** — operands stream global→register→mma with **no smem tiling**, so
+there is no ring to stage and cp.async is moot (nothing to pipeline into). It reloads operands from global on every
+mma step instead of reusing an smem tile — hence ~28 TFLOP/s. This is a *different* class-2 lockout from Finding 1:
+Finding 1 is smem-tiled-but-`d1/sync`; Finding 2 is **not smem-tiled at all**. The smem-tiled + cp.async tier the
+golden squares ride (`n32x16 … d2/cp/ring`, cuBLAS parity) is **not selected for the reduce-form projections**.
+
+**Not a search shortfall / not a prior miss.** `f1b366`'s pick is `eval variants` rank 22/28 by **-O1** ("misses
+best") but its **-O3 (2158) is the fastest of all its measured configs** (rank-1-by-O1's -O3 is 2273) — a
+`-O1/-O3` inversion, so the deployed pick is the -O3 optimum *within the offered (smem-less) tier*. The prior
+ranked it correctly at -O3; the ceiling is the schedule family, not the prior.
+
+**Fix (high priority).** Find where the `k_linear_reduce` K-reduction form is routed to a smem-less schedule
+instead of the smem-tiled `mma` tier (the recognition/scheduling in
+[`tile/010_recognize.py`](emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py) `Reduction`/`Contraction`
+dispatch + [`kernel/_factor.py`](emmy/compiler/pipeline/passes/lowering/kernel/_factor.py) staging) and enable the
+smem-tiled cp.async schedule for it. A 3× projection speedup is the second-largest win after Finding 1.
+
+## Finding 3 — the RTX 4080 bench path is unreliable in BOTH directions; per-kernel attribution and the e2e ratio can't be trusted
+
+**Symptom.** For `k_mean_linear_reduce` the **tune-DB -O3 is 3–7 µs** but the **`--bench` reproducer is
+338–2189 µs** — a **100–600× disagreement** on the same kernels. Neither bound is credible: 3–7 µs for a
+kernel that references `down_proj.weight` would be ~12 000 TFLOP/s (**physically impossible** — a degenerate-fast
+tune row, the roofline-floor problem the golden reports flagged), while the 2189 µs reproducer carries the known
+**4080 layer-bench artifact** ([[rtx4080-bench-anomaly]]: a near-constant multi-ms cost attaches to one
+kernel launch, position-stable, absent in a clean `--code` bench). Because the e2e (11657 µs) is a single
+whole-layer run, it inherits the same artifact — so the **0.27× headline is inflated** and the true emmy standing
+is better than 0.27× (but still ≥2.4× eager from the megakernel alone, which is the one term that cross-checks
+clean).
+
+**Why it matters.** This blocks clean per-kernel attribution on this card: the `--bench` reproducer table and the
+e2e total are both suspect, and the tune-DB has degenerate-fast rows at the other extreme. The only kernels I could
+report with confidence are those where **tune-DB -O3 ≈ reproducer -O3** (the megakernel, the three real
+projections) — everything with a large disagreement is unresolved.
+
+**Fix (blocks trusting any gemma e2e on the 4080).** (a) reject bench results below a FLOP-roofline floor before
+they enter the tune DB (kills the 3–7 µs degenerate rows); (b) root-cause the reproducer/e2e layer-bench artifact
+(per the memory, cross-check the suspect kernels via `emmy run --code` at the same shape — a clean-context bench —
+and diff against the reproducer path). Until then, treat single-layer gemma e2e numbers on this box as
+directional, not deployable.
+
+## Why the prior is not the culprit here
+
+Both dominant findings are **tier/enumeration gates**, not prior mispricing: the megakernel pick is the -O3
+optimum of its (sync-only) offered set, and `down_proj` is a `-O1/-O3` inversion whose -O3 pick is best. A
+`eval prior --dataset nodes` fork-regret pass would measure ranking *within* the offered tier — but the tier itself
+is the ceiling, so a prior refit changes nothing until the cp.async offer/refusal (Findings 1–2) is addressed. No
+per-half regret table is included for that reason; if Finding 1(a) lands and `d2/cp/ring` becomes reachable, re-run
+the tune and *then* a fork-regret pass is meaningful.
+
+## Repro / artifacts
+
+- Work dir: `_tune/gemma4-12b-layer0-4080/` (tune.log, `dump/`). Golden-sweep prior+DB backed up under
+  `_tune/golden-sweep-rtx4080/2026-07-10/` before this run's `--clean`.
+- Megakernel tier-lockout proof (no re-tune needed):
+  ```
+  K=_tune/gemma4-12b-layer0-4080/dump/08_lowering_cuda.kernels/k_linear_mean_reduce_02ef41.torch.json
+  emmy run --ir $K --bench --ab "STAGE=d2/cp/ring"     # pin realizes d1/sync — flagged unreproducible
+  emmy eval variants --kernel k_linear_mean_reduce      # 54 configs, all d1/sync
+  ```
+- Source-only (no GPU) inspection of the forced-sync staging:
+  `EMMY_KNOBS="STAGE=d2/cp/ring" emmy compile $K --ir cuda` (emits the d1/sync kernel regardless).
+- Down_proj offer-gap check: `emmy run --ir …/k_linear_reduce_f1b366.torch.json --bench --ab "STAGE=d2/cp/ring"`.
+
+## Workflow notes
+
+Retrospective for whoever maintains the emmy CLI + this skill. The prior gemma-4-12B report was on a 4090
+([`plans/gemma-4-12b-layer0-rtx4090-tune-findings.md`](plans/gemma-4-12b-layer0-rtx4090-tune-findings.md)); its
+finding-6 note ("the tune `--bench` per-kernel table misattributes split pairs; the `run --bench` launch-order
+table is the antidote") is a *milder cousin* of Finding 3 here — on the 4080 the per-kernel table isn't just
+mis-split, it's off by 100–600× from the tune DB.
+
+- **The 4080 bench path is the dominant analysis hazard and it cost the most time.** Every "surprising" per-kernel
+  number needed a tune-DB-vs-reproducer cross-check (and for the megakernel a standalone reproducer bench) before I
+  could tell a real 7.4 ms kernel from a 2189 µs artifact from a 5 µs degenerate row. *Improvement:* a single
+  `eval` view (or a `--bench` column) that prints **tune-DB -O3 next to the reproducer -O3 and flags a >N×
+  disagreement** would have collapsed the whole of Finding 3's legwork into one glance — the same shape as the
+  golden skill's node-store-vs-fresh cross-check, which this run reconfirms is needed per-card.
+- **`--ab` realizing a *different* knob than pinned is the single most useful signal in this run** — it turned
+  "cp.async isn't enumerated" (ambiguous: gap vs refusal) into "cp.async is *refused*" (a correctness gate) in one
+  command. Keep the "unreproducible pin" flag prominent; it is the tier-lockout detector.
+- **`eval variants --kernel` needs the kernel C-identifier, not the layer op** — I dumped provenance from each
+  `.torch.json` by hand to label rows "down_proj / q_proj / …". The per-kernel `--bench` table has no Layer-op
+  column either. *Improvement:* join the `.torch.json` provenance into both the `--bench` table and `eval variants`
+  so kernels self-label by the torch op they realize.
+- **Playwright PNG export failed** (`chrome-headless-shell` not installed) — `kernels.html` was written but the PNG
+  skipped with a full install banner in the log. Minor, but noisy. *Improvement:* detect the missing browser and
+  emit one line, not the framed banner; or drop the PNG step when the HTML suffices.
+- **Front-end (trace) was ~10 min of the 39** with no progress logging — a 12B multimodal `from_pretrained` +
+  `torch.export` of one layer. It looked stalled (GPU idle, log quiet at "weights loaded"). *Improvement:* a
+  `[trace] …` heartbeat between weight-load and the first pipeline dump would distinguish "tracing" from "hung".

--- a/plans/golden-sweep-rtx4080-findings.md
+++ b/plans/golden-sweep-rtx4080-findings.md
@@ -54,14 +54,20 @@ fp16 enumeration), the whole 4080 golden set was **re-swept cold on `main` (f7f3
 golden --clean`, ~34 min). **Result: zero YAML changes — every recorded golden is confirmed on #339.** What the
 re-sweep established:
 
-- **No f16-accumulate win is reachable by default — the atom is enumeration-gated.** Every fp16-square greedy
-  pick and golden still rides `mma_m16n8k16_f16_f32` (f32-accumulate); all 24 measured fp16-square configs are
-  f32-accum. The f16-accumulate atom `mma_m16n8k16_f16_f16` — #339's headline, running at **2× the f32-accum
-  rate on the 4080's consumer GeForce die** — is registered but its **enumeration is gated behind
-  `F16_MMA_F32_ACC` / `FAST_MATH`** ([`emmy/compiler/ir/atom.py:135`](emmy/compiler/ir/atom.py#L135)), which the
-  default sweep does not set, so it is never offered. Capturing #339's speedup on these goldens needs a sweep
-  with those flags on — an accuracy/speed trade (the f16-accum path bounds error to one K chunk via
-  `FragmentPromote`), a separate deliberate exercise, not a default re-tune.
+- **No f16-accumulate win — and enabling `FAST_MATH` makes these kernels SLOWER, not faster.** By default the
+  f16-accumulate atom `mma_m16n8k16_f16_f16` (#339's headline, ~2× the f32-accum mma-chain rate on the 4080's
+  consumer die) is off — its enumeration is gated behind `F16_MMA_F32_ACC` / `FAST_MATH`
+  ([`emmy/compiler/ir/atom.py:135`](emmy/compiler/ir/atom.py#L135); consumer-die gate `_f16acc_allowed`,
+  [`tile/_schedule.py:107`](emmy/compiler/pipeline/passes/lowering/tile/_schedule.py#L107)). **Exploration
+  (2026-07-10, `EMMY_FAST_MATH=1`):** re-tuning `2048.fp16` / `4096.fp16` with it on enumerated 32 f16-accum
+  configs head-to-head, and the tuner **still picked f32-accum** — because f16-accum is **17–23 % slower** on
+  these shapes. A direct multi-tile A/B on `2048.fp16` confirmed: every f16-accum tile 220–231 µs vs the
+  f32-accum golden 188.6 µs, with **register pressure blown to 228+ regs → 17 % occupancy** (the `FragmentPromote`
+  keeps both f16 accumulators and f32 shadows live). These GEMMs are occupancy/bandwidth-bound at their optimal
+  tiles, so the 2× mma-chain rate is wasted and the promote overhead dominates. Accuracy stayed within emmy's
+  wrong-answer gate (flags clean). **Conclusion: the f32-accum goldens are correct; `FAST_MATH` is a net loss
+  here** — it may still pay off on register-light, genuinely mma-bound kernels, untested. Data:
+  `_tune/fastmath-explore/`.
 - **The retrained #339 prior fixed the fp32 greedy reachability.** `square.1024` / `square.2048` greedy now
   *reach* their goldens (0.97–1.02× vs 1.09–1.14× on bad4e89d) — the two fp32 findings below are resolved on
   main (the picks match the golden knobs; nothing to record).

--- a/plans/golden-sweep-rtx4080-findings.md
+++ b/plans/golden-sweep-rtx4080-findings.md
@@ -47,6 +47,33 @@ run), medianed over passes. Golden rows were rock-stable (0.1–2.2 % spread); t
 New ratio `cublas/emmy = 197.0/188.3 = 1.046` (was 0.951) — the win crosses emmy from just-below to just-above cuBLAS
 HGEMM. The old `w2x1/f4x4/k2 d1/cp` entry is >3 % slower than the new one, so it was **deleted** (replace, not add).
 
+## Update — full cold re-sweep on `main` (#339 f16-accumulate), 2026-07-10
+
+After #339 landed (renamed the fp16 mma atom `_f16`→`_f16_f32`, registered an f16-accumulate atom, reshaped the
+fp16 enumeration), the whole 4080 golden set was **re-swept cold on `main` (f7f35a38)** (`emmy tune --dataset
+golden --clean`, ~34 min). **Result: zero YAML changes — every recorded golden is confirmed on #339.** What the
+re-sweep established:
+
+- **No f16-accumulate win is reachable by default — the atom is enumeration-gated.** Every fp16-square greedy
+  pick and golden still rides `mma_m16n8k16_f16_f32` (f32-accumulate); all 24 measured fp16-square configs are
+  f32-accum. The f16-accumulate atom `mma_m16n8k16_f16_f16` — #339's headline, running at **2× the f32-accum
+  rate on the 4080's consumer GeForce die** — is registered but its **enumeration is gated behind
+  `F16_MMA_F32_ACC` / `FAST_MATH`** ([`emmy/compiler/ir/atom.py:135`](emmy/compiler/ir/atom.py#L135)), which the
+  default sweep does not set, so it is never offered. Capturing #339's speedup on these goldens needs a sweep
+  with those flags on — an accuracy/speed trade (the f16-accum path bounds error to one K chunk via
+  `FragmentPromote`), a separate deliberate exercise, not a default re-tune.
+- **The retrained #339 prior fixed the fp32 greedy reachability.** `square.1024` / `square.2048` greedy now
+  *reach* their goldens (0.97–1.02× vs 1.09–1.14× on bad4e89d) — the two fp32 findings below are resolved on
+  main (the picks match the golden knobs; nothing to record).
+- **`square.2048.fp16` golden independently re-confirmed** at 188.6 µs (≈ the recorded 188.4); the greedy still
+  cannot reach it (218 µs, `w2x4/f4x4` — a persistent reachability regression on this one shape, worth its own
+  look).
+- **Left as marginal (sub-5 % floor):** `square.1024.fp16` greedy 3.2 % faster (31.9 vs 32.9, 0.3 % spread over
+  4 passes) and `square.512` 4.9 % faster — both reproducible but below the recording threshold.
+
+The findings and fork-regret analysis below are from the original `bad4e89d` sweep; the fp32 reachability
+findings are superseded by the re-sweep (fixed), the fp16 tier findings still stand (f16-accum still gated).
+
 ## Fork sibling regret (`emmy eval prior --dataset nodes`, -O1 block, 3173 nodes / 55 forks)
 
 The command prints every metric twice: `=== analytic prior ===` is the cold-start ranking that decides what a cold

--- a/plans/golden-sweep-rtx4080-findings.md
+++ b/plans/golden-sweep-rtx4080-findings.md
@@ -1,0 +1,211 @@
+# Golden sweep findings — NVIDIA GeForce RTX 4080 (sm_89)
+
+**Date:** 2026-07-10  **GPU:** NVIDIA GeForce RTX 4080 (`rtx4080_sm89.yaml`)  **Where:** local dev box (the 4080),
+cold in-repo sweep; all data under `_tune/golden-sweep-rtx4080/2026-07-10/` (tune log, per-shape A/B JSON, eval dumps,
+pre/post-sweep prior + DB backups).
+
+**Sweep command (cold, one invocation):**
+
+```
+EMMY_O3_TOL=0.10 emmy tune --dataset golden --clean     # patience 50 (default); O3_TOL trims -O3 recompiles of fp16 non-contenders
+```
+
+**Wall time:** ~33 min for **9** tune targets — the live-card-filtered golden set (4 fp32 squares, 4 fp16 squares,
+1 `attention.hd256.dynM`). Per-target tune (`done: … in N s`): 512=28 s, 1024=50 s, 2048=51 s, 4096=142 s,
+**512.fp16=437 s**, 1024.fp16=294 s, 2048.fp16=380 s, 4096.fp16=308 s, attn.hd256.dynM=269 s. `bench_fails`:
+`square.4096` (a `HungKernelError` + a `CUDA_ERROR_ILLEGAL_ADDRESS` variant on the big fp32 tiles) and
+`attention.hd256.dynM` (12 hung wide-attention variants at the 1000 ms guard) — the expected big-shape /
+wide-attention bench guards, isolated in the bench-worker subprocess; the tune completed **9/9**.
+
+**A/B method:** `emmy run --bench --golden NAME --json` per shape — pass 1 for all 9, passes 2–3 for all 9 (cubins
+cached from the tune, so the 18 re-passes cost ~2 min), plus **5 extra passes on `square.2048.fp16`** to resolve a
+bimodal greedy. All µs below are the live **-O3** A/B (greedy = deploy pick vs the recorded golden, both benched this
+run), medianed over passes. Golden rows were rock-stable (0.1–2.2 % spread); the noise lived on the greedy side.
+
+## Category tally (9 shapes)
+
+| Category | N | Action |
+| --- | --- | --- |
+| **REPLACE** (greedy >3 % faster, reproduced above noise) | 1 | recorded |
+| ADD | 0 | — |
+| same / parity (≤~5 %, or identical knobs) | 3 | none |
+| **SLOWER** (prior couldn't reach golden, >3 %) | 5 | findings |
+
+**Recorded (1 replacement):**
+
+| shape | old knobs → new | emmy_us | vs live golden | note |
+| --- | --- | --- | --- | --- |
+| `square.2048.fp16` | `w2x1/f4x4/k2 d1/cp` → `w1x4/f4x4 d2/cp/ring` | 207.1 → **188.3** | 0.90× | greedy ≥ golden in **all 8** passes; 10 % faster in 5/8 (bimodal 188 / 209 — see Finding 3 / Workflow) |
+
+> **Re-validated on `main` (#339 f16-accumulate) 2026-07-10:** this sweep ran on `bad4e89d`; #339 later renamed the
+> fp16 mma atom `_f16`→`_f16_f32` and reshaped the fp16 enumeration. Re-A/B on #339 code: the pinned config
+> `w1x4/f4x4 d2/cp/ring` reproduces at **188.4 µs** (flags clean, ≈ the pre-#339 188.3) and still beats the recorded
+> golden (209.3) and eager cuBLAS (198) — so the win holds. Note the #339 *greedy* no longer reaches it (it picks
+> `w4x1/f2x4/k2 d1/cp` @ 218–242 µs, slower than the golden) — a reachability regression on this shape worth its own
+> look. The YAML records the config under the `_f16_f32` atom name at 188.4 µs.
+
+New ratio `cublas/emmy = 197.0/188.3 = 1.046` (was 0.951) — the win crosses emmy from just-below to just-above cuBLAS
+HGEMM. The old `w2x1/f4x4/k2 d1/cp` entry is >3 % slower than the new one, so it was **deleted** (replace, not add).
+
+## Fork sibling regret (`emmy eval prior --dataset nodes`, -O1 block, 3173 nodes / 55 forks)
+
+The command prints every metric twice: `=== analytic prior ===` is the cold-start ranking that decides what a cold
+sweep measures at all; `=== learned prior ===` is the CatBoost this sweep trained. Columns below are the two halves on
+the same 4080 nodes.
+
+| metric (-O1, 55 forks) | analytic prior | learned prior (CatBoost) |
+| --- | --- | --- |
+| TILE fork regret (median) | **2.35×** | **1.07×** |
+| STAGE fork regret (median) | 1.00× | 1.00× |
+| structural PLACE+R+S+T (median, 1 fork) | 6.61× | 1.00× |
+| worst TILE fork | 10.34× `free=4096 red=4096` | 1.44× `free=2048 red=2048` |
+| 2nd-worst TILE fork | 2.58× `free=2048 red=2048` | 1.26× `free=4096 red=4096` |
+| 3rd-worst TILE fork | 2.50× `free=512 red=512` | 1.19× `free=1024 red=1024` |
+| leaf reachability (mean / median / worst) | 2.89× / 1.35× / 18.47× | 1.10× / 1.01× / 1.35× |
+| leaf calibration (median per-op Spearman) | +0.13 | +0.89 |
+
+The worst analytic reachability (18.47×, best 5212 µs on `free=4096 red=4096`) is **not** a degenerate baseline:
+2·4096³ / 5212 µs = 26.4 TFLOP/s ≈ 54 % of the 4080's ~48.7 TFLOP/s fp32 CUDA-core peak, physically real. The 96 267 µs
+`pick` is a genuine pathological -O1 tile the cold ranking chose, corrected by the -O3 recompile + search. No `(*)`
+footnote needed — the medians *and* the worst-case are trustworthy here (cleaner than the 4090's degenerate 2200 TFLOP/s
+outlier).
+
+**Diagnosis — the 4080 is the inverse of the 4090.** The analytic half misprices TILE (2.35× median, +0.13
+calibration) — the same cold-start weakness the 4090 report found. But **unlike the 4090, the learned half is
+well-calibrated on the node store** (TILE 1.07×, +0.89, reachability median 1.01×). So node-store fork regret does
+**not** explain the deploy shortfalls. Two mechanisms *outside* the fork-regret lens do: **(1)** 4080 tune-time bench
+noise polluting the node store (the golden `square.1024` config was recorded at -O3 93.3 µs during the tune but
+benches a stable **83.9 µs** in three fresh A/B passes — so the search saw greedy ≈ golden and deployed greedy), and
+**(2)** the learned prior's **full-enumeration extrapolation** burying the analytic-preferred fp16 goldens
+(`square.512.fp16` ranks **0** under analytic but **7482/9846** under the learned prior). The `--blame --ablate`
+attribution backs this: the analytic TILE column's regret is driven by small *actively-misleading* features
+(`D_tile_m` −0.12×, `D_aspect` / `D_near_intensity` / `D_threads` / `D_near_threads` −0.08× each), while the learned
+TILE column has **no** strong misleading feature (its −0.01× entries are noise) — the learned model is fine on what it
+measured; its misses are in the region it never measured.
+
+## Per-shape outcome table (live -O3 A/B, greedy vs best live golden; cuBLAS = live Eager row this run)
+
+| shape | cuBLAS µs | greedy µs | golden µs | greedy/golden | greedy/cuBLAS | outcome |
+| --- | --- | --- | --- | --- | --- | --- |
+| `square.2048` | 498.7 | 659.5 | 578.0 | **1.141** | 1.32 | SLOWER (finding) |
+| `attention.hd256.dynM` | 55.1 | 77.4 | 68.5 | **1.131** | 1.40 | SLOWER (finding) |
+| `square.512.fp16` | 5.7 | 9.3 | 8.3 | **1.119** | 1.63 | SLOWER (finding) |
+| `square.1024` | 76.6 | 91.3 | 83.9 | **1.089** | 1.19 | SLOWER (finding) |
+| `square.1024.fp16` | 27.1 | 35.3 | 32.9 | **1.073** | 1.30 | SLOWER (finding) |
+| `square.4096` | 3829.7 | 4632.6 | 4463.6 | 1.038 | 1.21 | same knobs → bench-order noise |
+| `square.4096.fp16` | 1347.5 | 1425.4 | 1400.8 | 1.018 | 1.06 | same (parity, diff knobs, greedy 1.8 % slower) |
+| `square.512` | 17.1 | 14.1 | 14.8 | 0.951 | 0.82 | same (greedy 4.9 % faster, sub-5 % — see below) |
+| `square.2048.fp16` | 197.8 | 188.3 | 209.5 | **0.899** | 0.95 | FASTER → **recorded (replace)** |
+
+**`square.512` is a stale-golden, not a shortfall.** `eval variants` (the `-O3 us` column) shows the greedy pick
+`n16x16/f4x4` is **-O1 rank 11** (23.9 µs, looks terrible) yet **-O3 rank 1 (14.1 µs)** — it is the true -O3 optimum,
+beating the golden `n32x8/f2x8` (-O1 rank 1, -O3 14.8). The recorded golden is a **-O1-pinned** config that lost the
+-O3 crown. The greedy edge (4.9 %) is dead-stable (0.1 % spread over 3 passes) but sits below the skill's 5 % recording
+floor, so I left it. **Recommendation (low priority):** re-pin `square.512` to `n16x16/f4x4 d2/cp/ring` @ 14.1 in a
+future pass — it is what deploys and it is the -O3 winner; the current entry mis-records both the knobs and the µs.
+
+`square.4096` reproduces its golden knobs exactly (`n32x16/f4x10 d2/cp/ring`, 2/2 in `eval golden`); its 3.8 % A/B gap
+is bench-order noise (greedy 4632 µs matches the recorded `emmy_us` 4636.7; the golden row's 4463 µs was the fast side
+of the same-knob re-bench). Nothing to do.
+
+## Finding 1 — fp16 squares (`512.fp16` 1.119×, `1024.fp16` 1.073×): learned prior buries the analytic-preferred golden
+
+This is the 4080's headline and the **inverse** of the 4090's analytic-TILE story.
+
+| shape | greedy knobs | golden knobs | analytic rank | learned rank |
+| --- | --- | --- | --- | --- |
+| `square.512.fp16` | `w4x1/f2x4/k2 d2/cp/ring` | `w2x1/f1x4/k2 d4/cp/ring` | **0** / 9846 | **7482** / 9846 |
+| `square.1024.fp16` | `w4x1/f2x4/k2 d1/cp` | `w4x1/f4x4/k2 d2/cp/ring/p2` | **0** / 8838 | 138–183 / 8838 |
+
+`eval golden` per-knob: `512.fp16` 0/2 (TILE *and* STAGE miss), `1024.fp16` 1/2. The common thread — greedy picks a
+**narrow `f2x4` N-fragment** where both goldens want `f4x4` (and greedy drops the `d4/cp/ring` / `d2/cp/ring/p2` STAGE
+refinements). The analytic prior ranks **both goldens #0** over enumerations of ~9–10 k configs; the learned prior
+buries `512.fp16` at 7482/9846. Since the learned TILE fork regret on the *measured* node store is a healthy 1.07×,
+this is **not** a measured-fork mispricing — it is extrapolation into the huge fp16 warp-TILE enumeration the sweep
+sampled only sparsely (and the learned model inherits the analytic's censoring of that region… except here the
+analytic is *right*, so the censoring argument doesn't even apply — the learned model simply mis-extrapolates where the
+analytic is optimal).
+
+**Recommendation (high priority):** the fix is on the **learned** side, not an analytic weight refit (analytic already
+ranks these #0). Options, in order: (a) have the deploy prior **defer to the analytic ranking in regions the learned
+model is out-of-distribution** (few measured neighbors) — the analytic would deploy both goldens directly; (b) add a
+`D_*` feature that separates the mma **N-fragment size** (`f2` vs `f4`) so the learned model can tell the goldens'
+`f4x4` from greedy's `f2x4`; (c) more tune-time exploration in the `f4x4` fp16 region (512.fp16 already costs 437 s, so
+target it via `--kernel`, don't widen globally).
+
+## Finding 2 — fp32 squares (`square.2048` 1.141×, `square.1024` 1.089×): -O1/-O3 top-of-ranking gap + 4080 bench noise
+
+| shape | greedy TILE | golden TILE | greedy -O3 | golden -O3 (A/B) | golden -O3 (node store) |
+| --- | --- | --- | --- | --- | --- |
+| `square.1024` | `n16x16/f4x8` (BN16) | `n32x16/f4x8` (BN32) | 90.9 | **83.9** (stable) | **93.3** ← mis-measured |
+| `square.2048` | `n32x16/f4x8` (BM16) | `n32x8/f4x8` (BM8) | 658.4 | 578.0 | — |
+
+`square.1024` is the clearest 4080-bench-noise case: the greedy `n16x16/f4x8` is **-O1 rank 1** (`k_matmul_262948`,
+-O3 90.9) and the golden `n32x16/f4x8` is **-O1 rank 2** (-O3 recorded **93.3** in the node store). At tune time the
+golden looked *slower* (93.3 > 90.9), so the search deployed greedy — correctly, by the data it had. But three fresh
+A/B passes bench the same golden config at a stable **83.9 µs** (8 % faster than greedy), so the node-store 93.3 was a
+**mis-measurement** (the known 4080 bench flakiness — [[rtx4080-bench-anomaly]]). Both priors rank the golden shallow
+(analytic 1, learned 2), so this is **not** a steering or patience failure — it is bad tune-time data. `square.2048`
+is a cleaner genuine miss: greedy `n32x16/f4x8` (-O1 rank 8, 1.19× of -O1 best; -O3 658) vs golden `n32x8/f4x8`
+(-O3 578) — a real BM (8 vs 16) miss the -O1→-O3 gap hides.
+
+**Recommendation:** (a) **high** — add a tune-time re-bench-median gate on this card (median of K isolated re-benches
+before a config's -O3 latency enters the node store); the `square.1024` miss is purely bad data, and it would also
+catch the `square.2048.fp16` bimodality. (b) **medium** — `square.2048`'s BM miss is a top-of-ranking -O1/-O3
+calibration gap (golden -O1 rank 8, -O3 best); a patience bump won't help (golden ranks shallow), and the analytic TILE
+weights *are* mispriced (2.35× median) — a `scripts/golden_knob_heuristics.py` refit that down-weights the
+actively-misleading `D_tile_m` / `D_aspect` / `D_near_*` features (per the `--blame --ablate` table) is the durable
+fix, but it is secondary to the bench-noise gate.
+
+## Finding 3 — `attention.hd256.dynM` (1.131×): split-TILE schema + wide-attention bench censoring
+
+Greedy pick: a **split TILE** — `fuse`, with `a:mma_m16n8k16_f16/w4x1/f1x4/k16` on one matmul and
+`a:mma_m16n8k16_f16/w4x1/f1x32/k2` on the other, STAGE `d1/cp`; golden: a single unified
+`w4x1/f1x2/k16 d2/cp/ring`. This is the **same schema gap the 4090 report flagged** for `attention.*.dynM`: the dynM
+attention YAML records one unified `TILE`, but the greedy pick carries per-matmul split TILE — not representable, so
+even a win here couldn't be recorded (it's a 1.13× loss, so moot this sweep). The attention tune logged **12
+`bench_fail`s** (hung wide-attention variants at the 1000 ms guard) and the node store has **no -O3 measurement** for
+this shape (all `—`), so the search space is heavily censored. This is a masked-tile dynamic (3 symbolic seq axes) —
+the static↔dynamic gap the skill calls out.
+
+**Recommendation (low priority — 1 shape, and it's the 4090's open item):** (a) unify the attention knob schema to
+accept split (dd/pj) TILE for `.dynM` attention, **or** document the single-TILE constraint and prune split forks for
+dynM attention at tune time so the sweep doesn't land on an unrepresentable pick; (b) the wide-attention `bench_fail`s
+censor reachability on hd256 — a longer per-variant guard or a memory-tiled hd256 attention variant would let the
+search actually measure the region. Cross-card recurring gap; track with the 4090's.
+
+## Workflow notes
+
+Retrospective for whoever maintains the CLI + this skill. One prior RTX 4080 sweep report exists (deleted in
+`4346a889`); diffs against its notes below.
+
+- **Tune dominated (~33 min) but tuned exactly the right 9 shapes — the prior report's top complaint is FIXED.** That
+  report flagged "the tune re-runs 34 shapes though only 23 are recorded for this GPU; the 11 extra dynM/pointwise/
+  GPU-agnostic produce no 4080 golden to A/B." `live_recorded_goldens()` now scopes `--dataset golden` to the live
+  card's own recordings, so this sweep ran 9 targets, zero correctness-irrelevant. The golden set was also trimmed
+  (23 → 9) by the poisoned-data cleanup (#343). Fix held; nothing more to do here.
+- **`eval variants` still can't be reached by golden name — UNFIXED from the prior report.** `--kernel square.512.fp16`
+  returns "no measured variants"; the view keys on the DB kernel hash (`k_matmul_262948`, `k_matmul_bed174`, …). I had
+  to `eval variants --top 0` dump the whole thing and map shape → hash by matching the rank-1 TILE knobs — the exact
+  multi-command detour the last report described. *Improvement (repeat):* accept a golden name in
+  `eval variants --kernel NAME` and resolve it to the hash (the plumbing half-exists — it already errors "`--dataset
+  golden has no per-variant measurements`").
+- **4080 tune-time bench noise polluted the node store — this is the dominant *analysis* hazard on this card.** The
+  golden `square.1024` config recorded -O3 93.3 µs at tune time but benches a stable 83.9 µs in three fresh A/B passes
+  (11 % mis-measurement, and it flipped the deploy decision — Finding 2); greedy `square.2048.fp16` is bimodal (188 µs
+  in 5/8 passes, 209 in 3/8). Consistent with the known 4080 anomaly ([[rtx4080-bench-anomaly]]). *Improvement:* a
+  re-bench-median gate before a config's -O3 latency enters the node store — it would have prevented the `square.1024`
+  finding entirely.
+- **The `-O3 us` column in `eval variants` was decisive** — it exposed `square.512` as a -O1/-O3 inversion (greedy
+  `n16x16/f4x4` is -O1 rank 11 / 23.9 µs but -O3 rank 1 / 14.1 µs). Without it I'd have mis-filed `square.512` as a
+  shortfall instead of a stale -O1-pinned golden. Keep surfacing -O3 next to the -O1 rank; it is the single most useful
+  column in this workflow.
+- **`--json` is still the reliable A/B capture.** I broke my own text capture (`tee … | tail -0` → SIGPIPE → 0-byte
+  `.txt` files), but every one of the 27 passes was recovered from JSON alone — `greedy` / `pinned` / `backends` /
+  `flags`, all present, `flags: []` everywhere (no integrity issues, realized == pinned knobs). Reconfirms the prior
+  report: the text tables are disposable, JSON is the primitive.
+- **Noise-floor re-runs were cheap and decisive** (cubins cached from the tune): 9 × 3 passes + 5 extra on the one
+  bimodal shape, ~4 min total. Only `square.2048.fp16` needed the extra passes (to prove greedy ≥ golden in every one
+  of 8 passes despite the 209 outliers). The ~10–13 % band held for the small shapes; the golden rows themselves were
+  the *stable* side this sweep (0.1–2.2 % spread) — the greedy pick was the noisy one, the opposite of the skill's
+  stated failure mode, and worth flagging in step 4's guidance.

--- a/plans/golden-sweep-rtx4080-findings.md
+++ b/plans/golden-sweep-rtx4080-findings.md
@@ -65,9 +65,17 @@ re-sweep established:
   f32-accum golden 188.6 µs, with **register pressure blown to 228+ regs → 17 % occupancy** (the `FragmentPromote`
   keeps both f16 accumulators and f32 shadows live). These GEMMs are occupancy/bandwidth-bound at their optimal
   tiles, so the 2× mma-chain rate is wasted and the promote overhead dominates. Accuracy stayed within emmy's
-  wrong-answer gate (flags clean). **Conclusion: the f32-accum goldens are correct; `FAST_MATH` is a net loss
-  here** — it may still pay off on register-light, genuinely mma-bound kernels, untested. Data:
-  `_tune/fastmath-explore/`.
+  wrong-answer gate (flags clean). **Conclusion: the f32-accum goldens are correct; `FAST_MATH` is a net loss on
+  the squares.**
+- **Probe — where f16-accum DOES win: K-heavy, small-output-tile shapes (modest +3–9 %).** A follow-up probe
+  (matched-tile f16-accum-vs-f32-accum A/Bs) found the sign flips with the tile's occupancy profile. Small output
+  tile (`w2x1/f4x4`, ~6 extra regs → 33 % occ preserved) + deep K (mma-bound): synthetic **512²×K8192 +9 %**
+  (161.9 vs 178.3 µs), **256²×K16384 +7 %** (83.0 vs 89.5), gemma **`down_proj` K=15360 +3.3 %** (1272.8 vs
+  1316.2). Large output tile (the squares, gate/up N=15360): the `FragmentPromote` shadows crush occupancy to
+  17 % → **loss**. Even the wins are far below the theoretical 2× (memory traffic, smem staging, promote, split-K
+  reduction all dilute the mma-chain speedup). So f16-accum is **situational** — worth enabling only for genuinely
+  mma-bound, register-light kernels (deep-K reductions with small output tiles); correctly off-by-default, since a
+  blanket `FAST_MATH` slows more kernels than it speeds. Data: `_tune/fastmath-explore/`.
 - **The retrained #339 prior fixed the fp32 greedy reachability.** `square.1024` / `square.2048` greedy now
   *reach* their goldens (0.97–1.02× vs 1.09–1.14× on bad4e89d) — the two fp32 findings below are resolved on
   main (the picks match the golden knobs; nothing to record).


### PR DESCRIPTION
RTX 4080 (sm_89) tuning work on latest `main` (#339 f16-accumulate). One golden data change + two findings reports.

## Golden change
- **`square.2048.fp16`**: `w2x1/f4x4/k2 d1/cp @ 207.1µs` → **`w1x4/f4x4 d2/cp/ring @ 188.4µs`** (0.90× the old
  golden, 1.046× cuBLAS HGEMM). The win was found on `bad4e89d` and **re-validated on `main`/#339** (pinned it
  reproduces at 188.4µs, still beats the golden and eager). Schema test 23/23, lint clean.

## Findings reports (analysis, no code change)
- **`plans/golden-sweep-rtx4080-findings.md`** — the cold golden sweep, a full **#339 re-sweep** (goldens confirmed;
  the retrained prior fixed the fp32 greedy reachability), and a **FAST_MATH / f16-accumulate exploration**:
  the `mma_m16n8k16_f16_f16` atom is a **net loss on the fp16 squares** (17–23% slower — `FragmentPromote` shadows
  crush occupancy to 17%) but a **modest win (+3–9%) on K-heavy, small-output-tile shapes** (synthetic + gemma
  `down_proj`). Correctly off-by-default; situational.
- **`plans/gemma-4-12b-layer0-rtx4080-tune-findings.md`** — gemma-4-12B layer-0 tune: emmy ≥2.4× eager, dominated by
  the fused RMSNorm→gate_up megakernel **locked to `d1/sync`** (cp.async pipelining refused because the matmul's
  A-operand is the on-chip-computed normalized row — A/B-proven), plus `down_proj` on a **smem-less schedule**
  (3× cuBLAS), and a note that the 4080's per-kernel bench path is unreliable both ways (tune-DB vs reproducer
  disagree 100–600×).

Both perf findings are **tier/schedule lockouts, not prior mispricing** (picks are -O3-optimal within the offered
tier). A rented-4090 reproduction of the same sweeps is planned on a separate branch to confirm which conclusions are
architectural vs 4080-box-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)