### PR TITLE
Alternating single-slab staging for the warp-flash stream (STAGE=d1/tma/alt)

### DIFF
--- a/emmy/compiler/ir/schedule.py
+++ b/emmy/compiler/ir/schedule.py
@@ -785,7 +785,8 @@ class Stage:
     # read them — K refills under softmax + P·V, V under the next step's Q·K — so a wide (64-key)
     # streaming block overlaps its copies within HALF the paired ring's smem. Implies the A (query)
     # operand stages through smem too (the freed resident fragments are what make the wide block's
-    # registers fit). ``d1/tma/alt``; flash stream only — the matmul resolvers decline it.
+    # registers fit). ``d1/tma/alt`` / ``d1/cp/alt``; flash stream only — the matmul resolvers
+    # decline it.
     alt: bool = False
 
     def __post_init__(self) -> None:

--- a/emmy/compiler/ir/schedule.py
+++ b/emmy/compiler/ir/schedule.py
@@ -737,9 +737,10 @@ _STAGE_SCHEMA = Schema(
         Field("d", FieldKind.TUPLE, emit=Emit.ALWAYS),
         Field("transport", FieldKind.CHOICE, choices=tuple(_TRANSPORT_CODEC.items()), default="sync", emit=Emit.ALWAYS),
         Field("ring", FieldKind.FLAG, emit=Emit.TRUE),
+        Field("alt", FieldKind.FLAG, emit=Emit.TRUE),
         Field("p", FieldKind.TUPLE),
     ),
-    expect="expect d<depth> / sync|cp|tma / ring / p<reg_depth>",
+    expect="expect d<depth> / sync|cp|tma / ring / alt / p<reg_depth>",
 )
 
 
@@ -752,7 +753,7 @@ class Stage:
 
     A constructed ``Stage`` means staging is **on** (the reused gmem operands ride a shared-
     memory slab); ``schedule.stage is None`` is the register / gmem-direct baseline (no
-    slab). Spelled by the ``STAGE`` codec ``d<depth>/sync|cp|tma[/ring][/p<reg_depth>]``
+    slab). Spelled by the ``STAGE`` codec ``d<depth>/sync|cp|tma[/ring][/alt][/p<reg_depth>]``
     (decided in ``_schedule`` (inside ``010_recognize``)). A stage stamped on a ``TileOp`` is **RESOLVED**, not the raw
     pin: the scheduler runs eligibility + sizing against the node ONCE
     (``_schedule._resolve_warp_stage`` / ``_resolve_scalar_stage`` for a contraction's operand
@@ -779,6 +780,13 @@ class Stage:
     ring: bool = False  # ring buffer vs static double-buffer
     reg_depth: int = 1  # smem→register double-buffer depth (1 = no inner ldmatrix prefetch)
     bk_elems: int = 0  # contraction slab K-chunk, elements (derived at resolution; not in the codec)
+    # The ALTERNATING single-slab pipeline (the warp-flash stream's FA-2 choreography): each operand
+    # keeps ONE slab and its own mbarrier, and the refills interleave with the phases that no longer
+    # read them — K refills under softmax + P·V, V under the next step's Q·K — so a wide (64-key)
+    # streaming block overlaps its copies within HALF the paired ring's smem. Implies the A (query)
+    # operand stages through smem too (the freed resident fragments are what make the wide block's
+    # registers fit). ``d1/tma/alt``; flash stream only — the matmul resolvers decline it.
+    alt: bool = False
 
     def __post_init__(self) -> None:
         if self.transport not in _TRANSPORT_SPELL:
@@ -789,6 +797,8 @@ class Stage:
             raise ValueError("a ring buffer needs depth ≥ 2 (nothing to cycle at depth 1)")
         if self.reg_depth < 1:
             raise ValueError(f"Stage reg_depth must be ≥ 1, got {self.reg_depth}")
+        if self.alt and (self.depth != 1 or self.ring):
+            raise ValueError("the alternating pipeline is single-slab (d1, no ring) — its overlap comes from the phase split")
 
     @classmethod
     def parse(cls, spec: str | None) -> Stage:
@@ -800,7 +810,7 @@ class Stage:
         non-empty spec). ``smem`` is filled in later by the scheduler. Ser/de routes through
         :func:`decode`; ``cls(...)`` then runs :meth:`__post_init__` (the depth / ring semantics)."""
         v = decode(_STAGE_SCHEMA, spec)
-        return cls(depth=v["d"], transport=v["transport"], ring=v["ring"], reg_depth=v["p"])
+        return cls(depth=v["d"], transport=v["transport"], ring=v["ring"], alt=v["alt"], reg_depth=v["p"])
 
     def spell(self) -> str:
         """The ``STAGE`` codec string for this stage (inverse of :meth:`parse`). ``smem`` is
@@ -808,7 +818,7 @@ class Stage:
         default is omitted, so an unstaged-register config round-trips byte-identical)."""
         return encode(
             _STAGE_SCHEMA,
-            {"d": self.depth, "transport": self.transport, "ring": self.ring, "p": self.reg_depth},
+            {"d": self.depth, "transport": self.transport, "ring": self.ring, "alt": self.alt, "p": self.reg_depth},
         )
 
     @property

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -753,10 +753,11 @@ rides the atomic; a non-distributive epilogue (`l2`'s `sqrt`, a fused bias/activ
 `d<depth>/sync|cp|tma[/ring][/alt][/p<reg_depth>]` on the typed `Stage` schedule struct (composes with both fragments
 of the `TILE` knob): `d<depth>` the gmem→smem ring depth, `sync`/`cp.async`/TMA transport, `p<reg_depth>` the
 smem→register double-buffer. `stage=None` (unset / unparseable) = gmem-direct. Also rides the warp-flash TWISTED
-stream (`STAGE@<kv>` — the K/V slabs of one streaming block; `reg_depth` clamps to 1), where `d1/tma/alt` is the
-**alternating single-slab pipeline**: one slab + one mbarrier per operand, refills interleaved with the phases that no
-longer read them, Q staged through smem — the wide (64-key) streaming block's staging (flash stream only; the matmul
-resolvers decline it). See `lowering/kernel/ARCHITECTURE.md`.
+stream (`STAGE@<kv>` — the K/V slabs of one streaming block; `reg_depth` clamps to 1), where `d1/tma/alt` /
+`d1/cp/alt` is the **alternating single-slab pipeline**: one slab per operand (TMA: its own mbarrier; cp.async: its
+own commit group, a uniform `wait_group(1)` completing the older sibling), refills interleaved with the phases that
+no longer read them, Q staged through smem — the wide (64-key) streaming block's staging (flash stream only; the
+matmul resolvers decline it). See `lowering/kernel/ARCHITECTURE.md`.
 
 **`WSPEC`** (STR codec, `010_recognize` / `_schedule` → `lowering/kernel/010_materialize`) — the warp-specialization
 codec `p<np>`: a producer warp band split over the fixed pipeline (bare/root-global; the fourth schedule-fork level).

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -750,11 +750,13 @@ rides the atomic; a non-distributive epilogue (`l2`'s `sqrt`, a fused bias/activ
 `030_split_reduce._projection_distributes`.
 
 **`STAGE`** (STR codec, `010_recognize` / `_schedule` → `lowering/kernel/010_materialize`) — the operand-staging codec
-`d<depth>/sync|cp|tma[/ring][/p<reg_depth>]` on the typed `Stage` schedule struct (composes with both fragments of the
-`TILE` knob): `d<depth>` the gmem→smem ring depth, `sync`/`cp.async`/TMA transport, `p<reg_depth>` the smem→register
-double-buffer. `stage=None` (unset / unparseable) = gmem-direct. Also rides the warp-flash TWISTED stream
-(`STAGE@<kv>` — the K/V slabs of one streaming block; cp.async only, `reg_depth` clamps to 1). See
-`lowering/kernel/ARCHITECTURE.md`.
+`d<depth>/sync|cp|tma[/ring][/alt][/p<reg_depth>]` on the typed `Stage` schedule struct (composes with both fragments
+of the `TILE` knob): `d<depth>` the gmem→smem ring depth, `sync`/`cp.async`/TMA transport, `p<reg_depth>` the
+smem→register double-buffer. `stage=None` (unset / unparseable) = gmem-direct. Also rides the warp-flash TWISTED
+stream (`STAGE@<kv>` — the K/V slabs of one streaming block; `reg_depth` clamps to 1), where `d1/tma/alt` is the
+**alternating single-slab pipeline**: one slab + one mbarrier per operand, refills interleaved with the phases that no
+longer read them, Q staged through smem — the wide (64-key) streaming block's staging (flash stream only; the matmul
+resolvers decline it). See `lowering/kernel/ARCHITECTURE.md`.
 
 **`WSPEC`** (STR codec, `010_recognize` / `_schedule` → `lowering/kernel/010_materialize`) — the warp-specialization
 codec `p<np>`: a producer warp band split over the fixed pipeline (bare/root-global; the fourth schedule-fork level).

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -174,8 +174,12 @@ V_{i+1}` — K's copy runs under softmax + P·V, V's under the next step's Q·K)
 copies within HALF the paired ring's smem. Q stages through smem too: a padded row-major tile (`head_dim + 8` element
 rows) cp.async-filled once before the stream, its A fragments ldmatrix'd per atom-K chunk INSIDE the step — the freed
 resident Q registers are what make the wide block's register file fit (the hd256 nt8 form went from 255 regs + 848 B
-spill loads to 240 regs / zero spills, 55.5 → 32.2 µs — past the nt4-d2 frontier). TMA + static block-divisible kv
-only; composes with the causal tile-skip (`k_end`) and the split-KV window; flash stream only (the matmul resolvers
+spill loads to 240 regs / zero spills, 55.5 → 31.7 µs — past the nt4-d2 frontier, and the fm sibling on `d1/cp/alt`
+is the first emmy-past-torch-SDPA hd256 entry on the 5090 at 29.7). Both async transports ride the skeleton: TMA arms
+per-operand mbarriers (`d1/tma/alt`); cp.async commits each fill into its own group — the K,V,K,V commits queue per
+thread, so a uniform `wait_group(1)` at either wait point completes exactly the older sibling (`d1/cp/alt`, the sm_89
+form — and the faster one on the 5090 too, the fm-prefers-cp lane rule again). Static block-divisible kv only;
+composes with the causal tile-skip (`k_end`) and the split-KV window; flash stream only (the matmul resolvers
 decline `alt`).
 
 **A split-KV partial windows the same stream** (`030_split_reduce._split_twisted_warp`, the flash `REDUCE=g<n>k` arm): the

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -167,6 +167,17 @@ prefetch clamp re-pinned onto the last needed chunk. CTA-uniform (the in-loop ba
 (skipped steps fold the carrier's exact identity: `α = 1`, `P = expf(−1e30 − m_i) = 0`); it halves the streamed
 keys/mma work on average, paying wall-clock wherever the grid oversubscribes the SMs.
 
+**The alternating single-slab pipeline** (`STAGE=d1/tma/alt`, `_stage.alternating_kloop`) is the wide-block form of the
+same stream — the FA-2 choreography: one K slab and one V slab, each on its OWN mbarrier, with the refills interleaved
+into the phases that no longer read them (`wait K | Q·K | sync | fill K_{i+1} | softmax | wait V | P·V | sync | fill
+V_{i+1}` — K's copy runs under softmax + P·V, V's under the next step's Q·K), so a 64-key streaming block overlaps its
+copies within HALF the paired ring's smem. Q stages through smem too: a padded row-major tile (`head_dim + 8` element
+rows) cp.async-filled once before the stream, its A fragments ldmatrix'd per atom-K chunk INSIDE the step — the freed
+resident Q registers are what make the wide block's register file fit (the hd256 nt8 form went from 255 regs + 848 B
+spill loads to 240 regs / zero spills, 55.5 → 32.2 µs — past the nt4-d2 frontier). TMA + static block-divisible kv
+only; composes with the causal tile-skip (`k_end`) and the split-KV window; flash stream only (the matmul resolvers
+decline `alt`).
+
 **A split-KV partial windows the same stream** (`030_split_reduce._split_twisted_warp`, the flash `REDUCE=g<n>k` arm): the
 `Reduction` arrives with its axis shrunk to the slice length and the slice's absolute base on `Reduction.offset` —
 the fold walks its local `[0, B)` window and `_twist` re-bases every absolute-key consumer (the score-column mask

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -792,8 +792,8 @@ def _wspec_kloop(
 
 def alternating_kloop(
     *,
-    k_transport: TmaTransport,
-    v_transport: TmaTransport,
+    k_transport,
+    v_transport,
     qk_drain: Callable[[Expr], list[Stmt]],
     mid: list[Stmt],
     pv_drain: Callable[[Expr], list[Stmt]],
@@ -810,15 +810,21 @@ def alternating_kloop(
         step i:   wait K_i | qk_drain | Sync | fill K_{i+1} | mid (softmax) |
                   wait V_i | pv_drain | Sync | fill V_{i+1}
 
-    K_{i+1}'s box copy runs under ``mid`` + the P·V mmas; V_{i+1}'s under step ``i+1``'s Q·K.
-    The single slot's parity alternates per generation (``phase = i % 2``); the tail refills
-    clamp onto the last needed chunk (re-fetching it — harmless, never waited). ``k_end`` is the
-    causal early stop (the hoisted ``<k0>_end`` for-init bound, as :func:`staged_kloop`). Static
-    block-divisible extents only (the resolver's gate)."""
+    K_{i+1}'s copy runs under ``mid`` + the P·V mmas; V_{i+1}'s under step ``i+1``'s Q·K.
+    Both async transports ride the same seam: TMA parity-waits the operand's own mbarrier (the
+    single slot's parity alternates per generation, ``phase = i % 2``); cp.async commits each
+    fill into its own group — the K,V,K,V commits form a per-thread QUEUE, so a uniform
+    ``wait_group(1)`` at either wait point completes exactly the OLDER (this phase's) group while
+    the newer sibling stays in flight. The tail refills clamp onto the last needed chunk
+    (re-fetching it — harmless, never waited). ``k_end`` is the causal early stop (the hoisted
+    ``<k0>_end`` for-init bound, as :func:`staged_kloop`). Static block-divisible extents only
+    (the resolver's gate)."""
     decls = k_transport.slab_decls(1) + v_transport.slab_decls(1)
     pre = [*k_transport.prologue(1), *v_transport.prologue(1)]
     pre += k_transport.fill(k0=_lit(0), slot=_lit(0))
+    pre += k_transport.commit()
     pre += v_transport.fill(k0=_lit(0), slot=_lit(0))
+    pre += v_transport.commit()
 
     i_expr = BinaryExpr("/", Var(k0), _lit(bk_elems))
     phase = BinaryExpr("%", i_expr, _lit(2))
@@ -831,15 +837,19 @@ def alternating_kloop(
         k0_pref = TernaryExpr(cond=BinaryExpr("<", k0_next, _lit(k_extent)), if_true=k0_next, if_false=_lit(k_extent - bk_elems))
 
     body: list[Stmt] = []
-    body += k_transport.wait(in_flight=0, slot=_lit(0), phase=phase)
+    # ``in_flight=1``: cp.async keeps the newer sibling group outstanding (TMA ignores it — the
+    # per-operand mbarrier parity is the gate there).
+    body += k_transport.wait(in_flight=1, slot=_lit(0), phase=phase)
     body += qk_drain(_lit(0))
     body.append(Sync())  # every warp done reading the K slab before its refill
     body += k_transport.fill(k0=k0_pref, slot=_lit(0))
+    body += k_transport.commit()
     body += mid
-    body += v_transport.wait(in_flight=0, slot=_lit(0), phase=phase)
+    body += v_transport.wait(in_flight=1, slot=_lit(0), phase=phase)
     body += pv_drain(_lit(0))
     body.append(Sync())  # every warp done reading the V slab before its refill
     body += v_transport.fill(k0=k0_pref, slot=_lit(0))
+    body += v_transport.commit()
 
     outer = StridedLoop(
         axis=Axis(name=k0, extent=k_extent), start=_lit(0), step=_lit(bk_elems), body=Body(tuple(body)), unroll=False, end=k_end

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -790,6 +790,63 @@ def _wspec_kloop(
     return decls, [*pre, role]
 
 
+def alternating_kloop(
+    *,
+    k_transport: TmaTransport,
+    v_transport: TmaTransport,
+    qk_drain: Callable[[Expr], list[Stmt]],
+    mid: list[Stmt],
+    pv_drain: Callable[[Expr], list[Stmt]],
+    bk_elems: int,
+    k_extent: int,
+    k0: str,
+    k_end: Expr | None = None,
+) -> tuple[list[Stmt], list[Stmt]]:
+    """The ALTERNATING single-slab K-loop — the warp-flash stream's FA-2 choreography (the
+    ``d1/tma/alt`` stage). Each operand keeps ONE slab on its OWN mbarrier, and the refill lands
+    in the phase that no longer reads it, so both copies overlap compute without a second slot::
+
+        prologue: fill K_0, fill V_0
+        step i:   wait K_i | qk_drain | Sync | fill K_{i+1} | mid (softmax) |
+                  wait V_i | pv_drain | Sync | fill V_{i+1}
+
+    K_{i+1}'s box copy runs under ``mid`` + the P·V mmas; V_{i+1}'s under step ``i+1``'s Q·K.
+    The single slot's parity alternates per generation (``phase = i % 2``); the tail refills
+    clamp onto the last needed chunk (re-fetching it — harmless, never waited). ``k_end`` is the
+    causal early stop (the hoisted ``<k0>_end`` for-init bound, as :func:`staged_kloop`). Static
+    block-divisible extents only (the resolver's gate)."""
+    decls = k_transport.slab_decls(1) + v_transport.slab_decls(1)
+    pre = [*k_transport.prologue(1), *v_transport.prologue(1)]
+    pre += k_transport.fill(k0=_lit(0), slot=_lit(0))
+    pre += v_transport.fill(k0=_lit(0), slot=_lit(0))
+
+    i_expr = BinaryExpr("/", Var(k0), _lit(bk_elems))
+    phase = BinaryExpr("%", i_expr, _lit(2))
+    k0_next = BinaryExpr("+", Var(k0), _lit(bk_elems))
+    if k_end is not None:
+        end_var = Var(f"{k0}_end")  # the loop's hoisted for-init bound (StridedLoop.end)
+        last_k0 = BinaryExpr("*", BinaryExpr("/", BinaryExpr("-", end_var, _lit(1)), _lit(bk_elems)), _lit(bk_elems))
+        k0_pref = TernaryExpr(cond=BinaryExpr("<", k0_next, end_var), if_true=k0_next, if_false=last_k0)
+    else:
+        k0_pref = TernaryExpr(cond=BinaryExpr("<", k0_next, _lit(k_extent)), if_true=k0_next, if_false=_lit(k_extent - bk_elems))
+
+    body: list[Stmt] = []
+    body += k_transport.wait(in_flight=0, slot=_lit(0), phase=phase)
+    body += qk_drain(_lit(0))
+    body.append(Sync())  # every warp done reading the K slab before its refill
+    body += k_transport.fill(k0=k0_pref, slot=_lit(0))
+    body += mid
+    body += v_transport.wait(in_flight=0, slot=_lit(0), phase=phase)
+    body += pv_drain(_lit(0))
+    body.append(Sync())  # every warp done reading the V slab before its refill
+    body += v_transport.fill(k0=k0_pref, slot=_lit(0))
+
+    outer = StridedLoop(
+        axis=Axis(name=k0, extent=k_extent), start=_lit(0), step=_lit(bk_elems), body=Body(tuple(body)), unroll=False, end=k_end
+    )
+    return decls, [*pre, outer]
+
+
 def staged_kloop(
     *,
     transport,

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -701,12 +701,18 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             )
             state += cp_async_commit()
             state += cp_async_wait(0)
-            k_transport = TmaTransport(
-                operands=(k_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta, mbar="_kbar"
-            )
-            v_transport = TmaTransport(
-                operands=(v_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta, mbar="_vbar"
-            )
+            if is_tma:
+                k_transport = TmaTransport(
+                    operands=(k_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta, mbar="_kbar"
+                )
+                v_transport = TmaTransport(
+                    operands=(v_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta, mbar="_vbar"
+                )
+            else:
+                # cp.async: per-operand commit groups — the K,V,K,V commits queue per thread, and
+                # the skeleton's uniform ``wait_group(1)`` completes exactly the older sibling.
+                k_transport = CpAsyncTransport(operands=(k_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta)
+                v_transport = CpAsyncTransport(operands=(v_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta)
             qk_seg, mid_seg, pv_seg = _stream_segments(k_op.slot_row(Literal(0, "int")), v_op.slot_row(Literal(0, "int")), staged=True)
             decls, fold = alternating_kloop(
                 k_transport=k_transport,

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -74,7 +74,12 @@ from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
     CtaTile,
     Operand,
     TmaTransport,
+    alternating_kloop,
+    cp_async_commit,
+    cp_async_fill,
+    cp_async_wait,
     pick_swizzle_atom,
+    slab_smem,
     staged_kloop,
 )
 
@@ -440,46 +445,79 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             )
         )
 
-    state: list[Stmt] = []
-    for qt in qtiles:
-        for c in _COMPS:
-            state.append(Init(name=f"{qt.pivot}{c}", identity=-1e30, dtype=F32))
-            state.append(Init(name=f"{qt.denom}{c}", identity=0.0, dtype=F32))
-        for f in qt.ofrags:
-            state.append(RegFragment(name=f, role="c", shape=shape, dtype=F32))
+    # Per-transport staging facts, visible to the stream builder's drains: cp.async slabs take the
+    # +16 B row pad (the bank-conflict break), TMA slabs stay dense and take the hardware swizzle
+    # (``pick_swizzle_atom`` per operand) with the drain's address XOR undoing it. The ALTERNATING
+    # pipeline (``stage.alt``) additionally stages Q: a padded row-major smem tile filled once,
+    # its A fragments ldmatrix'd per atom-K chunk INSIDE the stream — the freed resident registers
+    # are what make the wide (64-key) block fit.
+    stage = ctx.stage
+    alt = stage is not None and stage.alt
+    is_tma = stage is not None and stage.transport == "tma"
+    elem_bytes = atom.operand_dtype("b").nbytes
+    kv_pad = 0 if is_tma else _PAD
+    k_swz = pick_swizzle_atom(qk.k_axis.extent.as_static(), elem_bytes)[1] if is_tma else "NONE"
+    v_swz = pick_swizzle_atom(d_v, elem_bytes)[1] if is_tma else "NONE"
+    head_dim_s = qk.k_axis.extent.as_static()
+    q_ldm = head_dim_s + _PAD  # the staged-Q slab row stride (padded, like the cp.async K/V rows)
+
+    def _q_frag_stmts(qt, i: int) -> list[Stmt]:
+        """The query tile's ``bk`` A-fragment declarations + loads. Resident form (default): gmem
+        loads hoisted ahead of the stream. Alternating form (``stage.alt``): per-block ldmatrix
+        from the staged Q slab (slab-local rows — the tile's offset within the CTA's query block),
+        block-scoped so the registers die each step. Same values either way: bit-identical."""
+        stmts: list[Stmt] = []
+        if alt:
+            rel = Literal(i * shape[0], "int")
+            if um > 1:
+                rel = BinaryExpr("+", BinaryExpr("*", Var(FLASH_WARP_AXIS), Literal(fm * shape[0], "int")), rel)
+            for s, qaf in enumerate(qt.qa):
+                stmts.append(RegFragment(name=qaf, role="a", shape=shape, dtype=atom.operand_dtype("a")))
+                stmts.append(
+                    LdmatrixLoad(
+                        frag=qaf, src_buffer="_q_smem", src_index=(rel, Literal(s * atom.atom_k, "int")), role="a", ldm=q_ldm, staged=True
+                    )
+                )
+            return stmts
         # The Q A-fragments are loop-INVARIANT (Q's index carries the query/head-dim axes, never
         # the stream axis — structural: the contraction binder puts the m-carrying load on A), so
         # they load ONCE ahead of the stream — ``bk`` resident fragments per tile instead of
         # ``bk`` gmem fills per KV block. Same loads, same values: bit-identical to the in-loop form.
         q_guard = (qt.row_base, _ext(qk.m_axis)) if symbolic_q else None
         for s, qaf in enumerate(qt.qa):
-            state.append(RegFragment(name=qaf, role="a", shape=shape, dtype=atom.operand_dtype("a")))
-            state.append(
+            stmts.append(RegFragment(name=qaf, role="a", shape=shape, dtype=atom.operand_dtype("a")))
+            stmts.append(
                 LdmatrixLoad(
                     frag=qaf,
                     src_buffer=qk.a_operand.input,
                     src_index=_idx(qk.a_operand, {qk.m_axis.name: qt.row_base, qk.k_axis.name: Literal(s * atom.atom_k, "int")}),
                     role="a",
-                    ldm=qk.k_axis.extent.as_static(),
+                    ldm=head_dim_s,
                     staged=False,
                     gmem_guard=q_guard,
                 )
             )
+        return stmts
 
-    # Per-transport staging facts, visible to the stream builder's drains: cp.async slabs take the
-    # +16 B row pad (the bank-conflict break), TMA slabs stay dense and take the hardware swizzle
-    # (``pick_swizzle_atom`` per operand) with the drain's address XOR undoing it.
-    stage = ctx.stage
-    is_tma = stage is not None and stage.transport == "tma"
-    elem_bytes = atom.operand_dtype("b").nbytes
-    kv_pad = 0 if is_tma else _PAD
-    k_swz = pick_swizzle_atom(qk.k_axis.extent.as_static(), elem_bytes)[1] if is_tma else "NONE"
-    v_swz = pick_swizzle_atom(d_v, elem_bytes)[1] if is_tma else "NONE"
+    state: list[Stmt] = []
+    for i, qt in enumerate(qtiles):
+        for c in _COMPS:
+            state.append(Init(name=f"{qt.pivot}{c}", identity=-1e30, dtype=F32))
+            state.append(Init(name=f"{qt.denom}{c}", identity=0.0, dtype=F32))
+        for f in qt.ofrags:
+            state.append(RegFragment(name=f, role="c", shape=shape, dtype=F32))
+        if not alt:
+            state.extend(_q_frag_stmts(qt, i))
 
-    # ---- the streaming step (a builder — the staged path re-parents it under the ring drain) --- #
-    def _stream_step(k_slot: Expr | None = None, v_slot: Expr | None = None, staged: bool = False) -> list[Stmt]:
+    # ---- the streaming step (a builder — the staged path re-parents it under the ring drain; the
+    # alternating path takes the three segments separately, its K/V refills between them) -------- #
+    def _stream_segments(
+        k_slot: Expr | None = None, v_slot: Expr | None = None, staged: bool = False
+    ) -> tuple[list[Stmt], list[Stmt], list[Stmt]]:
         stream: list[Stmt] = []
-        for qt in qtiles:
+        for i, qt in enumerate(qtiles):
+            if alt:
+                stream.extend(_q_frag_stmts(qt, i))  # per-block A fragments off the staged Q slab
             for f in qt.sfrags:
                 stream.append(RegFragment(name=f, role="c", shape=shape, dtype=F32))
             for f in qt.ohfrags:
@@ -504,6 +542,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             b_swizzle=k_swz if staged else "NONE",
             reg_depth=stage.reg_depth if staged else 1,
         )
+        qk_seg, stream = stream, []
 
         for qi, qt in enumerate(qtiles):
             hoisted, pro = _realize_prologue(partial[1:], qk, qt.sfrags, col_bases, qt.row_base, set(names))
@@ -548,6 +587,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             for si, paf in enumerate(qt.pa):
                 stream.append(RegFragment(name=paf, role="a", shape=shape, dtype=atom.operand_dtype("a")))
                 stream.append(FragmentRepack(frag=paf, srcs=(qt.pfrags[2 * si], qt.pfrags[2 * si + 1]), ab_dtype=atom.ab_dtype))
+        mid_seg, stream = stream, []
         pv_mask = {kv_axis.name: (kv0_var, seq)} if symbolic_k else {}
         stream += _frag_contraction(
             _pv_streamed(pv, kv_axis),
@@ -570,7 +610,11 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
                 stream += [FragmentPromote(dst=of, src=oh) for of, oh in zip(qt.ofrags, qt.ohfrags, strict=True)]
         for qt in qtiles:
             stream += _rebind(qt.pivot, f"_mn{qt.sfx}")  # advance the running pivot: m = mn
-        return stream
+        return qk_seg, mid_seg, stream
+
+    def _stream_step(k_slot: Expr | None = None, v_slot: Expr | None = None, staged: bool = False) -> list[Stmt]:
+        qk_seg, mid_seg, pv_seg = _stream_segments(k_slot, v_slot, staged)
+        return [*qk_seg, *mid_seg, *pv_seg]
 
     if stage is not None:
         # The staged K/V stream: the resolved ``Stage`` (``_schedule._resolve_twisted_stage`` —
@@ -635,25 +679,67 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
         ltid: Expr = (
             BinaryExpr("%", Builtin("thread_idx.x"), Literal(block_threads, "int")) if ctx.workers is not None else Builtin("thread_idx.x")
         )
-        transport = transport_cls(
-            operands=(k_op, v_op),
-            slab_dtype=_cuda(atom.operand_dtype("b")),
-            elem_bytes=elem_bytes,
-            cta=CtaTile(linear_tid=ltid, n_threads=block_threads),
-        )
-        decls, fold = staged_kloop(
-            transport=transport,
-            drain=lambda slot: _stream_step(k_op.slot_row(slot), v_op.slot_row(slot), staged=True),
-            depth=stage.depth,
-            bk_elems=bn,
-            n_chunks=n_chunks,
-            k_extent=kv_ext,
-            k0=kv0.name,
-            workers=ctx.workers,
-            block_threads=block_threads,
-            k_end=kv_end,
-        )
-        state = decls + state
+        cta = CtaTile(linear_tid=ltid, n_threads=block_threads)
+        if alt:
+            # The ALTERNATING single-slab pipeline (``d1/tma/alt``): one slab + one mbarrier per
+            # operand, the refills interleaved with the phases that no longer read them (K under
+            # softmax + P·V, V under the next step's Q·K — the FA-2 choreography). Q stages
+            # through smem: a padded row-major slab cooperatively cp.async-filled ONCE before the
+            # stream (verbatim copy — bit-identical values), its A fragments ldmatrix'd per
+            # atom-K chunk inside the step (``_q_frag_stmts``), freeing the resident Q registers.
+            q_rows = um * fm * shape[0]
+            cta_row0 = BinaryExpr("*", Var(grid[-1].name), Literal(q_rows, "int"))
+            state.append(slab_smem("_q_smem", q_rows, q_ldm, _cuda(atom.operand_dtype("a")), align=16))
+            state += cp_async_fill(
+                slab="_q_smem",
+                shape=(q_rows, head_dim_s),
+                src=qk.a_operand.input,
+                gmem_index=lambda row, col: _idx(qk.a_operand, {qk.m_axis.name: BinaryExpr("+", cta_row0, row), qk.k_axis.name: col}),
+                cta=cta,
+                elem_bytes=elem_bytes,
+                name="q",
+            )
+            state += cp_async_commit()
+            state += cp_async_wait(0)
+            k_transport = TmaTransport(
+                operands=(k_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta, mbar="_kbar"
+            )
+            v_transport = TmaTransport(
+                operands=(v_op,), slab_dtype=_cuda(atom.operand_dtype("b")), elem_bytes=elem_bytes, cta=cta, mbar="_vbar"
+            )
+            qk_seg, mid_seg, pv_seg = _stream_segments(k_op.slot_row(Literal(0, "int")), v_op.slot_row(Literal(0, "int")), staged=True)
+            decls, fold = alternating_kloop(
+                k_transport=k_transport,
+                v_transport=v_transport,
+                qk_drain=lambda _slot: qk_seg,
+                mid=mid_seg,
+                pv_drain=lambda _slot: pv_seg,
+                bk_elems=bn,
+                k_extent=kv_ext,
+                k0=kv0.name,
+                k_end=kv_end,
+            )
+            state = decls + state
+        else:
+            transport = transport_cls(
+                operands=(k_op, v_op),
+                slab_dtype=_cuda(atom.operand_dtype("b")),
+                elem_bytes=elem_bytes,
+                cta=cta,
+            )
+            decls, fold = staged_kloop(
+                transport=transport,
+                drain=lambda slot: _stream_step(k_op.slot_row(slot), v_op.slot_row(slot), staged=True),
+                depth=stage.depth,
+                bk_elems=bn,
+                n_chunks=n_chunks,
+                k_extent=kv_ext,
+                k0=kv0.name,
+                workers=ctx.workers,
+                block_threads=block_threads,
+                k_end=kv_end,
+            )
+            state = decls + state
     else:
         static_small = unroll_ok(kv_axis.extent, 128) and kv_end is None
         body = Body(tuple(_stream_step()))

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -733,6 +733,9 @@ def _resolve_warp_stage(c: Contraction, stage: Stage, budget: int = STATIC_SMEM_
     (``bk_elems`` is codec-spelled here, not derived), and a resolved-but-unfittable stage would
     sail through the fork only to be rejected at materialize (the issue-#327 unlowered-``TileOp``
     bench fails)."""
+    if stage.alt:
+        return None  # the alternating single-slab pipeline is the warp-flash stream's (K/V phase split + staged Q)
+
     atom = c.atom
     a_nbytes = atom.operand_dtype("a").nbytes
     bk = c.tile.bk
@@ -775,6 +778,9 @@ def _resolve_scalar_stage(c: Contraction, stage: Stage, inputs, budget: int = ST
     contributing only the slab drain; when no K-chunk fits at the requested depth, the depth steps
     down (a smaller ring beats gmem-direct), single-buffer last. ``reg_depth`` stays 1 (the
     smem→register double-buffer is an ``ldmatrix`` transform, no scalar counterpart)."""
+    if stage.alt:
+        return None  # the alternating single-slab pipeline is the warp-flash stream's (K/V phase split + staged Q)
+
     if not c.k_axis.extent.is_static or stage.transport not in ("tma", "cp.async"):
         return None
     # A masked-N (overhanging inner dim) or transposed-B B-slab fill would clamp a chunk-start column
@@ -1628,7 +1634,9 @@ def _demoted_warp_option(tile: TileOp, place, name: str, knobs: dict) -> TileOp 
     return TileOp(op=node, name=name, place=place, tier=wt, stage=stage, knobs=stamped)
 
 
-def _resolve_twisted_stage(stage: Stage, kv_extent, bn: int, head_dim: int, d_v: int, elem_bytes: int, budget: int) -> Stage | None:
+def _resolve_twisted_stage(
+    stage: Stage, kv_extent, bn: int, head_dim: int, d_v: int, elem_bytes: int, budget: int, m_rows: int = 0
+) -> Stage | None:
     """Resolve an operand ``Stage`` against a warp-flash streaming pair — the K/V slabs of one
     ``bn``-key streaming step (K ``bn × head_dim`` in its native N-major layout, V ``bn × d_v``
     K-major; both verbatim row copies, so staging stays bit-identical to gmem-direct). Two
@@ -1646,6 +1654,23 @@ def _resolve_twisted_stage(stage: Stage, kv_extent, bn: int, head_dim: int, d_v:
     ``bk_elems`` records the streamed keys per step."""
     if stage.transport not in ("cp.async", "tma"):
         return None
+    if stage.alt:
+        # The ALTERNATING single-slab pipeline (``d1/tma/alt``): one K slab + one V slab, each on
+        # its own mbarrier, refilled in the phase that no longer reads it (K under softmax + P·V,
+        # V under the next step's Q·K) — the FA-2 choreography that overlaps a WIDE (64-key)
+        # streaming block's copies in HALF the paired ring's smem. The Q (query) tile stages
+        # through smem too — a padded row-major slab filled once, its A fragments ldmatrix'd per
+        # atom-K chunk — which frees the resident Q registers that made the wide block spill.
+        # TMA + static block-divisible kv only (per-operand expect-tx arming; the symbolic
+        # tail/box-overhang story is not built for the split phases).
+        if stage.transport != "tma" or not kv_extent.is_static or kv_extent.as_static() % bn != 0 or m_rows <= 0:
+            return None
+        if bn > 256 or head_dim > 256 or d_v > 256 or (head_dim * elem_bytes) % 16 or (d_v * elem_bytes) % 16:
+            return None
+        q_bytes = m_rows * (head_dim + 8) * elem_bytes  # +8 elem row pad (the flash cp-path bank break)
+        if q_bytes + bn * (head_dim + d_v) * elem_bytes > budget:
+            return None
+        return replace(stage, reg_depth=1, bk_elems=bn)
     if stage.transport == "cp.async":
         # A symbolic kv stages: the fill clamp-reads the overhanging tail rows to the last valid
         # key (cp.async has no OOB zero-fill) and the drain's tail masks zero their P columns, so
@@ -1678,7 +1703,7 @@ def _resolve_twisted_stage(stage: Stage, kv_extent, bn: int, head_dim: int, d_v:
 
 
 def _twisted_stage_candidates(
-    kv_extent, bn: int, head_dim: int, d_v: int, elem_bytes: int, budget: int, tma_ok: bool = True
+    kv_extent, bn: int, head_dim: int, d_v: int, elem_bytes: int, budget: int, tma_ok: bool = True, m_rows: int = 0
 ) -> list[Stage | None]:
     """The K/V operand-stage candidates for one warp-flash geometry row — gmem-direct ``None``
     first (the conservative option-0), then every ``stage_moves`` entry that RESOLVES against the
@@ -1693,7 +1718,7 @@ def _twisted_stage_candidates(
         st = Stage.parse(spec)
         if st.transport == "tma" and not tma_ok:
             return None  # TMA is Hopper+ (sm_90); nvcc has no sm_89a — decline below it
-        return _resolve_twisted_stage(st, kv_extent, bn, head_dim, d_v, elem_bytes, budget)
+        return _resolve_twisted_stage(st, kv_extent, bn, head_dim, d_v, elem_bytes, budget, m_rows)
 
     if STAGE.raw() is not None:
         pinned = STAGE.narrow([""])[0]
@@ -1713,7 +1738,10 @@ def _twisted_stage_candidates(
         return [None]
     out: list[Stage | None] = [None]
     spelled: set[str] = set()
-    for move in stage_moves(warp=True):
+    # ``d1/tma/alt`` (the alternating single-slab pipeline) rides the flash candidate list only —
+    # it is not a ``stage_moves`` entry (the matmul resolvers decline it), and it resolves only
+    # where the wide-block Q+K+V slabs fit (:func:`_resolve_twisted_stage`).
+    for move in [*stage_moves(warp=True), "d1/tma/alt"]:
         if not move:
             continue
         r = resolve(move)
@@ -1868,8 +1896,10 @@ def _twisted_warp_options(
         # ``_wspec_workers`` gates the thread budgets — the aux band must not exceed the
         # ``32·um`` compute band); a degraded candidate is skipped rather than duplicating the
         # uniform row.
-        for stage in _twisted_stage_candidates(kv_ext, bn, head_dim.as_static(), d_v.as_static(), elem_bytes, budget, tma_ok):
-            wspecs = list(WSPEC.narrow(wspec_moves())) if (stage is not None and stage.transport == "tma") else [""]
+        for stage in _twisted_stage_candidates(
+            kv_ext, bn, head_dim.as_static(), d_v.as_static(), elem_bytes, budget, tma_ok, m_rows=um * fm * atom_m
+        ):
+            wspecs = list(WSPEC.narrow(wspec_moves())) if (stage is not None and stage.transport == "tma" and not stage.alt) else [""]
             for wspec_cand in wspecs:
                 workers, wspec_spec = _wspec_workers(wspec_cand, stage, 32 * um)
                 if wspec_cand and workers is None:

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1661,14 +1661,20 @@ def _resolve_twisted_stage(
         # streaming block's copies in HALF the paired ring's smem. The Q (query) tile stages
         # through smem too — a padded row-major slab filled once, its A fragments ldmatrix'd per
         # atom-K chunk — which frees the resident Q registers that made the wide block spill.
-        # TMA + static block-divisible kv only (per-operand expect-tx arming; the symbolic
-        # tail/box-overhang story is not built for the split phases).
-        if stage.transport != "tma" or not kv_extent.is_static or kv_extent.as_static() % bn != 0 or m_rows <= 0:
+        # Static block-divisible kv only (the symbolic tail story is not built for the split
+        # phases). Both async transports ride the same seam: TMA arms per-operand mbarriers
+        # (``d1/tma/alt``); cp.async commits each fill into its own group and a uniform
+        # ``wait_group(1)`` completes the older sibling (``d1/cp/alt`` — the sm_89 form).
+        if not kv_extent.is_static or kv_extent.as_static() % bn != 0 or m_rows <= 0:
             return None
-        if bn > 256 or head_dim > 256 or d_v > 256 or (head_dim * elem_bytes) % 16 or (d_v * elem_bytes) % 16:
-            return None
+        if stage.transport == "tma":
+            if bn > 256 or head_dim > 256 or d_v > 256 or (head_dim * elem_bytes) % 16 or (d_v * elem_bytes) % 16:
+                return None
+            kv_pad = 0  # dense hardware-swizzled slabs
+        else:
+            kv_pad = 16  # the two K/V slabs' padded rows (2 x _twist._PAD elems)
         q_bytes = m_rows * (head_dim + 8) * elem_bytes  # +8 elem row pad (the flash cp-path bank break)
-        if q_bytes + bn * (head_dim + d_v) * elem_bytes > budget:
+        if q_bytes + bn * (head_dim + d_v + kv_pad) * elem_bytes > budget:
             return None
         return replace(stage, reg_depth=1, bk_elems=bn)
     if stage.transport == "cp.async":
@@ -1741,7 +1747,7 @@ def _twisted_stage_candidates(
     # ``d1/tma/alt`` (the alternating single-slab pipeline) rides the flash candidate list only —
     # it is not a ``stage_moves`` entry (the matmul resolvers decline it), and it resolves only
     # where the wide-block Q+K+V slabs fit (:func:`_resolve_twisted_stage`).
-    for move in [*stage_moves(warp=True), "d1/tma/alt"]:
+    for move in [*stage_moves(warp=True), "d1/tma/alt", "d1/cp/alt"]:
         if not move:
             continue
         r = resolve(move)

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
@@ -230,8 +230,31 @@ configs:
     knobs: {PLACE: 'fuse', STAGE: 'd2/cp/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32', WSPEC: ''}
     emmy_us: 41.1
     cublas_us: 41.0
-  # The std-lane PRIMARY post-tile-skip: the nt=4 streaming block (mirrors the 5090's primary) — 1.07x
-  # past torch SDPA.
+  # The std-lane PRIMARY (2026-07-14, alternating staging): the 64-key block on d1/cp/alt (the
+  # commit-group alternating pipeline + Q-in-smem) — 37.1 = 1.11x vs torch SDPA, 3x reproduced.
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 37.1
+    cublas_us: 41.0
+  # The FM PRIMARY: the f16acc-PV sibling on d1/cp/alt — 33.8 = 1.21x vs torch SDPA (3x reproduced),
+  # a 10% jump over the paired-ring fm nt=2 frontier below.
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 33.8
+    cublas_us: 41.0
+  # The paired-ring nt=4 runner-up (pre-alt std primary) — 1.07x past torch SDPA.
   - kernel: attention
     name: gemma4_12b.attention.hd256
     n_heads: 16

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -514,6 +514,19 @@ configs:
     knobs: {FAST_EXP: false, INTERLEAVE_LOADS: true, PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w2x1/f1x16/k4', VECTORIZE_LOADS: true, WSPEC: ''}
     emmy_us: 16.5
     cublas_us: 18.42
+  # The std-lane PRIMARY (2026-07-14, alternating staging): the same w2x1 geometry on d1/tma/alt —
+  # 1.17x vs torch SDPA, 3x reproduced. hd64 keeps the paired ring (alt loses there: 9.2 vs 8.6 —
+  # its slabs already fit and the phase split's extra sync outweighs); nt16 (128-key) adds nothing.
+  - kernel: attention
+    name: attention.hd128
+    n_heads: 8
+    seq: 512
+    head_dim: 128
+    dtype: 'fp16'
+    causal: false
+    knobs: {PLACE: 'fuse', STAGE: 'd1/tma/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w2x1/f1x16/k4', WSPEC: ''}
+    emmy_us: 15.7
+    cublas_us: 18.42
   # Fast-math sibling (FAST_MATH lane): P·V on the f16-accumulate atom, QK^T stays f32-acc (softmax
   # statistics). 14.6 µs vs the standard golden's live 16.4 (0.89x), 1.26x vs torch SDPA. 2026-07-12
   # manual sweep, 3x reproduced at zero spread; accuracy vs torch passes. Kept beside the standard
@@ -528,6 +541,17 @@ configs:
     causal: false
     knobs: {PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w2x1/f1x16/k4', WSPEC: ''}
     emmy_us: 14.6
+    cublas_us: 18.42
+  # The fm PRIMARY (2026-07-14): the fm sibling on d1/tma/alt — 1.36x vs torch SDPA, 3x reproduced.
+  - kernel: attention
+    name: attention.hd128
+    n_heads: 8
+    seq: 512
+    head_dim: 128
+    dtype: 'fp16'
+    causal: false
+    knobs: {PLACE: 'fuse', STAGE: 'd1/tma/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w2x1/f1x16/k4', WSPEC: ''}
+    emmy_us: 13.5
     cublas_us: 18.42
   - kernel: attention
     name: attention.hd64.dynM

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -237,7 +237,23 @@ configs:
     knobs: {PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32', WSPEC: ''}
     emmy_us: 35.5
     cublas_us: 30.7
-  # The PRIMARY post-tile-skip: the nt=4 streaming block (32 keys/step, 32 KB slabs) — 32.9, 7% past
+  # The PRIMARY (2026-07-14, post alternating staging): the 64-key streaming block (nt=8) on
+  # d1/tma/alt — one K slab + one V slab on separate mbarriers, refills interleaved with the phases
+  # that no longer read them, Q staged through smem (240 regs, zero spills; the paired-ring nt=8
+  # form was spill-bound at 55.5). 32.2 µs = 0.95x vs torch SDPA, 3x reproduced zero-spread. The
+  # fm sibling loses here (33.8 — the per-block promote outweighs at 64-key steps); FAST_EXP
+  # neutral; alt+g2k 33.3 (the finalize costs more than the split recovers at this grid).
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/tma/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 32.2
+    cublas_us: 30.7
+  # The paired-ring runner-up: the nt=4 streaming block (32 keys/step, 32 KB slabs) — 32.9, 7% past
   # the nt=2 entry (pre-skip they were parity alternates). The knob frontier ends here — nt=8 fattens
   # to 55 µs, w2x1 forms reach 35.1 (parity with nt=2, no longer the 97 µs hazard), w1x1 38.6,
   # d3 34.0, WSPEC bands nvcc-fail on this kernel. The 0.93x residual vs torch SDPA is per-step

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -237,12 +237,23 @@ configs:
     knobs: {PLACE: 'fuse', STAGE: 'd2/tma/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32', WSPEC: ''}
     emmy_us: 35.5
     cublas_us: 30.7
-  # The PRIMARY (2026-07-14, post alternating staging): the 64-key streaming block (nt=8) on
-  # d1/tma/alt — one K slab + one V slab on separate mbarriers, refills interleaved with the phases
-  # that no longer read them, Q staged through smem (240 regs, zero spills; the paired-ring nt=8
-  # form was spill-bound at 55.5). 32.2 µs = 0.95x vs torch SDPA, 3x reproduced zero-spread. The
-  # fm sibling loses here (33.8 — the per-block promote outweighs at 64-key steps); FAST_EXP
+  # The std-lane PRIMARY (2026-07-14, alternating staging): the 64-key streaming block (nt=8) on
+  # d1/cp/alt — one K slab + one V slab, refills interleaved with the phases that no longer read
+  # them (cp.async commit-group queue, uniform wait_group(1)), Q staged through smem. The cp
+  # transport BEATS the tma sibling here (31.7 vs 32.2 — the lane/transport flip again); 0.97x vs
+  # torch SDPA, 3x reproduced. The paired-ring nt=8 form was spill-bound at 55.5. FAST_EXP
   # neutral; alt+g2k 33.3 (the finalize costs more than the split recovers at this grid).
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 31.7
+    cublas_us: 30.7
+  # The tma-alt sibling (0.95x) — kept beside the cp primary (both directions 3x reproduced).
   - kernel: attention
     name: gemma4_12b.attention.hd256
     n_heads: 16
@@ -252,6 +263,19 @@ configs:
     causal: true
     knobs: {PLACE: 'fuse', STAGE: 'd1/tma/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32/k4', WSPEC: ''}
     emmy_us: 32.2
+    cublas_us: 30.7
+  # The FM PRIMARY — and the first emmy-past-torch-SDPA hd256 entry on the 5090: the f16-accumulate
+  # PV sibling on d1/cp/alt runs 29.7 = 1.03x vs SDPA 30.7 (3x reproduced zero-spread; on tma-alt
+  # the fm promote outweighed at 33.8 — cp's issue pattern absorbs it, the fm-prefers-cp lane rule).
+  - kernel: attention
+    name: gemma4_12b.attention.hd256
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 29.7
     cublas_us: 30.7
   # The paired-ring runner-up: the nt=4 streaming block (32 keys/step, 32 KB slabs) — 32.9, 7% past
   # the nt=2 entry (pre-skip they were parity alternates). The knob frontier ends here — nt=8 fattens

--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -75,7 +75,7 @@ TILE = Knob(
 STAGE = Knob(
     "STAGE",
     KnobType.STR,
-    help="Operand-staging codec (d<depth>/sync|cp|tma[/ring][/p<reg_depth>]; empty=gmem-direct). "
+    help="Operand-staging codec (d<depth>/sync|cp|tma[/ring][/alt][/p<reg_depth>]; empty=gmem-direct). "
     "Decided in lowering/tile/010_recognize (the _schedule helper), materialized in lowering/kernel/010_materialize.",
     off="",
 )

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -939,6 +939,38 @@ def test_warp_flash_causal_tile_skip(monkeypatch):
 
 @requires_cuda
 @pytest.mark.parametrize("variant", ["plain", "causal"])
+def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant):
+    """The ALTERNATING single-slab staging (``STAGE=d1/tma/alt``): one K slab + one V slab on
+    separate mbarriers, refilled in the phase that no longer reads them (K under softmax + P·V,
+    V under the next step's Q·K), and Q staged through a padded smem tile (its A fragments
+    ldmatrix'd per atom-K chunk). Structure pinned via the emitted source (the per-operand
+    mbarriers + the Q slab), values vs torch — the fills are verbatim copies, so alt stays
+    bit-identical to gmem-direct."""
+    monkeypatch.setenv("EMMY_PLACE", "fuse")
+    monkeypatch.setenv("EMMY_STAGE", "d1/tma/alt")
+    torch.manual_seed(11)
+    module = _Causal() if variant == "causal" else _Sdpa()
+    q, k, v = (torch.randn(1, 4, 128, 64, dtype=torch.float16) for _ in range(3))
+    backend, compiled, graph, kernels = _trace(module, (q, k, v))
+    assert len(kernels) == 1
+    src = compiled.nodes[kernels[0]].op.kernel_source
+    assert "_kbar" in src and "_vbar" in src, "alt staging must run the per-operand mbarrier pair"
+    assert "_q_smem" in src, "alt staging must stage Q through smem"
+
+    def ref():
+        with torch.no_grad():
+            out = torch.nn.functional.scaled_dot_product_attention(q.cuda(), k.cuda(), v.cuda(), is_causal=variant == "causal")
+            return out.cpu().flatten().float().numpy()
+
+    data = {n: t for n, t in zip(graph.inputs, (q.numpy(), k.numpy(), v.numpy()), strict=True)}
+    run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
+    got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
+    max_diff = float(np.max(np.abs(got - eager)))
+    assert max_diff < 5e-3, f"alt-staged flash ({variant}) max_diff={max_diff:.2e}"
+
+
+@requires_cuda
+@pytest.mark.parametrize("variant", ["plain", "causal"])
 def test_warp_flash_split_kv_matches_torch(monkeypatch, variant):
     """Flash split-KV (``REDUCE=g<n>k`` on the warp tier): the kv stream splits across CTAs, each
     partial keeping fragment residence and storing its raw ``(m, l, O)`` state to the f32

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -938,8 +938,9 @@ def test_warp_flash_causal_tile_skip(monkeypatch):
 
 
 @requires_cuda
+@pytest.mark.parametrize("stage", ["d1/tma/alt", "d1/cp/alt"])
 @pytest.mark.parametrize("variant", ["plain", "causal"])
-def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant):
+def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant, stage):
     """The ALTERNATING single-slab staging (``STAGE=d1/tma/alt``): one K slab + one V slab on
     separate mbarriers, refilled in the phase that no longer reads them (K under softmax + P·V,
     V under the next step's Q·K), and Q staged through a padded smem tile (its A fragments
@@ -947,14 +948,17 @@ def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant):
     mbarriers + the Q slab), values vs torch — the fills are verbatim copies, so alt stays
     bit-identical to gmem-direct."""
     monkeypatch.setenv("EMMY_PLACE", "fuse")
-    monkeypatch.setenv("EMMY_STAGE", "d1/tma/alt")
+    monkeypatch.setenv("EMMY_STAGE", stage)
     torch.manual_seed(11)
     module = _Causal() if variant == "causal" else _Sdpa()
     q, k, v = (torch.randn(1, 4, 128, 64, dtype=torch.float16) for _ in range(3))
     backend, compiled, graph, kernels = _trace(module, (q, k, v))
     assert len(kernels) == 1
     src = compiled.nodes[kernels[0]].op.kernel_source
-    assert "_kbar" in src and "_vbar" in src, "alt staging must run the per-operand mbarrier pair"
+    if "tma" in stage:
+        assert "_kbar" in src and "_vbar" in src, "tma alt must run the per-operand mbarrier pair"
+    else:
+        assert "_kbar" not in src and "cp_async" in src, "cp alt rides commit groups, no mbarriers"
     assert "_q_smem" in src, "alt staging must stage Q through smem"
 
     def ref():


### PR DESCRIPTION
## What

The `STAGE` codec gains an `alt` flag: the **alternating single-slab pipeline** for the warp-flash stream — FA-2's choreography. One K slab + one V slab, each on its own mbarrier, refills interleaved into the phases that no longer read them (K's copy under softmax+P·V, V's under the next step's Q·K), and **Q staged through smem** (padded tile, filled once, A-fragments `ldmatrix`'d per atom-K chunk). This makes the 64-key streaming block viable: its copies overlap in half the paired ring's smem, and freeing the resident Q registers takes it from 255 regs + 848 B spill loads to **240 regs, zero spills**.

## Why 64-key blocks

NCU showed torch's hd256 kernel (FA-2 `flash_fwd_splitkv`, kBlockN=64) executes far fewer ALU/FMA instructions per key — the O(head_dim) softmax/rescale machinery amortizes over twice the keys per step. Our nt8 form existed but was budget-degraded to an unpipelined, spill-bound d1 (55.5 µs). A hand-edited prototype of this design measured 32.0 µs before the emitter work (via clobber-verified cubin injection — the earlier single-key injection harness was found broken and PR #357 retracted).

## Measured (RTX 5090, hd256 16h seq-512 fp16 causal, 3× reproduced)

| config | µs | vs SDPA 30.7 |
| --- | --: | --: |
| previous frontier (nt4 `d2/tma/ring`) | 32.9 | 0.93× |
| nt8 `d1/tma` (paired, spilling) | 55.5 | 0.55× |
| **nt8 `d1/tma/alt` (this PR)** | **32.2** | **0.95×** |
| non-causal alt | 33 | **1.23× vs eager — wins outright** |

Probed and recorded: fm sibling 33.8 (the per-block promote outweighs at 64-key steps), FAST_EXP neutral, alt+`g2k` 33.3, nt4-alt 34.8.

## Mechanics

- `Stage.alt` (codec `d1/tma/alt`; single-slab only — depth/ring refused in `__post_init__`), offered on the flash stage-candidate list where it resolves (TMA, static block-divisible kv, Q+K+V within the smem budget); matmul resolvers decline it; WSPEC gated off.
- `_stage.alternating_kloop` — the new skeleton beside `staged_kloop`; composes with the causal tile-skip (`k_end`) and the split-KV window.
- `_twist._stream_segments` — the one stream builder now yields its QK/softmax/PV segments so both skeletons share it; Q residency branches between the hoisted gmem fragments (default) and the per-chunk smem loads (alt). Fills are verbatim copies → bit-identical to gmem-direct.
- New golden primary (32.2) recorded, replays clean through the golden plumbing; permanence tests pass (nt8 and the alt spelling are grid members).
- Tests: `test_warp_flash_alt_staging_matches_torch[plain|causal]` pins the structure (per-operand mbarriers + Q slab) and accuracy. `make test`: 2335 passed. `make lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)