### PR TITLE
Golden coverage for gemma-4 fused megakernels + lm_head

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -223,9 +223,12 @@ prefix-consistent with the fastest `H_opt=3` row of the same op), (3) the tune D
 that ships with a clone — the reservoir and tune DB are machine-local caches written by local tunes, so a fresh
 machine (every rented box) previously deployed on pure model extrapolation (the gemma 12–29× cold misdeploys). At a
 fork, `greedy_decide` joins the op against the deploy card's recorded goldens — every kind: matmul, attention
-(flash), rms_norm, softmax, reduce, pointwise — by `ShapeKey` (static and dynamic twins never cross; the key's
-`kind` discriminator, classified off the stamped histogram via the sweep identity
-`S_loop_depth < n_free + n_reduce + n_symbolic`, keeps a flash/norm op apart from an extent-coincident contraction;
+(flash), rms_norm, softmax, reduce, pointwise, norm_linear (the fused RMSNorm→linear computed-A megakernel) — by
+`ShapeKey` (static and dynamic twins never cross; the key's `kind` discriminator, classified off the stamped
+histogram via the sweep identity `S_loop_depth < n_free + n_reduce + n_symbolic`, keeps a flash/norm op apart from
+an extent-coincident contraction — and within the rsqrt family a SECOND reduce axis (`S_ext_n_reduce_axis >= 2`,
+the contraction beside the statistic reduce) marks the `"fused"` computed-A form, `is_warp` forced True since a
+computed-A contraction is a warp mma whose f32 statistic constants would otherwise read scalar;
 at the DEPLOY fork the flash op is recognized from its offer's `TILE@dd` + `TILE@pj` pair instead — the tile pass's
 restructured twisted op carries re-derived extents only, no histogram, so the stamp classifier cannot fire there)
 and picks the offered candidate prefix-consistent with the fastest recorded entry — keys and values compare through
@@ -644,9 +647,12 @@ lowering edges + the `perf` row per kernel, and returns the aggregate `PerfStats
 
 ## Part 7: Golden configs and the A/B integrity gates
 
-`golden.py` holds `GoldenConfig` and its matmul / attention / softmax / reduce / rms_norm / pointwise subclasses — the
-`OfflinePrior`'s ground truth. Every kind carries `shape_key()` / `snippet()` / `dtype`, so `tune --dataset golden`
-and the `run --bench --golden` A/B cover the reduce / pointwise entries too, not just matmul.
+`golden.py` holds `GoldenConfig` and its matmul / attention / softmax / reduce / rms_norm / norm_linear / pointwise
+subclasses — the `OfflinePrior`'s ground truth. Every kind carries `shape_key()` / `snippet()` / `dtype`, so `tune
+--dataset golden` and the `run --bench --golden` A/B cover the reduce / pointwise entries too, not just matmul.
+`NormLinearGoldenConfig` (the fused `rms_norm(x)·nw @ W` computed-A megakernel) is the one snippet-reproducible
+computed-A kind — its `F.rms_norm(x,(H,),nw) @ w` snippet traces to the single mma kernel; the multi-channel gate⊗up
+(SwiGLU/GeGLU) megakernel shares `kind="fused"` but a torch snippet cannot express its shared-`xn` two-matmul form.
 
 **Live-GPU scoping.** `tune --dataset golden` (and `--golden NAME` resolution) scopes to the **live** card's goldens
 (`goldens_for_live_gpu`) — names repeat across per-GPU golden files with diverging shapes/dtypes, so a flat union

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -647,12 +647,13 @@ lowering edges + the `perf` row per kernel, and returns the aggregate `PerfStats
 
 ## Part 7: Golden configs and the A/B integrity gates
 
-`golden.py` holds `GoldenConfig` and its matmul / attention / softmax / reduce / rms_norm / norm_linear / pointwise
-subclasses — the `OfflinePrior`'s ground truth. Every kind carries `shape_key()` / `snippet()` / `dtype`, so `tune
---dataset golden` and the `run --bench --golden` A/B cover the reduce / pointwise entries too, not just matmul.
-`NormLinearGoldenConfig` (the fused `rms_norm(x)·nw @ W` computed-A megakernel) is the one snippet-reproducible
-computed-A kind — its `F.rms_norm(x,(H,),nw) @ w` snippet traces to the single mma kernel; the multi-channel gate⊗up
-(SwiGLU/GeGLU) megakernel shares `kind="fused"` but a torch snippet cannot express its shared-`xn` two-matmul form.
+`golden.py` holds `GoldenConfig` and its matmul / attention / softmax / reduce / rms_norm / norm_linear / mlp_geglu /
+pointwise subclasses — the `OfflinePrior`'s ground truth. Every kind carries `shape_key()` / `snippet()` / `dtype`, so
+`tune --dataset golden` and the `run --bench --golden` A/B cover the reduce / pointwise entries too, not just matmul.
+`NormLinearGoldenConfig` (the fused `rms_norm(x)·nw @ W` computed-A megakernel) and `MlpGeGluGoldenConfig` (its
+multi-channel gate⊗up→GeGLU sibling) are the snippet-reproducible computed-A kinds — both trace to the single fused
+mma kernel and share `kind="fused"`; the gate⊗up snippet binds its shared RMSNorm output via a lambda
+(`(lambda r: gelu(r@Wg)*(r@Wu))(rms_norm(x))`) since a torch expression cannot otherwise share it.
 
 **Live-GPU scoping.** `tune --dataset golden` (and `--golden NAME` resolution) scopes to the **live** card's goldens
 (`goldens_for_live_gpu`) — names repeat across per-GPU golden files with diverging shapes/dtypes, so a flat union

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -648,7 +648,9 @@ lowering edges + the `perf` row per kernel, and returns the aggregate `PerfStats
 ## Part 7: Golden configs and the A/B integrity gates
 
 `golden.py` holds `GoldenConfig` and its matmul / attention / softmax / reduce / rms_norm / norm_linear / mlp_geglu /
-pointwise subclasses — the `OfflinePrior`'s ground truth. Every kind carries `shape_key()` / `snippet()` / `dtype`, so
+rope / embedding / pointwise subclasses — the `OfflinePrior`'s ground truth. The `rope` / `embedding` kinds are
+fork-nothing memory-bound anchors: they record empty knobs and can only serve as `eval golden` regression checks (no
+fork means nothing to warm at deploy). Every kind carries `shape_key()` / `snippet()` / `dtype`, so
 `tune --dataset golden` and the `run --bench --golden` A/B cover the reduce / pointwise entries too, not just matmul.
 `NormLinearGoldenConfig` (the fused `rms_norm(x)·nw @ W` computed-A megakernel) and `MlpGeGluGoldenConfig` (its
 multi-channel gate⊗up→GeGLU sibling) are the snippet-reproducible computed-A kinds — both trace to the single fused

--- a/emmy/compiler/pipeline/search/data/shape.py
+++ b/emmy/compiler/pipeline/search/data/shape.py
@@ -37,11 +37,16 @@ class ShapeKey:
     is_dyn: bool = False
     # The op-kind discriminator for the SWEEP kinds — ``""`` for a plain loop nest
     # (matmul / bare reduce / pointwise: ``S_loop_depth`` equals the axis count), else
-    # ``"flash"`` / ``"softmax"`` / ``"rms_norm"``, where a projection sweep rides the
-    # reduction (``S_loop_depth < n_free + n_reduce + n_symbolic`` — the same stamp
-    # identity the node-store plausibility gate uses). Without it, a flash op whose
-    # extents coincide with a recorded matmul shape would join the matmul golden (and
-    # vice versa) even though the knob grammars don't transfer across kinds.
+    # ``"flash"`` / ``"softmax"`` / ``"rms_norm"`` / ``"fused"``, where a projection sweep
+    # rides the reduction (``S_loop_depth < n_free + n_reduce + n_symbolic`` — the same
+    # stamp identity the node-store plausibility gate uses). ``"fused"`` is the computed-A
+    # contraction (the RMSNorm→linear / gate⊗up megakernel): a warp mma whose A cone carries
+    # a statistic (rsqrt) prologue, so it stamps LIKE an ``rms_norm`` sweep but with a SECOND
+    # reduce axis — the contraction — beside the statistic reduce (``S_ext_n_reduce_axis >= 2``).
+    # Without the discriminator the fused op would join a real ``rms_norm`` (or bare ``mlp_gate_up``
+    # matmul) golden even though it is a different kernel family; and its stamp's ``is_warp`` is
+    # unreliable (the f32 statistic constants flip ``S_dtype_f32`` on), so ``from_s_features``
+    # forces ``is_warp=True`` for the kind — a computed-A contraction is always a warp mma.
     kind: str = ""
     # The largest single static free extent (``S_ext_free_max`` / ``max(M, N)``) — the
     # ASPECT discriminator ``free_prod`` alone lacks: 32×8192 and 512×512 share the
@@ -96,21 +101,26 @@ class ShapeKey:
         ``S_loop_depth < n_free + n_reduce + n_symbolic`` (the projection sweep shares
         the reduce axis, so the loop nest is shallower than the axis count — matmul,
         bare reduce and pointwise are exactly equal); among sweeps, ``S_pw_rsqrt``
-        marks RMSNorm, ``S_pw_exp`` the softmax family, and ``S_n_free_loop >= 3``
+        marks the RMSNorm family, ``S_pw_exp`` the softmax family, and ``S_n_free_loop >= 3``
         (heads x rows x head_dim — histogram counts, so symbolic axes still count)
-        separates flash attention from row softmax. An unrecognized sweep keeps
+        separates flash attention from row softmax. Within the rsqrt family a SECOND reduce
+        axis (``S_ext_n_reduce_axis >= 2``) means the statistic reduce rides a CONTRACTION —
+        the computed-A ``"fused"`` megakernel (RMSNorm→linear / gate⊗up) — where a bare
+        RMSNorm has just the one statistic reduce. The fused op's ``is_warp`` is forced True:
+        it is a warp mma contraction, but its f32 statistic constants set ``S_dtype_f32``, so
+        the dtype-multiset signal would wrongly read scalar. An unrecognized sweep keeps
         ``""`` — conservative: it can only stop a cross-kind join, never invent one."""
         n_axes = s.get("S_ext_n_free_axis", 0) + s.get("S_ext_n_reduce_axis", 0) + s.get("S_ext_n_symbolic_axis", 0)
         kind = ""
         if 0 < s.get("S_loop_depth", 0) < n_axes:
             if s.get("S_pw_rsqrt", 0):
-                kind = "rms_norm"
+                kind = "fused" if s.get("S_ext_n_reduce_axis", 0) >= 2 else "rms_norm"
             elif s.get("S_pw_exp", 0):
                 kind = "flash" if s.get("S_n_free_loop", 0) >= 3 else "softmax"
         return cls(
             free_prod=int(s.get("S_ext_free_prod", 0)),
             reduce_max=int(s.get("S_ext_reduce_max", 0)),
-            is_warp=not s.get("S_dtype_f32", 0),
+            is_warp=kind == "fused" or not s.get("S_dtype_f32", 0),
             is_dyn=s.get("S_ext_n_symbolic_axis", 0) > 0,
             kind=kind,
             free_max=int(s.get("S_ext_free_max", 0)),

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -24,7 +24,8 @@ can read :data:`GOLDEN_CONFIGS` cheaply. The data lives as **per-GPU YAML files*
 under ``goldens/`` (e.g. ``goldens/rtx5090_sm120.yaml``): a ``gpu_name`` /
 ``compute_cap`` header plus a ``configs`` list, each tagged with a ``kernel``
 discriminator (``matmul`` / ``reduce`` / ``pointwise`` / ``rms_norm`` / ``softmax`` /
-``attention`` / ``norm_linear`` — the fused RMSNorm→linear computed-A megakernel). A GPU may carry more than
+``attention`` / ``norm_linear`` — the fused RMSNorm→linear computed-A megakernel — / ``mlp_geglu`` —
+its multi-channel gate⊗up→GeGLU sibling). A GPU may carry more than
 one file (a themed set such as ``rtx5090_sm120_gemma4.yaml`` beside the card's main
 file — same header, merged by the live-GPU ``(gpu_name, compute_cap)`` scoping).
 :func:`_load_goldens` concatenates every file into :data:`GOLDEN_CONFIGS`. The set is hand-maintained via
@@ -354,11 +355,10 @@ class NormLinearGoldenConfig(GoldenConfig):
     PyTorch's norm-then-matmul. Its ONLY realizable configs are the sync compute-fill tiles
     (``d1/d2/sync``, no ``d2/tma/ring``) — record the tuned twin's ``record_knobs`` verbatim.
 
-    The multi-channel gate⊗up (SwiGLU/GeGLU) megakernel shares this kind but is not reproducible
-    from a torch snippet (its two matmuls must share one RMSNorm output, which a torch expression
-    cannot express — a preamble ``xn = ...`` precomputes it to a constant, and inlining ``rms(x)``
-    twice traces two un-shared norms that never fork the computed-A). It is a separate deliverable
-    gated on a graph-builder snippet vehicle; this single-channel kind is what a torch snippet reaches."""
+    The multi-channel gate⊗up (SwiGLU/GeGLU) megakernel shares ``kind="fused"`` but is a distinct
+    snippet — see :class:`MlpGeGluGoldenConfig` (both matmuls must share ONE RMSNorm output, which a
+    lambda binding — ``(lambda r: f(r@Wg)*(r@Wu))(rms_norm(x))`` — expresses; a preamble ``xn = ...``
+    would precompute it to a constant and inlining ``rms(x)`` twice traces two un-shared norms)."""
 
     M: int
     H: int
@@ -392,6 +392,58 @@ class NormLinearGoldenConfig(GoldenConfig):
         from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
 
         free = self.N if self.dynamic else self.M * self.N
+        return ShapeKey(free_prod=free, reduce_max=self.H, is_warp=True, is_dyn=self.dynamic, kind="fused")
+
+
+@dataclass(frozen=True, kw_only=True)
+class MlpGeGluGoldenConfig(GoldenConfig):
+    """The fused RMSNorm→gate⊗up→GeGLU **multi-channel computed-A** megakernel:
+    ``gelu(rms_norm(x)·nw @ Wg) * (rms_norm(x)·nw @ Wu)`` in ONE mma kernel (``(M, H) → (M, inter)``).
+
+    The MLP hot kernel gemma-4 actually deploys (``k_linear_mean_reduce``): the gate and up matmuls
+    are ⊗-fold CHANNELS sharing ONE compute-filled A slab (one ldmatrix'd A fragment feeding per-fold
+    B slabs / C fragments), the per-row RMSNorm statistic rides the A cone as a ``sync`` compute-fill
+    prologue, and the GeGLU ⊗-combine rides the store's fragment epilogue. It shares
+    :class:`NormLinearGoldenConfig`'s ``kind="fused"`` (rsqrt + a second reduce axis) but keys on the
+    ``(M, inter)`` OUTPUT (``free_prod = M*inter``, reduce ``H``) — the geglu collapses the two channels
+    to one inter-wide output. The snippet binds the shared ``rms_norm`` via a lambda (a torch expression
+    cannot otherwise share it — a preamble precomputes, inlining duplicates). gemma-4 uses GeGLU
+    (tanh-approx gelu), not SwiGLU. The reference is torch's UNFUSED decomposition, so the ratio compares
+    emmy's one fused mma against PyTorch's norm→2 matmuls→gelu→multiply. Only the sync compute-fill tiles
+    realize (``d1/d2/sync``); record the tuned twin's ``record_knobs`` verbatim."""
+
+    M: int
+    H: int
+    inter: int
+    dtype: str = "fp16"  # a computed-A contraction is a warp mma (fp16/bf16)
+
+    def __post_init__(self):
+        self._require_dynamic_hint(self.M)
+
+    def dynamic_specs(self) -> list[str]:
+        return ["seq_len@x:0"] if self.dynamic else []
+
+    def snippet(self) -> str:
+        tdt = {"fp16": ",dtype=torch.float16", "bf16": ",dtype=torch.bfloat16", "fp32": ""}[self.dtype]
+        return (
+            f"wg = torch.randn({self.H},{self.inter}{tdt})\n"
+            f"wu = torch.randn({self.H},{self.inter}{tdt})\n"
+            f"nw = torch.randn({self.H}{tdt})\n"
+            f"x = torch.randn({self.M},{self.H}{tdt})\n"
+            f"(lambda r: F.gelu(r @ wg, approximate='tanh') * (r @ wu))(F.rms_norm(x,({self.H},),nw))"
+        )
+
+    def flops(self) -> float:
+        return 4.0 * self.M * self.inter * self.H  # two K-contractions (gate + up) of the shared A; norm/gelu extra
+
+    def shape_key(self):
+        """Keys the stamped multi-channel computed-A fused op (``kind="fused"``): the GeGLU output is
+        ``(M, inter)`` so ``free_prod = M*inter``, the reduce is the shared contraction extent ``H``;
+        the dynamic twin excludes the symbolic M. ``is_warp`` is always True (a computed-A contraction
+        is a warp mma — :meth:`ShapeKey.from_s_features` forces it for the kind)."""
+        from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
+
+        free = self.inter if self.dynamic else self.M * self.inter
         return ShapeKey(free_prod=free, reduce_max=self.H, is_warp=True, is_dyn=self.dynamic, kind="fused")
 
 
@@ -502,6 +554,7 @@ _KERNEL_CLASSES = {
     "pointwise": PointwiseGoldenConfig,
     "rms_norm": RmsNormGoldenConfig,
     "norm_linear": NormLinearGoldenConfig,
+    "mlp_geglu": MlpGeGluGoldenConfig,
     "softmax": SoftmaxGoldenConfig,
     "attention": AttentionGoldenConfig,
 }
@@ -513,7 +566,7 @@ def _load_goldens() -> list[GoldenConfig]:
     One file per GPU: a ``gpu_name`` / ``compute_cap`` header (stamped onto every
     config so it isn't repeated per entry) plus a ``configs`` list, each tagged with
     a ``kernel`` discriminator (``matmul`` / ``attention`` / ``softmax`` / ``reduce`` / ``rms_norm`` / ``norm_linear`` /
-    ``pointwise``) selecting the dataclass. All files are concatenated — a ``name`` may recur across GPUs.
+    ``mlp_geglu`` / ``pointwise``) selecting the dataclass. All files are concatenated — a ``name`` may recur across GPUs.
 
     NOTE: ``compute_cap`` does **not** uniquely identify a GPU — two different cards
     can share a capability (e.g. ``rtx5090_sm120.yaml`` and

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -25,7 +25,8 @@ under ``goldens/`` (e.g. ``goldens/rtx5090_sm120.yaml``): a ``gpu_name`` /
 ``compute_cap`` header plus a ``configs`` list, each tagged with a ``kernel``
 discriminator (``matmul`` / ``reduce`` / ``pointwise`` / ``rms_norm`` / ``softmax`` /
 ``attention`` / ``norm_linear`` — the fused RMSNorm→linear computed-A megakernel — / ``mlp_geglu`` —
-its multi-channel gate⊗up→GeGLU sibling). A GPU may carry more than
+its multi-channel gate⊗up→GeGLU sibling — / ``rope`` / ``embedding`` — the fork-nothing memory-bound
+regression anchors). A GPU may carry more than
 one file (a themed set such as ``rtx5090_sm120_gemma4.yaml`` beside the card's main
 file — same header, merged by the live-GPU ``(gpu_name, compute_cap)`` scoping).
 :func:`_load_goldens` concatenates every file into :data:`GOLDEN_CONFIGS`. The set is hand-maintained via
@@ -547,6 +548,86 @@ class AttentionGoldenConfig(GoldenConfig):
         )
 
 
+@dataclass(frozen=True, kw_only=True)
+class RopeGoldenConfig(GoldenConfig):
+    """Rotary position embedding apply — ``q*cos + rotate_half(q)*sin`` over ``(1, n_heads, seq,
+    head_dim)`` (the ``k_cat_slice_unsqueeze_pointwise`` kernel; ``rotate_half`` is ``cat(-q[…d/2:],
+    q[…:d/2])``). A pure **memory-bound pointwise map** (no reduce, no contraction) applied to q and k
+    every layer. It FORKS NOTHING — one coalesced elementwise config, so a golden cannot warm a cold
+    deploy (there is no misdeploy to fix); it is a REGRESSION ANCHOR for ``emmy eval golden`` (the
+    recorded latency vs torch eager catches a codegen slowdown). The reference is torch eager."""
+
+    n_heads: int
+    seq: int
+    head_dim: int
+    dtype: str = "fp16"
+
+    def __post_init__(self):
+        self._require_dynamic_hint(self.seq)
+
+    def dynamic_specs(self) -> list[str]:
+        return ["seq_len@q:2", "seq_len@cos:2", "seq_len@sin:2"] if self.dynamic else []
+
+    def snippet(self) -> str:
+        tdt = {"fp16": ",dtype=torch.float16", "bf16": ",dtype=torch.bfloat16", "fp32": ""}[self.dtype]
+        h = self.head_dim // 2
+        return (
+            f"cos = torch.randn(1,1,{self.seq},{self.head_dim}{tdt})\n"
+            f"sin = torch.randn(1,1,{self.seq},{self.head_dim}{tdt})\n"
+            f"q = torch.randn(1,{self.n_heads},{self.seq},{self.head_dim}{tdt})\n"
+            f"q*cos + torch.cat((-q[...,{h}:], q[...,:{h}]),dim=-1)*sin"
+        )
+
+    def flops(self) -> float:
+        return float(self.n_heads * self.seq * self.head_dim)  # one fused-multiply-add per element
+
+    def shape_key(self):
+        """Keys the stamped pointwise map (``kind=""``, ``reduce_max=0``): free = the output extents
+        (heads x seq x head_dim). The dynamic twin excludes the symbolic seq (``free_prod`` keeps
+        heads x head_dim, ``free_max`` normalizes to 0 like every non-plain / dynamic key)."""
+        from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
+
+        free = self.n_heads * self.head_dim if self.dynamic else self.n_heads * self.seq * self.head_dim
+        fm = 0 if self.dynamic else max(self.n_heads, self.seq, self.head_dim)
+        return ShapeKey(free_prod=free, reduce_max=0, is_warp=self.dtype != "fp32", is_dyn=self.dynamic, free_max=fm)
+
+
+@dataclass(frozen=True, kw_only=True)
+class EmbeddingGoldenConfig(GoldenConfig):
+    """Token embedding gather — ``embed_tokens[ids]`` over a ``(vocab, hidden)`` table (the
+    ``k_embedding`` kernel; ``F.embedding``). A pure **memory-bound gather** (one hidden-wide row copy
+    per token, no compute). Like :class:`RopeGoldenConfig` it FORKS NOTHING — a REGRESSION ANCHOR for
+    ``emmy eval golden``, not a deploy warmer. The reference is torch eager (``F.embedding``)."""
+
+    vocab: int
+    seq: int
+    hidden: int
+    dtype: str = "fp16"
+
+    def __post_init__(self):
+        self._require_dynamic_hint(self.seq)
+
+    def dynamic_specs(self) -> list[str]:
+        return ["seq_len@ids:1"] if self.dynamic else []
+
+    def snippet(self) -> str:
+        tdt = {"fp16": ",dtype=torch.float16", "bf16": ",dtype=torch.bfloat16", "fp32": ""}[self.dtype]
+        return f"ids = torch.randint(0,{self.vocab},(1,{self.seq}))\nw = torch.randn({self.vocab},{self.hidden}{tdt})\nF.embedding(ids, w)"
+
+    def flops(self) -> float:
+        return float(self.seq * self.hidden)  # one copy per gathered element (no arithmetic)
+
+    def shape_key(self):
+        """Keys the stamped gather (``kind=""``, ``reduce_max=0``): the output is ``(seq, hidden)`` so
+        ``free_prod = seq*hidden`` (the vocab is the indexed axis, not a free extent); the dynamic twin
+        excludes the symbolic seq."""
+        from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
+
+        free = self.hidden if self.dynamic else self.seq * self.hidden
+        fm = 0 if self.dynamic else max(self.seq, self.hidden)
+        return ShapeKey(free_prod=free, reduce_max=0, is_warp=self.dtype != "fp32", is_dyn=self.dynamic, free_max=fm)
+
+
 _GOLDENS_DIR = Path(__file__).parent / "goldens"
 _KERNEL_CLASSES = {
     "matmul": MatmulGoldenConfig,
@@ -555,6 +636,8 @@ _KERNEL_CLASSES = {
     "rms_norm": RmsNormGoldenConfig,
     "norm_linear": NormLinearGoldenConfig,
     "mlp_geglu": MlpGeGluGoldenConfig,
+    "rope": RopeGoldenConfig,
+    "embedding": EmbeddingGoldenConfig,
     "softmax": SoftmaxGoldenConfig,
     "attention": AttentionGoldenConfig,
 }
@@ -566,7 +649,8 @@ def _load_goldens() -> list[GoldenConfig]:
     One file per GPU: a ``gpu_name`` / ``compute_cap`` header (stamped onto every
     config so it isn't repeated per entry) plus a ``configs`` list, each tagged with
     a ``kernel`` discriminator (``matmul`` / ``attention`` / ``softmax`` / ``reduce`` / ``rms_norm`` / ``norm_linear`` /
-    ``mlp_geglu`` / ``pointwise``) selecting the dataclass. All files are concatenated — a ``name`` may recur across GPUs.
+    ``mlp_geglu`` / ``rope`` / ``embedding`` / ``pointwise``) selecting the dataclass. All files are concatenated — a
+    ``name`` may recur across GPUs.
 
     NOTE: ``compute_cap`` does **not** uniquely identify a GPU — two different cards
     can share a capability (e.g. ``rtx5090_sm120.yaml`` and

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -23,7 +23,8 @@ This module is import-light (no torch / cupy at module top) so passes and tests
 can read :data:`GOLDEN_CONFIGS` cheaply. The data lives as **per-GPU YAML files**
 under ``goldens/`` (e.g. ``goldens/rtx5090_sm120.yaml``): a ``gpu_name`` /
 ``compute_cap`` header plus a ``configs`` list, each tagged with a ``kernel``
-discriminator (``matmul`` / ``reduce`` / ``pointwise``). A GPU may carry more than
+discriminator (``matmul`` / ``reduce`` / ``pointwise`` / ``rms_norm`` / ``softmax`` /
+``attention`` / ``norm_linear`` — the fused RMSNorm→linear computed-A megakernel). A GPU may carry more than
 one file (a themed set such as ``rtx5090_sm120_gemma4.yaml`` beside the card's main
 file — same header, merged by the live-GPU ``(gpu_name, compute_cap)`` scoping).
 :func:`_load_goldens` concatenates every file into :data:`GOLDEN_CONFIGS`. The set is hand-maintained via
@@ -337,6 +338,64 @@ class RmsNormGoldenConfig(GoldenConfig):
 
 
 @dataclass(frozen=True, kw_only=True)
+class NormLinearGoldenConfig(GoldenConfig):
+    """A golden config for the fused RMSNorm→linear **computed-A** megakernel:
+    ``rms_norm(x, (H,))·nw @ W`` in ONE mma kernel (``(M, H) → (M, N)``).
+
+    This is the single-channel computed-A ``Contraction`` (``010_recognize``'s
+    ``bind_prologue_contraction`` merge): the per-row RMSNorm statistic rides the A cone as a
+    ``sync`` compute-fill prologue and the warp mma rows contract the scaled A against ``W`` — a
+    different kernel family than the bare ``mlp_gate_up`` matmul (which round-trips ``xn`` through
+    gmem) or a bare ``rms_norm`` sweep. It stamps LIKE an RMSNorm sweep (rsqrt, a sweep loop nest)
+    but with a SECOND reduce axis — the contraction — beside the statistic reduce, so its
+    :class:`ShapeKey` carries ``kind="fused"`` (``S_ext_n_reduce_axis >= 2``), keeping it off both
+    the ``rms_norm`` and the ``mlp_gate_up`` matmul goldens. The reference is torch's UNFUSED
+    decomposition (``F.rms_norm`` eager + ``@``), so the ratio compares emmy's one fused mma against
+    PyTorch's norm-then-matmul. Its ONLY realizable configs are the sync compute-fill tiles
+    (``d1/d2/sync``, no ``d2/tma/ring``) — record the tuned twin's ``record_knobs`` verbatim.
+
+    The multi-channel gate⊗up (SwiGLU/GeGLU) megakernel shares this kind but is not reproducible
+    from a torch snippet (its two matmuls must share one RMSNorm output, which a torch expression
+    cannot express — a preamble ``xn = ...`` precomputes it to a constant, and inlining ``rms(x)``
+    twice traces two un-shared norms that never fork the computed-A). It is a separate deliverable
+    gated on a graph-builder snippet vehicle; this single-channel kind is what a torch snippet reaches."""
+
+    M: int
+    H: int
+    N: int
+    dtype: str = "fp16"  # a computed-A contraction is a warp mma (fp16/bf16); fp32 has no fused form
+
+    def __post_init__(self):
+        self._require_dynamic_hint(self.M)
+
+    def dynamic_specs(self) -> list[str]:
+        return ["seq_len@x:0"] if self.dynamic else []
+
+    def snippet(self) -> str:
+        tdt = {"fp16": ",dtype=torch.float16", "bf16": ",dtype=torch.bfloat16", "fp32": ""}[self.dtype]
+        return (
+            f"nw = torch.randn({self.H}{tdt})\n"
+            f"w = torch.randn({self.H},{self.N}{tdt})\n"
+            f"x = torch.randn({self.M},{self.H}{tdt})\n"
+            f"F.rms_norm(x,({self.H},),nw) @ w"
+        )
+
+    def flops(self) -> float:
+        return 2.0 * self.M * self.N * self.H  # the contraction; the norm/rsqrt prologue is extra (stays an underestimate)
+
+    def shape_key(self):
+        """Keys the stamped computed-A fused op (``kind="fused"``): the output is ``(M, N)`` so
+        ``free_prod = M*N``, the reduce is the contraction extent ``H`` (the statistic reduce shares
+        ``H``); the dynamic twin excludes the symbolic M. ``is_warp`` is always True — a computed-A
+        contraction is a warp mma even though its f32 statistic constants would flip the stamp's
+        dtype signal (:meth:`ShapeKey.from_s_features` forces it for the kind)."""
+        from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
+
+        free = self.N if self.dynamic else self.M * self.N
+        return ShapeKey(free_prod=free, reduce_max=self.H, is_warp=True, is_dyn=self.dynamic, kind="fused")
+
+
+@dataclass(frozen=True, kw_only=True)
 class SoftmaxGoldenConfig(GoldenConfig):
     """Row-softmax ``(M, K) → (M, K)`` over the last axis (``torch.softmax(dim=-1)``).
 
@@ -442,6 +501,7 @@ _KERNEL_CLASSES = {
     "reduce": ReduceGoldenConfig,
     "pointwise": PointwiseGoldenConfig,
     "rms_norm": RmsNormGoldenConfig,
+    "norm_linear": NormLinearGoldenConfig,
     "softmax": SoftmaxGoldenConfig,
     "attention": AttentionGoldenConfig,
 }
@@ -452,8 +512,8 @@ def _load_goldens() -> list[GoldenConfig]:
 
     One file per GPU: a ``gpu_name`` / ``compute_cap`` header (stamped onto every
     config so it isn't repeated per entry) plus a ``configs`` list, each tagged with
-    a ``kernel`` discriminator (``matmul`` / ``attention`` / ``softmax`` / ``reduce`` / ``rms_norm`` / ``pointwise``) selecting the
-    dataclass. All files are concatenated — a ``name`` may recur across GPUs.
+    a ``kernel`` discriminator (``matmul`` / ``attention`` / ``softmax`` / ``reduce`` / ``rms_norm`` / ``norm_linear`` /
+    ``pointwise``) selecting the dataclass. All files are concatenated — a ``name`` may recur across GPUs.
 
     NOTE: ``compute_cap`` does **not** uniquely identify a GPU — two different cards
     can share a capability (e.g. ``rtx5090_sm120.yaml`` and

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -1007,3 +1007,28 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f2x2/k4', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: 'p1'}
     emmy_us: 1199.1
     cublas_us: 1208.2
+  # ---- memory-bound kernels (regression anchors) ------------------------------------------------
+  # These kernels FORK NOTHING — one coalesced elementwise / gather config, no tuning choice — so a
+  # golden cannot warm a cold deploy (there is no misdeploy to fix). They are REGRESSION ANCHORS for
+  # `emmy eval golden`: the recorded latency vs torch eager catches a future codegen slowdown. Seeded
+  # 2026-07-18. rope: q*cos + rotate_half(q)*sin over (1, 16, 512, 256) — emmy's fused apply beats
+  # eager 4.6x. embedding: the F.embedding gather over the 262144x3840 table — at eager parity (both
+  # DRAM-bound on the gathered rows). Knobs are empty (no schedule fork); the reference is torch eager.
+  - kernel: rope
+    name: gemma4_12b.rope.s512
+    n_heads: 16
+    seq: 512
+    head_dim: 256
+    dtype: 'fp16'
+    knobs: {}
+    emmy_us: 4.5
+    cublas_us: 20.5
+  - kernel: embedding
+    name: gemma4_12b.embedding.s512
+    vocab: 262144
+    seq: 512
+    hidden: 3840
+    dtype: 'fp16'
+    knobs: {}
+    emmy_us: 4.3
+    cublas_us: 4.1

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -957,3 +957,53 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x16/f2x2/k2', REDUCE: 'g8k', RASTER: '', STAGE: 'd2/sync', WSPEC: ''}
     emmy_us: 24.1
     cublas_us: 16.4
+  # norm→k/v projection (input_layernorm → k_proj/v_proj, N=2048): the other single-channel norm→linear
+  # prologue in the block (q/k/v all fuse the input norm; q is above). Narrower N than q_proj, so the
+  # un=8 tile wins (w1x16 over-splits the 2048 columns): w1x8/f2x2/k2 d2/sync g8k, 20.8 = 0.60x. Same
+  # cold-start-anchor rationale as norm_q_proj (the tuned decode splits it). fp16, torch eager reference.
+  # (o_proj / down_proj carry a norm EPILOGUE, not a prologue — a different fused structure the
+  # norm_linear kind does not model; gate/up is the MULTI-channel megakernel — see the coverage note.)
+  - kernel: norm_linear
+    name: gemma4_12b.norm_kv_proj.m32
+    M: 32
+    H: 3840
+    N: 2048
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f2x2/k2', REDUCE: 'g8k', RASTER: '', STAGE: 'd2/sync', WSPEC: ''}
+    emmy_us: 20.8
+    cublas_us: 12.5
+  # ---- fused RMSNorm→gate⊗up→GeGLU megakernel (computed-A / mlp_geglu kind) ----------------------
+  # The MLP hot kernel gemma-4 ACTUALLY deploys (k_linear_mean_reduce, the mul_4 twin): gate + up matmuls
+  # share ONE compute-filled A slab (product-monoid ⊗-fold channels), the pre-FF RMSNorm statistic rides
+  # the A cone as a sync prologue, and the GeGLU (tanh-approx gelu) ⊗-combine rides the store epilogue —
+  # output (M, inter). Seeded 2026-07-18 by manual --ab (decode M=32). Cold greedy misdeploys a
+  # w2x1/f2x8 d1/sync tile at 274 µs (0.58x eager); the golden pins w1x8/f2x2/k4 d1/sync g4k at 171.9 =
+  # 0.92x vs torch's UNFUSED decomposition (norm→2 matmuls→gelu→multiply, eager 158.2). Unlike the
+  # bare mlp_gate_up matmul golden (which round-trips the norm through gmem), this is the ONE fused
+  # kernel. fp16, torch eager reference. (The residual 0.08x is the large-M computed-A pipeline — the
+  # research-class async-B-staging lever, out of scope for coverage.)
+  - kernel: mlp_geglu
+    name: gemma4_12b.mlp_geglu.m32
+    M: 32
+    H: 3840
+    inter: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f2x2/k4', REDUCE: 'g4k', RASTER: '', STAGE: 'd1/sync', WSPEC: ''}
+    emmy_us: 171.9
+    cublas_us: 158.2
+  # ---- lm_head (the vocab logits projection) ----------------------------------------------------
+  # hidden 3840 → vocab 262144: the single LARGEST matmul in the model (2 GB fp16 weight, DRAM-bound),
+  # run per decode step. Seeded 2026-07-18 (manual --ab, decode M=32). Cold greedy MISDEPLOYS a scalar
+  # b256 tile at 299 ms (0.004x — a 248x disaster over an 8.4M-block grid); the golden pins the serial
+  # w1x8/f2x2/k4 d2/tma/ring form (WSPEC p1 auto-resolves on the TMA stage) at 1199 µs = 1.01x cuBLAS
+  # HGEMM (one kernel, no split-K finalize — the finalize over N=262144 costs more than the split
+  # recovers). torch.matmul fp16 (cuBLAS HGEMM) reference.
+  - kernel: matmul
+    name: gemma4_12b.lm_head.m32
+    M: 32
+    N: 262144
+    K: 3840
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f2x2/k4', REDUCE: '', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: 'p1'}
+    emmy_us: 1199.1
+    cublas_us: 1208.2

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -936,3 +936,24 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f2x2/k2', REDUCE: 'g8k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
     emmy_us: 74.1
     cublas_us: 77.1
+  # ---- fused RMSNorm→linear (computed-A / norm_linear kind) --------------------------------------
+  # The single-channel computed-A megakernel rms_norm(x)·nw @ Wq (kind="fused"): the per-row RMSNorm
+  # statistic rides the A cone as a sync compute-fill prologue and the warp mma contracts the scaled A
+  # against Wq (the k_rms_norm_matmul_reduce kernel; split-K partial + 1 µs finalize). Seeded 2026-07-17
+  # by manual pinned --ab (3x, <1% spread). This is a COLD-START ANCHOR, not a win: cold greedy on this
+  # unseeded shape mis-RANKS a w2x1/f2x2 d1/sync tile at 158.6 µs (0.10x eager) — the golden pins the
+  # tuned winner (w1x16/f2x2/k2 d2/sync g8k, 24.1) for a 6.6x cold-start rescue. It reads 0.68x vs torch's
+  # UNFUSED decomposition (rms_norm 6 + matmul 10, eager 16.4): the computed-A pipeline loses to the split
+  # at decode M here (why the TUNED gemma-4 decode splits norm→qkv into bare projections), and this entry
+  # anchors that loss so a future win is measurable. The wide-N decode winner is the un=16 tile added to
+  # _WARP_UNITS (thin-M / wide-N: 16 warps down the columns; +5% over un=8 on both q-proj and gate/up
+  # fused edges at M=32). fp16, torch eager (F.rms_norm + @) reference.
+  - kernel: norm_linear
+    name: gemma4_12b.norm_q_proj.m32
+    M: 32
+    H: 3840
+    N: 4096
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x16/f2x2/k2', REDUCE: 'g8k', RASTER: '', STAGE: 'd2/sync', WSPEC: ''}
+    emmy_us: 24.1
+    cublas_us: 16.4

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -337,7 +337,8 @@ def _warn_disjoint_evidence(index: dict[frozenset, list[tuple[dict, float, bool]
 
 def _golden_evidence_index(ctx: Context) -> dict:
     """The deploy card's recorded goldens — every kind: matmul, attention (flash), rms_norm, softmax,
-    reduce, pointwise, norm_linear / mlp_geglu (the fused RMSNorm→linear / gate⊗up computed-A) — grouped by
+    reduce, pointwise, norm_linear / mlp_geglu (the fused RMSNorm→linear / gate⊗up computed-A), and the
+    fork-nothing rope / embedding regression anchors (which never bind here — no fork) — grouped by
     :class:`~emmy.compiler.pipeline.search.data.shape.ShapeKey` (whose ``kind``
     discriminator keeps the sweep kinds apart from extent-coincident contractions)
     and sorted fastest-first — the verified-evidence tier a greedy compile consults

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -336,8 +336,8 @@ def _warn_disjoint_evidence(index: dict[frozenset, list[tuple[dict, float, bool]
 
 
 def _golden_evidence_index(ctx: Context) -> dict:
-    """The deploy card's recorded goldens — every kind: matmul, attention (flash),
-    rms_norm, softmax, reduce, pointwise, norm_linear (the fused RMSNorm→linear computed-A) — grouped by
+    """The deploy card's recorded goldens — every kind: matmul, attention (flash), rms_norm, softmax,
+    reduce, pointwise, norm_linear / mlp_geglu (the fused RMSNorm→linear / gate⊗up computed-A) — grouped by
     :class:`~emmy.compiler.pipeline.search.data.shape.ShapeKey` (whose ``kind``
     discriminator keeps the sweep kinds apart from extent-coincident contractions)
     and sorted fastest-first — the verified-evidence tier a greedy compile consults

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -337,7 +337,7 @@ def _warn_disjoint_evidence(index: dict[frozenset, list[tuple[dict, float, bool]
 
 def _golden_evidence_index(ctx: Context) -> dict:
     """The deploy card's recorded goldens — every kind: matmul, attention (flash),
-    rms_norm, softmax, reduce, pointwise — grouped by
+    rms_norm, softmax, reduce, pointwise, norm_linear (the fused RMSNorm→linear computed-A) — grouped by
     :class:`~emmy.compiler.pipeline.search.data.shape.ShapeKey` (whose ``kind``
     discriminator keeps the sweep kinds apart from extent-coincident contractions)
     and sorted fastest-first — the verified-evidence tier a greedy compile consults

--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -383,10 +383,26 @@ def scalar_tile_moves() -> list[str]:
 # register fragments × ``bk`` K-chunks, spelled ``a:<atom>/w..x../f..x../k..``. Bounded to shapes the
 # golden sweeps have deployed (``FM·FN ≤ 32`` C-fragment cells, shallow pipelined bk; ``(8, 2)`` and
 # ``(2, 8)`` are recorded golden winners on the RTX 4090 / PRO 6000 — the permanence test keeps them).
-# Per-node legality — the atom's operand dtype and the ``_check_warp_static_k`` K-divisibility —
-# is the scheduler's (``_schedule``), not the grid's.
+# ``(1, 16)`` is the thin-M / wide-N decode geometry (16 warps down the N axis, 1 down M — the same
+# 16-warp CTA as ``(8, 2)``): a decode-M computed-A (fused norm→linear) contraction wants its warps
+# spread across the wide output columns, and it beat the ``(1, 8)`` sibling ~5% on both the q-proj
+# (N=4096) and gate/up (N=15360) fused edges at M=32 (5090). Per-node legality — the atom's operand
+# dtype and the ``_check_warp_static_k`` K-divisibility — is the scheduler's (``_schedule``), not the grid's.
 # (WM, WN) / (FM, FN)
-_WARP_UNITS: tuple[tuple[int, int], ...] = ((1, 1), (2, 1), (1, 2), (2, 2), (4, 1), (1, 4), (2, 4), (4, 2), (4, 4), (1, 8), (8, 2))
+_WARP_UNITS: tuple[tuple[int, int], ...] = (
+    (1, 1),
+    (2, 1),
+    (1, 2),
+    (2, 2),
+    (4, 1),
+    (1, 4),
+    (2, 4),
+    (4, 2),
+    (4, 4),
+    (1, 8),
+    (8, 2),
+    (1, 16),
+)
 _WARP_REGS: tuple[tuple[int, int], ...] = ((1, 1), (2, 2), (1, 4), (4, 1), (2, 4), (4, 2), (4, 4), (4, 8), (2, 8))
 _WARP_BK: tuple[int, ...] = (1, 2, 4, 8)
 

--- a/tests/compiler/pipeline/search/test_golden_evidence_deploy.py
+++ b/tests/compiler/pipeline/search/test_golden_evidence_deploy.py
@@ -370,3 +370,70 @@ def test_cross_kind_isolation_via_the_kind_discriminator(monkeypatch):
         _ROW_GOLD, base={**_BASE, "S_ext_reduce_max": 512.0, "S_ext_n_free_axis": 2.0, "S_ext_n_reduce_axis": 1.0, "S_loop_depth": 3.0}
     )
     assert _golden_pick(a_index, mm_rows, "n0") is None
+
+
+# --- fused computed-A (norm_linear) kind ---------------------------------------------------------
+# Stamp base captured off the real deploy fork of ``F.rms_norm(x,(H,),nw) @ w`` (M32 x N4096, K3840):
+# a sweep (S_loop_depth 3 < n_free 2 + n_reduce 2) with rsqrt AND a SECOND reduce axis (the
+# contraction) -> kind="fused". S_dtype_f32 present (the real 12B model's f32 statistic constants):
+# is_warp is FORCED True for the kind (a computed-A contraction is a warp mma). The fork leaves are
+# axis-keyed TILE@a3 + STAGE@a3 + REDUCE@a3 over the ``sync`` compute-fill (d1/d2/sync, not tma/ring).
+
+from emmy.compiler.pipeline.search.golden import NormLinearGoldenConfig  # noqa: E402
+
+_FUSED_SIG = {
+    "S_ext_free_prod": 131072.0,
+    "S_ext_free_max": 4096.0,
+    "S_ext_reduce_max": 3840.0,
+    "S_ext_reduce_prod": 14745600.0,
+    "S_ext_n_free_axis": 2.0,
+    "S_ext_n_reduce_axis": 2.0,
+    "S_ext_n_symbolic_axis": 0.0,
+    "S_loop_depth": 3.0,
+    "S_pw_rsqrt": 1.0,
+    "S_dtype_f16": 6.0,
+    "S_dtype_f32": 2.0,
+    "H_opt": 3.0,
+}
+_FUSED_TILE = "a:mma_m16n8k16_f16_f32/w1x8/f2x2/k2"
+
+
+def _fused_row(tile, stage="d2/sync", reduce="g4k"):
+    return {**_FUSED_SIG, "TILE@a3": tile, "STAGE@a3": stage, "REDUCE@a3": reduce, "RASTER": ""}
+
+
+def _norm_linear(name="gemma4_12b.q_proj_fused", knobs=None, us=34.8):
+    return NormLinearGoldenConfig(
+        name=name,
+        M=32,
+        H=3840,
+        N=4096,
+        dtype="fp16",
+        knobs=knobs or {"TILE": _FUSED_TILE, "STAGE": "d2/sync", "REDUCE": "g4k", "RASTER": "", "WSPEC": ""},
+        emmy_us=us,
+        gpu_name=CARD,
+        compute_cap=CAP,
+    )
+
+
+def test_fused_golden_decides_its_op_over_a_warp_sibling(monkeypatch):
+    """The fused norm→linear golden decides its computed-A op: the recorded bare knobs match the
+    axis-keyed warp leaf (``TILE@a3`` etc.) over an offered sibling on a different tile."""
+    index = _index(monkeypatch, [_norm_linear()])
+    rows = [_fused_row("a:mma_m16n8k16_f16_f32/w1x1/f1x1", stage="d1/sync", reduce=""), _fused_row(_FUSED_TILE)]
+    assert _golden_pick(index, rows, "n0") == (1, 34.8)
+
+
+def test_fused_golden_never_crosses_rms_norm_or_matmul(monkeypatch):
+    """The fused key (``kind="fused"``) never joins a bare RMSNorm sweep nor a plain matmul, even at
+    coincident extents — the ``S_ext_n_reduce_axis>=2`` discriminator keeps the families apart."""
+    # A fused golden must not decide a bare rms_norm op (one reduce axis, kind="rms_norm").
+    index = _index(monkeypatch, [_norm_linear()])
+    rms_rows = [{**_RMS_SIG, "REDUCE@r0": "b256"}]
+    assert _golden_pick(index, rms_rows, "n0") is None
+    # A fused golden must not decide a plain matmul op (no rsqrt, kind="").
+    mm_rows = _rows(_ROW_GOLD)
+    assert _golden_pick(index, mm_rows, "n0") is None
+    # And a bare rms_norm golden must not decide the fused op.
+    rms_gold = RmsNormGoldenConfig(name="rms.k3840", M=512, K=3840, knobs={"REDUCE": "b256"}, emmy_us=6.3, gpu_name=CARD, compute_cap=CAP)
+    assert _golden_pick(_index(monkeypatch, [rms_gold]), [_fused_row(_FUSED_TILE)], "n0") is None

--- a/tests/compiler/pipeline/search/test_shape_key_kinds.py
+++ b/tests/compiler/pipeline/search/test_shape_key_kinds.py
@@ -13,6 +13,7 @@ from emmy.compiler.pipeline.search.data.shape import ShapeKey
 from emmy.compiler.pipeline.search.golden import (
     AttentionGoldenConfig,
     MatmulGoldenConfig,
+    MlpGeGluGoldenConfig,
     NormLinearGoldenConfig,
     PointwiseGoldenConfig,
     ReduceGoldenConfig,
@@ -29,6 +30,8 @@ _CASES = [
     RmsNormGoldenConfig(name="r.dyn", M=512, K=3840, knobs={}, dynamic=True),
     NormLinearGoldenConfig(name="nl", M=512, H=3840, N=4096, knobs={}),
     NormLinearGoldenConfig(name="nl.dyn", M=512, H=3840, N=4096, knobs={}, dynamic=True),
+    MlpGeGluGoldenConfig(name="ggu", M=512, H=3840, inter=15360, knobs={}),
+    MlpGeGluGoldenConfig(name="ggu.dyn", M=512, H=3840, inter=15360, knobs={}, dynamic=True),
     ReduceGoldenConfig(name="red", M=512, K=4096, knobs={}),
     SoftmaxGoldenConfig(name="s", M=512, K=4096, knobs={}),
     PointwiseGoldenConfig(name="p", M=512, N=4096, knobs={}),

--- a/tests/compiler/pipeline/search/test_shape_key_kinds.py
+++ b/tests/compiler/pipeline/search/test_shape_key_kinds.py
@@ -12,12 +12,14 @@ import pytest
 from emmy.compiler.pipeline.search.data.shape import ShapeKey
 from emmy.compiler.pipeline.search.golden import (
     AttentionGoldenConfig,
+    EmbeddingGoldenConfig,
     MatmulGoldenConfig,
     MlpGeGluGoldenConfig,
     NormLinearGoldenConfig,
     PointwiseGoldenConfig,
     ReduceGoldenConfig,
     RmsNormGoldenConfig,
+    RopeGoldenConfig,
     SoftmaxGoldenConfig,
 )
 
@@ -35,6 +37,8 @@ _CASES = [
     ReduceGoldenConfig(name="red", M=512, K=4096, knobs={}),
     SoftmaxGoldenConfig(name="s", M=512, K=4096, knobs={}),
     PointwiseGoldenConfig(name="p", M=512, N=4096, knobs={}),
+    RopeGoldenConfig(name="rope", n_heads=16, seq=512, head_dim=256, knobs={}),
+    EmbeddingGoldenConfig(name="emb", vocab=262144, seq=512, hidden=3840, knobs={}),
 ]
 
 

--- a/tests/compiler/pipeline/search/test_shape_key_kinds.py
+++ b/tests/compiler/pipeline/search/test_shape_key_kinds.py
@@ -13,6 +13,7 @@ from emmy.compiler.pipeline.search.data.shape import ShapeKey
 from emmy.compiler.pipeline.search.golden import (
     AttentionGoldenConfig,
     MatmulGoldenConfig,
+    NormLinearGoldenConfig,
     PointwiseGoldenConfig,
     ReduceGoldenConfig,
     RmsNormGoldenConfig,
@@ -26,6 +27,8 @@ _CASES = [
     AttentionGoldenConfig(name="a.dyn", n_heads=16, seq=512, head_dim=256, knobs={}, dynamic=True),
     RmsNormGoldenConfig(name="r", M=512, K=3840, knobs={}),
     RmsNormGoldenConfig(name="r.dyn", M=512, K=3840, knobs={}, dynamic=True),
+    NormLinearGoldenConfig(name="nl", M=512, H=3840, N=4096, knobs={}),
+    NormLinearGoldenConfig(name="nl.dyn", M=512, H=3840, N=4096, knobs={}, dynamic=True),
     ReduceGoldenConfig(name="red", M=512, K=4096, knobs={}),
     SoftmaxGoldenConfig(name="s", M=512, K=4096, knobs={}),
     PointwiseGoldenConfig(name="p", M=512, N=4096, knobs={}),
@@ -78,6 +81,20 @@ def test_free_max_splits_the_aspect_collision():
     assert ShapeKey(free_prod=1, reduce_max=1, is_warp=True, kind="flash", free_max=7).free_max == 0
 
 
+def test_fused_key_never_collides_with_rms_norm_or_matmul():
+    """The fused computed-A key (``kind="fused"``) must not equal a bare RMSNorm sweep nor a plain
+    ``mlp_gate_up`` matmul that happens to share extents — the ``kind`` discriminator keeps the
+    three kernel families apart at the golden↔op join."""
+    fused = NormLinearGoldenConfig(name="nl", M=512, H=3840, N=4096, knobs={}).shape_key()
+    assert fused.kind == "fused"
+    # A bare RMSNorm whose free product coincides (M*K == M*N) keys rms_norm, never fused.
+    rms = RmsNormGoldenConfig(name="r", M=512, K=4096, knobs={}).shape_key()
+    assert rms.kind == "rms_norm" and rms != fused
+    # A plain matmul of the same output/contraction extents keys "" (warp contraction), never fused.
+    mm = MatmulGoldenConfig(name="m", M=512, N=4096, K=3840, dtype="fp16", knobs={}).shape_key()
+    assert mm.kind == "" and mm != fused
+
+
 def test_attention_qk_contraction_never_joins_the_flash_golden():
     """The attention trace's OTHER stamped op — the QKᵀ contraction — keys as a plain
     contraction and must not equal the attention golden's flash key."""
@@ -113,6 +130,22 @@ def test_sweep_classifier_from_measured_stamps():
         "S_dtype_f32": 5.0,
     }
     assert ShapeKey.from_s_features(rms).kind == "rms_norm"
+    # The fused computed-A megakernel stamps LIKE rms_norm (rsqrt sweep) but with a SECOND reduce
+    # axis (the contraction). ``is_warp`` is forced True even though its f32 statistic constants set
+    # S_dtype_f32 (the dtype-multiset signal would wrongly read scalar for a warp mma).
+    fused = {
+        "S_ext_free_prod": 131072.0,
+        "S_ext_reduce_max": 3840.0,
+        "S_ext_n_free_axis": 2.0,
+        "S_ext_n_reduce_axis": 2.0,
+        "S_ext_n_symbolic_axis": 0.0,
+        "S_loop_depth": 3.0,
+        "S_pw_rsqrt": 1.0,
+        "S_dtype_f32": 2.0,
+        "S_dtype_f16": 6.0,
+    }
+    got = ShapeKey.from_s_features(fused)
+    assert got.kind == "fused" and got.is_warp is True
     softmax = {
         "S_ext_free_prod": 2097152.0,
         "S_ext_reduce_max": 4096.0,

--- a/tests/compiler/test_golden_configs.py
+++ b/tests/compiler/test_golden_configs.py
@@ -17,6 +17,7 @@ from emmy.compiler.pipeline.search.golden import (
     AttentionGoldenConfig,
     GoldenConfig,
     MatmulGoldenConfig,
+    MlpGeGluGoldenConfig,
     NormLinearGoldenConfig,
     PointwiseGoldenConfig,
     ReduceGoldenConfig,
@@ -65,6 +66,7 @@ def test_golden_configs_set_is_well_formed():
                 ReduceGoldenConfig,
                 RmsNormGoldenConfig,
                 NormLinearGoldenConfig,
+                MlpGeGluGoldenConfig,
                 SoftmaxGoldenConfig,
                 PointwiseGoldenConfig,
                 AttentionGoldenConfig,
@@ -76,6 +78,9 @@ def test_golden_configs_set_is_well_formed():
             # The fused RMSNorm→linear computed-A megakernel: a warp contraction (M,H)@(H,N), not the
             # reduce family — its REDUCE knob is a split-K (g4k), not a coop, so no coop>1 requirement.
             assert c.M > 0 and c.H > 0 and c.N > 0, c.name
+        elif isinstance(c, MlpGeGluGoldenConfig):
+            # The fused RMSNorm→gate⊗up→GeGLU multi-channel computed-A megakernel (M,H)→(M,inter).
+            assert c.M > 0 and c.H > 0 and c.inter > 0, c.name
         elif isinstance(c, (ReduceGoldenConfig, RmsNormGoldenConfig, SoftmaxGoldenConfig)):
             from emmy.compiler.ir.schedule import ReducePlan
 
@@ -343,6 +348,20 @@ def test_norm_linear_golden_snippet_shape_key_and_flops():
 
     with pytest.raises(ValueError, match="DEFAULT_SEQ_HINT"):
         NormLinearGoldenConfig(name="nl.bad", M=DEFAULT_SEQ_HINT + 1, H=3840, N=4096, dynamic=True)
+
+
+def test_mlp_geglu_golden_snippet_shape_key_and_flops():
+    """The fused RMSNorm→gate⊗up→GeGLU multi-channel golden: the lambda-bound shared-``r`` snippet,
+    ``kind="fused"`` keyed on the ``(M, inter)`` GeGLU output, and the dynamic twin excludes M."""
+    c = MlpGeGluGoldenConfig(name="ggu", M=32, H=3840, inter=15360, knobs={"TILE": "a:mma_m16n8k16_f16_f32/w1x8/f2x2/k4"})
+    snip = c.snippet()
+    assert "lambda r:" in snip and "F.rms_norm(x,(3840,),nw)" in snip and "approximate='tanh'" in snip
+    sk = c.shape_key()
+    assert (sk.free_prod, sk.reduce_max, sk.is_warp, sk.is_dyn, sk.kind) == (32 * 15360, 3840, True, False, "fused")
+    assert c.flops() == 4.0 * 32 * 15360 * 3840  # two shared-A contractions
+    dyn = MlpGeGluGoldenConfig(name="ggu.dynM", M=512, H=3840, inter=15360, dynamic=True, knobs={})
+    assert (dyn.shape_key().free_prod, dyn.shape_key().is_dyn) == (15360, True)  # symbolic M excluded
+    assert dyn.dynamic_specs() == ["seq_len@x:0"]
 
 
 def test_fast_math_regime_derived_from_knobs():

--- a/tests/compiler/test_golden_configs.py
+++ b/tests/compiler/test_golden_configs.py
@@ -15,6 +15,7 @@ from emmy.compiler.pipeline.search.golden import (
     _KERNEL_CLASSES,
     GOLDEN_CONFIGS,
     AttentionGoldenConfig,
+    EmbeddingGoldenConfig,
     GoldenConfig,
     MatmulGoldenConfig,
     MlpGeGluGoldenConfig,
@@ -22,6 +23,7 @@ from emmy.compiler.pipeline.search.golden import (
     PointwiseGoldenConfig,
     ReduceGoldenConfig,
     RmsNormGoldenConfig,
+    RopeGoldenConfig,
     SoftmaxGoldenConfig,
     _load_goldens,
     matmul_snippet,
@@ -67,11 +69,17 @@ def test_golden_configs_set_is_well_formed():
                 RmsNormGoldenConfig,
                 NormLinearGoldenConfig,
                 MlpGeGluGoldenConfig,
+                RopeGoldenConfig,
+                EmbeddingGoldenConfig,
                 SoftmaxGoldenConfig,
                 PointwiseGoldenConfig,
                 AttentionGoldenConfig,
             ),
         ), c.name
+        # The memory-bound anchors (rope / embedding) FORK NOTHING — one coalesced elementwise / gather
+        # config, so they record empty knobs and serve as ``eval golden`` regression anchors, not deploy
+        # warmers. Every other kind carries a scheduling knob set.
+        fork_nothing = isinstance(c, (RopeGoldenConfig, EmbeddingGoldenConfig))
         if isinstance(c, MatmulGoldenConfig):
             assert c.M > 0 and c.N > 0 and c.K > 0, c.name
         elif isinstance(c, NormLinearGoldenConfig):
@@ -81,6 +89,10 @@ def test_golden_configs_set_is_well_formed():
         elif isinstance(c, MlpGeGluGoldenConfig):
             # The fused RMSNorm→gate⊗up→GeGLU multi-channel computed-A megakernel (M,H)→(M,inter).
             assert c.M > 0 and c.H > 0 and c.inter > 0, c.name
+        elif isinstance(c, RopeGoldenConfig):
+            assert c.n_heads > 0 and c.seq > 0 and c.head_dim > 0, c.name
+        elif isinstance(c, EmbeddingGoldenConfig):
+            assert c.vocab > 0 and c.seq > 0 and c.hidden > 0, c.name
         elif isinstance(c, (ReduceGoldenConfig, RmsNormGoldenConfig, SoftmaxGoldenConfig)):
             from emmy.compiler.ir.schedule import ReducePlan
 
@@ -96,7 +108,7 @@ def test_golden_configs_set_is_well_formed():
         assert c.emmy_us > 0 and c.cublas_us > 0, c.name
         assert c.ratio >= 0.0, c.name
         assert c.golden == (c.ratio >= 0.95), c.name
-        assert c.knobs, f"{c.name} has no recorded knobs"
+        assert fork_nothing or c.knobs, f"{c.name} has no recorded knobs"
         assert c.snippet(), c.name
 
 

--- a/tests/compiler/test_golden_configs.py
+++ b/tests/compiler/test_golden_configs.py
@@ -17,6 +17,7 @@ from emmy.compiler.pipeline.search.golden import (
     AttentionGoldenConfig,
     GoldenConfig,
     MatmulGoldenConfig,
+    NormLinearGoldenConfig,
     PointwiseGoldenConfig,
     ReduceGoldenConfig,
     RmsNormGoldenConfig,
@@ -63,6 +64,7 @@ def test_golden_configs_set_is_well_formed():
                 MatmulGoldenConfig,
                 ReduceGoldenConfig,
                 RmsNormGoldenConfig,
+                NormLinearGoldenConfig,
                 SoftmaxGoldenConfig,
                 PointwiseGoldenConfig,
                 AttentionGoldenConfig,
@@ -70,6 +72,10 @@ def test_golden_configs_set_is_well_formed():
         ), c.name
         if isinstance(c, MatmulGoldenConfig):
             assert c.M > 0 and c.N > 0 and c.K > 0, c.name
+        elif isinstance(c, NormLinearGoldenConfig):
+            # The fused RMSNorm→linear computed-A megakernel: a warp contraction (M,H)@(H,N), not the
+            # reduce family — its REDUCE knob is a split-K (g4k), not a coop, so no coop>1 requirement.
+            assert c.M > 0 and c.H > 0 and c.N > 0, c.name
         elif isinstance(c, (ReduceGoldenConfig, RmsNormGoldenConfig, SoftmaxGoldenConfig)):
             from emmy.compiler.ir.schedule import ReducePlan
 
@@ -215,6 +221,7 @@ def test_dynamic_supported_for_all_kinds():
         RmsNormGoldenConfig(name="rms_norm.k2048.dynM", M=512, K=2048, dynamic=True),
         SoftmaxGoldenConfig(name="softmax.k2048.dynM", M=512, K=2048, dynamic=True),
         PointwiseGoldenConfig(name="pointwise.n4096.dynM", M=512, N=4096, dynamic=True),
+        NormLinearGoldenConfig(name="norm_linear.n4096.dynM", M=512, H=3840, N=4096, dynamic=True),
     ]
     assert all(c.dynamic_specs() == ["seq_len@x:0"] for c in one_input)
     att = AttentionGoldenConfig(name="attention.hd128.dynM", n_heads=8, seq=512, head_dim=128, dynamic=True)
@@ -314,6 +321,28 @@ def test_resolve_golden_arg_applies_dynamic_spec(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         cmod.resolve_golden_arg(clash)
     assert exc.value.code == 2
+
+
+def test_norm_linear_golden_snippet_shape_key_and_flops():
+    """The fused RMSNorm→linear computed-A golden: its snippet is the ``F.rms_norm(x)·nw @ w`` form
+    that traces to the megakernel, its shape_key carries ``kind="fused"`` with ``is_warp=True`` (a
+    computed-A contraction is a warp mma), and the dynamic twin excludes the symbolic M."""
+    c = NormLinearGoldenConfig(name="nl", M=32, H=3840, N=4096, knobs={"TILE": "a:mma_m16n8k16_f16_f32/w1x8/f2x2/k2"})
+    snip = c.snippet()
+    assert "F.rms_norm(x,(3840,),nw)" in snip and snip.strip().endswith("@ w")
+    assert "dtype=torch.float16" in snip  # fp16 default → warp mma
+    sk = c.shape_key()
+    assert (sk.free_prod, sk.reduce_max, sk.is_warp, sk.is_dyn, sk.kind) == (32 * 4096, 3840, True, False, "fused")
+    assert c.flops() == 2.0 * 32 * 4096 * 3840
+    dyn = NormLinearGoldenConfig(name="nl.dynM", M=512, H=3840, N=4096, dynamic=True, knobs={})
+    dsk = dyn.shape_key()
+    assert (dsk.free_prod, dsk.is_dyn, dsk.kind) == (4096, True, "fused")  # symbolic M excluded
+    assert dyn.dynamic_specs() == ["seq_len@x:0"]
+    # A dynamic golden's traced M must equal DEFAULT_SEQ_HINT (the axis is benched at the hint).
+    from emmy.compiler.dim import DEFAULT_SEQ_HINT
+
+    with pytest.raises(ValueError, match="DEFAULT_SEQ_HINT"):
+        NormLinearGoldenConfig(name="nl.bad", M=DEFAULT_SEQ_HINT + 1, H=3840, N=4096, dynamic=True)
 
 
 def test_fast_math_regime_derived_from_knobs():


### PR DESCRIPTION
## Summary

Two-part effort. First, a compiler correctness fix that gives the computed-A fused kernels a first-class golden identity; then a full sweep of gemma-4-12B's kernel set to seed every kernel that can misdeploy.

### Part 1 — `ShapeKey` `kind="fused"` (correctness)
The computed-A fused contraction (RMSNorm→linear / gate⊗up megakernel) was mis-classified as `kind="rms_norm"` at the golden↔op join, risking collisions with real rms_norm / `mlp_gate_up` matmul goldens. Now classified `kind="fused"`: within the rsqrt sweep family a **second reduce axis** (`S_ext_n_reduce_axis >= 2` — the contraction beside the statistic reduce) marks it, and `is_warp` is forced True (a warp mma whose f32 statistic constants would otherwise read scalar). The fused fork rows retain the full histogram, so no flash-style `_fork_shape_key` special-case is needed.

### Part 2 — golden coverage of gemma-4's kernel set
Swept the layer-0 + whole-model kernels and seeded every kernel that **forks** (can misdeploy):

| Golden | Kind | Result |
|---|---|---|
| `lm_head.m32` | matmul | vocab 262144 — the biggest kernel. **250× cold-start rescue** (299 ms scalar → 1199 µs, 1.01× cuBLAS) |
| `mlp_geglu.m32` | **mlp_geglu (new)** | fused RMSNorm→gate⊗up→GeGLU — the real MLP hot kernel, 0.91× (cold misdeploys at 0.58×) |
| `norm_q_proj.m32`, `norm_kv_proj.m32` | norm_linear | fused norm→qkv prologues, 0.6× cold anchors |

**`MlpGeGluGoldenConfig`** makes the multi-channel gate⊗up snippet-reproducible via a lambda that binds the shared RMSNorm output once (`(lambda r: gelu(r@Wg)*(r@Wu))(rms_norm(x))`), which a plain torch expression cannot express.

**`_WARP_UNITS += (1, 16)`** — the thin-M / wide-N decode warp tile (16 warps down the columns), +5% on the fused decode edges; lets the wide-N goldens record their tuned winner.

### Coverage findings (what does *not* need a golden)
- RoPE / slice / cat / unsqueeze / embedding-gather **fork nothing** (single-config memory-bound) → can't misdeploy → no golden needed.
- The o_proj / down_proj norm **epilogue** splits into a bare matmul + bare rms_norm (both already covered).
- **Residual:** the fused SDPA-tail + o_proj (`k_linear_sdpa_reduce`) reaches MMA but needs a dedicated attention→projection kind (research-class, known unrealizable-golden hazard).

### Verification
Full `make test` green (**2514 passed**), lint clean. Every seeded golden verified to bind cleanly (`emmy run --golden … --bench`, no drift warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)