### PR TITLE
Deterministic deploy picks: break score/µs ties by candidate content, not enumeration order

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -667,6 +667,15 @@ multi-channel gate⊗up→GeGLU sibling) are the snippet-reproducible computed-A
 mma kernel and share `kind="fused"`; the gate⊗up snippet binds its shared RMSNorm output via a lambda
 (`(lambda r: gelu(r@Wg)*(r@Wu))(rms_norm(x))`) since a torch expression cannot otherwise share it.
 
+**A matmul golden's layout must match the fork it is meant to decide.** `MatmulGoldenConfig.trans_b` spells the
+serving Linear layout — B given `(N, K)`, contracted as `x @ w.T` via an `F.linear` snippet. The traced contraction
+carries `b_trans`, and its enumeration offers **gmem-direct rows only** (staged transports decline transposed B), so
+a golden tuned on the canonical `(M,K) @ (K,N)` form can pin a staged config that never realizes against a served
+model's linear forks — every boot then logs the enumeration-drift warning and the fork falls to the cold model (the
+gemma-4 m16/dynM o_proj + mlp_down class behind the 5090 boot-flap ties). The two layouts share one ShapeKey on
+purpose: at a fork, an entry whose config the offer can't realize simply never matches, so a canonical entry (the
+harness/eval truth) and a `trans_b` entry (the serving truth) coexist under one shape, fastest-realizable-first.
+
 **Live-GPU scoping.** `tune --dataset golden` (and `--golden NAME` resolution) scopes to the **live** card's goldens
 (`goldens_for_live_gpu`) — names repeat across per-GPU golden files with diverging shapes/dtypes, so a flat union
 would tune another card's config under the live card's name. For `tune` the scoping is strict: a live card with no

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -318,6 +318,16 @@ one batched `predict`, invariant to the tree's level order. Cold, the `OfflinePr
 `MMA_tier` warp preference); option-0 (first leaf, emission order) only if `load_prior` returns nothing entirely.
 Greedy benches nothing, so it can only *use* a prior, never train one.
 
+**Every deploy pick breaks ties by candidate content, never enumeration order.** The model can score many
+same-featurized siblings identically (the offline `D_*` geometry doesn't separate an `f2x4` from an `f4x2` fragment or
+the `bk` variants — 8 exact ties at the gemma-4 m16 mlp_down/o_proj forks), and one measured row / one golden prefix
+can match several offered candidates. Every tier therefore resolves its ties through `knob.canonical_row_key` (the
+sorted tuning-knob rendering): the model argmin (`Prior.pick` and the greedy fallback), the reservoir and DB
+measured-evidence argmins, and the golden realization pick. An order-broken tie is a per-boot coin flip — leaf order
+can shift across processes — and shipped the 2026-07 RTX 5090 gemma-4 image with a bimodal boot-time cubin set.
+Pinned by `tests/compiler/pipeline/search/test_deploy_pick_determinism.py` (tier-level permutation invariance plus a
+cross-subprocess selected-kernel-set pin, the resolution twin of `test_source_determinism.py`).
+
 **Structural options are priced, never raw-scored.** With the trained prior loaded, `greedy_decide`'s
 `_pick_structural` prices each side of a structural fork: a nested `resolve` per kernel over a `lowering/tile`-only
 pipeline, the price being the `score` of the slice-resolve's partition-fork `Decision`, memoized per `op_cache_key`.

--- a/emmy/compiler/pipeline/knob.py
+++ b/emmy/compiler/pipeline/knob.py
@@ -578,6 +578,19 @@ def tuning_knob_items(knobs: dict) -> list[tuple[str, str]]:
     return sorted(rendered, key=lambda kv: knob_sort_key(kv[0]))
 
 
+def canonical_row_key(knobs: dict) -> tuple[tuple[str, str], ...]:
+    """Content-based ORDER over candidate knob rows — the :func:`tuning_knob_items`
+    view as a comparable tuple. Every deploy pick (model argmin, measured-evidence
+    argmin, golden realization) breaks score / µs ties with this key, so the selected
+    variant is a function of the candidates' CONTENT, never of their enumeration
+    order. Without it, a tie falls to whichever leaf a fork emitted first — an order
+    that can shift across processes — and the deployed kernel flips boot to boot (the
+    2026-07 gemma-4 5090 image's bimodal cubin set: the offline prior scored 8
+    same-featurized tiles identically at the drifted m16 forks, and emission order
+    chose among them)."""
+    return tuple(tuning_knob_items(knobs))
+
+
 def stamp_schedule_families(knobs: dict) -> dict[str, str]:
     """The ready-to-record knob map for one realized kernel: its tuning knobs
     (:func:`tuning_knob_items`) plus an explicit OFF value for every :data:`SCHEDULE_FAMILIES`

--- a/emmy/compiler/pipeline/search/data/sample.py
+++ b/emmy/compiler/pipeline/search/data/sample.py
@@ -51,7 +51,7 @@ def _split_by_prefix(knobs: dict) -> tuple[dict, dict, dict]:
 
 @lru_cache(maxsize=256)
 def compiled_s_features(
-    M: int, N: int, K: int, dtype: str, compute_cap: tuple[int, int], dynamic: tuple[str, ...] = ()
+    M: int, N: int, K: int, dtype: str, compute_cap: tuple[int, int], dynamic: tuple[str, ...] = (), trans_b: bool = False
 ) -> tuple[tuple[str, float], ...]:
     """The full ``S_*`` structural histogram for a matmul shape — by compiling its
     snippet to the loop dialect (where ``992_stamp_structural_features`` runs) and
@@ -69,7 +69,7 @@ def compiled_s_features(
     from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs  # noqa: PLC0415
 
     dynamic_shapes = build_torch_dynamic_shapes(parse_position_specs(list(dynamic))) if dynamic else None
-    graph, _, _ = graph_from_code(matmul_snippet(M, N, K, dtype), dynamic_shapes=dynamic_shapes)
+    graph, _, _ = graph_from_code(matmul_snippet(M, N, K, dtype, trans_b), dynamic_shapes=dynamic_shapes)
     compiled = Pipeline.build(LOOP_PASSES).run(graph)  # loop dialect — S_* stamped, no codegen
     s_feats: dict[str, float] = {}
     for n in compiled.nodes.values():
@@ -140,7 +140,7 @@ class Sample:
         tunable, _ctx, _s = _split_by_prefix(cfg.knobs)
         dyn_specs = tuple(cfg.dynamic_specs())
         s_full = (
-            dict(compiled_s_features(cfg.M, cfg.N, cfg.K, cfg.dtype, cfg.compute_cap, dyn_specs))
+            dict(compiled_s_features(cfg.M, cfg.N, cfg.K, cfg.dtype, cfg.compute_cap, dyn_specs, cfg.trans_b))
             if compile_s_feats and isinstance(cfg, MatmulGoldenConfig)
             else None
         )

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -64,7 +64,7 @@ QWEN3_06B_Q_DIM = 2048  # fused Q-projection output (16 heads * 128)
 QWEN3_06B_KV_DIM = 1024  # fused K/V-projection output (8 heads * 128)
 
 
-def matmul_snippet(M: int, N: int, K: int, dtype: str = "fp32") -> str:
+def matmul_snippet(M: int, N: int, K: int, dtype: str = "fp32", trans_b: bool = False) -> str:
     """The torch expression a matmul golden config tunes / benches / reproduces.
 
     Single source of truth: the autotune / repro paths feed this to
@@ -72,10 +72,22 @@ def matmul_snippet(M: int, N: int, K: int, dtype: str = "fp32") -> str:
     config reproduces from the same call. fp32 is ``torch.randn``'s default, so
     no dtype kwarg is emitted for fp32 — matching the canonical example
     ``torch.matmul(torch.randn(2048,2048), torch.randn(2048,2048))``.
-    """
+
+    ``trans_b`` spells the **serving Linear layout** — B given ``(N, K)``,
+    contracted as ``x @ w.T`` via ``F.linear``. The traced contraction carries
+    ``b_trans``, whose enumeration offers NO staged (``d*/tma*`` / ``d*/cp*``)
+    rows (the B-slab fill would issue row-crossing copies — the schedule
+    declines), so a golden tuned on the canonical ``(M,K) @ (K,N)`` form can
+    pin a staged config that NEVER realizes against a served model's linear
+    forks (the gemma-4 m16/dynM o_proj + mlp_down drift-warning class). A
+    golden meant to decide a serving fork must be tuned on this layout."""
     if dtype == "fp32":
+        if trans_b:
+            return f"torch.nn.functional.linear(torch.randn({M},{K}), torch.randn({N},{K}))"
         return f"torch.matmul(torch.randn({M},{K}), torch.randn({K},{N}))"
     tdt = {"fp16": "torch.float16", "bf16": "torch.bfloat16"}[dtype]
+    if trans_b:
+        return f"torch.nn.functional.linear(torch.randn({M},{K},dtype={tdt}), torch.randn({N},{K},dtype={tdt}))"
     return f"torch.matmul(torch.randn({M},{K},dtype={tdt}), torch.randn({K},{N},dtype={tdt}))"
 
 
@@ -207,13 +219,20 @@ class MatmulGoldenConfig(GoldenConfig):
     N: int
     K: int
     dtype: str = "fp32"
+    # The serving Linear layout: B given (N, K), contracted as ``x @ w.T`` (``F.linear``).
+    # Its fork offers gmem-direct rows ONLY (staged transports decline transposed B), so a
+    # golden meant to decide a served model's linear fork must be tuned with this on — a
+    # canonical-B tuning records staged configs that never realize there (see
+    # ``matmul_snippet``). Same ShapeKey either way: at the fork, an unrealizable entry
+    # simply never matches, so layout twins coexist under one shape.
+    trans_b: bool = False
 
     def __post_init__(self):
         self._require_dynamic_hint(self.M)
 
     def snippet(self) -> str:
         """The torch expression this config tunes / benches / reproduces."""
-        return matmul_snippet(self.M, self.N, self.K, self.dtype)
+        return matmul_snippet(self.M, self.N, self.K, self.dtype, self.trans_b)
 
     def shape_key(self):
         """This config's :class:`~emmy.compiler.pipeline.search.data.ShapeKey` —

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -936,6 +936,82 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x8/f2x2/k2', REDUCE: 'g8k', RASTER: '', STAGE: 'd2/tma/ring', WSPEC: ''}
     emmy_us: 74.1
     cublas_us: 77.1
+  # ---- serving Linear layout (trans_b) twins: o_proj / mlp_down at decode m16 + dynM -------------
+  # The serving-traced decode/symbolic twins contract a TRANSPOSED B (F.linear; the weight transpose
+  # survives the trace), and that fork offers gmem-direct rows ONLY — the canonical entries above pin
+  # d2/tma/ring staging, which never realizes there, so every serve boot logged the enumeration-drift
+  # warning and the forks fell to the cold offline model (whose 8-way score ties were the 2026-07 boot
+  # flap; see the deploy-pick canonical tiebreak). These trans_b entries are the SERVING truth for the
+  # same ShapeKeys: tuned on the F.linear snippet (emmy tune -c, fresh DB/prior) and A/B'd 3x at -O3
+  # on a vast.ai RTX 5090 (2026-07-18, <1% spread), matching the serving offer exactly — the golden
+  # tier now decides these forks deterministically. COLD-START ANCHORS, not wins: the transposed-B
+  # gmem-direct form loses to cuBLAS (0.36-0.77x eager; the canonical staged twins read 0.9-1.0x),
+  # and the K=15360 mlp_down decode row pays the most (233.8 vs 85 eager). Recording the loss makes
+  # the staged-transposed-B (or layout-canonicalizing) follow-up measurable. q/kv/gate-up decode forms
+  # ride the fused computed-A kinds (norm_linear / mlp_geglu) — no bare-matmul twin needed there.
+  - kernel: matmul
+    name: gemma4_12b.o_proj.m16.lin
+    M: 16
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x1/f4x2/k4', REDUCE: 'g2k', RASTER: '', STAGE: '', WSPEC: ''}
+    emmy_us: 21.4
+    cublas_us: 14.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj_global.m16.lin
+    M: 16
+    N: 3840
+    K: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x1/f4x8/k8', REDUCE: 'g8k', RASTER: '', STAGE: '', WSPEC: ''}
+    emmy_us: 37.6
+    cublas_us: 29.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.m16.lin
+    M: 16
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x1/f4x8', REDUCE: 'g8k', RASTER: '', STAGE: '', WSPEC: ''}
+    emmy_us: 233.8
+    cublas_us: 85.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj.dynM.lin
+    M: 512
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    dynamic: true
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x1/f4x8', REDUCE: '', RASTER: '', STAGE: '', WSPEC: ''}
+    emmy_us: 198.5
+    cublas_us: 97.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj_global.dynM.lin
+    M: 512
+    N: 3840
+    K: 8192
+    dtype: 'fp16'
+    dynamic: true
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x1/f4x8/k4', REDUCE: 'g8k', RASTER: '', STAGE: '', WSPEC: ''}
+    emmy_us: 306.1
+    cublas_us: 159.0
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.dynM.lin
+    M: 512
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    dynamic: true
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x2/f4x8/k2', REDUCE: 'g8k', RASTER: '', STAGE: '', WSPEC: ''}
+    emmy_us: 596.9
+    cublas_us: 295.0
   # ---- fused RMSNorm→linear (computed-A / norm_linear kind) --------------------------------------
   # The single-channel computed-A megakernel rms_norm(x)·nw @ Wq (kind="fused"): the per-row RMSNorm
   # statistic rides the A cone as a sync compute-fill prologue and the warp mma contracts the scaled A

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -262,7 +262,9 @@ def _db_measured_index(db, ctx) -> dict[frozenset, list[tuple[dict, float, bool]
     try:
         o1_key = replace(ctx, compile_flags=_TUNE_RANKING_FLAGS).structural_key()
         keys = {ctx.structural_key(), o1_key, replace(ctx, compile_flags=O3_NVCC_FLAGS).structural_key()}
-        for ck in keys:
+        # Sorted — set iteration order is per-process (hash-seeded), and the index's
+        # per-signature row order must not vary across boots (ties resolve through it).
+        for ck in sorted(keys):
             for row in db.iter_perf(ck, backend="cuda"):
                 if row.status != "ok" or row.stats.median <= 0:
                     continue
@@ -295,6 +297,13 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
     tune *measured* fastest from losing the deploy to an unmeasured model
     extrapolation (eighth golden sweep, finding 2). -O3 reservoir evidence,
     where present, still takes precedence at the call site."""
+    from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+
+    def better(us: float, i: int, cur: tuple[int, float] | None) -> bool:
+        # Tie on µs (one measured row matching several candidates) breaks by the
+        # candidates' canonical content, never their enumeration order.
+        return cur is None or us < cur[1] or (us == cur[1] and canonical_row_key(rows[i]) < canonical_row_key(rows[cur[0]]))
+
     best: tuple[int, float] | None = None  # deployable lane
     best_rank: tuple[int, float] | None = None  # -O1 ranking-lane fallback
     for i, cand in enumerate(rows):
@@ -305,9 +314,9 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
                 if any(k in row_tun and row_tun[k] != v for k, v in cand_tun.items()):
                     continue
                 if deployable:
-                    if best is None or us < best[1]:
+                    if better(us, i, best):
                         best = (i, us)
-                elif best_rank is None or us < best_rank[1]:
+                elif better(us, i, best_rank):
                     best_rank = (i, us)
     return best if best is not None else best_rank
 
@@ -445,7 +454,7 @@ def _golden_pick(index: dict, rows: list[dict], node_id: str) -> tuple[int, floa
     match with NO realizable golden logs a loud drift warning (the enumeration no
     longer offers what the golden recorded) and falls through to the normal
     hierarchy. Returns ``(candidate_index, recorded_µs)`` or ``None``."""
-    from emmy.compiler.pipeline.knob import tuning_knob_items  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import canonical_row_key, tuning_knob_items  # noqa: PLC0415
     from emmy.compiler.pipeline.search.prior.base import _O3_OPT  # noqa: PLC0415
 
     if not rows or float(rows[0].get("H_opt", _O3_OPT)) != _O3_OPT:
@@ -455,9 +464,12 @@ def _golden_pick(index: dict, rows: list[dict], node_id: str) -> tuple[int, floa
         return None
     for g in goldens:  # fastest recorded entry first
         gold = dict(tuning_knob_items(g.knobs))
-        for i, row in enumerate(rows):
-            if _golden_matches_row(gold, row):
-                return i, float(g.emmy_us or 0.0)
+        # Several rows can realize one golden (a golden pins a knob PREFIX); the
+        # canonically-smallest realization wins, never the first-enumerated.
+        matches = [i for i, row in enumerate(rows) if _golden_matches_row(gold, row)]
+        if matches:
+            best = min(matches, key=lambda i: canonical_row_key(rows[i]))
+            return best, float(g.emmy_us or 0.0)
     logger.warning(
         "deploy: node %r matches golden shape %s (%d recorded entr%s), but no offered candidate realizes any of "
         "them — the golden(s) no longer realize under the current enumeration; falling through to the normal "
@@ -595,8 +607,10 @@ def greedy_decide(
         elif got is not None:  # golden decides even for bare-mean_scores priors
             best_i, price = got
         else:  # bare-mean_scores prior object (tests / custom callers)
+            from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+
             scores = the_prior.mean_scores(rows)
-            best_i = min(range(len(live)), key=scores.__getitem__)
+            best_i = min(range(len(live)), key=lambda i: (scores[i], canonical_row_key(rows[i])))
             price = scores[best_i]
         fp.score = price  # measured µs when evidence decided, predicted µs otherwise
         return live[best_i][0]

--- a/emmy/compiler/pipeline/search/prior/base.py
+++ b/emmy/compiler/pipeline/search/prior/base.py
@@ -222,6 +222,8 @@ class Prior(ABC):
         index = self._o3_evidence()
         if not index:
             return None
+        from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+
         best: tuple[int, float] | None = None
         for i, cand in enumerate(rows):
             sig = frozenset((k, v) for k, v in cand.items() if k.startswith("S_"))
@@ -230,20 +232,27 @@ class Prior(ABC):
                 for row_tun, us in measured:
                     if any(k in row_tun and row_tun[k] != v for k, v in cand_tun.items()):
                         continue
-                    if best is None or us < best[1]:
+                    # Tie on µs (one measured row matching several candidates) breaks by
+                    # the candidates' canonical content, never their enumeration order.
+                    if best is None or us < best[1] or (us == best[1] and canonical_row_key(cand) < canonical_row_key(rows[best[0]])):
                         best = (i, us)
         return best
 
     def pick(self, rows: list[dict]) -> tuple[int, float]:
         """The deploy argmin: measured -O3 evidence first (:meth:`evidence_pick`),
         the model's :meth:`mean_scores` argmin when no candidate has evidence.
+        Score ties break by :func:`~emmy.compiler.pipeline.knob.canonical_row_key`
+        (candidate content, never enumeration order — same-featurized siblings score
+        identically, and an order-broken tie flips the deployed kernel per boot).
         Returns ``(index, µs)`` — measured when evidence decided, predicted
         otherwise."""
         ev = self.evidence_pick(rows)
         if ev is not None:
             return ev
+        from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+
         scores = self.mean_scores(rows)
-        best_i = min(range(len(scores)), key=scores.__getitem__)
+        best_i = min(range(len(scores)), key=lambda i: (scores[i], canonical_row_key(rows[i])))
         return best_i, scores[best_i]
 
     # --- dataset + batched refit ------------------------------------------

--- a/emmy/compiler/pipeline/search/prior/fallback.py
+++ b/emmy/compiler/pipeline/search/prior/fallback.py
@@ -124,8 +124,12 @@ class FallbackPrior(Prior):
         ev = self.online.evidence_pick(rows)
         if ev is not None:
             return ev
+        from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+
+        # Score ties break by candidate content (``canonical_row_key``), never by
+        # enumeration order — see ``Prior.pick``.
         scores = self.mean_scores(rows)
-        best_i = min(range(len(scores)), key=scores.__getitem__)
+        best_i = min(range(len(scores)), key=lambda i: (scores[i], canonical_row_key(rows[i])))
         return best_i, scores[best_i]
 
     # --- training + inspection: delegate to the online half ------------------

--- a/tests/compiler/pipeline/search/test_deploy_pick_determinism.py
+++ b/tests/compiler/pipeline/search/test_deploy_pick_determinism.py
@@ -1,0 +1,166 @@
+"""Deploy-pick determinism — the fork RESOLUTION twin of
+``tests/compiler/backend/test_source_determinism.py`` (which pins the rendered bytes).
+
+A deploy pick must be a function of the candidates' CONTENT, never of their
+enumeration order: the offline prior can score many same-featurized siblings
+identically (8 exact ties at the gemma-4 m16 mlp_down / o_proj forks, where the
+recorded goldens don't realize against the serving trace), and an order-broken tie
+flips the deployed kernel whenever leaf order shifts across processes — the 2026-07
+RTX 5090 gemma-4 image's bimodal boot-time cubin set. Two layers of pinning:
+
+1. Unit: every pick tier (model argmin, measured-evidence argmin, golden
+   realization) selects the same CONTENT under any permutation of the candidate rows.
+2. Subprocess: two fresh-interpreter greedy compiles of a serving-shape graph (fresh
+   hash seed + address space, CUDA hidden, deployable -O3 regime, 5090 golden card)
+   produce the identical SELECTED kernel set — knobs and source bytes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from emmy.compiler.pipeline.search.policy import greedy as greedy_mod
+from emmy.compiler.pipeline.search.prior.base import Prior
+
+
+class _ConstPrior(Prior):
+    """Every candidate scores identically — the pick must fall to the canonical
+    content tiebreak, so any order dependence shows immediately."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @property
+    def fitted(self) -> bool:
+        return True
+
+    def fit(self) -> None:  # pragma: no cover — never trained
+        pass
+
+    def score(self, knobs: dict) -> float:
+        return 1.0
+
+    def mean_score(self, knobs: dict) -> float:
+        return 1.0
+
+
+def _rows() -> list[dict]:
+    base = {"H_opt": 3.0, "S_ext_k": "512"}
+    tiles = [
+        "a:mma_m16n8k16_f16_f32/w1x1/f2x4",
+        "a:mma_m16n8k16_f16_f32/w1x1/f4x2",
+        "a:mma_m16n8k16_f16_f32/w1x1/f2x4/k2",
+        "a:mma_m16n8k16_f16_f32/w1x1/f4x2/k2",
+    ]
+    return [{**base, "TILE@k": t, "REDUCE@k": r, "STAGE@k": "", "RASTER": "", "WSPEC": ""} for t in tiles for r in ("", "g2k")]
+
+
+def _selected(pick: tuple[int, float] | None, rows: list[dict]):
+    assert pick is not None
+    return {k: v for k, v in rows[pick[0]].items() if not k.startswith(("S_", "H_"))}
+
+
+def test_model_argmin_is_order_invariant():
+    prior = _ConstPrior()
+    rows = _rows()
+    want = _selected(prior.pick(rows), rows)
+    for perm in (rows[::-1], rows[3:] + rows[:3]):
+        assert _selected(prior.pick(perm), perm) == want
+
+
+def test_evidence_pick_tie_is_order_invariant():
+    prior = _ConstPrior()
+    rows = _rows()
+    # One measured row that matches EVERY candidate (records no tunable knob) — all
+    # candidates tie at its µs, so only the canonical tiebreak can decide.
+    prior.add_rows([({"H_opt": 3.0, "S_ext_k": "512"}, 12.5)])
+    want = _selected(prior.evidence_pick(rows), rows)
+    assert _selected(prior.evidence_pick(rows[::-1]), rows[::-1]) == want
+
+
+def test_db_measured_pick_tie_is_order_invariant():
+    rows = _rows()
+    sig = frozenset({("S_ext_k", "512")})
+    index = {sig: [({}, 33.0, True)]}  # matches every candidate at one µs — a full tie
+    rows_fwd, rows_rev = rows, rows[::-1]
+    a = _selected(greedy_mod._db_measured_pick(index, rows_fwd), rows_fwd)
+    b = _selected(greedy_mod._db_measured_pick(index, rows_rev), rows_rev)
+    assert a == b
+
+
+# --- subprocess pin: the SELECTED kernel set across fresh interpreters -------------
+
+_SNIPPET = """
+import hashlib
+import os
+
+os.environ["EMMY_ONLINE_FILE"] = "/nonexistent/online.json"
+os.environ["EMMY_TUNE_DB"] = "/nonexistent/autotune.db"
+os.environ["EMMY_NVCC_FLAGS"] = ""  # deployable -O3 regime — the golden tier's guard
+
+from emmy.compiler import dtype as _dt
+from emmy.compiler.context import Context
+from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.frontend.ir import LinearOp, RmsNormOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp
+from emmy.compiler.pipeline import CUDA_PASSES, Pipeline
+from emmy.compiler.pipeline.knob import tuning_knob_items
+
+F16 = _dt.get("f16")
+
+# The gemma-4-12B decode-twin shapes whose deploy flapped on the 5090 image: the m16
+# mlp_down matmul (8-way offline-prior tie behind a drifted golden) and the fused
+# norm->gate/up->GeGLU cone (the multi-channel computed-A fork from #389).
+def mlp_down(m=16, n=3840, k=15360):
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("a", (1, m, k), F16), node_id="a")
+    g.add_node(InputOp(), [], Tensor("w", (n, k), F16), node_id="w")
+    g.add_node(LinearOp(), ["a", "w"], Tensor("o", (1, m, n), F16), node_id="o")
+    g.inputs, g.outputs = ["a", "w"], ["o"]
+    return g
+
+def geglu(m=16, h=3840, inter=15360):
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (1, m, h), F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("nw", (h,), F16), node_id="nw")
+    g.add_node(InputOp(), [], Tensor("wg", (inter, h), F16), node_id="wg")
+    g.add_node(InputOp(), [], Tensor("wu", (inter, h), F16), node_id="wu")
+    g.add_node(RmsNormOp(eps=1e-6), ["x", "nw"], Tensor("xn", (1, m, h), F16), node_id="xn")
+    g.add_node(LinearOp(), ["xn", "wg"], Tensor("gate", (1, m, inter), F16), node_id="gate")
+    g.add_node(LinearOp(), ["xn", "wu"], Tensor("up", (1, m, inter), F16), node_id="up")
+    g.add_node(ElementwiseOp("gelu"), ["gate"], Tensor("sg", (1, m, inter), F16), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, m, inter), F16), node_id="o")
+    g.inputs, g.outputs = ["x", "nw", "wg", "wu"], ["o"]
+    return g
+
+ctx = Context.from_target((12, 0), gpu_name="NVIDIA GeForce RTX 5090")
+pipe = Pipeline.build(CUDA_PASSES)
+for name, g in (("mlp_down.m16", mlp_down()), ("mlp_geglu.m16", geglu())):
+    terminal = pipe.run(g, ctx=ctx)
+    for nid, node in sorted(terminal.nodes.items()):
+        src = getattr(node.op, "kernel_source", None)
+        if not src:
+            continue
+        knobs = ",".join(f"{k}={v}" for k, v in tuning_knob_items(getattr(node.op, "knobs", {}) or {}))
+        print(name, nid, hashlib.sha1(src.encode()).hexdigest(), f"[{knobs}]")
+"""
+
+
+def _resolve_once(tag: str) -> str:
+    import os
+
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = ""
+    env.pop("PYTHONHASHSEED", None)  # each subprocess gets its own hash seed — the point
+    out = subprocess.run([sys.executable, "-c", _SNIPPET], capture_output=True, text=True, env=env, timeout=600)
+    assert out.returncode == 0, f"resolve {tag} failed: {out.stderr[-800:]}"
+    return out.stdout
+
+
+def test_selected_kernel_set_identical_across_processes():
+    a = _resolve_once("a")
+    b = _resolve_once("b")
+    assert a.strip(), "no kernels selected — the serving-shape resolve is broken, repick the graphs"
+    assert a == b, f"selected kernel set differs across processes (boot-to-boot deploy flap):\n--- a\n{a}\n--- b\n{b}"

--- a/tests/compiler/test_golden_configs.py
+++ b/tests/compiler/test_golden_configs.py
@@ -40,6 +40,28 @@ def test_matmul_snippet_typed():
     assert "dtype=torch.float16" in matmul_snippet(128, 128, 128, "fp16")
 
 
+def test_matmul_snippet_trans_b_spells_linear_layout():
+    # The serving Linear layout: B given (N, K), contracted as x @ w.T via F.linear —
+    # its traced fork offers gmem-direct rows only (staged transports decline
+    # transposed B), so a golden meant to decide a serving linear fork must be tuned
+    # on this spelling, not the canonical (M,K) @ (K,N).
+    assert matmul_snippet(16, 3840, 15360, "fp16", trans_b=True) == (
+        "torch.nn.functional.linear(torch.randn(16,15360,dtype=torch.float16), torch.randn(3840,15360,dtype=torch.float16))"
+    )
+    assert matmul_snippet(32, 64, 128, trans_b=True) == "torch.nn.functional.linear(torch.randn(32,128), torch.randn(64,128))"
+
+
+def test_trans_b_golden_snippet_and_shape_key():
+    # A trans_b config reproduces through its own snippet and shares the layout-blind
+    # ShapeKey with its canonical twin — at a fork, an entry whose config the offer
+    # can't realize simply never matches, so layout twins coexist under one shape.
+    c = MatmulGoldenConfig(name="mlp_down.m16.lin", M=16, N=3840, K=15360, dtype="fp16", trans_b=True)
+    assert "functional.linear" in c.snippet()
+    assert c.snippet() in c.repro_command()
+    twin = MatmulGoldenConfig(name="mlp_down.m16", M=16, N=3840, K=15360, dtype="fp16")
+    assert c.shape_key() == twin.shape_key()
+
+
 @pytest.mark.parametrize(
     ("emmy_us", "cublas_us", "ratio", "golden"),
     [(100.0, 99.0, 0.99, True), (100.0, 95.0, 0.95, True), (100.0, 80.0, 0.80, False), (0.0, 99.0, 0.0, False)],


### PR DESCRIPTION
## Root cause (the 5090 gemma-4 image boot-to-boot cubin flap)

Across boots of the byte-identical `vllm-emmy-gemma4` image, the boot-compiled kernel set was bimodal — most boots compiled 2 extra kernels, a minority did not, with each variant's source byte-stable. This was a fork **resolution** flip, and the chain is:

1. **The m16 decode goldens don't realize.** `gemma4_12b.o_proj.m16` / `gemma4_12b.mlp_down.m16` pin `STAGE: d2/tma/ring`, but the serving-traced decode twins (transposed-B `LinearOp` layout) never offer a staged row at that fork — `_resolve_warp_stage` declines, the golden tier logs its enumeration-drift warning, and the pick falls through to the cold offline prior (the image ships no online checkpoint or tune DB).
2. **The offline prior ties 8 leaves exactly.** The `D_*` geometry features don't separate an `f2x4` from an `f4x2` fragment, nor the `bk` (`/k2..k8`) variants — 8 candidates score bit-identically at the minimum (measured on the real gemma-4-12B traced layer graphs under a reconstructed 5090 deploy context).
3. **The argmin tie fell to emission order.** Whichever tied leaf the fork enumerated first won — an order that can shift across processes — so the deployed variant (and its cubin) flipped per boot.

The `warm.sh` offline fixpoint passes (`fix/gemma4-release-followups`) contain the symptom; this PR fixes both links that were emmy's to fix.

## Fix 1 — deterministic picks (the mechanical bug)

Every deploy-pick tier now breaks ties through `knob.canonical_row_key` — the sorted tuning-knob rendering, a pure function of candidate **content**:

- model argmin: `Prior.pick`, `FallbackPrior.pick`, greedy's bare-`mean_scores` fallback
- measured evidence: `Prior.evidence_pick` and `_db_measured_pick` µs ties (one measured row can match several candidates)
- golden realization: `_golden_pick` picks the canonically-smallest realizing row, not the first-enumerated
- `_db_measured_index` iterates its context-key **set** sorted (per-process hash order otherwise ordered the index rows)

Local picks are unchanged — the canonical winner coincides with today's first-emitted leaf; only the incidental order dependence is gone.

Regression pin: `tests/compiler/pipeline/search/test_deploy_pick_determinism.py` — the fork-RESOLUTION twin of `test_source_determinism.py`: tier-level permutation invariance (a constant-score prior forces every pick onto the tiebreak) plus a cross-subprocess **selected-kernel-set** pin on the flapped serving shapes.

## Fix 2 — the golden drift (the evidence gap)

The drifted goldens were tuned on the canonical `(M,K) @ (K,N)` harness snippet, whose fork stages freely — but a served model's linear forks are **transposed-B** and offer gmem-direct rows only, so those entries could never realize where they were meant to decide.

- `MatmulGoldenConfig.trans_b` spells the serving Linear layout (`F.linear` snippet) — verified to trace to the **same ShapeKey and the same gmem-direct-only offer** as the real gemma-4 serving graphs, static m16 and dynM alike. The two layouts share one ShapeKey on purpose: an unrealizable entry never matches, so canonical (harness truth) and `trans_b` (serving truth) entries coexist per shape.
- Six `.lin` entries seeded on a vast.ai RTX 5090 (`emmy tune -c` + 3× `run --bench` at -O3, <1% spread): `{o_proj K4096, o_proj_global K8192, mlp_down K15360} × {m16, dynM}`.
- Verified on the real traced gemma-4-12B layer graphs: **zero drift warnings**, every affected fork deploys its recorded config verbatim.

These entries are cold-start anchors, not wins: the transposed-B gmem-direct decode matmuls read 0.36–0.77× vs cuBLAS (`mlp_down.m16`: 233.8 vs 85 µs). That is the true serving cost today — recording it pins the forks deterministically and makes a staged-transposed-B (or layout-canonicalizing) follow-up measurable. That perf lever remains open.

Tests: full suite 2406 passed / 152 skipped; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)