### PR TITLE
Symbolic-kv alternating staging + gemma4 golden gap fill (4090 norms, dynM attention)

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -165,8 +165,10 @@ slab.) The **TMA transport** boxes the batched K/V via rank-N descriptors (leadi
 extent-1 box dims; the load's batch/head index exprs as origin coords — GQA's `h // group` included) into dense
 1024 B-aligned slabs under the hardware swizzle, the drains' address XOR undoing it; under a `WSPEC` band split the
 transport's elected fill thread rides the WRAPPED linear tid (`threadIdx.x % block_threads` — the raw tid would elect
-a compute thread and the producer band would never fill). Static block-divisible kv only (the symbolic stream keeps
-its masked gmem-direct loads), and bit-identity to the gmem-direct sibling holds — same values, same mma order.
+a compute thread and the producer band would never fill). A symbolic kv stages too (TMA zero-fills the box overhang
+past the last key; cp.async clamp-reads the tail's key rows; the drain's tail masks zero the overhanging P columns);
+a static NON-block-divisible kv has no tail mask and stays gmem-direct. Bit-identity to the gmem-direct sibling
+holds either way — same values, same mma order.
 
 **A causal stream tile-skips** (staged and gmem-direct alike): when the score prologue carries the triangular
 `Select` (`kv ≤ m`, detected off the predicate shape in `_twist`), the stream stops at the CTA's last query row —
@@ -189,9 +191,13 @@ spill loads to 240 regs / zero spills, 55.5 → 31.7 µs — past the nt4-d2 fro
 is the first emmy-past-torch-SDPA hd256 entry on the 5090 at 29.7). Both async transports ride the skeleton: TMA arms
 per-operand mbarriers (`d1/tma/alt`); cp.async commits each fill into its own group — the K,V,K,V commits queue per
 thread, and the counting pass derives the uniform `wait_group(1)` that completes exactly the older sibling
-(`d1/cp/alt`, the sm_89 form — and the faster one on the 5090 too, the fm-prefers-cp lane rule again). Static
-block-divisible kv only; composes with the causal tile-skip (`k_end`) and the split-KV window; flash stream only
-(the matmul resolvers decline `alt`).
+(`d1/cp/alt`, the sm_89 form — and the faster one on the 5090 too, the fm-prefers-cp lane rule again). A symbolic
+kv rides the same runtime clamps as the ring: the kill-point refill clamps onto the runtime last chunk exactly as
+the ring prefetch does, and the staged-Q fill clamp-reads a tail CTA's overhanging query rows (their outputs are
+store-guarded) — the 5090 `attention.hd256.dynM` frontier moved 34.4 → 32.0 on `d1/cp/alt` and `hd128.dynM`
+13.5 on the fm `d1/tma/alt`, closing the symbolic-vs-static gap. A static non-block-divisible kv stays gmem-direct;
+composes with the causal tile-skip (`k_end`) and the split-KV window; flash stream only (the matmul resolvers
+decline `alt`).
 
 **A split-KV partial windows the same stream** (`030_split_reduce._split_twisted_warp`, the flash `REDUCE=g<n>k` arm): the
 `Reduction` arrives with its axis shrunk to the slice length and the slice's absolute base on `Reduction.offset` —

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -868,8 +868,8 @@ def pipelined_kloop(
     ``k_end`` (CTA-uniform, ``≤ k_extent``) stops the chunk loop early — the causal flash stream's
     triangular kv bound; the clamp re-pins onto the last NEEDED chunk via the loop's hoisted
     ``<k0>_end`` for-init bound. A symbolic ``k_extent`` (a ``Dim``) allocates the full ``depth``
-    ring and clamps against the runtime chunk count (kill-point groups are static-only — the alt
-    resolver's gate). Returns ``(slab_decls, [prologue…, outer_loop])``."""
+    ring and clamps every fill — ring prefetch and kill-point refill alike — against the runtime
+    chunk count. Returns ``(slab_decls, [prologue…, outer_loop])``."""
     symbolic = isinstance(k_extent, Dim)
     i_expr = BinaryExpr("/", Var(k0), _lit(bk_elems))  # chunk index of the current step
 
@@ -895,8 +895,7 @@ def pipelined_kloop(
         elif g.first == 0 and g.last == len(segments) - 1:
             g.kind, g.lag = "current", 0
         else:
-            assert not symbolic, "a kill-point refill needs a static extent (the alt resolver's gate)"
-            g.kind, g.lag = "kill", 1
+            g.kind, g.lag = "kill", 1  # a symbolic extent rides the same runtime clamp as the ring prefetch
 
     def _fill_k0(lag: int) -> Expr:
         """The refill's chunk base — ``k0 + lag·bk``, clamped onto the last needed chunk (the

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -25,7 +25,7 @@ residence — the fragment row of the placement-keyed fold (a within-warp ``Frag
 - the projection tail (``O / l``) realizes as an in-place ``FragmentApply`` + the ``RegStore``
   output close;
 - a resolved K/V ``Stage`` on the ``TileOp`` (``ctx.stage`` — ``_schedule._resolve_twisted_stage``,
-  cp.async or TMA over a static block-divisible kv) re-parents the streaming step under the same
+  cp.async or TMA over a block-divisible-or-symbolic kv) re-parents the streaming step under the same
   ``staged_kloop`` skeleton the matmul tier runs: the K/V slabs fill per KV block (each in its
   operand's own layout — verbatim row copies, so staged stays bit-identical to gmem-direct) and
   the step's B fragments drain them via the staged ldmatrix variants (plain ``x2`` for the
@@ -625,7 +625,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
 
     if stage is not None:
         # The staged K/V stream: the resolved ``Stage`` (``_schedule._resolve_twisted_stage`` —
-        # static, block-divisible kv only) rides the SAME ``staged_kloop`` skeleton the matmul tier
+        # block-divisible or symbolic kv) rides the SAME ``staged_kloop`` skeleton the matmul tier
         # runs, the streaming step as its drain. The K slab keeps K's own N-major layout (``bn`` key
         # rows × head_dim) and the V slab V's K-major one (``bn`` key rows × d_v) — the fills are
         # verbatim row copies, so the staged kernel stays bit-identical to its gmem-direct sibling.
@@ -700,12 +700,20 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             # resident Q registers.
             q_rows = um * fm * shape[0]
             cta_row0 = BinaryExpr("*", Var(grid[-1].name), Literal(q_rows, "int"))
+
+            def _q_row(row) -> Expr:
+                # A symbolic M clamp-reads the tail CTA's overhanging query rows to the last valid
+                # row (cp.async has no OOB zero-fill) — their outputs are store-guarded (the
+                # ``RegStore`` m_guard), so the duplicates are never written back.
+                r = BinaryExpr("+", cta_row0, row)
+                return _clamp_last(r, _ext(qk.m_axis)) if symbolic_q else r
+
             state.append(slab_smem("_q_smem", q_rows, q_ldm, _cuda(atom.operand_dtype("a")), align=16))
             state += cp_async_fill(
                 slab="_q_smem",
                 shape=(q_rows, head_dim_s),
                 src=qk.a_operand.input,
-                gmem_index=lambda row, col: _idx(qk.a_operand, {qk.m_axis.name: BinaryExpr("+", cta_row0, row), qk.k_axis.name: col}),
+                gmem_index=lambda row, col: _idx(qk.a_operand, {qk.m_axis.name: _q_row(row), qk.k_axis.name: col}),
                 cta=cta,
                 elem_bytes=elem_bytes,
                 name="q",

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1661,11 +1661,16 @@ def _resolve_twisted_stage(
         # streaming block's copies in HALF the paired ring's smem. The Q (query) tile stages
         # through smem too — a padded row-major slab filled once, its A fragments ldmatrix'd per
         # atom-K chunk — which frees the resident Q registers that made the wide block spill.
-        # Static block-divisible kv only (the symbolic tail story is not built for the split
-        # phases). Both async transports ride the same seam: TMA arms per-operand mbarriers
+        # A SYMBOLIC kv rides the ring's tail story unchanged (TMA zero-fills the box overhang,
+        # cp.async clamp-reads the tail's key rows, the drain masks zero the overhanging P
+        # columns — bit-identical either way); the kill-point refill clamps onto the runtime
+        # last chunk exactly as the ring prefetch does, and a symbolic M clamp-reads the
+        # staged-Q fill's overhanging query rows (their outputs are store-guarded). A static
+        # non-block-divisible kv has no tail mask, so it stays gmem-direct (the ring's gate).
+        # Both async transports ride the same seam: TMA arms per-operand mbarriers
         # (``d1/tma/alt``); cp.async commits each fill into its own group and a uniform
         # ``wait_group(1)`` completes the older sibling (``d1/cp/alt`` — the sm_89 form).
-        if not kv_extent.is_static or kv_extent.as_static() % bn != 0 or m_rows <= 0:
+        if m_rows <= 0 or (kv_extent.is_static and kv_extent.as_static() % bn != 0):
             return None
         if stage.transport == "tma":
             if bn > 256 or head_dim > 256 or d_v > 256 or (head_dim * elem_bytes) % 16 or (d_v * elem_bytes) % 16:

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89.yaml
@@ -604,6 +604,31 @@ configs:
     knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k8', STAGE: 'd2/cp/ring'}
     emmy_us: 20.3
     cublas_us: 19.0
+  # FAST_MATH-lane pair on the symbolic twin (2026-07-14 — the alternating pipeline now resolves on
+  # a symbolic kv): fm-alt 18.1 is the dynM frontier (fm-ring 18.6, std ring 20.0 live / 20.3
+  # recorded); std-alt loses (21.8). Mirrors the static hd128 fm pair above; cp.async only (sm_89).
+  - kernel: attention
+    name: attention.hd128.dynM
+    n_heads: 8
+    seq: 512
+    head_dim: 128
+    dtype: 'fp16'
+    causal: false
+    dynamic: true
+    knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f1x16/k4', STAGE: 'd2/cp/ring'}
+    emmy_us: 18.6
+    cublas_us: 19.0
+  - kernel: attention
+    name: attention.hd128.dynM
+    n_heads: 8
+    seq: 512
+    head_dim: 128
+    dtype: 'fp16'
+    causal: false
+    dynamic: true
+    knobs: {PLACE: 'fuse', TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f1x16/k4', STAGE: 'd1/cp/alt'}
+    emmy_us: 18.1
+    cublas_us: 19.0
   # Values re-measured 2026-07-13 after the causal tile-skip (3x reproduced): nt=2 44.1 → 40.4, and
   # the nt=4 streaming block (below) is the new twin frontier at 1.11x past torch SDPA — post-skip
   # the nt=4 form realizes on sm_89 (the pre-skip realize-back-to-nt2 note is obsolete).

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
@@ -278,3 +278,30 @@ configs:
     knobs: {PLACE: 'fuse', STAGE: 'd2/cp/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w4x1/f1x32', WSPEC: ''}
     emmy_us: 37.6
     cublas_us: 41.0
+  # The norm rows (2026-07-14, 3x reproduced) — filled the coverage gap vs the 5090 file. b256 wins
+  # the block-split fork on both forms (b128 7.7 / b512 7.6); the greedy pick lands b128 (7.6) on
+  # the static shape, so the row matters. Note: a missing per-GPU row also blocks `run --golden`
+  # name resolution on this card (live_gpu scoping), which is how the gap surfaced.
+  - kernel: rms_norm
+    name: gemma4_12b.rms_norm.k3840
+    M: 512
+    K: 3840
+    knobs: {REDUCE: 'b256'}
+    emmy_us: 6.9
+    cublas_us: 7.0
+  - kernel: rms_norm
+    name: gemma4_12b.rms_norm.k3840.dynM
+    M: 512
+    K: 3840
+    dynamic: true
+    knobs: {REDUCE: 'b256'}
+    emmy_us: 6.9
+    cublas_us: 7.0
+  # qknorm: b64 wins (b128 3.85, b256 6.0, b512 11.2 — the wide splits starve the 4096-row grid).
+  - kernel: rms_norm
+    name: gemma4_12b.qknorm.k256
+    M: 4096
+    K: 256
+    knobs: {REDUCE: 'b64'}
+    emmy_us: 3.6
+    cublas_us: 4.8

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120.yaml
@@ -604,3 +604,29 @@ configs:
     knobs: {PLACE: 'fuse', STAGE: 'd2/tma/ring', TILE: 'a:mma_m16n8k16_f16_f16/w2x1/f1x16/k4', WSPEC: ''}
     emmy_us: 15.3
     cublas_us: 18.4
+  # Symbolic-kv alt pair (2026-07-14): the alternating pipeline resolves on dynM and closes the gap
+  # to the static frontier — std tma-alt 16.0 (ring twin 16.6), fm tma-alt 13.5 = the static fm-alt
+  # value exactly (ring twin 15.4); both 3x zero-spread. cp-alt loses (17.1 std / 14.8 fm) — the
+  # hd128-prefers-tma transport rule carries over from the static rows.
+  - kernel: attention
+    name: attention.hd128.dynM
+    n_heads: 8
+    seq: 512
+    head_dim: 128
+    dtype: 'fp16'
+    causal: false
+    dynamic: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/tma/alt', TILE: 'a:mma_m16n8k16_f16_f32/w2x1/f1x8/k8', WSPEC: ''}
+    emmy_us: 16.0
+    cublas_us: 18.4
+  - kernel: attention
+    name: attention.hd128.dynM
+    n_heads: 8
+    seq: 512
+    head_dim: 128
+    dtype: 'fp16'
+    causal: false
+    dynamic: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/tma/alt', TILE: 'a:mma_m16n8k16_f16_f16/w2x1/f1x16/k4', WSPEC: ''}
+    emmy_us: 13.5
+    cublas_us: 18.4

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -352,6 +352,24 @@ configs:
     knobs: {PLACE: 'fuse', STAGE: 'd2/cp/ring', TILE: 'a:mma_m16n8k16_f16_f16/w4x1/f1x32', WSPEC: ''}
     emmy_us: 35.5
     cublas_us: 30.7
+  # The dynM PRIMARY (2026-07-14, symbolic-kv alt): the alternating pipeline now resolves on a
+  # symbolic kv (the kill-point refill clamps onto the runtime last chunk like the ring prefetch;
+  # the staged-Q fill clamp-reads a tail CTA's overhanging query rows, store-guarded) — 32.0 vs the
+  # ring twin 34.4, 3x zero-spread, closing most of the dynM-vs-static gap (static std cp-alt 31.7).
+  # The geometry/lane preferences FLIP vs static: nt=4 alt (32.0) beats nt=8 alt (32.3; static nt8
+  # won), and the fm sibling LOSES on the symbolic form (34.7 — the static fm-alt 29.7 does not
+  # transfer), so std stays the dynM primary. tma-alt 35.4 (hd256 prefers cp, as static).
+  - kernel: attention
+    name: gemma4_12b.attention.hd256.dynM
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    dynamic: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f1x4/k16', WSPEC: ''}
+    emmy_us: 32.0
+    cublas_us: 30.7
   # ---- norms -----------------------------------------------------------------------------------------
   - kernel: rms_norm
     name: gemma4_12b.rms_norm.k3840

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -561,10 +561,28 @@ def test_print_ncu_compare_renders_dep_then_ref(capsys):
 @requires_cuda
 def test_run_ab_bench_shows_pinned_row(run_cli):
     """``run --code ... --bench --ab KNOBS`` benches the pinned config and prints it
-    as an ``ab KNOBS``-labeled row in the kernel table."""
-    rc, stdout, stderr = run_cli("run", "--code", "torch.matmul(torch.randn(64, 64), torch.randn(64, 64))", "--bench", "--ab", "BM=8,BN=16")
+    as an ``ab KNOBS``-labeled row in the kernel table. The pin must REALIZE (a valid
+    scalar-tile spelling for this shape) — an unmatched pin now fails its row loudly
+    and exits non-zero instead of benching the planner's pick under the pin's name."""
+    rc, stdout, stderr = run_cli(
+        "run", "--code", "torch.matmul(torch.randn(64, 64), torch.randn(64, 64))", "--bench", "--ab", "TILE=n16x16/f2x2"
+    )
     assert rc == 0, f"stderr: {stderr}"
-    assert "ab BM=8,BN=16" in stdout, stdout
+    assert "ab TILE=n16x16/f2x2" in stdout, stdout
+
+
+@requires_cuda
+def test_run_ab_bench_unmatched_pin_fails_loudly(run_cli):
+    """An ``--ab`` pin that matches no offered row (a knob family that does not exist)
+    is NOT benched — the row fails loudly (``unreproducible pin`` on the row, no timing)
+    and the run exits non-zero, instead of silently benching the planner's own pick
+    under the pin's name (the pin-spelling trap the golden sweeps kept hitting)."""
+    rc, stdout, _stderr = run_cli(
+        "run", "--code", "torch.matmul(torch.randn(64, 64), torch.randn(64, 64))", "--bench", "--ab", "BM=8,BN=16"
+    )
+    assert rc != 0, "an unmatched --ab pin must fail the run"
+    assert "unreproducible pin" in stdout, stdout
+    assert "! ab BM=8,BN=16" in stdout, stdout
 
 
 @requires_cuda

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -974,6 +974,44 @@ def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant, stage):
 
 
 @requires_cuda
+@pytest.mark.parametrize(("variant", "stage"), [("plain", "d1/cp/alt"), ("plain", "d1/tma/alt"), ("causal", "d1/cp/alt")])
+def test_warp_flash_alt_staging_symbolic_bit_identical(monkeypatch, variant, stage):
+    """The alternating staging over a SYMBOLIC ``seq_len`` — the resolver accepts it and the
+    liveness scheduler's kill-point refills ride the same runtime clamp as the ring prefetch:
+    cp.async clamp-reads the tail's key rows (TMA zero-fills its box), the staged-Q fill
+    clamp-reads a tail CTA's overhanging query rows (their outputs are store-guarded), and the
+    drain's tail masks zero the overhanging P columns. All fills are verbatim copies, so the alt
+    kernel is BIT-identical to its gmem-direct symbolic sibling at both a block-divisible (64)
+    and an overhanging (100) seq; the causal case composes the ``k_end`` early stop with the
+    symbolic clamp."""
+    monkeypatch.setenv("EMMY_PLACE", "fuse")
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16/w2x1/f1x4/k4")
+    B, H, D = 1, 4, 64
+    sd = torch.export.Dim("seq_len", min=4, max=4096)
+    seed = tuple(torch.randn(B, H, 16, D, dtype=torch.float16) for _ in range(3))
+    ds = {"q": {2: sd}, "k": {2: sd}, "v": {2: sd}}
+    module = _Causal() if variant == "causal" else _Sdpa()
+
+    backend, compiled, graph, _ = _trace(module, seed, dynamic_shapes=ds)
+    monkeypatch.setenv("EMMY_STAGE", stage)
+    backend2, compiled2, graph2, kernels2 = _trace(module, seed, dynamic_shapes=ds)
+    src = compiled2.nodes[kernels2[0]].op.kernel_source
+    assert "int seq_len" in src, "the symbolic kernel must carry the runtime seq_len arg"
+    assert "_q_smem" in src, "alt staging must stage Q through smem"
+    if "tma" in stage:
+        assert "_kbar" in src and "_vbar" in src, "tma alt must run the per-operand mbarrier pair"
+    else:
+        assert "_kbar" not in src and "cp.async" in src, "cp alt rides commit groups, no mbarriers"
+
+    for s in (64, 100):
+        torch.manual_seed(s)
+        q, k, v = (torch.randn(B, H, s, D, dtype=torch.float16) for _ in range(3))
+        base = _run_flash(backend, compiled, graph, (q, k, v))
+        staged = _run_flash(backend2, compiled2, graph2, (q, k, v))
+        assert np.array_equal(base, staged), f"symbolic alt ({variant}/{stage}, seq={s}) differs from gmem-direct sibling"
+
+
+@requires_cuda
 @pytest.mark.parametrize("variant", ["plain", "causal"])
 def test_warp_flash_split_kv_matches_torch(monkeypatch, variant):
     """Flash split-KV (``REDUCE=g<n>k`` on the warp tier): the kv stream splits across CTAs, each


### PR DESCRIPTION
## What

Two pieces of dataset + one small feature, from the gemma4 per-kernel review:

### 1. Symbolic-kv alternating staging (`d1/…/alt` on `.dynM` shapes)

The alt pipeline was static-block-divisible only — which left every `.dynM` attention golden on the paired ring, including the worst gemma4 entry (5090 `attention.hd256.dynM`, 0.86–0.89× vs torch SDPA). The symbolic tail story is the **ring's, reused**:

- the kill-point refill clamps onto the runtime last chunk exactly as the ring prefetch does (`pipelined_kloop._fill_k0` already carried the symbolic branch — only the assert fell);
- the staged-Q fill clamp-reads a tail CTA's overhanging query rows (`_clamp_last`, outputs store-guarded — the standard masked-M treatment);
- the K/V fills (cp clamp-read / TMA box zero-fill) and the drain's tail masks were already symbolic-ready.

The resolver now accepts a symbolic kv for `alt`; a static non-divisible kv stays gmem-direct (unchanged). New e2e: symbolic alt (cp/tma × plain/causal) is **bit-identical** to the gmem-direct symbolic sibling at both a block-divisible (64) and an overhanging (100) seq.

**Measured, 3× zero-spread, goldens recorded + replay-verified on both cards:**

| Shape | Card | Ring (old golden) | Alt (new) | torch |
|---|---|---|---|---|
| gemma4 attention.hd256.dynM | 5090 | 34.4 | **32.0** (`d1/cp/alt`, std nt4) | 30.7 |
| attention.hd128.dynM | 5090 | 15.4 fm / 16.6 std | **13.5** fm / 16.0 std (`d1/tma/alt`) | 18.4 |
| attention.hd128.dynM | 4090 | 20.3 std | **18.1** fm (`d1/cp/alt`; fm-ring 18.6 sibling recorded) | 19.0 |
| attention.hd256.dynM | 4090 | 38.0 | 38.4 — parity, ring kept | 42 |

hd128.dynM fully closes the symbolic-vs-static gap (13.5 = the static fm-alt value). The hd256.dynM preferences flip vs static (nt4 > nt8, fm loses 34.7) — std stays the dynM primary there. Established transport rules carry over (hd128→tma, hd256→cp).

### 2. 4090 gemma4 golden gaps (norms)

`rms_norm.k3840` (static + dynM, `b256`, 6.9 µs vs eager 7.0) and `qknorm.k256` (`b64`, 3.6 vs 4.8) — 3× reproduced, replay clean. A missing per-GPU row also blocks `run --golden` name resolution on the card (live_gpu scoping), so the gap was self-hiding.

## Verification

- New e2e symbolic-alt bit-identity tests (3 cases); full `make test` 2350 passed / 39 skipped (perf lane); `make lint` clean.
- Every recorded golden row replay-verified on its card at the recorded value (5090 local, 4090 rented box).
- Stale "static block-divisible kv only" claims fixed in the kernel ARCHITECTURE.md / `_twist` docstrings (one predated this change and contradicted the existing symbolic ring-staging tests).

Stacked on #360 (the liveness-scheduled staging refactor) — the kill-point clamp reuses its `pipelined_kloop` scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)