### PR TITLE
EmmyGenModel: honor generation-config suppress_tokens in compute_logits

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -135,7 +135,10 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   Gemma-4 global layers use a larger head_dim) and gets `per_layer_sliding_window` so Gemma's sliding/global layers
   window correctly) + one RoPE module **per layer** (`_build_rotaries`: homogeneous models share one; Gemma-3/4
   keys theta AND head_dim on layer type — local vs global — a bare `Attention` does no RoPE) + `ParallelLMHead` + `LogitsProcessor`
-  (`soft_cap=final_logit_softcapping`, so Gemma-4's final-logit softcap applies). The trunk compute (embed + per-layer
+  (`soft_cap=final_logit_softcapping`, so Gemma-4's final-logit softcap applies; `compute_logits` also -infs the
+  generation config's `suppress_tokens` — gemma-4 lists the mm delimiter tokens `<image|>`/`<audio|>` there, HF
+  generate and stock vLLM honor the list, and a degenerate text prompt can genuinely rank one top-1, which would
+  decode to empty output). The trunk compute (embed + per-layer
   pre/post + final norm) is the `EmmyGenRunner`; vLLM owns only `lm_head` (`load_weights` claims `lm_head.weight`, or the
   tied embed alias). `forward` brackets each `self.attn[L](q,k,v)` with two emmy replays (pre/post), applying that
   layer's RoPE in between (A2). Uniform sliding-window (Qwen2-style `use_sliding_window`) and dual-chunk are rejected. `forward` branches on `num_tokens`: the decode hot

--- a/emmy/serving/vllm_model_gen.py
+++ b/emmy/serving/vllm_model_gen.py
@@ -177,6 +177,12 @@ class EmmyGenModel(nn.Module):
             scale=getattr(config, "logit_scale", 1.0),
             soft_cap=getattr(config, "final_logit_softcapping", None),
         )
+        # The checkpoint's generation config may list tokens to suppress outright (gemma-4 lists
+        # the mm delimiters '<image|>'/'<audio|>'; a degenerate text prompt can genuinely rank
+        # one top-1, and an emitted mm token decodes to empty text). HF generate honors the
+        # list; stock vLLM's gemma4 models -inf those ids in compute_logits — mirror that.
+        gen_cfg = vllm_config.model_config.try_get_generation_config()
+        self._suppress_token_ids = gen_cfg.get("suppress_tokens") if gen_cfg else None
 
     def forward(self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None, **kwargs):
         device = positions.device
@@ -223,7 +229,10 @@ class EmmyGenModel(nn.Module):
         return self.runner.final_norm_device(hidden)
 
     def compute_logits(self, hidden_states, *args):
-        return self.logits_processor(self.lm_head, hidden_states)
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if logits is not None and self._suppress_token_ids:
+            logits[:, self._suppress_token_ids] = -float("inf")
+        return logits
 
     def embed_input_ids(self, input_ids):
         # vLLM embedding hook → the runner owns embedding; on-device gather (no host hop).

--- a/tests/serving/test_gen_suppress_tokens.py
+++ b/tests/serving/test_gen_suppress_tokens.py
@@ -1,0 +1,33 @@
+"""``EmmyGenModel.compute_logits`` honors the generation config's ``suppress_tokens`` (no GPU).
+
+gemma-4 checkpoints list the mm delimiter tokens ('<image|>'/'<audio|>') there; a degenerate text
+prompt can genuinely rank one top-1 (verified vs HF eager fp16), and an emitted mm token decodes to
+empty text. HF generate and stock vLLM -inf those ids; the plugin must match.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def _model_with(suppress_ids):
+    vllm_model_gen = pytest.importorskip("emmy.serving.vllm_model_gen")
+    m = vllm_model_gen.EmmyGenModel.__new__(vllm_model_gen.EmmyGenModel)
+    # compute_logits touches only these three attributes; the identity processor makes the
+    # hidden-states argument stand in for the logits tensor.
+    m.logits_processor = lambda lm_head, hidden: hidden
+    m.lm_head = None
+    m._suppress_token_ids = suppress_ids
+    return m
+
+
+def test_suppressed_ids_are_neg_inf_others_untouched():
+    out = _model_with([3, 5]).compute_logits(torch.zeros((2, 8)))
+    assert torch.isneginf(out[:, [3, 5]]).all()
+    keep = [i for i in range(8) if i not in (3, 5)]
+    assert (out[:, keep] == 0).all()
+
+
+def test_no_suppress_list_is_noop():
+    out = _model_with(None).compute_logits(torch.zeros((2, 8)))
+    assert (out == 0).all()


### PR DESCRIPTION
## Problem

`emmy serve --generate google/gemma-4-12B` can return **empty completions**: on a degenerate repetitive prompt
(`"The industrial revolution transformed …" * 12 + " In summary, the industrial revolution"`, greedy), the served
model emits `<image|>` (id 258882) for every generated token, which the tokenizer decodes to `''`.

This is not a numerics bug — emmy's logits match HF eager fp16 within ~0.01 nats on the knife-edge first token
(`<image|>` −1.59 vs −1.6; measured on a vast.ai RTX 5090, 2026-07-21). The raw model genuinely ranks the token
top-1 there. HF `generate` and stock vLLM still produce sensible text because both honor the checkpoint's
`generation_config.suppress_tokens` (`[258883, 258882]` = the `<audio|>`/`<image|>` delimiters); stock vLLM's
gemma4 models set `logits[:, ids] = -inf` in `compute_logits`. `EmmyGenModel` ignored the list.

## Fix

Read `suppress_tokens` via `model_config.try_get_generation_config()` at init and `-inf` those ids in
`compute_logits`, exactly mirroring stock vLLM's gemma4 models. Models without the config field are untouched.

## Testing

- `tests/serving/test_gen_suppress_tokens.py` — CPU-only unit test of the `compute_logits` suppression (+ no-op
  when the config has no list).
- Full `make test`: 2485 passed / 157 skipped; `make lint` clean.
- End-to-end evidence from the 5090 serving session: emmy-vs-stock-vs-HF logit comparison above; the same session
  validated 4/4 first-token parity vs HF eager and 424/424 successful bench requests across input lens 32–2048 and
  concurrency 1–64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)