### PR TITLE
Device-resident symbolic prefill: run the pre/post programs on-GPU at every width (TTFT lever 1)

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -71,10 +71,14 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   Attention dims are **per layer** (`layer_meta(L)` → head_dim / num_heads / num_kv / scaling) — Gemma-4's global layers
   use a larger `global_head_dim` than its sliding ones, so each layer's `pre`/`post` compiles at its own width. The caller stitches between
   `pre` and `post` (a reference torch SDPA in the Phase-2 host stitch; vLLM paged `Attention` in Phase 3). **I/O:**
-  prefill / `num_tokens > bucket` use the host numpy `rebind` path; the **decode hot path** (`num_tokens ≤ bucket`)
-  is **device-resident** (Phase A — `run_device` / `embed_device` / `forward_layer_*_device` / `final_norm_device`:
-  captured-replay over the static program with torch↔cupy DLPack zero-copy, no host hop; reuses the embedding
-  runner's pattern). This removed the ~40% host/dispatch overhead and ~2×'d served decode. **Decode bucket:** it
+  the plugin runs **device-resident at every width**: the **decode hot path** (`num_tokens ≤ bucket`) rides the
+  captured static twins (`run_device` — captured-replay, torch↔cupy DLPack zero-copy), and **prefill /
+  chunked-prefill steps** (`bucket < num_tokens ≤ prefill_capacity`, capacity = vLLM's `max_num_batched_tokens`,
+  passed as `max_tokens` at runner build) ride the SYMBOLIC programs' `run_device_sym` — grids sized per step via
+  `set_sym_values` over capacity-built buffers, launches issued on torch's stream, no per-T graph capture
+  (chunked-prefill T varies per step; the dispatch hides behind prefill-width GPU work). The per-layer host numpy
+  `rebind` path survives only for the standalone `emmy generate` oracle and as the over-capacity fallback — its
+  ~2-per-layer `.cpu()` hops per prefill step were the TTFT wall. **Decode bucket:** it
   also compiles a **static M=`decode_bucket` (default 16)** `pre`/`post` twin per layer and uses it when
   `num_tokens ≤ bucket` (pad → run → slice the real rows) — the symbolic hint-512 M-tile is ~66× too slow at decode
   M=1; falls back to symbolic above the bucket or if a static compile fails. So

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -12,9 +12,12 @@ symbolic, and exposes the per-token, everything-but-attention compute:
 - ``final_norm(hidden) -> hidden``.
 
 The caller stitches attention between ``pre`` and ``post`` (a reference torch SDPA in the
-Phase-2 host stitch; vLLM's paged ``Attention`` in Phase 3). I/O is host numpy (the
-serving ``rebind`` path) — correctness-first; the device zero-copy + captured-replay path
-is the Phase-3/4 optimization. NOTE: the per-layer ``CompiledProgram``s share BOTH their
+Phase-2 host stitch; vLLM's paged ``Attention`` in Phase 3). I/O: the vLLM plugin runs
+device-resident at EVERY width — decode (``T <= bucket``) through the captured static twins,
+prefill / chunked-prefill (``bucket < T <= prefill_capacity``) through the symbolic programs'
+``run_device_sym`` (grids sized per step, capacity buffers, no per-layer host hop); the host
+numpy ``rebind`` path survives for the standalone oracle and as the over-capacity fallback.
+NOTE: the per-layer ``CompiledProgram``s share BOTH their
 weights (one device buffer per constant, ``_bind_device_constants``) and their activation
 buffers + scratch slabs (one ``BufferArena`` per runner) — the footprint no longer scales
 with ``num_layers`` (the memory budget the plan flagged, Phase 2 / Top risk #9).
@@ -80,6 +83,31 @@ class _Program:
             outs = self.program.output_prefix_device()
             return [torch.from_dlpack(outs[n])[:t].clone() for n in self.output_names]
 
+    def run_device_sym(self, arrays):
+        """Device-resident twin of :meth:`run` for the SYMBOLIC (prefill) programs at any width
+        ``T`` up to the build capacity: size the launch grids to ``T`` (``set_sym_values`` — no
+        re-allocation, the buffers stay at capacity), upload the ``T`` real rows into the buffer
+        prefix device-to-device, issue the launch sequence on torch's current stream, and return
+        the outputs as torch CUDA tensors at their resolved ``T`` shapes — no per-layer host numpy
+        round-trip (the pre-device prefill path's ~2×48 ``.cpu()`` hops per step were the TTFT
+        wall). No per-T graph capture: at prefill widths the dispatch hides behind the GPU work,
+        and chunked-prefill ``T`` varies step to step — a per-T graph cache would re-capture
+        constantly. Requires the program to have been built with a ``capacity`` feed
+        (:func:`_compile_split`); ``set_sym_values`` raises past it."""
+        import cupy as cp
+        import torch
+
+        from emmy.compiler.backend.gpu_lock import gpu_lock
+
+        t = arrays[0].shape[0]
+        with gpu_lock(), cp.cuda.Stream.from_external(torch.cuda.current_stream()):
+            feed = {n: cp.from_dlpack(a.detach().contiguous()) for n, a in zip(self.input_names, arrays, strict=True)}
+            self.program.set_sym_values({"num_tokens": t})
+            self.program.upload_prefix_device(feed)
+            self.program.run_once()
+            outs = self.program.output_prefix_device({"num_tokens": t})
+            return [torch.from_dlpack(outs[n]).clone() for n in self.output_names]
+
 
 def _pad_rows(arr, bucket):
     """Pad axis 0 from ``t`` up to ``bucket`` with zeros. The decode programs are static at
@@ -118,7 +146,7 @@ def _bind_device_constants(graph, sources, cache):
     return out
 
 
-def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, arena=None):
+def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, arena=None, capacity=None):
     """Trace ``wrapper`` and build a :class:`_Program`. ``argnames`` (a list) ties each named
     arg's axis-0 to a shared symbolic ``num_tokens`` Dim — the **prefill** program (one program,
     any width). ``argnames=None`` traces a **fully static** graph at the example shapes — the
@@ -126,7 +154,11 @@ def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, a
     pathological at decode). ``dev_consts`` (a per-wrapper dict) shares each weight's device
     buffer across the builds that pass the same dict — see :func:`_bind_device_constants`.
     ``arena`` (one per runner) pools the activation buffers + scratch slab across every
-    program built with it — layers run sequentially, so N layers hold ~one layer's worth."""
+    program built with it — layers run sequentially, so N layers hold ~one layer's worth.
+    ``capacity`` (symbolic programs only) sizes the BUILD feed's token axis so the device
+    buffers hold any step up to it — the :meth:`_Program.run_device_sym` prefill path needs
+    fixed capacity buffers (``set_sym_values`` never re-allocates); without it the build feed
+    is the example (the host ``rebind`` path re-sizes per call)."""
     import torch
 
     from emmy.compiler.backend.cuda.backend import CudaBackend
@@ -149,7 +181,10 @@ def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, a
     for path, t in wrapper.named_buffers(remove_duplicate=False):
         sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
 
-    feed = {n: a.detach().cpu().to(torch.float32).numpy().astype(np_dtype) for n, a in zip(compiled.inputs, example_args, strict=True)}
+    build_args = example_args
+    if capacity is not None and argnames:
+        build_args = [torch.zeros((capacity, *a.shape[1:]), dtype=a.dtype) for a in example_args]
+    feed = {n: a.detach().cpu().to(torch.float32).numpy().astype(np_dtype) for n, a in zip(compiled.inputs, build_args, strict=True)}
     with gpu_lock():
         if dev_consts is None:
             const_feed = bind_constants(compiled, sources)
@@ -160,7 +195,20 @@ def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, a
 
 
 class EmmyGenRunner:
-    def __init__(self, *, embed_weight, norm, pre, post, attn_meta, np_dtype, pre_decode=None, post_decode=None, decode_bucket=16):
+    def __init__(
+        self,
+        *,
+        embed_weight,
+        norm,
+        pre,
+        post,
+        attn_meta,
+        np_dtype,
+        pre_decode=None,
+        post_decode=None,
+        decode_bucket=16,
+        prefill_capacity=None,
+    ):
         self._embed_weight = embed_weight  # numpy [vocab, H]
         self._norm = norm  # torch module
         self._pre = pre  # list[_Program] — symbolic (prefill / any width)
@@ -168,6 +216,7 @@ class EmmyGenRunner:
         self._pre_decode = pre_decode  # list[_Program] — static M=decode_bucket (or None → no bucket)
         self._post_decode = post_decode
         self._decode_bucket = decode_bucket
+        self._prefill_capacity = prefill_capacity  # symbolic programs' device-buffer token capacity (None -> host rebind only)
         self._attn_meta = attn_meta  # per-layer list of (head_dim, num_heads, num_kv, scaling)
         # Layer-0 convenience scalars — correct for homogeneous models (Qwen3 / Llama). Gemma-4's
         # global layers differ, so the vLLM model reads per-layer dims via ``layer_meta``.
@@ -193,18 +242,25 @@ class EmmyGenRunner:
         (``embed_device`` / ``forward_layer_*_device`` / ``final_norm_device``) is available."""
         return self._pre_decode is not None
 
+    @property
+    def prefill_capacity(self) -> int:
+        """The symbolic programs' device-buffer token capacity — the widest step
+        ``forward_layer_*_device`` serves without a host fallback (0 = built without
+        capacity, host ``rebind`` only)."""
+        return self._prefill_capacity or 0
+
     @classmethod
-    def create(cls, model_id, *, dtype_str="float16", decode_bucket=16):
+    def create(cls, model_id, *, dtype_str="float16", decode_bucket=16, max_tokens=None):
         import torch
         from transformers import AutoModelForCausalLM
 
         logger.info("[gen_runner] loading %s (%s, CPU trace)...", model_id, dtype_str)
         with torch.device("cpu"):
             model = AutoModelForCausalLM.from_pretrained(model_id, dtype=getattr(torch, dtype_str)).eval()
-            return cls.from_model(model, dtype_str=dtype_str, decode_bucket=decode_bucket)
+            return cls.from_model(model, dtype_str=dtype_str, decode_bucket=decode_bucket, max_tokens=max_tokens)
 
     @classmethod
-    def from_model(cls, model, *, dtype_str="float16", decode_bucket=16):
+    def from_model(cls, model, *, dtype_str="float16", decode_bucket=16, max_tokens=None):
         """Build from an already-loaded CausalLM module (the network-free path). ``model``
         must be on CPU for the trace."""
         import numpy as np
@@ -250,7 +306,15 @@ class EmmyGenRunner:
             post_consts: dict = {}
             with torch.device("cpu"):
                 pre_programs.append(
-                    _compile_split(pre_w, [torch.zeros(8, hidden, dtype=dtype)], ["hidden"], np_dtype, dev_consts=pre_consts, arena=arena)
+                    _compile_split(
+                        pre_w,
+                        [torch.zeros(8, hidden, dtype=dtype)],
+                        ["hidden"],
+                        np_dtype,
+                        dev_consts=pre_consts,
+                        arena=arena,
+                        capacity=max_tokens,
+                    )
                 )
                 post_programs.append(
                     _compile_split(
@@ -260,6 +324,7 @@ class EmmyGenRunner:
                         np_dtype,
                         dev_consts=post_consts,
                         arena=arena,
+                        capacity=max_tokens,
                     )
                 )
                 # Static M=decode_bucket twins — fast at decode (small M). If a layer's static
@@ -304,6 +369,7 @@ class EmmyGenRunner:
             pre_decode=pre_decode if use_decode else None,
             post_decode=post_decode if use_decode else None,
             decode_bucket=decode_bucket,
+            prefill_capacity=max_tokens,
         )
 
     def embed(self, input_ids):
@@ -368,13 +434,23 @@ class EmmyGenRunner:
         return self._embed_weight_dev[input_ids.long()]
 
     def forward_layer_pre_device(self, layer, hidden):
-        """Device twin of :meth:`forward_layer_pre` (decode path, ``T <= decode_bucket``):
-        ``hidden[T,H]`` CUDA → un-rotated ``(q, k, v)`` CUDA tensors."""
-        return tuple(self._pre_decode[layer].run_device([hidden]))
+        """Device twin of :meth:`forward_layer_pre`: ``hidden[T,H]`` CUDA → un-rotated
+        ``(q, k, v)`` CUDA tensors. ``T <= decode_bucket`` rides the static decode twin
+        (captured-replay); wider ``T`` (prefill / mixed chunked-prefill steps) rides the
+        SYMBOLIC program device-resident (``run_device_sym``) when it was built with
+        capacity — no per-layer host numpy hop either way."""
+        t = hidden.shape[0]
+        if self._pre_decode is not None and t <= self._decode_bucket:
+            return tuple(self._pre_decode[layer].run_device([hidden]))
+        return tuple(self._pre[layer].run_device_sym([hidden]))
 
     def forward_layer_post_device(self, layer, attn_out, residual):
-        """Device twin of :meth:`forward_layer_post`: ``(attn_out, residual)`` CUDA → ``[T,H]`` CUDA."""
-        return self._post_decode[layer].run_device([attn_out, residual])[0]
+        """Device twin of :meth:`forward_layer_post`: ``(attn_out, residual)`` CUDA → ``[T,H]``
+        CUDA. Decode-bucketed / symbolic-routed like :meth:`forward_layer_pre_device`."""
+        t = attn_out.shape[0]
+        if self._post_decode is not None and t <= self._decode_bucket:
+            return self._post_decode[layer].run_device([attn_out, residual])[0]
+        return self._post[layer].run_device_sym([attn_out, residual])[0]
 
     def final_norm_device(self, hidden):
         """Apply the final norm on CUDA to a ``hidden[T,H]`` CUDA tensor."""

--- a/emmy/serving/vllm_model_gen.py
+++ b/emmy/serving/vllm_model_gen.py
@@ -113,8 +113,14 @@ class EmmyGenModel(nn.Module):
                 f"serve with --max-num-batched-tokens {DYNAMIC_DIM_MAX} or lower"
             )
 
+        # ``max_tokens`` sizes the symbolic programs' device buffers at the widest step vLLM
+        # can schedule — the device-resident PREFILL path (``run_device_sym``) needs fixed
+        # capacity buffers; without it prefill falls back to the per-layer host numpy hops.
         self.runner = EmmyGenRunner.create(
-            model_id=mc.model, dtype_str=_trunk_dtype_str(mc.dtype), decode_bucket=emmy_config.gen_decode_bucket()
+            model_id=mc.model,
+            dtype_str=_trunk_dtype_str(mc.dtype),
+            decode_bucket=emmy_config.gen_decode_bucket(),
+            max_tokens=max_batched or None,
         )
         n_layers = self.runner.num_layers
 
@@ -170,9 +176,14 @@ class EmmyGenModel(nn.Module):
         # clamp guards vLLM's _dummy_run garbage-id profiling batches (out-of-vocab → IndexError).
         ids = input_ids.clamp(0, self.config.vocab_size - 1)
         t = int(ids.shape[0])
-        # Decode hot path (T <= bucket): device-resident, no host numpy round-trip (Phase A).
-        # Prefill / larger T keeps the host path.
-        if self.runner.has_device_decode and 0 < t <= self.runner.decode_bucket:
+        # Device-resident forward for EVERY width the compiled programs cover: decode
+        # (T <= bucket, the captured static twins) AND prefill / mixed chunked-prefill steps
+        # (bucket < T <= prefill_capacity, the symbolic programs via ``run_device_sym``) — no
+        # per-layer host numpy round-trip. The numpy path below survives only as the fallback
+        # for a runner built without capacity (the standalone oracle) or an over-capacity T.
+        decode_ok = self.runner.has_device_decode and 0 < t <= self.runner.decode_bucket
+        prefill_ok = 0 < t <= self.runner.prefill_capacity
+        if decode_ok or prefill_ok:
             return self._forward_device(ids, positions)
         ids_np = ids.cpu().numpy()
         hidden_np = self.runner.embed(ids_np)  # [T, H] numpy

--- a/plans/gemma4-decode-goldens-seeding-findings.md
+++ b/plans/gemma4-decode-goldens-seeding-findings.md
@@ -160,3 +160,22 @@ program-caching items on the roadmap.
   contents, which entry matched which row.
 - The fm-superset sweep (`EMMY_FAST_MATH=1` tune + per-regime A/B) cost nothing extra and proved std ≡ fm on this
   family — keep it as the default seeding recipe on consumer dies.
+
+## TTFT/prefill wall (2026-07-16, late night) — device-resident symbolic prefill (PR #387) + symbolic twin tune
+
+Prefill ran the per-layer HOST numpy path (~96 `.cpu()` hops/step). PR #387 runs the symbolic programs
+device-resident at every width (`run_device_sym`: grids per step via `set_sym_values`, capacity-built buffers =
+vLLM's mnbt, no per-T capture), and the four symbolic twin graphs were tuned into the serving DB (~70 min).
+Measured (matched config, capture default, bucket 32):
+
+| workload | metric | host prefill | device prefill | matched stock |
+| --- | --- | --: | --: | --: |
+| in-8/out-64 | TTFT / TPOT | 4 119 / 21.33 ms | **125 / 21.50 ms** | — |
+| in-256/out-64 | TTFT / TPOT / req/s | 113 777 / 2 939 / 0.10¹ | **1 579 / 29.3 / 7.06** | 1 310 / 23.6 / 10.33 |
+
+¹ the pre-#386 original A/B numbers at this workload class.
+
+**e2e standing: 0.68× matched stock req/s (from 0.01×); pure decode stays AHEAD of stock.** The residual gap is
+prefill-step COMPUTE (TTFT 1.2×, mixed-step TPOT 1.24×): the symbolic-path kernels at T≈256 chunks — the
+computed-A forms at prefill M and packed-varlen attention — plus mixed steps running uncaptured by design.
+Integration overhead is no longer the story anywhere in serving.

--- a/tests/serving/test_gen_prefill_device_gpu.py
+++ b/tests/serving/test_gen_prefill_device_gpu.py
@@ -1,0 +1,57 @@
+"""Device-resident SYMBOLIC prefill path (``_Program.run_device_sym``). Needs CUDA + cupy
+(skips itself off-GPU).
+
+Builds a tiny random-weight Llama layer through the gen runner with a prefill ``capacity``
+(``max_tokens``), then checks the device path at a width ABOVE the decode bucket — the
+prefill/chunked-prefill regime that used to take the per-layer host numpy hops — against the
+host ``rebind`` path on the same programs: identical kernels, so the outputs must match
+bit-for-bit (both fp16, same launch sequence, only the I/O transport differs).
+"""
+
+import numpy as np
+import pytest
+
+# NOT perf-marked (correctness pin, must run under ``make test``; see tests/ARCHITECTURE.md).
+pytestmark = [pytest.mark.xdist_group("cuda")]
+
+
+def test_run_device_sym_matches_host_path():
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    from emmy.serving.gen_runner import EmmyGenRunner
+
+    config = LlamaConfig(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(config).eval().to(torch.float16)
+    runner = EmmyGenRunner.from_model(model, dtype_str="float16", decode_bucket=16, max_tokens=64)
+    assert runner.prefill_capacity == 64
+
+    rng = np.random.default_rng(0)
+    T, H = 48, config.hidden_size  # bucket < T <= capacity — the symbolic device regime
+    hidden = (rng.standard_normal((T, H)) * 0.3).astype(np.float16)
+
+    q_np, k_np, v_np = runner.forward_layer_pre(0, hidden)  # host rebind path
+    q, k, v = runner.forward_layer_pre_device(0, torch.from_numpy(hidden).cuda())
+    for host, dev in ((q_np, q), (k_np, k), (v_np, v)):
+        assert dev.shape[0] == T
+        np.testing.assert_array_equal(dev.cpu().numpy(), host)
+
+    attn = (rng.standard_normal((T, config.num_attention_heads * 16)) * 0.3).astype(np.float16)
+    out_np = runner.forward_layer_post(0, attn, hidden)
+    out = runner.forward_layer_post_device(0, torch.from_numpy(attn).cuda(), torch.from_numpy(hidden).cuda())
+    np.testing.assert_array_equal(out.cpu().numpy(), out_np)


### PR DESCRIPTION
First lever on the TTFT/prefill wall (the remaining serving gap after #384/#386 took decode TPOT to 21.3 ms, under stock's 24.9): prefill and mixed chunked-prefill steps still ran the per-layer **host numpy path** — ~2 `.cpu()`/numpy hops per layer per step across 48 layers (4–5 s TTFT at small inputs; ~2–3 s per mnbt-256 prefill chunk).

- **`_Program.run_device_sym`** — the symbolic programs run device-resident at any step width: grids sized per step via `set_sym_values` (no re-allocation), inputs uploaded into the buffer prefix device-to-device, launches issued on torch's stream, outputs returned as device views at the resolved shapes. No per-T graph capture: chunked-prefill T varies step to step, and at prefill widths the dispatch hides behind GPU work.
- **`_compile_split(capacity=…)`** — the symbolic programs build with a capacity-width feed (vLLM's `max_num_batched_tokens`, passed as `max_tokens` from `EmmyGenModel`), so the device buffers hold any schedulable step; `set_sym_values` raises past capacity.
- **`EmmyGenModel.forward`** routes every covered width through `_forward_device`; the numpy path survives only for the standalone oracle (no capacity) and as the over-capacity fallback.
- GPU test: the device symbolic path is **bit-identical** to the host rebind path on the same programs (pre q/k/v + post at T above the decode bucket).

Test plan: `make test` (2499 passed, 35 skipped), `make lint` clean.

Next (measurement, queued): tune the symbolic twin graphs into the serving DB on top of #386's enumeration, then the serving A/B at the in-256 prefill-heavy workload for the TTFT before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)