### PR TITLE
Deterministic vector-store temp names: content digest, not id(self)

### DIFF
--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -30,7 +30,11 @@ arg_order).
   from `graph.inputs` / `ConstantOp` membership / `graph.outputs`.
 - Compiles each unique `kernel_name` via `nvcc.load_function` (`nvcc.py`):
   offline `nvcc --cubin` into a content-addressed disk cache, then a cupy
-  `RawModule` load. This avoids the driver PTX→SASS JIT cupy's NVRTC path
+  `RawModule` load. Content addressing makes **cross-process source determinism a hard
+  contract**: any address- or seed-derived token in rendered source re-keys the kernel
+  every boot and silently defeats the cache (a server restart recompiles everything it
+  touches) — pinned by `tests/compiler/backend/test_source_determinism.py`, which
+  compiles in two subprocesses and asserts identical sources. This avoids the driver PTX→SASS JIT cupy's NVRTC path
   pays on a cold compile — ~3× faster on the complex tile-search kernels that
   dominate autotune, and the compile step is GPU-free so the cubin cache can be
   warmed by a parallel pool (planned). Falls back to `cupy.RawKernel` (NVRTC)

--- a/emmy/compiler/ir/stmt/leaves.py
+++ b/emmy/compiler/ir/stmt/leaves.py
@@ -870,11 +870,18 @@ class Write(Stmt):
         # (``uint2`` / ``uint4``) re-interpret arrays of elements — we
         # stage the elements into a local array, then store the array's
         # uint{2,4} view in one transaction.
-        # ``id(self)`` disambiguates the temp name across sibling Writes
+        # A content digest disambiguates the temp name across sibling Writes
         # that read from the same SSA — e.g. broadcasting a shared
         # literal-constant value (where every Write's ``values[0]`` is the
-        # same SSA name) used to collide on ``_vs_<name>``.
-        temp = f"_vs_{self.values[0]}_{id(self) & 0xFFFF:04x}"
+        # same SSA name) used to collide on ``_vs_<name>``. Siblings differ in
+        # destination and/or operands, so (output, index, values) separates
+        # them — and unlike the old ``id(self)`` suffix it is deterministic
+        # across processes, which the content-addressed cubin cache requires
+        # (an address-derived name re-keys the kernel on every boot).
+        import hashlib  # noqa: PLC0415 — render-path-only dependency
+
+        sig = f"{self.output}|{flat}|{','.join(converted)}"
+        temp = f"_vs_{self.values[0]}_{hashlib.sha1(sig.encode()).hexdigest()[:4]}"
         if vec_type == "__half2":
             return [
                 f"{pad}{vec_type} {temp} = __halves2half2({converted[0]}, {converted[1]});",

--- a/tests/compiler/backend/test_source_determinism.py
+++ b/tests/compiler/backend/test_source_determinism.py
@@ -1,0 +1,57 @@
+"""Cross-process source determinism — the contract the content-addressed cubin cache
+(``nvcc._cache_key``: sha1 over source among others) stands on.
+
+Rendered kernel source must be byte-identical across interpreter launches: an
+address- or seed-derived token in the text re-keys the kernel on every boot, which
+silently defeats the on-disk cubin cache (each server start recompiles) and makes a
+prebuilt-cache image impossible. Found on a real RTX 5090 release run: ~270 of ~580
+serving kernels re-keyed per boot — the vectorized-store temp name embedded
+``id(self)``. The compile here runs in two SUBPROCESSES (fresh address space and hash
+seed — an in-process double compile cannot see this class of bug), off-GPU (CUDA
+hidden; sources render without a device), and the traced module is picked to emit a
+vectorized store so the historically-affected path stays covered.
+"""
+
+import subprocess
+import sys
+
+_SNIPPET = """
+import hashlib
+import torch
+from emmy.compiler.backend.cuda.backend import CudaBackend
+from emmy.compiler.trace.torch import trace_module
+
+class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l = torch.nn.Linear(64, 64, bias=False)
+    def forward(self, x):
+        return self.l(x).reshape(8, 4, 16)
+
+torch.manual_seed(0)
+g = trace_module(M().eval(), (torch.zeros(8, 64),))
+c = CudaBackend(tune_db="auto").compile(g)
+for _nid, node in sorted(c.nodes.items()):
+    src = getattr(node.op, "kernel_source", None)
+    if src:
+        marker = "VS" if "_vs_" in src else "--"
+        print(node.op.kernel_name, marker, hashlib.sha1(src.encode()).hexdigest())
+"""
+
+
+def _render_once(tmp_path, tag):
+    import os
+
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = ""
+    env.pop("PYTHONHASHSEED", None)  # each subprocess gets its own hash seed — the point
+    out = subprocess.run([sys.executable, "-c", _SNIPPET], capture_output=True, text=True, env=env, timeout=600)
+    assert out.returncode == 0, f"render {tag} failed: {out.stderr[-800:]}"
+    return out.stdout
+
+
+def test_kernel_source_identical_across_processes(tmp_path):
+    a = _render_once(tmp_path, "a")
+    b = _render_once(tmp_path, "b")
+    assert "VS" in a, "the traced module no longer emits a vectorized store — the covered path is gone, repick the module"
+    assert a == b, f"kernel sources differ across processes (cache re-keys every boot):\n--- a\n{a}\n--- b\n{b}"


### PR DESCRIPTION
## What

**The cross-boot cubin-cache killer** found by the gemma-4 image release session on a real 5090 — the finding that blocked the prebuilt-kernel image: ~270 of ~580 serving kernels re-keyed on every boot (boot 2: 265 new cache keys; boot 3, with the union cache baked in: 273 new), making the content-addressed cache structurally unable to hit across server restarts.

**Root cause** (one line, [`leaves.py`](../blob/main/emmy/compiler/ir/stmt/leaves.py)): the vectorized-store temp name embedded `id(self)` — a per-process memory address — into rendered source:

```python
temp = f"_vs_{self.values[0]}_{id(self) & 0xFFFF:04x}"
```

`sha1(source, name, arch, toolkit, flags)` cache keys therefore changed on every interpreter launch for every kernel carrying a vector store — exactly the `k_linear_pointwise` / `k_reshape` family (the matmul/norm/attention kernels were the stable ~310).

**Fix:** the `id()` existed to disambiguate sibling `Write`s sharing `values[0]` (broadcast stores). A sha1 digest of `(output, rendered index, converted operands)` separates those siblings equally well — they differ in destination and/or operands — and is process-deterministic.

## Diagnosis notes (why this hid so long)

- `emmy compile --golden` is deterministic — the golden shapes emit no vector stores, so the CLI repro from the task came up clean; only the serving trace path (linear+reshape fusions) exercises the emit.
- `PYTHONHASHSEED=0` does **not** mask it — address-derived, not hash-ordering — which ruled out the set/dict-iteration hypothesis.
- Any in-process double-compile test would pass: the bug only appears across interpreter launches.

## Verification

- Probe over the full serving graph set (48-layer-style pre/post × symbolic/decode graphs): **3 on-GPU runs + 2 off-GPU runs byte-identical** after the fix; before it, ~half the kernels differed on every run.
- **`test_source_determinism.py`** pins the contract: compile in two *subprocesses* (fresh address space + hash seed), assert byte-identical sources, and assert the traced module still emits a vectorized store (so the covered path can't silently vanish). Verified the test **fails on the unfixed code**.
- cuda ARCHITECTURE now documents cross-process source determinism as a hard contract of content addressing.
- Suite: 2386 passed; the one failure (`test_fused_rmsnorm_linear[scalar]`) is **pre-existing on pristine main** (arrived with #386, fails with a clean tune DB too — flagged as a separate task). `make lint` clean.

## Impact beyond the image

Every emmy user pays this today: any server restart / repeated CLI run recompiles every vector-store kernel it touches. With this fix the on-disk cubin cache actually works across processes. After merge, the gemma-4 release session can re-run — the ARCHITECTURE "known blocker" note on #378 comes out at that point, and `util` can likely return to 0.97 thanks to #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)