### PR TITLE
Golden evals featurize under the golden's own card, not the live host's

### DIFF
--- a/emmy/commands/eval.py
+++ b/emmy/commands/eval.py
@@ -552,7 +552,8 @@ def _emit_offline_eval(kernel_filter: str | None) -> None:
         gold = dict(tuning_knob_items(g.knobs))  # the native codec knobs (TILE/REDUCE/STAGE), tier-agnostic
         try:
             dyn = bool(getattr(g, "dynamic", None))
-            got, rank, pool = evaluate_golden(g.M, g.N, g.K, g.dtype, gold, Context.from_target(g.compute_cap), dynamic=dyn)
+            ctx = Context.from_target(g.compute_cap, gpu_name=g.gpu_name)  # the golden's own card, not the live host's
+            got, rank, pool = evaluate_golden(g.M, g.N, g.K, g.dtype, gold, ctx, dynamic=dyn)
         except Exception as e:  # noqa: BLE001 — one shape's error shouldn't abort the report
             entries.append(("err", g.name, " ".join(f"{type(e).__name__}: {e}".split())[:100]))
             continue

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -643,6 +643,14 @@ partial+finalize pair) still prints and lands in the record.
 
 ## Part 8: Evaluating the prior (`emmy eval`)
 
+**Golden evals featurize under the golden's own card.** `eval offline` / `eval online` rebuild each golden's compile
+context as `Context.from_target(compute_cap, gpu_name=…)` — the card recorded in the golden file, with its memorized
+SM count / smem specs — never the live host's. The host-context version silently made golden ranks
+machine-dependent (a 4090 golden scored on a 5090 host featurized as "sm_89 with 170 SMs"; on a GPU-less host, with
+the default SM count) — the occupancy features then priced tiles for a card that doesn't exist, reporting rank 0 on
+shapes the real card misdeployed 12–29×. The fitter (`golden_knob_heuristics`) always did this correctly; the eval
+gate now matches it.
+
 **Fork-sibling regret** (`eval online --dataset nodes`, via `iter_nodes` → `diagnostics.node_report`): **per card**, it
 groups nodes by `parent_key` and prices what following the prior's per-fork pick costs —
 `value_us(predicted-best child) / value_us(true best)` (1.00x = the prior steers into the best-reachable subtree;

--- a/emmy/compiler/pipeline/search/prior/diagnostics.py
+++ b/emmy/compiler/pipeline/search/prior/diagnostics.py
@@ -150,12 +150,13 @@ def golden_prior_eval(prior, kernel_filter: str | None = None) -> str:
             # every unjoinable shape gets a per-shape line instead.
             skipped.append((g.name, "no tuned rows for this shape in the prior dataset"))
             continue
-        base = {**Context.from_target(g.compute_cap).features(), **s_feats}
+        ctx = Context.from_target(g.compute_cap, gpu_name=g.gpu_name)  # the golden's own card, not the live host's
+        base = {**ctx.features(), **s_feats}
         gold = dict(tuning_knob_items(g.knobs))  # native codec knobs (TILE/REDUCE/STAGE), tier-agnostic
         # ``evaluate_golden`` ranks by descending score; the prior predicts latency
         # (lower = better), so negate to rank the predicted-fastest config first.
         _, rank, pool = golden_eval.evaluate_golden(
-            g.M, g.N, g.K, g.dtype, gold, Context.from_target(g.compute_cap), scorer=lambda r, b=base: -prior.mean_score({**b, **r})
+            g.M, g.N, g.K, g.dtype, gold, ctx, scorer=lambda r, b=base: -prior.mean_score({**b, **r})
         )
         if rank is None:
             skipped.append((g.name, f"recorded knobs not in the enumeration ({pool} rows) — pin/dtype mismatch?"))

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -509,3 +509,40 @@ def test_bare_families_canonicalizes_axis_suffixed_knobs():
     assert got == {"TILE": "n16x8/f2x4", "STAGE": "d3/tma/ring", "REDUCE": "g2a", "WSPEC": ""}
     # bare keys pass through; first key wins a family collision (single-node picks in practice)
     assert _bare_families({"TILE": "a", "TILE@x": "b"}) == {"TILE": "a"}
+
+
+def test_offline_eval_scores_each_golden_under_its_own_card(monkeypatch):
+    """``eval offline`` must featurize a golden under the golden's OWN card
+    (``Context.from_target(cap, gpu_name=...)``), never the live host's. With the
+    ``gpu_name`` dropped, the SM count fell back to the host device (or the GPU-less
+    default), so the occupancy features priced tiles for a card that doesn't exist —
+    the eval said rank 0 on gemma goldens the real 4090 misdeployed 12-29x. The fitter
+    (``golden_knob_heuristics``) already passed it; this pins the eval side to match."""
+    import emmy.commands.eval as eval_cmd
+    from emmy.compiler.pipeline.search.golden import MatmulGoldenConfig
+
+    golden = MatmulGoldenConfig(
+        name="gemma4_12b.q_proj",
+        M=512,
+        N=4096,
+        K=3840,
+        dtype="fp16",
+        knobs={"TILE": "a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2"},
+        gpu_name="NVIDIA GeForce RTX 4090",
+        compute_cap=(8, 9),
+    )
+    seen: list = []
+
+    def fake_evaluate_golden(M, N, K, dtype, gold, ctx, *, dynamic=False):
+        seen.append(ctx)
+        return dict(gold), 0, 1
+
+    monkeypatch.setattr(eval_cmd, "_golden_configs", lambda _f: [golden])
+    monkeypatch.setattr("emmy.compiler.pipeline.search.golden_eval.evaluate_golden", fake_evaluate_golden)
+    eval_cmd._emit_offline_eval(None)
+
+    assert len(seen) == 1
+    ctx = seen[0]
+    assert ctx.gpu_name == "NVIDIA GeForce RTX 4090"
+    assert ctx.sm_count == 128  # the 4090's registered SM count, regardless of the host GPU
+    assert ctx.compute_capability == (8, 9)


### PR DESCRIPTION
Both golden-rank evals (eval offline's body and the online golden_prior_eval diagnostics) built the golden's compile context as Context.from_target(compute_cap) without the gpu_name — so the SM count and device props fell back to the live host (or the GPU-less default), and the occupancy features priced every candidate for a card that doesn't exist. Golden ranks were machine-dependent: a 4090 golden scored on a 5090 host featurized as "sm_89 with 170 SMs", and an off-GPU eval reported the gemma-4 goldens at rank 0 while a real cold 4090 deploy shipped tiles 12-29x slower than the goldens (w1x1 degenerate picks). The fitter (golden_knob_heuristics) always passed gpu_name — training and evaluation disagreed about the hardware, so refit accept/reject decisions were adjudicated on distorted numbers.

Both call sites now pass the golden's recorded gpu_name, matching the fitter and Sample.from_golden. Regression test pins the offline path (a 4090 golden must featurize with the 4090's registered 128 SMs regardless of host); a repo sweep confirms no bare from_target(g.compute_cap) call sites remain.