### PR TITLE
Make golden-scoped CLI tests and TMA-staged flash tests hardware-independent

### DIFF
--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -210,4 +210,11 @@ masked-symbolic sweep (symbolic M/N/K at off-hint sizes), the static-vs-dynamic 
 `d2/tma` transports, and the operand-pipelining transforms — the gmem→smem ring (`d<depth>/cp`) and the smem→register
 double-buffer (`/p<n>`), each asserted **bit-identical** to the single-buffer / gmem-direct baseline (a pure perf
 transform) — gating its GPU cases on `requires_sm90` / `_supports_tma()` (≥ sm_90); its GPU-less render / structure cases
-run anywhere. The TMA accuracy path additionally exercises the host descriptor encoder (`backend/cuda/_tma.py`).
+run anywhere. The TMA accuracy path additionally exercises the host descriptor encoder (`backend/cuda/_tma.py`). The same
+gate applies to TMA-transport `STAGE` pins (`…/tma…`) anywhere: below sm_90 the pin declines and the kernel stays
+gmem-direct, so `test_attention_coverage.py`'s TMA-staged flash cases carry `requires_sm90` (their `cp` siblings run on
+sm_80+). Golden-scoped CLI tests are the other environment trap: `--golden` / `--dataset golden` resolve against the
+**live card's** recordings, so tests asserting specific golden names (or monkeypatching `GOLDEN_CONFIGS` with card-less
+fakes) must pin themselves off-GPU (`torch.cuda.is_available → False` in-process, `CUDA_VISIBLE_DEVICES=""` for
+`run_cli` subprocesses) to take the multi-card-union path — otherwise they pass or fail depending on which shapes the
+local card happens to have recorded.

--- a/tests/compiler/cli/test_compile.py
+++ b/tests/compiler/cli/test_compile.py
@@ -183,19 +183,25 @@ def test_compile_dynamic_bad_spec_rejected(run_cli):
     assert "NAME@INPUT:AXIS" in stdout + stderr
 
 
-def test_compile_golden_substring_resolves_dynamic(run_cli):
+def test_compile_golden_substring_resolves_dynamic(run_cli, monkeypatch):
     """``compile --golden`` accepts the same name **substring** ``eval --kernel``
     filters on, and a dynamic golden carries its recorded symbolic spec through — so
     the rendered kernel gains an ``int seq_len`` arg (the masked-tile path), proving
     the golden was resolved via compile, not just run."""
+    # Hide CUDA from the subprocess: --golden scopes to the live card's recordings,
+    # so the name only resolves everywhere via the off-GPU multi-card union.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
     rc, stdout, stderr = run_cli("compile", "--golden", "o_proj.h4096.dynM", "--ir", "cuda")
     assert rc == 0, f"stderr: {stderr}"
     assert "int seq_len" in stdout, f"expected masked-tile ``int seq_len`` from the dynamic golden, got:\n{stdout[:500]}"
 
 
-def test_compile_golden_ambiguous_substring_lists_shapes(run_cli):
+def test_compile_golden_ambiguous_substring_lists_shapes(run_cli, monkeypatch):
     """A ``--golden`` substring spanning several shapes can't select one graph — it
     exits 2 listing the matched shapes so the user can narrow it."""
+    # Hide CUDA from the subprocess: the asserted shape pair only co-exists in the
+    # off-GPU multi-card union, not necessarily in one card's own recordings.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
     rc, stdout, stderr = run_cli("compile", "--golden", "mlp_down", "--ir", "tile")
     assert rc == 2, f"expected exit 2, got {rc}: {stdout}{stderr}"
     out = stdout + stderr

--- a/tests/compiler/cli/test_tune_dataset_golden.py
+++ b/tests/compiler/cli/test_tune_dataset_golden.py
@@ -91,10 +91,15 @@ def _dyn_golden(name="square.512.dynM"):
 def test_golden_dataset_target_carries_dynamic_spec(monkeypatch):
     """A dynamic golden expands to a target carrying its own ``--dynamic`` spec; a
     static golden's target carries ``None``."""
+    import torch
+
     from emmy.compiler.pipeline.search import golden as gmod
 
     static = gmod.MatmulGoldenConfig(name="square.512", M=512, N=512, K=512, knobs={"TILE": "n16x8/f2x2"}, emmy_us=9.0, cublas_us=14.0)
     monkeypatch.setattr(gmod, "GOLDEN_CONFIGS", [static, _dyn_golden()])
+    # Pin off-GPU: the fake goldens carry no card, so a live card would filter them to
+    # the empty set and trip the uncovered-card guard.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     targets = tune._tune_targets(_args(dataset="golden"))
     by_name = {name: dyn for name, _code, _inp, dyn in targets}
     assert by_name == {"square.512": None, "square.512.dynM": ["seq_len@x0:0"]}
@@ -304,6 +309,8 @@ def test_loop_sets_dynamic_per_target(monkeypatch):
     """The loop threads each target's dynamic spec onto ``args.dynamic`` before
     ``_tune_one`` (which traces via ``load_or_trace``), so a dynamic golden in the
     sweep traces symbolically and its static neighbors don't inherit the spec."""
+    import torch
+
     from emmy.compiler.pipeline.search import golden as gmod
 
     _stub_runtime(monkeypatch)
@@ -316,6 +323,9 @@ def test_loop_sets_dynamic_per_target(monkeypatch):
     monkeypatch.setattr(tune, "_tune_one", capture)
     static = gmod.MatmulGoldenConfig(name="square.512", M=512, N=512, K=512, knobs={"TILE": "n16x8/f2x2"}, emmy_us=9.0, cublas_us=14.0)
     monkeypatch.setattr(gmod, "GOLDEN_CONFIGS", [static, _dyn_golden()])
+    # Pin off-GPU: the fake goldens carry no card, so a live card would filter them to
+    # the empty set and trip the uncovered-card guard.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     with pytest.raises(SystemExit) as exc:
         tune.handle_tune(_args(dataset="golden"))
     assert exc.value.code == 0

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -29,7 +29,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from ..conftest import from_pretrained_or_skip, requires_cuda
+from ..conftest import from_pretrained_or_skip, requires_cuda, requires_sm90
 
 
 class _Sdpa(torch.nn.Module):
@@ -603,7 +603,16 @@ def _run_flash(backend, compiled, graph, tensors) -> np.ndarray:
 
 
 @requires_cuda
-@pytest.mark.parametrize("stage", ["d1/cp", "d2/cp/ring", "d3/cp/ring", "d1/tma", "d2/tma/ring"])
+@pytest.mark.parametrize(
+    "stage",
+    [
+        "d1/cp",
+        "d2/cp/ring",
+        "d3/cp/ring",
+        pytest.param("d1/tma", marks=requires_sm90),
+        pytest.param("d2/tma/ring", marks=requires_sm90),
+    ],
+)
 def test_staged_warp_flash_matches_torch(monkeypatch, stage):
     """A pinned K/V operand ``STAGE`` on the warp-flash stream: the kernel fills per-block K/V smem
     slabs (cooperative cp.async into padded rows, or rank-N TMA box copies into dense
@@ -652,7 +661,7 @@ def test_staged_warp_flash_bit_identical_to_gmem_direct(monkeypatch, stage):
 
 
 @requires_cuda
-@pytest.mark.parametrize("stage", ["d2/cp/ring", "d2/tma/ring"])
+@pytest.mark.parametrize("stage", ["d2/cp/ring", pytest.param("d2/tma/ring", marks=requires_sm90)])
 def test_staged_warp_flash_causal_and_gqa_match_torch(monkeypatch, stage):
     """The staged stream composes with the fragment causal mask and the GQA ``head // group`` K/V
     indexing — both ride the slab fill's operand index verbatim (the σ passes batch/head terms
@@ -758,6 +767,7 @@ def test_staged_flash_symbolic_cp_bit_identical_to_gmem_direct(monkeypatch, s):
 
 
 @requires_cuda
+@requires_sm90
 def test_staged_flash_stage_pin_keeps_warp_not_scalar(monkeypatch):
     """A ``STAGE`` pin keeps the flash fork on the WARP (mma) tier — only the warp tier stages, so
     the pin must not fall through to the chain / scalar reduce-partition siblings and let the prior
@@ -775,6 +785,7 @@ def test_staged_flash_stage_pin_keeps_warp_not_scalar(monkeypatch):
 
 
 @requires_cuda
+@requires_sm90
 def test_staged_flash_symbolic_tma_stages_and_matches_torch(monkeypatch):
     """A **TMA** ``STAGE`` pin on a SYMBOLIC ``seq_len`` flash STAGES the K/V stream: the
     descriptor rides the runtime globalDim and zero-fills the box overhang past the last key, so
@@ -806,6 +817,7 @@ def test_staged_flash_symbolic_tma_stages_and_matches_torch(monkeypatch):
 
 
 @requires_cuda
+@requires_sm90
 @pytest.mark.parametrize("s", [64, 100])
 def test_staged_flash_symbolic_tma_bit_identical_to_gmem_direct(monkeypatch, s):
     """The symbolic TMA-staged stream is a pure perf transform: verbatim K/V row copies, and the
@@ -938,7 +950,7 @@ def test_warp_flash_causal_tile_skip(monkeypatch):
 
 
 @requires_cuda
-@pytest.mark.parametrize("stage", ["d1/tma/alt", "d1/cp/alt"])
+@pytest.mark.parametrize("stage", [pytest.param("d1/tma/alt", marks=requires_sm90), "d1/cp/alt"])
 @pytest.mark.parametrize("variant", ["plain", "causal"])
 def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant, stage):
     """The ALTERNATING single-slab staging (``STAGE=d1/tma/alt``): one K slab + one V slab on
@@ -974,7 +986,10 @@ def test_warp_flash_alt_staging_matches_torch(monkeypatch, variant, stage):
 
 
 @requires_cuda
-@pytest.mark.parametrize(("variant", "stage"), [("plain", "d1/cp/alt"), ("plain", "d1/tma/alt"), ("causal", "d1/cp/alt")])
+@pytest.mark.parametrize(
+    ("variant", "stage"),
+    [("plain", "d1/cp/alt"), pytest.param("plain", "d1/tma/alt", marks=requires_sm90), ("causal", "d1/cp/alt")],
+)
 def test_warp_flash_alt_staging_symbolic_bit_identical(monkeypatch, variant, stage):
     """The alternating staging over a SYMBOLIC ``seq_len`` — the resolver accepts it and the
     liveness scheduler's kill-point refills ride the same runtime clamp as the ring prefetch:


### PR DESCRIPTION
## What

`make test` was red on `main` on GPU machines whose card can't satisfy two implicit environment assumptions — 14 failures on an RTX 4080 (sm_89), masking real regressions. Both failure classes are test bugs, not product bugs.

**Golden-scoped CLI tests (4).** `--golden` / `--dataset golden` resolve against the **live card's** recordings:

- `test_tune_dataset_golden.py`: `test_golden_dataset_target_carries_dynamic_spec` and `test_loop_sets_dynamic_per_target` monkeypatch `GOLDEN_CONFIGS` with card-less fakes; on any GPU machine the live-card filter reduces that set to empty and the uncovered-card guard exits 2. Fixed by pinning them off-GPU (`torch.cuda.is_available → False`) — the exact idiom `test_golden_dataset_full_union_off_gpu` in the same file already uses, and the off-GPU union is the documented pure-logic-test path.
- `test_compile.py`: `test_compile_golden_substring_resolves_dynamic` / `test_compile_golden_ambiguous_substring_lists_shapes` assert golden names that only co-exist in the multi-card union (the 4080 has goldens, so the no-goldens fallback doesn't kick in — but it lacks the `matmul.o_proj.h4096`/`mlp_down.h4096` shapes). These are `run_cli` subprocess tests, so they hide CUDA via `monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")` (inherited by the child).

**TMA-staged flash tests (10).** TMA transport needs sm_90+; on sm_89 the `STAGE` pin declines (`"does not resolve … the flash kernel stays gmem-direct"`) and the staging-marker asserts fail. The ten TMA cases in `test_attention_coverage.py` now carry `requires_sm90` — per-param `pytest.param(..., marks=requires_sm90)` where a parametrize mixes cp/tma stages, whole-test where the test is TMA-only. This matches `test_matmul_coverage.py`'s existing convention; the `cp` siblings keep running on sm_80+.

`tests/ARCHITECTURE.md` documents both traps so new tests don't reintroduce them.

## Verification

- RTX 4080 (sm_89): `make test` — **2308 passed, 162 skipped, 0 failed** (was 2304 passed / 14 failed / 152 skipped; the +10 skips are exactly the TMA cases).
- Off-GPU (CI lane): both touched CLI test files pass with `CUDA_VISIBLE_DEVICES=""` (33 passed).
- `make lint` clean.

On sm_90+ hardware nothing is skipped that ran before — the marker only fires below sm_90, where the tests could never pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)