### PR TITLE
Pin the serial fold in both test_fused_rmsnorm_linear cells (sm_89 split-row pick)

### DIFF
--- a/tests/compiler/e2e/test_fused_edge.py
+++ b/tests/compiler/e2e/test_fused_edge.py
@@ -118,10 +118,12 @@ def test_fused_rmsnorm_linear(tier, monkeypatch):
     A cone, run once per tile row by the sync stat fill)."""
     if tier == "warp":
         monkeypatch.setenv("EMMY_TILE", _WARP_TILE)
-        # Pin the serial fold: the computed-A form now offers redundant-statistic split-K
-        # siblings on this decode-M shape, and this test pins the ONE-kernel fused form
-        # (the split form has its own test: test_fused_cone_splitk_matches_reference).
-        monkeypatch.setenv("EMMY_REDUCE", "")
+    # Pin the serial fold in BOTH cells: the computed-A form offers redundant-statistic split-K
+    # siblings on this decode-M shape, and this test pins the ONE-kernel fused form. The scalar
+    # cell is an unpinned greedy compile, so without the pin the device's evidence may steer it
+    # to a (legal) 2-kernel split row (seen on sm_89). The split form has its own test
+    # (test_fused_cone_splitk_matches_reference); the free pick, test_fused_rmsnorm_linear_unpinned.
+    monkeypatch.setenv("EMMY_REDUCE", "")
     S, H, inter = 32, 1024, 3072
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (1, S, H), F16), node_id="x")


### PR DESCRIPTION
## Problem

On current main, `tests/compiler/e2e/test_fused_edge.py::test_fused_rmsnorm_linear[scalar]` fails on an
RTX 4080 (sm_89): "the fused norm→linear must be ONE kernel, got 2". Verified environment-independent of
local state (pristine main, fresh empty `EMMY_TUNE_DB`, standalone and under `make test`).

## Root cause — expectation gap from #386, not a placement regression

The two kernels in the failure are exactly the redundant-statistic split-K form #386 introduced: an mma
partial writing `o__partial[ks * 98304 …]` plus a `k_rms_norm_linear_reduce` finalize summing 2 partials.
#386's commit message even predicts the pick: "Cold greedy already picks split rows on the real M=32 PRE twin."

The `scalar` cell sets **no pins at all** — it is an unpinned greedy compile at the same decode-M shape
(S=32, H=1024, inter=3072), so it is just as exposed to the widened fork as the `warp` cell. #386 added the
`EMMY_REDUCE=""` serial-fold pin only inside the `if tier == "warp"` branch; on a device whose evidence steers
greedy to the split row (the 4080 here), the scalar cell picks a perfectly legal 2-kernel fork member and the
ONE-kernel assert fires. Machines whose evidence favors the fused row pass by luck of the prior.

## Fix

Move the `EMMY_REDUCE=""` pin out of the warp-only branch so both cells pin the serial fold — this test's
contract is the ONE-kernel fused form. Coverage of the other rows is untouched: the split form has its own
test (`test_fused_cone_splitk_matches_reference`, both sync depths), and the free greedy pick is
`test_fused_rmsnorm_linear_unpinned`, which already accepts 1 or 2 kernels.

## Verification

- `test_fused_edge.py` full file on the sm_89 machine: 19 passed, 4 skipped (sm90-gated) — the `scalar` cell
  now passes, previously failing.
- `make test`: 2386 passed, 152 skipped, 0 failed.
- `make lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)