### PR TITLE
Decode-serving kernel readiness: ShapeKey aspect discriminator + computed-A split-K and d2/sync enumeration

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -143,11 +143,17 @@ codec's atom token and priced by the `MMA_acc_bits` feature; f16 only (mma.sync 
 `wspec_moves()` is the fourth level (bare `WSPEC`, option-0 `""` = uniform SIMT) — offered only on a warp row over a
 resolved **TMA** stage without a cross-CTA split, and resolved/thread-budget-gated at materialization
 (`_wspec_workers`; an ineligible spec degrades to uniform). A computed-A (fused-cone) contraction enumerates its own
-warp-only rows (`_schedule._computed_a_rows` — the mandatory resolved `sync` compute-fill stage crossed with the
-shared `RASTER` launch-order candidates (its B stripes re-stream per M-tile row, exactly the grouped order's L2
-reuse — `gn8` measured −8% on the gemma gate_up fused edge, 5090), no scalar /
-gmem-direct / split-K / WSPEC rows; the compute-producer role for the fused edge is the anticipated `RoleKind`
-extension). The **flash-form fork**: a `TWISTED` streaming contraction pair (the flash tree) offers its
+warp-only rows (`_schedule._computed_a_rows` — the mandatory resolved `sync` compute-fill stage at BOTH depths
+(`d1` + the asymmetric B-only prefetch ring `d2` as fork siblings — the M=512 occupancy loss inverts at decode M,
+so the depth is measured per shape), crossed with the shared `RASTER` launch-order candidates (its B stripes
+re-stream per M-tile row, exactly the grouped order's L2 reuse — `gn8` measured −8% on the gemma gate_up fused
+edge, 5090) and — single-channel nodes only — the **redundant-statistic split-K** rows: the contraction K slices
+across CTAs while the k-invariant stat prologue stays full-row in every partition (each recomputes it, cheap
+exactly on the small-free decode shapes the `_SPLITK_MAX_CTAS` gate admits), the per-cell cone σ-reindexed to
+absolute k and the `Map`-wrapper projection folded into the deferred finalize (`_splitk_option`'s computed-A arm
+→ `030_split_reduce`'s structural path). Still no scalar / gmem-direct / WSPEC rows, and no split on
+multi-channel (gate/up) nodes — their product-monoid carrier is not the 1-component additive state the split
+finalize folds; the compute-producer role for the fused edge is the anticipated `RoleKind` extension. The **flash-form fork**: a `TWISTED` streaming contraction pair (the flash tree) offers its
 structurally-different schedules as ONE prior-ranked fork — the warp (fragment-resident) rows over
 `twisted_warp_moves()`'s `(warps-per-CTA × key-atoms-per-block × query-tiles-per-warp)` geometry grid (option-0 = the
 conservative one-warp / `2·atom_n` block / one tile; the third dimension is the `TILE` codec's `f<FM>x<FN>` reg_m —

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -498,9 +498,14 @@ def _reduce_candidates(kernel, place, plan: TilePlan, probe: Contraction | None 
             if p.coop <= k and p.reg <= k:
                 out.append(move)
     free = prod(_hint_extent(a) for a in place.free) if place.free else 1
-    # A computed-A (fused-cone) contraction offers no split-K: the split σ-reindexes the operand
-    # Loads, and a producer-cone A cannot be sliced over K (its statistic prologue spans the row).
-    if k is not None and free // _tile_area(plan) <= _SPLITK_MAX_CTAS and (probe is None or not probe.a_computed):
+    # A computed-A (fused-cone) contraction splits over K via the REDUNDANT-STATISTIC form: the
+    # k-invariant stat prologue spans the whole row and stays full-row in every partition (each
+    # recomputes it — cheap exactly where split-K pays, the small-free decode shapes this offer
+    # is gated to), while only the per-cell cone is σ-reindexed (``_splitk_option``). Multi-channel
+    # nodes (the gate/up fused edge) stay excluded — their carrier is not the 1-component additive
+    # state ``030_split_reduce``'s finalize folds.
+    splittable = probe is None or not probe.a_computed or len(probe.folds) == 1
+    if k is not None and free // _tile_area(plan) <= _SPLITK_MAX_CTAS and splittable:
         step = plan.atom.atom_k * plan.bk if plan.is_warp else 1
         atomic_ok = probe is not None and (len(probe.epilogue) == 0 or projection_distributes(probe.epilogue, (probe.acc,)))
         for move in splitk_moves(warp=plan.is_warp):
@@ -881,15 +886,16 @@ def _resolve_sync_stage(c: Contraction, budget: int = STATIC_SMEM_CAP, want_dept
     sibling and a ``STAGE`` pin degrades to this resolved row. ``None`` when the slabs don't fit
     the 48 KiB smem budget: the A/B operand slabs plus one fp32 row per bridged statistic
     (``sync_stat_fill``'s decls — the same ``Contraction.stat_prologue`` seam the materializer
-    fills through). ``want_depth >= 2`` (a ``STAGE`` ``d<n>/sync`` pin — pin / tune-explorable)
-    is the **asymmetric B-only prefetch ring**: only the canonical-B cp.async slabs ring (their
-    copies for chunk ``i+d-1`` fly under chunk ``i``'s compute fill AND drain), while the
-    compute-filled A slab and the stat rows stay single-buffer — ringing a compute fill buys no
-    overlap (it runs on the drain's own threads). Measured on the gemma gate_up fused edge
-    (5090): the B-only ring STILL loses (897 vs 665 µs at d2) — the extra B slot alone crosses
-    the smem occupancy quantization (3 → 2 CTAs/SM), the same cliff that killed the historical
-    full-slab ring; the depth stays pin-only and option-0 ``d1`` is the deployable form. A
-    transposed-B
+    fills through). ``want_depth >= 2`` is the **asymmetric B-only prefetch ring**: only the
+    canonical-B cp.async slabs ring (their copies for chunk ``i+d-1`` fly under chunk ``i``'s
+    compute fill AND drain), while the compute-filled A slab and the stat rows stay
+    single-buffer — ringing a compute fill buys no overlap (it runs on the drain's own
+    threads). Measured on the gemma gate_up fused edge at M=512 (5090) the B-only ring loses
+    (897 vs 665 µs at d2) — the extra B slot alone crosses the smem occupancy quantization
+    (3 → 2 CTAs/SM), the same cliff that killed the historical full-slab ring — but at decode
+    M (tile_m ≤ 32) the A slab + stat rows are tiny and the tradeoff inverts, so
+    :func:`_computed_a_rows` enumerates ``d1`` and ``d2`` as fork siblings (measured per
+    shape) and a ``STAGE`` pin's depth stays authoritative. A transposed-B
     (all-sync) pipeline has nothing async to overlap and stays single-buffer. ``budget`` is the
     device's per-block dynamic-smem opt-in cap (``ctx.max_dynamic_smem`` — the backend declares
     an ``extern __shared__`` pool and sets the func attribute past the 48 KiB static cap),
@@ -950,7 +956,14 @@ def _computed_a_rows(kernel, place, probe: Contraction, kaxis: str, budget: int 
             for s in warp_tile_moves(atoms)
             if _warp_move_ok(kernel, s) and probe.k_axis.extent.is_static and not replace(probe, tile=TilePlan.parse(s)).n.mask
         ]
-    want_depth = Stage.parse(_stage_spec(kernel)).depth if _stage_spec(kernel) else 1
+    # Depths: a STAGE pin is authoritative; unpinned rows enumerate the d1 compute-fill AND the
+    # asymmetric B-only prefetch ring at d2 as fork siblings. The ring was measured a LOSS on the
+    # M=512 gate⊗up edge (the extra B slot crosses the smem occupancy quantization — the
+    # :func:`_resolve_sync_stage` note), but the tradeoff INVERTS at decode M (tile_m ≤ 32: the
+    # compute-filled A slab and stat rows are tiny, so the d2 slot rarely moves occupancy while the
+    # B prefetch hides the dominant weight stream) — so the depth is measured per shape, not
+    # hardwired. A d2 that clamps back to d1 (budget) spells identically and dedupes below.
+    depths = [Stage.parse(_stage_spec(kernel)).depth] if _stage_spec(kernel) else [1, 2]
     rows: list[dict] = []
     # The launch-order codec rides these rows exactly like the plain contraction's
     # (:func:`_raster_candidates` — a computed-A kernel's output is the same static 2-D block-tile
@@ -959,14 +972,21 @@ def _computed_a_rows(kernel, place, probe: Contraction, kaxis: str, budget: int 
     # codec's best customer: its B stripes re-stream per M-tile row (64.6% DRAM on the gemma
     # gate_up shape), which is precisely the L2 reuse a grouped order buys.
     for spec in tiles:
-        stage = _resolve_sync_stage(replace(probe, tile=TilePlan.parse(spec)), budget, want_depth)
-        if stage is None:
-            if TILE.raw() is not None:
-                raise ValueError(f"warp TILE pin {spec!r} on a fused-cone contraction: the sync slabs exceed the {budget} B smem budget.")
-            continue
-        for red in _reduce_candidates(kernel, place, TilePlan.parse(spec), probe):
-            for raster in _raster_candidates(place):
-                rows.append({_at(TILE, kaxis): spec, _at(STAGE, kaxis): stage.spell(), _at(REDUCE, kaxis): red, RASTER.name: raster})
+        spellings: list[str] = []
+        for want_depth in depths:
+            stage = _resolve_sync_stage(replace(probe, tile=TilePlan.parse(spec)), budget, want_depth)
+            if stage is None:
+                if TILE.raw() is not None:
+                    raise ValueError(
+                        f"warp TILE pin {spec!r} on a fused-cone contraction: the sync slabs exceed the {budget} B smem budget."
+                    )
+                continue
+            if stage.spell() in spellings:
+                continue  # d2 clamped to d1 — same resolved pipeline, one row
+            spellings.append(stage.spell())
+            for red in _reduce_candidates(kernel, place, TilePlan.parse(spec), probe):
+                for raster in _raster_candidates(place):
+                    rows.append({_at(TILE, kaxis): spec, _at(STAGE, kaxis): stage.spell(), _at(REDUCE, kaxis): red, RASTER.name: raster})
     return rows
 
 
@@ -1101,10 +1121,10 @@ def _splitk_option(
             f"{MAX_BLOCK_THREADS}-thread/CTA limit; shrink n/m or move work to the f register sub-tile."
         )
     inner = _contraction_node(tile.op, place, wt)
-    if inner.a_computed:
+    if inner.a_computed and len(inner.folds) != 1:
         raise ValueError(
-            "split-K REDUCE pin on a fused-cone (computed-A) contraction: the producer cone cannot be "
-            "sliced over K (its per-row statistic prologue spans the whole row); drop the g<w> pin."
+            "split-K REDUCE pin on a multi-channel fused-cone contraction: the product-monoid "
+            "carrier is not the 1-component additive state the split finalize folds; drop the g<w> pin."
         )
     w = ReducePlan.parse(split_spec).cta
     # A warp (mma) slice must keep the inner K-step dividing K/w — the warp K-loop has no static-K
@@ -1118,14 +1138,46 @@ def _splitk_option(
                 f"(atom_k={wt.atom.atom_k}·bk={wt.bk}); pick a split width whose slice is divisible."
             )
     ksplit, kslice, sigma = _factor_k(inner.k_axis, w)
-    inner = replace(
-        inner,
-        k_axis=kslice,
-        a_operand=replace(inner.a_operand, index=tuple(sigma.apply(e) for e in inner.a_operand.index)),
-        folds=tuple((replace(bl, index=tuple(sigma.apply(e) for e in bl.index)), acc) for bl, acc in inner.folds),
-    )
+    if inner.a_computed:
+        # REDUNDANT-STATISTIC split: the leading k-invariant run of the cone (the per-row stat
+        # prologue — the same seam ``Contraction.stat_prologue`` reads) stays FULL-ROW in every
+        # partition, recomputed redundantly; only the k-indexed per-cell remainder is σ-reindexed
+        # to absolute k. The sync fill's own σ (``k := k0 + col``) then composes to
+        # ``ksplit·(K/w) + k0 + col``. The projection riding the recognizer's ``Map`` wrapper is
+        # folded into the node epilogue so ``030_split_reduce``'s deferred finalize re-applies it
+        # after the cross-partition sum (the partial's epilogue becomes the workspace write).
+        from emmy.compiler.ir.tile.ir import _refs_axis  # noqa: PLC0415
+
+        body = list(inner.a_operand)
+        pro: list = []
+        while body and not _refs_axis(body[0], kslice.name):
+            pro.append(body.pop(0))
+        cell = [s.rewrite(lambda nm: nm, sigma) for s in body]
+        epi = inner.epilogue
+        if isinstance(tile.op, Map) and isinstance(tile.op.source, Contraction):
+            epi = Body((*epi, *tile.op.body))
+        inner = replace(
+            inner,
+            k_axis=kslice,
+            a_operand=Body((*pro, *cell)),
+            folds=tuple((replace(bl, index=tuple(sigma.apply(e) for e in bl.index)), acc) for bl, acc in inner.folds),
+            epilogue=epi,
+        )
+    else:
+        inner = replace(
+            inner,
+            k_axis=kslice,
+            a_operand=replace(inner.a_operand, index=tuple(sigma.apply(e) for e in inner.a_operand.index)),
+            folds=tuple((replace(bl, index=tuple(sigma.apply(e) for e in bl.index)), acc) for bl, acc in inner.folds),
+        )
     stage = None
-    if stage_spec:
+    if inner.a_computed:
+        # The sync compute-fill is MANDATORY for a computed-A partial (same contract as
+        # ``_warp_option``); resolve it against the SLICED node at the row's spelled depth.
+        stage = _resolve_sync_stage(inner, budget, Stage.parse(stage_spec).depth if stage_spec else 1)
+        if stage is None:
+            raise ValueError(f"split-K on a fused-cone contraction: the sync slabs exceed the {budget} B smem budget at TILE {tile_spec!r}")
+    elif stage_spec:
         st = Stage.parse(stage_spec)
         stage = _resolve_warp_stage(inner, st, budget) if wt.is_warp else _resolve_scalar_stage(inner, st, tile.inputs, budget)
     carrier = Accum(name=inner.acc, value=f"{inner.acc}__v", op=ElementwiseImpl("add"), dtype=F32).as_carrier()

--- a/emmy/compiler/pipeline/search/data/shape.py
+++ b/emmy/compiler/pipeline/search/data/shape.py
@@ -43,6 +43,19 @@ class ShapeKey:
     # extents coincide with a recorded matmul shape would join the matmul golden (and
     # vice versa) even though the knob grammars don't transfer across kinds.
     kind: str = ""
+    # The largest single static free extent (``S_ext_free_max`` / ``max(M, N)``) — the
+    # ASPECT discriminator ``free_prod`` alone lacks: 32×8192 and 512×512 share the
+    # product (the decode-twin vs square collision that let ``k_proj_global.s512``
+    # silently shadow ``q_proj_global.m32``'s golden), but not the max. Participates
+    # only for STATIC plain-nest keys (``kind == "" and not is_dyn``) — every other
+    # key class normalizes it to 0 in ``__post_init__`` so the sweep-kind and
+    # symbolic-axis joins (whose builders don't all see the same extent list the
+    # stamp saw) stay bit-identical to the pre-``free_max`` behavior.
+    free_max: int = 0
+
+    def __post_init__(self) -> None:
+        if (self.kind or self.is_dyn) and self.free_max:
+            object.__setattr__(self, "free_max", 0)
 
     @classmethod
     def from_matmul(cls, M: int, N: int, K: int, dtype: str, *, dynamic: bool = False) -> ShapeKey:
@@ -54,7 +67,13 @@ class ShapeKey:
         hint-sized ``M*N``) and flagged via ``S_ext_n_symbolic_axis`` — because
         the stamped histogram is the only identity the op side has (it doesn't
         know the hint), so a hint-sized golden key would never join it."""
-        return cls(free_prod=N if dynamic else M * N, reduce_max=K, is_warp=dtype != "fp32", is_dyn=dynamic)
+        return cls(
+            free_prod=N if dynamic else M * N,
+            reduce_max=K,
+            is_warp=dtype != "fp32",
+            is_dyn=dynamic,
+            free_max=0 if dynamic else max(M, N),
+        )
 
     @classmethod
     def from_s_features(cls, s: dict) -> ShapeKey:
@@ -94,6 +113,7 @@ class ShapeKey:
             is_warp=not s.get("S_dtype_f32", 0),
             is_dyn=s.get("S_ext_n_symbolic_axis", 0) > 0,
             kind=kind,
+            free_max=int(s.get("S_ext_free_max", 0)),
         )
 
     def s_features_arith(self) -> dict[str, float]:
@@ -109,6 +129,8 @@ class ShapeKey:
             "S_ext_reduce_prod": float(self.reduce_max),
             "S_ext_reduce_max": float(self.reduce_max),
         }
+        if self.free_max:
+            out["S_ext_free_max"] = float(self.free_max)
         if self.is_dyn:
             out["S_ext_n_symbolic_axis"] = 1.0
         return out

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -264,7 +264,7 @@ class ReduceGoldenConfig(GoldenConfig):
         matching what ``992_stamp_structural_features`` stamps on the reduce kernel."""
         from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
 
-        return ShapeKey(free_prod=self.M, reduce_max=self.K, is_warp=False, is_dyn=self.dynamic)
+        return ShapeKey(free_prod=self.M, reduce_max=self.K, is_warp=False, is_dyn=self.dynamic, free_max=self.M)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -295,7 +295,7 @@ class PointwiseGoldenConfig(GoldenConfig):
         axis (``reduce_max=0``, the ``from_s_features`` default for an unstamped extent)."""
         from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
 
-        return ShapeKey(free_prod=self.M * self.N, reduce_max=0, is_warp=False, is_dyn=self.dynamic)
+        return ShapeKey(free_prod=self.M * self.N, reduce_max=0, is_warp=False, is_dyn=self.dynamic, free_max=max(self.M, self.N))
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -788,12 +788,10 @@ configs:
   # converged on — the four m16 entries below were re-pinned to it manually (q_proj 13.3→9.4,
   # kv_proj 10.3→5.7, o_proj 11.0→8.8, q_proj_global 23.0→16.7), as was q_proj_global.m32 (28.0→17.6,
   # its unpinned search picked w2x2/f2x4, UNDER eager).
-  # KNOWN JOIN LIMITATION (ShapeKey free_prod aspect-blindness): 32x8192 == 512x512 == 262144, so
-  # q_proj_global.m32 shares a key bucket with k_proj_global.s512 (both K=3840) and the s512 entry
-  # (faster-recorded) shadows it at cold deploy — that shape deploys ~eager-parity (26.5 us) instead of
-  # 16.3 until ShapeKey gains a free_max discriminator (S_ext_free_max is already stamped; follow-up).
-  # The m16/m32 twin collisions (16x4096==32x2048, 16x8192==32x4096) are BENIGN: the shadowing entry
-  # records the same family config the shadowed shape wants.
+  # (A former join limitation is FIXED: ShapeKey now carries a free_max aspect discriminator, so the
+  # 32x8192 == 512x512 free_prod collision that let k_proj_global.s512 shadow q_proj_global.m32 at
+  # cold deploy — and the benign m16/m32 twin collisions — no longer bucket together; every decode
+  # entry cold-deploys itself.)
   - kernel: matmul
     name: gemma4_12b.q_proj.m16
     M: 16

--- a/plans/gemma4-decode-goldens-seeding-findings.md
+++ b/plans/gemma4-decode-goldens-seeding-findings.md
@@ -118,6 +118,27 @@ concurrency 32, 32 prompts, out 64, seed 0; logs `_tune/decode-goldens-5090/serv
   and gate⊗up at M=16/32, from the twins' own dumps) the way the s2048 family was seeded, or land the
   computed-A enumeration work. Only then does the whole-step graph turn kernel wins into TPOT.
 
+## RE-A/B after the computed-A readiness branch (2026-07-16 night) — emmy decode TPOT BEATS stock vLLM
+
+The readiness branch (`feature/computed-a-decode-readiness`, PR #386: ShapeKey `free_max`, unpinned `d2/sync`,
+redundant-statistic split-K on computed-A cones) + a tune of the four M=32 twin graphs (sliding + global
+pre/post, `_tune/decode-twin-readiness/twins.db`, ~65 min) closed the fused-form gap:
+
+| twin (M=32) | cold pre-branch | tuned post-branch |
+| --- | --: | --: |
+| pre (sliding cones) | 357 µs | **102 µs** |
+| post (gate⊗up + mains) | 339 µs | **244 µs** (gate⊗up at its weight-bound floor) |
+| pre-global | — | 84 µs |
+| post-global | — | 252 µs |
+
+Serving re-A/B (same matched config, in-8/out-64 decode-dominated, `EMMY_TUNE_DB`/`EMMY_ONLINE_FILE` → the twins
+DB): **TPOT 21.33 ms captured / 21.44 ms eager** — down from 1 924 ms (90×), and **UNDER stock vLLM's 24.9 ms**
+(the first emmy-beats-stock serving metric). 374.7 tok/s output throughput at concurrency 32, all requests
+correct. Capture ≈ eager at batch 32 (the ~96-launch host stream still hides behind ~21 ms of GPU step time);
+its payoff moves to small decode batches and to whatever the next kernel wins shave — it stays the default.
+Remaining wall: TTFT ~4.1–4.8 s (the symbolic prefill path + boot compile) — the packed-varlen prefill and
+program-caching items on the roadmap.
+
 ## Repro / artifacts
 
 - Work dir: `_tune/decode-goldens-5090/` — `sweep.sh` + `sweep.log`, `tune.db` / `online.json`,

--- a/tests/compiler/e2e/test_fused_edge.py
+++ b/tests/compiler/e2e/test_fused_edge.py
@@ -118,6 +118,10 @@ def test_fused_rmsnorm_linear(tier, monkeypatch):
     A cone, run once per tile row by the sync stat fill)."""
     if tier == "warp":
         monkeypatch.setenv("EMMY_TILE", _WARP_TILE)
+        # Pin the serial fold: the computed-A form now offers redundant-statistic split-K
+        # siblings on this decode-M shape, and this test pins the ONE-kernel fused form
+        # (the split form has its own test: test_fused_cone_splitk_matches_reference).
+        monkeypatch.setenv("EMMY_REDUCE", "")
     S, H, inter = 32, 1024, 3072
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (1, S, H), F16), node_id="x")
@@ -158,7 +162,7 @@ def _rmsnorm_linear_graph(S, H: int, inter: int) -> Graph:
     return g
 
 
-def _rmsnorm_linear_check(g: Graph, S: int, H: int, inter: int, *, want_mma: bool) -> None:
+def _rmsnorm_linear_check(g: Graph, S: int, H: int, inter: int, *, want_mma: bool, kernels: tuple = (1,)) -> None:
     rng = np.random.default_rng(0)
     ins = {
         "x": (rng.standard_normal((1, S, H)) * 0.3).astype(np.float16),
@@ -166,9 +170,9 @@ def _rmsnorm_linear_check(g: Graph, S: int, H: int, inter: int, *, want_mma: boo
         "wg": (rng.standard_normal((inter, H)) * 0.1).astype(np.float16),
     }
     got, srcs = _compile_run(g, ins)
-    assert len(srcs) == 1, f"the fused norm→linear must be ONE kernel, got {len(srcs)}"
+    assert len(srcs) in kernels, f"the fused norm→linear must be {kernels} kernel(s), got {len(srcs)}"
     if want_mma:
-        assert "emmy_mma" in srcs[0], "the pinned mma tier must engage on the fused matmul"
+        assert any("emmy_mma" in s for s in srcs), "the pinned mma tier must engage on the fused matmul"
     x, nw, wg = (ins[k].astype(np.float32) for k in ("x", "nw", "wg"))
     rms = x[0] * (1.0 / np.sqrt((x[0] ** 2).mean(axis=-1, keepdims=True) + 1e-6)) * nw
     np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), rms @ wg.T, atol=0.5, rtol=0.1)
@@ -193,6 +197,7 @@ def test_fused_sync_fill_slab_swizzle(tile, monkeypatch):
     the same static 2-D block-tile grid, and the grouped launch order is its B-re-streaming
     fix): the ``_rsub`` grouped decode must be emitted, not silently degraded to flat."""
     monkeypatch.setenv("EMMY_TILE", tile)
+    monkeypatch.setenv("EMMY_REDUCE", "")  # serial fold — the swizzle inspection needs the ONE fused kernel
     if tile.endswith("k4"):
         monkeypatch.setenv("EMMY_RASTER", "gn8")
     S, H, inter = 64, 1024, 3072
@@ -259,6 +264,7 @@ def test_fused_rmsnorm_linear_symbolic_m(runtime_s, monkeypatch):
     the sync compute-fill / stat-prologue σ clamp the overhanging rows and the ``RegStore`` guard
     discards their store."""
     monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16_f32/w2x2/f2x2/k2")  # tile 64×32 — every runtime S is masked
+    monkeypatch.setenv("EMMY_REDUCE", "")  # serial fold — the ONE-masked-kernel contract is what's under test
     H, inter = 256, 512
     g = _rmsnorm_linear_graph(Dim("seq_len", hint=64), H, inter)
     _rmsnorm_linear_check(g, runtime_s, H, inter, want_mma=True)
@@ -268,9 +274,11 @@ def test_fused_rmsnorm_linear_symbolic_m(runtime_s, monkeypatch):
 def test_fused_rmsnorm_linear_unpinned():
     """UNPINNED greedy on the fused norm→linear: the merged fork (coop ``Map`` rows + the
     computed-A Contraction's warp rows) lowers and matches numpy whichever row the prior picks —
-    the fork-integrity e2e (runs on any CUDA device; option-0 stays the coop row)."""
+    the fork-integrity e2e (runs on any CUDA device; option-0 stays the coop row). The pick may
+    be the 1-kernel fused row or a 2-kernel redundant-statistic split row; both are legal fork
+    members on this decode-M shape."""
     S, H, inter = 32, 256, 512
-    _rmsnorm_linear_check(_rmsnorm_linear_graph(S, H, inter), S, H, inter, want_mma=False)
+    _rmsnorm_linear_check(_rmsnorm_linear_graph(S, H, inter), S, H, inter, want_mma=False, kernels=(1, 2))
 
 
 @requires_cuda
@@ -384,3 +392,43 @@ def test_sdpa_consumer_projection_reaches_mma(monkeypatch):
     att = p @ v[0]  # (H, S, D)
     ref = np.transpose(att, (1, 0, 2)).reshape(S, H * D) @ wo.T
     np.testing.assert_allclose(got.reshape(S, NO).astype(np.float32), ref, atol=0.5, rtol=0.1)
+
+
+@requires_cuda
+@pytest.mark.parametrize("stage", ["d1/sync", "d2/sync"])
+def test_fused_cone_splitk_matches_reference(stage, monkeypatch):
+    """Redundant-statistic split-K on a computed-A (norm→linear) cone: the contraction K is
+    sliced across CTAs (``REDUCE=g4k``) while the k-invariant stat prologue stays FULL-ROW in
+    every partition (each recomputes it), and the deferred finalize sums the partials before
+    the projection — the output must match the fp32 reference. Parametrized over both sync
+    depths (``d1`` + the asymmetric B-only prefetch ring ``d2``). The decode-M shape class
+    (M=32) is where this split pays: the un-split cone grid starves the SMs."""
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16_f32/w1x4/f2x2/k2")
+    monkeypatch.setenv("EMMY_REDUCE", "g4k")
+    monkeypatch.setenv("EMMY_STAGE", stage)
+    S, H, inter = 32, 1024, 3072
+    # CANONICAL-B matmul (w shaped (H, inter)) rather than the transposed-B linear: a
+    # transposed B clamps the sync ring back to d1 (nothing async to overlap), so the d2
+    # cell would silently re-test d1. The real decode twins bake weights as constants
+    # (the transpose folds), so canonical-B is the shape class the ring actually serves.
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, S, H), _dt.F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("nw", (H,), _dt.F16), node_id="nw")
+    g.add_node(InputOp(), [], Tensor("wg", (H, inter), _dt.F16), node_id="wg")
+    g.add_node(RmsNormOp(eps=1e-6), ["x", "nw"], Tensor("xn", (1, S, H), _dt.F16), node_id="xn")
+    g.add_node(MatmulOp(), ["xn", "wg"], Tensor("o", (1, S, inter), _dt.F16), node_id="o")
+    g.inputs, g.outputs = ["x", "nw", "wg"], ["o"]
+    rng = np.random.default_rng(0)
+    ins = {
+        "x": (rng.standard_normal((1, S, H)) * 0.3).astype(np.float16),
+        "nw": (rng.standard_normal((H,)) * 0.3).astype(np.float16),
+        "wg": (rng.standard_normal((H, inter)) * 0.1).astype(np.float16),
+    }
+    got, srcs = _compile_run(g, ins)
+    assert len(srcs) == 2, f"split-K must produce partial + finalize, got {len(srcs)} kernel(s)"
+    assert any("emmy_mma" in s for s in srcs), "the mma tier must engage on the split partial"
+    if stage == "d2/sync":
+        assert any("cp.async" in s for s in srcs), "the d2 B-only prefetch ring must issue cp.async on the canonical-B slab"
+    x, nw, wg = (ins[k].astype(np.float32) for k in ("x", "nw", "wg"))
+    rms = x[0] * (1.0 / np.sqrt((x[0] ** 2).mean(axis=-1, keepdims=True) + 1e-6)) * nw
+    np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), rms @ wg, atol=0.5, rtol=0.1)

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -100,19 +100,33 @@ def _is_warp_row(row: dict) -> bool:
 
 def test_norm_linear_offers_map_rows_then_warp_contraction_rows():
     """The merged fork: the ``Map``-form reduce rows lead (option-0 = the conservative coop pick,
-    lowerable everywhere), then the computed-A Contraction form's warp rows, each riding the
-    mandatory resolved ``sync`` compute-fill stage with the contraction K partition decided-empty."""
+    lowerable everywhere), then the computed-A Contraction form's warp rows — every one riding a
+    resolved ``sync`` compute-fill stage, at BOTH depths (``d1`` + the asymmetric B-ring ``d2``
+    as fork siblings), with the K partition either decided-empty or a redundant-statistic
+    deferred split (``g<w>k`` — the single-channel computed-A split-K family)."""
     rows, _ = _resolve(_norm_linear_graph())
     assert rows, "no fork was offered for the fused norm→linear"
     assert not _is_warp_row(rows[0]), "option-0 must be the Map-form coop row, not a warp row"
     assert any(v.startswith("b") for v in rows[0].values() if isinstance(v, str)), "option-0 must cooperate on the stat reduce"
     warp = [r for r in rows if _is_warp_row(r)]
     assert warp, "the Contraction form contributed no warp rows"
+    stages_seen = set()
+    reds_seen = set()
     for r in warp:
         stage = [v for k, v in r.items() if k.startswith("STAGE@")]
         red = [v for k, v in r.items() if k.startswith("REDUCE@")]
-        assert stage == ["d1/sync"], f"warp rows must ride the resolved sync compute-fill: {r}"
-        assert all(v == "" for v in red), f"the computed-A form has no reduce partition: {r}"
+        assert stage and all(v in ("d1/sync", "d2/sync") for v in stage), f"warp rows must ride the resolved sync compute-fill: {r}"
+        assert all(v == "" or (v.startswith("g") and v.endswith("k")) for v in red), (
+            f"the computed-A form allows only the empty or deferred-split (g<w>k) K partition: {r}"
+        )
+        stages_seen.update(stage)
+        reds_seen.update(red)
+    # This fixture's weight is a graph INPUT, so the linear's B is transposed and the d2
+    # B-only ring clamps back to d1 (nothing async to overlap) — d1 alone is correct here.
+    # The canonical-B (constant-weight) shape class exercises d2 in
+    # test_fused_cone_splitk_matches_reference.
+    assert "d1/sync" in stages_seen, f"the resolved sync compute-fill must be offered: {stages_seen}"
+    assert "" in reds_seen and any(v for v in reds_seen), f"both the serial and split K partitions must be offered: {reds_seen}"
 
 
 def test_norm_linear_warp_pick_is_computed_a_contraction():

--- a/tests/compiler/pipeline/search/test_data.py
+++ b/tests/compiler/pipeline/search/test_data.py
@@ -35,7 +35,8 @@ def _seed(db: SearchDB, key: str, pretty: str, knobs: dict, us: float) -> None:
 def test_shapekey_from_matmul_arith() -> None:
     sk = ShapeKey.from_matmul(512, 256, 64, "fp32")
     assert (sk.free_prod, sk.reduce_max, sk.is_warp) == (512 * 256, 64, False)
-    assert sk.s_features_arith() == {"S_ext_free_prod": 131072.0, "S_ext_reduce_prod": 64.0, "S_ext_reduce_max": 64.0}
+    want = {"S_ext_free_prod": 131072.0, "S_ext_reduce_prod": 64.0, "S_ext_reduce_max": 64.0, "S_ext_free_max": 512.0}
+    assert sk.s_features_arith() == want
     assert ShapeKey.from_matmul(64, 64, 64, "fp16").is_warp is True
 
 
@@ -45,8 +46,8 @@ def test_shapekey_from_s_features_joins_with_from_matmul() -> None:
     and the fp32/fp16 twins must never merge. The dtype flag comes from the
     ``S_dtype_f32`` load multiset — ``S_n_mma`` is 0.0 on every stamped row (the
     stamp runs before the tile tier emits ``Mma``) and must not enter the key."""
-    fp32 = {"S_ext_free_prod": 131072.0, "S_ext_reduce_max": 64.0, "S_dtype_f32": 2.0, "S_n_mma": 0.0}
-    fp16 = {"S_ext_free_prod": 131072.0, "S_ext_reduce_max": 64.0, "S_dtype_f16": 2.0, "S_n_mma": 0.0}
+    fp32 = {"S_ext_free_prod": 131072.0, "S_ext_free_max": 512.0, "S_ext_reduce_max": 64.0, "S_dtype_f32": 2.0, "S_n_mma": 0.0}
+    fp16 = {"S_ext_free_prod": 131072.0, "S_ext_free_max": 512.0, "S_ext_reduce_max": 64.0, "S_dtype_f16": 2.0, "S_n_mma": 0.0}
     assert ShapeKey.from_s_features(fp32) == ShapeKey.from_matmul(512, 256, 64, "fp32")
     assert ShapeKey.from_s_features(fp16) == ShapeKey.from_matmul(512, 256, 64, "fp16")
     assert ShapeKey.from_s_features(fp32) != ShapeKey.from_s_features(fp16)  # twins split on dtype

--- a/tests/compiler/pipeline/search/test_diagnostics.py
+++ b/tests/compiler/pipeline/search/test_diagnostics.py
@@ -21,7 +21,8 @@ def _sig(free_prod, reduce_max, *, fp32=True, matmul=True):
     reduce-shaped one. ``S_n_mma`` is stamped 0.0, as on every real row."""
     d = {
         "S_ext_free_prod": float(free_prod),
-        "S_ext_free_max": float(free_prod),
+        # matmul fixtures here are SQUARE (free_max = sqrt); a reduce has one free dim (= free_prod)
+        "S_ext_free_max": float(round(free_prod**0.5)) if matmul else float(free_prod),
         "S_ext_reduce_max": float(reduce_max),
         "S_n_mma": 0.0,
         "S_reduce_add": 1.0,

--- a/tests/compiler/pipeline/search/test_golden_deploy_perf.py
+++ b/tests/compiler/pipeline/search/test_golden_deploy_perf.py
@@ -49,6 +49,7 @@ def _row(free_prod, reduce_max, *, fp32, h_opt, latency):
     knobs = {
         "H_opt": float(h_opt),
         "S_ext_free_prod": float(free_prod),
+        "S_ext_free_max": float(round(free_prod**0.5)),  # fixtures are square matmuls
         "S_ext_reduce_max": float(reduce_max),
         ("S_dtype_f32" if fp32 else "S_dtype_f16"): 2.0,
         # The matmul histogram markers (_matmul_sig): product → reduce-add, 2 inputs.

--- a/tests/compiler/pipeline/search/test_golden_evidence_deploy.py
+++ b/tests/compiler/pipeline/search/test_golden_evidence_deploy.py
@@ -20,7 +20,7 @@ CARD = "NVIDIA GeForce RTX 4090"
 CAP = (8, 9)
 
 # q_proj-shaped fp16 matmul: M512 x N4096, K3840 — static stamps (S_dtype_f32 absent -> warp tier).
-_SIG = {"S_ext_free_prod": 2097152.0, "S_ext_reduce_max": 3840.0, "S_ext_reduce_prod": 3840.0}
+_SIG = {"S_ext_free_prod": 2097152.0, "S_ext_free_max": 4096.0, "S_ext_reduce_max": 3840.0, "S_ext_reduce_prod": 3840.0}
 _BASE = {**_SIG, "H_opt": 3.0}
 
 _STD_TILE = "a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2"

--- a/tests/compiler/pipeline/search/test_shape_key_kinds.py
+++ b/tests/compiler/pipeline/search/test_shape_key_kinds.py
@@ -57,12 +57,25 @@ def test_golden_key_round_trips_through_the_stamped_op(cfg):
     assert keys.count(cfg.shape_key()) == 1, f"{cfg.name}: golden key {cfg.shape_key()} not uniquely stamped in {keys}"
 
 
-def test_matmul_keys_are_byte_compatible_with_the_pre_kind_constructor():
-    """Every matmul key — golden side and op side — carries ``kind=""``, so joins built
-    before the discriminator existed keep matching (the whole point of the default)."""
+def test_matmul_keys_carry_kind_and_aspect():
+    """Every matmul key — golden side and op side — carries ``kind=""`` plus the
+    ``free_max`` aspect discriminator (``max(M, N)``); the round-trip tests above pin
+    that the stamped side fills the same value, so the joins keep matching."""
     got = MatmulGoldenConfig(name="m", M=512, N=4096, K=3840, dtype="fp16", knobs={}).shape_key()
-    assert got == ShapeKey(free_prod=512 * 4096, reduce_max=3840, is_warp=True)
+    assert got == ShapeKey(free_prod=512 * 4096, reduce_max=3840, is_warp=True, free_max=4096)
     assert got.kind == ""
+
+
+def test_free_max_splits_the_aspect_collision():
+    """32×8192 and 512×512 share ``free_prod`` (the decode-twin vs square collision that
+    let ``k_proj_global.s512`` silently shadow ``q_proj_global.m32``'s golden) — the
+    ``free_max`` discriminator keys them apart. Dynamic and sweep-kind keys normalize
+    ``free_max`` to 0, keeping those join classes untouched."""
+    thin = ShapeKey.from_matmul(32, 8192, 3840, "fp16")
+    square = ShapeKey.from_matmul(512, 512, 3840, "fp16")
+    assert thin.free_prod == square.free_prod and thin != square
+    assert ShapeKey.from_matmul(512, 4096, 3840, "fp16", dynamic=True).free_max == 0
+    assert ShapeKey(free_prod=1, reduce_max=1, is_warp=True, kind="flash", free_max=7).free_max == 0
 
 
 def test_attention_qk_contraction_never_joins_the_flash_golden():


### PR DESCRIPTION
Follow-up to #384's capture-vs-eager A/B, which showed 12B decode GPU-bound at ~1.92 s/step (~160× over the golden-kernel floor) with the gap pinned to the computed-A fused twin forms. This PR closes the kernel-side gaps so the twin re-tune + serving re-A/B measure kernels, not lockouts.

## 1. ShapeKey `free_max` aspect discriminator

`free_prod` alone can't tell 32×8192 from 512×512, so `k_proj_global.s512` silently shadowed `q_proj_global.m32`'s golden at cold deploy (eager parity instead of its 17.5 µs entry — found by spying `_golden_pick`). `S_ext_free_max` is already stamped on every row and keys are recomputed per process, so the fix is the constructor pair + per-kind builders. Normalized to 0 for dynamic/sweep-kind keys — those join classes stay bit-identical (round-trip tests pin every kind, both sides). Cold-deploy verified: the shadowed shape and the existing prefill/decode goldens all deploy exactly.

## 2. Computed-A decode enumeration

- **`d2/sync` (asymmetric B-only prefetch ring) offered unpinned** as a fork sibling — the measured M=512 occupancy loss inverts at decode M (tiny A slab + stat rows), so the depth is now measured per shape instead of hardwired pin-only. Transposed-B cones still clamp to d1.
- **Redundant-statistic split-K for single-channel computed-A cones** — the real unlock: the un-split norm→q/kv cone grids run 32–64 CTAs on a 170-SM card (92–160 µs vs ~6–11 µs bare-golden twins). The contraction K slices across CTAs while the k-invariant stat prologue stays full-row per partition (recomputed redundantly — cheap exactly on the small-free shapes `_SPLITK_MAX_CTAS` admits); the per-cell cone σ-reindexes to absolute k, the Map-wrapper projection folds into the deferred finalize, and the sync stage resolves against the sliced node. Multi-channel (gate⊗up) stays excluded — its product-monoid carrier isn't the 1-component additive state the finalize folds.
- Accuracy-verified vs fp32 at both depths (`test_fused_cone_splitk_matches_reference`; the d2 cell asserts cp.async engages on a canonical-B slab). Cold greedy already picks split rows on the real M=32 PRE twin: **357 → 247 µs before any tuning**.

## Test updates

Six fused-edge tests met the wider fork: serial-`REDUCE` pins where the ONE-kernel fused form is under test (swizzle inspection, masked-M contract), the unpinned fork-integrity test accepts both forms, and the row-structure test now asserts the split/depth families with the transposed-B caveat documented.

Test plan: `make test` (2501 passed, 35 skipped), `make lint` clean, cold-deploy golden A/Bs, PRE/POST twin probes. Next (not in this PR): tune the four M=32 twin graphs (sliding + global layer classes) into a serving DB and re-run the capture A/B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)