### PR TITLE
Multi-channel computed-A split-K: the gate/up fused cone splits over K at decode M

### DIFF
--- a/emmy/compiler/ir/tile/ir.py
+++ b/emmy/compiler/ir/tile/ir.py
@@ -384,13 +384,22 @@ class Contraction(Stmt):
         if len(self.folds) == 1:
             return base
         # Each extra fold channel splices its ``b_load → lift → accum`` triple after the primary's,
-        # reusing the shared A value (the carrier stays the primary channel's — a multi-channel node
-        # never rides the coop / split tiers, so the carrier only serves role/axis reads).
+        # reusing the shared A value. The carrier is the N-COMPONENT identity-family state (one
+        # additive component per channel) — the true product-monoid state, so the cross-CTA split
+        # tier folds every channel's partials (the redundant-statistic split of the gate/up edge);
+        # ``carrier.out`` stays the primary component, and the coop tier remains contraction-blind.
+        from emmy.compiler.ir.stmt.algebra import Carrier, State, Twist  # noqa: PLC0415 — algebra imports leaves
+        from emmy.compiler.ir.stmt.carrier import Channel  # noqa: PLC0415
+
         extra: list[Stmt] = []
         for bl, acc in self.folds[1:]:
             lift = Assign(name=f"{acc}__v", op=ElementwiseImpl("multiply"), args=(self.a_name, bl.names[0]))
             extra += [bl, lift, Accum(name=acc, value=lift.name, op=ElementwiseImpl("add"), axes=(self.k_axis.name,))]
-        return Loop(axis=base.axis, body=Body((*base.body, *extra)), unroll=base.unroll, role=base.role, carrier=base.carrier)
+        add = ElementwiseImpl("add")
+        names = (self.acc, *(acc for _, acc in self.folds[1:]))
+        channels = tuple(Channel(fold=add, term=f"{nm}__v", dtype=base.carrier.twist.channels[0].dtype) for nm in names)
+        carrier = Carrier(state=State(names=names), twist=Twist(family="id", channels=channels))
+        return Loop(axis=base.axis, body=Body((*base.body, *extra)), unroll=base.unroll, role=base.role, carrier=carrier)
 
     def lower(self) -> list[Stmt]:
         """Flatten to the loop-IR body — the synthesized reduce ``Loop`` followed by the projection

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -151,9 +151,12 @@ edge, 5090) and — single-channel nodes only — the **redundant-statistic spli
 across CTAs while the k-invariant stat prologue stays full-row in every partition (each recomputes it, cheap
 exactly on the small-free decode shapes the `_SPLITK_MAX_CTAS` gate admits), the per-cell cone σ-reindexed to
 absolute k and the `Map`-wrapper projection folded into the deferred finalize (`_splitk_option`'s computed-A arm
-→ `030_split_reduce`'s structural path). Still no scalar / gmem-direct / WSPEC rows, and no split on
-multi-channel (gate/up) nodes — their product-monoid carrier is not the 1-component additive state the split
-finalize folds; the compute-producer role for the fused edge is the anticipated `RoleKind` extension. The **flash-form fork**: a `TWISTED` streaming contraction pair (the flash tree) offers its
+→ `030_split_reduce`'s structural path). Multi-channel (gate/up) nodes split too: the synthesized fold loop
+carries the true N-component identity-family carrier (one additive state per channel), the partial stores each
+channel's raw C fragment to its `ws[comp, ksplit, *cell]` slice (the per-acc `RegStore` arm — no ⊗-combine in
+the partial), and the deferred finalize folds every component before applying the combine projection once.
+Still no scalar / gmem-direct / WSPEC rows; the compute-producer role for the fused edge is the anticipated
+`RoleKind` extension. The **flash-form fork**: a `TWISTED` streaming contraction pair (the flash tree) offers its
 structurally-different schedules as ONE prior-ranked fork — the warp (fragment-resident) rows over
 `twisted_warp_moves()`'s `(warps-per-CTA × key-atoms-per-block × query-tiles-per-warp)` geometry grid (option-0 = the
 conservative one-warp / `2·atom_n` block / one tile; the third dimension is the `TILE` codec's `f<FM>x<FN>` reg_m —

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -920,8 +920,28 @@ class _MmaOps(_AtomOps):
         m, n = mn
         mcell, ncell = offset[0].base(i), offset[1].base(j)
         tail = list(c.epilogue)
-        write = next(s for s in tail if isinstance(s, Write))
         sigma = Sigma({m.axis.name: mcell, n.axis.name: ncell})
+        accs = (c.acc, *(acc for _, acc in c.folds[1:]))
+        frags = (f"_c{i}_{j}", *(_fold_frag(f"_c{i}_{j}", f) for f in range(1, len(c.folds))))
+        writes = [s for s in tail if isinstance(s, Write)]
+        if len(c.folds) > 1 and len(tail) == len(writes) == len(c.folds) and {w.value for w in writes} == set(accs):
+            # RAW per-channel stores — the split-K partial's epilogue is one workspace ``Write``
+            # per accumulator, NO ⊗-combine (the finalize applies the projection once after the
+            # cross-partition sums): each channel's C fragment stores to its own ws slice.
+            by_acc = {w.value: w for w in writes}
+            return [
+                RegStore(
+                    dst_buffer=by_acc[acc].output,
+                    dst_index=tuple(sigma.apply(e) for e in by_acc[acc].index),
+                    frag=frag,
+                    shape=atom.shape,
+                    epilogue=None,
+                    m_guard=_guard(m, mcell),
+                    n_guard=_guard(n, ncell),
+                )
+                for acc, frag in zip(accs, frags, strict=True)
+            ]
+        write = next(s for s in writes)
         extra = tuple((acc, _fold_frag(f"_c{i}_{j}", f)) for f, (_, acc) in enumerate(c.folds[1:], 1))
         epi = _warp_epilogue(tail, c.acc, m.axis.name, n.axis.name, sigma, extra_accs=extra)
         assert len(c.folds) == 1 or epi is not None, "a multi-fold contraction's projection must combine the accumulators"

--- a/emmy/compiler/pipeline/passes/lowering/tile/030_split_reduce.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/030_split_reduce.py
@@ -157,8 +157,7 @@ def _split_contraction(match: Match, root: Node, tile: TileOp, contraction: Cont
     grid = tile.place.grid
     cell = tuple(Var(a.name) for a in grid)
     states = carrier.state.names
-    if len(states) != 1:
-        raise NotImplementedError("split-K contraction carrier must be additive (1-component)")
+    n_comp = len(states)  # 1 = plain matmul; N = the multi-channel (gate/up) node's per-channel accs
     acc = states[0]
     lead = (split, *contraction.lead_axes)
     epilogue = list(contraction.epilogue)  # the fused projection (empty for a bare matmul)
@@ -168,6 +167,8 @@ def _split_contraction(match: Match, root: Node, tile: TileOp, contraction: Cont
     # below stay here (they need the graph context the selector doesn't hold).
     (cross_move,) = next(st for st in plan.stages if st.level is Level.GRID).combine(warp_size=32)
     if cross_move is Fold.ATOMIC:
+        if n_comp != 1:
+            raise NotImplementedError("atomic finalize needs an additive (1-component) carrier; pin the deferred g<w>k finalize")
         if isinstance(contraction.atom, AtomKind):
             raise NotImplementedError(
                 "atomic finalize can't accumulate an mma C-fragment (RegStore has no atomicAdd); "
@@ -186,25 +187,34 @@ def _split_contraction(match: Match, root: Node, tile: TileOp, contraction: Cont
         part = replace(contraction, lead_axes=lead, epilogue=Body(atomic_epi))
         return _mapped(part, (split, *grid), name=tile.name, stage=tile.stage, knobs=tile.knobs)
 
-    # --- deferred kernel finalize: partial writes raw ``acc`` to ``ws[ksplit, *cell]`` -----------
-    # The workspace shape MUST match the rank of the index the writes/loads use — ``(ksplit,
-    # *grid vars)`` — or ``render_index``'s rank-mismatch fallback silently flattens without
-    # strides (colliding partials; the misaligned-vector-store crash). ``cell`` is the GRID vars
-    # (the structural partial has no original Write to copy), so size the workspace by the grid
-    # extents, not ``out.shape`` (whose extent-1 batch dims the grid never carries).
+    # --- deferred kernel finalize: partial writes each raw state to ``ws[(comp,) ksplit, *cell]``.
+    # The workspace shape MUST match the rank of the index the writes/loads use — or
+    # ``render_index``'s rank-mismatch fallback silently flattens without strides (colliding
+    # partials; the misaligned-vector-store crash). ``cell`` is the GRID vars (the structural
+    # partial has no original Write to copy), so size the workspace by the grid extents, not
+    # ``out.shape`` (whose extent-1 batch dims the grid never carries). A multi-channel node
+    # packs its per-channel accs into a leading ``comp`` axis (the residual path's convention);
+    # the single-component workspace stays ``ws[ksplit, *cell]``.
     ws_name = f"{out.name}__partial"
-    ws_shape = (Dim(plan.cta), *(a.extent for a in grid))
-    ws_write = Write(output=ws_name, index=(Var(split.name), *cell), value=acc)
-    part = replace(contraction, lead_axes=lead, epilogue=Body((ws_write,)))
+    ws_shape = (Dim(plan.cta), *(a.extent for a in grid)) if n_comp == 1 else (Dim(n_comp), Dim(plan.cta), *(a.extent for a in grid))
+
+    def ws_index(i: int) -> tuple:
+        lead_ix = (Var(split.name),) if n_comp == 1 else (Literal(i, "int"), Var(split.name))
+        return (*lead_ix, *cell)
+
+    ws_writes = tuple(Write(output=ws_name, index=ws_index(i), value=states[i]) for i in range(n_comp))
+    part = replace(contraction, lead_axes=lead, epilogue=Body(ws_writes))
     partial_tile = _mapped(part, (split, *grid), name=f"{tile.name}__partial", stage=tile.stage, knobs=tile.knobs)
 
-    # --- finalize kernel: seed ``acc``, fold ``ws`` over ``ksplit`` (``as_state_merge``), then the
-    # original projection epilogue (or a bare store) — the same additive finalize the residual path uses.
-    other = (f"{acc}__p",)
+    # --- finalize kernel: seed each state, fold ``ws`` over ``ksplit`` (``as_state_merge`` — the
+    # 1-component additive fold, or the N-component per-channel sums), then the original
+    # projection epilogue (the multi-channel ⊗-combine applies HERE, once, after the sums) or a
+    # bare store — the same finalize shape the residual path uses.
+    other = tuple(f"{nm}__p" for nm in states)
     combine = carrier.as_state_merge(other)
     ids = _carrier_identities(carrier)
-    seeds = (Init(name=acc, identity=ids[acc], dtype=F32),)
-    loads = (Load(name=other[0], input=ws_name, index=(Var(split.name), *cell)),)
+    seeds = tuple(Init(name=nm, identity=ids[nm], dtype=F32) for nm in states)
+    loads = tuple(Load(name=other[i], input=ws_name, index=ws_index(i)) for i in range(n_comp))
     fin_loop = Loop(axis=split, body=Body((*loads, combine)))
     fin_proj = list(epilogue)
     if not any(isinstance(s, Write) for s in fin_proj):

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -39,10 +39,8 @@ from types import SimpleNamespace
 
 from emmy.compiler.context import STATIC_SMEM_CAP
 from emmy.compiler.dim import DEFAULT_SEQ_HINT, Dim
-from emmy.compiler.dtype import F32
 from emmy.compiler.ir.atom import ATOM_REGISTRY
 from emmy.compiler.ir.axis import Axis, AxisRole
-from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.schedule import Raster, Stage, WarpSpec, has_scalar_atom_alias, is_warp_codec
 from emmy.compiler.ir.sigma import Sigma
@@ -502,10 +500,10 @@ def _reduce_candidates(kernel, place, plan: TilePlan, probe: Contraction | None 
     # k-invariant stat prologue spans the whole row and stays full-row in every partition (each
     # recomputes it — cheap exactly where split-K pays, the small-free decode shapes this offer
     # is gated to), while only the per-cell cone is σ-reindexed (``_splitk_option``). Multi-channel
-    # nodes (the gate/up fused edge) stay excluded — their carrier is not the 1-component additive
-    # state ``030_split_reduce``'s finalize folds.
-    splittable = probe is None or not probe.a_computed or len(probe.folds) == 1
-    if k is not None and free // _tile_area(plan) <= _SPLITK_MAX_CTAS and splittable:
+    # nodes (the gate/up fused edge) split too: each channel's fold is an independent additive
+    # state, so the deferred finalize folds the N-component carrier exactly like flash's (m,l,O)
+    # and applies the ⊗-combine projection once after the cross-partition sums.
+    if k is not None and free // _tile_area(plan) <= _SPLITK_MAX_CTAS:
         step = plan.atom.atom_k * plan.bk if plan.is_warp else 1
         atomic_ok = probe is not None and (len(probe.epilogue) == 0 or projection_distributes(probe.epilogue, (probe.acc,)))
         for move in splitk_moves(warp=plan.is_warp):
@@ -1121,11 +1119,6 @@ def _splitk_option(
             f"{MAX_BLOCK_THREADS}-thread/CTA limit; shrink n/m or move work to the f register sub-tile."
         )
     inner = _contraction_node(tile.op, place, wt)
-    if inner.a_computed and len(inner.folds) != 1:
-        raise ValueError(
-            "split-K REDUCE pin on a multi-channel fused-cone contraction: the product-monoid "
-            "carrier is not the 1-component additive state the split finalize folds; drop the g<w> pin."
-        )
     w = ReducePlan.parse(split_spec).cta
     # A warp (mma) slice must keep the inner K-step dividing K/w — the warp K-loop has no static-K
     # tail masking (same guard as ``_check_warp_static_k``, but on the post-split slice).
@@ -1180,7 +1173,10 @@ def _splitk_option(
     elif stage_spec:
         st = Stage.parse(stage_spec)
         stage = _resolve_warp_stage(inner, st, budget) if wt.is_warp else _resolve_scalar_stage(inner, st, tile.inputs, budget)
-    carrier = Accum(name=inner.acc, value=f"{inner.acc}__v", op=ElementwiseImpl("add"), dtype=F32).as_carrier()
+    # The carrier comes from the node's own synthesized fold loop — the 1-component additive
+    # ``Accum`` for a plain matmul, the N-component product-monoid state for a multi-channel
+    # (gate/up) node — so the split finalize folds exactly the state the kernel accumulates.
+    carrier = reduce_loop(inner).carrier
     op = Reduction(carrier=carrier, axis=ksplit, role=AxisRole.CONTRACTION, source=inner, reduce=ReducePlan.parse(split_spec))
     kaxis = reduce_loop(tile.op).axis.name  # the ORIGINAL k-axis name — single-eligible-axis keying
     stamped = {**knobs, _at(TILE, kaxis): tile_spec, _at(REDUCE, kaxis): split_spec}

--- a/plans/gemma4-decode-goldens-seeding-findings.md
+++ b/plans/gemma4-decode-goldens-seeding-findings.md
@@ -179,3 +179,14 @@ Measured (matched config, capture default, bucket 32):
 prefill-step COMPUTE (TTFT 1.2×, mixed-step TPOT 1.24×): the symbolic-path kernels at T≈256 chunks — the
 computed-A forms at prefill M and packed-varlen attention — plus mixed steps running uncaptured by design.
 Integration overhead is no longer the story anywhere in serving.
+
+## Leftover-perf round (2026-07-17): prefill-chunk twin (+) and multi-channel split (null) — measured
+
+PR #388 (static M=mnbt prefill-chunk twin) + PR #389 (multi-channel computed-A split-K), tuned and A/B'd
+jointly: req/s 7.06 → **7.26 (0.70× matched stock)**, median TTFT 1 094 → **974 ms (UNDER stock's 1 303)**;
+decode held (TPOT 21.54, TTFT-in8 120.6 ms). Attribution: the chunk twin is a real-but-modest win (the tuned
+symbolic device path had already absorbed most masked-tile overhead); the multi-channel split is CORRECT
+(SwiGLU-reference-verified) but a null result on gate⊗up.m32 — that kernel was never grid-starved (240 CTAs),
+its 240-vs-145 µs residual is the fused compute-fill overhead, i.e. the LARGE-M computed-A pipeline class.
+Everything left is research-class: the large-M computed-A pipeline (mixed-step TPOT 1.24× + the gate⊗up
+residual), packed/mixed-step capture, and portability of the twin evidence beyond this box.

--- a/tests/compiler/e2e/test_fused_edge.py
+++ b/tests/compiler/e2e/test_fused_edge.py
@@ -291,6 +291,7 @@ def test_fused_gate_up_swiglu_symbolic_m(runtime_s, monkeypatch):
     fragment epilogue; the seq axis is symbolic with a masked M tail (31 under / 130 over the
     64-row tile)."""
     monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16_f32/w2x2/f2x2/k2")
+    monkeypatch.setenv("EMMY_REDUCE", "")  # serial fold — ONE masked kernel is the contract; the split form has its own test
     S, H, inter = runtime_s, 256, 512
     Sd = Dim("seq_len", hint=64)
     g = Graph()
@@ -432,3 +433,42 @@ def test_fused_cone_splitk_matches_reference(stage, monkeypatch):
     x, nw, wg = (ins[k].astype(np.float32) for k in ("x", "nw", "wg"))
     rms = x[0] * (1.0 / np.sqrt((x[0] ** 2).mean(axis=-1, keepdims=True) + 1e-6)) * nw
     np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), rms @ wg, atol=0.5, rtol=0.1)
+
+
+@requires_cuda
+def test_fused_gate_up_splitk_matches_reference(monkeypatch):
+    """Redundant-statistic split-K on the MULTI-CHANNEL (gate/up) fused cone: both channels'
+    additive states slice over K across CTAs (the stat prologue full-row per partition), the
+    deferred finalize folds the 2-component carrier and applies the SwiGLU ⊗-combine ONCE after
+    the cross-partition sums — the output must match the fp32 reference. The decode-M shape
+    class (M=32) is where the multi-channel split pays (the gemma gate⊗up twin)."""
+    monkeypatch.setenv("EMMY_TILE", "a:mma_m16n8k16_f16_f32/w1x4/f2x2/k2")
+    monkeypatch.setenv("EMMY_REDUCE", "g4k")
+    S, H, inter = 32, 256, 512
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, S, H), F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("nw", (H,), F16), node_id="nw")
+    g.add_node(InputOp(), [], Tensor("wg", (inter, H), F16), node_id="wg")
+    g.add_node(InputOp(), [], Tensor("wu", (inter, H), F16), node_id="wu")
+    g.add_node(RmsNormOp(eps=1e-6), ["x", "nw"], Tensor("xn", (1, S, H), F16), node_id="xn")
+    g.add_node(LinearOp(), ["xn", "wg"], Tensor("gate", (1, S, inter), F16), node_id="gate")
+    g.add_node(LinearOp(), ["xn", "wu"], Tensor("up", (1, S, inter), F16), node_id="up")
+    g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("sg", (1, S, inter), F16), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, S, inter), F16), node_id="o")
+    g.inputs, g.outputs = ["x", "nw", "wg", "wu"], ["o"]
+
+    rng = np.random.default_rng(0)
+    ins = {
+        "x": (rng.standard_normal((1, S, H)) * 0.3).astype(np.float16),
+        "nw": (rng.standard_normal((H,)) * 0.3).astype(np.float16),
+        "wg": (rng.standard_normal((inter, H)) * 0.1).astype(np.float16),
+        "wu": (rng.standard_normal((inter, H)) * 0.1).astype(np.float16),
+    }
+    got, srcs = _compile_run(g, ins)
+    assert len(srcs) == 2, f"split-K must produce partial + finalize, got {len(srcs)} kernel(s)"
+    assert any("emmy_mma" in s for s in srcs), "the mma tier must engage on the split partial"
+    x, nw, wg, wu = (ins[k].astype(np.float32) for k in ("x", "nw", "wg", "wu"))
+    rms = x[0] * (1.0 / np.sqrt((x[0] ** 2).mean(axis=-1, keepdims=True) + 1e-6)) * nw
+    gate, up = rms @ wg.T, rms @ wu.T
+    ref = gate / (1.0 + np.exp(-gate)) * up
+    np.testing.assert_allclose(got.reshape(S, inter).astype(np.float32), ref, atol=0.5, rtol=0.1)


### PR DESCRIPTION
The last fused decode form above its floor: gate⊗up at M=32 runs 240 µs vs its 145 µs bare-golden twin — it was excluded from #386's redundant-statistic split-K because the multi-fold node's carrier claimed only the primary channel's state ("a multi-channel node never rides the split tiers").

Three-surface generalization, each at the principled spot:

1. **`Contraction.loop`** synthesizes the true **N-component identity-family carrier** for multi-fold nodes (one additive state per channel; `carrier.out` stays the primary component and the coop tier remains contraction-blind), so the split tier folds every channel's partials. `_splitk_option` now reads the carrier off this loop for single- and multi-channel alike.
2. **`030_split_reduce._split_contraction`** generalizes to N components with the residual path's `ws[comp, ksplit, *cell]` packing: one write/load/seed per state, the ⊗-combine (SwiGLU) applied **once** at the finalize after the cross-partition sums. The atomic arm refuses multi-component loudly.
3. **The mma store** gains a raw per-channel arm: when the epilogue is exactly one workspace `Write` per accumulator (the split partial's shape), each channel's C fragment stores to its own slice with no combine — the previous assert demanded a combining projection.

Verified: `test_fused_gate_up_splitk_matches_reference` (M=32, `g4k` pinned) matches the fp32 SwiGLU reference; the symbolic gate⊗up tests pin the serial fold where ONE masked kernel is their contract (the split is now a legal sibling there too). `make test` green, `make lint` clean.

Measurement queued with #388's: re-tune the decode + prefill twins against the widened space, then the serving A/B — numbers will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)