### PR TITLE
Drop the statically-vacuous sliding-window band so flash still fuses (the gemma-4 layer-0 grid-1 hang)

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -215,7 +215,11 @@ bound is CTA-uniform (barriers stay legal) and every skipped step is the carrier
 paying wall-clock wherever the grid oversubscribes the SMs (1.67× on hd256 seq-2048) and re-opening the small-CTA flash
 forms that previously paid double K/V re-streaming. **A banded stream additionally starts late**: a trace-time
 `SdpaOp.sliding_window` stamp (the HF wrapper knows `config.sliding_window` + `layer_types`; the trace itself erases
-the window) decomposes to a second coordinate `Select` (`kv > m − W`) beside the causal one — flash classification
+the window) decomposes to a second coordinate `Select` (`kv > m − W`) beside the causal one — unless the band is
+STATICALLY VACUOUS (static seq, `W ≥ S`), which the decomposition drops instead of emitting: a vacuous Select's
+predicate constant-folds, the +0 mask term hoists out of the reduce loops, and the mask-chain walk below can no
+longer resolve it — the fuse then silently degraded to cut and the softmax·P@V fell to the unstructured sequential
+lowering (the gemma-4 layer-0 `seq 512 < window 1024` trace deployed a grid-1 kernel). Flash classification
 reads the whole mask CHAIN off the rowmax feed (coord Selects and the explicit additive bias compose; the bias stays
 loaded, it may mask more, e.g. padding), re-synthesizes each canonically, and the realizer derives the stream START
 off the band predicate exactly as it derives the causal end (`kv_start = ⌊max(0, first_row − W + 1)/bn⌋·bn`, the

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/010_sdpa.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/010_sdpa.py
@@ -151,7 +151,13 @@ def rewrite(match: Match, root: Node, inp_q: Node, inp_k: Node, inp_v: Node, inp
     # Sliding-window band: add -1e9 where key_pos ≤ query_pos − window (keep kv > m − W). The
     # stamped band is synthesized even alongside an explicit bias — bit-neutral there (the bias
     # already holds -inf on that region) and it is what the lowering skips key blocks off.
-    if window is not None:
+    # A STATICALLY VACUOUS band (static seq, W ≥ S: every m − W < 0, so the keep predicate holds
+    # everywhere) is dropped instead of emitted: its Select's predicate constant-folds and the
+    # +0 mask term hoists out of the reduce loops, where the flash recognizer's mask-chain walk
+    # (``_flash._classify_rowmax``) can no longer resolve it — the fuse then silently degrades to
+    # cut and the softmax·P@V falls to the unstructured sequential lowering (the layer-0
+    # ``seq 512 < window 1024`` gemma trace deployed a grid-1 kernel that "hangs").
+    if window is not None and not (seq_len.is_static and window >= seq_len.as_static()):
         _coord_mask(BinaryExpr(">", j_var, BinaryExpr("-", i_var, Literal(window, "int"))), "_b")
 
     softmax = softmax_decompose(frag, scaled_id, -1, name=f"{name}_softmax")

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -1192,6 +1192,34 @@ def test_warp_flash_banded_tile_skip_structure(monkeypatch):
 
 
 @requires_cuda
+@pytest.mark.parametrize("W", [256, 1024])
+def test_warp_flash_vacuous_band_still_fuses(monkeypatch, W):
+    """A stamped ``sliding_window`` ≥ the static seq is VACUOUS (every ``m − W < 0``): the band
+    term must be dropped at decomposition, not emitted — an emitted vacuous Select's predicate
+    constant-folds, the +0 mask term hoists out of the reduce loops, and the flash recognizer's
+    mask-chain walk can't resolve it, silently degrading the fuse to cut (the gemma-4 layer-0
+    ``seq 512 < window 1024`` trace deployed a sequential grid-1 softmax·P@V that ran for
+    minutes). Expect: ONE fused flash kernel, causal stream end only (no banded start), plain
+    causal numerics."""
+    monkeypatch.setenv("EMMY_PLACE", "fuse")
+    torch.manual_seed(W)
+    S = 256
+    q, k, v = (torch.randn(1, 4, S, 64, dtype=torch.float16) for _ in range(3))
+    backend, compiled, graph, kernels = _stamp_window(_Causal(), (q, k, v), W)
+    assert len(kernels) == 1, f"vacuous-band flash should stay one fused kernel, got {len(kernels)}"
+    src = compiled.nodes[kernels[0]].op.kernel_source
+    assert "emmy_c_to_a" in src, "must be the fused warp-chain"
+    assert "kv0_end" in src, "the causal stream end must survive"
+    assert f"- {W - 1}" not in src, "a vacuous band must not stamp a banded stream start"
+
+    data = {n: t for n, t in zip(graph.inputs, (q.numpy(), k.numpy(), v.numpy()), strict=True)}
+    run_result, eager = backend.run(compiled, input_data=data, pre_run=_banded_ref(q, k, v, W))
+    got = list(run_result.outputs.values())[0].flatten().astype(np.float32)
+    max_diff = float(np.max(np.abs(got - eager)))
+    assert max_diff < 5e-3, f"vacuous-band flash (W={W}) max_diff={max_diff:.2e}"
+
+
+@requires_cuda
 @pytest.mark.parametrize("seq", [40, 300, 512])
 def test_warp_flash_banded_symbolic_matches_torch(monkeypatch, seq):
     """SYMBOLIC banded flash: the banded start is grid-derived (CTA row × W), independent of the


### PR DESCRIPTION
## Investigation: "reproducer benches diverge from model-path picks" on the rented 4090

The premise inverted under controlled comparison: **the `.torch.json` reproducers pick identically to the model
path.** Re-lowering the model dump's `00_input.json` and each fused reproducer under a cold spoofed-4090 context
(memorized SKU regime via `Context.from_target`, goldens active, no tune DB / online prior) yields kernel-for-kernel
identical greedy picks. The catastrophic reproducer numbers were the **model path's own cold-deploy bugs** — the
model path was never benched per-kernel on that box. (`--golden gemma4_12b.o_proj` picking well is not a
counterexample: a bare-matmul snippet *offers* different schedule tiers than the in-model fused form — the
already-warned `no offered candidate realizes` drift for o_proj/mlp_down.)

## The fix: the hang

Gemma-4 layer 0 stamps `sliding_window=1024`; at the traced static `seq 512` the band keep-predicate
`kv > m − W` is vacuously true. The emitted Select's predicate constant-folds, the +0 mask term hoists out of the
reduce loops, and `_flash._classify_rowmax`'s mask-chain walk (defs resolved inside the rowmax loop body only)
declines — the fuse silently degrades to cut and the softmax·P@V lowers **unstructured**: no fork, no knobs, a
sequential `if (_gid < 1)` grid-1 kernel (~1e9 iterations = the `>1s HungKernelError`). `grid=[1,1,1]` is visible in
the model-path dump's `08_lowering_cuda.json` itself.

Fix at the source: the SDPA decomposition skips the band when statically vacuous (static seq, `W ≥ S`) — the
`-1e9` region is empty, so the term is semantically a no-op. Symbolic seq keeps the band (runtime extent can exceed
W); real windows (`W < S`) and the banded tile-skip are unchanged.

**Verified**: post-fix the layer-0 model path *and* every SDPA reproducer deploy the fused flash kernel and join
the attention goldens (spoofed-4090: MATCH at the recorded 37.1µs; norm→linear reproducers re-checked — still
identical picks to the model path). The previously hanging reproducer benches **155µs, 2.21× vs eager** on an RTX
4080 (sm_89). Regression test `test_warp_flash_vacuous_band_still_fuses` fails pre-fix on the kernel count.
`make test`: 2410 passed, 152 skipped.

## Remaining (out of scope, both paths affected equally)

- **norm→linear cones 8–12×**: the cone fork consults only the `kind='fused'` key (#398); the 4090 ships no
  `norm_linear`/`mlp_geglu` goldens, and zero of ~3300 offered rows can realize the plain `q_proj`/`kv_proj`
  goldens anyway (computed-A tiers have no gmem-A `d2/cp/ring` staging). Remedy: seed the 4090 fused goldens —
  the follow-up #398 already names.
- **o_proj / mlp_down**: the known offer gap (f32 flash-tail view blocks the warp tier); already warns loudly.
- **Whole-model dumps trace f32 by design** (`compile.py`), locking whole-model reproducers out of the f16 mma
  tier entirely — worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)