### PR TITLE
Static prefill-chunk twin (M = mnbt): exact grids on the hot chunked-prefill width

### DIFF
--- a/emmy/config.py
+++ b/emmy/config.py
@@ -51,6 +51,7 @@ GPU_LOCK = "EMMY_GPU_LOCK"
 NCU_CHILD = "EMMY_NCU_CHILD"
 SERVING_STATIC = "EMMY_SERVING_STATIC"
 GEN_DECODE_BUCKET = "EMMY_GEN_DECODE_BUCKET"
+GEN_PREFILL_BUCKET = "EMMY_GEN_PREFILL_BUCKET"
 READABLE = "EMMY_READABLE"
 
 _CACHE_ROOT = Path.home() / ".cache" / "emmy"
@@ -302,6 +303,15 @@ def serving_static(default: bool = False) -> bool:
     dynamic-seq kernels miscompute batch>1, so it is a deliberate opt-in, not a
     default. See `serving/ARCHITECTURE.md`."""
     return _bool(SERVING_STATIC, default)
+
+
+def gen_prefill_bucket(default: int = -1) -> int:
+    """``EMMY_GEN_PREFILL_BUCKET`` — the generative runner's static prefill-chunk M.
+    The default ``-1`` means "vLLM's ``max_num_batched_tokens``" (chunked prefill fills
+    steps to it whenever the queue is deep, so the static twin runs exact grids on the
+    hot chunk width); **0 disables** the twin (prefill stays on the symbolic masked-tile
+    programs). See `serving/gen_runner.py`."""
+    return int_env(GEN_PREFILL_BUCKET, default)
 
 
 def gen_decode_bucket(default: int = 16) -> int:

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -73,8 +73,11 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `pre` and `post` (a reference torch SDPA in the Phase-2 host stitch; vLLM paged `Attention` in Phase 3). **I/O:**
   the plugin runs **device-resident at every width**: the **decode hot path** (`num_tokens ≤ bucket`) rides the
   captured static twins (`run_device` — captured-replay, torch↔cupy DLPack zero-copy), and **prefill /
-  chunked-prefill steps** (`bucket < num_tokens ≤ prefill_capacity`, capacity = vLLM's `max_num_batched_tokens`,
-  passed as `max_tokens` at runner build) ride the SYMBOLIC programs' `run_device_sym` — grids sized per step via
+  chunked-prefill steps** ride the static **prefill-chunk twin** (`decode_bucket < num_tokens ≤ prefill_bucket`
+  — default = mnbt, `EMMY_GEN_PREFILL_BUCKET` overrides / `0` disables; exact grids on the hot chunk width, pad →
+  run → slice like the decode twin) or, past the bucket, the SYMBOLIC programs' `run_device_sym`
+  (`num_tokens ≤ prefill_capacity`, capacity = vLLM's `max_num_batched_tokens`, passed as `max_tokens` at runner
+  build) — grids sized per step via
   `set_sym_values` over capacity-built buffers, launches issued on torch's stream, no per-T graph capture
   (chunked-prefill T varies per step; the dispatch hides behind prefill-width GPU work). The per-layer host numpy
   `rebind` path survives only for the standalone `emmy generate` oracle and as the over-capacity fallback — its

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -208,6 +208,9 @@ class EmmyGenRunner:
         post_decode=None,
         decode_bucket=16,
         prefill_capacity=None,
+        pre_prefill=None,
+        post_prefill=None,
+        prefill_bucket=0,
     ):
         self._embed_weight = embed_weight  # numpy [vocab, H]
         self._norm = norm  # torch module
@@ -217,6 +220,9 @@ class EmmyGenRunner:
         self._post_decode = post_decode
         self._decode_bucket = decode_bucket
         self._prefill_capacity = prefill_capacity  # symbolic programs' device-buffer token capacity (None -> host rebind only)
+        self._pre_prefill = pre_prefill  # list[_Program] — static M=prefill_bucket chunk twins (or None → symbolic prefill)
+        self._post_prefill = post_prefill
+        self._prefill_bucket = prefill_bucket
         self._attn_meta = attn_meta  # per-layer list of (head_dim, num_heads, num_kv, scaling)
         # Layer-0 convenience scalars — correct for homogeneous models (Qwen3 / Llama). Gemma-4's
         # global layers differ, so the vLLM model reads per-layer dims via ``layer_meta``.
@@ -249,18 +255,28 @@ class EmmyGenRunner:
         capacity, host ``rebind`` only)."""
         return self._prefill_capacity or 0
 
+    @property
+    def prefill_bucket(self) -> int:
+        """The static prefill-chunk twins' M (0 = twins not built — prefill rides the
+        symbolic programs). Chunked prefill fills steps to ``max_num_batched_tokens``
+        whenever the queue is deep, so a twin at that width runs exact static grids
+        (and captured-replay) on the hot chunk shape."""
+        return self._prefill_bucket if self._pre_prefill is not None else 0
+
     @classmethod
-    def create(cls, model_id, *, dtype_str="float16", decode_bucket=16, max_tokens=None):
+    def create(cls, model_id, *, dtype_str="float16", decode_bucket=16, max_tokens=None, prefill_bucket=0):
         import torch
         from transformers import AutoModelForCausalLM
 
         logger.info("[gen_runner] loading %s (%s, CPU trace)...", model_id, dtype_str)
         with torch.device("cpu"):
             model = AutoModelForCausalLM.from_pretrained(model_id, dtype=getattr(torch, dtype_str)).eval()
-            return cls.from_model(model, dtype_str=dtype_str, decode_bucket=decode_bucket, max_tokens=max_tokens)
+            return cls.from_model(
+                model, dtype_str=dtype_str, decode_bucket=decode_bucket, max_tokens=max_tokens, prefill_bucket=prefill_bucket
+            )
 
     @classmethod
-    def from_model(cls, model, *, dtype_str="float16", decode_bucket=16, max_tokens=None):
+    def from_model(cls, model, *, dtype_str="float16", decode_bucket=16, max_tokens=None, prefill_bucket=0):
         """Build from an already-loaded CausalLM module (the network-free path). ``model``
         must be on CPU for the trace."""
         import numpy as np
@@ -289,7 +305,11 @@ class EmmyGenRunner:
 
         pre_programs, post_programs = [], []
         pre_decode, post_decode = [], []
+        pre_prefill, post_prefill = [], []
         decode_ok = decode_bucket and decode_bucket > 0
+        # The prefill-chunk twin only pays ABOVE the decode bucket (an equal-or-smaller
+        # bucket is fully shadowed by the decode twins' routing).
+        prefill_ok = prefill_bucket and prefill_bucket > max(decode_bucket or 0, 0)
         # One arena for every program this runner builds: layers run sequentially, so
         # all layers' activation buffers + scratch slabs share one layer's worth of
         # device memory instead of scaling with num_layers.
@@ -350,6 +370,34 @@ class EmmyGenRunner:
                     except Exception as ex:  # noqa: BLE001 — any lowering/compile failure → disable the bucket
                         logger.warning("[gen_runner] decode-bucket compile failed at layer %d (%s); decode falls back to symbolic", i, ex)
                         decode_ok = False
+                # Static M=prefill_bucket chunk twins — exact grids on the hot chunked-prefill
+                # width (the symbolic masked-tile programs at off-hint T are the residual
+                # prefill cost). Same failure contract as the decode twins.
+                if prefill_ok:
+                    try:
+                        pre_prefill.append(
+                            _compile_split(
+                                pre_w,
+                                [torch.zeros(prefill_bucket, hidden, dtype=dtype)],
+                                None,
+                                np_dtype,
+                                dev_consts=pre_consts,
+                                arena=arena,
+                            )
+                        )
+                        post_prefill.append(
+                            _compile_split(
+                                post_w,
+                                [torch.zeros(prefill_bucket, attn_width, dtype=dtype), torch.zeros(prefill_bucket, hidden, dtype=dtype)],
+                                None,
+                                np_dtype,
+                                dev_consts=post_consts,
+                                arena=arena,
+                            )
+                        )
+                    except Exception as ex:  # noqa: BLE001 — any lowering/compile failure → disable the twin
+                        logger.warning("[gen_runner] prefill-bucket compile failed at layer %d (%s); prefill falls back to symbolic", i, ex)
+                        prefill_ok = False
 
         embed_weight = trunk.embed_tokens.weight.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
         # Gemma scales embeddings by sqrt(hidden) (a ``Gemma3TextScaledWordEmbedding`` carries it as
@@ -359,6 +407,7 @@ class EmmyGenRunner:
         if embed_scale != 1.0:
             embed_weight = embed_weight * np_dtype.type(embed_scale)
         use_decode = decode_ok and len(pre_decode) == len(layers)
+        use_prefill = prefill_ok and len(pre_prefill) == len(layers)
         runner = cls(
             embed_weight=embed_weight,
             norm=trunk.norm,
@@ -370,6 +419,9 @@ class EmmyGenRunner:
             post_decode=post_decode if use_decode else None,
             decode_bucket=decode_bucket,
             prefill_capacity=max_tokens,
+            pre_prefill=pre_prefill if use_prefill else None,
+            post_prefill=post_prefill if use_prefill else None,
+            prefill_bucket=prefill_bucket,
         )
         if runner.has_device_decode:
             # EAGER, not lazy: vLLM sizes its KV cache from a profiling pass that runs
@@ -454,6 +506,10 @@ class EmmyGenRunner:
         t = hidden.shape[0]
         if self._pre_decode is not None and t <= self._decode_bucket:
             return tuple(self._pre_decode[layer].run_device([hidden]))
+        if self._pre_prefill is not None and t <= self._prefill_bucket:
+            # The static chunk twin: T real rows into the prefix, the bucket's exact grids
+            # compute (stale padding rows sliced away by ``run_device``'s ``[:t]``).
+            return tuple(self._pre_prefill[layer].run_device([hidden]))
         return tuple(self._pre[layer].run_device_sym([hidden]))
 
     def forward_layer_post_device(self, layer, attn_out, residual):
@@ -462,6 +518,8 @@ class EmmyGenRunner:
         t = attn_out.shape[0]
         if self._post_decode is not None and t <= self._decode_bucket:
             return self._post_decode[layer].run_device([attn_out, residual])[0]
+        if self._post_prefill is not None and t <= self._prefill_bucket:
+            return self._post_prefill[layer].run_device([attn_out, residual])[0]
         return self._post[layer].run_device_sym([attn_out, residual])[0]
 
     def final_norm_device(self, hidden):

--- a/emmy/serving/vllm_model_gen.py
+++ b/emmy/serving/vllm_model_gen.py
@@ -116,11 +116,18 @@ class EmmyGenModel(nn.Module):
         # ``max_tokens`` sizes the symbolic programs' device buffers at the widest step vLLM
         # can schedule — the device-resident PREFILL path (``run_device_sym``) needs fixed
         # capacity buffers; without it prefill falls back to the per-layer host numpy hops.
+        # The prefill-chunk twin defaults to the mnbt width (chunked prefill fills steps to
+        # it whenever the queue is deep); EMMY_GEN_PREFILL_BUCKET=0 disables, an explicit
+        # value overrides.
+        prefill_bucket = emmy_config.gen_prefill_bucket()
+        if prefill_bucket < 0:
+            prefill_bucket = max_batched or 0
         self.runner = EmmyGenRunner.create(
             model_id=mc.model,
             dtype_str=_trunk_dtype_str(mc.dtype),
             decode_bucket=emmy_config.gen_decode_bucket(),
             max_tokens=max_batched or None,
+            prefill_bucket=prefill_bucket,
         )
         n_layers = self.runner.num_layers
 

--- a/tests/serving/test_gen_prefill_device_gpu.py
+++ b/tests/serving/test_gen_prefill_device_gpu.py
@@ -38,20 +38,26 @@ def test_run_device_sym_matches_host_path():
     )
     torch.manual_seed(0)
     model = LlamaForCausalLM(config).eval().to(torch.float16)
-    runner = EmmyGenRunner.from_model(model, dtype_str="float16", decode_bucket=16, max_tokens=64)
+    runner = EmmyGenRunner.from_model(model, dtype_str="float16", decode_bucket=16, max_tokens=64, prefill_bucket=32)
     assert runner.prefill_capacity == 64
+    assert runner.prefill_bucket == 32
 
     rng = np.random.default_rng(0)
-    T, H = 48, config.hidden_size  # bucket < T <= capacity — the symbolic device regime
-    hidden = (rng.standard_normal((T, H)) * 0.3).astype(np.float16)
+    H = config.hidden_size
+    # T=24: decode_bucket < T <= prefill_bucket — the static CHUNK-TWIN regime (pad → run →
+    # slice); the host reference runs the SYMBOLIC program, a different kernel, so fp16
+    # accumulation order may differ by rounding (allclose). T=48: prefill_bucket < T <=
+    # capacity — the SYMBOLIC device regime, same program as the host path (bit-exact).
+    for T, check in ((24, lambda dev, host: np.testing.assert_allclose(dev, host, rtol=2e-2, atol=2e-3)),
+                     (48, np.testing.assert_array_equal)):
+        hidden = (rng.standard_normal((T, H)) * 0.3).astype(np.float16)
+        q_np, k_np, v_np = runner.forward_layer_pre(0, hidden)  # host rebind path
+        q, k, v = runner.forward_layer_pre_device(0, torch.from_numpy(hidden).cuda())
+        for host, dev in ((q_np, q), (k_np, k), (v_np, v)):
+            assert dev.shape[0] == T
+            check(dev.cpu().numpy().astype(np.float32), host.astype(np.float32))
 
-    q_np, k_np, v_np = runner.forward_layer_pre(0, hidden)  # host rebind path
-    q, k, v = runner.forward_layer_pre_device(0, torch.from_numpy(hidden).cuda())
-    for host, dev in ((q_np, q), (k_np, k), (v_np, v)):
-        assert dev.shape[0] == T
-        np.testing.assert_array_equal(dev.cpu().numpy(), host)
-
-    attn = (rng.standard_normal((T, config.num_attention_heads * 16)) * 0.3).astype(np.float16)
-    out_np = runner.forward_layer_post(0, attn, hidden)
-    out = runner.forward_layer_post_device(0, torch.from_numpy(attn).cuda(), torch.from_numpy(hidden).cuda())
-    np.testing.assert_array_equal(out.cpu().numpy(), out_np)
+        attn = (rng.standard_normal((T, config.num_attention_heads * 16)) * 0.3).astype(np.float16)
+        out_np = runner.forward_layer_post(0, attn, hidden)
+        out = runner.forward_layer_post_device(0, torch.from_numpy(attn).cuda(), torch.from_numpy(hidden).cuda())
+        check(out.cpu().numpy().astype(np.float32), out_np.astype(np.float32))

--- a/tests/serving/test_gen_prefill_device_gpu.py
+++ b/tests/serving/test_gen_prefill_device_gpu.py
@@ -48,8 +48,10 @@ def test_run_device_sym_matches_host_path():
     # slice); the host reference runs the SYMBOLIC program, a different kernel, so fp16
     # accumulation order may differ by rounding (allclose). T=48: prefill_bucket < T <=
     # capacity — the SYMBOLIC device regime, same program as the host path (bit-exact).
-    for T, check in ((24, lambda dev, host: np.testing.assert_allclose(dev, host, rtol=2e-2, atol=2e-3)),
-                     (48, np.testing.assert_array_equal)):
+    for T, check in (
+        (24, lambda dev, host: np.testing.assert_allclose(dev, host, rtol=2e-2, atol=2e-3)),
+        (48, np.testing.assert_array_equal),
+    ):
         hidden = (rng.standard_normal((T, H)) * 0.3).astype(np.float16)
         q_np, k_np, v_np = runner.forward_layer_pre(0, hidden)  # host rebind path
         q, k, v = runner.forward_layer_pre_device(0, torch.from_numpy(hidden).cuda())


### PR DESCRIPTION
Leftover prefill-performance item from the TTFT arc (#387 took TTFT 113.8 s → 1.58 s; the residual 1.2× TTFT / 1.24× mixed-step TPOT vs stock is prefill-step compute). One of the two components is the symbolic masked-tile programs running chunks at off-hint widths — this PR mirrors the proven decode-bucket design at the chunk width:

- **A third static pre/post twin per layer at `M = prefill_bucket`** (default = vLLM's `max_num_batched_tokens` — chunked prefill fills steps to it whenever the queue is deep; `EMMY_GEN_PREFILL_BUCKET` overrides, `0` disables). Weights shared through the per-wrapper constant cache, activations through the runner arena, same compile-failure fallback contract as the decode twins.
- **Routing:** `T ≤ decode_bucket` → decode twin (captured), `decode_bucket < T ≤ prefill_bucket` → chunk twin (pad → run → slice), else the symbolic device path from #387.
- GPU test extended to pin both regimes (chunk-twin allclose vs the host reference — different kernels, fp16 rounding; symbolic bit-exact).

Test plan: `make test` green, `make lint` clean. Measurement queued: tune the prefill-bucket twin graphs, then the in-256 serving A/B — numbers will be posted here like #386/#387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)