### PR TITLE
Greedy re-benched isolated: a pinned-comparable baseline for the run …

### DIFF
--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -122,10 +122,11 @@ def register_run_command(subparsers):
         default=None,
         help=(
             "With --bench: also write the whole comparison as machine-readable JSON to PATH — the "
-            "backend table (eager / torch.compile / emmy), the per-kernel greedy rows, and every "
-            "--golden / --ab A/B row with its integrity flags (realized-vs-pinned knob check, "
-            "arithmetic-intensity floor, wrong-answer check). Retires ad-hoc table parsing in "
-            "the golden-sweep workflow."
+            "backend table (eager / torch.compile / emmy), the per-kernel greedy rows (plus, when "
+            "pinned rows benched, the ``greedy.isolated`` emmy-only re-bench — the pinned-comparable "
+            "greedy baseline), and every --golden / --ab A/B row with its integrity flags "
+            "(realized-vs-pinned knob check, arithmetic-intensity floor, wrong-answer check). "
+            "Retires ad-hoc table parsing in the golden-sweep workflow."
         ),
     )
     parser.add_argument("--dump-dir", default=None, help="Directory to dump intermediate compilation artifacts.")
@@ -275,7 +276,11 @@ def handle_run(args):
     # clean, the row records bench_fail, the next job respawns a fresh context), so no
     # ``os._exit`` and no per-row special-casing. The greedy job also carries the accuracy
     # check (in-child, on the rebuilt module's real inputs) and — when pinned rows exist —
-    # returns that run's (inputs, outputs) as their wrong-answer reference.
+    # returns that run's (inputs, outputs) as their wrong-answer reference. When pinned
+    # rows exist the greedy graph is ALSO re-benched emmy-only through the pinned-row path
+    # (``_bench_greedy_isolated``): the interleaved greedy number is torch-comparable but
+    # NOT pinned-comparable (the documented ~7% environment skew), so pinned speedups read
+    # against the isolated row.
     _resolve_backends(args.bench_backends)  # validate the spelling before spending a worker job
     pinned = list(getattr(args, "golden_configs", None) or []) + (_ab_samples(args.ab, dynamic=args.dynamic) if args.ab else [])
     trace_payload = {
@@ -287,7 +292,7 @@ def handle_run(args):
     }
 
     async def _bench_session():
-        greedy_fail = results = bench = accuracy_error = ab_ref = golden_benches = None
+        greedy_fail = results = bench = accuracy_error = ab_ref = golden_benches = greedy_iso = None
         captured = True
         try:
             try:
@@ -311,12 +316,13 @@ def handle_run(args):
             if pinned and accuracy_error is None:
                 if greedy_fail:
                     logger.error("%s — greedy row marked bench_fail; pinned rows still bench in the worker", greedy_fail)
+                greedy_iso = await _bench_greedy_isolated(backend, compiled, warmup=args.warmup, iters=args.iters)
                 golden_benches = await _bench_golden_variants(backend, args.code, pinned, warmup=args.warmup, iters=args.iters, ref=ab_ref)
         finally:
             await backend.aclose_async_worker()
-        return greedy_fail, results, bench, captured, accuracy_error, golden_benches
+        return greedy_fail, results, bench, captured, accuracy_error, golden_benches, greedy_iso
 
-    greedy_fail, results, bench, captured, accuracy_error, golden_benches = asyncio.run(_bench_session())
+    greedy_fail, results, bench, captured, accuracy_error, golden_benches, greedy_iso = asyncio.run(_bench_session())
 
     if accuracy_error is not None:
         # Correctness gate: the deployed program computes the wrong answer, so no latency
@@ -332,12 +338,16 @@ def handle_run(args):
         capture_note = None if captured else "(graph-capture fallback: timings include host launch overhead)"
         notes = [n for n in (_symbolic_bench_note(_collect_sym_env([compiled])), capture_note) if n]
         _print_table(results, note="\n".join(notes) if notes else None)
-    _print_kernel_stats(compiled, bench, golden_benches=golden_benches, greedy_fail=greedy_fail)
+    _print_kernel_stats(compiled, bench, golden_benches=golden_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
     if getattr(args, "json", None):
-        _write_ab_json(args, results or {}, compiled, bench, golden_benches, greedy_fail=greedy_fail)
+        _write_ab_json(args, results or {}, compiled, bench, golden_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
     if args.profile and greedy_fail is None:
         _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
-    if greedy_fail is not None or any(gb.status != "ok" for gb in golden_benches or []):
+    if (
+        greedy_fail is not None
+        or (greedy_iso is not None and greedy_iso.status != "ok")
+        or any(gb.status != "ok" for gb in golden_benches or [])
+    ):
         sys.exit(1)  # every row is reported above; any failed row (greedy or pinned) exits non-zero
 
 
@@ -672,6 +682,29 @@ async def _bench_golden_variants(backend, code, golden_configs, *, warmup, iters
     return out
 
 
+async def _bench_greedy_isolated(backend, compiled, *, warmup, iters):
+    """Re-bench the greedy deploy's compiled graph emmy-only through the pinned-row worker
+    path (``bench_pinned_async``) — the pinned-comparable greedy baseline. The greedy
+    comparison row times emmy interleaved with the live torch closures (same warm clocks /
+    caches for the eager / torch.compile table — deliberate), which leaves torch allocator
+    state and cuBLAS L2 carveouts active while emmy is measured; a pinned row never runs
+    torch, so the same config reads ~7% apart between the two positions (worst on split-K
+    pairs, whose finalize re-reads the partials workspace). One number can't be both
+    torch-comparable and pinned-comparable, so the greedy config benches twice: this row is
+    the one pinned golden / ``--ab`` speedups read against. Reuses the already-compiled
+    greedy graph — one extra worker job, no recompile. Returns a ``_GoldenBench`` (status
+    ``ok`` / ``bench_fail``); a failure never blocks the pinned rows."""
+    from types import SimpleNamespace  # noqa: PLC0415
+
+    sample = SimpleNamespace(name="greedy (isolated)", knobs={}, shape=None, dynamic=None)
+    try:
+        g_bench, _ = await backend.bench_pinned_async(compiled, warmup=warmup, num_iters=iters)
+    except Exception as exc:  # noqa: BLE001 — an iso-bench failure must not abort the pinned rows
+        logger.warning("greedy isolated re-bench failed (%s) — row kept as bench_fail; pinned rows still bench", exc)
+        return _GoldenBench(sample, compiled, None, [f"bench_fail: {exc}"], "bench_fail")
+    return _GoldenBench(sample, compiled, g_bench, [], "ok")
+
+
 def _launch_order_cuda_nodes(graph):
     """CudaOp nodes in the backend's launch order (``graph.topological_order()`` — the order
     ``bench.per_launch`` indexes). Graph dict order diverges from launch order after
@@ -682,7 +715,7 @@ def _launch_order_cuda_nodes(graph):
     return [graph.nodes[nid] for nid in graph.topological_order() if isinstance(graph.nodes[nid].op, CudaOp)]
 
 
-def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None):
+def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, greedy_iso=None):
     """Per-kernel breakdown. Pulls structural stats off each ``CudaOp``
     (block / grid / smem), per-launch timings from ``bench.per_launch``,
     and per-kernel hardware attributes from the compiled cupy RawKernels
@@ -698,6 +731,14 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None):
     cells are colored red where they differ from the greedy pick (like ``eval``).
     A pinned row that never benched (unmatched pin / bench_fail — ``gb.bench is None``)
     still prints its kernels with ``--`` timings so the failure is visible, never dropped.
+
+    ``greedy_iso`` (a ``_GoldenBench`` from :func:`_bench_greedy_isolated`, present when
+    pinned rows benched) is the greedy graph re-benched emmy-only through the pinned-row
+    path: each greedy kernel row gets a ``greedy (isolated)`` twin right beneath it (same
+    kernel, pinned-row timing semantics) — the number to compare golden / ``--ab`` rows
+    against; the greedy row's own µs is torch-comparable, not pinned-comparable (the
+    documented ~7% skew). A failed iso re-bench prints as a ``!`` note, its rows skipped
+    (they would duplicate the greedy geometry with ``--`` timings).
 
     ``bench=None`` + ``greedy_fail`` is the degraded mode: the greedy deploy itself failed
     (hung / blew the bench budget) in its worker child, so its rows print with ``--``
@@ -807,12 +848,21 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None):
                 (label, g_times.get(gidx) if gb.bench is None else g_times.get(gidx, 0.0), "--", _geom(gnode.op, g_attrs), gk, ref)
             )
 
+    # Per-launch times of the isolated greedy re-bench — same graph, so indexes align
+    # 1:1 with ``cuda_nodes`` and each greedy kernel row gets its iso twin beneath it.
+    iso_times = (
+        None
+        if greedy_iso is None or greedy_iso.bench is None
+        else {lt.idx: (min(lt.samples) if lt.samples else lt.time_ms) * 1000 for lt in (greedy_iso.bench.per_launch or [])}
+    )
     for idx, node in enumerate(cuda_nodes):
         op = node.op
         t_us = None if bench is None else times_by_idx.get(idx, 0.0)
         pct_cell = "--" if total_us is None else f"{((t_us / total_us * 100) if total_us > 0 else 0.0):.1f}%"
         gknobs = dict(tuning_knob_items(op.knobs or {}))
         records.append((op.kernel_name, t_us, pct_cell, _geom(op, attrs_by_kname), gknobs, None))
+        if iso_times is not None:
+            records.append(("greedy (isolated)", iso_times.get(idx, 0.0), "--", _geom(op, attrs_by_kname), gknobs, gknobs))
         for gb in _matching(op):
             _gb_rows(gb, gknobs)
     # Catch-all: pinned rows that matched no greedy kernel still print — the golden
@@ -854,12 +904,12 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None):
         print(line)
     if greedy_fail is not None:
         print(f"! greedy: bench_fail — {greedy_fail}")
-    for gb in golden_benches or []:
+    for gb in ([greedy_iso] if greedy_iso is not None else []) + list(golden_benches or []):
         for flag in gb.flags:
             print(f"! {gb.sample.name}: {flag}")
 
 
-def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fail=None) -> None:
+def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fail=None, greedy_iso=None) -> None:
     """``--json PATH``: the whole ``--bench`` comparison as one machine-readable record —
     the backend table (eager / torch.compile / emmy), the per-kernel greedy rows, and every
     ``--golden`` / ``--ab`` pinned row with its recorded reference latencies and integrity
@@ -874,7 +924,13 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
     unpinned-``REDUCE`` drift class). Failure states are fields, not absences: the greedy
     block carries ``status`` (``"bench_fail"`` + ``error`` when the deploy failed) and each
     pinned row its ``status`` (``ok`` / ``pin_unmatched`` / ``bench_fail``) with ``us`` /
-    ``total_us`` null where nothing was measured."""
+    ``total_us`` null where nothing was measured.
+
+    ``greedy_iso`` (present when pinned rows benched) lands as ``greedy.isolated`` —
+    the same graph re-benched emmy-only through the pinned-row path, shaped like a pinned
+    row (``status`` / ``total_us`` / ``kernels`` / ``flags``). Sweep tooling compares
+    pinned ``total_us`` against THIS block; the greedy block's own ``total_us`` is the
+    interleaved (torch-comparable) number, ~7% apart from pinned-row semantics."""
     import json as _json  # noqa: PLC0415
 
     from emmy import gpu  # noqa: PLC0415
@@ -922,6 +978,13 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
     greedy = {"status": "ok" if greedy_fail is None else "bench_fail", "total_us": _total_us(bench), "kernels": _kernel_rows(graph, bench)}
     if greedy_fail is not None:
         greedy["error"] = greedy_fail
+    if greedy_iso is not None:
+        greedy["isolated"] = {
+            "status": greedy_iso.status,
+            "total_us": _total_us(greedy_iso.bench),
+            "kernels": _kernel_rows(greedy_iso.graph, greedy_iso.bench),
+            "flags": list(greedy_iso.flags),
+        }
     payload = {
         "input": args.code or args.input or getattr(args, "ir", None),
         "golden": getattr(args, "golden", None),
@@ -1550,7 +1613,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         logger.warning("--ab ignored: %s IR is fully lowered (no forks left to pin)", stage)
 
     async def _bench_session():
-        greedy_fail = results = bench = accuracy_error = ab_benches = None
+        greedy_fail = results = bench = accuracy_error = ab_benches = greedy_iso = None
         torch_available = captured = False
         try:
             try:
@@ -1571,12 +1634,13 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
             if args.ab and tail:
                 if greedy_fail:
                     logger.error("%s — greedy row marked bench_fail; --ab rows still bench in the worker", greedy_fail)
+                greedy_iso = await _bench_greedy_isolated(backend, graph, warmup=args.warmup, iters=args.iters)
                 ab_benches = await _bench_ab_variants_ir(backend, path, tail, args.ab, warmup=args.warmup, iters=args.iters, db=db)
         finally:
             await backend.aclose_async_worker()
-        return greedy_fail, results, bench, torch_available, captured, accuracy_error, ab_benches
+        return greedy_fail, results, bench, torch_available, captured, accuracy_error, ab_benches, greedy_iso
 
-    greedy_fail, results, bench, torch_available, captured, accuracy_error, ab_benches = asyncio.run(_bench_session())
+    greedy_fail, results, bench, torch_available, captured, accuracy_error, ab_benches, greedy_iso = asyncio.run(_bench_session())
 
     if accuracy_error is not None:
         # Non-fatal here (random boundary inputs) — the child's own log is invisible, relay it.
@@ -1593,12 +1657,16 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         print()
         for line in render_table([Col("Backend"), Col("Latency (us)", "r")], [["Emmy", f"{bench.time_ms * 1000:.0f}"]], rule=True):
             print(line)
-    _print_kernel_stats(graph, bench, golden_benches=ab_benches, greedy_fail=greedy_fail)
+    _print_kernel_stats(graph, bench, golden_benches=ab_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
     if getattr(args, "json", None):
-        _write_ab_json(args, results or {}, graph, bench, ab_benches, greedy_fail=greedy_fail)
+        _write_ab_json(args, results or {}, graph, bench, ab_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
     if args.profile and greedy_fail is None:
         _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
-    if greedy_fail is not None or any(gb.status != "ok" for gb in ab_benches or []):
+    if (
+        greedy_fail is not None
+        or (greedy_iso is not None and greedy_iso.status != "ok")
+        or any(gb.status != "ok" for gb in ab_benches or [])
+    ):
         sys.exit(1)  # every row is reported above; any failed row (greedy or --ab) exits non-zero
 
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -646,8 +646,11 @@ clean, the row is reported `bench_fail` (with the reason), and the next row's jo
 escalation modes, no `os._exit`. NOTE: process placement is unified, the measurement *environment* is not — the
 greedy row benches interleaved with the live torch closures (torch allocator state, cuBLAS L2 carveouts resident),
 while a pinned row benches emmy-only in a job that never touches torch, so a greedy-row µs and a pinned-row µs for
-the same config are NOT directly comparable (the field-observed gap is ~7% on split-K pairs). Compare pinned rows
-against each other and record goldens from `--ab`/golden rows only, never from the greedy row's number. The greedy
+the same config are NOT directly comparable (the field-observed gap is ~7% on split-K pairs). One number can't be
+both torch-comparable and pinned-comparable, so when pinned rows bench, the greedy graph is ALSO re-benched
+emmy-only through the same pinned path (one extra worker job, no recompile): the `greedy (isolated)` twin row
+beneath each greedy kernel in the table, the `greedy.isolated` block in `--json` — the baseline pinned-row
+speedups read against. Record goldens from `--ab`/golden rows only, never from the greedy row's number. The greedy
 pick hanging or blowing the bench budget is a *finding* — the exact hazard a golden exists to pin — so pinned rows
 still bench after it; failed pinned rows (compile / bench) are kept as `bench_fail` rows, never dropped, and the run
 exits non-zero when any row failed. The greedy job also carries the accuracy check (the emmy program runs on the

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -183,10 +183,13 @@ def test_build_torch_fns_resets_dynamo_before_compile(monkeypatch):
 @requires_cuda
 def test_run_golden_bench_shows_benched_golden_row(run_cli):
     """``run --golden NAME --bench`` compiles + benches the recorded golden (knobs
-    pinned) and prints it as a ``golden NAME``-labeled row in the kernel table."""
+    pinned) and prints it as a ``golden NAME``-labeled row in the kernel table, plus the
+    ``greedy (isolated)`` twin — the greedy graph re-benched through the pinned-row path,
+    the baseline the golden rows compare against."""
     rc, stdout, stderr = run_cli("run", "--golden", "matmul.square.512", "--bench")
     assert rc == 0, f"stderr: {stderr}"
     assert "golden matmul.square.512" in stdout, stdout
+    assert "greedy (isolated)" in stdout, stdout
 
 
 def test_run_ab_requires_bench(run_cli):
@@ -494,6 +497,36 @@ def test_bench_golden_variants_wrong_answer_gate_uses_worker_outputs(monkeypatch
     assert any("wrong-answer" in f for f in benches[1].flags)
 
 
+def test_bench_greedy_isolated_ok_and_bench_fail():
+    """The isolated greedy re-bench ships the ALREADY-compiled greedy graph through
+    ``bench_pinned_async`` — pinned-row timing semantics, no re-trace / recompile — so
+    pinned speedups get a comparable baseline (the interleaved greedy number is ~7% off
+    pinned-row semantics). A worker failure is kept as a ``bench_fail`` row and must not
+    raise (the pinned rows still bench after it)."""
+    from types import SimpleNamespace
+
+    from emmy.commands.run import _bench_greedy_isolated
+
+    compiled = object()
+    benched: list = []
+
+    async def ok_bench(g, *, warmup, num_iters):
+        benched.append(g)
+        return SimpleNamespace(min_ms=1.0, time_ms=1.0, per_launch=[]), None
+
+    gb = asyncio.run(_bench_greedy_isolated(SimpleNamespace(bench_pinned_async=ok_bench), compiled, warmup=1, iters=1))
+    assert benched == [compiled]  # the deployed graph itself rode the worker job
+    assert gb.status == "ok" and gb.bench is not None and gb.flags == []
+    assert gb.sample.name == "greedy (isolated)" and gb.sample.shape is None
+
+    async def hung_bench(g, *, warmup, num_iters):
+        raise RuntimeError("bench worker exceeded 100.0s wall budget — SIGKILL'd, stream cleaned")
+
+    gb = asyncio.run(_bench_greedy_isolated(SimpleNamespace(bench_pinned_async=hung_bench), compiled, warmup=1, iters=1))
+    assert gb.status == "bench_fail" and gb.bench is None
+    assert any("bench_fail" in f for f in gb.flags)
+
+
 @requires_cuda
 def test_run_golden_bench_json_record(run_cli, tmp_path):
     """``run --bench --golden NAME --json PATH`` writes the machine-readable A/B record:
@@ -507,6 +540,8 @@ def test_run_golden_bench_json_record(run_cli, tmp_path):
     rec = json.loads(out.read_text())
     assert rec["golden"] == "matmul.square.512"
     assert rec["greedy"]["kernels"] and rec["greedy"]["total_us"] > 0
+    # The pinned-comparable greedy baseline: the same graph re-benched emmy-only.
+    assert rec["greedy"]["isolated"]["status"] == "ok" and rec["greedy"]["isolated"]["total_us"] > 0
     assert rec["pinned"] and all(p["kind"] == "golden" for p in rec["pinned"])
     for p in rec["pinned"]:
         assert "flags" in p and p["total_us"] > 0 and p["pinned_knobs"]
@@ -1128,3 +1163,61 @@ def test_print_kernel_stats_greedy_bench_fail_row(capsys):
     outp = capsys.readouterr().out
     assert "bench_fail" in outp and "greedy bench failed: hung" in outp
     assert "k_greedy" in outp and "ab TILE=w4x2/f2x4" in outp
+
+
+def _iso_bench_fixtures():
+    """One-kernel greedy graph + interleaved bench (500 µs) + isolated re-bench (400 µs)
+    ``_GoldenBench`` — the ``greedy_iso`` display/json inputs."""
+    from types import SimpleNamespace
+
+    from emmy.commands.run import _GoldenBench
+    from emmy.compiler.graph import Graph, Tensor
+    from emmy.compiler.ir.cuda.ir import CudaOp
+
+    greedy = Graph()
+    greedy.add_node(op=CudaOp(kernel_name="k_greedy", knobs={"TILE": "w2x1/f1x8"}), inputs=[], output=Tensor("o", (4,)), node_id="n0")
+    bench = SimpleNamespace(min_ms=0.5, time_ms=0.5, per_launch=[SimpleNamespace(idx=0, samples=[0.5], time_ms=0.5)], e2e_min_ms=None)
+    iso_bench = SimpleNamespace(min_ms=0.4, time_ms=0.4, per_launch=[SimpleNamespace(idx=0, samples=[0.4], time_ms=0.4)], e2e_min_ms=None)
+    iso_sample = SimpleNamespace(name="greedy (isolated)", knobs={}, shape=None, dynamic=None)
+    return greedy, bench, _GoldenBench(iso_sample, greedy, iso_bench, [])
+
+
+def test_print_kernel_stats_greedy_isolated_rows(capsys):
+    """With ``greedy_iso`` present, each greedy kernel row gets a ``greedy (isolated)``
+    twin with the emmy-only re-bench's per-launch timing (same graph — indexes align 1:1),
+    the pinned-comparable baseline. A failed iso re-bench prints as a ``!`` note only —
+    its rows would just duplicate the greedy geometry with ``--`` timings."""
+    from emmy.commands.run import _GoldenBench, _print_kernel_stats
+
+    greedy, bench, iso = _iso_bench_fixtures()
+    _print_kernel_stats(greedy, bench, golden_benches=[], greedy_iso=iso)
+    outp = capsys.readouterr().out
+    assert "greedy (isolated)" in outp and "400.0" in outp and "500.0" in outp
+
+    failed = _GoldenBench(iso.sample, greedy, None, ["bench_fail: hung"], "bench_fail")
+    _print_kernel_stats(greedy, bench, golden_benches=[], greedy_iso=failed)
+    outp = capsys.readouterr().out
+    assert "! greedy (isolated): bench_fail: hung" in outp
+    assert outp.count("greedy (isolated)") == 1  # the note, no `--` twin rows
+
+
+def test_write_ab_json_greedy_isolated_block(tmp_path):
+    """``greedy.isolated`` rides the ``--json`` record when pinned rows benched: the
+    emmy-only re-bench of the greedy graph, shaped like a pinned row (``status`` /
+    ``total_us`` / ``kernels`` / ``flags``) — the block pinned ``total_us`` compares
+    against, where the greedy block's own number is interleaved with torch (~7% apart)."""
+    import json
+    from types import SimpleNamespace
+
+    from emmy.commands.run import _write_ab_json
+
+    greedy, bench, iso = _iso_bench_fixtures()
+    args = SimpleNamespace(
+        json=str(tmp_path / "ab.json"), code="torch.matmul(a, b)", input=None, ir=None, golden=None, dynamic=None, warmup=1, iters=1
+    )
+    _write_ab_json(args, {}, greedy, bench, [], greedy_iso=iso)
+    rec = json.loads((tmp_path / "ab.json").read_text())
+    assert rec["greedy"]["total_us"] == 500.0
+    iso_rec = rec["greedy"]["isolated"]
+    assert iso_rec["status"] == "ok" and iso_rec["total_us"] == 400.0
+    assert iso_rec["kernels"][0]["us"] == 400.0 and iso_rec["flags"] == []


### PR DESCRIPTION
…--bench A/B

The greedy comparison row times emmy interleaved with the live torch closures (same warm clocks/caches for the eager / torch.compile table — deliberate), while a pinned golden / --ab row benches emmy-only in a job that never runs torch; the same config reads ~7% apart between the two positions (worst on split-K pairs), the documented main noise source at the end of golden descent. One number can't be both torch-comparable and pinned-comparable, so when pinned rows bench, the greedy graph now ALSO re-benches emmy-only through the same pinned-row worker path — the already compiled graph rides one extra job, no recompile.

- Kernel table: a `greedy (isolated)` twin row beneath each greedy kernel (per-launch indexes align — same graph); a failed re-bench prints as a `!` note and exits non-zero like any failed row.
- --json: a `greedy.isolated` block (status / total_us / kernels / flags, pinned-row shape) — sweep tooling compares pinned total_us against this, not the interleaved greedy number.
- Both entry points covered: the model/--code path and the --ir reproducer path.
- The re-bench also runs after a greedy-row bench_fail, splitting "hangs only next to torch" from "genuinely broken config".