### PR TITLE
Seed gemma-4-12B goldens for RTX 4090: 23 entries via manual --ab sweep

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
@@ -1,0 +1,243 @@
+# Gemma-4-12B kernel shapes (hidden 3840, intermediate 15360, 16 Q / 8 KV heads, head_dim 256) on the
+# RTX 4090 — seeded 2026-07-13 by a manual pinned --ab sweep on a rented CloudRift box (no tuner), each
+# entry 3x reproduced at <=1% spread. cublas_us is the median live `Eager PyTorch` row (cuBLAS HGEMM for
+# the matmuls, torch SDPA for attention). Companion of rtx5090_sm120_gemma4.yaml; the gemma norm entries
+# (rms_norm.k3840(+dynM), gemma4_12b.qknorm.k256) and attention.hd256.dynM already live in
+# rtx4090_sm89.yaml and are NOT duplicated here.
+#
+# sm_89 notes: all cp.async staging (no TMA tier on this cap). The std lane's q/o_proj winner is the
+# un-split w2x2/f4x4/k2 on d2/cp/ring/p2 (the ldmatrix reg double-buffer); kv_proj and mlp_gate_up std
+# sit BELOW parity (0.86x / 0.91x — the known sm_89 latency-bound residual; nothing in the knob space
+# closes it, matching the h4096 twins). The fm lane is the post-swizzle f16acc atom-swap family
+# (w2x2/f4x8/k2, w4x1/f4x8/k2 on gate_up) — 1.02-1.35x past cuBLAS everywhere, and the attention fm
+# sibling BEATS torch SDPA (40.1 vs 41.0).
+gpu_name: NVIDIA GeForce RTX 4090
+compute_cap:
+  - 8
+  - 9
+configs:
+  # ---- attention projections -------------------------------------------------------------------------
+  - kernel: matmul
+    name: gemma4_12b.q_proj
+    M: 512
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2', WSPEC: ''}
+    emmy_us: 102.3
+    cublas_us: 104.0
+  - kernel: matmul
+    name: gemma4_12b.q_proj
+    M: 512
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 84.5
+    cublas_us: 104.0
+  - kernel: matmul
+    name: gemma4_12b.q_proj.dynM
+    M: 512
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2', WSPEC: ''}
+    emmy_us: 101.9
+    cublas_us: 103.0
+  - kernel: matmul
+    name: gemma4_12b.q_proj.dynM
+    M: 512
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 84.0
+    cublas_us: 103.0
+  # kv_proj (8 KV heads x 256 = N 2048; k/v dedup into one kernel launched twice). The std lane tops out
+  # at 0.86x (w1x4/f4x4 g2k ties, g4k/g8k/p2/f4x8 all worse) — sm_89 residual; the fm g4k entry is the
+  # deployable winner at 1.02x.
+  - kernel: matmul
+    name: gemma4_12b.kv_proj
+    M: 512
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 57.2
+    cublas_us: 49.0
+  - kernel: matmul
+    name: gemma4_12b.kv_proj
+    M: 512
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g4k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 48.0
+    cublas_us: 49.0
+  - kernel: matmul
+    name: gemma4_12b.kv_proj.dynM
+    M: 512
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 58.4
+    cublas_us: 49.0
+  - kernel: matmul
+    name: gemma4_12b.kv_proj.dynM
+    M: 512
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g4k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 47.8
+    cublas_us: 49.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj
+    M: 512
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2', WSPEC: ''}
+    emmy_us: 109.3
+    cublas_us: 115.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj
+    M: 512
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 85.8
+    cublas_us: 115.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj.dynM
+    M: 512
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring/p2', WSPEC: ''}
+    emmy_us: 108.8
+    cublas_us: 115.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj.dynM
+    M: 512
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 88.8
+    cublas_us: 115.0
+  # ---- MLP -------------------------------------------------------------------------------------------
+  # mlp_gate_up (fused gate+up, N 30720): std 0.91x — better than the h4096 twin's 0.78x but still the
+  # sm_89 gate_up gap (w4x1/f4x4/k2, w2x4/f4x4, w1x4/f4x8, w2x2 and p2 all worse). fm at 1.11x.
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up
+    M: 512
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 877.6
+    cublas_us: 801.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up
+    M: 512
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 719.9
+    cublas_us: 801.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up.dynM
+    M: 512
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 879.6
+    cublas_us: 799.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up.dynM
+    M: 512
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f4x8/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 718.8
+    cublas_us: 799.0
+  # mlp_down (deep K 15360): std at parity on the un-k'd wide tile; fm 1.34x.
+  - kernel: matmul
+    name: gemma4_12b.mlp_down
+    M: 512
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x8', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 395.3
+    cublas_us: 392.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_down
+    M: 512
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 291.7
+    cublas_us: 392.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.dynM
+    M: 512
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x8', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 395.8
+    cublas_us: 393.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.dynM
+    M: 512
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    dynamic: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x2/f4x8/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 293.0
+    cublas_us: 393.0
+  # ---- attention (flash, hd256, STATIC — the .dynM golden lives in rtx4090_sm89.yaml) ----------------
+  # Same w4x1 geometry + pin-spelling contract as the 5090 file (TILE@pj is the PV plan w4x1/f1x32; a
+  # dd-spelled pj matches nothing). On sm_89 the w2x1 form does NOT realize (flagged unreproducible —
+  # the mirror image of the 5090, where w2x1 was the greedy pick) and the nt=4 dd spelling
+  # (w4x1/f1x4/k16) realizes back to nt=2. d3 / p2 within noise; no TMA tier on this cap.
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd2/cp/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32', WSPEC: ''}
+    emmy_us: 44.3
+    cublas_us: 41.0
+  # Fast-math sibling (FAST_MATH lane): P·V on the f16-accumulate atom, QK^T stays f32-acc. BEATS torch
+  # SDPA (1.02x) — the first emmy-past-SDPA hd256 entry on sm_89.
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd2/cp/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w4x1/f1x32', WSPEC: ''}
+    emmy_us: 40.1
+    cublas_us: 41.0

--- a/plans/gemma4-goldens-findings.md
+++ b/plans/gemma4-goldens-findings.md
@@ -1,4 +1,4 @@
-# Gemma-4 golden seeding — RTX 5090 (sm_120), manual A/B sweep findings
+# Gemma-4 golden seeding — RTX 5090 (sm_120) + RTX 4090 (sm_89), manual A/B sweep findings
 
 - **Date / method**: 2026-07-13, local RTX 5090, manual pinned `--ab` exploration (no tuner runs, no search-code
   changes). Per shape: one broad round of 4–6 pinned candidates from the card's known winner families via
@@ -157,3 +157,64 @@ EMMY_KNOBS="TILE=a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4,REDUCE=g2k,RASTER=,STAGE=d2
 # golden replay (works for 11 of 15 names):
 venv/bin/emmy run --bench --golden gemma4_12b.q_proj
 ```
+
+---
+
+# Part 2 — RTX 4090 (sm_89), 2026-07-13 (post-#352 merge, branch feature/gemma4-goldens-rtx4090)
+
+- **Method**: same manual pinned `--ab` workflow, run over SSH on a rented CloudRift RTX 4090
+  (riftuser@176.124.69.202; fresh `make setup` — needed `python3.12-venv` + `python3.12-dev` apt packages and
+  `/usr/local/cuda/bin` on PATH for non-interactive shells; the Makefile's `setup` target silently no-ops when a
+  half-built `venv/` exists from a failed install). One broad round (candidates from the post-swizzle
+  `rtx4090_sm89.yaml` h4096 winner families), one refinement round, winners 3× reproduced at ≤1% spread. All runs
+  deploy-pinned via `EMMY_KNOBS` (dodges greedy hazards up front).
+- **Deliverable**: `goldens/rtx4090_sm89_gemma4.yaml` — **23 entries / 11 names**: the 5 matmul shapes ×
+  {static, dynM} × {standard, fm} + attention hd256 **static** (std + fm). The gemma norm entries and
+  `attention.hd256.dynM` already live in `rtx4090_sm89.yaml` and were not duplicated.
+
+## Per-shape outcomes (all -O3 `--ab` rows, 3× reproduced; split-K totals; ref = median live eager)
+
+### Standard lane (f32-accumulate)
+
+| shape | config | emmy µs | cuBLAS µs | vs cuBLAS |
+| --- | --- | --: | --: | --: |
+| q_proj (+dynM) | `w2x2/f4x4/k2 d2/cp/ring/p2` (un-split) | 102.3 / 101.9 | 104 / 103 | **1.02×** |
+| kv_proj (+dynM) | `w2x2/f4x4/k2 g2k d2/cp/ring` | 57.2 / 58.4 | 49.0 | **0.86× / 0.84×** |
+| o_proj (+dynM) | `w2x2/f4x4/k2 d2/cp/ring/p2` | 109.3 / 108.8 | 115.0 | **1.05×** |
+| mlp_gate_up (+dynM) | `w4x1/f4x8/k2 d2/cp/ring` | 877.6 / 879.6 | 801 / 799 | **0.91×** |
+| mlp_down (+dynM) | `w2x2/f4x8 g2k d2/cp/ring` | 395.3 / 395.8 | 392 / 393 | 0.99× |
+| attention.hd256 (static) | `dd w4x1/f1x2/k16, pj w4x1/f1x32, d2/cp/ring` | 44.3 | 41.0 | 0.93× |
+
+### Fast-math lane (f16-accumulate atom — the post-swizzle atom-swap family)
+
+| shape | config | emmy µs | vs cuBLAS |
+| --- | --- | --: | --: |
+| q_proj (+dynM) | `f16acc w2x2/f4x8/k2 g2k d2/cp/ring` | 84.5 / 84.0 | **1.23×** |
+| kv_proj (+dynM) | `f16acc w2x2/f4x8/k2 g4k` | 48.0 / 47.8 | **1.02×** |
+| o_proj (+dynM) | `f16acc w2x2/f4x8/k2 g2k` | 85.8 / 88.8 | **1.34× / 1.30×** |
+| mlp_gate_up (+dynM) | `f16acc w4x1/f4x8/k2` | 719.9 / 718.8 | **1.11×** |
+| mlp_down (+dynM) | `f16acc w2x2/f4x8/k2 g2k` | 291.7 / 293.0 | **1.34×** |
+| attention.hd256 (static) | fm P·V (`pj` f16acc), `d2/cp/ring` | 40.1 | **1.02× — beats torch SDPA** |
+
+## 4090-specific findings
+
+1. **The fm atom-swap family sweeps here too** (`w2x2/f4x8/k2`, gate_up on `w4x1/f4x8/k2`) at 1.02–1.34×, and
+   the attention fm sibling is the **first emmy-past-torch-SDPA hd256 entry on sm_89** (40.1 vs 41.0).
+2. **The std lane's q/o_proj winner is the un-split `p2` reg double-buffer** (not split-K as on the 5090) —
+   the post-swizzle "p2 newly pays on big tiles" observation extends to the gemma projections.
+3. **kv_proj and mlp_gate_up std stay below parity** (0.86× / 0.91×) with nothing in the knob space closing it
+   (g4k/g8k/p2/wide-f4x8/w1x4 all worse) — the known sm_89 latency-bound residual; the gemma gate_up shape is
+   nonetheless better than its h4096 twin (0.91× vs 0.78×).
+4. **Flash form realization is the mirror image of the 5090**: on sm_89 the `w2x1` static form is the one that
+   does NOT realize (flagged unreproducible), and the `nt=4` dd spelling realizes back to nt=2 — so the 5090's
+   nt=4 parity alternate has no sm_89 twin. The `w4x1` + PV-plan-spelled pj contract from Part 1 carries over
+   verbatim.
+5. Same pin-leak hazard hit once during replay validation: an un-keyed matmul `TILE` in `EMMY_KNOBS` leaked
+   onto the flash kernel of the attention golden's run and hung it (>10 s abort) — replay attention goldens with
+   a flash-shaped pin.
+
+## Repro / artifacts
+
+Box work dir `~/emmy/_tune/gemma4-goldens-4090/` (rented box — copy off or accept loss on teardown): sweep.log,
+rep.log, per-shape `--json` A/B records. Replay validated on-box for q_proj, kv_proj.dynM, mlp_gate_up,
+attention.hd256 (all within noise of the recordings, clean flags).


### PR DESCRIPTION
## What

`goldens/rtx4090_sm89_gemma4.yaml` — the sm_89 companion of the merged 5090 gemma file (#352). **23 entries / 11 names**: the five gemma projection matmuls (q_proj `512×4096 K3840`, kv_proj `512×2048 K3840`, o_proj `512×3840 K4096`, fused mlp_gate_up `512×30720 K3840`, deep-K mlp_down `512×3840 K15360`) each static + `.dynM`, standard + `[fm]`, plus attention hd256 **static** (std + fm). The gemma norms and `attention.hd256.dynM` already live in `rtx4090_sm89.yaml` and are not duplicated.

Method: same manual pinned `--ab` workflow as #352, run over SSH on a rented CloudRift 4090 (fresh setup); one broad round from the post-swizzle h4096 winner families, one refinement round, winners 3× reproduced at ≤1% spread, replay-validated on-box through the golden plumbing. All runs deploy-pinned via `EMMY_KNOBS` to dodge the greedy-hazard aborts up front. Part-2 section appended to `plans/gemma4-goldens-findings.md` (renamed from the 5090 report).

## Results

**Fast-math lane** — the post-swizzle f16acc atom-swap family (`w2x2/f4x8/k2`; gate_up on `w4x1/f4x8/k2`) wins everywhere, 1.02–1.34× past cuBLAS HGEMM. Highlight: the attention fm P·V sibling runs **40.1 µs vs torch SDPA 41.0 — the first emmy-past-SDPA hd256 entry on sm_89**.

**Standard lane** — q/o_proj ride the un-split `d2/cp/ring/p2` reg double-buffer at 1.02–1.05× (p2, not split-K as on the 5090 — the "p2 newly pays on big tiles" post-swizzle observation extends to gemma); mlp_down at parity; kv_proj (0.86×) and mlp_gate_up (0.91×) stay below parity with the knob space exhausted — the known sm_89 latency-bound residual (gemma gate_up is still better than its h4096 twin's 0.78×).

## Findings

- **Flash form realization mirrors the 5090**: on sm_89 the `w2x1` static form does NOT realize (loudly flagged) and the `nt=4` dd spelling realizes back to nt=2, so the 5090's nt=4 parity alternate has no sm_89 twin. The `w4x1` + PV-plan-spelled `TILE@pj` contract from #352 carries over verbatim.
- The un-keyed-pin leak hazard hit once during replay validation: a matmul `TILE` in `EMMY_KNOBS` leaked onto the attention golden's flash kernel and hung it (>10 s abort) — replay attention goldens with a flash-shaped pin.
- Box setup gotchas recorded in the report: `python3.12-venv` + `python3.12-dev` apt packages, `/usr/local/cuda/bin` missing from non-interactive PATH, and `make setup` silently no-ops on a half-built `venv/`.

## Validation

- `tests/compiler/test_golden_configs.py` + full `make test`: **2318 passed, 39 skipped**; `make lint` clean
- On-box golden replay spot-checks (q_proj, kv_proj.dynM, mlp_gate_up, attention.hd256): all within noise of the recordings, clean integrity flags
- A/B JSON records (51 files incl. all reproduction passes) copied off the box to the dev machine's `_tune/gemma4-goldens-4090/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)