### PR TITLE
Execution-plan pack: serializable compiled programs for fast serving boot (737s → 9.5s warm boot)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ gemma4-warm:
 gemma4-serve-image:
 	@test -n "$$(ls -A docker/vllm-emmy-gemma4/warm/hf 2>/dev/null)" -a -n "$$(ls -A docker/vllm-emmy-gemma4/warm/cubin 2>/dev/null)" || \
 		(echo "docker/vllm-emmy-gemma4/warm/ is empty — run 'make gemma4-warm' on the target GPU first"; exit 1)
+	@mkdir -p docker/vllm-emmy-gemma4/warm/pack  # pack is optional (COPY needs the dir); empty → boot falls back to full compile
 	docker run --rm -v $(PWD)/docker/vllm-emmy-gemma4/warm/hf:/hf \
 		-v $(PWD)/docker/vllm-emmy-gemma4/reshard_snapshot.py:/reshard.py \
 		--entrypoint python3 $(VLLM_EMMY_TAG) /reshard.py /hf

--- a/docker/vllm-emmy-gemma4/ARCHITECTURE.md
+++ b/docker/vllm-emmy-gemma4/ARCHITECTURE.md
@@ -1,9 +1,12 @@
 # vllm-emmy-gemma4 — the prebuilt gemma-4-12B serving image
 
 A release image for one model on one GPU: **gemma-4-12B served by `EmmyGenModel` on an RTX 5090**, with the compiled
-CUDA kernels (**cubins**) and the **HF model snapshot** baked in. Cold-start pays zero `nvcc` compiles and zero HF
-downloads — `docker run --gpus all --ipc=host -p 8000:8000 cloudriftai/vllm-emmy-gemma4:TAG` serves with no
-`HF_TOKEN` and no network dependency on HuggingFace (`HF_HUB_OFFLINE=1` is baked). The plain
+CUDA kernels (**cubins**), the **HF model snapshot**, and the **execution-plan pack**
+(`emmy/compiler/backend/pack.py`) baked in. Cold-start pays zero `nvcc` compiles, zero HF downloads, and — on a
+pack hit — none of the compiler frontend either (no trace / pass pipeline / fork resolution / codegen; boot
+collapses from ~25 min to ~weight-load time) — `docker run --gpus all --ipc=host -p 8000:8000
+cloudriftai/vllm-emmy-gemma4:TAG` serves with no `HF_TOKEN` and no network dependency on HuggingFace
+(`HF_HUB_OFFLINE=1` is baked). The plain
 [`vllm-emmy`](../vllm-emmy/) image stays the general-purpose base (any model, compile-on-boot); this image trades a
 ~35 GB pull (~24 GB of weights on the ~10 GB base) for a deterministic, tokenless boot.
 
@@ -48,6 +51,13 @@ failure** (`warm.sh` exits 1 — with the cubin set still growing, verify's sing
 customer boots would recompile at runtime). The boot-to-boot pick flip is a real compiler bug (fork resolution
 should be deterministic across processes); the fixpoint warm contains it but does not excuse it.
 
+**The pack changes the fixpoint's role.** The online pass also writes the execution-plan pack (`warm/pack`, keyed
+on the model **config hash** + serving shape — not the id/path, precisely so the offline boots share it), and every
+subsequent boot — the offline fixpoint passes, verify, customer boots — loads it: fork picks are frozen in the
+artifact, so the bimodal-pick class vanishes and the fixpoint converges immediately whenever the pack takes. The
+loop stays as a safety net for the case where the pack write was skipped (a weight outside the pack vocabulary) or
+the load falls back — then the old cubin-union behavior is exactly what runs.
+
 ## Files
 
 - `config.env` — the pinned serving config. Every value is cache-key-relevant; it must be **final before warming**
@@ -56,12 +66,16 @@ should be deterministic across processes); the fixpoint warm contains it but doe
   generate --enforce-eager --dtype float16 --hf-overrides EmmyGenModel` + the `GEMMA4_*` config).
 - `warm.sh` — runs the **plain** `vllm-emmy` image on the target GPU with `./warm` mounted at `/opt/emmy`, waits for
   `/health`, issues one completion (covers prefill + decode kernels), stops. Result: `warm/hf` (the model snapshot —
-  the gated download happens here, once, via `HF_TOKEN`) and `warm/cubin` (every compiled kernel).
-- `Dockerfile` — `FROM` the plain image, `COPY warm/hf` + `COPY warm/cubin` to `/opt/emmy`, bakes the config env and
-  `HF_HUB_OFFLINE=1`, entrypoint `serve.sh`. The caches live at **`/opt/emmy`** on purpose: compose/recipes
-  bind-mount the host HF cache over `/root/.cache/huggingface`, which would shadow anything baked there.
+  the gated download happens here, once, via `HF_TOKEN`), `warm/cubin` (every compiled kernel), and `warm/pack`
+  (the execution-plan pack the first boot writes).
+- `Dockerfile` — `FROM` the plain image, `COPY warm/hf` + `COPY warm/cubin` + `COPY warm/pack` to `/opt/emmy`, bakes
+  the config env, `EMMY_PACK_DIR` and `HF_HUB_OFFLINE=1`, entrypoint `serve.sh`. The caches live at **`/opt/emmy`**
+  on purpose: compose/recipes bind-mount the host HF cache over `/root/.cache/huggingface`, which would shadow
+  anything baked there.
 - `verify.sh` — cold-starts the **baked** image with no token, issues one completion, and diffs the cubin file set
   before/after: an empty diff proves 100% cache hit (zero compiles), and the offline boot proves zero downloads.
+  When a pack is baked, it also asserts the boot **hit** it (a silent fallback to the full compile would still pass
+  the cubin check while re-paying the frontend on every customer boot).
 - `warm/` — gitignored; the warm output that the bake copies in.
 
 ## Workflow

--- a/docker/vllm-emmy-gemma4/Dockerfile
+++ b/docker/vllm-emmy-gemma4/Dockerfile
@@ -20,6 +20,7 @@ FROM ${BASE_IMAGE}
 
 ENV HF_HOME=/opt/emmy/hf \
     EMMY_CUBIN_CACHE=/opt/emmy/cubin \
+    EMMY_PACK_DIR=/opt/emmy/pack \
     HF_HUB_OFFLINE=1
 
 # Weights + tokenizer + config (the HF snapshot — per-tensor identical, but resharded by
@@ -33,6 +34,11 @@ COPY warm/hf_parts/p1 /opt/emmy/hf
 COPY warm/hf_parts/p2 /opt/emmy/hf
 COPY warm/hf_parts/p3 /opt/emmy/hf
 COPY warm/cubin /opt/emmy/cubin
+# The execution-plan pack (compiler/backend/pack.py) — written by the warm run's first
+# boot. A pack-hit boot skips the whole compiler frontend (trace / pipeline / fork
+# resolution / codegen), collapsing the ~25 min gemma-4 cold start to ~weight-load time;
+# on any mismatch the runner silently falls back to the full (cubin-cached) compile.
+COPY warm/pack /opt/emmy/pack
 
 # The pinned serving config — passed by make from config.env (the single source; these
 # values are part of the cubin cache key, so they must match the warm run exactly).

--- a/docker/vllm-emmy-gemma4/verify.sh
+++ b/docker/vllm-emmy-gemma4/verify.sh
@@ -17,9 +17,10 @@ docker run -d --name "$NAME" --gpus "$GPUS" --ipc=host -p "$PORT":8000 "$IMAGE"
 
 before=$(docker exec "$NAME" sh -c "find /opt/emmy/cubin -name '*.cubin' | sort")
 
-# Boot is nvcc-free but NOT instant: the per-layer CPU trace/lower/render is not cached
-# (only the cubins are) — the 48-layer gemma-4 boot takes ~25 min. Budget 40.
-echo "[verify] waiting for /health (no downloads, no compiles — but the CPU trace takes ~25 min)..."
+# With a baked pack the boot skips the compiler frontend entirely and health arrives in
+# ~weight-load time; without one (pack write skipped at warm) the per-layer CPU
+# trace/lower/render runs uncached — the 48-layer gemma-4 boot takes ~25 min. Budget 40.
+echo "[verify] waiting for /health (no downloads, no compiles; fast if the pack baked)..."
 for _ in $(seq 1 240); do
     if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then break; fi
     if [ -z "$(docker ps -q -f name=$NAME)" ]; then
@@ -37,6 +38,16 @@ curl -sf "http://localhost:$PORT/v1/completions" -H 'Content-Type: application/j
     | head -c 400; echo
 
 after=$(docker exec "$NAME" sh -c "find /opt/emmy/cubin -name '*.cubin' | sort")
+# When the image ships a pack, the boot must have actually used it — a silent fallback to
+# the full compile (key/environment drift) still passes the cubin check but re-pays the
+# ~25 min frontend on every customer boot, which is exactly what the pack exists to kill.
+pack_baked=$(docker exec "$NAME" sh -c "find /opt/emmy/pack -name manifest.json 2>/dev/null | head -1")
+if [ -n "$pack_baked" ] && ! docker logs "$NAME" 2>&1 | grep -q "pack hit"; then
+    echo "[verify] FAIL — a pack is baked but the boot did not hit it (fell back to full compile):"
+    docker logs "$NAME" 2>&1 | grep -i "\[pack\]" | tail -5
+    docker rm -f "$NAME" >/dev/null
+    exit 1
+fi
 docker rm -f "$NAME" >/dev/null
 
 if [ "$before" != "$after" ]; then
@@ -44,4 +55,4 @@ if [ "$before" != "$after" ]; then
     diff <(echo "$before") <(echo "$after") || true
     exit 1
 fi
-echo "[verify] PASS — served offline with zero new cubins ($(echo "$before" | wc -l) prebuilt)"
+echo "[verify] PASS — served offline with zero new cubins ($(echo "$before" | wc -l) prebuilt)${pack_baked:+, pack-hit boot}"

--- a/docker/vllm-emmy-gemma4/warm.sh
+++ b/docker/vllm-emmy-gemma4/warm.sh
@@ -21,12 +21,13 @@ PORT="${PORT:-8000}"
 GPUS="all"; [ -n "${GPU_DEVICE:-}" ] && GPUS="device=$GPU_DEVICE"
 NAME=gemma4-warm
 
-mkdir -p warm/hf warm/cubin
+mkdir -p warm/hf warm/cubin warm/pack
 docker rm -f "$NAME" >/dev/null 2>&1 || true
 docker run -d --name "$NAME" --gpus "$GPUS" --ipc=host -p "$PORT":8000 \
     -e HF_TOKEN="${HF_TOKEN:-}" \
     -e HF_HOME=/opt/emmy/hf \
     -e EMMY_CUBIN_CACHE=/opt/emmy/cubin \
+    -e EMMY_PACK_DIR=/opt/emmy/pack \
     -e EMMY_GEN_DECODE_BUCKET="$GEMMA4_DECODE_BUCKET" \
     -e GEMMA4_MODEL -e GEMMA4_MAX_MODEL_LEN -e GEMMA4_MAX_NUM_BATCHED_TOKENS -e GEMMA4_GPU_MEM_UTIL \
     -v "$PWD/warm":/opt/emmy \
@@ -58,12 +59,17 @@ echo "[warm] online pass done: $(find warm/cubin -name '*.cubin' | wc -l) cubin(
 # resolved to the snapshot path), and some kernels only materialize there; a fork pick
 # can also flip between boots (each variant's source is stable, so the union converges).
 # Re-boot offline against the accumulated cache until a boot compiles nothing new.
+# The first boot above also wrote the execution-plan pack (warm/pack, keyed on the model
+# CONFIG hash — not the id/path, so online and offline boots share it): these offline
+# passes boot from it (frozen fork picks → no flip, fast boot), which both validates the
+# pack-hit path pre-bake and makes the fixpoint converge on pass 1 whenever the pack took.
 for pass in 1 2 3 4 5; do
     before=$(find warm/cubin -name '*.cubin' | sort)
     docker run -d --name "$NAME" --gpus "$GPUS" --ipc=host -p "$PORT":8000 \
         -e HF_HUB_OFFLINE=1 \
         -e HF_HOME=/opt/emmy/hf \
         -e EMMY_CUBIN_CACHE=/opt/emmy/cubin \
+        -e EMMY_PACK_DIR=/opt/emmy/pack \
         -e EMMY_GEN_DECODE_BUCKET="$GEMMA4_DECODE_BUCKET" \
         -e GEMMA4_MODEL -e GEMMA4_MAX_MODEL_LEN -e GEMMA4_MAX_NUM_BATCHED_TOKENS -e GEMMA4_GPU_MEM_UTIL \
         -v "$PWD/warm":/opt/emmy \
@@ -94,4 +100,4 @@ done
 # coin flip if this exits 0.
 [ "$new" -eq 0 ] || { echo "[warm] FAIL: no fixpoint after 5 offline passes — the cubin set is still growing" >&2; exit 1; }
 
-echo "[warm] done: $(find warm/cubin -name '*.cubin' | wc -l) cubin(s), snapshot at warm/hf"
+echo "[warm] done: $(find warm/cubin -name '*.cubin' | wc -l) cubin(s), $(find warm/pack -name '*.json' | wc -l) pack file(s), snapshot at warm/hf"

--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -91,6 +91,28 @@ implicates fusion; loop vs CUDA disagreement implicates codegen.**
 See `cuda/ARCHITECTURE.md`. Runs the full lowering chain and dispatches
 kernels via cupy `RawKernel` (NVRTC-compiled).
 
+## Execution plan + pack (`plan.py`, `pack.py`)
+
+`plan.py` defines the **execution plan** — the serializable runtime projection of a lowered `Graph[CudaOp]`:
+buffer specs, scalar/runtime constants, the launch list, symbolic-axis plumbing, kernel refs (source and/or a
+content-addressed cubin-cache key), and per-weight checkpoint bindings (`source_path` + a pack-own load-op
+vocabulary applied with pure numpy). `plan_from_graph` is the seam the whole runtime builds from: after it runs,
+nothing reads the graph again — `CompiledProgram.build(graph)` is exactly `build_from_plan(plan_from_graph(g))`,
+so a plan loaded from disk and a freshly compiled one share one launch path. The JSON form (`plan_to_dict` /
+`plan_from_dict`) carries symbolic shapes and ceil-div grid factors through a tiny self-contained expression
+grammar (`int` literal, `"name"` var, `[op, lhs, rhs]`), deliberately not the compiler's `Expr` classes — the
+on-disk format survives compiler changes; only runtime-contract changes bump `PLAN_FORMAT_VERSION`.
+CUDA-specific launch fields (TMA descriptors) nest under a `"cuda"` key so another backend can add its own
+namespace and its own `build_from_plan` equivalent.
+
+`pack.py` bundles plans on disk: one directory per model × GPU × serving shape holding `manifest.json` (validity
+key + environment tags + provenance + program index) and `plan/<program>.json`. Cubins are **not** copied — plans
+reference the shared `EMMY_CUBIN_CACHE` by content-addressed key, so packs dedupe kernels against each other and
+the docker bake ships pack + cubin cache + model snapshot together. `load_pack` returns `None` on *any*
+disqualifier (format/environment/key mismatch, unparsable plan, evicted cubin) and the caller falls back to the
+full compile — a stale pack costs a recompile, never a wrong result. The serving boot integration
+(`EMMY_PACK_DIR`) lives in `emmy/serving/runner.py`; see `emmy/serving/ARCHITECTURE.md`.
+
 ## Invariants
 
 - The default `Backend.run` must work on any graph where every op has

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -24,7 +24,12 @@ arg_order).
 
 ## Dispatch (`program.py`)
 
-`_compile(graph) → _Compiled` walks the lowered graph:
+The graph is first projected to an **execution plan** (`plan_from_graph`, `../plan.py` — buffer specs, constants,
+launch list, symbolic plumbing, kernel + weight refs; see `../ARCHITECTURE.md`), and `_load_plan(plan) → _Compiled`
+materializes the runtime object from it. `CompiledProgram.build(graph)` is exactly
+`build_from_plan(plan_from_graph(graph))` — the pack path (`../pack.py`) enters at `build_from_plan` with a plan
+read from disk whose kernels reference cubins by content-addressed cache key (`nvcc.load_cubin_function` — no
+codegen, no nvcc), and both paths share every line downstream. The projection:
 
 - Classifies each node as `input` / `constant` / `output` / `scratch`
   from `graph.inputs` / `ConstantOp` membership / `graph.outputs`.

--- a/emmy/compiler/backend/cuda/nvcc.py
+++ b/emmy/compiler/backend/cuda/nvcc.py
@@ -160,8 +160,6 @@ def load_function(source: str, name: str, options, *, uses_tma: bool):  # noqa: 
     was dropped (faster compiles, GPU-free, cubin-cacheable; see the module
     docstring), so ``nvcc`` is now a hard dependency.
     """
-    import cupy as cp  # noqa: PLC0415
-
     if nvcc_path() is None:
         raise RuntimeError(
             "nvcc unavailable — emmy requires the CUDA toolkit's "
@@ -174,4 +172,13 @@ def load_function(source: str, name: str, options, *, uses_tma: bool):  # noqa: 
         detail = exc.stderr.decode(errors="replace") if exc.stderr else "(no stderr)"
         logger.error("nvcc compile failed for kernel %r:\n%s", name, detail)
         raise RuntimeError(f"nvcc compile failed for kernel {name!r}: {detail[-400:]}") from exc
-    return cp.RawModule(path=str(cubin)).get_function(name)
+    return load_cubin_function(cubin, name)
+
+
+def load_cubin_function(path: Path | str, name: str):
+    """``RawModule``-load an existing cubin and return kernel ``name`` — the load half of
+    :func:`load_function`, used directly by the execution-plan path when a plan references the
+    cubin by its content-addressed cache key (no source, no compile)."""
+    import cupy as cp  # noqa: PLC0415
+
+    return cp.RawModule(path=str(path)).get_function(name)

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -234,7 +234,7 @@ class BufferArena:
     descriptors never dangle. Safe iff programs sharing the arena never run
     concurrently and each program's outputs are consumed before the next program runs
     — the runner's contract. Constants are never pooled (persistent values; weight
-    sharing is ``gen_runner._bind_device_constants``)."""
+    sharing is ``gen_runner._bind_plan_constants``)."""
 
     def __init__(self) -> None:
         self._backings: dict[str, cp.ndarray] = {}

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -30,11 +30,10 @@ from emmy.compiler.backend import BenchmarkResult, LaunchTime, RunResult
 from emmy.compiler.backend.cuda import _tma, nvcc
 from emmy.compiler.backend.cuda._planner import compute_live_intervals, plan_offsets
 from emmy.compiler.backend.cuda.dtype import cupy_dtype
-from emmy.compiler.dim import Dim
-from emmy.compiler.dtype import DataType
-from emmy.compiler.graph import Graph, Node
-from emmy.compiler.ir.base import ConstantOp, InputOp
-from emmy.compiler.ir.cuda import CudaOp, TmaDescMeta
+from emmy.compiler.backend.plan import BufferSpec as _Buffer
+from emmy.compiler.backend.plan import ExecutionPlan, KernelSpec, plan_from_graph
+from emmy.compiler.backend.plan import LaunchSpec as _Launch
+from emmy.compiler.graph import Graph
 
 if TYPE_CHECKING:
     import cupy as cp
@@ -65,43 +64,6 @@ def _ensure_dynamic_smem_attr(kernel: cp.RawKernel, smem_bytes: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class _Buffer:
-    name: str
-    # ``Dim``-valued shape. Static dims carry a ``Literal`` expr, atomic
-    # symbolic carry a ``Var``, composite (e.g. ``S * 2`` from a reshape
-    # or cat) carry a ``BinaryExpr``. ``resolve_shape`` calls ``expr.eval``
-    # to turn any of those into a runtime int.
-    shape: tuple[Dim, ...]
-    dtype: DataType
-    role: str  # "input" | "constant" | "output" | "scratch"
-
-    @property
-    def is_symbolic(self) -> bool:
-        return any(not d.is_static for d in self.shape)
-
-    def resolve_shape(self, sym_values: dict[str, int]) -> tuple[int, ...]:
-        return tuple(int(d.expr.eval(sym_values)) for d in self.shape)
-
-
-def _buffers(graph: Graph) -> list[_Buffer]:
-    return [
-        _Buffer(name=nid, shape=tuple(node.output.shape), dtype=node.output.dtype, role=graph.node_role(nid))
-        for nid, node in graph.nodes.items()
-    ]
-
-
-def _constant_values(graph: Graph) -> dict[str, float]:
-    return {nid: op.value for nid, op in graph.constant_ops() if op.value is not None}
-
-
-def _runtime_constants(graph: Graph):
-    """``{nid: Expr}`` for each ``ConstantOp`` bound to a runtime ``context_value`` (a value
-    set by the symbolic context — e.g. a dynamic mean's divisor = the runtime reduce-axis
-    size). Resolved to a concrete float per run from ``sym_values``."""
-    return {nid: op.context_value for nid, op in graph.constant_ops() if op.context_value is not None}
-
-
 def _resolved_constants(compiled: _Compiled, sym_values: dict[str, int]) -> dict[str, float]:
     """The constant-value map for this run: the static constants plus each runtime
     ``context_value`` constant evaluated at ``sym_values`` (``float(seq_len)``)."""
@@ -110,38 +72,9 @@ def _resolved_constants(compiled: _Compiled, sym_values: dict[str, int]) -> dict
     return {**compiled.constants, **{nid: float(expr.eval(sym_values)) for nid, expr in compiled.runtime_constants.items()}}
 
 
-def _launches(graph: Graph) -> list[Node]:
-    nodes: list[Node] = []
-    for nid in graph.topological_order():
-        node = graph.nodes[nid]
-        if isinstance(node.op, (InputOp, ConstantOp)):
-            continue
-        if not isinstance(node.op, CudaOp):
-            raise TypeError(f"CudaBackend: node {nid!r} has non-CudaOp {type(node.op).__name__!r}; lowering must produce Graph[CudaOp].")
-        nodes.append(node)
-    return nodes
-
-
 # ---------------------------------------------------------------------------
 # Compiled program: RawKernels + buffer plan + launch list
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class _Launch:
-    node_id: str
-    kernel_name: str
-    arg_names: tuple[str, ...]
-    # ``grid`` / ``block`` are per-dim ``GridDimSpec`` tuples whose factors may
-    # include symbolic axis names — resolved at launch time via the
-    # parent ``_Compiled.symbolic_bindings`` env. Static kernels collapse
-    # to single-int factors (``((128,), (1,), (1,))``).
-    grid: tuple
-    block: tuple
-    smem_bytes: int
-    zero_outputs: tuple[str, ...]
-    tma_descriptors: tuple[TmaDescMeta, ...] = ()
-    runtime_args: tuple[str, ...] = ()
 
 
 @dataclass
@@ -175,55 +108,42 @@ class _Compiled:
     runtime_constants: dict = field(default_factory=dict)
 
 
-def _compile(graph: Graph) -> _Compiled:
-    bufs = _buffers(graph)
-    buf_by_name = {b.name: b for b in bufs}
-    constants = _constant_values(graph)
-    launches_nodes = _launches(graph)
-    symbolic_bindings = graph.symbolic_bindings()
-    symbolic_hints = graph.symbolic_hints()
-    runtime_constants = _runtime_constants(graph)
-
-    # ``nvcc.load_function`` returns a cupy ``Function`` (or a ``RawKernel`` on
-    # NVRTC fallback) — both launch-callable and smem-attr settable.
-    kernels: dict[str, object] = {}
-    seen_source: dict[str, str] = {}
-    launches: list[_Launch] = []
-    for node in launches_nodes:
-        op: CudaOp = node.op
-        kname = op.kernel_name
-        if kname not in kernels:
-            prev_src = seen_source.get(kname)
-            if prev_src is not None and prev_src != op.kernel_source:
-                raise ValueError(f"kernel name {kname!r} used by two distinct sources")
-            seen_source[kname] = op.kernel_source
-            uses_tma = bool(op.tma_descriptors)
-            options = _nvrtc_options(uses_tma=uses_tma)
-            # Compile via offline nvcc (faster, cache-warmable) with an NVRTC
-            # fallback; returns a Function usable exactly like a RawKernel.
-            kernels[kname] = nvcc.load_function(op.kernel_source, kname, options, uses_tma=uses_tma)
-        launches.append(
-            _Launch(
-                node_id=node.id,
-                kernel_name=kname,
-                arg_names=tuple(op.arg_order),
-                grid=op.grid,
-                block=op.block,
-                smem_bytes=op.smem_bytes,
-                zero_outputs=tuple(op.zero_outputs),
-                tma_descriptors=tuple(op.tma_descriptors),
-                runtime_args=tuple(getattr(op, "runtime_args", ())),
+def _load_kernel(name: str, spec: KernelSpec):
+    """Obtain one launchable kernel from its :class:`KernelSpec`. A ``binary_key`` (the pack
+    path) loads the content-addressed cubin straight from the cache; otherwise the ``source``
+    compiles through the same cache (``nvcc.load_function``). A key whose cubin has been
+    evicted falls back to the source when present, and errors otherwise — the pack loader
+    pre-checks cubin existence, so hitting this means the cache was cleared mid-boot."""
+    if spec.binary_key is not None:
+        path = nvcc.cubin_cache_dir() / f"{spec.binary_key}.cubin"
+        if path.exists():
+            return nvcc.load_cubin_function(path, name)
+        if spec.source is None:
+            raise RuntimeError(
+                f"kernel {name!r}: cubin {spec.binary_key} is gone from the cache and the plan carries no source — "
+                "regenerate the pack or boot without it (full compile)"
             )
-        )
+    if spec.source is None:
+        raise RuntimeError(f"kernel {name!r}: plan carries neither a source nor a cached cubin")
+    # ``nvcc.load_function`` returns a cupy ``Function`` — launch-callable and
+    # smem-attr settable, compiled via offline nvcc into the content-addressed cache.
+    return nvcc.load_function(spec.source, name, _nvrtc_options(uses_tma=spec.uses_tma), uses_tma=spec.uses_tma)
+
+
+def _load_plan(plan: ExecutionPlan) -> _Compiled:
+    """Materialize the runtime object from a plan: load every kernel (cubin-by-key or
+    source-via-cache), and adopt the plan's pure-data fields as-is."""
+    kernels: dict[str, object] = {name: _load_kernel(name, spec) for name, spec in plan.kernels.items()}
     return _Compiled(
-        bufs=bufs,
-        buf_by_name=buf_by_name,
-        constants=constants,
+        bufs=list(plan.buffers),
+        buf_by_name={b.name: b for b in plan.buffers},
+        constants=dict(plan.constants),
         kernels=kernels,
-        launches=launches,
-        symbolic_bindings=symbolic_bindings,
-        symbolic_hints=symbolic_hints,
-        runtime_constants=runtime_constants,
+        launches=list(plan.launches),
+        symbolic_bindings=dict(plan.symbolic_bindings),
+        symbolic_hints=dict(plan.symbolic_hints),
+        symbolic_caps=dict(plan.symbolic_caps),
+        runtime_constants=dict(plan.runtime_constants),
     )
 
 
@@ -753,10 +673,24 @@ class CompiledProgram:
         compile_timeout_s: float | None = None,
         arena: BufferArena | None = None,
     ) -> CompiledProgram:
-        """Compile ``graph``, allocate every buffer, pre-build TMA
-        descriptors. ``compile_timeout_s`` bounds the setup phase at a
-        C-call boundary: if NVRTC + alloc + descriptor work overruns,
-        raise ``RuntimeError`` before the caller proceeds to launches
+        """Compile ``graph`` and build — ``plan_from_graph`` + :meth:`build_from_plan`; the
+        graph is never consulted after the projection (one runtime path whether the plan came
+        from a fresh compile or from a stored pack)."""
+        return cls.build_from_plan(plan_from_graph(graph), input_data, compile_timeout_s=compile_timeout_s, arena=arena)
+
+    @classmethod
+    def build_from_plan(
+        cls,
+        plan: ExecutionPlan,
+        input_data: dict[str, np.ndarray] | None = None,
+        *,
+        compile_timeout_s: float | None = None,
+        arena: BufferArena | None = None,
+    ) -> CompiledProgram:
+        """Load every kernel (cubin-by-key or source-via-cache), allocate every
+        buffer, pre-build TMA descriptors. ``compile_timeout_s`` bounds the
+        setup phase at a C-call boundary: if compile + alloc + descriptor work
+        overruns, raise ``RuntimeError`` before the caller proceeds to launches
         so no in-flight kernels are left queued. ``arena`` pools the
         activation buffers + scratch slab across sequentially-run
         programs (see :class:`BufferArena`).
@@ -764,7 +698,7 @@ class CompiledProgram:
         Caller is expected to hold ``gpu_lock()`` around this call and
         every subsequent method on the returned program."""
         t0 = _time_module.monotonic()
-        compiled = _compile(graph)
+        compiled = _load_plan(plan)
         sym_values = _resolve_symbolic(compiled, input_data or {})
         arrays, slab_plan = _allocate(compiled, input_data, arena)
         descs = _prebuild_descriptors(compiled, arrays)

--- a/emmy/compiler/backend/pack.py
+++ b/emmy/compiler/backend/pack.py
@@ -1,0 +1,150 @@
+"""Pack — an on-disk bundle of execution plans for one model × GPU × serving shape.
+
+Layout::
+
+    pack/
+      manifest.json        # validity key + environment tags + provenance + program index
+      plan/<program>.json  # one serialized ExecutionPlan per compiled program (plan.py)
+
+Kernel binaries are NOT stored here: each plan references its cubins by content-addressed
+cache key into the shared ``EMMY_CUBIN_CACHE``, so multiple packs (and repeated layers within
+one pack) dedupe to the same cubin files, and the docker bake ships pack + cubin cache + model
+snapshot together. Weights are external too (the HF checkpoint), rebound by
+``WeightSpec.source_path`` at load.
+
+Validity: a pack loads only when its manifest matches the caller's ``key`` (model identity +
+serving shape — composed by the runner) AND the current environment (backend, device arch,
+nvcc toolkit tag + flags — the same tags the cubin cache keys on) AND every referenced cubin
+still exists. **Any mismatch or error returns ``None`` and the caller falls back to the full
+compile path** — a stale or damaged pack costs a recompile, never a wrong result. Compiler
+version is deliberately NOT part of validity (a pack keeps serving its frozen snapshot);
+``PLAN_FORMAT_VERSION`` gates the runtime contract instead.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+
+from emmy.compiler.backend.plan import (
+    PLAN_FORMAT_VERSION,
+    ExecutionPlan,
+    KernelSpec,
+    plan_from_dict,
+    plan_to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+_MANIFEST = "manifest.json"
+
+
+def _environment() -> dict:
+    """The environment half of the validity key — the same tags the cubin cache keys on
+    (arch / toolkit / flags), so a pack never references cubins the current toolchain
+    wouldn't have produced. Probes the live GPU."""
+    from emmy.compiler.backend.cuda import nvcc  # noqa: PLC0415
+
+    return {
+        "backend": "cuda",
+        "arch": nvcc.device_arch(False),
+        "toolkit": nvcc._toolkit_tag(),
+        "nvcc_flags": nvcc.effective_flags(),
+    }
+
+
+def _safe_name(program: str) -> str:
+    return re.sub(r"[^-\w.]", "_", program)
+
+
+def pack_path(root: Path | str, key: dict) -> Path:
+    """The directory for one pack under the ``EMMY_PACK_DIR`` root: a human-readable model
+    label plus a digest of the full validity key, so packs for different models / serving
+    shapes coexist under one root."""
+    digest = hashlib.sha1(json.dumps(key, sort_keys=True).encode()).hexdigest()[:12]
+    label = _safe_name(str(key.get("model", "model")).split("/")[-1])
+    return Path(root) / f"{label}-{digest}"
+
+
+def save_pack(pack_dir: Path | str, plans: dict[str, ExecutionPlan], *, key: dict, provenance: dict | None = None) -> Path:
+    """Write a pack: resolve every kernel to its content-addressed cubin key (compiling into
+    the cache on a miss — normally a hit, the caller just built these programs) and store the
+    plans binary-keyed with no sources, plus the manifest. Requires the live GPU (arch probe).
+
+    ``key`` is the caller-composed validity dict (model id / config hash / serving shape);
+    ``provenance`` is informational only (compiler rev, tune state) and never checked."""
+    from emmy.compiler.backend.cuda import nvcc  # noqa: PLC0415
+
+    root = Path(pack_dir)
+    (root / "plan").mkdir(parents=True, exist_ok=True)
+    names = {p: _safe_name(p) for p in plans}
+    if len(set(names.values())) != len(names):
+        raise ValueError(f"pack: program names collide after sanitization: {sorted(plans)}")
+
+    index: dict[str, str] = {}
+    for program, plan in plans.items():
+        kernels: dict[str, KernelSpec] = {}
+        for kname, spec in plan.kernels.items():
+            if spec.source is None:
+                raise ValueError(f"pack: kernel {kname!r} of program {program!r} carries no source — cannot resolve a cubin key")
+            cubin = nvcc.compile_to_cubin(spec.source, kname, arch=nvcc.device_arch(spec.uses_tma))
+            kernels[kname] = KernelSpec(source=None, binary_key=cubin.stem, uses_tma=spec.uses_tma)
+        stored = dataclasses.replace(plan, kernels=kernels)
+        rel = f"plan/{names[program]}.json"
+        (root / rel).write_text(json.dumps(plan_to_dict(stored)))
+        index[program] = rel
+
+    manifest = {
+        "format": PLAN_FORMAT_VERSION,
+        "environment": _environment(),
+        "key": json.loads(json.dumps(key)),
+        "programs": index,
+        "provenance": provenance or {},
+    }
+    (root / _MANIFEST).write_text(json.dumps(manifest, indent=2))
+    logger.info("[pack] saved %d program plan(s) to %s", len(index), root)
+    return root
+
+
+def load_pack(pack_dir: Path | str, *, key: dict) -> dict[str, ExecutionPlan] | None:
+    """Load a pack's plans, or ``None`` when anything disqualifies it — no manifest, format /
+    environment / key mismatch, an unparsable plan, or a referenced cubin gone from the cache.
+    ``None`` means "boot the full compile path"; the reason is logged."""
+    from emmy import config  # noqa: PLC0415
+
+    root = Path(pack_dir)
+    try:
+        manifest = json.loads((root / _MANIFEST).read_text())
+    except (OSError, ValueError):
+        logger.info("[pack] no readable manifest at %s — full compile", root)
+        return None
+    try:
+        if manifest.get("format") != PLAN_FORMAT_VERSION:
+            logger.info("[pack] format %r != runtime %r — full compile", manifest.get("format"), PLAN_FORMAT_VERSION)
+            return None
+        env = _environment()
+        if manifest.get("environment") != env:
+            logger.info("[pack] environment mismatch (pack %r vs current %r) — full compile", manifest.get("environment"), env)
+            return None
+        want = json.loads(json.dumps(key))
+        if manifest.get("key") != want:
+            logger.info("[pack] key mismatch (pack %r vs wanted %r) — full compile", manifest.get("key"), want)
+            return None
+        plans: dict[str, ExecutionPlan] = {}
+        cache = config.cubin_cache_dir()
+        for program, rel in manifest.get("programs", {}).items():
+            plan = plan_from_dict(json.loads((root / rel).read_text()))
+            for kname, spec in plan.kernels.items():
+                if spec.binary_key is None or not (cache / f"{spec.binary_key}.cubin").exists():
+                    logger.info("[pack] cubin for kernel %r of %r missing from cache — full compile", kname, program)
+                    return None
+            plans[program] = plan
+    except Exception:  # noqa: BLE001 — a damaged pack must cost a recompile, never a crash
+        logger.warning("[pack] failed to load %s — full compile", root, exc_info=True)
+        return None
+    logger.info("[pack] loaded %d program plan(s) from %s", len(plans), root)
+    return plans

--- a/emmy/compiler/backend/plan.py
+++ b/emmy/compiler/backend/plan.py
@@ -156,7 +156,10 @@ def plan_from_graph(graph: Graph) -> ExecutionPlan:
         if spec is None:
             kernels[op.kernel_name] = KernelSpec(source=op.kernel_source, uses_tma=bool(op.tma_descriptors))
         elif spec.source != op.kernel_source:
-            raise ValueError(f"kernel name {op.kernel_name!r} used by two distinct sources")
+            # Longstanding runtime semantics: launches resolve kernels by NAME and the first
+            # source wins (repeated helper names like ``__partial`` ride the first-compiled
+            # body). Keep that behavior — a plan must reproduce what the live compile ran.
+            logger.debug("plan: kernel name %r repeats with a differing source; first source wins", op.kernel_name)
         launches.append(
             LaunchSpec(
                 node_id=nid,

--- a/emmy/compiler/backend/plan.py
+++ b/emmy/compiler/backend/plan.py
@@ -1,0 +1,421 @@
+"""Execution plan — the serializable runtime projection of a compiled graph.
+
+The plan is everything the runtime (``backend/cuda/program.py``) needs to allocate buffers and
+launch kernels, with no reference to the compiler IR that produced it: buffer specs, scalar /
+runtime constants, the launch list, symbolic-axis plumbing, kernel refs (source and/or a
+content-addressed cubin-cache key), and per-weight checkpoint bindings. ``plan_from_graph``
+projects a lowered ``Graph[CudaOp]`` into a plan; the JSON form (``plan_to_dict`` /
+``plan_from_dict``) is the on-disk pack format (``backend/pack.py``).
+
+Stack independence: the JSON schema carries only plain data plus a tiny expression grammar —
+``int`` literal, ``"name"`` var, ``[op, lhs, rhs]`` with ``op ∈ {+, -, *, /, //, %}`` — so a
+stored plan survives compiler changes; only runtime-contract changes (arg passing, buffer
+semantics) bump ``PLAN_FORMAT_VERSION``. CUDA-specific launch fields (TMA descriptors) nest
+under a ``"cuda"`` key so another backend can add its own namespace.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from emmy.compiler import dtype as dtypes
+from emmy.compiler.dim import Dim
+from emmy.compiler.dtype import DataType
+from emmy.compiler.ir.cuda import TmaDescMeta
+from emmy.compiler.ir.expr import BinaryExpr, Expr, Literal, Var
+
+if TYPE_CHECKING:
+    from emmy.compiler.graph import Graph
+
+logger = logging.getLogger(__name__)
+
+# Version of the runtime contract a stored plan assumes (arg-passing convention, zero_outputs
+# semantics, bf16-bits buffer encoding, TMA descriptor construction). Compiler-side changes do
+# NOT bump this — a stored plan keeps serving its frozen snapshot; bump only when the runtime's
+# interpretation of the plan changes.
+PLAN_FORMAT_VERSION = 1
+
+# Binary ops the on-disk expression grammar admits. Everything a ``Dim`` shape, a ceil-div grid
+# factor, or a runtime-constant expr can contain; anything else fails serialization loudly.
+_EXPR_OPS = ("+", "-", "*", "/", "//", "%")
+
+
+@dataclass
+class BufferSpec:
+    """One named device buffer: shape (``Dim``-valued — static ``Literal``, atomic symbolic
+    ``Var``, or composite ``BinaryExpr``), dtype, and planning role."""
+
+    name: str
+    shape: tuple[Dim, ...]
+    dtype: DataType
+    role: str  # "input" | "constant" | "output" | "scratch"
+
+    @property
+    def is_symbolic(self) -> bool:
+        return any(not d.is_static for d in self.shape)
+
+    def resolve_shape(self, sym_values: dict[str, int]) -> tuple[int, ...]:
+        return tuple(int(d.expr.eval(sym_values)) for d in self.shape)
+
+
+@dataclass
+class LaunchSpec:
+    """One kernel launch site, in program order. ``grid`` / ``block`` are per-dim factor tuples
+    whose entries are ``int`` (static), ``str`` (symbolic axis name resolved from sym_values),
+    or ``Expr`` (composite extent, e.g. ceil-div) — see ``ir.cuda.resolve_dim``."""
+
+    node_id: str
+    kernel_name: str
+    arg_names: tuple[str, ...]
+    grid: tuple
+    block: tuple
+    smem_bytes: int
+    zero_outputs: tuple[str, ...]
+    tma_descriptors: tuple[TmaDescMeta, ...] = ()
+    runtime_args: tuple[str, ...] = ()
+
+
+@dataclass
+class KernelSpec:
+    """How to obtain one kernel's device code: ``source`` (compile via the cubin cache — the
+    from-graph path) and/or ``binary_key`` (a content-addressed cubin-cache key — the pack
+    path). A pack stores only the key; a missing cubin falls back to full recompilation."""
+
+    source: str | None = None
+    binary_key: str | None = None
+    uses_tma: bool = False
+
+
+@dataclass
+class WeightSpec:
+    """Checkpoint binding for one constant buffer: the ``state_dict`` key it loads from and the
+    encoded load-op chain (the plan's own vocabulary, applied with pure numpy — see
+    ``apply_weight_loads``). ``load_ops`` is ``None`` when the graph carried a load op the
+    grammar can't express — such a plan still runs, but can't rebind weights from a pack."""
+
+    source_path: str
+    load_ops: tuple[tuple, ...] | None = ()
+
+
+@dataclass
+class ExecutionPlan:
+    """The pure-data half of a compiled program. ``_Compiled`` (the live runtime object) is this
+    plus loaded kernel modules; everything else the runtime builds (buffers, slab layout, TMA
+    descriptors, captured graphs) derives from these fields plus the live GPU."""
+
+    backend: str
+    inputs: list[str]
+    outputs: list[str]
+    buffers: list[BufferSpec]
+    constants: dict[str, float]
+    runtime_constants: dict[str, Expr]
+    launches: list[LaunchSpec]
+    kernels: dict[str, KernelSpec]
+    weights: dict[str, WeightSpec] = field(default_factory=dict)
+    symbolic_bindings: dict[str, tuple[str, int]] = field(default_factory=dict)
+    symbolic_hints: dict[str, int] = field(default_factory=dict)
+    symbolic_caps: dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Graph → plan projection
+# ---------------------------------------------------------------------------
+
+
+def plan_from_graph(graph: Graph) -> ExecutionPlan:
+    """Project a lowered ``Graph[CudaOp]`` into an :class:`ExecutionPlan`.
+
+    This is the seam the whole runtime builds from: after this call nothing reads the graph
+    again. Kernel specs carry the rendered source (the cubin-cache key input); grid/block specs
+    are normalized to factor tuples (a legacy bare-int spec becomes a single-factor tuple) so a
+    plan round-trips the JSON form exactly."""
+    from emmy.compiler.ir.base import ConstantOp, InputOp  # noqa: PLC0415
+    from emmy.compiler.ir.cuda import CudaOp  # noqa: PLC0415
+
+    buffers = [
+        BufferSpec(name=nid, shape=tuple(node.output.shape), dtype=node.output.dtype, role=graph.node_role(nid))
+        for nid, node in graph.nodes.items()
+    ]
+    constants = {nid: float(op.value) for nid, op in graph.constant_ops() if op.value is not None}
+    runtime_constants = {nid: op.context_value for nid, op in graph.constant_ops() if op.context_value is not None}
+
+    kernels: dict[str, KernelSpec] = {}
+    launches: list[LaunchSpec] = []
+    for nid in graph.topological_order():
+        node = graph.nodes[nid]
+        op = node.op
+        if isinstance(op, (InputOp, ConstantOp)):
+            continue
+        if not isinstance(op, CudaOp):
+            raise TypeError(f"plan_from_graph: node {nid!r} has non-CudaOp {type(op).__name__!r}; lowering must produce Graph[CudaOp].")
+        spec = kernels.get(op.kernel_name)
+        if spec is None:
+            kernels[op.kernel_name] = KernelSpec(source=op.kernel_source, uses_tma=bool(op.tma_descriptors))
+        elif spec.source != op.kernel_source:
+            raise ValueError(f"kernel name {op.kernel_name!r} used by two distinct sources")
+        launches.append(
+            LaunchSpec(
+                node_id=nid,
+                kernel_name=op.kernel_name,
+                arg_names=tuple(op.arg_order),
+                grid=tuple(_normalize_spec(s) for s in op.grid),
+                block=tuple(_normalize_spec(s) for s in op.block),
+                smem_bytes=op.smem_bytes,
+                zero_outputs=tuple(op.zero_outputs),
+                tma_descriptors=tuple(op.tma_descriptors),
+                runtime_args=tuple(getattr(op, "runtime_args", ())),
+            )
+        )
+
+    weights: dict[str, WeightSpec] = {}
+    for nid, op in graph.loadable_constants():
+        weights[nid] = WeightSpec(source_path=op.source_path, load_ops=_encode_load_ops(op.load_ops))
+
+    return ExecutionPlan(
+        backend="cuda",
+        inputs=list(graph.inputs),
+        outputs=list(graph.outputs),
+        buffers=buffers,
+        constants=constants,
+        runtime_constants=runtime_constants,
+        launches=launches,
+        kernels=kernels,
+        weights=weights,
+        symbolic_bindings=graph.symbolic_bindings(),
+        symbolic_hints=graph.symbolic_hints(),
+        symbolic_caps={},
+    )
+
+
+def _normalize_spec(spec) -> tuple:
+    """A grid/block dim spec as a factor tuple: legacy bare-int specs become one-factor tuples,
+    and scalar ``Expr`` factors collapse to their plain form (``Literal`` int → ``int``,
+    ``Var`` → ``str``) — identical at resolve time, and it keeps the plan's JSON round-trip
+    exact (the grammar reserves the list form for genuinely composite factors)."""
+    if isinstance(spec, int):
+        return (spec,)
+    out = []
+    for f in spec:
+        if isinstance(f, Literal) and isinstance(f.value, int):
+            out.append(int(f.value))
+        elif isinstance(f, Var):
+            out.append(f.name)
+        else:
+            out.append(f)
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Weight load-op vocabulary (pure numpy — no IR classes at apply time)
+# ---------------------------------------------------------------------------
+
+
+def _encode_load_ops(load_ops: tuple) -> tuple[tuple, ...] | None:
+    """Encode a ``ConstantOp.load_ops`` chain into the plan's vocabulary
+    (``("transpose", axes)`` / ``("reshape", shape)``), or ``None`` when a chain member isn't
+    expressible — the plan still runs (binding came from the live module), it just can't rebind
+    that weight from a pack."""
+    from emmy.compiler.ir.frontend.ir import ReshapeOp, TransposeOp  # noqa: PLC0415
+
+    out: list[tuple] = []
+    for op in load_ops:
+        if isinstance(op, TransposeOp):
+            out.append(("transpose", tuple(int(a) for a in op.axes)))
+        elif isinstance(op, ReshapeOp) and all(isinstance(d, int) for d in op.shape):
+            out.append(("reshape", tuple(op.shape)))
+        else:
+            logger.warning("plan: load op %r not expressible in the pack vocabulary; weight will not rebind from a pack", op)
+            return None
+    return tuple(out)
+
+
+def apply_weight_loads(source: np.ndarray, load_ops: tuple[tuple, ...]) -> np.ndarray:
+    """Apply an encoded load-op chain to a raw checkpoint tensor — the pack-side counterpart of
+    ``loader.binder.apply_load_ops``, matching its semantics (a 2-tuple transpose is a swap, à
+    la ``aten.transpose``; longer tuples are full permutations)."""
+    a = np.ascontiguousarray(source)
+    for kind, arg in load_ops:
+        if kind == "transpose":
+            a = np.swapaxes(a, arg[0] % a.ndim, arg[1] % a.ndim) if len(arg) == 2 else np.transpose(a, arg)
+        elif kind == "reshape":
+            a = a.reshape(arg)
+        else:
+            raise ValueError(f"apply_weight_loads: unknown load op kind {kind!r}")
+    return np.ascontiguousarray(a)
+
+
+# ---------------------------------------------------------------------------
+# Expression grammar — the only non-plain data in the JSON schema
+# ---------------------------------------------------------------------------
+
+
+def _expr_to_json(e):
+    """``Expr`` → JSON prefix form: ``int``/``float`` literal, ``"name"`` var, ``[op, l, r]``."""
+    if isinstance(e, Literal):
+        if isinstance(e.value, int) and e.dtype == "int":
+            return int(e.value)
+        return float(e.value)
+    if isinstance(e, Var):
+        return e.name
+    if isinstance(e, BinaryExpr) and e.op in _EXPR_OPS:
+        return [e.op, _expr_to_json(e.left), _expr_to_json(e.right)]
+    raise ValueError(f"plan: expression {e!r} not expressible in the plan grammar (ops {_EXPR_OPS})")
+
+
+def _expr_from_json(v) -> Expr:
+    if isinstance(v, bool):
+        raise ValueError(f"plan: invalid expression literal {v!r}")
+    if isinstance(v, int):
+        return Literal(v, "int")
+    if isinstance(v, float):
+        return Literal(v)
+    if isinstance(v, str):
+        return Var(v)
+    if isinstance(v, list) and len(v) == 3 and v[0] in _EXPR_OPS:
+        return BinaryExpr(v[0], _expr_from_json(v[1]), _expr_from_json(v[2]))
+    raise ValueError(f"plan: malformed expression {v!r}")
+
+
+def _factor_to_json(f):
+    """Grid/block factor → JSON: ``int`` and ``str`` (symbolic name) pass through, ``Expr``
+    becomes the grammar's list form."""
+    if isinstance(f, (int, str)):
+        return f
+    return [*_expr_to_json_as_list(f)]
+
+
+def _expr_to_json_as_list(e) -> list:
+    v = _expr_to_json(e)
+    # A factor that is an Expr must serialize as a list so deserialization can tell it apart
+    # from the plain int/str factor forms (a bare Var/Literal factor never reaches here — the
+    # lowering emits those as str/int directly).
+    if not isinstance(v, list):
+        raise ValueError(f"plan: grid factor {e!r} reduces to a scalar — expected int/str factor instead")
+    return v
+
+
+def _factor_from_json(v):
+    if isinstance(v, (int, str)):
+        return v
+    return _expr_from_json(v)
+
+
+def _dim_to_json(d: Dim):
+    return _expr_to_json(d.expr)
+
+
+def _dim_from_json(v) -> Dim:
+    return Dim(_expr_from_json(v))
+
+
+# ---------------------------------------------------------------------------
+# Plan ⇄ dict (the JSON pack format)
+# ---------------------------------------------------------------------------
+
+
+def plan_to_dict(plan: ExecutionPlan) -> dict:
+    return {
+        "format": PLAN_FORMAT_VERSION,
+        "backend": plan.backend,
+        "inputs": list(plan.inputs),
+        "outputs": list(plan.outputs),
+        "buffers": [
+            {"name": b.name, "shape": [_dim_to_json(d) for d in b.shape], "dtype": b.dtype.name, "role": b.role} for b in plan.buffers
+        ],
+        "constants": dict(plan.constants),
+        "runtime_constants": {nid: _expr_to_json(e) for nid, e in plan.runtime_constants.items()},
+        "launches": [
+            {
+                "node_id": lc.node_id,
+                "kernel": lc.kernel_name,
+                "args": list(lc.arg_names),
+                "grid": [[_factor_to_json(f) for f in spec] for spec in lc.grid],
+                "block": [[_factor_to_json(f) for f in spec] for spec in lc.block],
+                "smem": lc.smem_bytes,
+                "zero_outputs": list(lc.zero_outputs),
+                "runtime_args": list(lc.runtime_args),
+                "cuda": {
+                    "tma": [
+                        {"name": t.name, "src_buf": t.src_buf, "box_extents": list(t.box_extents), "swizzle": t.swizzle}
+                        for t in lc.tma_descriptors
+                    ]
+                },
+            }
+            for lc in plan.launches
+        ],
+        "kernels": {
+            name: {
+                **({"source": spec.source} if spec.source is not None else {}),
+                **({"binary_key": spec.binary_key} if spec.binary_key is not None else {}),
+                "uses_tma": spec.uses_tma,
+            }
+            for name, spec in plan.kernels.items()
+        },
+        "weights": {
+            nid: {"path": w.source_path, **({"ops": [[k, list(a)] for k, a in w.load_ops]} if w.load_ops is not None else {})}
+            for nid, w in plan.weights.items()
+        },
+        "symbols": {
+            "bindings": {name: [buf, idx] for name, (buf, idx) in plan.symbolic_bindings.items()},
+            "hints": dict(plan.symbolic_hints),
+            "caps": dict(plan.symbolic_caps),
+        },
+    }
+
+
+def plan_from_dict(d: dict) -> ExecutionPlan:
+    fmt = d.get("format")
+    if fmt != PLAN_FORMAT_VERSION:
+        raise ValueError(f"plan format {fmt!r} unsupported (runtime speaks {PLAN_FORMAT_VERSION})")
+    symbols = d.get("symbols", {})
+    return ExecutionPlan(
+        backend=d["backend"],
+        inputs=list(d["inputs"]),
+        outputs=list(d["outputs"]),
+        buffers=[
+            BufferSpec(
+                name=b["name"],
+                shape=tuple(_dim_from_json(v) for v in b["shape"]),
+                dtype=dtypes.get(b["dtype"]),
+                role=b["role"],
+            )
+            for b in d["buffers"]
+        ],
+        constants={nid: float(v) for nid, v in d.get("constants", {}).items()},
+        runtime_constants={nid: _expr_from_json(v) for nid, v in d.get("runtime_constants", {}).items()},
+        launches=[
+            LaunchSpec(
+                node_id=lc["node_id"],
+                kernel_name=lc["kernel"],
+                arg_names=tuple(lc["args"]),
+                grid=tuple(tuple(_factor_from_json(f) for f in spec) for spec in lc["grid"]),
+                block=tuple(tuple(_factor_from_json(f) for f in spec) for spec in lc["block"]),
+                smem_bytes=int(lc["smem"]),
+                zero_outputs=tuple(lc.get("zero_outputs", ())),
+                tma_descriptors=tuple(
+                    TmaDescMeta(name=t["name"], src_buf=t["src_buf"], box_extents=tuple(t["box_extents"]), swizzle=t["swizzle"])
+                    for t in lc.get("cuda", {}).get("tma", ())
+                ),
+                runtime_args=tuple(lc.get("runtime_args", ())),
+            )
+            for lc in d["launches"]
+        ],
+        kernels={
+            name: KernelSpec(source=spec.get("source"), binary_key=spec.get("binary_key"), uses_tma=bool(spec.get("uses_tma", False)))
+            for name, spec in d.get("kernels", {}).items()
+        },
+        weights={
+            nid: WeightSpec(
+                source_path=w["path"],
+                load_ops=tuple((k, tuple(a)) for k, a in w["ops"]) if "ops" in w else None,
+            )
+            for nid, w in d.get("weights", {}).items()
+        },
+        symbolic_bindings={name: (buf, int(idx)) for name, (buf, idx) in symbols.get("bindings", {}).items()},
+        symbolic_hints={name: int(v) for name, v in symbols.get("hints", {}).items()},
+        symbolic_caps={name: int(v) for name, v in symbols.get("caps", {}).items()},
+    )

--- a/emmy/config.py
+++ b/emmy/config.py
@@ -46,6 +46,7 @@ O3_TOL = "EMMY_O3_TOL"
 OFFLINE_TILT = "EMMY_OFFLINE_TILT"
 BENCH_BACKENDS = "EMMY_BENCH_BACKENDS"
 CUBIN_CACHE = "EMMY_CUBIN_CACHE"
+PACK_DIR = "EMMY_PACK_DIR"
 NO_NVCC = "EMMY_NO_NVCC"
 GPU_LOCK = "EMMY_GPU_LOCK"
 NCU_CHILD = "EMMY_NCU_CHILD"
@@ -356,6 +357,14 @@ def cubin_cache_dir() -> Path:
     """Content-addressed cubin cache dir: ``EMMY_CUBIN_CACHE`` → ``~/.cache/emmy/cubin``."""
     override = os.environ.get(CUBIN_CACHE)
     return Path(override) if override else _CACHE_ROOT / "cubin"
+
+
+def pack_dir() -> Path | None:
+    """``EMMY_PACK_DIR`` — root directory for execution-plan packs (``backend/pack.py``).
+    When set, the serving runner loads a matching pack (skipping trace / pipeline / fork
+    resolution / codegen) and writes one after a full compile. ``None`` (unset) disables."""
+    override = os.environ.get(PACK_DIR)
+    return Path(override) if override else None
 
 
 def nvcc_disabled() -> bool:

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -223,7 +223,12 @@ Recorded follow-ups, in impact order:
   **generative** path no longer needs it: `run_device` is capture-aware and `serve --generate` defaults to
   whole-step decode graphs (see `gen_runner.py` above).
 - Startup compiles the whole model (~1–2 min for 0.6B warm-cubin-cache; first boot pays nvcc). `EMMY_CUBIN_CACHE`
-  persistence across container restarts is what keeps reboots fast.
+  persistence across container restarts is what keeps reboots fast. **`EMMY_PACK_DIR`** cuts the rest of the warm
+  boot: `EmmyForwardRunner.create` keys an execution-plan pack (`compiler/backend/pack.py`) on model id + config
+  hash + serving shape — a hit loads binary-keyed plans (`CompiledProgram.build_from_plan`) and skips trace, pass
+  pipeline, fork resolution, and codegen entirely (weights still bind from the checkpoint via the plan's
+  `source_path` refs); a miss compiles in full and writes the pack for the next boot. Any mismatch — retune under
+  a different config, nvcc/toolkit change, evicted cubin — silently falls back to the full compile.
 - The shared buffer set is allocated at `max_seq_len` (`--max-model-len`); every accepted request (S ≤ `max_seq_len`)
   uses the captured-graph path. The S²-attention scratch dominates that allocation (0.6B at 4096 ≈ 15 GB), so lower
   `--max-model-len` for bigger models / smaller cards.

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -123,24 +123,29 @@ def _pad_rows(arr, bucket):
     return out
 
 
-def _bind_device_constants(graph, sources, cache):
-    """Upload each distinct ``(source_path, load_ops)`` constant ONCE and share the cupy
-    array across program builds. The symbolic and decode-bucket twins bind the same
-    weights; per-build numpy feeds would upload a second full on-GPU copy of the trunk
-    (~2× the weight footprint). ``cache`` must be scoped to one wrapper — param paths
-    are wrapper-relative, so a cross-wrapper cache would collide."""
-    import cupy as cp
-
-    from emmy.compiler.loader.binder import apply_load_ops
+def _bind_plan_constants(plan, sources, cache):
+    """Build the constant feed from the plan's weight specs (works identically whether the
+    plan came from a fresh compile or a pack). With a ``cache`` (per-wrapper), each distinct
+    ``(source_path, load_ops)`` weight uploads ONCE and the cupy array is shared across
+    program builds — the symbolic and decode/prefill-bucket twins bind the same weights;
+    per-build numpy feeds would upload a second full on-GPU copy of the trunk (~2× the
+    weight footprint). ``cache`` must be scoped to one wrapper — param paths are
+    wrapper-relative, so a cross-wrapper cache would collide."""
+    from emmy.compiler.backend.plan import apply_weight_loads
 
     out = {}
-    for nid, op in graph.loadable_constants():
-        if op.source_path not in sources:
+    for nid, w in plan.weights.items():
+        if w.source_path not in sources or w.load_ops is None:
             continue
-        key = (op.source_path, repr(op.load_ops))
+        if cache is None:
+            out[nid] = apply_weight_loads(sources[w.source_path], w.load_ops)
+            continue
+        import cupy as cp
+
+        key = (w.source_path, w.load_ops)
         arr = cache.get(key)
         if arr is None:
-            arr = cp.asarray(apply_load_ops(sources[op.source_path], op.load_ops))
+            arr = cp.asarray(apply_weight_loads(sources[w.source_path], w.load_ops))
             cache[key] = arr
         out[nid] = arr
     return out
@@ -162,28 +167,33 @@ def trace_split(wrapper, example_args, argnames):
     return trace_module(wrapper, tuple(example_args), dynamic_shapes=dynamic_shapes)
 
 
-def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, arena=None, capacity=None):
-    """Trace ``wrapper`` and build a :class:`_Program`. ``argnames`` (a list) ties each named
-    arg's axis-0 to a shared symbolic ``num_tokens`` Dim — the **prefill** program (one program,
-    any width). ``argnames=None`` traces a **fully static** graph at the example shapes — the
-    **decode-bucket** program (efficient at small M; the symbolic program's hint-sized M-tile is
-    pathological at decode). ``dev_consts`` (a per-wrapper dict) shares each weight's device
-    buffer across the builds that pass the same dict — see :func:`_bind_device_constants`.
-    ``arena`` (one per runner) pools the activation buffers + scratch slab across every
-    program built with it — layers run sequentially, so N layers hold ~one layer's worth.
-    ``capacity`` (symbolic programs only) sizes the BUILD feed's token axis so the device
-    buffers hold any step up to it — the :meth:`_Program.run_device_sym` prefill path needs
-    fixed capacity buffers (``set_sym_values`` never re-allocates); without it the build feed
-    is the example (the host ``rebind`` path re-sizes per call)."""
+def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, arena=None, capacity=None, plan=None):
+    """Trace ``wrapper`` and build a :class:`_Program`; returns ``(program, plan)``. ``argnames``
+    (a list) ties each named arg's axis-0 to a shared symbolic ``num_tokens`` Dim — the
+    **prefill** program (one program, any width). ``argnames=None`` traces a **fully static**
+    graph at the example shapes — the **decode-bucket** program (efficient at small M; the
+    symbolic program's hint-sized M-tile is pathological at decode). ``dev_consts`` (a
+    per-wrapper dict) shares each weight's device buffer across the builds that pass the same
+    dict — see :func:`_bind_plan_constants`. ``arena`` (one per runner) pools the activation
+    buffers + scratch slab across every program built with it — layers run sequentially, so N
+    layers hold ~one layer's worth. ``capacity`` (symbolic programs only) sizes the BUILD
+    feed's token axis so the device buffers hold any step up to it — the
+    :meth:`_Program.run_device_sym` prefill path needs fixed capacity buffers
+    (``set_sym_values`` never re-allocates); without it the build feed is the example (the
+    host ``rebind`` path re-sizes per call). ``plan`` (a pack-loaded ``ExecutionPlan``) skips
+    the trace + compile entirely and builds from the stored plan — kernels load by cubin key,
+    weights rebind from the live wrapper through the same shared-upload cache."""
     import torch
 
-    from emmy.compiler.backend.cuda.backend import CudaBackend
     from emmy.compiler.backend.cuda.program import CompiledProgram
     from emmy.compiler.backend.gpu_lock import gpu_lock
-    from emmy.compiler.loader.binder import bind_constants
 
-    graph = trace_split(wrapper, example_args, argnames)
-    compiled = CudaBackend(tune_db="auto").compile(graph)
+    if plan is None:
+        from emmy.compiler.backend.cuda.backend import CudaBackend
+        from emmy.compiler.backend.plan import plan_from_graph
+
+        graph = trace_split(wrapper, example_args, argnames)
+        plan = plan_from_graph(CudaBackend(tune_db="auto").compile(graph))
 
     sources = {}
     for path, t in wrapper.named_parameters(remove_duplicate=False):
@@ -194,14 +204,11 @@ def _compile_split(wrapper, example_args, argnames, np_dtype, dev_consts=None, a
     build_args = example_args
     if capacity is not None and argnames:
         build_args = [torch.zeros((capacity, *a.shape[1:]), dtype=a.dtype) for a in example_args]
-    feed = {n: a.detach().cpu().to(torch.float32).numpy().astype(np_dtype) for n, a in zip(compiled.inputs, build_args, strict=True)}
+    feed = {n: a.detach().cpu().to(torch.float32).numpy().astype(np_dtype) for n, a in zip(plan.inputs, build_args, strict=True)}
     with gpu_lock():
-        if dev_consts is None:
-            const_feed = bind_constants(compiled, sources)
-        else:
-            const_feed = _bind_device_constants(compiled, sources, dev_consts)
-        program = CompiledProgram.build(compiled, {**const_feed, **feed}, arena=arena)
-    return _Program(program, list(compiled.inputs), list(compiled.outputs))
+        const_feed = _bind_plan_constants(plan, sources, dev_consts)
+        program = CompiledProgram.build_from_plan(plan, {**const_feed, **feed}, arena=arena)
+    return _Program(program, list(plan.inputs), list(plan.outputs)), plan
 
 
 class EmmyGenRunner:
@@ -320,6 +327,44 @@ class EmmyGenRunner:
         # The prefill-chunk twin only pays ABOVE the decode bucket (an equal-or-smaller
         # bucket is fully shadowed by the decode twins' routing).
         prefill_ok = prefill_bucket and prefill_bucket > max(decode_bucket or 0, 0)
+
+        # Pack lookup (EMMY_PACK_DIR): one pack for the whole per-layer program set. The
+        # validity key is the model's config hash + the serving shape — deliberately NO model
+        # id/path: the baked image resolves the model to a snapshot *path* offline while the
+        # warm boot uses the hub id, and the config hash already pins identity.
+        import hashlib
+
+        from emmy import config as emmy_config
+        from emmy.compiler.backend.pack import load_pack, pack_path
+
+        pack_key = {
+            "kind": "gen-split",
+            "model": str(getattr(text_config, "model_type", "gen")),  # label + key; config-derived, path-stable
+            "config_sha": hashlib.sha1(model.config.to_json_string().encode()).hexdigest()[:16],
+            "dtype": dtype_str,
+            "decode_bucket": int(decode_bucket or 0),
+            "max_tokens": int(max_tokens or 0),
+            "prefill_bucket": int(prefill_bucket or 0),
+        }
+        pack_at = pack_path(emmy_config.pack_dir(), pack_key) if emmy_config.pack_dir() is not None else None
+        loaded = load_pack(pack_at, key=pack_key) if pack_at is not None else None
+        if loaded is not None:
+            logger.info("[gen_runner] pack hit at %s — skipping trace + compile for %d program(s)", pack_at, len(loaded))
+            # The pack records which twin sets survived their compiles — honor that instead
+            # of re-attempting a twin the save-time boot already saw fail.
+            decode_ok = decode_ok and "L00.pre.decode" in loaded
+            prefill_ok = prefill_ok and "L00.pre.prefill" in loaded
+
+        def stored(name):
+            return loaded.get(name) if loaded is not None else None
+
+        plans: dict = {}
+
+        def build(name, *args, **kw):
+            prog, built_plan = _compile_split(*args, plan=stored(name), **kw)
+            plans[name] = built_plan
+            return prog
+
         # One arena for every program this runner builds: layers run sequentially, so
         # all layers' activation buffers + scratch slabs share one layer's worth of
         # device memory instead of scaling with num_layers.
@@ -336,7 +381,8 @@ class EmmyGenRunner:
             post_consts: dict = {}
             with torch.device("cpu"):
                 pre_programs.append(
-                    _compile_split(
+                    build(
+                        f"L{i:02d}.pre.sym",
                         pre_w,
                         [torch.zeros(8, hidden, dtype=dtype)],
                         ["hidden"],
@@ -347,7 +393,8 @@ class EmmyGenRunner:
                     )
                 )
                 post_programs.append(
-                    _compile_split(
+                    build(
+                        f"L{i:02d}.post.sym",
                         post_w,
                         [torch.zeros(8, attn_width, dtype=dtype), torch.zeros(8, hidden, dtype=dtype)],
                         ["attn_out", "residual"],
@@ -363,12 +410,19 @@ class EmmyGenRunner:
                 if decode_ok:
                     try:
                         pre_decode.append(
-                            _compile_split(
-                                pre_w, [torch.zeros(decode_bucket, hidden, dtype=dtype)], None, np_dtype, dev_consts=pre_consts, arena=arena
+                            build(
+                                f"L{i:02d}.pre.decode",
+                                pre_w,
+                                [torch.zeros(decode_bucket, hidden, dtype=dtype)],
+                                None,
+                                np_dtype,
+                                dev_consts=pre_consts,
+                                arena=arena,
                             )
                         )
                         post_decode.append(
-                            _compile_split(
+                            build(
+                                f"L{i:02d}.post.decode",
                                 post_w,
                                 [torch.zeros(decode_bucket, attn_width, dtype=dtype), torch.zeros(decode_bucket, hidden, dtype=dtype)],
                                 None,
@@ -386,7 +440,8 @@ class EmmyGenRunner:
                 if prefill_ok:
                     try:
                         pre_prefill.append(
-                            _compile_split(
+                            build(
+                                f"L{i:02d}.pre.prefill",
                                 pre_w,
                                 [torch.zeros(prefill_bucket, hidden, dtype=dtype)],
                                 None,
@@ -396,7 +451,8 @@ class EmmyGenRunner:
                             )
                         )
                         post_prefill.append(
-                            _compile_split(
+                            build(
+                                f"L{i:02d}.post.prefill",
                                 post_w,
                                 [torch.zeros(prefill_bucket, attn_width, dtype=dtype), torch.zeros(prefill_bucket, hidden, dtype=dtype)],
                                 None,
@@ -418,6 +474,21 @@ class EmmyGenRunner:
             embed_weight = embed_weight * np_dtype.type(embed_scale)
         use_decode = decode_ok and len(pre_decode) == len(layers)
         use_prefill = prefill_ok and len(pre_prefill) == len(layers)
+        if pack_at is not None and loaded is None:
+            # Best-effort save after a full compile: only the program sets that survived
+            # (a mid-run twin failure leaves partial lists — those must not be recorded).
+            keep = {
+                name: p for name, p in plans.items() if (".decode" not in name or use_decode) and (".prefill" not in name or use_prefill)
+            }
+            if any(w.load_ops is None for p in keep.values() for w in p.weights.values()):
+                logger.warning("[gen_runner] not writing pack: a weight load-op chain is outside the pack vocabulary")
+            else:
+                try:
+                    from emmy.compiler.backend.pack import save_pack
+
+                    save_pack(pack_at, keep, key=pack_key)
+                except Exception:  # noqa: BLE001 — the pack is an optimization, never a boot blocker
+                    logger.warning("[gen_runner] pack write failed at %s", pack_at, exc_info=True)
         runner = cls(
             embed_weight=embed_weight,
             norm=trunk.norm,

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -18,7 +18,7 @@ prefill / chunked-prefill (``bucket < T <= prefill_capacity``) through the symbo
 ``run_device_sym`` (grids sized per step, capacity buffers, no per-layer host hop); the host
 numpy ``rebind`` path survives for the standalone oracle and as the over-capacity fallback.
 NOTE: the per-layer ``CompiledProgram``s share BOTH their
-weights (one device buffer per constant, ``_bind_device_constants``) and their activation
+weights (one device buffer per constant, ``_bind_plan_constants``) and their activation
 buffers + scratch slabs (one ``BufferArena`` per runner) — the footprint no longer scales
 with ``num_layers`` (the memory budget the plan flagged, Phase 2 / Top risk #9).
 """

--- a/emmy/serving/runner.py
+++ b/emmy/serving/runner.py
@@ -73,16 +73,18 @@ class EmmyForwardRunner:
 
     @classmethod
     def create(cls, model_id: str, max_seq_len: int, dtype_str: str = "float16", batch: int = 1) -> EmmyForwardRunner:
+        import hashlib
+
         import torch
         from transformers import AutoModel
 
-        from emmy.compiler.backend.cuda.backend import CudaBackend
+        from emmy import config
         from emmy.compiler.backend.cuda.program import CompiledProgram
         from emmy.compiler.backend.gpu_lock import gpu_lock
-        from emmy.compiler.loader.binder import bind_constants
-        from emmy.compiler.trace.dynamic import DYNAMIC_DIM_MAX, build_torch_dynamic_shapes, parse_position_specs
-        from emmy.compiler.trace.huggingface import build_causal_mask, build_full_model_wrapper
-        from emmy.compiler.trace.torch import trace_module
+        from emmy.compiler.backend.pack import load_pack, pack_path
+        from emmy.compiler.backend.plan import apply_weight_loads
+        from emmy.compiler.trace.dynamic import DYNAMIC_DIM_MAX
+        from emmy.compiler.trace.huggingface import build_full_model_wrapper
 
         if max_seq_len > DYNAMIC_DIM_MAX:
             raise ValueError(
@@ -101,37 +103,24 @@ class EmmyForwardRunner:
         with torch.device("cpu"):
             model = AutoModel.from_pretrained(model_id, dtype=dtype)
             model.eval()
-            if batch > 1:
-                # Static batched path: ONE fully-static (batch, max_seq_len)
-                # program (the symbolic-seq kernels miscompute batch>1; a static
-                # trace bakes correct batch strides). Each step pads to this shape.
-                logger.info("[serving] tracing STATIC batched (batch=%d, S=%d)...", batch, max_seq_len)
-                wrapper = build_full_model_wrapper(model, max_seq_len, dtype, dynamic=True)
-                example = (
-                    torch.zeros((batch, max_seq_len), dtype=torch.long),
-                    build_causal_mask(max_seq_len, dtype),
-                    torch.arange(max_seq_len).unsqueeze(0).expand(batch, max_seq_len).contiguous(),
-                )
-                graph = trace_module(wrapper, example)  # no dynamic_shapes → fully static
-            else:
-                logger.info("[serving] tracing (dynamic seq_len, example S=%d)...", _TRACE_SEQ)
-                specs = parse_position_specs(
-                    ["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"]
-                )
-                wrapper = build_full_model_wrapper(model, _TRACE_SEQ, dtype, dynamic=True)
-                example = (
-                    torch.zeros((1, _TRACE_SEQ), dtype=torch.long),
-                    build_causal_mask(_TRACE_SEQ, dtype),
-                    torch.arange(_TRACE_SEQ).unsqueeze(0),
-                )
-                graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
+            wrapper = build_full_model_wrapper(model, max_seq_len if batch > 1 else _TRACE_SEQ, dtype, dynamic=True)
 
-        logger.info("[serving] compiling...")
-        compiled = CudaBackend(tune_db="auto").compile(graph)
-        if len(compiled.inputs) != 3:
-            raise RuntimeError(f"expected 3 graph inputs (input_ids, attention_mask, position_ids), got {compiled.inputs}")
-        if len(compiled.outputs) != 1:
-            raise RuntimeError(f"expected 1 graph output (hidden states), got {compiled.outputs}")
+        # Pack lookup: model identity (id + config hash, so a same-config fine-tune shares the
+        # pack) × the serving shape. A hit skips trace + pipeline + fork resolution + codegen;
+        # any mismatch / missing cubin falls back to the full compile below.
+        pack_key = {
+            "kind": "embed-trunk",
+            "model": model_id,
+            "config_sha": hashlib.sha1(model.config.to_json_string().encode()).hexdigest()[:16],
+            "max_seq_len": max_seq_len,
+            "dtype": dtype_str,
+            "batch": batch,
+        }
+        pack_at = pack_path(config.pack_dir(), pack_key) if config.pack_dir() is not None else None
+        plan = None
+        if pack_at is not None:
+            plans = load_pack(pack_at, key=pack_key)
+            plan = plans.get("trunk") if plans is not None else None
 
         # Weight sources in the traced dtype: named_buffers (NOT state_dict)
         # so non-persistent buffers — the wrapper's precomputed rotary
@@ -142,9 +131,25 @@ class EmmyForwardRunner:
             sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
         for path, t in wrapper.named_buffers(remove_duplicate=False):
             sources[path] = t.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
-        const_feed = bind_constants(compiled, sources)
 
-        ids_name, mask_name, pos_name = compiled.inputs
+        if plan is not None:
+            logger.info("[serving] pack hit at %s — skipping trace + compile", pack_at)
+            const_feed = {
+                nid: apply_weight_loads(sources[w.source_path], w.load_ops)
+                for nid, w in plan.weights.items()
+                if w.load_ops is not None and w.source_path in sources
+            }
+        else:
+            plan, const_feed = cls._trace_and_compile(model, wrapper, sources, max_seq_len, dtype, batch)
+            if pack_at is not None:
+                cls._save_pack(pack_at, plan, pack_key, model_id)
+
+        if len(plan.inputs) != 3:
+            raise RuntimeError(f"expected 3 graph inputs (input_ids, attention_mask, position_ids), got {plan.inputs}")
+        if len(plan.outputs) != 1:
+            raise RuntimeError(f"expected 1 graph output (hidden states), got {plan.outputs}")
+
+        ids_name, mask_name, pos_name = plan.inputs
         if batch > 1:
             # Static (batch, max_seq_len) buffers. The causal mask + position_ids
             # are request-independent (full causal at max_seq_len, arange positions),
@@ -164,7 +169,8 @@ class EmmyForwardRunner:
                 pos_name: np.arange(max_seq_len, dtype=np.int64).reshape(1, max_seq_len),
             }
         with gpu_lock():
-            program = CompiledProgram.build(compiled, {**const_feed, **feed})
+            program = CompiledProgram.build_from_plan(plan, {**const_feed, **feed})
+        output_name = plan.outputs[0]
         del model, wrapper, sources, const_feed
         logger.info(
             "[serving] ready: %d launches, max_seq_len=%d, batch_cap=%d",
@@ -175,11 +181,67 @@ class EmmyForwardRunner:
         return cls(
             program=program,
             input_names=(ids_name, mask_name, pos_name),
-            output_name=compiled.outputs[0],
+            output_name=output_name,
             np_dtype=np_dtype,
             max_seq_len=max_seq_len,
             batch_cap=batch,
         )
+
+    @classmethod
+    def _trace_and_compile(cls, model, wrapper, sources: dict[str, np.ndarray], max_seq_len: int, dtype, batch: int):
+        """The full frontend: torch.export trace + CUDA pass pipeline, projected to an
+        execution plan, plus the weight feed bound from the live wrapper."""
+        import torch
+
+        from emmy.compiler.backend.cuda.backend import CudaBackend
+        from emmy.compiler.backend.plan import plan_from_graph
+        from emmy.compiler.loader.binder import bind_constants
+        from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs
+        from emmy.compiler.trace.huggingface import build_causal_mask
+        from emmy.compiler.trace.torch import trace_module
+
+        with torch.device("cpu"):
+            if batch > 1:
+                # Static batched path: ONE fully-static (batch, max_seq_len)
+                # program (the symbolic-seq kernels miscompute batch>1; a static
+                # trace bakes correct batch strides). Each step pads to this shape.
+                logger.info("[serving] tracing STATIC batched (batch=%d, S=%d)...", batch, max_seq_len)
+                example = (
+                    torch.zeros((batch, max_seq_len), dtype=torch.long),
+                    build_causal_mask(max_seq_len, dtype),
+                    torch.arange(max_seq_len).unsqueeze(0).expand(batch, max_seq_len).contiguous(),
+                )
+                graph = trace_module(wrapper, example)  # no dynamic_shapes → fully static
+            else:
+                logger.info("[serving] tracing (dynamic seq_len, example S=%d)...", _TRACE_SEQ)
+                specs = parse_position_specs(
+                    ["seq_len@input_ids:1", "seq_len@attention_mask:2", "seq_len@attention_mask:3", "seq_len@position_ids:1"]
+                )
+                example = (
+                    torch.zeros((1, _TRACE_SEQ), dtype=torch.long),
+                    build_causal_mask(_TRACE_SEQ, dtype),
+                    torch.arange(_TRACE_SEQ).unsqueeze(0),
+                )
+                graph = trace_module(wrapper, example, dynamic_shapes=build_torch_dynamic_shapes(specs))
+
+        logger.info("[serving] compiling...")
+        compiled = CudaBackend(tune_db="auto").compile(graph)
+        return plan_from_graph(compiled), bind_constants(compiled, sources)
+
+    @staticmethod
+    def _save_pack(pack_at, plan, pack_key: dict, model_id: str) -> None:
+        """Best-effort pack write after a full compile — a failure costs nothing but the log
+        line (the next boot recompiles). Skipped when any weight can't be expressed in the
+        pack vocabulary (a pack-hit boot could then not rebind it)."""
+        from emmy.compiler.backend.pack import save_pack
+
+        if any(w.load_ops is None for w in plan.weights.values()):
+            logger.warning("[serving] not writing pack: a weight load-op chain is outside the pack vocabulary")
+            return
+        try:
+            save_pack(pack_at, {"trunk": plan}, key=pack_key, provenance={"model": model_id})
+        except Exception:  # noqa: BLE001 — the pack is an optimization, never a boot blocker
+            logger.warning("[serving] pack write failed at %s", pack_at, exc_info=True)
 
     @property
     def hidden_size(self) -> int:

--- a/emmy/serving/runner.py
+++ b/emmy/serving/runner.py
@@ -140,7 +140,7 @@ class EmmyForwardRunner:
                 if w.load_ops is not None and w.source_path in sources
             }
         else:
-            plan, const_feed = cls._trace_and_compile(model, wrapper, sources, max_seq_len, dtype, batch)
+            plan, const_feed = cls._trace_and_compile(wrapper, sources, max_seq_len, dtype, batch)
             if pack_at is not None:
                 cls._save_pack(pack_at, plan, pack_key, model_id)
 
@@ -188,7 +188,7 @@ class EmmyForwardRunner:
         )
 
     @classmethod
-    def _trace_and_compile(cls, model, wrapper, sources: dict[str, np.ndarray], max_seq_len: int, dtype, batch: int):
+    def _trace_and_compile(cls, wrapper, sources: dict[str, np.ndarray], max_seq_len: int, dtype, batch: int):
         """The full frontend: torch.export trace + CUDA pass pipeline, projected to an
         execution plan, plus the weight feed bound from the live wrapper."""
         import torch

--- a/plans/execution-plan-pack.md
+++ b/plans/execution-plan-pack.md
@@ -63,8 +63,14 @@ pack/
   plan/<program>.json    # serialized plan per program (embed, L00.pre.sym, L00.pre.decode, …)
 ```
 
-Cubins stay in the shared `EMMY_CUBIN_CACHE` (content-addressed); the docker bake already ships that cache.
-Weights stay external (the HF checkpoint), bound by `source_path` at load.
+Cubins stay in the shared `EMMY_CUBIN_CACHE` (content-addressed); weights stay external (the HF checkpoint),
+bound by `source_path` at load.
+
+**Docker image = model + cubins + pack.** The `docker/vllm-emmy-gemma4` build already bakes the HF model
+snapshot (`warm/hf`) and the cubin cache (`warm/cubin`) into the image; the pack joins them as a third baked
+artifact (`warm/pack`), so a container cold-start ships everything: weights (no download), cubins (no nvcc), and
+the pack (no trace/pipeline/resolution/codegen). `warm.sh` emits the pack during its serving run; the Dockerfile
+`COPY`s it next to the cubin cache; `verify.sh`'s zero-recompile check tightens to zero-frontend.
 
 ### Plan JSON schema (per program)
 

--- a/plans/execution-plan-pack.md
+++ b/plans/execution-plan-pack.md
@@ -115,6 +115,14 @@ round-trip — the pack never serializes the Graph.)
 
 Steps 1–3 are pure refactor + serialization, testable without a GPU. Step 4–5 need a CUDA box for the A/B.
 
+## Status (2026-07-20)
+
+Steps 1–6 landed on `feature/execution-plan-pack` (PR #405), including the gen-runner pack boot and the
+docker bake wiring (image = model + cubins + pack; `verify.sh` asserts the pack-hit boot). Measured on the
+RTX 5090: 0.6B embed warm boot 737 s → **9.5 s** pack hit, outputs bit-exact; gen-runner round-trip pinned by
+`tests/serving/test_gen_pack_gpu.py`. Remaining: exercise the pack-enabled `release-gemma4-image` pipeline end
+to end on a rental (needs base image + HF_TOKEN) and measure the shipped image's cold start.
+
 ## Remaining per-boot costs after the pack (accepted)
 
 `cuModuleLoad` (~25 ms × unique kernels), weight load + upload, buffer/arena allocation, TMA descriptor rebuild

--- a/plans/execution-plan-pack.md
+++ b/plans/execution-plan-pack.md
@@ -1,0 +1,115 @@
+# Execution-plan pack: a serializable compiled-program format for fast serving boot
+
+## Problem
+
+On a fully-warm boot (cubins cached, goldens/prior/DB seeded), serving still redoes the entire compiler frontend
+every time: HF model load, torch.export trace, the full CUDA pass pipeline, greedy fork resolution, and CUDA C
+codegen for every kernel — codegen is unavoidable today because the source string *is* the cubin-cache key. The
+only skipped stage is the nvcc/cicc/ptxas subprocess (`nvcc.py` cache hit). Measured costs: ~1–2 min for the 0.6B
+embedding model warm; the gemma-4 generative path compiles ~96 programs (pre/post × 48 layers + decode/prefill
+twins) through that chain per boot; a bloated online file once stalled a boot 15 min in pure resolution. The
+a1145d00 serve-boot memos (prior parse, DB perf index) amortize only *within* one process — nothing persists.
+
+## Key insight: serialize the runtime projection, not the Graph
+
+`_Compiled` (`backend/cuda/program.py`) is the compiler↔runtime seam. After `_compile(graph)` runs, nothing
+downstream ever touches the Graph again: slab liveness is computed from the launch list
+(`_plan_slab` → `compute_live_intervals(sizes, compiled.launches)`), allocation from the buffer specs, launch
+resolution from the symbolic bindings. `_Compiled` is pure data except the loaded kernel modules:
+
+- `bufs`: name, shape (`Dim` — static int / symbolic var / composite expr), dtype, role
+- `constants: {name: float}` (scalars are NOT inlined into kernel source — value-independent codegen),
+  `runtime_constants: {name: Expr}`
+- `launches`: kernel name, arg names, grid/block (`GridDimSpec` — factors are int | sym-name | `Expr` ceil-div),
+  smem, zero_outputs, `TmaDescMeta` tuple, runtime_args
+- `symbolic_bindings` / `symbolic_hints` / `symbolic_caps`
+- `kernels: {name: RawKernel}` — the only live objects; rebuilt at load
+
+Weights are referenced by `ConstantOp.source_path` (matches `state_dict` keys verbatim) and bound late — never
+baked into codegen. So a serialized plan is re-bindable from any same-config checkpoint (fine-tunes share packs).
+
+## Decisions (from the design discussion)
+
+1. **Reuse the existing cubin cache; reference binaries by content-addressed key** (the sha1 from
+   `nvcc._cache_key`), never by filesystem path. Multiple packs (and the ~2 layer types × 48 layers within one
+   pack) dedupe to the same cubin files automatically.
+2. **Missing/invalidated cubin → recompile.** The pack loader falls back to the full frontend compile path when a
+   referenced cubin is absent or the manifest key mismatches. No embedded kernel sources in the pack.
+3. **Stack-independent format.** The plan schema carries only tensors/launches/symbols/binary-refs plus a tiny
+   self-contained expression grammar — no compiler IR classes, no op types. Compiler changes (new passes,
+   re-tunes, refactors) do NOT invalidate a pack; it keeps serving its frozen snapshot. What versions the format
+   is the *runtime contract* (arg-passing convention, `runtime_args` by value, `zero_outputs` semantics,
+   bf16-bits-as-uint16 encoding, TMA descriptor construction) — changes there bump the format version.
+4. **Validity key** = format version × model id + `config.json` hash × serving shape (max_model_len, batched-token
+   capacity, decode/prefill bucket, dtype) × {backend, arch `sm_XX(+a)`, toolkit tag, nvcc flags}. Compiler git
+   rev, goldens/prior state, tune date are recorded as *provenance metadata only* — informational, not validity.
+5. **Backend-extensible (ROCm later).** Neutral core (buffers, symbols, constants, launches, grid/block/smem);
+   CUDA-specific fields (TMA descriptors, `sm_XXa` tag) live in a namespaced `backend.cuda` section. Loaders are
+   polymorphic: `from_plan(plan, weights, arena) → program` dispatched on `manifest.backend`. A ROCm pack changes
+   the manifest backend/arch, the binary keys (hsaco cache analog), and supplies its own loader. No ROCm code now
+   — just the namespacing.
+6. **No code duplication: the main launch path goes through the plan.** `CompiledProgram.build(graph)` becomes
+   `build_from_plan(plan_from_graph(graph))`; the pack loader calls the same `build_from_plan`. One runtime path
+   whether the plan came from a fresh compile or from disk.
+7. **Frozen picks are a feature.** A pack sidesteps the known cross-process fork-pick nondeterminism (the bimodal
+   picks that force `warm.sh`'s fixpoint loop) — picks are frozen in the artifact. Staleness after an
+   `emmy tune` is accepted; regeneration is the answer (slots into the warm/bake image flow).
+
+## Pack layout
+
+```
+pack/
+  manifest.json          # validity key + provenance + program index
+  plan/<program>.json    # serialized plan per program (embed, L00.pre.sym, L00.pre.decode, …)
+```
+
+Cubins stay in the shared `EMMY_CUBIN_CACHE` (content-addressed); the docker bake already ships that cache.
+Weights stay external (the HF checkpoint), bound by `source_path` at load.
+
+### Plan JSON schema (per program)
+
+- `buffers`: `[{name, shape: [dimexpr…], dtype, role}]`
+- `constants`: `{name: float}`; `runtime_constants`: `{name: dimexpr}`
+- `launches`: `[{kernel, args: [name…], grid: [[factor…]×3], block: [[factor…]×3], smem, zero_outputs,
+  runtime_args, cuda: {tma: [{name, src_buf, box_extents, swizzle}]}}]`
+- `symbols`: `{bindings: {sym: [input_buf, dim_idx]}, hints: {sym: int}, caps: {sym: int}}`
+- `kernels`: `{name: {binary_key, uses_tma}}`
+
+**Expression grammar** (dims, grid factors, runtime constants): JSON prefix form — `int` literal, `"name"` var,
+`[op, lhs, rhs]` with `op ∈ {"+", "-", "*", "//"}`. This is the only non-plain data in the format; defining it in
+the format (not reusing compiler `Expr`/`Dim`) is what buys stack independence. The loader maps it back to the
+runtime's expression objects. (Bonus: sidesteps the known Graph-JSON bug where `Expr`-valued grid factors don't
+round-trip — the pack never serializes the Graph.)
+
+## Implementation steps
+
+1. **`ExecutionPlan` dataclasses + `plan_from_graph`** (`emmy/compiler/backend/plan.py`): extract the pure-data
+   half of `_compile` (buffers, constants, launches, symbols, kernel specs `{source, uses_tma}`); `_Compiled`
+   becomes plan + loaded kernels. → verify: existing CPU tests green; `_compile` behavior unchanged.
+2. **Plan serialization** (`plan_to_dict` / `plan_from_dict` + the expression grammar): round-trip every field
+   including `Expr` grid factors, composite `Dim` shapes, `TmaDescMeta`. → verify: new round-trip tests, no GPU
+   needed (property: `plan_from_dict(plan_to_dict(p)) == p` over representative graphs, incl. symbolic SDPA).
+3. **Wire the runtime through the plan**: `CompiledProgram.build(graph, …)` = `plan_from_graph` +
+   `build_from_plan`; kernel loading accepts `binary_key` (direct cubin load — factor a load-by-path helper out of
+   `nvcc.load_function`) with source-compile as the from-graph path. → verify: full GPU suite green (`make test`),
+   no behavior change.
+4. **Pack save/load** (`emmy/compiler/backend/pack.py`): manifest write (compose the key from `nvcc._cache_key`
+   components + model config hash + serving-shape params), save resolves each kernel's cubin key after compile;
+   load validates the key, builds each program via `build_from_plan`, and **falls back to the frontend compile on
+   any missing cubin / key mismatch** (decision 2). → verify: save→load→run matches compile→run on a small model;
+   corrupt/missing-cubin test exercises the fallback.
+5. **Serving integration**: runners (`EmmyForwardRunner.create`, `EmmyGenRunner.from_model`) check a pack path
+   (env var, e.g. `EMMY_PACK_DIR` via `config.py`) before the trace-and-compile path; emit-on-boot so the warm
+   flow produces the pack (upgrade `docker/vllm-emmy-gemma4` bake from cubins-only to pack; `verify.sh` becomes a
+   zero-frontend check). Loading weights directly from safetensors (skip `AutoModel` instantiation) is the
+   follow-on win once the pack removes the trace. → verify: A/B a warm serve boot with/without pack on a GPU box;
+   embeddings/generations byte-match; boot time drops to ~weight-load + module-load + alloc.
+6. **Docs**: `backend/cuda/ARCHITECTURE.md` (plan/pack format, loader), `serving/ARCHITECTURE.md` (boot path),
+   `CLAUDE.md` env-var note via `config.py`.
+
+Steps 1–3 are pure refactor + serialization, testable without a GPU. Step 4–5 need a CUDA box for the A/B.
+
+## Remaining per-boot costs after the pack (accepted)
+
+`cuModuleLoad` (~25 ms × unique kernels), weight load + upload, buffer/arena allocation, TMA descriptor rebuild
+(bakes device pointers), CUDA graph capture on first request per seq_len. All inherent to a fresh process/GPU.

--- a/scripts/bench_gen_post.py
+++ b/scripts/bench_gen_post.py
@@ -118,13 +118,13 @@ def main():
 
     logger.info("Compiling post (symbolic + static M=%d)...", bucket)
     with torch.device("cpu"):
-        post_sym = _compile_split(
+        post_sym, _ = _compile_split(
             post_w,
             [torch.zeros(8, attn_width, dtype=dtype), torch.zeros(8, hidden, dtype=dtype)],
             ["attn_out", "residual"],
             np_dtype,
         )
-        post_bucket = _compile_split(
+        post_bucket, _ = _compile_split(
             post_w,
             [torch.zeros(bucket, attn_width, dtype=dtype), torch.zeros(bucket, hidden, dtype=dtype)],
             None,

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -94,6 +94,8 @@ tests/
 │   │   ├── test_emit.py                        # CUDA source-level assertions + GPU runs
 │   │   ├── test_loader.py / test_nvcc_compile.py
 │   │   ├── test_program.py                     # cupy dispatch of Graph[CudaOp]
+│   │   ├── test_execution_plan.py              # plan projection + JSON round-trip (CPU)
+│   │   ├── test_pack_gpu.py                    # pack save/load + recompile fallback (CUDA)
 │   │   ├── test_torch_ref.py                   # eager-reference evaluator
 │   │   └── test_bench_worker_recovery.py       # sticky-CUDA-error sub-process recovery
 │   ├── trace/

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -23,6 +23,7 @@ tests/
 │   └── test_command_workload.py # build_substitution_map(), render_command()
 ├── serving/                   # mirrors emmy/serving/ (vLLM embedding plugin)
 │   ├── test_packed.py       # split_spans packed-batch span splitting (pure, no GPU)
+│   ├── test_gen_pack_gpu.py # gen-runner EMMY_PACK_DIR round-trip: 2nd boot hits, outputs bit-equal (CUDA)
 │   └── test_vllm_plugin_gpu.py # in-process vLLM engine + plugin vs HF eager (perf-marked, CUDA + vllm)
 ├── recipe/
 │   ├── test_types.py        # Recipe.from_dict(), LLMConfig properties, dataclass defaults

--- a/tests/compiler/backend/test_execution_plan.py
+++ b/tests/compiler/backend/test_execution_plan.py
@@ -1,0 +1,136 @@
+"""Execution-plan projection + JSON round-trip (``backend/plan.py``) — CPU-only.
+
+The plan is the runtime projection of a lowered ``Graph[CudaOp]``; these tests pin
+(1) the projection (buffers/constants/launches/kernels/weights/symbols pulled off a
+hand-built graph), (2) the JSON round-trip through the pack expression grammar —
+including the composite ceil-div grid factors that the Graph-JSON path can't
+round-trip — and (3) the pack-side weight load-op vocabulary matching the binder.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from emmy.compiler.backend.plan import (
+    PLAN_FORMAT_VERSION,
+    WeightSpec,
+    _encode_load_ops,
+    apply_weight_loads,
+    plan_from_dict,
+    plan_from_graph,
+    plan_to_dict,
+)
+from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.base import ConstantOp, InputOp
+from emmy.compiler.ir.cuda import CudaOp, TmaDescMeta
+from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
+from emmy.compiler.ir.frontend.ir import ReshapeOp, TransposeOp
+from emmy.compiler.loader.binder import apply_load_ops
+
+
+def _sample_graph() -> Graph:
+    """One symbolic-seq CudaOp launch over an input, a weight (with a load chain), a static
+    scalar, and a runtime (context_value) constant — every plan field populated."""
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", ("seq_len", 64)), node_id="x")
+    g.add_node(op=ConstantOp(name="eps", value=1e-6), inputs=[], output=Tensor("eps", (1,)), node_id="eps")
+    g.add_node(
+        op=ConstantOp(name="w", source_path="model.w", load_ops=(TransposeOp(axes=(1, 0)),), source_shape=(64, 64)),
+        inputs=[],
+        output=Tensor("w", (64, 64)),
+        node_id="w",
+    )
+    g.add_node(op=ConstantOp(name="div", context_value=Var("seq_len")), inputs=[], output=Tensor("div", (1,)), node_id="div")
+    ceil_div = BinaryExpr("//", BinaryExpr("+", Var("seq_len"), Literal(15, "int")), Literal(16, "int"))
+    g.add_node(
+        op=CudaOp(
+            kernel_source="__global__ void k_test() {}",
+            kernel_name="k_test",
+            arg_order=("x", "w", "eps", "div", "y"),
+            grid=((ceil_div,), ("seq_len", 2), (1,)),
+            block=((128,), (1,), (1,)),
+            smem_bytes=1024,
+            zero_outputs=("y",),
+            tma_descriptors=(TmaDescMeta(name="x_desc", src_buf="x", box_extents=(64, 32), swizzle="B128"),),
+            runtime_args=("seq_len",),
+        ),
+        inputs=["x", "w", "eps", "div"],
+        output=Tensor("y", ("seq_len", 64)),
+        node_id="y",
+    )
+    g.inputs = ["x"]
+    g.outputs = ["y"]
+    return g
+
+
+def test_plan_projection():
+    plan = plan_from_graph(_sample_graph())
+    assert plan.backend == "cuda"
+    assert plan.inputs == ["x"] and plan.outputs == ["y"]
+    roles = {b.name: b.role for b in plan.buffers}
+    assert roles == {"x": "input", "eps": "constant", "w": "constant", "div": "constant", "y": "output"}
+    assert plan.constants == {"eps": 1e-6}
+    assert plan.runtime_constants == {"div": Var("seq_len")}
+    assert plan.weights == {"w": WeightSpec(source_path="model.w", load_ops=(("transpose", (1, 0)),))}
+    assert set(plan.kernels) == {"k_test"}
+    assert plan.kernels["k_test"].uses_tma and plan.kernels["k_test"].source.startswith("__global__")
+    assert plan.symbolic_bindings == {"seq_len": ("x", 0)}
+    (launch,) = plan.launches
+    assert launch.kernel_name == "k_test" and launch.runtime_args == ("seq_len",)
+
+
+def test_plan_json_round_trip():
+    plan = plan_from_graph(_sample_graph())
+    wire = json.loads(json.dumps(plan_to_dict(plan)))
+    assert plan_from_dict(wire) == plan
+
+
+def test_plan_round_trip_preserves_binary_key():
+    plan = plan_from_graph(_sample_graph())
+    spec = plan.kernels["k_test"]
+    spec.source = None
+    spec.binary_key = "deadbeef" * 5
+    restored = plan_from_dict(json.loads(json.dumps(plan_to_dict(plan))))
+    assert restored.kernels["k_test"].binary_key == spec.binary_key
+    assert restored.kernels["k_test"].source is None
+    assert restored == plan
+
+
+def test_plan_format_version_gate():
+    d = plan_to_dict(plan_from_graph(_sample_graph()))
+    d["format"] = PLAN_FORMAT_VERSION + 1
+    with pytest.raises(ValueError, match="format"):
+        plan_from_dict(d)
+
+
+def test_grid_expr_survives_round_trip():
+    plan = plan_from_graph(_sample_graph())
+    restored = plan_from_dict(json.loads(json.dumps(plan_to_dict(plan))))
+    (launch,) = restored.launches
+    # The composite ceil-div factor must come back as a real Expr (evaluable), not a string.
+    (factor,) = launch.grid[0]
+    assert factor.eval({"seq_len": 33}) == 3
+    assert launch.grid[1] == ("seq_len", 2)
+
+
+@pytest.mark.parametrize(
+    "load_ops",
+    [
+        (TransposeOp(axes=(1, 0)),),
+        (TransposeOp(axes=(0, 2)),),  # 2-tuple = swap, aten.transpose semantics
+        (TransposeOp(axes=(2, 0, 1)),),
+        (ReshapeOp(shape=(6, -1)),),
+        (TransposeOp(axes=(1, 0, 2)), ReshapeOp(shape=(4, 6))),
+    ],
+)
+def test_apply_weight_loads_matches_binder(load_ops):
+    src = np.arange(2 * 3 * 4 * 5, dtype=np.float32).reshape(2, 3, 4, 5)[:, :, :, 0] + 0.5  # (2, 3, 4) non-contiguous
+    encoded = _encode_load_ops(load_ops)
+    assert encoded is not None
+    np.testing.assert_array_equal(apply_weight_loads(src, encoded), apply_load_ops(src, load_ops))
+
+
+def test_unsupported_load_op_encodes_as_none():
+    # A symbolic reshape can't ride the pack vocabulary — the weight must be marked unbindable.
+    assert _encode_load_ops((ReshapeOp(shape=("seq_len", 64)),)) is None

--- a/tests/compiler/backend/test_pack_gpu.py
+++ b/tests/compiler/backend/test_pack_gpu.py
@@ -1,0 +1,75 @@
+"""Pack save/load on a real GPU (``backend/pack.py``): a compiled program stored as a
+binary-keyed plan must load without its sources and produce identical outputs; any
+disqualifier (key mismatch, evicted cubin) must return ``None`` — the recompile fallback."""
+
+import json
+
+import numpy as np
+import pytest
+
+from emmy.compiler.backend.cuda.program import CompiledProgram
+from emmy.compiler.backend.gpu_lock import gpu_lock
+from emmy.compiler.backend.pack import load_pack, pack_path, save_pack
+from emmy.compiler.backend.plan import plan_from_graph
+from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.base import InputOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp
+from emmy.compiler.pipeline import CUDA_PASSES, Pipeline
+
+from ..conftest import requires_cuda
+
+pytestmark = [requires_cuda, pytest.mark.xdist_group("cuda")]
+
+_KEY = {"kind": "test", "model": "test/pack-model", "max_seq_len": 32}
+
+
+def _plan():
+    g = Graph()
+    g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (32, 64)), node_id="x")
+    g.add_node(op=ElementwiseOp(op="exp"), inputs=["x"], output=Tensor("y", (32, 64)), node_id="y")
+    g.inputs = ["x"]
+    g.outputs = ["y"]
+    return plan_from_graph(Pipeline.build(CUDA_PASSES).run(g))
+
+
+def _run(plan, x):
+    with gpu_lock():
+        prog = CompiledProgram.build_from_plan(plan, {"x": x})
+        prog.run_once()
+        return prog.outputs()["y"]
+
+
+def test_pack_round_trip_runs_identically(tmp_path):
+    plan = _plan()
+    x = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
+    ref = _run(plan, x)
+
+    pdir = pack_path(tmp_path, _KEY)
+    save_pack(pdir, {"trunk": plan}, key=_KEY)
+    loaded = load_pack(pdir, key=_KEY)
+    assert loaded is not None
+    stored = loaded["trunk"]
+    # The stored plan is binary-keyed with no sources — the boot that never runs codegen.
+    for spec in stored.kernels.values():
+        assert spec.source is None and spec.binary_key
+    np.testing.assert_allclose(_run(stored, x), ref)
+    np.testing.assert_allclose(ref, np.exp(x), rtol=1e-3, atol=1e-4)
+
+
+def test_pack_key_mismatch_falls_back(tmp_path):
+    pdir = pack_path(tmp_path, _KEY)
+    save_pack(pdir, {"trunk": _plan()}, key=_KEY)
+    assert load_pack(pdir, key={**_KEY, "max_seq_len": 64}) is None
+
+
+def test_pack_missing_cubin_falls_back(tmp_path, monkeypatch):
+    # A private cubin cache so evicting the pack's cubins can't race parallel test workers.
+    monkeypatch.setenv("EMMY_CUBIN_CACHE", str(tmp_path / "cubin"))
+    pdir = pack_path(tmp_path, _KEY)
+    save_pack(pdir, {"trunk": _plan()}, key=_KEY)
+    manifest = json.loads((pdir / "manifest.json").read_text())
+    assert load_pack(pdir, key=_KEY) is not None
+    for f in (tmp_path / "cubin").glob("*.cubin"):
+        f.unlink()
+    assert manifest["programs"], "sanity: pack stored at least one program"
+    assert load_pack(pdir, key=_KEY) is None

--- a/tests/serving/test_gen_capture_gpu.py
+++ b/tests/serving/test_gen_capture_gpu.py
@@ -27,7 +27,7 @@ def test_run_device_inside_outer_capture_replays_live():
 
     torch.manual_seed(0)
     wrapper = torch.nn.Linear(16, 16, bias=False).to(torch.float16).eval()
-    prog = _compile_split(wrapper, [torch.zeros(4, 16, dtype=torch.float16)], None, np.dtype("float16"))
+    prog, _ = _compile_split(wrapper, [torch.zeros(4, 16, dtype=torch.float16)], None, np.dtype("float16"))
 
     x = torch.randn(4, 16, dtype=torch.float16, device="cuda")
     ref0 = prog.run_device([x])[0].clone()  # uncaptured baseline (also warms the program)

--- a/tests/serving/test_gen_pack_gpu.py
+++ b/tests/serving/test_gen_pack_gpu.py
@@ -1,0 +1,59 @@
+"""Gen-runner pack round-trip (``EMMY_PACK_DIR``): the first ``from_model`` boot writes the
+pack, the second boots from it (no trace / compile) and produces identical layer outputs.
+Needs CUDA + cupy (skips itself otherwise); tiny random Qwen3, same pattern as
+``test_gen_runner_gpu``."""
+
+import logging
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.xdist_group("cuda")]
+
+
+def test_gen_pack_second_boot_hits_and_matches(tmp_path, monkeypatch, caplog):
+    pytest.importorskip("cupy")
+    import torch
+    import transformers
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from emmy.serving.gen_runner import EmmyGenRunner
+
+    monkeypatch.setenv("EMMY_PACK_DIR", str(tmp_path))
+    config = transformers.Qwen3Config(
+        vocab_size=64,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=64,
+        use_sliding_window=False,
+    )
+    torch.manual_seed(0)
+    model = transformers.Qwen3ForCausalLM(config).eval()
+
+    caplog.set_level(logging.INFO, logger="emmy.serving.gen_runner")
+    first = EmmyGenRunner.from_model(model, dtype_str="float32", decode_bucket=16)
+    manifests = list(tmp_path.glob("*/manifest.json"))
+    assert len(manifests) == 1, "the full-compile boot must write exactly one pack"
+    assert not any("pack hit" in r.message for r in caplog.records)
+
+    caplog.clear()
+    second = EmmyGenRunner.from_model(model, dtype_str="float32", decode_bucket=16)
+    assert any("pack hit" in r.message for r in caplog.records), "second boot must load the pack"
+    assert second.has_device_decode == first.has_device_decode
+
+    t = 7
+    hidden = first.embed(list(range(1, t + 1)))
+    position_ids = torch.arange(t).unsqueeze(0)
+    q1, k1, v1 = first.forward_layer_pre(0, hidden, position_ids)
+    q2, k2, v2 = second.forward_layer_pre(0, hidden, position_ids)
+    np.testing.assert_array_equal(q2, q1)
+    np.testing.assert_array_equal(k2, k1)
+    np.testing.assert_array_equal(v2, v1)
+    attn = np.ascontiguousarray(np.random.default_rng(0).standard_normal((t, 4 * 16)).astype(np.float32) * 0.1)
+    np.testing.assert_array_equal(second.forward_layer_post(0, attn, hidden), first.forward_layer_post(0, attn, hidden))


### PR DESCRIPTION
Execution-plan pack: serializable compiled programs for fast serving boot (plans/execution-plan-pack.md)

## What

On a fully-warm boot (cubins cached, goldens seeded) serving still redid the whole compiler frontend — trace,
pass pipeline, fork resolution, codegen — every start; only nvcc was skipped. This PR makes the runtime's
input a first-class, serializable **execution plan** and adds an on-disk **pack** so a warm serving boot skips
the frontend entirely.

- **`compiler/backend/plan.py`** — `ExecutionPlan`: buffers, scalar/runtime constants, launch list,
  symbolic-axis plumbing, kernel refs (source and/or content-addressed cubin key), and per-weight checkpoint
  bindings (`source_path` + a pack-own numpy load-op vocabulary). `plan_from_graph` projects `Graph[CudaOp]`;
  JSON round-trip via a self-contained expression grammar (`int` | `"var"` | `[op, lhs, rhs]`) — symbolic
  shapes and ceil-div grid factors serialize exactly (the Graph-JSON path can't round-trip those).
- **Single launch path** — `CompiledProgram.build(graph)` is now literally
  `build_from_plan(plan_from_graph(graph))`; a pack-loaded plan and a fresh compile share every line of the
  runtime. Kernels load by cubin-cache key (`nvcc.load_cubin_function`, no codegen) or by source through the
  existing cache.
- **`compiler/backend/pack.py`** — pack dir = `manifest.json` (validity key + environment tags + provenance)
  + `plan/<program>.json`. Cubins stay in the shared `EMMY_CUBIN_CACHE` (packs dedupe against each other);
  weights stay in the checkpoint. `load_pack` returns `None` on any disqualifier (key/env mismatch, evicted
  cubin, unparsable plan) → **full recompile fallback**, never a wrong result.
- **Serving boot** — `EmmyForwardRunner.create` keys a pack on model id + config hash + serving shape via
  `EMMY_PACK_DIR`: hit → skip trace/pipeline/resolution/codegen (weights still bind from the checkpoint);
  miss → compile in full and write the pack for the next boot.

Stack-independence is deliberate: the format carries no compiler IR, so compiler changes never invalidate a
pack — only runtime-contract changes bump `PLAN_FORMAT_VERSION`. Frozen fork picks also sidestep the known
cross-process pick nondeterminism. CUDA-specific fields nest under a `"cuda"` namespace for a future ROCm
backend (`RocmCompiledProgram.build_from_plan` analog).

## Measured (RTX 5090, Qwen/Qwen3-Embedding-0.6B, `max_seq_len=512`)

| boot | time |
|---|---|
| cold (nvcc + full compile) | 769 s |
| warm cubin cache (today's best case) | 737 s |
| pack write (full compile + save) | 730 s |
| **pack hit** | **9.5 s** |

Outputs are **bit-exact** across all four boots (max abs diff 0.0 on a 128-token forward). The warm boot is
frontend-dominated on this box — trace + pass pipeline + fork resolution + codegen — which is exactly the work
the pack removes; the 9.5 s hit is model load + cuModuleLoad + buffer alloc + weight upload.

## Tests

- `tests/compiler/backend/test_execution_plan.py` (CPU): projection + JSON round-trip incl. Expr grid factors,
  binary-key round-trip, format gate, load-op vocabulary vs the binder.
- `tests/compiler/backend/test_pack_gpu.py` (CUDA): save→load→run matches compile→run; key mismatch and
  evicted-cubin fallbacks.
- Full suite on the RTX 5090 box: **identical failure sets** on this branch and `main` (7 pre-existing sm_120
  failures: 6× `test_matmul_mma_coverage` f16 source assertions — numerics pass, the `__floats2half2_rn`
  downconvert assertion trips — plus `test_bench_record::test_bench_leaves_keys_by_offer_site`). No
  regressions from this change.
- One semantic note: the projection preserves the longstanding first-source-wins behavior for repeated kernel
  names (`__partial`) — launches resolve kernels by name, and the old source-consistency check was dead code.

## Generative path + docker bake (also in this PR)

- **`EmmyGenRunner.from_model`** keys one pack over the whole per-layer program set (~96 programs for
  gemma-4: pre/post × layers × sym/decode/prefill twins); a hit skips every trace+compile chain. The validity
  key uses the model **config hash, not the id/path** — the baked image resolves the model to a snapshot path
  offline, so ids differ between the warm and released boots. Weight binding is unified on the plan's weight
  specs with the per-wrapper device-upload cache preserved (sym/decode/prefill twins still share one on-GPU
  weight copy). Twin sets that failed to compile at save time are recorded absent and not re-attempted on a
  hit. Verified: `tests/serving/test_gen_pack_gpu.py` (second boot logs a pack hit, layer outputs bit-equal).
- **`docker/vllm-emmy-gemma4`** now bakes model + cubins + **pack**: `EMMY_PACK_DIR=/opt/emmy/pack` +
  `COPY warm/pack`; `warm.sh`'s online pass writes the pack and the offline fixpoint passes boot from it
  (frozen picks — the bimodal-pick class the fixpoint existed for vanishes when the pack takes);
  `verify.sh` FAILS if a pack is baked but the boot didn't hit it (a silent fallback still passes the cubin
  check while re-paying the ~25 min frontend every customer boot). Expected effect: gemma-4 image cold start
  drops from ~25 min to ~weight-load time.

## Follow-ups (out of scope here)

- Run the full `release-gemma4-image` pipeline with the pack-enabled bake (needs the base image + gated
  HF_TOKEN download) — the scripted flow is wired, unexercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
