### PR TITLE
Static single-layer trace: synthetic PLE kwarg; serving carve rejects PLE blocks

### DIFF
--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -538,11 +538,17 @@ def _trace_model(model_id: str, layer: int | None, seq_len: int, *, dynamic_shap
     except TypeError:
         cos, sin = decoder.rotary_emb(x, position_ids)
 
-    from emmy.compiler.trace.huggingface import stamp_sliding_windows
+    from emmy.compiler.trace.huggingface import build_synthetic_ple, stamp_sliding_windows
 
-    graph = trace_module(block, (x,), kwargs={"position_embeddings": (cos, sin)}, dynamic_shapes=dynamic_shapes)
+    kwargs = {"position_embeddings": (cos, sin)}
+    # Gemma-nano PLE blocks multiply by ``per_layer_input``; without it the trace hits
+    # ``FakeTensor * None``. Same seeded synthetic buffer as the dynamic layer wrapper.
+    ple = build_synthetic_ple(block, seq_len, dtype)
+    if ple is not None:
+        kwargs["per_layer_input"] = ple
+    graph = trace_module(block, (x,), kwargs=kwargs, dynamic_shapes=dynamic_shapes)
     stamp_sliding_windows(graph, decoder.config, layer_type=layer_type)
-    return graph, (block, (x,), {"position_embeddings": (cos, sin)})
+    return graph, (block, (x,), kwargs)
 
 
 def _find_text_decoder(model):

--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -59,8 +59,13 @@ an `AutoModel` trunk yields hidden states instead of logits (the serving plugin'
   avoid. Forward arg is named `x`, so the CLI spec is `--dynamic seq_len@x:1`
   (`tests/compiler/ir/test_dynamic_shapes.py::test_qwen_layer_dynamic_compiles_and_matches_eager`).
   Gemma-nano PLE blocks (those exposing `hidden_size_per_layer_input`) additionally get a seeded synthetic
-  `per_layer_input` buffer sliced in-graph the same way — kernel shapes and latencies are the deployed model's,
-  numerics are synthetic; non-PLE architectures take the unchanged path (`tests/compiler/trace/test_huggingface.py`).
+  `per_layer_input` (`build_synthetic_ple`) — the dynamic wrapper registers it as a buffer sliced in-graph like
+  cos/sin, and the static single-layer trace (`commands/compile.py`) passes the same buffer as a concrete kwarg
+  (without it the trace dies on `FakeTensor * None` inside modeling_gemma4). Kernel shapes and latencies are the
+  deployed model's, numerics are synthetic; non-PLE architectures take the unchanged path. The attention-split
+  carve (`build_attention_split_wrapper`, serving) instead REJECTS PLE blocks with `NotImplementedError` — it has
+  no seam for the `hidden * per_layer_input` multiply and would silently drop it
+  (`tests/compiler/trace/test_huggingface.py`).
 
 - `stamp_sliding_windows(graph, config, layer_type=None)` re-asserts the per-layer sliding window the trace ERASES:
   a single-layer trace carries no mask at all (HF takes the `is_causal` path — the traced layer is pure causal at

--- a/emmy/compiler/trace/huggingface.py
+++ b/emmy/compiler/trace/huggingface.py
@@ -186,6 +186,28 @@ def build_full_model_wrapper(model, seq_len: int, dtype, *, dynamic: bool = Fals
     return FullModelWrapper()
 
 
+def build_synthetic_ple(block, n_pos: int, dtype):
+    """Synthetic ``per_layer_input`` for a single-decoder-layer trace, or ``None``
+    for non-PLE architectures.
+
+    Gemma-nano (E2B/E4B) Per-Layer Embeddings: each decoder layer computes
+    ``hidden * per_layer_input`` (modeling_gemma4). The real tensor is a per-layer
+    token embedding the whole-model path supplies; a single-layer trace has no
+    tokens, so stand in a deterministic synthetic one sized ``[1, n_pos, ple_dim]``.
+    Perf-representative — the PLE gate/mul/projection/norm kernels depend on shape,
+    not values, and the accuracy check stays valid (emmy and torch see the same
+    buffer). Non-uniform (randn, fixed seed) so the elementwise mul isn't
+    algebraically folded to identity."""
+    import torch
+
+    ple_dim = int(getattr(block, "hidden_size_per_layer_input", 0) or 0)
+    if not ple_dim:
+        return None
+    with torch.no_grad():
+        g = torch.Generator().manual_seed(0)
+        return torch.randn((1, n_pos, ple_dim), generator=g, dtype=torch.float32).to(dtype)
+
+
 def build_layer_wrapper(block, rotary_emb, hidden_size: int, dtype, *, layer_type=None) -> nn.Module:
     """Trace-friendly single-decoder-layer wrapper for dynamic mode:
     ``forward(x)`` slices rotary cos/sin to the runtime seq_len and calls
@@ -220,21 +242,10 @@ def build_layer_wrapper(block, rotary_emb, hidden_size: int, dtype, *, layer_typ
         except TypeError:
             cos, sin = rotary_emb(sample, full_pos)
 
-    # Gemma-nano (E2B/E4B) Per-Layer Embeddings: each decoder layer computes
-    # ``hidden * per_layer_input`` (modeling_gemma4). The real tensor is a per-layer
-    # token embedding the whole-model path supplies; the single-layer wrapper has no
-    # tokens, so stand in a deterministic synthetic one sized ``[1, S, ple_dim]`` and
-    # slice it in-graph like cos/sin. Perf-representative — the PLE gate/mul/projection/
-    # norm kernels depend on shape, not values, and the accuracy check stays valid
-    # (emmy and torch see the same buffer). Non-uniform (randn) so the elementwise mul
-    # isn't algebraically folded to identity. ``0`` for non-PLE architectures — they
-    # take the unchanged path below.
-    ple_dim = int(getattr(block, "hidden_size_per_layer_input", 0) or 0)
-    ple = None
-    if ple_dim:
-        with torch.no_grad():
-            g = torch.Generator().manual_seed(0)
-            ple = torch.randn((1, n_pos, ple_dim), generator=g, dtype=torch.float32).to(dtype)
+    # Sliced in-graph like cos/sin; ``None`` for non-PLE architectures — they take
+    # the unchanged path below.
+    ple = build_synthetic_ple(block, n_pos, dtype)
+    ple_dim = 0 if ple is None else ple.shape[-1]
 
     class LayerWrapper(nn.Module):
         def __init__(self) -> None:
@@ -277,8 +288,19 @@ def build_attention_split_wrapper(block):
     ``.view(B,S,-1,D).transpose(1,2)`` assumes a ``[batch, seq, hidden]`` input; on the
     flattened ``[T, H]`` layout the reshape is ``.view(T, n_heads, D)`` with **no transpose**.
     Qwen3 / Gemma-3/4 (q/k norm) and Llama (no q/k norm) all share the ``pre``; the ``post``
-    is the Llama/Qwen 2-norm form or the Gemma 4-norm form above."""
+    is the Llama/Qwen 2-norm form or the Gemma 4-norm form above.
+
+    Rejects Gemma-nano PLE blocks (``hidden_size_per_layer_input``): the carve has no seam for
+    the ``hidden * per_layer_input`` multiply and would silently drop it, corrupting outputs."""
     import torch.nn as nn
+
+    ple_dim = int(getattr(block, "hidden_size_per_layer_input", 0) or 0)
+    if ple_dim:
+        raise NotImplementedError(
+            f"build_attention_split_wrapper: block carries Per-Layer Embeddings "
+            f"(hidden_size_per_layer_input={ple_dim}, Gemma-nano E2B/E4B) — the attention-split carve "
+            f"would silently drop the per_layer_input multiply; this model is not servable via the split path"
+        )
 
     attn = block.self_attn
     head_dim = attn.head_dim

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -70,7 +70,8 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   `build_attention_split_wrapper` / `trace_split` path serving uses. Backs `emmy eval golden --in-model` and the
   golden drift CI gate; `scripts/capture_gen_twins.py` remains the full-checkpoint capture for tuning.
 - `gen_runner.py` — `EmmyGenRunner` (Phase 2; sibling to `EmmyForwardRunner`). Carves SDPA out of every
-  decoder layer (`build_attention_split_wrapper`), compiles **two dynamic-`num_tokens` programs per layer** (`pre` +
+  decoder layer (`build_attention_split_wrapper`; Gemma-nano PLE blocks — `hidden_size_per_layer_input` — are
+  rejected loudly there: the carve has no seam for the `per_layer_input` multiply), compiles **two dynamic-`num_tokens` programs per layer** (`pre` +
   `post`) over the flattened `[num_tokens, H]` layout, and exposes `embed` (Gemma's √hidden embed-scale folded into the
   gather table) / `forward_layer_pre(L,…)→(q,k,v)` (un-rotated 2-D seam; carves q/k/**v**-norm, and Gemma-4's global
   `attention_k_eq_v` where V reuses K's projection) / `forward_layer_post(L, attn_out, residual)→hidden` / `final_norm`.

--- a/tests/compiler/trace/test_huggingface.py
+++ b/tests/compiler/trace/test_huggingface.py
@@ -1,10 +1,12 @@
 """Tests for trace/huggingface.py wrapper builders.
 
-Covers ``build_layer_wrapper``'s synthetic Per-Layer-Embedding (PLE) support: a
-Gemma-nano block exposing ``hidden_size_per_layer_input`` receives a seeded
-synthetic ``per_layer_input`` buffer sliced in-graph to the runtime seq_len
-(like cos/sin); every other architecture takes the unchanged path (no ``ple``
-buffer, no extra kwarg).
+Covers the synthetic Per-Layer-Embedding (PLE) support for Gemma-nano blocks
+exposing ``hidden_size_per_layer_input``: ``build_layer_wrapper`` (dynamic mode)
+registers a seeded synthetic ``per_layer_input`` buffer sliced in-graph to the
+runtime seq_len (like cos/sin), and ``_trace_model``'s static single-layer path
+passes the same buffer as a concrete kwarg. Every other architecture takes the
+unchanged path (no ``ple`` buffer, no extra kwarg). The attention-split carve
+(serving) instead rejects PLE blocks loudly — it has no seam for the multiply.
 """
 
 import pytest
@@ -93,3 +95,83 @@ def test_layer_wrapper_non_ple_block_unchanged():
     assert "ple" not in dict(wrapper.named_buffers())
     out = wrapper(torch.randn(1, 8, HIDDEN))
     assert out.shape == (1, 8, HIDDEN)
+
+
+def _traceable_ple_block():
+    """Export-traceable PLE block reproducing the gemma-nano crash shape: forward
+    multiplies by ``per_layer_input`` unconditionally, so tracing without the kwarg
+    dies on ``FakeTensor * None`` exactly like modeling_gemma4. ``ple_dim == HIDDEN``
+    keeps the mul a plain broadcast-free op the FX→IR walker handles."""
+    import torch.nn as nn
+
+    class TraceablePleBlock(nn.Module):
+        hidden_size_per_layer_input = HIDDEN
+
+        def forward(self, x, per_layer_input=None, position_embeddings=None):
+            return x * per_layer_input
+
+    return TraceablePleBlock()
+
+
+def _fake_causal_lm(block):
+    """Minimal AutoModelForCausalLM stand-in for ``_trace_model``: a decoder module
+    exposing ``layers`` / ``rotary_emb`` / ``config`` (what ``_find_text_decoder``
+    matches) under ``.model``."""
+    from types import SimpleNamespace
+
+    import torch.nn as nn
+
+    class Decoder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = nn.ModuleList([block])
+            self.config = SimpleNamespace(hidden_size=HIDDEN)
+            self.rotary_emb = _fake_rotary
+
+    class FakeModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = Decoder()
+
+    return FakeModel()
+
+
+def test_static_layer_trace_supplies_synthetic_ple(monkeypatch):
+    """``_trace_model``'s static (non-dynamic) single-layer path passes the seeded
+    synthetic ``per_layer_input`` kwarg to a PLE block — without it the trace crashes
+    on ``FakeTensor * None`` (the ``emmy run google/gemma-4-E2B --layer 0`` bug)."""
+    transformers = pytest.importorskip("transformers")
+
+    from emmy.commands.compile import _trace_model
+
+    block = _traceable_ple_block()
+    monkeypatch.setattr(transformers.AutoModelForCausalLM, "from_pretrained", lambda model_id, **kw: _fake_causal_lm(block))
+
+    seq_len = 8
+    graph, (mod, args, kwargs) = _trace_model("fake/ple-model", 0, seq_len)
+    assert graph.nodes
+    ple = kwargs["per_layer_input"]
+    assert tuple(ple.shape) == (1, seq_len, HIDDEN)
+    assert ple.std() > 0  # non-uniform: the PLE mul can't fold to identity
+
+
+def test_static_layer_trace_non_ple_block_unchanged(monkeypatch):
+    """A non-PLE block traces through the static path without the extra kwarg."""
+    transformers = pytest.importorskip("transformers")
+
+    from emmy.commands.compile import _trace_model
+
+    monkeypatch.setattr(transformers.AutoModelForCausalLM, "from_pretrained", lambda model_id, **kw: _fake_causal_lm(_plain_block()))
+
+    graph, (mod, args, kwargs) = _trace_model("fake/plain-model", 0, 8)
+    assert graph.nodes
+    assert "per_layer_input" not in kwargs
+
+
+def test_attention_split_rejects_ple_block():
+    """The serving carve has no seam for the PLE multiply — it must reject loudly,
+    not silently drop the ``per_layer_input`` term."""
+    from emmy.compiler.trace.huggingface import build_attention_split_wrapper
+
+    with pytest.raises(NotImplementedError, match="hidden_size_per_layer_input"):
+        build_attention_split_wrapper(_ple_block())


### PR DESCRIPTION
## Problem

`emmy run google/gemma-4-E2B --layer 0` crashed with `TypeError: unsupported operand type(s) for *: 'FakeTensor' and 'NoneType'` at modeling_gemma4's `hidden_states * per_layer_input`. `_trace_model`'s static (non-dynamic) single-layer path traced the decoder block directly with only `position_embeddings`, while the dynamic path's `build_layer_wrapper` already synthesizes a seeded `per_layer_input` buffer for Gemma-nano PLE blocks.

## Fix

- Extracted the synthetic-PLE construction into `build_synthetic_ple(block, n_pos, dtype)` in `emmy/compiler/trace/huggingface.py` (same seed/semantics; `None` for non-PLE architectures). `build_layer_wrapper` now calls it.
- `_trace_model`'s static layer path passes the buffer as a concrete `per_layer_input` kwarg when the block exposes a truthy `hidden_size_per_layer_input`, and returns it in the bench bundle so `run --bench` eager comparisons see the same input.
- `build_attention_split_wrapper` (serving carve) previously would **silently drop** the PLE multiply for such models — it now raises `NotImplementedError` loudly. No current serving path feeds it a PLE block, so this is purely protective.

## Tests (CPU)

- `_trace_model` static path with a mocked `from_pretrained` and a PLE block whose forward multiplies by `per_layer_input` unconditionally — fails with the original `FakeTensor * None` crash without the fix, passes with it (verified both ways).
- Non-PLE control: static path traces without the extra kwarg.
- Carve rejection: `build_attention_split_wrapper` on a PLE block raises.

`make test`: 2486 passed, 157 skipped. `make lint` clean. ARCHITECTURE.md updated in `emmy/compiler/trace/` and `emmy/serving/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)