### PR TITLE
Gemma-4 long-seq arc: explicit-mask warp flash, three flash correctness fixes, seq-2048 goldens + audits, bench-worker EOF retry

### DIFF
--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -1525,8 +1525,9 @@ class _AsyncBenchWorker:
     async def run_job(self, request_obj: dict, *, wall_timeout_s: float) -> dict:
         """Send one request, read the response within ``wall_timeout_s`` (else SIGKILL
         + raise ``RuntimeError``), and return the unpickled response. A stale-worker
-        race on send respawns and retries once; a response-side timeout / EOF is a
-        hard error."""
+        race on send respawns and retries once; a response-side timeout is a hard
+        error. A response-side EOF (the child self-destructed mid-job) respawns and
+        retries ONCE after a short drain grace — see the handler for why."""
         request = pickle.dumps(request_obj, protocol=pickle.HIGHEST_PROTOCOL)
         frame = len(request).to_bytes(8, "little") + request
         deadline = _time_module.perf_counter() + wall_timeout_s
@@ -1572,7 +1573,20 @@ class _AsyncBenchWorker:
             except asyncio.IncompleteReadError as exc:
                 stderr_tail = await self._stderr_snapshot()
                 await self.aclose()
-                raise RuntimeError(f"bench worker EOF before response; stderr tail: {stderr_tail}") from exc
+                if attempt == 1:
+                    raise RuntimeError(f"bench worker EOF before response; stderr tail: {stderr_tail}") from exc
+                # The child self-destructs (``os._exit``) on a hung kernel to dodge the cupy
+                # atexit deadlock, so a mid-job EOF usually means THIS config hangs — the retry
+                # will EOF again and fail loudly, costing one extra watchdog interval. But right
+                # after a SIGKILL'd predecessor (a greedy-hang wall kill), the dead child's
+                # zombie context can still hold the GPU while the driver tears it down, hanging
+                # an INNOCENT first launch on the fresh child — a transient the golden refresh
+                # sweeps kept hitting on the row right after a hang. One respawn + retry after a
+                # short drain grace tells the two apart (the same row replays clean once the
+                # zombie context is gone).
+                logger.info("[bench-worker] child EOF'd mid-job — draining the device and retrying once%s", self._tail_suffix())
+                await asyncio.sleep(min(2.0, max(0.0, deadline - _time_module.perf_counter() - 1.0)))
+                continue
 
             resp = pickle.loads(body)
             if not resp.get("ok"):

--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1401,6 +1401,13 @@ class LdmatrixLoad(Stmt):
             # Operand not staged in smem — ldmatrix can't reach gmem, so read the
             # fragment straight from gmem (each lane adds its own (row,col) inside
             # the helper). No swizzle: that's a TMA-smem-layout concern only.
+            # A source buffer traced at a dtype other than the fragment's (the gemma layer's
+            # f32 V intermediate) converts per element: the helper's fragment element type F
+            # is passed explicitly, so the pack writes true 16-bit halves instead of raw f32
+            # bit patterns (matched dtypes keep the bare call — byte-identical output).
+            src_dt = ctx.buffer_dtypes.get(self.src_buffer, "f16")
+            frag_dt = ctx.ssa_dtypes.get(self.frag) or src_dt
+            targs = "" if src_dt == frag_dt else f"<{ctx.type_name(src_dt)}, {ctx.type_name(frag_dt)}>"
             if self.k_zero is not None:
                 # Masked-K (symbolic reduce): zero-fill (not clamp) the K halves
                 # past the runtime extent so the mma reduction stays correct — K is
@@ -1416,12 +1423,12 @@ class LdmatrixLoad(Stmt):
                         helper = "emmy_mma_load_a_gmem_mclamp_kzero"
                     else:
                         helper = "emmy_mma_load_b_gmem_trans_nclamp_kzero" if self.b_trans else "emmy_mma_load_b_gmem_nclamp_kzero"
-                    return [f"{_pad(ctx.indent)}{helper}({self.frag}, &{self.src_buffer}[{flat}], {ldm}, {mn_left}, {k_left});"]
+                    return [f"{_pad(ctx.indent)}{helper}{targs}({self.frag}, &{self.src_buffer}[{flat}], {ldm}, {mn_left}, {k_left});"]
                 if self.role == "a":
                     helper = "emmy_mma_load_a_gmem_kzero"
                 else:
                     helper = "emmy_mma_load_b_gmem_trans_kzero" if self.b_trans else "emmy_mma_load_b_gmem_kzero"
-                return [f"{_pad(ctx.indent)}{helper}({self.frag}, &{self.src_buffer}[{flat}], {ldm}, {k_left});"]
+                return [f"{_pad(ctx.indent)}{helper}{targs}({self.frag}, &{self.src_buffer}[{flat}], {ldm}, {k_left});"]
             if self.gmem_guard is not None:
                 # Masked axis: clamp the lane coordinate to the in-range
                 # elements left from the tile base (>= 1 — the boundary Cond
@@ -1431,12 +1438,12 @@ class LdmatrixLoad(Stmt):
                     helper = "emmy_mma_load_a_gmem_mclamp"
                 else:
                     helper = "emmy_mma_load_b_gmem_trans_nclamp" if self.b_trans else "emmy_mma_load_b_gmem_nclamp"
-                return [f"{_pad(ctx.indent)}{helper}({self.frag}, &{self.src_buffer}[{flat}], {ldm}, ({bound}) - ({base}));"]
+                return [f"{_pad(ctx.indent)}{helper}{targs}({self.frag}, &{self.src_buffer}[{flat}], {ldm}, ({bound}) - ({base}));"]
             if self.role == "a":
                 helper = "emmy_mma_load_a_gmem"
             else:
                 helper = "emmy_mma_load_b_gmem_trans" if self.b_trans else "emmy_mma_load_b_gmem"
-            return [f"{_pad(ctx.indent)}{helper}({self.frag}, &{self.src_buffer}[{flat}], {ldm});"]
+            return [f"{_pad(ctx.indent)}{helper}{targs}({self.frag}, &{self.src_buffer}[{flat}], {ldm});"]
         lane = "(threadIdx.x & 31)"
         if self.pair_frag is not None:
             # Paired x4 — two slab-adjacent B fragments in one ldmatrix (096_pair_ldmatrix_loads).

--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1150,6 +1150,62 @@ class FragmentMask(Stmt):
         return lines
 
 
+@dataclass(frozen=True)
+class FragmentBiasAdd(Stmt):
+    """Per-element **additive gmem bias** over an mma C-fragment — the fragment-tier realization of
+    the explicit additive score mask (SDPA's ``attn_mask`` float bias: the HF precomputed causal /
+    sliding-window band). For every element, load ``buf`` at the element's ABSOLUTE ``(row, col)``
+    coordinates and add it into the fragment: the render adds the tile origin (``row_base`` /
+    ``col_base``) to the layout's per-element offset and substitutes the result for the reserved
+    :data:`FRAG_ROW` / :data:`FRAG_COL` vars in ``index`` — the load-index TEMPLATE the realizer
+    built from the bias ``Load``'s own index (leading broadcast dims pre-folded to literals; a
+    symbolic seq pre-clamps the coordinate exprs, and the clamped duplicates land on cells the
+    boundary :class:`FragmentMask` / store guard discards). The buffer element converts to f32 on
+    the add (the fragment algebra is f32); lanes ``_t = 0..3`` of a column group read 8 contiguous
+    columns, so the warp's bias reads coalesce like the epilogue leaf loads."""
+
+    frag: str
+    buf: str
+    index: tuple[Expr, ...]  # load-index template over FRAG_ROW / FRAG_COL
+    col_base: Expr
+    row_base: Expr
+    layout: FragLayout = M16N8
+
+    def deps(self) -> tuple[str, ...]:
+        return (self.frag,)
+
+    def defines(self) -> tuple[str, ...]:
+        return (self.frag,)
+
+    def external_reads(self) -> tuple[str, ...]:
+        return (self.buf,)
+
+    def exprs(self) -> tuple[Expr, ...]:
+        return (*self.index, self.col_base, self.row_base)
+
+    def pretty(self, indent: str = "") -> list[str]:
+        idx = ", ".join(e.pretty() for e in self.index)
+        return [f"{indent}FragmentBiasAdd({self.frag} += {self.buf}[{idx}])"]
+
+    def render(self, ctx: RenderCtx) -> list[str]:
+        from emmy.compiler.ir.stmt import render_index  # noqa: PLC0415
+
+        pad = _pad(ctx.indent)
+        lay = self.layout
+        conv = {"f16": "__half2float({})", "bf16": "__bfloat162float({})"}
+        dt = ctx.buffer_dtypes.get(self.buf, "f32")
+        lines = _lane_preamble(ctx, pad, lay.lane_decl)
+        for i in range(lay.n_elems):
+            sub: dict[str, Expr] = {
+                FRAG_COL: BinaryExpr("+", self.col_base, lay.col_off[i]),
+                FRAG_ROW: BinaryExpr("+", self.row_base, lay.row_off[lay.elem_row[i]]),
+            }
+            idx = tuple(e.substitute(sub) for e in self.index)
+            flat = render_index(self.buf, idx, ctx)
+            lines.append(f"{pad}{self.frag}[{i}] += {conv.get(dt, '{}').format(f'{self.buf}[{flat}]')};")
+        return lines
+
+
 # ---------------------------------------------------------------------------
 # Warp-level MMA: ``mma.sync.aligned`` + ``ldmatrix`` (the ``s16816`` path
 # cuBLAS / CUTLASS use) — the sole tensor-core Stmt family. Operands are
@@ -2278,6 +2334,10 @@ def _(s: RegStore, rename, sigma, axis_fn):
             # real partition vars), so they're cell-invariant — pass through; the
             # per-cell M/N offset reaches them via ``dst_index`` at render.
             selects=epilogue.selects,
+            # The extra channel accumulators rename with the store's own fragment (they are
+            # per-cell C-fragment names too) — dropping them here left the multi-channel combine
+            # (the gemma GeGLU ``acc2``) unbound at render.
+            extra_accs=tuple((a, rename(fr)) for a, fr in epilogue.extra_accs),
         )
 
     # Guard base/bound Exprs σ-substitute like ``dst_index`` (the per-cell

--- a/emmy/compiler/ir/kernel/render.py
+++ b/emmy/compiler/ir/kernel/render.py
@@ -235,7 +235,7 @@ static __device__ __forceinline__ void emmy_c_to_a_bf16(unsigned* a, const float
 // emits these for an unstaged operand. ``ldm`` is the operand's gmem row stride
 // (K for the row-major A[M,K]; N for the row-major B[K,N]); ``g`` points at the
 // atom cell's base element, each lane adds its own (row,col) within the tile.
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_a_gmem(unsigned* r, const T* g, int ldm) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -244,13 +244,13 @@ static __device__ __forceinline__ void emmy_mma_load_a_gmem(unsigned* r, const T
         int col = (tig << 1) + ((i & 2) ? 8 : 0);   // K: 2*threadID_in_group, +8 for the k16 half
         const T* p = g + row * ldm + col;
         unsigned packed;
-        ((T*)&packed)[0] = p[0];                     // .f16x2: low half = col, high half = col+1
-        ((T*)&packed)[1] = p[1];
+        ((F*)&packed)[0] = F(p[0]);                     // .f16x2: low half = col, high half = col+1
+        ((F*)&packed)[1] = F(p[1]);
         r[i] = packed;
     }
 }
 
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem(unsigned* r, const T* g, int ldm) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -258,8 +258,8 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem(unsigned* r, const T
         int n = grp;                                 // N: groupID (0..7)
         int k = (tig << 1) + (i ? 8 : 0);            // K: 2*threadID_in_group, +8 for the k16 half
         unsigned packed;
-        ((T*)&packed)[0] = g[k * ldm + n];           // .f16x2: low half = k, high half = k+1
-        ((T*)&packed)[1] = g[(k + 1) * ldm + n];
+        ((F*)&packed)[0] = F(g[k * ldm + n]);           // .f16x2: low half = k, high half = k+1
+        ((F*)&packed)[1] = F(g[(k + 1) * ldm + n]);
         r[i] = packed;
     }
 }
@@ -271,7 +271,7 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem(unsigned* r, const T
 // the boundary Cond admitted the tile). Clamped lanes read a duplicate
 // in-bounds value — harmless, their stores are masked by the RegStore guard.
 // Same contract as the staged path's slab-fill clamp (_clamp_source_index).
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_a_gmem_mclamp(unsigned* r, const T* g, int ldm, int rows_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -281,13 +281,13 @@ static __device__ __forceinline__ void emmy_mma_load_a_gmem_mclamp(unsigned* r, 
         int col = (tig << 1) + ((i & 2) ? 8 : 0);
         const T* p = g + row * ldm + col;
         unsigned packed;
-        ((T*)&packed)[0] = p[0];
-        ((T*)&packed)[1] = p[1];
+        ((F*)&packed)[0] = F(p[0]);
+        ((F*)&packed)[1] = F(p[1]);
         r[i] = packed;
     }
 }
 
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_nclamp(unsigned* r, const T* g, int ldm, int cols_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -296,8 +296,8 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_nclamp(unsigned* r, 
         if (n >= cols_left) n = cols_left - 1;       // N: clamp to the runtime extent
         int k = (tig << 1) + (i ? 8 : 0);
         unsigned packed;
-        ((T*)&packed)[0] = g[k * ldm + n];
-        ((T*)&packed)[1] = g[(k + 1) * ldm + n];
+        ((F*)&packed)[0] = F(g[k * ldm + n]);
+        ((F*)&packed)[1] = F(g[(k + 1) * ldm + n]);
         r[i] = packed;
     }
 }
@@ -308,7 +308,7 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_nclamp(unsigned* r, 
 // but each lane now reads a contiguous (k, k+1) pair from row ``n`` of B. ``ldm``
 // is B's gmem row stride (the K extent). Mirrors ``emmy_mma_load_b_gmem`` with the
 // (k, n) index roles swapped to (n, k).
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans(unsigned* r, const T* g, int ldm) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -316,8 +316,8 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans(unsigned* r, c
         int n = grp;                                 // N: groupID (0..7)
         int k = (tig << 1) + (i ? 8 : 0);            // K: 2*threadID_in_group, +8 for the k16 half
         unsigned packed;
-        ((T*)&packed)[0] = g[n * ldm + k];           // .f16x2: contiguous (k, k+1) in row n
-        ((T*)&packed)[1] = g[n * ldm + k + 1];
+        ((F*)&packed)[0] = F(g[n * ldm + k]);           // .f16x2: contiguous (k, k+1) in row n
+        ((F*)&packed)[1] = F(g[n * ldm + k + 1]);
         r[i] = packed;
     }
 }
@@ -326,7 +326,7 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans(unsigned* r, c
 // row (``n``) here, so clamp ``n`` to the runtime extent (cf. _b_gmem_nclamp,
 // which clamps N as the column). Clamped lanes read a duplicate in-bounds row;
 // their stores are masked by the RegStore guard.
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_nclamp(unsigned* r, const T* g, int ldm, int cols_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -335,8 +335,8 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_nclamp(unsigne
         if (n >= cols_left) n = cols_left - 1;       // N: clamp to the runtime extent
         int k = (tig << 1) + (i ? 8 : 0);
         unsigned packed;
-        ((T*)&packed)[0] = g[n * ldm + k];
-        ((T*)&packed)[1] = g[n * ldm + k + 1];
+        ((F*)&packed)[0] = F(g[n * ldm + k]);
+        ((F*)&packed)[1] = F(g[n * ldm + k + 1]);
         r[i] = packed;
     }
 }
@@ -348,7 +348,7 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_nclamp(unsigne
 // by the mma, so a duplicate corrupts the reduction. ``k_left`` = in-range K
 // elements from the tile base; a half past it reads as +0.0 and is never
 // dereferenced. Mirrors the staged path's slab zero-fill (``_stage_expand``).
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_a_gmem_kzero(unsigned* r, const T* g, int ldm, int k_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -357,14 +357,14 @@ static __device__ __forceinline__ void emmy_mma_load_a_gmem_kzero(unsigned* r, c
         int col = (tig << 1) + ((i & 2) ? 8 : 0);
         const T* p = g + row * ldm + col;
         unsigned packed = 0;
-        if (col < k_left) ((T*)&packed)[0] = p[0];
-        if (col + 1 < k_left) ((T*)&packed)[1] = p[1];
+        if (col < k_left) ((F*)&packed)[0] = F(p[0]);
+        if (col + 1 < k_left) ((F*)&packed)[1] = F(p[1]);
         r[i] = packed;
     }
 }
 
 // A: masked-M (clamp rows) AND masked-K (zero-fill cols).
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_a_gmem_mclamp_kzero(unsigned* r, const T* g, int ldm, int rows_left, int k_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -374,14 +374,14 @@ static __device__ __forceinline__ void emmy_mma_load_a_gmem_mclamp_kzero(unsigne
         int col = (tig << 1) + ((i & 2) ? 8 : 0);
         const T* p = g + row * ldm + col;
         unsigned packed = 0;
-        if (col < k_left) ((T*)&packed)[0] = p[0];
-        if (col + 1 < k_left) ((T*)&packed)[1] = p[1];
+        if (col < k_left) ((F*)&packed)[0] = F(p[0]);
+        if (col + 1 < k_left) ((F*)&packed)[1] = F(p[1]);
         r[i] = packed;
     }
 }
 
 // B (row-major K×N, NOT transposed): K is the row, zero-fill past the extent.
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_kzero(unsigned* r, const T* g, int ldm, int k_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -389,14 +389,14 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_kzero(unsigned* r, c
         int n = grp;
         int k = (tig << 1) + (i ? 8 : 0);
         unsigned packed = 0;
-        if (k < k_left) ((T*)&packed)[0] = g[k * ldm + n];
-        if (k + 1 < k_left) ((T*)&packed)[1] = g[(k + 1) * ldm + n];
+        if (k < k_left) ((F*)&packed)[0] = F(g[k * ldm + n]);
+        if (k + 1 < k_left) ((F*)&packed)[1] = F(g[(k + 1) * ldm + n]);
         r[i] = packed;
     }
 }
 
 // B: masked-N (clamp col) AND masked-K (zero-fill row).
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_nclamp_kzero(unsigned* r, const T* g, int ldm, int cols_left, int k_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -405,8 +405,8 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_nclamp_kzero(unsigne
         if (n >= cols_left) n = cols_left - 1;
         int k = (tig << 1) + (i ? 8 : 0);
         unsigned packed = 0;
-        if (k < k_left) ((T*)&packed)[0] = g[k * ldm + n];
-        if (k + 1 < k_left) ((T*)&packed)[1] = g[(k + 1) * ldm + n];
+        if (k < k_left) ((F*)&packed)[0] = F(g[k * ldm + n]);
+        if (k + 1 < k_left) ((F*)&packed)[1] = F(g[(k + 1) * ldm + n]);
         r[i] = packed;
     }
 }
@@ -415,7 +415,7 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_nclamp_kzero(unsigne
 // halves past the runtime extent. K is summed by the mma, so a past-extent element
 // must read as +0.0 (never a duplicate). Mirrors ``emmy_mma_load_b_gmem_kzero`` with
 // the (k, n) index roles swapped to (n, k) — cf. ``emmy_mma_load_b_gmem_trans``.
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_kzero(unsigned* r, const T* g, int ldm, int k_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
     #pragma unroll
@@ -423,14 +423,14 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_kzero(unsigned
         int n = grp;                                 // N: groupID (0..7)
         int k = (tig << 1) + (i ? 8 : 0);            // K: 2*threadID_in_group, +8 for the k16 half
         unsigned packed = 0;
-        if (k < k_left) ((T*)&packed)[0] = g[n * ldm + k];       // .f16x2: contiguous (k, k+1) in row n
-        if (k + 1 < k_left) ((T*)&packed)[1] = g[n * ldm + k + 1];
+        if (k < k_left) ((F*)&packed)[0] = F(g[n * ldm + k]);       // .f16x2: contiguous (k, k+1) in row n
+        if (k + 1 < k_left) ((F*)&packed)[1] = F(g[n * ldm + k + 1]);
         r[i] = packed;
     }
 }
 
 // Transposed-B: masked-N (clamp the ``n`` row) AND masked-K (zero-fill the contiguous k).
-template <typename T>
+template <typename T, typename F = T>
 static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_nclamp_kzero(
     unsigned* r, const T* g, int ldm, int cols_left, int k_left) {
     int lane = threadIdx.x & 31, grp = lane >> 2, tig = lane & 3;
@@ -440,8 +440,8 @@ static __device__ __forceinline__ void emmy_mma_load_b_gmem_trans_nclamp_kzero(
         if (n >= cols_left) n = cols_left - 1;       // N: clamp to the runtime extent
         int k = (tig << 1) + (i ? 8 : 0);
         unsigned packed = 0;
-        if (k < k_left) ((T*)&packed)[0] = g[n * ldm + k];
-        if (k + 1 < k_left) ((T*)&packed)[1] = g[n * ldm + k + 1];
+        if (k < k_left) ((F*)&packed)[0] = F(g[n * ldm + k]);
+        if (k + 1 < k_left) ((F*)&packed)[1] = F(g[n * ldm + k + 1]);
         r[i] = packed;
     }
 }

--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -224,6 +224,38 @@ def _refs_axis(s: Stmt, name: str) -> bool:
     return any(_refs_axis(child, name) for b in s.nested() for child in b)
 
 
+def gmem_row_stride(load: Load, axis_name: str, inputs) -> int | None:
+    """The flattened gmem stride between successive ``axis_name`` rows of ``load``'s buffer — the
+    fragment loaders' row step (``ldm``). The axis var must appear in exactly ONE index component,
+    affinely; the stride is its coefficient times the product of the buffer extents AFTER that
+    component. ``head_dim`` for the canonical ``(batch…, row, dd)`` layout; ``H·D`` for an
+    un-transposed ``(B, S, H, D)`` trace, where assuming the trailing extent read the WRONG rows
+    (the gemma layer-0 NaN: resident-Q fragments at ``ldm=head_dim`` on a 4096-stride layout).
+    ``None`` when underivable — axis absent or split across components, a non-affine use, an
+    unknown buffer, or a symbolic trailing extent — the schedule gate's decline signal."""
+    from emmy.compiler.ir.expr import affine_form  # noqa: PLC0415 — avoid a module-import cycle
+
+    t = inputs.get(load.input) if inputs else None
+    if t is None:
+        return None
+    positions = [i for i, e in enumerate(load.index) if axis_name in e.free_vars()]
+    if len(positions) != 1:
+        return None
+    pos = positions[0]
+    form = affine_form(load.index[pos], {axis_name})
+    if form is None:
+        return None
+    coef = form[1].get(axis_name, 0)
+    if coef <= 0:
+        return None
+    stride = coef
+    for d in tuple(t.shape)[pos + 1 :]:
+        if not d.is_static:
+            return None
+        stride *= d.as_static()
+    return stride
+
+
 @dataclass(frozen=True)
 class Contraction(Stmt):
     """A contraction **before** atom factorization — built **recognize-side** at fork-emit

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -280,8 +280,11 @@ within-block → `SHFL`+`SMEM` tree, cross-CTA → `ATOMIC`/`KERNEL` — and eve
 (`emit_combine` at scalar residence, this realizer at fragment residence, `030_split_reduce` as the graph rewrite); only the
 residence-specific realization differs. Everything realizes from structure — the
 head contraction's `ldmatrix`/`mma.sync` off its node geometry (`_frag_contraction`); the score prologue stmt-by-stmt
-(`Assign` → `FragmentApply`, a coordinate `Select` → `FragmentMask` with the keep-predicate negated, loop-invariant
-constant `Load`s hoisted); the streaming merge REGENERATED from the carrier's channel spec (pivot → rowmax + running
+(`Assign` → `FragmentApply`, a coordinate `Select` → `FragmentMask` with the keep-predicate negated, an
+`(m, kv)`-indexed additive bias `Load` + `add` — SDPA's explicit `attn_mask`, the HF precomputed causal /
+sliding-window band — → a per-fragment `FragmentBiasAdd` reading the mask at each element's absolute coordinates
+(previously the whole kernel demoted to the scalar tier — every real-model gemma attention layer at seq > window),
+loop-invariant constant `Load`s hoisted); the streaming merge REGENERATED from the carrier's channel spec (pivot → rowmax + running
 stats + α-rescale; denom → rowsum; the expect channel's ⊗ `lift` IS the P@V node, the register-resident P converted
 straight into its A-operand fragments by the **C→A register repack** (`FragmentRepack` — the `AtomKind.c_to_a_repack`
 lane-map compatibility: the m16n8 C fragment is elementwise lane-aligned with the m16k16 A fragment's k-halves, so

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -176,6 +176,19 @@ def _warp_epilogue(
             write = s
     if write is None or (not ops and not selects):
         return None
+    # Every chain-op arg must be BOUND in the render env (the accumulator(s), a leaf load, a
+    # select, or an earlier op) — an unbound name means the variant's projection tail reads a
+    # value this node does not compute (a mis-sliced multi-channel combine: the gemma GeGLU
+    # tail on a single-fold row referenced the sibling channel's ``acc2`` and died with a
+    # ``KeyError`` in the RegStore render). Decline the variant cleanly instead.
+    from emmy.compiler.pipeline import RuleSkipped  # noqa: PLC0415 — avoid an import cycle
+
+    bound = {acc, *(a for a, _ in extra_accs), *(ld.name for ld in loads), *(nm for nm, _ in selects)}
+    for name, _op, args in ops:
+        unbound = [a for a in args if a not in bound]
+        if unbound:
+            raise RuleSkipped(f"projection epilogue reads {unbound} this node does not compute (mis-sliced multi-channel tail)")
+        bound.add(name)
     return RegEpilogue(acc=acc, loads=tuple(loads), ops=tuple(ops), result=write.value, selects=tuple(selects), extra_accs=extra_accs)
 
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -10,10 +10,13 @@ residence — the fragment row of the placement-keyed fold (a within-warp ``Frag
 - the head contraction (Q@K) emits ``ldmatrix`` + ``mma.sync`` into score C-fragments off its node
   geometry (:func:`_frag_contraction` — operands / ``b_trans`` / guards from the node, the atom
   counts from its stamped ``TilePlan``);
-- the score prologue (the scale ``Assign``, the causal ``Select``) is realized stmt-by-stmt
-  (:func:`_realize_prologue`): a pointwise ``Assign`` → :class:`FragmentApply`, a
-  coordinate-predicated ``Select`` → :class:`FragmentMask` (the keep-predicate negated), a
-  loop-invariant scalar ``Load`` hoisted above the stream;
+- the score prologue (the scale ``Assign``, the causal ``Select``, the explicit additive mask) is
+  realized stmt-by-stmt (:func:`_realize_prologue`): a pointwise ``Assign`` → :class:`FragmentApply`,
+  a coordinate-predicated ``Select`` → :class:`FragmentMask` (the keep-predicate negated), an
+  ``(m, kv)``-indexed bias ``Load`` + its ``add`` (SDPA's ``attn_mask`` — the HF precomputed causal /
+  sliding-window band) → one :class:`FragmentBiasAdd` per score fragment (each element reads the mask
+  at its absolute coordinates; a symbolic extent clamp-reads, the duplicates landing on masked /
+  store-guarded cells), a loop-invariant scalar ``Load`` hoisted above the stream;
 - the twisted carrier's streaming merge is regenerated FROM ITS CHANNEL SPEC (``twist.family ==
   "exp"``, ``channels = (pivot, …)``): the pivot's per-block fold is a ``FragmentRowReduce`` of its
   ``fold`` op (rowmax) + the running-stat update / rescale; a ``denom`` channel (no lift)
@@ -54,6 +57,7 @@ from emmy.compiler.ir.kernel.ir import (
     ROW,
     UNIFORM,
     FragmentApply,
+    FragmentBiasAdd,
     FragmentMask,
     FragmentPromote,
     FragmentRepack,
@@ -288,6 +292,14 @@ def _realize_prologue(stmts, qk: Contraction, frags: tuple[str, ...], col_bases,
     stream: list[Stmt] = []
     score = qk.acc
     m_name, n_name = qk.m_axis.name, qk.n_axis.name
+    # An additive score bias (the explicit SDPA ``attn_mask``): a per-``(m, kv)`` tensor ``Load``
+    # awaiting its ``add`` — realized as a :class:`FragmentBiasAdd` per score fragment when the add
+    # consumes it. The load-index template substitutes the fragment coordinate vars for the axis
+    # vars; a SYMBOLIC extent clamps the coordinate to the last valid index (cp-style clamp-read —
+    # the duplicates land on cells the boundary FragmentMask / store guard discards).
+    pending: dict[str, Load] = {}
+    row_coord: Expr = Var(FRAG_ROW) if qk.m_axis.extent.is_static else _clamp_last(Var(FRAG_ROW), _ext(qk.m_axis))
+    col_coord: Expr = Var(FRAG_COL) if qk.n_axis.extent.is_static else _clamp_last(Var(FRAG_COL), _ext(qk.n_axis))
     for s in stmts:
         if isinstance(s, Contraction):
             continue  # the expect contraction — regenerated from its channel
@@ -296,8 +308,19 @@ def _realize_prologue(stmts, qk: Contraction, frags: tuple[str, ...], col_bases,
         if isinstance(s, Load) and len(s.index) == 0:
             hoisted.append(s)  # a scalar constant (the 1/√d scale, the −inf fill) — loop-invariant
             continue
+        if isinstance(s, Load) and {v for e in s.index for v in e.free_vars()} <= {m_name, n_name}:
+            pending[s.name] = s  # the additive-bias tile read — realized by its consuming add below
+            continue
         if isinstance(s, Assign) and score in s.args:
             others = tuple(a for a in s.args if a != score)
+            op_name = s.op.name if hasattr(s.op, "name") else s.op
+            if op_name == "add" and len(others) == 1 and others[0] in pending:
+                ld = pending.pop(others[0])
+                idx = tuple(e.substitute({m_name: row_coord, n_name: col_coord}) for e in ld.index)
+                for t, f in enumerate(frags):
+                    stream.append(FragmentBiasAdd(frag=f, buf=ld.input, index=idx, col_base=col_bases[t], row_base=row_base))
+                score = s.name
+                continue
             for f in frags:
                 stream.append(FragmentApply(out=f, op=s.op, args=(f, *others), kinds=(FRAG, *(UNIFORM,) * len(others)), in_place=True))
             score = s.name
@@ -311,6 +334,9 @@ def _realize_prologue(stmts, qk: Contraction, frags: tuple[str, ...], col_bases,
             score = s.name
             continue
         raise NotImplementedError(f"fragment realizer: unrealizable score-prologue stmt {type(s).__name__}")
+    # A classified bias load MUST be consumed by its add — an unconsumed one means the prologue
+    # shape changed and the mask would silently drop (worse than any failure).
+    assert not pending, f"fragment realizer: additive-bias load(s) {sorted(pending)} never consumed by an add"
     used = {a for st in stream for a in (st.deps() if hasattr(st, "deps") else ())}
     return [ld for ld in hoisted if set(ld.names) & used], stream
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -71,7 +71,7 @@ from emmy.compiler.ir.kernel.ir import (
 from emmy.compiler.ir.schedule import Fold, Level, ReduceStage
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body, Cond, Init, Load, Select, Stmt, StridedLoop, Write
-from emmy.compiler.ir.tile.ir import Contraction, Map, Reduction
+from emmy.compiler.ir.tile.ir import Contraction, Map, Reduction, gmem_row_stride
 from emmy.compiler.pipeline.passes.lowering.kernel._atom import _clamp_last, _f16acc, unroll_ok
 from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
     CpAsyncTransport,
@@ -169,6 +169,7 @@ def _frag_contraction(
     b_slab: str | None = None,
     b_slot: Expr | None = None,
     b_ldm: int = 0,
+    b_gmem_ldm: int | None = None,
     b_swizzle: str = "NONE",
     reg_depth: int = 1,
 ) -> list[Stmt]:
@@ -194,7 +195,16 @@ def _frag_contraction(
     nt = c.tile.regs[1]  # output n-atoms per step (warp order (FM, FN))
     n_name, k_name = c.n_axis.name, c.k_axis.name
     b_trans = c.b_trans
-    ldm_b = b_ldm if b_slab is not None else (c.k_axis.extent.as_static() if b_trans else c.n_axis.extent.as_static())
+    if b_slab is not None:
+        ldm_b = b_ldm
+    else:
+        # Gmem-direct B fragments step the operand's ROW axis (transposed-B: its N/key coords;
+        # canonical-B: its K coords) at the buffer's REAL row stride — derived by the caller from
+        # the load index + buffer shape (``gmem_row_stride``), NOT the trailing-axis extent: an
+        # un-transposed ``(B, S, H, D)`` trace strides rows by ``H·D``, and assuming ``head_dim``
+        # read the wrong rows (the gemma layer-0 NaN).
+        assert b_gmem_ldm is not None, "_frag_contraction: gmem-direct B needs the derived row stride"
+        ldm_b = b_gmem_ldm
 
     bk = c.tile.bk
     # ``reg_depth == 2`` (the ``STAGE`` codec's ``p2``, staged drains with ≥ 2 atom-K steps): the
@@ -486,6 +496,15 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
     v_swz = pick_swizzle_atom(d_v, elem_bytes)[1] if is_tma else "NONE"
     head_dim_s = qk.k_axis.extent.as_static()
     q_ldm = head_dim_s + _PAD  # the staged-Q slab row stride (padded, like the cp.async K/V rows)
+    # Gmem-direct fragment ROW strides, derived from each operand's load index + buffer shape
+    # (``gmem_row_stride``) — NOT the trailing-axis extent: an un-transposed ``(B, S, H, D)``
+    # trace strides its rows by ``H·D``, and the old ``head_dim`` assumption read the wrong rows
+    # (the gemma layer-0 NaN). Canonical ``(batch…, row, dd)`` layouts derive the same values as
+    # before (bit-identical). The schedule gate guarantees derivability.
+    q_gmem_ldm = gmem_row_stride(qk.a_operand, qk.m_axis.name, ctx.inputs)
+    k_gmem_ldm = gmem_row_stride(qk.b_load, qk.n_axis.name if qk.b_trans else qk.k_axis.name, ctx.inputs)
+    v_gmem_ldm = gmem_row_stride(pv.b_load, pv.n_axis.name if pv.b_trans else kv_axis.name, ctx.inputs)
+    assert q_gmem_ldm and k_gmem_ldm and v_gmem_ldm, "warp twist: underivable gmem row stride (schedule-gate breach)"
 
     def _q_frag_stmts(qt, i: int) -> list[Stmt]:
         """The query tile's ``bk`` A-fragment declarations + loads. Resident form (default): gmem
@@ -518,7 +537,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
                     src_buffer=qk.a_operand.input,
                     src_index=_idx(qk.a_operand, {qk.m_axis.name: qt.row_base, qk.k_axis.name: Literal(s * atom.atom_k, "int")}),
                     role="a",
-                    ldm=head_dim_s,
+                    ldm=q_gmem_ldm,
                     staged=False,
                     gmem_guard=q_guard,
                 )
@@ -566,6 +585,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             b_slab="_k_smem" if staged else None,
             b_slot=k_slot,
             b_ldm=qk.k_axis.extent.as_static() + kv_pad if staged else 0,
+            b_gmem_ldm=k_gmem_ldm,
             b_swizzle=k_swz if staged else "NONE",
             reg_depth=stage.reg_depth if staged else 1,
         )
@@ -627,6 +647,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             b_slab="_v_smem" if staged else None,
             b_slot=v_slot,
             b_ldm=d_v + kv_pad if staged else 0,
+            b_gmem_ldm=v_gmem_ldm,
             b_swizzle=v_swz if staged else "NONE",
             reg_depth=stage.reg_depth if staged else 1,
         )

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1779,7 +1779,8 @@ def _twisted_warp_options(
     per CTA, each owning ``atom_m`` query rows; the value axis leaves the grid. Each geometry row
     crosses with its K/V operand-stage candidates (:func:`_twisted_stage_candidates` — gmem-direct
     option-0, then the resolver-gated cp.async ring depths, keyed ``STAGE@<kv>``). An additive
-    ``(m, kv)`` score bias is not realizable at the fragment tier → ``[]``. A warp ``TILE`` pin
+    ``(m, kv)`` score bias (the explicit SDPA ``attn_mask``) realizes as a per-element fragment
+    bias load (``FragmentBiasAdd``); a bias indexed beyond ``(m, kv)`` declines. A warp ``TILE`` pin
     narrows the grid to the pinned geometry (loud on a divisibility violation — the pin contract);
     a pin that doesn't fit the flash form (wrong atom / a column split / a foreign ``bk``) declines
     the tier with a log line — the standard pin-validity degrade, since a bare warp pin may target
@@ -1810,8 +1811,26 @@ def _twisted_warp_options(
     kv_ext, m_ext = red.axis.extent, head.m_axis.extent
     m_name, kv_name = head.m_axis.name, red.axis.name
     for s in list(red.partial)[1:]:
-        if isinstance(s, Load) and s.index and {m_name, kv_name} <= {v for e in s.index for v in e.free_vars()}:
-            return []  # an additive (m, kv) score bias — fragment-unrealizable, stay scalar
+        if isinstance(s, Load) and s.index and not {v for e in s.index for v in e.free_vars()} <= {m_name, kv_name}:
+            return []  # a score bias indexed beyond (m, kv) — no fragment realization for it
+        # An additive (m, kv) score bias (the explicit SDPA attn_mask) IS realizable: the fragment
+        # realizer loads the bias tile per element at its absolute coordinates (FragmentBiasAdd).
+
+    # TMA staging derives its box-origin coords POSITIONALLY (batch dims = the load index's leading
+    # components, the kv row at [-2], the contiguous head_dim last) — a K/V trace whose kv axis sits
+    # elsewhere (the un-transposed (B, S, H, D) layout: kv at position 1) would leak the raw axis
+    # var into the emitted coords (an undefined identifier in the kernel). cp.async is unaffected —
+    # its fill substitutes by axis NAME. Decline the tma moves for such layouts.
+    def _kv_penultimate(load) -> bool:
+        idx = load.index
+        return (
+            len(idx) >= 2
+            and isinstance(idx[-2], Var)
+            and idx[-2].name == kv_name
+            and not any(kv_name in e.free_vars() for e in (*idx[:-2], idx[-1]))
+        )
+
+    tma_ok = tma_ok and _kv_penultimate(head.b_load) and _kv_penultimate(pv.b_load)
     bk = head_dim.as_static() // atom_k
     # The f16-accumulate PV sibling (``f16acc_ok`` — the F16_MMA_F32_ACC / FAST_MATH gate): each
     # geometry row doubles with a variant whose **PV plan** rides the ``_f16acc`` atom (the O

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -48,6 +48,7 @@ from emmy.compiler.ir.schedule import Raster, Stage, WarpSpec, has_scalar_atom_a
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Stmt, Write
 from emmy.compiler.ir.tile import Contraction, Map, Placement, ReducePlan, Reduction, TileOp, TilePlan
+from emmy.compiler.ir.tile.ir import gmem_row_stride
 from emmy.compiler.ir.tile.ops import axis_role, nodify_reduce, reduce_loop
 from emmy.compiler.pipeline.fork import Fork, Level, build_fork_tree
 from emmy.compiler.pipeline.passes.lowering.tile._atomize import map_cone, semiring_binding
@@ -1831,6 +1832,18 @@ def _twisted_warp_options(
         )
 
     tma_ok = tma_ok and _kv_penultimate(head.b_load) and _kv_penultimate(pv.b_load)
+    # The fragment loaders step gmem rows at the buffer's REAL row stride, derived from the load
+    # index + buffer shape (``gmem_row_stride`` — H·D on an un-transposed (B, S, H, D) trace,
+    # where the old trailing-extent assumption read the wrong rows: the gemma layer-0 NaN).
+    # Underivable strides (an axis split across index components, a non-affine use, a symbolic
+    # trailing extent) have no fragment realization — decline the tier.
+    strides = (
+        gmem_row_stride(head.a_operand, m_name, tile.inputs),
+        gmem_row_stride(head.b_load, head.n_axis.name if head.b_trans else head.k_axis.name, tile.inputs),
+        gmem_row_stride(pv.b_load, pv.n_axis.name if pv.b_trans else kv_name, tile.inputs),
+    )
+    if any(s is None for s in strides):
+        return []
     bk = head_dim.as_static() // atom_k
     # The f16-accumulate PV sibling (``f16acc_ok`` — the F16_MMA_F32_ACC / FAST_MATH gate): each
     # geometry row doubles with a variant whose **PV plan** rides the ``_f16acc`` atom (the O
@@ -1918,6 +1931,7 @@ def _twisted_warp_options(
             if ax.name != pv.n_axis.name
         )
         place = Placement(free=tile.place.free, grid=grid)
+
         # Both contractions' plans are stamped (each keyed on its node's k axis), the reduce
         # partition decided-empty, and the K/V operand stage on the STREAM axis (the resolved
         # spelling, or the explicit OFF ``""`` — the honest-stamping rule), so every flash leaf
@@ -1926,9 +1940,28 @@ def _twisted_warp_options(
         # ``_wspec_workers`` gates the thread budgets — the aux band must not exceed the
         # ``32·um`` compute band); a degraded candidate is skipped rather than duplicating the
         # uniform row.
-        for stage in _twisted_stage_candidates(
-            kv_ext, bn, head_dim.as_static(), d_v.as_static(), elem_bytes, budget, tma_ok, m_rows=um * fm * atom_m
-        ):
+        # Staging byte-copies the operands into slabs typed at the ATOM's operand width — an
+        # operand traced at a different dtype (the gemma layer's f32 V intermediate) would deposit
+        # wrong-sized elements and drain garbage (the gemma layer-0 NaN's second head). Gmem-direct
+        # fragment loads convert per element, so a dtype-mismatched operand keeps the warp tier but
+        # declines its stage rows; ``alt`` additionally stages Q, so it also needs a matching A.
+        def _buf_dtype_name(load) -> str | None:
+            t = tile.inputs.get(load.input) if tile.inputs else None
+            return getattr(getattr(t, "dtype", None), "name", None)
+
+        b_dt = atom.operand_dtype("b").name
+        kv_stage_ok = _buf_dtype_name(head.b_load) == b_dt and _buf_dtype_name(pv.b_load) == b_dt
+        q_stage_ok = _buf_dtype_name(head.a_operand) == atom.operand_dtype("a").name
+        stage_cands = (
+            [None]
+            if not kv_stage_ok
+            else _twisted_stage_candidates(
+                kv_ext, bn, head_dim.as_static(), d_v.as_static(), elem_bytes, budget, tma_ok, m_rows=um * fm * atom_m
+            )
+        )
+        for stage in stage_cands:
+            if stage is not None and stage.alt and not q_stage_ok:
+                continue  # alt stages Q through smem too — a dtype-mismatched Q cannot byte-copy
             wspecs = list(WSPEC.narrow(wspec_moves())) if (stage is not None and stage.transport == "tma" and not stage.alt) else [""]
             for wspec_cand in wspecs:
                 workers, wspec_spec = _wspec_workers(wspec_cand, stage, 32 * um)

--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
@@ -305,3 +305,124 @@ configs:
     knobs: {REDUCE: 'b64'}
     emmy_us: 3.6
     cublas_us: 4.8
+  # ---- seq-2048 tier (2026-07-14) ----------------------------------------------------------------
+  # M=2048 drops the split-K almost everywhere on this card (the grid fills; only deep-K mlp_down
+  # keeps g2k) — fm serial wins all three projections. Winners 2-3x reproduced (o_proj fm had one
+  # outlier run at 325, settled 297.6/298.0); cublas_us = live torch same-session. cp.async only
+  # (sm_89). Attention: the fm lane keeps the RING here (nt2 288.8 = 1.09x vs SDPA 314.6; fm-alt
+  # jitters 311-341 and loses) while the std lane takes alt (346.8 vs ring 360) — the alt/ring and
+  # lane preferences flip per (card, seq) as usual. Cold greedy on the unseeded 2048 attention
+  # shape deploys a w1x1 kernel at ~1080 (3.4x off) — the rows pin that.
+  - kernel: matmul
+    name: gemma4_12b.q_proj.s2048
+    M: 2048
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 430.1
+    cublas_us: 398.6
+  - kernel: matmul
+    name: gemma4_12b.q_proj.s2048
+    M: 2048
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 277.7
+    cublas_us: 398.6
+  - kernel: matmul
+    name: gemma4_12b.kv_proj.s2048
+    M: 2048
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 225.0
+    cublas_us: 209.3
+  - kernel: matmul
+    name: gemma4_12b.kv_proj.s2048
+    M: 2048
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x4/f2x4/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 171.2
+    cublas_us: 209.3
+  - kernel: matmul
+    name: gemma4_12b.o_proj.s2048
+    M: 2048
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 455.7
+    cublas_us: 446.8
+  # o_proj fm is BIMODAL on this card (297.6/298.0 vs 325.3/325.6 across four runs — a stable
+  # fast and slow mode, cause unidentified); the slow mode is recorded so replays never read as
+  # drift. Still 1.37x vs cuBLAS in the slow mode, 1.50x in the fast one.
+  - kernel: matmul
+    name: gemma4_12b.o_proj.s2048
+    M: 2048
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 325.6
+    cublas_us: 446.8
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up.s2048
+    M: 2048
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 4347.0
+    cublas_us: 2945.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up.s2048
+    M: 2048
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 2316.0
+    cublas_us: 2945.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.s2048
+    M: 2048
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 1580.0
+    cublas_us: 1493.7
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.s2048
+    M: 2048
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 1100.0
+    cublas_us: 1493.7
+  - kernel: attention
+    name: gemma4_12b.attention.hd256.s2048
+    n_heads: 16
+    seq: 2048
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 346.8
+    cublas_us: 314.6
+  - kernel: attention
+    name: gemma4_12b.attention.hd256.s2048
+    n_heads: 16
+    seq: 2048
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd2/cp/ring', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w4x1/f1x32', WSPEC: ''}
+    emmy_us: 288.8
+    cublas_us: 314.6

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -395,3 +395,123 @@ configs:
     knobs: {REDUCE: 'b64'}
     emmy_us: 3.6
     cublas_us: 4.1
+  # ---- seq-2048 tier (2026-07-14) ----------------------------------------------------------------
+  # The 512-tuned picks are provably wrong at M=2048 (the grid no longer starves): q_proj std g8k
+  # collapses to 0.82x, and cold greedy on the unseeded 2048 attention shape picks a scalar kernel
+  # that HANGS the watchdog. Every row below is 2-4x reproduced at <1% spread; cublas_us = live
+  # torch (cuBLAS HGEMM / SDPA FA-2) measured the same session. Split-K rows record main+finalize.
+  # Split-K inversion is K-dependent at this M: shallow-K (q/kv) keeps only a shallow g2k or drops
+  # the split entirely; o_proj fm keeps g2k; deep-K mlp_down keeps g2k on the fm lane.
+  - kernel: matmul
+    name: gemma4_12b.q_proj.s2048
+    M: 2048
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 313.0
+    cublas_us: 318.4
+  - kernel: matmul
+    name: gemma4_12b.q_proj.s2048
+    M: 2048
+    N: 4096
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 223.7
+    cublas_us: 318.4
+  - kernel: matmul
+    name: gemma4_12b.kv_proj.s2048
+    M: 2048
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 168.4
+    cublas_us: 170.3
+  - kernel: matmul
+    name: gemma4_12b.kv_proj.s2048
+    M: 2048
+    N: 2048
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w2x4/f2x4/k4', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 136.9
+    cublas_us: 170.3
+  - kernel: matmul
+    name: gemma4_12b.o_proj.s2048
+    M: 2048
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 294.0
+    cublas_us: 285.4
+  - kernel: matmul
+    name: gemma4_12b.o_proj.s2048
+    M: 2048
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 205.0
+    cublas_us: 285.4
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up.s2048
+    M: 2048
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 2413.0
+    cublas_us: 2210.7
+  - kernel: matmul
+    name: gemma4_12b.mlp_gate_up.s2048
+    M: 2048
+    N: 30720
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 1413.0
+    cublas_us: 2210.7
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.s2048
+    M: 2048
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 1112.0
+    cublas_us: 1171.1
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.s2048
+    M: 2048
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: 'g2k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
+    emmy_us: 697.0
+    cublas_us: 1171.1
+  # Attention at seq 2048: the 512 alt family transfers (fm d1/cp/alt nt8 wins, same ordering);
+  # torch SDPA measured 237.6-257.2 across the session (median recorded). Cold greedy on this
+  # unseeded shape picks a scalar b256 kernel that hangs — the row exists to pin that down.
+  - kernel: attention
+    name: gemma4_12b.attention.hd256.s2048
+    n_heads: 16
+    seq: 2048
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f32/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 262.7
+    cublas_us: 247.0
+  - kernel: attention
+    name: gemma4_12b.attention.hd256.s2048
+    n_heads: 16
+    seq: 2048
+    head_dim: 256
+    dtype: 'fp16'
+    causal: true
+    knobs: {PLACE: 'fuse', STAGE: 'd1/cp/alt', 'TILE@dd': 'a:mma_m16n8k16_f16_f32/w4x1/f1x8/k16', 'TILE@pj': 'a:mma_m16n8k16_f16_f16/w4x1/f1x32/k4', WSPEC: ''}
+    emmy_us: 246.0
+    cublas_us: 247.0

--- a/plans/gemma4-seq-scaling-and-sliding-window-findings.md
+++ b/plans/gemma4-seq-scaling-and-sliding-window-findings.md
@@ -1,0 +1,54 @@
+# Gemma-4-12B seq-scaling + sliding-window findings — RTX 5090, 2026-07-14
+
+Two checks on the post-golden state: (1) does the real model's sliding-window attention reach the warp flash at
+seq > window; (2) do the seq-512-tuned golden picks still hold at seq 2048. Method: real-layer compiles
+(`emmy compile google/gemma-4-12B-it --layer N --seq-len S --dump-dir`), pinned `--ab` A/Bs on the golden snippet
+forms at M=2048, winners 3× reproduced.
+
+## 1. Attention at seq > 1024 never reaches the warp flash — and the deployed fallback hangs
+
+- **Layer 0 (sliding_attention, window 1024) @ seq 512**: fused warp-tier flash (mma + TMA descriptors, no mask
+  operand). The window ≥ seq, so the mask degenerates to plain causal and resolves structurally — this is the only
+  regime the attention goldens exercise.
+- **@ seq 2048**: the HF trace materializes an explicit ADDITIVE mask tensor (the kernel gains a `_flash_ninf`
+  operand). The warp tier does not realize the explicit-mask form: greedy deploys the scalar reduce partition —
+  an 8.4M-block per-cell kernel that **hangs the 1 s watchdog** (bench_fail, the known unseeded-shape hazard class,
+  now structural rather than a pick miss). Force-pinning the warp TILE crashes the emitter
+  (`KeyError: 'acc2'` in the fragment realizer's element-values env), so this is a RECOGNITION/REALIZATION gap —
+  no golden row can fix it.
+- **The full-attention layer (5) at seq 2048 behaves identically** (explicit mask tensor, scalar, no mma) — at real
+  context lengths EVERY gemma attention layer is on the scalar tier. Emmy attention on the real model at seq > 1024
+  is currently unusable, not merely slow.
+- Fix direction: teach the warp flash the explicit additive-mask form (a per-block mask tile added to the score
+  fragments ahead of the softmax merge — a `FragmentApply` add, structurally like the causal `Select` realization);
+  the banded sliding structure would then also admit a tile-skip analogue (skip KV blocks wholly outside
+  `[m − window, m]` — the same derived-bound machinery as the causal `k_end`, applied at both ends).
+
+## 2. Seq-512 golden picks at seq 2048: attention family transfers, split-K inverts on the shallow-K projections
+
+All static M=2048 A/Bs, canonical-matmul snippet form (NOTE the trap hit on the way: a `functional.linear`
+snippet traces transposed-B, which DECLINES cp/TMA staging entirely and silently benches gmem-direct at ~0.28× —
+bench golden shapes only through the golden snippet form).
+
+- **Attention** (synthetic causal 16h × 2048 × hd256; torch SDPA 237.6 µs): ordering preserved from seq 512 —
+  fm `d1/cp/alt` nt8 **245.8** (0.97×) < fm ring nt2 255.8 < std alt nt8 263.2 < std ring nt4 271.6. The 512
+  family transfers with slight erosion (1.03× → 0.97×), no pick flip. Cold greedy on the unseeded 2048 shape
+  picks a scalar b256 kernel that hangs.
+- **q_proj** (2048×4096, K=3840; cuBLAS 319 µs): **split-K inverts.** The std seq-512 golden (`g8k`) drops to
+  388.5 = **0.82×, losing to cuBLAS**; std g2k 312 / std serial 320 sit at parity; the fm seq-512 golden (`g2k`)
+  runs 242, and **fm serial wins at 223.8 = 1.43×** (3× stable). At M=2048 the output grid no longer starves the
+  SMs, so the split's finalize cost outweighs its occupancy gain.
+- **mlp_down** (2048×3840, K=15360; cuBLAS 1077 µs): **split still wins** — fm g2k 681 vs fm serial 872 (1.58×
+  vs cuBLAS). The inversion is grid-starvation-dependent: shallow-K/moderate-N shapes shed their split at large M,
+  deep-K keeps it.
+
+## What follows
+
+1. The explicit-mask warp-flash form is the gating item — without it none of the attention tuning matters on the
+   real model past seq 1024 (and 5 of every 6 gemma layers are sliding, so this is the model's dominant regime at
+   long context).
+2. The golden dataset needs seq-keyed rows (at least a 2048 tier) for attention and the split-K-carrying
+   projections — or an M-aware split heuristic — since the 512 picks are provably wrong (q_proj std 0.82×) and
+   cold greedy at 2048 both misdeploys and hangs.
+3. The emitter crash under the forced warp pin (`KeyError: 'acc2'`) deserves a guard regardless: an ineligible
+   mask form should decline at schedule time, never die in codegen.

--- a/plans/gemma4-seq-scaling-and-sliding-window-findings.md
+++ b/plans/gemma4-seq-scaling-and-sliding-window-findings.md
@@ -52,3 +52,27 @@ bench golden shapes only through the golden snippet form).
    cold greedy at 2048 both misdeploys and hangs.
 3. The emitter crash under the forced warp pin (`KeyError: 'acc2'`) deserves a guard regardless: an ineligible
    mask form should decline at schedule time, never die in codegen.
+
+## Post-implementation corrections (mask realization landed)
+
+The explicit-mask warp form is implemented (`FragmentBiasAdd` — see the PR), and chasing the layer-0 repro
+decomposed the original "seq > 1024" failure into FOUR distinct causes, two of them corrected findings:
+
+- **The `--layer` trace never carries the mask at all**: `trace/huggingface.py`'s `LayerWrapper` calls the block
+  with no `attention_mask`, so HF takes the `is_causal` path — the traced layer is pure causal at EVERY seq, and
+  the sliding window is silently dropped from the trace (a harness limitation, so `--layer` accuracy checks are
+  self-consistently causal and cannot see the band). The `mul_10` operand read as "the mask" in the first pass is
+  actually V (the `(B, S, H, D)` un-transposed layout). Whole-MODEL traces DO feed an explicit mask buffer — that
+  path (and real serving) is what the new warp mask realization unlocks.
+- **The scalar deploy + hang at 2048 was the cold-greedy pick on the unseeded shape** (the dataset-tier item 2
+  above), not mask-recognition — with pins the warp form now compiles at 2048.
+- **`KeyError: 'acc2'` was a σ-rewrite field drop**: the per-cell `RegStore` rewrite rebuilt `RegEpilogue`
+  WITHOUT `extra_accs`, unbinding the GeGLU combine's second channel accumulator. Fixed (renamed like the store's
+  own fragment) + a `RuleSkipped` guard in `_warp_epilogue` so a variant whose projection tail reads a value the
+  node doesn't compute declines instead of dying in render.
+- **TMA staging emitted an undefined `kv` on the `(B, S, H, D)` layout** (box coords are positional, kv assumed
+  at index[-2]) — now declines TMA for such layouts (cp.async substitutes by name and is unaffected).
+- **Still open (pre-existing on origin/main, reproduced there)**: the bare `TILE` pin
+  `a:mma_m16n8k16_f16_f32/w4x1/f1x4/k16` on the gemma layer makes the fused GeGLU megakernel produce NaN at any
+  seq — a mis-lowered variant in the pinned bare-TILE-on-multi-channel path. Blocks pinned whole-layer benches;
+  needs its own investigation.

--- a/plans/gemma4-seq-scaling-and-sliding-window-findings.md
+++ b/plans/gemma4-seq-scaling-and-sliding-window-findings.md
@@ -79,6 +79,25 @@ Both cards seeded with `.s2048` rows (all winners 2-4× reproduced; refs = live 
   read as "match no flash form"); bench attention A/Bs with NO env tile pin and tolerate the
   greedy bench_fail row.
 
+## Golden-value refresh check (2026-07-14) — RETRACTION: no values were stale
+
+The audit initially reported split-K matmul goldens reading 25-30% FASTER live than recorded,
+attributed to the #361 bare-child bench environment. **That finding was false** — an audit-parser
+artifact: the ad-hoc parser aligned recorded rows against a flat walk of json rows, pairing a
+split row's finalize kernel (or the other lane's main) with the wrong recorded value. The json
+already groups each pinned row's kernels under `/pinned[i]/kernels` (main + finalize together);
+paired correctly and re-measured 2× per name across ALL rows on BOTH cards:
+
+- **Every stable row is within 3% of its recorded value.** The residual deviations are ±3-6%
+  single-row jitter in BOTH directions (session noise), plus the known-jittery rows (the 4090
+  o_proj fm s2048 bimodality, hd128.dynM, q/o_proj.dynM at 8-9% run-to-run spread).
+- No yaml values changed; refreshing would churn numbers within the noise floor.
+- Audit methodology fixed for next time: read `/pinned[i]/kernels` sums, never a flat row walk.
+- One harness flake surfaced: after a greedy-hang kill, the respawned bench worker sometimes EOFs
+  the FIRST pinned row (`bench worker EOF before response`; the row records bench_fail, later
+  rows bench fine; the same row replays clean with the greedy env-pinned). Row-level, transient,
+  correlated with greedy-hang names (mlp_down.s2048 / mlp_gate_up.dynM std rows).
+
 ## Post-implementation corrections (mask realization landed)
 
 The explicit-mask warp form is implemented (`FragmentBiasAdd` — see the PR), and chasing the layer-0 repro

--- a/plans/gemma4-seq-scaling-and-sliding-window-findings.md
+++ b/plans/gemma4-seq-scaling-and-sliding-window-findings.md
@@ -64,13 +64,16 @@ Both cards seeded with `.s2048` rows (all winners 2-4× reproduced; refs = live 
 | o_proj | serial 294 | g2k **205.0** (1.39×) | 285.4 | serial 456 | serial **325.3** (1.37×) | 446.8 |
 | mlp_gate_up | ring 2413 | ring **1413** (1.56×) | 2210.7 | ring 4348 | ring **2316** (1.27×) | 2945.0 |
 | mlp_down | g2k 1112 | g2k **697** (1.68×) | 1171.1 | g2k 1580 | serial **1042** (1.43×) | 1493.7 |
-| attention hd256 | cp-alt nt8 262.7 | cp-alt nt8 **246.0** (~1.00×) | 237.6-257.2 | (see 4090 rows) | | 314.6 |
+| attention hd256 | cp-alt nt8 262.7 | cp-alt nt8 **246.0** (~1.00×) | 237.6-257.2 | cp-alt nt8 346.8 | cp-ring nt2 **288.8** (1.09×) | 314.6 |
 
 - The split-K story at M=2048 is K- AND card-dependent: the 5090 keeps a shallow `g2k` on the std
-  q/kv lanes and on deep-K mlp_down (both lanes); the 4090 drops the split almost everywhere
-  (only std mlp_down keeps g2k). fm serial is the winner on all three 4090 projections.
-- The 512 attention alt family transfers to 2048 with nt8 (the static-512 geometry), NOT the nt4
-  the symbolic dynM prefers — geometry preference is per-(shape, seq) as usual.
+  q/kv lanes and on deep-K mlp_down (both lanes); the 4090 drops the split on every projection
+  (only mlp_down keeps g2k, both lanes). fm serial is the winner on all three 4090 projections
+  (the o_proj fm pair needed a third rep — one 325.3 outlier vs the settled 297.6/298.0).
+- Attention at 2048 flips per card: the 5090 keeps the alt family (nt8, both lanes); the 4090's
+  fm lane RETURNS TO THE RING (nt2 288.8; fm-alt jitters 311-341 and loses) while its std lane
+  takes alt (346.8 vs ring 360). The 512-vs-2048 geometry also differs from the symbolic dynM
+  picks (nt8 static vs nt4 symbolic on the 5090) — every (card, seq, lane) cell is its own fork.
 - Bench-driver gotcha recorded: an `EMMY_TILE` ENV pin narrows the flash fork before `--ab`
   axis-keyed pins are matched, silently blocking geometries the env pin excludes (the nt8 rows
   read as "match no flash form"); bench attention A/Bs with NO env tile pin and tolerate the

--- a/plans/gemma4-seq-scaling-and-sliding-window-findings.md
+++ b/plans/gemma4-seq-scaling-and-sliding-window-findings.md
@@ -53,6 +53,29 @@ bench golden shapes only through the golden snippet form).
 3. The emitter crash under the forced warp pin (`KeyError: 'acc2'`) deserves a guard regardless: an ineligible
    mask form should decline at schedule time, never die in codegen.
 
+## The seq-2048 golden tier (2026-07-14, recorded)
+
+Both cards seeded with `.s2048` rows (all winners 2-4× reproduced; refs = live torch same-session):
+
+| shape | 5090 std | 5090 fm | 5090 ref | 4090 std | 4090 fm | 4090 ref |
+| --- | --: | --: | --: | --: | --: | --: |
+| q_proj | g2k 313 | serial **223.7** (1.42×) | 318.4 | serial 430 | serial **277.8** (1.43×) | 398.6 |
+| kv_proj | g2k 168.4 | serial **136.9** (1.24×) | 170.3 | serial 225 | serial **171.0** (1.22×) | 209.3 |
+| o_proj | serial 294 | g2k **205.0** (1.39×) | 285.4 | serial 456 | serial **325.3** (1.37×) | 446.8 |
+| mlp_gate_up | ring 2413 | ring **1413** (1.56×) | 2210.7 | ring 4348 | ring **2316** (1.27×) | 2945.0 |
+| mlp_down | g2k 1112 | g2k **697** (1.68×) | 1171.1 | g2k 1580 | serial **1042** (1.43×) | 1493.7 |
+| attention hd256 | cp-alt nt8 262.7 | cp-alt nt8 **246.0** (~1.00×) | 237.6-257.2 | (see 4090 rows) | | 314.6 |
+
+- The split-K story at M=2048 is K- AND card-dependent: the 5090 keeps a shallow `g2k` on the std
+  q/kv lanes and on deep-K mlp_down (both lanes); the 4090 drops the split almost everywhere
+  (only std mlp_down keeps g2k). fm serial is the winner on all three 4090 projections.
+- The 512 attention alt family transfers to 2048 with nt8 (the static-512 geometry), NOT the nt4
+  the symbolic dynM prefers — geometry preference is per-(shape, seq) as usual.
+- Bench-driver gotcha recorded: an `EMMY_TILE` ENV pin narrows the flash fork before `--ab`
+  axis-keyed pins are matched, silently blocking geometries the env pin excludes (the nt8 rows
+  read as "match no flash form"); bench attention A/Bs with NO env tile pin and tolerate the
+  greedy bench_fail row.
+
 ## Post-implementation corrections (mask realization landed)
 
 The explicit-mask warp form is implemented (`FragmentBiasAdd` — see the PR), and chasing the layer-0 repro

--- a/tests/compiler/backend/test_bench_worker_recovery.py
+++ b/tests/compiler/backend/test_bench_worker_recovery.py
@@ -204,6 +204,85 @@ def test_bench_retries_after_broken_pipe_on_first_write(monkeypatch) -> None:
     assert resp["result"].time_ms == 42.0
 
 
+def test_bench_retries_after_mid_job_eof(monkeypatch) -> None:
+    """A response-side EOF (the child ``os._exit``'d mid-job) must respawn and retry ONCE:
+    right after a SIGKILL'd predecessor, the dead child's zombie context can still hold the
+    GPU while the driver tears it down, hanging an innocent first launch on the fresh child
+    (the golden-refresh flake — the same row replays clean once the zombie is gone). A second
+    EOF is the config's own hang and stays a hard error (the test below)."""
+    import asyncio
+
+    from emmy.compiler.backend import BenchmarkResult
+    from emmy.compiler.backend.cuda import program as P
+
+    response_body = pickle.dumps(
+        {"ok": True, "result": BenchmarkResult(time_ms=17.0, num_launches=0)},
+        protocol=pickle.HIGHEST_PROTOCOL,
+    )
+    response_wire = len(response_body).to_bytes(8, "little") + response_body
+
+    class _FakeStdin:
+        def write(self, _data: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            pass
+
+    class _FakeStdout:
+        def __init__(self, wire: bytes) -> None:
+            self._buf = bytearray(wire)
+
+        async def readexactly(self, n: int) -> bytes:
+            if len(self._buf) < n:
+                raise asyncio.IncompleteReadError(bytes(self._buf), n)
+            chunk = bytes(self._buf[:n])
+            del self._buf[:n]
+            return chunk
+
+    class _FakeStderr:
+        async def read(self) -> bytes:
+            return b""
+
+    class _FakeProc:
+        def __init__(self, *, wire: bytes) -> None:
+            self.pid = 2000
+            self.returncode = None
+            self.stdin = _FakeStdin()
+            self.stdout = _FakeStdout(wire)
+            self.stderr = _FakeStderr()
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            return -9
+
+    def _run(wires: list[bytes]):
+        procs = [_FakeProc(wire=w_) for w_ in wires]
+        spawned = 0
+
+        async def fake_spawn(self: P._AsyncBenchWorker) -> None:
+            nonlocal spawned
+            self._proc = procs[spawned]
+            spawned += 1
+
+        monkeypatch.setattr(P._AsyncBenchWorker, "_spawn", fake_spawn)
+        w = P._AsyncBenchWorker()
+        resp = asyncio.run(w.run_job({"graph": None, "torch_spec": None, "kwargs": {}}, wall_timeout_s=5.0))
+        return spawned, resp
+
+    # First child EOFs mid-response (empty stdout), second answers: one retry, success.
+    spawned, resp = _run([b"", response_wire])
+    assert spawned == 2, "a mid-job EOF must trigger exactly one respawn + retry"
+    assert resp["result"].time_ms == 17.0
+
+    # Both children EOF: the config's own hang — a hard error after the single retry.
+    import pytest
+
+    with pytest.raises(RuntimeError, match="EOF before response"):
+        _run([b"", b""])
+
+
 def test_worker_survives_benign_error() -> None:
     # A failure that never touches CUDA (e.g. an NVRTC compile error) leaves the
     # context healthy — the worker must stay alive and keep serving so the

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -1502,6 +1502,47 @@ def test_sdpa_explicit_additive_mask(_chain_tile_pins, n_heads: int, seq_len: in
     _assert_close(dpd, eager)
 
 
+@requires_cuda
+def test_warp_flash_f32_value_operand_converts(monkeypatch):
+    """A V operand traced at f32 (gemma-4's V-norm: ``v_f16 * f32 row stat`` promotes, and the
+    ``.half()`` cast folds into the flash op's load) must CONVERT at the fragment load, not
+    reinterpret: the gmem-direct loaders take the fragment element type explicitly
+    (``<float, __half>``) and round each element — the raw-bit-pattern regression NaN'd every
+    even output column and scribbled past the 4-byte register. The staged rows decline (a
+    cp.async byte-copy cannot convert), so the kernel stays warp-tier gmem-direct."""
+    monkeypatch.setenv("EMMY_PLACE", "fuse")
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16_f32/w2x1/f1x4/k4")
+    monkeypatch.setenv("EMMY_STAGE", "d2/cp/ring")  # must DECLINE: the f32 V cannot byte-copy
+    monkeypatch.setenv("EMMY_WSPEC", "")
+    torch.manual_seed(5)
+    S, D = 128, 64
+
+    class VNormSdpa(torch.nn.Module):
+        def forward(self, q, k, v, s):
+            v32 = v.float() * s  # per-(token, head) f32 stat — promotes V to f32 in the trace
+            return F.scaled_dot_product_attention(q, k, v32.half())
+
+    q, k, v = (torch.randn(1, 4, S, D, dtype=torch.float16) for _ in range(3))
+    s = (torch.rand(1, 4, S, 1) + 0.5).float()
+    backend, compiled, graph, kernels = _trace(VNormSdpa(), (q, k, v, s))
+    srcs = "\n".join(compiled.nodes[n].op.kernel_source for n in kernels)
+    assert "mma.sync" in srcs, "the f32-V flash must stay on the warp (mma) tier"
+    assert "<float, __half>" in srcs, "the f32 operand must convert through the explicit fragment type"
+    assert "_v_smem" not in srcs, "staging must decline for a dtype-mismatched operand (byte-copy cannot convert)"
+
+    def ref():
+        with torch.no_grad():
+            v32 = (v.cuda().float() * s.cuda()).half()
+            return torch.nn.functional.scaled_dot_product_attention(q.cuda(), k.cuda(), v32).cpu().flatten().float().numpy()
+
+    data = {n: t.numpy() for n, t in zip(graph.inputs, (q, k, v, s), strict=True)}
+    run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
+    got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
+    assert not np.any(np.isnan(got)), "f32-V warp flash produced NaN (the reinterpret regression)"
+    max_diff = float(np.max(np.abs(got - eager)))
+    assert max_diff < 5e-3, f"f32-V warp flash max_diff={max_diff:.2e}"
+
+
 def _band_mask(seq: int, window: int) -> torch.Tensor:
     """A sliding-window additive float mask — causal AND within ``window`` keys of the query (the
     HF gemma sliding-attention band): 0 where ``m - window < kv <= m``, ``-inf`` elsewhere."""

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -1502,6 +1502,53 @@ def test_sdpa_explicit_additive_mask(_chain_tile_pins, n_heads: int, seq_len: in
     _assert_close(dpd, eager)
 
 
+def _band_mask(seq: int, window: int) -> torch.Tensor:
+    """A sliding-window additive float mask — causal AND within ``window`` keys of the query (the
+    HF gemma sliding-attention band): 0 where ``m - window < kv <= m``, ``-inf`` elsewhere."""
+    kv = torch.arange(seq)[None, :]
+    m = torch.arange(seq)[:, None]
+    keep = (kv <= m) & (kv > m - window)
+    return torch.where(keep, 0.0, float("-inf"))[None, None].half()
+
+
+@requires_cuda
+@pytest.mark.parametrize("stage", ["", "d2/tma/ring", "d1/cp/alt"])
+def test_warp_flash_explicit_additive_mask_matches_torch(monkeypatch, stage):
+    """An explicit additive ``attn_mask`` (the HF precomputed causal / sliding-window band)
+    realizes at the WARP tier: the score prologue's ``(m, kv)``-indexed bias ``Load`` + ``add``
+    becomes a per-element ``FragmentBiasAdd`` — each fragment element reads the mask at its
+    absolute coordinates and adds it before the softmax merge — instead of demoting the whole
+    kernel to the scalar tier (the gemma-4 seq>window regression: every layer's attention went
+    scalar and hung). Banded (sliding-window) mask; composes with the K/V staging forms."""
+    monkeypatch.setenv("EMMY_PLACE", "fuse")
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16_f32/w2x1/f1x4/k4")
+    monkeypatch.setenv("EMMY_WSPEC", "")
+    if stage:
+        monkeypatch.setenv("EMMY_STAGE", stage)
+    torch.manual_seed(3)
+    S, D = 128, 64
+    q, k, v = (torch.randn(1, 4, S, D, dtype=torch.float16) for _ in range(3))
+    mask = _band_mask(S, window=64)
+    backend, compiled, graph, kernels = _trace(_SdpaExplicitMask(), (q, k, v, mask))
+    assert len(kernels) == 1, f"masked warp flash should be one kernel, got {len(kernels)}"
+    src = compiled.nodes[kernels[0]].op.kernel_source
+    assert "mma.sync" in src, "the explicit-mask flash must stay on the warp (mma) tier"
+    assert "+= __half2float(mask[" in src, "the mask must realize as per-element fragment bias adds"
+    if stage == "d1/cp/alt":
+        assert "_q_smem" in src, "alt staging must compose with the mask bias"
+
+    def ref():
+        with torch.no_grad():
+            out = torch.nn.functional.scaled_dot_product_attention(q.cuda(), k.cuda(), v.cuda(), attn_mask=mask.cuda())
+            return out.cpu().flatten().float().numpy()
+
+    data = {n: t.numpy() for n, t in zip(graph.inputs, (q, k, v, mask), strict=True)}
+    run_result, eager = backend.run(compiled, input_data=data, pre_run=ref)
+    got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
+    max_diff = float(np.max(np.abs(got - eager)))
+    assert max_diff < 5e-3, f"masked warp flash (stage={stage!r}) max_diff={max_diff:.2e}"
+
+
 def _run_self_attn_tinyllama(seq_len: int, threshold: float = 1e-4) -> None:
     """Run TinyLlama's ``LlamaAttention`` sub-module at ``seq_len`` and verify emmy matches
     eager (forced MATH SDPA backend) within ``threshold``."""


### PR DESCRIPTION
One PR for the whole gemma-4 long-sequence arc (7 commits, each independently reviewable). Builds on #360/#361/#362 (merged).

## 1. Explicit additive `attn_mask` realizes at the warp-tier flash (`FragmentBiasAdd`)

The form HF passes for its precomputed causal / sliding-window band masks previously demoted the whole flash kernel to the scalar tier — on real gemma whole-model traces at seq > window (1024) that is **every** attention layer, and the deployed scalar kernel hangs the bench watchdog. The mask now realizes at fragment residence: the score prologue's `(m, kv)`-indexed bias `Load` + `add` becomes one `FragmentBiasAdd` per score fragment (each element reads the mask at its absolute coordinates — `FragmentMask`'s coordinate machinery with a gmem load in place of the fill; symbolic extents clamp-read). Composes with the K/V staging forms and split-KV; the schedule gate accepts `(m, kv)`-only biases; a classified-but-unconsumed bias load asserts (a silently dropped mask is worse than any failure). Tested with a banded sliding-window mask vs torch across gmem-direct / `d2/tma/ring` / `d1/cp/alt`.

## 2. Three flash correctness bugs, root-caused from the "GeGLU NaN"

The bare-pin layer-0 NaN decomposed (per-launch debug scan) into the ATTENTION kernel, with three independent causes — all fixed, each with the canonical-layout output byte-identical:

- **Wrong gmem row stride**: fragment loaders hardcoded `ldm` to the trailing-axis extent; on the un-transposed `(B,S,H,D)` trace, rows are `H·D` apart. New `gmem_row_stride()` derives the step from the load index + buffer shape; the schedule gate declines underivable layouts.
- **Staging byte-copied a dtype-mismatched operand**: gemma's V is f32 in-graph (V-norm promotes); cp.async deposited 4-byte elements into an f16 slab. Stage candidates now decline on operand-dtype mismatch (gmem-direct keeps the warp tier).
- **Loader templates reinterpreted instead of converting**: `((T*)&packed)` with `T=float` wrote raw f32 bit patterns and 4 bytes past the register. All loaders now take the fragment element type explicitly (`template <typename T, typename F = T>`) and round per element.

Plus two hardening fixes exposed on the way: `RegStore`'s per-cell sigma-rewrite dropped `RegEpilogue.extra_accs` (the GeGLU `KeyError: 'acc2'` — the multi-channel combine's second accumulator now renames with the store's fragment), and a `RuleSkipped` guard so a variant whose projection tail reads a value the node doesn't compute declines instead of dying in render. TMA staging also declines the `(B,S,H,D)` K/V layout (positional box coords would emit an undefined `kv`).

The pinned gemma layer 0 runs NaN-free at seq 512 and 2048. Residual (documented): the full-layer accuracy check sits 3.7% over its heuristic tolerance — the irreducible f16 rounding of the f32-traced V on tensor cores vs an f32-math eager reference.

## 3. seq-2048 golden tier, both cards (24 rows) + full audits

- The 512-tuned picks are provably wrong at M=2048 (q_proj std g8k collapses to 0.82x; cold greedy on the unseeded attention shape hangs or deploys 3.4x off). New `.s2048` rows for all five projections (std + fm) and attention hd256, all 2-4x reproduced and replay-verified: **fm 1.22-1.68x vs cuBLAS**; attention 5090 keeps `d1/cp/alt` nt8 (246 us ~ SDPA parity), the 4090's fm lane returns to the ring (nt2, 288.8 = 1.09x).
- **Full golden audits on both cards: zero regressions** (51 + 55 names).
- **Retraction commit included**: the audit's initial "split-K values read 25-30% high" finding was the audit parser's own row-misalignment artifact — re-measured 2x per name with correct `/pinned[i]/kernels` pairing, every stable row is within 3% of its recorded value; no yaml values changed.

## 4. Bench worker: retry once (with drain grace) on a mid-job response EOF

After a SIGKILL'd predecessor (greedy-hang wall kill), the dead child's zombie CUDA context can still hold the GPU while the driver tears it down, hanging an innocent first launch on the fresh child — the transient `bench worker EOF before response` the golden sweeps kept hitting. `run_job` now respawns and retries once after a <=2s drain grace (mirroring the send-side `BrokenPipeError` retry); a genuinely hanging config EOFs again and stays a loud hard error. Unit-tested both ways.

## Verification

`make test` 2375 passed / 39 skipped, lint clean. New e2e: banded-mask warp flash (3 staging forms), f32-V conversion regression, worker EOF-retry pair. All 24 golden rows replay-verified on their cards; both audits re-run clean. Findings report: `plans/gemma4-seq-scaling-and-sliding-window-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
