### PR TITLE
sm_89: cp.async slab software swizzle (−16–21%) + 4090 golden refresh — fm lane past cuBLAS on 9/11 shapes; WSPEC refuted

### DIFF
--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -447,6 +447,10 @@ class CpAsyncCopy(Stmt):
     src: str  # source global buffer name
     src_index: tuple
     nbytes: int = 4  # bytes per cp.async (4/8/16); 16 ⇒ .cg, else .ca
+    # Software smem swizzle mode ("NONE"/"B32"/"B64"/"B128"): XOR the flattened destination
+    # element index via ``emmy_swizzle_<mode>`` — the same address-based permutation the
+    # ``LdmatrixLoad`` drain applies, so a swizzled slab round-trips (``LDMATRIX_SWIZZLE_XOR``).
+    swizzle: str = "NONE"
 
     def external_reads(self) -> tuple[str, ...]:
         return (self.src,)
@@ -454,13 +458,16 @@ class CpAsyncCopy(Stmt):
     def pretty(self, indent: str = "") -> list[str]:
         smem_idx = ", ".join(e.pretty() for e in self.smem_index)
         src_idx = ", ".join(e.pretty() for e in self.src_index)
-        return [f"{indent}cp.async[{self.nbytes}B] {self.smem}[{smem_idx}] <- {self.src}[{src_idx}]"]
+        swz = f" swz={self.swizzle}" if self.swizzle in LDMATRIX_SWIZZLE_XOR else ""
+        return [f"{indent}cp.async[{self.nbytes}B] {self.smem}[{smem_idx}]{swz} <- {self.src}[{src_idx}]"]
 
     def render(self, ctx: RenderCtx) -> list[str]:
         from emmy.compiler.ir.stmt import render_index
 
         smem_flat = render_index(self.smem, self.smem_index, ctx)
         src_flat = render_index(self.src, self.src_index, ctx)
+        if self.swizzle in LDMATRIX_SWIZZLE_XOR:
+            smem_flat = f"emmy_swizzle_{self.swizzle.lower()}({smem_flat})"
         pad = _pad(ctx.indent)
         # ``emmy_cp_async_{cg,ca}`` (the cp.async prelude) does the ``cvta`` internally, so this is a
         # single call — no ``_smem_addr`` local and no wrapping ``{ }`` block. .cg is 16-byte-only.
@@ -1243,6 +1250,14 @@ class RegFragment(Stmt):
 # 8-row × atom period divides the slab + slot strides, so the XOR is correct
 # measured from the buffer base. Maps mode → (element shift, row mask); the
 # chunk delta is always ``<< 3``.
+#
+# The XOR is purely address-based, so it is also the SOFTWARE swizzle: a
+# ``cp.async``-filled slab applies the same helper to its fill DESTINATION
+# index (:class:`CpAsyncCopy` ``swizzle``) and the ldmatrix drain reads it
+# back through the identical XOR — fill and drain agree by construction, no
+# hardware copy engine involved. Intra-chunk bits (0..2) pass through, so
+# narrower 4/8-byte fills keep their offset inside the relocated 16-byte
+# chunk and ``cp.async`` address alignment is preserved.
 LDMATRIX_SWIZZLE_XOR: dict[str, tuple[int, int]] = {
     "B128": (6, 0x7),
     "B64": (6, 0x3),
@@ -2107,6 +2122,7 @@ def _(s: CpAsyncCopy, rename, sigma, axis_fn):
         src=s.src,
         src_index=tuple(sigma.apply(e) for e in s.src_index),
         nbytes=s.nbytes,
+        swizzle=s.swizzle,
     )
 
 

--- a/emmy/compiler/ir/kernel/render.py
+++ b/emmy/compiler/ir/kernel/render.py
@@ -12,7 +12,7 @@ from emmy.compiler.backend.cuda.dtype import cuda_includes, cuda_name
 from emmy.compiler.backend.cuda.dtype import nbytes_of as _nbytes_of
 from emmy.compiler.backend.cuda.render_target import CudaRenderTarget
 from emmy.compiler.dtype import F32
-from emmy.compiler.ir.kernel.ir import LDMATRIX_SWIZZLE_XOR, KernelOp, LdmatrixLoad, Smem, TmaDescriptor, pack_smem
+from emmy.compiler.ir.kernel.ir import LDMATRIX_SWIZZLE_XOR, CpAsyncCopy, KernelOp, LdmatrixLoad, Smem, TmaDescriptor, pack_smem
 from emmy.compiler.ir.stmt import RenderCtx, render_body
 from emmy.compiler.tensor import Tensor
 
@@ -496,17 +496,22 @@ static __device__ __forceinline__ void emmy_mma_promote_f16acc(float* c, unsigne
 
 
 def _swizzle_prelude(kernel_op: KernelOp) -> str:
-    """One ``emmy_swizzle_<mode>`` helper per TMA swizzle mode the body's ``LdmatrixLoad`` drains
-    use — built from ``LDMATRIX_SWIZZLE_XOR`` (the single source of the shift/mask), so the drain
-    call sites spell their (often long) element index once instead of inlining it twice around the
-    XOR. ``__forceinline__``; same SASS as the inlined form."""
-    modes = sorted({s.swizzle for s in kernel_op.body.iter() if isinstance(s, LdmatrixLoad) and s.swizzle in LDMATRIX_SWIZZLE_XOR})
+    """One ``emmy_swizzle_<mode>`` helper per swizzle mode the body uses — on ``LdmatrixLoad``
+    drains (undoing the TMA hardware in-copy permutation, or reading back a software-swizzled
+    slab) and on ``CpAsyncCopy`` fills (the software swizzle's producer side). Built from
+    ``LDMATRIX_SWIZZLE_XOR`` (the single source of the shift/mask), so the call sites spell their
+    (often long) element index once instead of inlining it twice around the XOR.
+    ``__forceinline__``; same SASS as the inlined form."""
+    modes = sorted(
+        {s.swizzle for s in kernel_op.body.iter() if isinstance(s, (LdmatrixLoad, CpAsyncCopy)) and s.swizzle in LDMATRIX_SWIZZLE_XOR}
+    )
     chunks = []
     for mode in modes:
         shift, mask = LDMATRIX_SWIZZLE_XOR[mode]
         chunks.append(
-            f"// {mode} slab swizzle: XOR a b16 smem element index the way the TMA copy engine\n"
-            f"// permuted the 16-byte chunks on fill (the ldmatrix drain must read them back).\n"
+            f"// {mode} slab swizzle: XOR a b16 smem element index the way the fill permuted the\n"
+            f"// 16-byte chunks (TMA in-copy, or the same XOR on a cp.async fill destination);\n"
+            f"// the ldmatrix drain must read them back through the identical permutation.\n"
             f"static __device__ __forceinline__ int emmy_swizzle_{mode.lower()}(int e) {{\n"
             f"    return e ^ (((e >> {shift}) & {mask}) << 3);\n"
             f"}}\n\n"

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -62,11 +62,13 @@ bound (e.g. a non-`Load` operand — a computed-cone / demoted matmul) is reject
   slab is codec-sized and cannot shrink; the scalar resolver steps `bk_elems` / depth down first), so every offered
   stage row materializes within budget — a resolved-but-unfittable row would only die at `validate(ctx)`, leaving an
   un-lowered `TileOp` in the tune's terminal (issue #327). One staging fact
-  is derived at materialization rather than resolved here because it is layout, not eligibility: a TMA slab feeding an
+  is derived at materialization rather than resolved here because it is layout, not eligibility: a slab feeding an
   mma drain is **swizzled** (`_stage.pick_swizzle_atom` picks B32/B64/B128 per operand from the slab's inner row span;
-  the hardware permutes 16 B chunks in-copy, each staged `LdmatrixLoad` XORs the address back, and the kernel stays
-  bit-identical to its unswizzled sibling — swizzle relocates smem bytes only, which is what keeps the ldmatrix drain
-  free of shared-memory bank conflicts; cp.async / sync slabs stay plain row-major).
+  TMA permutes the 16 B chunks in hardware during the box copy, a cp.async fill applies the identical XOR in software
+  on its destination index, each staged `LdmatrixLoad` XORs the address back, and the kernel stays bit-identical to
+  its unswizzled sibling — swizzle relocates smem bytes only, which is what keeps the ldmatrix drain free of
+  shared-memory bank conflicts; the unswizzled cp path was 4-way/8-way conflict-bound on sm_89, the measured residual
+  to cuBLAS there. Sync compute-fill slabs and scalar-`Load`-drained slabs stay plain row-major).
 - the **MONOID-producer composition** — the fused norm→linear edge and its N-channel form, the gate/up MLP edge —
   binds at recognize time too (`_atomize.bind_prologue_contraction`, structure-only): a projecting `Map` over a
   per-row `PLANAR` statistic whose tail is one or more ⊗-folds of one shared A value nodifies to

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -148,10 +148,11 @@ fill, `d2+/ring` the prefetch ring overlapping the next KV block's copies with t
 its operand's own layout (K stays N-major, V K-major; verbatim row copies), so the transposed-B K slab drains via the
 **plain `x2` (no `.trans`) staged ldmatrix** — its 8×8 rows ARE the mma's col-major B columns (the `LdmatrixLoad`
 render's third variant) — and the V slab via the canonical `x2.trans`. The K/V slab rows are **padded +16 B**
-(`Operand.pad_cols` / `_twist._PAD`) — the cp.async-path counterpart of the TMA slab swizzle: a power-of-two row
+(`Operand.pad_cols` / `_twist._PAD`) — the flash stream's bank-conflict fix: a power-of-two row
 span lands every ldmatrix row read on one bank group (a measured ~8-way replay profile), and the pad shifts
 consecutive rows across groups. Intrinsic, not a fork (a near-strict win, like the masked-K alignment pad); padding
-relocates smem bytes only. The **TMA transport** boxes the batched K/V via rank-N descriptors (leading
+relocates smem bytes only. (The matmul tier's cp.async slabs use the software swizzle XOR instead — same modes as
+TMA, applied on the fill destination index, zero smem growth; pad and swizzle are mutually exclusive per slab.) The **TMA transport** boxes the batched K/V via rank-N descriptors (leading
 extent-1 box dims; the load's batch/head index exprs as origin coords — GQA's `h // group` included) into dense
 1024 B-aligned slabs under the hardware swizzle, the drains' address XOR undoing it; under a `WSPEC` band split the
 transport's elected fill thread rides the WRAPPED linear tid (`threadIdx.x % block_threads` — the raw tid would elect
@@ -261,7 +262,8 @@ the two apply paths stay distinct on a coop-K contraction.
 `030_stamp_types` / `040_demote_to_write_dtype` resolve element dtypes; `050_vectorize_loads` / `080_vectorize_stores` /
 `095_interleave_loads` pack/reorder memory ops; `096_pair_ldmatrix_loads` fuses slab-adjacent staged `x2` B-fragment
 `LdmatrixLoad`s into one `x4` (`pair_frag` — plain `x4` for an N-adjacent transposed-B pair, `x4.trans` for a
-col-adjacent canonical pair; NONE-swizzle only, halves the staged drains' LSU count, bit-identical; fires on both the
+col-adjacent canonical pair; equal swizzle modes pair too — the per-lane address XOR commutes with the paired lane
+map; halves the staged drains' LSU count, bit-identical; fires on both the
 warp-flash streaming drains and the matmul tier's staged drains — two emitters, one pass, which is why it is a pass);
 `110_drop_redundant_syncs` collapses the defensive `Sync`s the
 cooperative / shared-row templates emit (body-level only — a slab `Smem` decl flags `smem_seen`, so a load-bearing

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -151,8 +151,9 @@ render's third variant) — and the V slab via the canonical `x2.trans`. The K/V
 (`Operand.pad_cols` / `_twist._PAD`) — the flash stream's bank-conflict fix: a power-of-two row
 span lands every ldmatrix row read on one bank group (a measured ~8-way replay profile), and the pad shifts
 consecutive rows across groups. Intrinsic, not a fork (a near-strict win, like the masked-K alignment pad); padding
-relocates smem bytes only. (The matmul tier's cp.async slabs use the software swizzle XOR instead — same modes as
-TMA, applied on the fill destination index, zero smem growth; pad and swizzle are mutually exclusive per slab.) The **TMA transport** boxes the batched K/V via rank-N descriptors (leading
+relocates smem bytes only. (The matmul tier's cp.async slabs use the software swizzle XOR instead — same modes
+as TMA, applied on the fill destination index, zero smem growth; pad and swizzle are mutually exclusive per
+slab.) The **TMA transport** boxes the batched K/V via rank-N descriptors (leading
 extent-1 box dims; the load's batch/head index exprs as origin coords — GQA's `h // group` included) into dense
 1024 B-aligned slabs under the hardware swizzle, the drains' address XOR undoing it; under a `WSPEC` band split the
 transport's elected fill thread rides the WRAPPED linear tid (`threadIdx.x % block_threads` — the raw tid would elect

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -181,9 +181,10 @@ def _warp_epilogue(
 
 # ---- operand staging (smem slab + ldmatrix drain) ---------------------------------------------- #
 # The warp tier's smem operand pipeline, driven off the node's :class:`Stage`. cp.async and TMA
-# share the slab + the staged-``LdmatrixLoad`` drain (:func:`_staged_inner_atom_loop`); only the
-# producer differs — a cp.async slab is plain row-major (NONE-swizzle), a TMA slab is
-# hardware-swizzled in-copy with the drain XOR undoing it (:meth:`_MmaOps.slab_swizzles`). Staging is a **pure perf
+# share the slab + the staged-``LdmatrixLoad`` drain (:func:`_staged_inner_atom_loop`) AND the
+# slab swizzle modes (:meth:`_MmaOps.slab_swizzles`); only who applies the fill-side permutation
+# differs — TMA swizzles in hardware during the box copy, a cp.async fill XORs its destination
+# index in software — and the drain XOR undoes either. Staging is a **pure perf
 # transform**: an ineligible kernel silently falls back to gmem-direct, and a staged kernel is
 # bit-identical to its gmem-direct baseline. The transport primitives (the fill loops + the
 # commit/wait / mbarrier handshakes) live in ``_stage.py``; these functions schedule them onto the
@@ -248,9 +249,10 @@ def _staged_inner_atom_loop(
     each slab's ROW (A's tile row / B's K row) so the drain reads the ring slot the producer already
     filled, while a later chunk prefetches into another slot.
 
-    ``swizzles`` (per-slab, aligned with ``slabs``): the TMA smem swizzle mode each slab was written
-    with — threaded onto each ``LdmatrixLoad`` so its address XOR undoes the hardware chunk
-    permutation (``"NONE"`` reads the plain row-major slab)."""
+    ``swizzles`` (per-slab, aligned with ``slabs``): the smem swizzle mode each slab was written
+    with (TMA in-copy, or the cp.async fill's software XOR) — threaded onto each ``LdmatrixLoad``
+    so its address XOR undoes the fill's chunk permutation (``"NONE"`` reads the plain row-major
+    slab)."""
     (a_slab, *b_slabs), (m, n) = slabs, mn
     offs = offs if offs is not None else (None,) * len(slabs)
     swizzles = swizzles if swizzles is not None else ("NONE",) * len(slabs)
@@ -379,7 +381,7 @@ def _slab_operands(
     looped over the two operands. A is ``(tile_m × bk)`` indexed by the M tile axis (the slab ROW); B is
     ``(bk × tile_n)`` by the N tile axis (the slab COL) — ``is_row`` flips the slot shape + the TMA box
     origin. ``base`` is the ``(row_base, col_base)`` CTA tile origin; ``index_srcs`` are the operands'
-    gmem index expressions (``load.index``); ``swizzles`` the per-operand TMA smem swizzle modes (the
+    gmem index expressions (``load.index``); ``swizzles`` the per-operand smem swizzle modes (the
     mma tier's :meth:`_MmaOps.slab_swizzles` — ``("NONE", "NONE")`` everywhere else). ``elems`` are the
     per-operand element dtypes (``DataType`` or ``None`` = the transport-level dtype) — a mixed-dtype
     scalar contraction (fp32 A × fp16 B) must size each slab and fill by its OWN element width."""
@@ -530,7 +532,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
             k_axis=k_axis,
             bk_elems=stage.bk_elems,
             base=_tile_base(mn),
-            swizzles=ops.slab_swizzles(mn, elem.nbytes) if stage.transport == "tma" else ("NONE", "NONE"),
+            swizzles=ops.slab_swizzles(mn, elem.nbytes),
             elems=ops.slab_elems(),
         )
         common = dict(
@@ -755,10 +757,15 @@ class _MmaOps(_AtomOps):
         return stmts
 
     def slab_swizzles(self, mn, elem_bytes: int) -> tuple[str, str]:
-        """The TMA smem swizzle mode per operand slab, from each slab's inner (contiguous) row
-        span — A's is ``bk_elems`` (the K chunk), B's ``tile_n``. The pre-rebuild bar for the fp16
-        squares (``square.2048.fp16`` at 106.7 µs / 1.06× cuBLAS) was set by swizzled slabs; the
-        rebuilt NONE-swizzle transport left the ``ldmatrix`` drain bank-conflict-bound. Modes are
+        """The smem swizzle mode per operand slab, from each slab's inner (contiguous) row
+        span — A's is ``bk_elems`` (the K chunk), B's ``tile_n``. TMA applies the mode in
+        hardware (in-copy); the cp.async transport applies the identical XOR in software on
+        each fill's destination index — both drains read back through the same ldmatrix XOR.
+        The pre-rebuild bar for the fp16 squares (``square.2048.fp16`` at 106.7 µs / 1.06×
+        cuBLAS) was set by swizzled slabs; the rebuilt NONE-swizzle transport left the
+        ``ldmatrix`` drain bank-conflict-bound — and the never-swizzled cp path the same way
+        (4-way on 64 B rows / 8-way on 128 B; conflict replays were 81% of the sm_89 gate_up fm
+        golden's shared-mem wavefronts, the measured residual to cuBLAS). Modes are
         DERIVED, not tuned — the widest atom that divides the span (matching the pre-rebuild
         behavior: A → B64 on a 32-elem fp16 chunk, B → B128 on a 64-elem row)."""
         return (

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -17,10 +17,13 @@ skeleton, :func:`staged_kloop` (``fill → commit → wait → drain → Sync``,
 buffering knob), driven by a :class:`Transport` strategy (:class:`CpAsyncTransport` /
 :class:`TmaTransport`) — the two producers put behind one ``fill``/``commit``/``wait`` seam. The
 slab feeds the same staged ``LdmatrixLoad`` / scalar ``Load`` drain regardless of which producer
-(cp.async / TMA) filled it. cp.async/sync slabs are plain row-major (NONE-swizzle, linear writes
-and reads); a TMA slab feeding an mma drain is **swizzled** (:func:`pick_swizzle_atom` per operand
-— the hardware permutes 16 B chunks during the box copy and each staged ``LdmatrixLoad`` applies
-the matching address XOR), which is what keeps the ldmatrix drain free of smem bank conflicts.
+(cp.async / TMA) filled it. A slab feeding an mma drain is **swizzled** (:func:`pick_swizzle_atom`
+per operand): TMA permutes the 16 B chunks in hardware during the box copy, a cp.async fill applies
+the identical XOR in software on its destination index, and each staged ``LdmatrixLoad`` reads back
+through the matching address XOR — which is what keeps the ldmatrix drain free of smem bank
+conflicts (the unswizzled cp path was 4-way conflicted on 64 B rows / 8-way on 128 B ones — the
+sm_89 gap to cuBLAS). Sync compute-fill slabs and scalar-``Load``-drained slabs stay plain
+row-major (NONE-swizzle, linear writes and reads).
 ``_atom._staged`` — the one atom-agnostic driver — builds the transport, asks the atom strategy
 for the drain leaf, and calls :func:`staged_kloop`.
 
@@ -90,7 +93,16 @@ def _cp_async_width(slab_cols: int, elem_bytes: int) -> int:
 
 
 def cp_async_fill(
-    *, slab: str, shape: tuple[int, int], src: str, gmem_index, cta: CtaTile, elem_bytes: int, name: str, row_offset: Expr | None = None
+    *,
+    slab: str,
+    shape: tuple[int, int],
+    src: str,
+    gmem_index,
+    cta: CtaTile,
+    elem_bytes: int,
+    name: str,
+    row_offset: Expr | None = None,
+    swizzle: str = "NONE",
 ) -> list[Stmt]:
     """Cooperatively ``cp.async``-copy a ``rows × cols`` (= ``shape``) row-major smem
     ``slab`` from gmem ``src``. ``gmem_index(row_expr, col_expr)`` returns the gmem
@@ -103,7 +115,14 @@ def cp_async_fill(
 
     ``row_offset`` (the gmem→smem ring): when staging through a depth>1 slab, it picks
     the ring SLOT — the write row becomes ``row_offset + row`` (each slot is a contiguous
-    ``rows``-row block), so the fill targets one slot while the drain reads another."""
+    ``rows``-row block), so the fill targets one slot while the drain reads another.
+
+    ``swizzle`` (the cp.async SOFTWARE slab swizzle): XOR the flattened destination element
+    index (``CpAsyncCopy.swizzle`` → ``emmy_swizzle_<mode>``), permuting 16-byte chunks within
+    each swizzle row exactly as the TMA hardware would — the staged ``LdmatrixLoad`` drain
+    reads back through the same XOR, so fill and drain agree by construction and the un-XORed
+    NONE-swizzle kernel is bit-identical. This is the sm_89 bank-conflict fix: the plain
+    row-major slab leaves the drain 4-way (64 B rows) / 8-way (128 B rows) conflicted."""
     slab_rows, slab_cols = shape
     v = _cp_async_width(slab_cols, elem_bytes)
     n_chunks = (slab_rows * slab_cols) // v
@@ -118,6 +137,7 @@ def cp_async_fill(
         src=src,
         src_index=tuple(gmem_index(row, col)),
         nbytes=v * elem_bytes,
+        swizzle=swizzle,
     )
     loop = StridedLoop(axis=fe, start=cta.linear_tid, step=_lit(cta.n_threads), body=Body((copy,)), unroll=False)
     return [loop]
@@ -211,8 +231,10 @@ _SWIZZLE_BY_BYTES: tuple[tuple[int, str], ...] = ((128, "B128"), (64, "B64"), (3
 
 
 def pick_swizzle_atom(inner_elems: int, elem_bytes: int) -> tuple[int, str]:
-    """The TMA swizzle atom for a slab whose inner (contiguous) row is ``inner_elems``
-    elements of ``elem_bytes``. Returns ``(atom_elems, mode)``: the widest atom in
+    """The swizzle atom for a slab whose inner (contiguous) row is ``inner_elems``
+    elements of ``elem_bytes`` — the ONE mode derivation the TMA descriptor (hardware
+    in-copy swizzle) and the cp.async fill (software destination XOR) both consume.
+    Returns ``(atom_elems, mode)``: the widest atom in
     ``{128, 64, 32}`` B that fits and divides the span wins — a 256 B inner (128 fp16
     elems) picks ``B128`` (64 elems, descriptor box split ``[2, 64]``); a 64 B inner (32
     fp16 elems) picks ``B64`` (32 elems, no split). ``(inner_elems, "NONE")`` when no
@@ -281,16 +303,20 @@ class Operand:
     shape: tuple[int, int]  # (rows, cols) of one ring slot
     index: Callable[[Expr], Callable]  # k0 -> ((row, col) -> gmem index)   (cp.async)
     coords: Callable[[Expr], tuple]  # k0 -> gmem box origin                (TMA)
-    # TMA smem swizzle mode this operand's slab is written with ("NONE"/"B32"/"B64"/"B128") —
-    # derived by the mma tier (`_MmaOps.slab_swizzles`, TMA transport only: the hardware swizzles
-    # in-copy and the ldmatrix drain applies the matching XOR; a scalar plain-`Load` drain and the
-    # cp.async/sync write paths stay NONE).
+    # Smem swizzle mode this operand's slab is written with ("NONE"/"B32"/"B64"/"B128") — derived
+    # by the mma tier (`_MmaOps.slab_swizzles`). TMA transport: the hardware swizzles in-copy; the
+    # cp.async transport applies the same XOR in SOFTWARE on each fill's destination index
+    # (:func:`cp_async_fill` ``swizzle``). Either way the ldmatrix drain applies the matching XOR;
+    # a scalar plain-`Load` drain and the sync write path stay NONE.
     swizzle: str = "NONE"
     # Extra smem columns padding each slab row (cp.async transport only — a TMA box deposit is
-    # dense). The pad breaks the same-bank stride of a power-of-two row (the bank-conflict fix the
-    # cp.async path has in place of TMA's hardware swizzle); the fill's logical (row, col) writes
-    # stride the padded decl automatically (``render_index`` flattens against it), and the drain's
-    # ``ldm`` carries the padded stride. Data cells only — a chunk never straddles the pad.
+    # dense). The pad breaks the same-bank stride of a power-of-two row — the flash K/V slabs'
+    # bank-conflict fix (`_twist._PAD`), whose drains are not plain ldmatrix rows; the mma matmul
+    # tier uses the software ``swizzle`` above instead (zero smem growth). Mutually exclusive with
+    # a non-NONE ``swizzle`` (the XOR's atom derivation assumes dense rows). The fill's logical
+    # (row, col) writes stride the padded decl automatically (``render_index`` flattens against
+    # it), and the drain's ``ldm`` carries the padded stride. Data cells only — a chunk never
+    # straddles the pad.
     pad_cols: int = 0
     # The TMA descriptor box, when it differs from the 2-D slab ``shape`` — a BATCHED operand
     # (flash K/V: gmem ``(B, H, S, D)``) boxes as rank-N with leading extent-1 dims
@@ -386,6 +412,7 @@ class SyncTransport:
                 elem_bytes=self.elem_bytes,
                 name=op.tag,
                 row_offset=op.slot_row(slot),
+                swizzle=op.swizzle,
             )
         for op in self.operands:
             rows, cols = op.shape
@@ -438,6 +465,9 @@ class CpAsyncTransport:
     def fill(self, *, k0: Expr, slot: Expr) -> list[Stmt]:
         out: list[Stmt] = []
         for op in self.operands:
+            # The software swizzle XOR assumes dense power-of-two rows; a padded slab already
+            # breaks the same-bank stride another way — the two fixes are mutually exclusive.
+            assert op.swizzle == "NONE" or op.pad_cols == 0, "a padded slab must stay NONE-swizzle"
             out += cp_async_fill(
                 slab=op.slab,
                 shape=op.shape,
@@ -447,6 +477,7 @@ class CpAsyncTransport:
                 elem_bytes=op.elem_bytes or self.elem_bytes,
                 name=op.tag,
                 row_offset=op.slot_row(slot),
+                swizzle=op.swizzle,
             )
         return out
 

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
@@ -39,8 +39,9 @@ configs:
     N: 512
     K: 512
     dtype: fp16
+    # 2026-07-12 post-swizzle refresh (cp.async slab swizzle, PR #351): 6.1 -> 4.9 (3x at zero spread).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x2/f2x2/k4', RASTER: '', STAGE: 'd2/cp/ring/p2'}
-    emmy_us: 6.1
+    emmy_us: 4.9
     cublas_us: 5.8
   - kernel: matmul
     name: matmul.square.512.fp16
@@ -48,8 +49,21 @@ configs:
     N: 512
     K: 512
     dtype: fp16
+    # 2026-07-12 post-swizzle refresh: 6.3 -> 6.0 total (4.5 + 1.5 finalize, 3x).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x2/f4x2/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 6.3
+    emmy_us: 6.0
+    cublas_us: 5.8
+  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): atom-swap of the p2 standard golden.
+  # 4.8 µs (3x at zero spread) vs the standard's live 4.9 — the fm twin the 5090 file also carries.
+  # 2026-07-12 post-swizzle manual refresh.
+  - kernel: matmul
+    name: matmul.square.512.fp16
+    M: 512
+    N: 512
+    K: 512
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w1x2/f2x2/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2'}
+    emmy_us: 4.8
     cublas_us: 5.8
   - kernel: matmul
     name: matmul.square.1024.fp16
@@ -57,14 +71,14 @@ configs:
     N: 1024
     K: 1024
     dtype: fp16
-    # 2026-07-12 manual sweep: REDUCE stamped '' (replayed fill-free); emmy_us refreshed 22.2 -> 24.0
-    # (live median of 4 passes; the recorded value reproduced once, drifted +8% on the other three).
+    # 2026-07-12 manual sweep: REDUCE stamped '' (replayed fill-free); emmy_us refreshed 22.2 -> 24.0.
+    # Post-swizzle refresh (same day, PR #351): 24.0 -> 20.4 (2 passes 20.2/20.4).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 24.0
+    emmy_us: 20.4
     cublas_us: 18.1
   # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): atom-swap of the standard golden.
-  # 19.9 µs (4x reproduced at zero spread) vs the standard's live 24.0 (0.83x). 2026-07-12 manual
-  # sweep on a rented 4090. Kept beside the standard entry — gate-off compiles can't reach it.
+  # 2026-07-12 manual sweep on a rented 4090; kept beside the standard entry — gate-off compiles
+  # can't reach it. Post-swizzle refresh (same day): 19.9 -> 15.8 (3x at zero spread), 0.87x cuBLAS.
   - kernel: matmul
     name: matmul.square.1024.fp16
     M: 1024
@@ -72,7 +86,7 @@ configs:
     K: 1024
     dtype: fp16
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w1x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 19.9
+    emmy_us: 15.8
     cublas_us: 18.1
   - kernel: matmul
     name: matmul.square.2048.fp16
@@ -85,16 +99,18 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x4/f4x4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
     emmy_us: 123.4
     cublas_us: 115.2
-  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): atom-swap of the standard golden.
-  # 119.3 µs (4x, 119.0-119.3) vs the standard's live 123.4 (0.97x). 2026-07-12 manual sweep.
+  # Fast-math sibling (FAST_MATH lane). 2026-07-12 post-swizzle manual refresh (PR #351): the
+  # bank-conflict fix flipped the optimum to the wide-N f4x8 register tile — w2x2/f4x8/k2 at 82.7
+  # (2x, 82.4/82.7) replaces the old w1x4/f4x4 fm entry (live 106.7, 29% slower, pruned). 0.72x vs
+  # cuBLAS HGEMM — beats cuBLAS. Accuracy vs torch passes.
   - kernel: matmul
     name: matmul.square.2048.fp16
     M: 2048
     N: 2048
     K: 2048
     dtype: fp16
-    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w1x4/f4x4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 119.3
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
+    emmy_us: 82.7
     cublas_us: 115.2
   - kernel: matmul
     name: matmul.square.4096.fp16
@@ -107,17 +123,17 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x4/f4x8', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
     emmy_us: 869.4
     cublas_us: 822.3
-  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): the atom-swap + k2 chunking. 750.6 µs
-  # (3x, 731-767) vs the standard's live 841 (0.89x) and 0.93x vs cuBLAS HGEMM — beats cuBLAS.
-  # Accuracy vs torch passes. 2026-07-12 manual sweep.
+  # Fast-math sibling (FAST_MATH lane). 2026-07-12 post-swizzle manual refresh (PR #351): w2x2/f4x8/k2
+  # at 603.1 (3x, 602.1-611.8) replaces the old w1x4/f4x8/k2 fm entry (live 634-639, 5.5% slower,
+  # pruned). 0.73x vs cuBLAS HGEMM. Accuracy vs torch passes.
   - kernel: matmul
     name: matmul.square.4096.fp16
     M: 4096
     N: 4096
     K: 4096
     dtype: fp16
-    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w1x4/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 750.6
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
+    emmy_us: 603.1
     cublas_us: 822.3
   - kernel: matmul
     name: matmul.square.512.dynM
@@ -134,9 +150,10 @@ configs:
     N: 12288
     K: 4096
     dtype: fp16
-    # 2026-07-12 manual sweep: REDUCE stamped '' (fill-free). emmy_us kept — live wobbled 361-387.
+    # 2026-07-12 manual sweep: REDUCE stamped '' (fill-free). Post-swizzle refresh (PR #351):
+    # 374.1 -> 343.7 (4 passes 343.0-353.6).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 374.1
+    emmy_us: 343.7
     cublas_us: 328.0
   # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): 336.8 µs total (324.2 + 12.6 finalize;
   # 3x at <0.5% spread) vs the standard's live ~374 (0.90x), parity with cuBLAS HGEMM. 2026-07-12.
@@ -149,8 +166,10 @@ configs:
     N: 12288
     K: 4096
     dtype: fp16
+    # Post-swizzle refresh (2026-07-12, PR #351): 323.5 -> 267.7 total (255.2 + 12.5 finalize, 3x
+    # at <0.3% spread), 0.82x vs cuBLAS — beats cuBLAS.
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: 'gm8', STAGE: 'd2/cp/ring'}
-    emmy_us: 323.5
+    emmy_us: 267.7
     cublas_us: 328.0
   - kernel: matmul
     name: matmul.qkv.h4096
@@ -158,8 +177,9 @@ configs:
     N: 12288
     K: 4096
     dtype: fp16
+    # Post-swizzle refresh (2026-07-12, PR #351): 380.3 -> 362.0 total (3 tight passes).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 380.3
+    emmy_us: 362.0
     cublas_us: 328.0
   - kernel: matmul
     name: matmul.o_proj.h4096
@@ -176,9 +196,24 @@ configs:
     N: 4096
     K: 4096
     dtype: fp16
-    # 2026-07-12 manual sweep: REDUCE stamped '' (replayed fill-free at 117.4, 2x).
+    # 2026-07-12 manual sweep: REDUCE stamped '' (replayed fill-free at 117.4, 2x). Post-swizzle
+    # refresh (same day, PR #351): 121.6 -> 108.7 (4 passes 108.5-108.8).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2'}
-    emmy_us: 121.6
+    emmy_us: 108.7
+    cublas_us: 119.0
+  # Fast-math sibling (FAST_MATH lane), first fm entry for this shape — pre-swizzle the fm atom was
+  # parity here and went unrecorded; the bank-conflict fix (2026-07-12 post-swizzle manual refresh,
+  # PR #351) makes the wide-N f4x8 tile win outright: 88.4 total (83.6 + 4.8 finalize; 3x at <0.2%
+  # spread) vs the standard's live 108.7 (0.81x), 0.74x vs cuBLAS HGEMM — beats cuBLAS. Accuracy vs
+  # torch passes.
+  - kernel: matmul
+    name: matmul.o_proj.h4096
+    M: 512
+    N: 4096
+    K: 4096
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
+    emmy_us: 88.4
     cublas_us: 119.0
   - kernel: matmul
     name: matmul.mlp_gate_up.h4096
@@ -186,13 +221,15 @@ configs:
     N: 28672
     K: 4096
     dtype: fp16
-    # 2026-07-12 manual sweep: REDUCE stamped '' (fill-free). emmy_us kept — live wobbled 902-980.
+    # 2026-07-12 manual sweep: REDUCE stamped '' (fill-free); pre-swizzle live wobbled 902-980.
+    # Post-swizzle refresh (same day, PR #351): 964.6 -> 919.5 (5 tight passes 917.5-919.6).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 964.6
+    emmy_us: 919.5
     cublas_us: 721.0
   # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): the atom-swap of the standard golden —
-  # the f16 accumulator's 2x HMMA rate on this mma-bound wide-N shape. 786.9 µs (4x, 750-788) vs
-  # the standard's live ~940 (0.84x), 1.08x vs cuBLAS. Accuracy vs torch passes. 2026-07-12.
+  # the f16 accumulator's 2x HMMA rate on this mma-bound wide-N shape. Accuracy vs torch passes.
+  # 2026-07-12. Post-swizzle refresh (same day, PR #351): 786.9 -> 664.6 (7 passes 662.0-667.6),
+  # 0.92x vs cuBLAS HGEMM — beats cuBLAS.
   - kernel: matmul
     name: matmul.mlp_gate_up.h4096
     M: 512
@@ -200,7 +237,19 @@ configs:
     K: 4096
     dtype: fp16
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 786.9
+    emmy_us: 664.6
+    cublas_us: 721.0
+  # Fast-math parity sibling: same tile through the /p2 smem->register double-buffer — 648.2 (3x,
+  # 647.7-649.2), 2.5% under the plain-ring fm twin (inside the 3% gate, kept as a parity entry).
+  # 2026-07-12 post-swizzle manual refresh.
+  - kernel: matmul
+    name: matmul.mlp_gate_up.h4096
+    M: 512
+    N: 28672
+    K: 4096
+    dtype: fp16
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2'}
+    emmy_us: 648.2
     cublas_us: 721.0
   - kernel: matmul
     name: matmul.mlp_down.h4096
@@ -213,9 +262,9 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x8', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
     emmy_us: 371.0
     cublas_us: 388.0
-  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): 348.5 µs total (343.7 + 4.8 finalize;
-  # 3x at <0.3% spread) vs the standard's live 371 (0.94x), 0.90x vs cuBLAS HGEMM — beats cuBLAS on
-  # the deep-K (14336) shape. Accuracy vs torch passes. 2026-07-12 manual sweep.
+  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): beats cuBLAS on the deep-K (14336)
+  # shape. Accuracy vs torch passes. 2026-07-12 manual sweep. Post-swizzle refresh (same day,
+  # PR #351): 348.5 -> 274.0 total (269.1 + 4.9 finalize, 3x), 0.71x vs cuBLAS HGEMM.
   - kernel: matmul
     name: matmul.mlp_down.h4096
     M: 512
@@ -223,7 +272,7 @@ configs:
     K: 14336
     dtype: fp16
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 348.5
+    emmy_us: 274.0
     cublas_us: 388.0
   - kernel: matmul
     name: matmul.qkv.h4096.dynM
@@ -232,13 +281,14 @@ configs:
     K: 4096
     dtype: fp16
     dynamic: true
-    # 2026-07-12 manual sweep: REDUCE stamped '' (fill-free).
+    # 2026-07-12 manual sweep: REDUCE stamped '' (fill-free). Post-swizzle refresh (same day,
+    # PR #351): 370.0 -> 343.0 (3 passes 342.7-351.6).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 370.0
+    emmy_us: 343.0
     cublas_us: 330.0
-  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): mirrors the static twin. 332.0 µs
-  # total (319.5 + 12.5 finalize) vs the standard's live 385.4 (0.86x), ~parity vs cuBLAS.
-  # 2026-07-12 manual sweep.
+  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): mirrors the static twin.
+  # 2026-07-12 manual sweep. Post-swizzle refresh (same day, PR #351): 332.0 -> 298.9 total
+  # (286.4 + 12.5 finalize, 3 passes), 0.91x vs cuBLAS — beats cuBLAS.
   - kernel: matmul
     name: matmul.qkv.h4096.dynM
     M: 512
@@ -247,7 +297,7 @@ configs:
     dtype: fp16
     dynamic: true
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 332.0
+    emmy_us: 298.9
     cublas_us: 330.0
   - kernel: matmul
     name: matmul.o_proj.h4096.dynM
@@ -256,8 +306,23 @@ configs:
     K: 4096
     dtype: fp16
     dynamic: true
+    # Post-swizzle refresh (2026-07-12, PR #351): 123.3 -> 119.5 (4 tight passes 119.0-119.5).
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x8', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 123.3
+    emmy_us: 119.5
+    cublas_us: 112.0
+  # Fast-math sibling (FAST_MATH lane), first fm entry for this shape — the static twin's
+  # post-swizzle winner transfers with no masked-tile penalty: 89.3 total (84.5 + 4.8 finalize; 3x)
+  # vs the standard's live 119.5 (0.75x), 0.80x vs cuBLAS — beats cuBLAS. 2026-07-12 post-swizzle
+  # manual refresh (PR #351). Accuracy vs torch passes.
+  - kernel: matmul
+    name: matmul.o_proj.h4096.dynM
+    M: 512
+    N: 4096
+    K: 4096
+    dtype: fp16
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
+    emmy_us: 89.3
     cublas_us: 112.0
   - kernel: matmul
     name: matmul.mlp_gate_up.h4096.dynM
@@ -270,8 +335,9 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
     emmy_us: 923.6
     cublas_us: 742.0
-  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): mirrors the static twin. 802.8 µs
-  # (3x, 800.8-802.8) vs the standard's live ~955 (0.84x), 1.08x vs cuBLAS. 2026-07-12.
+  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): mirrors the static twin. 2026-07-12.
+  # Post-swizzle refresh (same day, PR #351): 802.8 -> 665.6 (3 passes 665.5-668.7), 0.90x vs
+  # cuBLAS — beats cuBLAS; no masked-tile penalty (static twin 664.6).
   - kernel: matmul
     name: matmul.mlp_gate_up.h4096.dynM
     M: 512
@@ -280,7 +346,7 @@ configs:
     dtype: fp16
     dynamic: true
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 802.8
+    emmy_us: 665.6
     cublas_us: 742.0
   - kernel: matmul
     name: matmul.mlp_down.h4096.dynM
@@ -289,14 +355,16 @@ configs:
     K: 14336
     dtype: fp16
     dynamic: true
-    # 2026-07-12 manual sweep: emmy_us refreshed 412.9 -> 387.3 (live 382.5 + 4.8 finalize — the
-    # recorded value was 6.2% pessimistic).
+    # 2026-07-12 manual sweep: emmy_us refreshed 412.9 -> 387.3. Post-swizzle refresh (same day,
+    # PR #351): 387.3 -> 425.2 (3 consistent passes 424.6-425.2) — the ONE entry that replays
+    # SLOWER post-swizzle; this value has wobbled 387-425 across sessions and the shape's fm twin
+    # dominates it regardless. Flagged in the refresh findings.
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x4/f4x4', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 387.3
+    emmy_us: 425.2
     cublas_us: 388.0
-  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): mirrors the static twin. 332.8 µs
-  # total (328.0 + 4.8 finalize) vs the standard's live 387.3 (0.86x), 0.86x vs cuBLAS HGEMM —
-  # beats cuBLAS. 2026-07-12 manual sweep.
+  # Fast-math sibling (f16-accumulate atom, FAST_MATH lane): mirrors the static twin. 2026-07-12
+  # manual sweep. Post-swizzle refresh (same day, PR #351): 332.8 -> 275.5 total (270.6 + 4.8
+  # finalize, 3 passes), 0.71x vs cuBLAS HGEMM — beats cuBLAS.
   - kernel: matmul
     name: matmul.mlp_down.h4096.dynM
     M: 512
@@ -305,7 +373,7 @@ configs:
     dtype: fp16
     dynamic: true
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring'}
-    emmy_us: 332.8
+    emmy_us: 275.5
     cublas_us: 388.0
   - kernel: pointwise
     name: pointwise.n4096

--- a/plans/cpasync-slab-swizzle-findings.md
+++ b/plans/cpasync-slab-swizzle-findings.md
@@ -60,8 +60,10 @@ the pre-existing staged-vs-gmem bit-identity suite, which now exercises swizzled
 | square.4096.fp16 [fm] | 750.6 | **631.3** | **−16%** | **0.78** (eager ~808) — was 0.93 |
 
 Accuracy checks pass (silent-success `emmy run`). **Every cp-transport matmul golden's recorded `emmy_us` is now
-stale-high across the sm_89 cards** — a golden refresh sweep (tune-golden flow, 4090 + 4080) is the follow-up, and
-greedy-vs-golden gaps will look larger until then since live replays already run swizzled.
+stale-high across the sm_89 cards.** The 4090 file was refreshed the same day by a manual sweep — 15 value
+refreshes, 2 fm replaces, 4 fm adds, fm lane past cuBLAS on 9 of 11 fp16 shapes; see
+`golden-postswizzle-refresh-rtx4090-findings.md`. The 4080 file (and any other cp-transport cards) still needs the
+same refresh, and the tune DB / learned prior have no post-swizzle measurements at all.
 
 ## Implementation sketch (as scoped before landing)
 

--- a/plans/cpasync-slab-swizzle-findings.md
+++ b/plans/cpasync-slab-swizzle-findings.md
@@ -49,6 +49,20 @@ with the paired lane map — verified in the emitted sm_89 kernel: paired `x4.tr
 Covered by `test_cp_staged_slab_is_swizzled` (mode pinned ON, fill+drain XOR presence, CPU render at sm_89) and
 the pre-existing staged-vs-gmem bit-identity suite, which now exercises swizzled cp kernels on GPU.
 
+**End-to-end verification (golden replays through the real pipeline, same 4090, `emmy run --bench --golden`):**
+
+| golden (rtx4090) | recorded µs | live w/ swizzle | delta | vs cuBLAS |
+| --- | --- | --- | --- | --- |
+| mlp_gate_up.h4096 [fm] | 786.9 | **662.0–664.6** (3×) | **−16%** | **0.92** (721.0) — was 1.08 |
+| mlp_gate_up.h4096 std | 964.6 (live ~940) | 918.4–919.5 | −2–5% | — |
+| mlp_down.h4096 [fm] | 348.5 | **273.6** (268.8 + 4.8 finalize) | **−21%** | **0.92** (297) — was 0.90 vs live-940-era std |
+| mlp_down.h4096 std | 371 | 372.9 | parity | — |
+| square.4096.fp16 [fm] | 750.6 | **631.3** | **−16%** | **0.78** (eager ~808) — was 0.93 |
+
+Accuracy checks pass (silent-success `emmy run`). **Every cp-transport matmul golden's recorded `emmy_us` is now
+stale-high across the sm_89 cards** — a golden refresh sweep (tune-golden flow, 4090 + 4080) is the follow-up, and
+greedy-vs-golden gaps will look larger until then since live replays already run swizzled.
+
 ## Implementation sketch (as scoped before landing)
 
 - The drain side already has the machinery: `LdmatrixLoad` carries a `swizzle` field and the pair-fusion

--- a/plans/cpasync-slab-swizzle-findings.md
+++ b/plans/cpasync-slab-swizzle-findings.md
@@ -37,7 +37,19 @@ throughput" that motivated RASTER was the **shared-memory pipe**, not DRAM — w
 traffic moved nothing. At ~695 µs emmy passes cuBLAS on gate_up (~728 µs from the recorded 1.08× ratio):
 the "structural" sm_89 residual was bank conflicts.
 
-## Implementation sketch (not started)
+## Implementation — LANDED (same branch, same day)
+
+Exactly the sketch below: `_MmaOps.slab_swizzles` now feeds BOTH transports (the `transport == "tma"` gate at
+`_atom._staged` is gone), `cp_async_fill` threads the mode onto `CpAsyncCopy.swizzle`, and the render XORs the
+fill's flattened destination index through the same `emmy_swizzle_<mode>` helper the ldmatrix drain uses — fill
+and drain agree by construction, purely address-based, zero smem growth. The scalar tier (plain-`Load` drains)
+and the sync compute-fill stay NONE; the flash K/V slabs keep their `pad_cols` fix (pad and swizzle are asserted
+mutually exclusive). `096_pair_ldmatrix_loads` pairs swizzled loads as before (equal-mode check; the XOR commutes
+with the paired lane map — verified in the emitted sm_89 kernel: paired `x4.trans` drains read through the XOR).
+Covered by `test_cp_staged_slab_is_swizzled` (mode pinned ON, fill+drain XOR presence, CPU render at sm_89) and
+the pre-existing staged-vs-gmem bit-identity suite, which now exercises swizzled cp kernels on GPU.
+
+## Implementation sketch (as scoped before landing)
 
 - The drain side already has the machinery: `LdmatrixLoad` carries a `swizzle` field and the pair-fusion
   pass (`096_pair_ldmatrix_loads`) is swizzle-aware ("the swizzle XOR is per-lane address-based, so it

--- a/plans/cpasync-slab-swizzle-findings.md
+++ b/plans/cpasync-slab-swizzle-findings.md
@@ -1,0 +1,62 @@
+# cp.async slab XOR-swizzle — prototype win on the sm_89 gap (−12–17%, past cuBLAS on gate_up)
+
+> Prototype measured 2026-07-12 (rented 4090, 176.124.69.204), same session as the WSPEC refutation.
+> **Gate passed decisively — this is the implementation candidate for the sm_89 residual.** Harness:
+> `_tune/codegen/swizzle-proto.py` on the box (pattern-rewrites the dumped fm gate_up kernel; A-only /
+> B-only / both variants for attribution).
+
+## The finding
+
+The cp.async transport stages its slabs **plain row-major with no swizzle** — `_atom.py` says so explicitly
+("a cp.async slab is plain row-major (NONE-swizzle), a TMA slab is hardware-swizzled in-copy with the drain
+XOR undoing it"), and `slab_swizzles`' own docstring records what that costs on the TMA path ("the rebuilt
+NONE-swizzle transport left the ldmatrix drain bank-conflict-bound"). On sm_89 there is no TMA, so every
+warp-tier matmul eats it: in the gate_up fm winner the A slab's 64B row stride makes each ldmatrix phase
+4-way bank-conflicted and the B slab's 128B stride (a full 32-bank period) makes it **8-way** — the B
+pair-loads are the bulk of the drain. No sweep could ever find this: staging layout is not a search
+dimension on the cp transport.
+
+Fix prototyped: XOR the 16B-unit column with row bits — A: `c ^= (row/2) & 3`, B: `c ^= row & 7` — applied
+identically to the cp.async fill destinations and the ldmatrix drain addresses (contents per logical element
+unchanged, so outputs are **bit-identical**; fills stay conflict-free since the XOR permutes units within a
+row). cp.async 16B alignment holds; zero smem growth; +0–4 registers, no spills.
+
+## Measurements (gate_up fm winner, 512×4096 @ 4096×28672, 6 interleaved rounds)
+
+| variant | regs | µs (rounds) | vs baseline |
+| --- | --- | --- | --- |
+| fm baseline (NONE-swizzle) | 250 | 796–844 | — |
+| A swizzled only | 251 | 758–762 | −5–10% |
+| B swizzled only | 254 | 715–752 | −9–15% |
+| **both** | 254 | **693–700** | **−12–17%** |
+
+NCU (same kernel, launch-matched): shared-mem bank conflicts **146.8M → 14K** (~zero), shared wavefronts
+180.6M → 33.8M (**5.3× fewer** — conflicts were 81% of all shared traffic), issue-active 23.6% → 32.1%,
+eligible warps 0.26 → 0.38. This also re-reads the earlier NCU record correctly: the 72.7% "Memory
+throughput" that motivated RASTER was the **shared-memory pipe**, not DRAM — which is why halving DRAM
+traffic moved nothing. At ~695 µs emmy passes cuBLAS on gate_up (~728 µs from the recorded 1.08× ratio):
+the "structural" sm_89 residual was bank conflicts.
+
+## Implementation sketch (not started)
+
+- The drain side already has the machinery: `LdmatrixLoad` carries a `swizzle` field and the pair-fusion
+  pass (`096_pair_ldmatrix_loads`) is swizzle-aware ("the swizzle XOR is per-lane address-based, so it
+  commutes with the paired lane map"). Today `_atom.py` only sets non-NONE modes when
+  `stage.transport == "tma"` (hardware in-copy swizzle); the change is to pick software swizzle modes for
+  cp transports (`pick_swizzle_atom` on the slab row stride, as the TMA path does) and emit the **matching
+  XOR in the cp.async fill destination index** — the one genuinely new piece, since TMA swizzles in-copy
+  and cp.async must swizzle in the store address.
+- Not a schedule knob: it is a pure staging-layout property, unconditionally better (conflicts only go
+  down; the XOR costs ~1 LOP per fill address and is thread-constant in the drains). No search-space
+  change, no golden-schema change.
+- Applies to every cp.async-staged kernel: both lanes (std gate_up should gain too — same layout), all
+  sm_89 cards (4090/4080), and any cp-staged shapes on sm_120. Expect golden re-benches to move; the
+  recorded `emmy_us` values for cp-transport matmul entries go stale wholesale once this lands.
+- Validation: bit-identical outputs per shape (same accumulation order), the usual coverage tests plus a
+  bank-conflict NCU spot-check; A/B per golden shape as with RASTER.
+
+## Prototype-gated status of the sm_89 lever list (for the record)
+
+RASTER (neutral), address-CSE (refuted), WSPEC-over-cp.async (refuted, SMSP banking), forced occupancy
+(refuted) — and now slab swizzle: **the first measured win of the series**, found by reading the emitted
+addressing against the bank layout rather than permuting schedule knobs.

--- a/plans/golden-manual-sweep-rtx5090-findings.md
+++ b/plans/golden-manual-sweep-rtx5090-findings.md
@@ -198,9 +198,11 @@ then refuted by prototype**: hand-hoisting the K-loop fill addressing (pointer-s
 on the real gate_up fm kernel freed 3 registers and ran **3.3% SLOWER** (797.1 → 823.0 µs, outputs
 bit-identical) — ptxas already CSEs optimally, and the hoist's loop-carried pointer chain destroys the fill
 burst's ILP. Not implemented. The residual ~8% to cuBLAS on sm_89 is structural to the tile architecture at
-2 CTAs/SM; the one credible remaining lever is **extending WSPEC to the cp.async transport** (a producer
+2 CTAs/SM; the one credible remaining lever was **extending WSPEC to the cp.async transport** (a producer
 warp band owning fills would cut consumer-warp register pressure and add latency-hiding warps — today WSPEC
-is TMA-only by design), a substantial schedule/realizer work item, not a peephole.
+is TMA-only by design). **Also prototyped and REFUTED (same box, next day)** — the sm_89 SMSP register
+banking makes a 9th resident warp cap the kernel at 168 regs, and at iso-warp-count the split is
+perf-neutral; see `wspec-cpasync-producer-band.md` for the measured refutation.
 
 ## Workflow notes
 

--- a/plans/golden-manual-sweep-rtx5090-findings.md
+++ b/plans/golden-manual-sweep-rtx5090-findings.md
@@ -202,7 +202,10 @@ burst's ILP. Not implemented. The residual ~8% to cuBLAS on sm_89 is structural 
 warp band owning fills would cut consumer-warp register pressure and add latency-hiding warps — today WSPEC
 is TMA-only by design). **Also prototyped and REFUTED (same box, next day)** — the sm_89 SMSP register
 banking makes a 9th resident warp cap the kernel at 168 regs, and at iso-warp-count the split is
-perf-neutral; see `wspec-cpasync-producer-band.md` for the measured refutation.
+perf-neutral; see `wspec-cpasync-producer-band.md` for the measured refutation. The gap then fell to a
+different lever entirely: the unswizzled cp.async slabs leave the ldmatrix drains 4–8-way bank-conflicted
+(81% of shared wavefronts were conflict replays), and the XOR-swizzle prototype wins −12–17%, past cuBLAS
+on gate_up — see `cpasync-slab-swizzle-findings.md`.
 
 ## Workflow notes
 

--- a/plans/golden-postswizzle-refresh-rtx4090-findings.md
+++ b/plans/golden-postswizzle-refresh-rtx4090-findings.md
@@ -1,0 +1,80 @@
+# Post-swizzle manual golden refresh — RTX 4090 (rented 176.124.69.204), 2026-07-12
+
+**Method: manual by explicit direction — NO tuner, NO prior** (the prior is trained on pre-swizzle
+measurements and its known deploy-evidence holes would steer the exploration; every variant was a pinned
+`--ab` row benched live against the golden + eager rows in the same run). Three waves off the box's
+`_tune/manual-refresh-4090/` logs: wave 0 replayed all 17 matmul goldens (27 entries) on the swizzle branch
+(PR #351), wave 1 ran ~45 pinned exploration variants around the fp16 incumbents (k4 chunks, warp splits,
+`/p2` reg double-buffer, d1/d3 depth, fm atom where it had been parity), wave 2 confirmed every candidate
+2–3× plus dynM transfer probes. ~2 h wall. All new configs accuracy-checked (`EMMY_KNOBS`-pinned `run`);
+post-stamp the whole file replays true.
+
+**Tally: 15 `emmy_us` refreshes / 2 fm replaces / 4 fm adds / 0 std-lane config changes / fp32 squares
+untouched** (scalar tier — `Load` drains, unswizzled by design — replayed within ±3%, confirming the
+swizzle changed nothing there).
+
+## Headline — the swizzle moved the fm optima to wide-N `f4x8` tiles; five more shapes now beat cuBLAS
+
+The conflict-bound smem pipe had been taxing exactly the tiles with the widest B drains, so several
+pre-swizzle "losers" flipped to winners — a region no prior trained on old data would revisit, which is why
+this refresh had to be manual:
+
+| shape | change | new best µs (total) | was | vs cuBLAS |
+| --- | --- | --- | --- | --- |
+| o_proj.h4096 | **fm ADD** `f16_f16/w2x2/f4x8/k2 g2k` (fm was parity pre-swizzle, unrecorded) | **88.4** | 108.7 (std/p2) | **0.74** |
+| o_proj.h4096.dynM | **fm ADD** (static winner transfers, no masked penalty) | **89.3** | 119.5 (std) | **0.80** |
+| square.2048.fp16 | **fm REPLACE** `w1x4/f4x4` → `w2x2/f4x8/k2` (old entry 29% slower, pruned) | **82.7** | 106.7 | **0.72** |
+| square.4096.fp16 | **fm REPLACE** `w1x4/f4x8/k2` → `w2x2/f4x8/k2` (old 5.5% slower, pruned) | **603.1** | 639 | **0.73** |
+| mlp_gate_up.h4096 | fm parity ADD: incumbent tile + `/p2` (−2.5%, inside the 3% gate) | 648.2 | 664.6 | 0.90 |
+| square.512.fp16 | fm parity ADD: atom-swap of the `/p2` std golden (mirrors the 5090 file) | 4.8 | 4.9 | 0.83 |
+
+With the pure `emmy_us` refreshes (gate_up fm 786.9→664.6, mlp_down fm 348.5→274.0 at 0.71×, qkv fm
+323.5→267.7 at 0.82×, sq1024 fm 19.9→15.8, dynM twins in line), **the fm lane now beats cuBLAS HGEMM on 9
+of the 11 fp16 matmul shapes** (parity on sq512/sq1024-class smalls); the std lane improved 2–11% where the
+drain was conflict-bound (o_proj/p2 121.6→108.7 the largest) and its incumbent configs all still stand.
+
+## Finding 1 — every incumbent config survived; the swizzle only re-priced, never invalidated, the std lane
+
+No std-lane exploration row beat its incumbent beyond noise (k4/d1/d3 still lose everywhere — d1 766 vs 648
+on gate_up fm, d3 755–966, k4 678–784: depth/chunk tradeoffs are occupancy-bound, not smem-bound, so the
+swizzle didn't move them). The fm lane's flips are all one mechanism: `f4x8` B tiles read 128 B slab rows,
+which were 8-way conflicted and are now clean.
+
+## Finding 2 — `/p2` (smem→register double-buffer) is newly live on the biggest tiles
+
+Pre-swizzle `/p2` was noise-to-negative on the fm winners; post-swizzle it's a consistent −2.5% on gate_up
+(3×, 647.7–649.2 vs 664–668) and the o_proj std `/p2` entry gained 11%. With conflict replays gone, the
+ldmatrix latency the double-buffer hides is now the visible term. Recorded as a parity-add on gate_up only
+(inside the 3% gate); worth re-probing on other cards' cp shapes in their refreshes.
+
+## Finding 3 — the one regression-shaped drift: `mlp_down.h4096.dynM` std (w2x4/f4x4)
+
+Replays 424.6–425.2 (3 consistent passes) vs its recorded 387.3 — +10%, the only entry slower post-swizzle.
+Its history already wobbled 387–425 across sessions (the 07-12 sweep refreshed it 412.9→387.3 the other
+way), and its `f4x4` geometry makes a large conflict win impossible while the fill-side XOR adds a few
+instructions — a small real regression on this specific tile is plausible but not separable from the
+wobble. `emmy_us` refreshed to 425.2 (honest current value); the shape's fm twin (275.5) dominates it by
+35%, so nothing deploys through it. If a future sweep needs this lane, re-derive the std config rather than
+trusting either historical number.
+
+## Fork sibling regret
+
+Not run — this refresh deliberately used no tuner (`emmy tune` retrains the prior on -O1 rankings; the
+user's direction was manual precisely because the prior is suspected broken, and the -O1 censoring issue
+from the 07-12 5090 report still stands). The prior/node-store is now doubly stale: it has NO post-swizzle
+measurements, and the fm optima moved. A future `--clean` golden tune (with the family-aware -O3 rebench
+floor, still open) should re-seed it; until then the goldens are the only trustworthy source for these
+shapes.
+
+## Workflow notes
+
+- Three nohup'd wave scripts + log scraping worked well (~2 h wall, zero babysitting); the `--ab` harness
+  again caught everything (no declined pins this time — all 45 variants realized their knobs).
+- The split-K finalize row still requires hand-summing totals per config — the `golden NAME (total)` row
+  proposal from the 5090 report stands and would have saved the most error-prone step of this analysis.
+- Refresh criterion used: ≥3 passes, spread <2%, drift >3% (the older "≥5%" rule alone would have kept
+  stale values on tight 4–5% drifts like gate_up std 964.6→919.5 across 5 passes at <0.3% spread).
+- `--ab` rows are bench-only; accuracy needed a second `EMMY_KNOBS`-pinned `run` per new config. A
+  `--check-accuracy` flag on `--ab` rows (or an accuracy column) would fold those 6 extra invocations away.
+- Replay wobble was small this time (most entries <1% across passes); the noisy ones remain sq2048 std
+  (115–127) and gate_up.dynM std (856–922), both left unrefreshed where inconsistent.

--- a/plans/wspec-cpasync-producer-band.md
+++ b/plans/wspec-cpasync-producer-band.md
@@ -121,4 +121,9 @@ consumers is roughly perf-neutral, so the 76%-no-eligible latency starvation is 
 it is the warp count itself, which this family cannot raise. Producer-band warp specialization on sm_89
 could only pay inside tile families that already fit ≥3 warps/SMSP (≤168 regs), and the manual sweeps
 showed those geometries lose the fm winners' margin outright. WSPEC stays TMA-only (sm_90+, where
-`setmaxnreg` also exists); the sm_89 residual ~8% to cuBLAS stands as structural at this tile size.
+`setmaxnreg` also exists).
+
+(Same-session postscript: the residual itself turned out NOT to be structural — it was ldmatrix bank
+conflicts from the unswizzled cp.async staging, prototyped at −12–17% and past cuBLAS; see
+`cpasync-slab-swizzle-findings.md`. The latency starvation these splits tried to fix was largely
+conflict-replay latency in the shared pipe.)

--- a/plans/wspec-cpasync-producer-band.md
+++ b/plans/wspec-cpasync-producer-band.md
@@ -1,8 +1,9 @@
-# WSPEC over cp.async — producer fill band for the latency-starved sm_89 warp kernels (scoping)
+# WSPEC over cp.async — producer fill band for the latency-starved sm_89 warp kernels (REFUTED)
 
-> Scoping doc for the one remaining credible lever on the sm_89 residual gap to cuBLAS (~8% on the fm
-> winners), after two measured dead ends. Status: **not started; gated on a prototype** (see the phasing —
-> this family of hypotheses has a 0-for-2 record this week and earns no implementation before a measured win).
+> Status: **REFUTED by the phase-1 hand prototype (2026-07-12, rented 4090, 176.124.69.204) — do not
+> implement.** Six variants measured, all bit-identical to the baseline, best split −29% vs baseline; the
+> full result and the two hardware mechanisms the scoping math missed are in "Prototype result" at the
+> bottom. Phases 2–3 are dead. The scoping content below is kept as written for the record.
 
 ## Why (the evidence chain that leads here)
 
@@ -81,3 +82,43 @@ range: 0–8% (the full residual). It also composes with `RASTER` and the fm ato
    already opt-in via search/pins); coverage tests mirroring the TMA WSPEC ones.
 3. Manual `--ab` A/Bs on the 4090 golden set (`WSPEC=p1/p2` over the fm winners); record `[fm]`+WSPEC golden
    entries where they win; findings update.
+
+## Prototype result (2026-07-12, rented 4090 176.124.69.204) — REFUTED, gate failed decisively
+
+Hand prototype built exactly as phased: the dumped gate_up fm winner (`k_matmul_a8ecf3`, `w4x1/f4x8/k2
+d2/cp/ring`, 512×4096 @ 4096×28672) split into consumer warps + a producer band owning all `LDGSTS` fills,
+handed off through per-slot mbarriers (`cp.async.mbarrier.arrive.noinc` producer-side, spin on
+`mbarrier.test_wait.parity` consumer-side — no `try_wait` on sm_89 — consumers release each slot *before*
+their register-only promotes, no `__syncthreads` in the K loop). Harness + kernels on the box under
+`_tune/codegen/` (`wspec-proto.py`, `wspec_p1.cu`, `wspec_merged.cu`); every variant's output is
+**bit-identical** to the baseline (same per-accumulator op order), so the handoff machinery itself is sound
+and reusable. Three interleaved rounds each:
+
+| variant | warps/SM | ptxas regs (spill B) | µs (3 rounds) | vs fm |
+| --- | --- | --- | --- | --- |
+| fm baseline, 2 CTA/SM | 8 | 250 (0) | 796 / 802 / 830 | — |
+| fm forced 1 CTA/SM (41KB smem pad — iso-warp control) | 4 | 250 (0) | 1122 / 1070 / 1108 | +35% |
+| p1: 128 consumers + 32 producers | 5 | 238 (0) | 1171 / 1160 / 1190 | +45% |
+| p2: 128 + 64 | 6 | 238 (0) | 1034 / 1043 / 1060 | +29% |
+| p1 forced 2 CTA/SM (`__launch_bounds__(160,2)`) | 10 | 168 (452) | 2209–2212 | 2.7× |
+| merged super-CTA: 2 N-tiles sharing the A slab + 1 producer warp, 288 thr | 9 | 168 (436) | 1773–1831 | 2.2× |
+
+Two hardware facts kill the idea on sm_89, both missed by the scoping math above:
+
+1. **Registers are allocated uniformly per kernel** — there is no `setmaxnreg` before sm_90, so "32
+   producers × ~40 regs" does not exist: every producer warp costs the full kernel regcount. The scoping
+   doc's 30080-regs-still-2-CTAs arithmetic was unrealizable from the start.
+2. **The 64K regfile is banked 16K per SM sub-partition.** At 250 regs the baseline sits at exactly 2
+   warps/SMSP (16000/16384) — 8 warps/SM is a *hardware ceiling* for this tile family, and any 9th resident
+   warp puts 3 warps on one SMSP, capping the whole kernel at 16384/3/32 → **168 regs**. ptxas confirms:
+   both the 9-warp merged CTA and the 10-warp lb2 target compile to exactly 168 regs and spill ~60
+   accumulator registers (436–452 B) → the 2.2–2.7× rows. The merged shape was tried twice (A fragments
+   cached, then streamed per M-row to shave 12 regs) — ptxas lands on the same 168-reg plateau either way.
+
+And the iso-warp-count control shows there was no latent win to unlock anyway: at 4 compute warps/SM,
+self-filling (1100) vs producer-split (p1 1173, p2 1046) is **±6%** — decoupling fill issue from the
+consumers is roughly perf-neutral, so the 76%-no-eligible latency starvation is *not* fill-issue coupling;
+it is the warp count itself, which this family cannot raise. Producer-band warp specialization on sm_89
+could only pay inside tile families that already fit ≥3 warps/SMSP (≤168 regs), and the manual sweeps
+showed those geometries lose the fm winners' margin outright. WSPEC stays TMA-only (sm_90+, where
+`setmaxnreg` also exists); the sm_89 residual ~8% to cuBLAS stands as structural at this tile size.

--- a/tests/compiler/e2e/test_matmul_coverage.py
+++ b/tests/compiler/e2e/test_matmul_coverage.py
@@ -1284,6 +1284,30 @@ def test_tma_staged_slab_is_swizzled(monkeypatch):
     assert "int emmy_swizzle_b64(int e)" in op.kernel_source, "the swizzle helper must be emitted in the preamble"
 
 
+def test_cp_staged_slab_is_swizzled(monkeypatch):
+    """A cp.async-staged mma kernel swizzles its operand slabs in SOFTWARE (CPU render, forced
+    sm_89): the same modes the TMA path derives (``_WARP_CODEC``: A's 32-elem fp16 K chunk and
+    B's 32-elem tile_n rows are both 64 B → B64) are applied as an address XOR on each
+    ``cp.async`` fill DESTINATION and undone by the same XOR in the ldmatrix drain — fill and
+    drain agree by construction, so the staged-vs-gmem bit-identity tests above pin the
+    numerics; this pins the mode ON. The unswizzled cp slab left the drain 4-way (64 B rows) /
+    8-way (128 B rows) bank-conflicted — the measured sm_89 residual to cuBLAS (conflict
+    replays were 81% of the gate_up fm golden's shared-mem wavefronts; the XOR won −12–17%)."""
+    monkeypatch.setenv("EMMY_TILE", _WARP_CODEC)
+    monkeypatch.setenv("EMMY_STAGE", "d2/cp")
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    lowered = Pipeline.build(CUDA_PASSES).run(_parity_mma_graph("static", M=256), ctx=Context(compute_capability=(8, 9)))
+    op = lowered.nodes["o"].op
+    src = op.kernel_source
+    assert not op.tma_descriptors, "sm_89 has no TMA — the fills must be cp.async"
+    assert "int emmy_swizzle_b64(int e)" in src, "the swizzle helper must be emitted in the preamble"
+    # Producer side: every cp.async fill writes through the XOR'd destination index...
+    assert "emmy_cp_async_cg(&_a_smem[emmy_swizzle_b64(" in src, "the A slab fill must XOR its smem destination"
+    assert "emmy_cp_async_cg(&_b_smem[emmy_swizzle_b64(" in src, "the B slab fill must XOR its smem destination"
+    # ...and the drain reads back through the identical XOR (fill/drain symmetry).
+    assert "emmy_ldmatrix" in src and src.count("emmy_swizzle_b64(") >= 4, "the ldmatrix drains must apply the matching XOR"
+
+
 @requires_sm90
 @requires_cuda
 def test_bf16_operands_stage_via_cp_async(monkeypatch):


### PR DESCRIPTION
## Summary

One sm_89 investigation, prototype-gated end to end, in four chapters: two findings-only (a refutation and a
root-cause), one code change (the fix), and the golden refresh that records its wins.

### 1. WSPEC over cp.async — REFUTED (`plans/wspec-cpasync-producer-band.md`)

Producer/consumer split of the dumped gate_up fm winner with an mbarrier handoff: six variants, all bit-identical,
best split −29%. Mechanism: no `setmaxnreg` before sm_90, and the 64K regfile is banked 16K/SMSP — any 9th resident
warp caps the kernel at 168 regs and spills ~60 accumulator registers. Iso-warp-count control: the fill decoupling
itself is ±6%. WSPEC stays TMA-only.

### 2. The actual residual: ldmatrix bank conflicts (`plans/cpasync-slab-swizzle-findings.md`)

cp.async slabs were staged NONE-swizzle (only TMA slabs got the hardware in-copy swizzle), leaving the drains 4-way
(A, 64B rows) / 8-way (B, 128B rows) conflicted — NCU: **146.8M shared-mem conflicts → 14K** with the XOR, shared
wavefronts 5.3× fewer (conflict replays were 81% of all shared traffic). Hand prototype: −12–17%, bit-identical.
Also retro-explains the RASTER null result (the 72.7% "Memory throughput" was the shared pipe, not DRAM).

### 3. The fix — software slab swizzle on the cp transport (the code change)

One mode derivation for both transports: the `transport == "tma"` gate in `_atom._staged` is gone, `cp_async_fill`
threads the mode onto a new `CpAsyncCopy.swizzle` field, and the render XORs the fill's flattened destination index
through the same `emmy_swizzle_<mode>` helper the `LdmatrixLoad` drain applies — fill and drain agree by
construction (purely address-based), outputs bit-identical, zero smem growth, **not a search knob**. Scalar
`Load`-drained slabs and the sync compute-fill stay NONE; flash K/V slabs keep `pad_cols` (asserted mutually
exclusive); `096_pair_ldmatrix_loads` pairs swizzled loads as before. Covered by `test_cp_staged_slab_is_swizzled`
+ the staged-vs-gmem bit-identity suite (now exercising swizzled cp kernels on GPU).

### 4. RTX 4090 golden refresh — manual, no tuner/prior (`plans/golden-postswizzle-refresh-rtx4090-findings.md`)

Both are pre-swizzle-stale, so the refresh ran as 3 waves of pinned `--ab` exploration (~45 variants, 3×-confirmed,
accuracy-checked, post-stamp file replays true). The swizzle moved the fm optima to wide-N `f4x8` tiles — exactly
the region a prior trained on conflict-bound data would skip:

| shape | change | new µs | vs cuBLAS |
| --- | --- | --- | --- |
| o_proj ±dynM | **first fm entries** (`w2x2/f4x8/k2 g2k`; fm was parity pre-swizzle) | 88.4 / 89.3 | **0.74 / 0.80** |
| square.2048.fp16 | fm replace `w1x4/f4x4` → `w2x2/f4x8/k2` | 106.7 → **82.7** | **0.72** |
| square.4096.fp16 | fm replace → `w2x2/f4x8/k2` | 639 → **603.1** | **0.73** |
| gate_up / down / qkv fm | `emmy_us` refreshes | 664.6 / 274.0 / 267.7 | **0.92 / 0.71 / 0.82** |

Tally: 15 `emmy_us` refreshes / 2 fm replaces / 4 fm adds / std configs all stand / fp32 squares (scalar tier,
unswizzled) unchanged within ±3% — a clean control. **The fm lane now beats cuBLAS HGEMM on 9 of 11 fp16 matmul
shapes on the 4090.** Flagged: `mlp_down.h4096.dynM` std replays +10% (history wobbles 387–425; its fm twin
dominates by 35%). Follow-ups: same refresh for the 4080 file; the tune DB / learned prior have no post-swizzle
data at all.

## Validation

- `make test`: 2313 passed, 39 skipped (×3 runs across the chapters); `make lint`: clean
- Golden schema: `test_golden_configs.py` 23 passed; post-stamp replay of every changed entry reproduces on the box
- Prototype harnesses + wave logs on the box under `_tune/codegen/` and `_tune/manual-refresh-4090/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
