### PR TITLE
Golden floor: a realizable golden decides even prior-less resolves

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -262,6 +262,10 @@ deploys the std config there. Goldens are
 **consulted, never trained on**: they enter no reservoir, no checkpoint, no dataset (they are the held-out
 acceptance set). Golden µs is deployable-regime truth and never arbitrates a non--O3 compile. A shape match none of
 whose entries realizes against the offer logs a loud enumeration-drift warning and falls through to the tiers below.
+The tier depends on **no prior**: a resolve with no prior at all — a failed `load_prior` (corrupt/unreadable online
+checkpoint) or `Pipeline.run`'s last-resort emission-order resolve — still consults the goldens and deploys a
+realizable one (the **golden floor**, logged loudly when it overrides option-0), so a broken checkpoint can never
+silently cost a fork its verified golden.
 
 ### `FallbackPrior` and the calibration gate
 
@@ -338,7 +342,8 @@ pinned, so the prior would be blind at the `BM/BN` choice. Instead `greedy_decid
 complete leaves (`fork.flatten_leaves` expands branches depth-first; only knob dicts — materialization stays deferred
 to the chosen leaf) and picks the lowest `Prior.mean_scores` over the full `{H_*, S_*, complete-knob-row}` vector in
 one batched `predict`, invariant to the tree's level order. Cold, the `OfflinePrior` ranks (including a positive
-`MMA_tier` warp preference); option-0 (first leaf, emission order) only if `load_prior` returns nothing entirely.
+`MMA_tier` warp preference); if `load_prior` returns nothing entirely the recorded goldens still floor the pick and
+only the golden-less forks fall to option-0 (first leaf, emission order).
 Greedy benches nothing, so it can only *use* a prior, never train one.
 
 **Every deploy pick breaks ties by candidate content, never enumeration order.** The model can score many
@@ -380,8 +385,10 @@ leaves a node un-lowered, `Pipeline.run` blocklists that tile's `tile_identity` 
 `greedy_decide(blocked=…)` drops the matching leaf and picks the next-best. This is bounded by `_MAX_GREEDY_RETRIES`.
 When the retry budget exhausts with the node still un-lowered (an *online* prior can rank many over-budget tiles above
 the first in-budget one), `Pipeline.run` takes one last **option-0 (emission-order) resolve**
-(`greedy_decide(prior=None)`): the planner emits a budget-safe tile first, so it lowers whenever any in-budget tile
-exists. Only when even option-0 overflows does `_raise_on_unlowered` fire the loud `LoweringError`.
+(`greedy_decide(blocked=…, prior=None)`): the planner emits a budget-safe tile first, so it lowers whenever any
+in-budget tile exists. The goldens still floor this resolve — one over-budget node must not cost every *other* kernel
+its verified golden — and the blocklist rides along so the floor can never re-pick a tile that already failed
+`validate(ctx)`. Only when even option-0 overflows does `_raise_on_unlowered` fire the loud `LoweringError`.
 
 ### `Pipeline.tune_async` — the autotune sweep
 

--- a/emmy/compiler/pipeline/pipeline.py
+++ b/emmy/compiler/pipeline/pipeline.py
@@ -542,14 +542,18 @@ class Pipeline:
         # exhausts before reaching an in-budget leaf. Before giving up, take the
         # conservative emission-order pick (``greedy_decide(prior=None)`` =
         # option-0): it ignores the prior, and the planner emits a budget-safe
-        # tile first, so it lowers whenever any in-budget tile exists. When even
+        # tile first, so it lowers whenever any in-budget tile exists. The card's
+        # recorded goldens still floor this resolve (they are prior-independent
+        # evidence — one over-budget node must not cost every OTHER kernel its
+        # verified golden), and ``blocked`` rides along so the floor can never
+        # re-pick a tile that already failed ``validate(ctx)``. When even
         # option-0 overflows (the over-budget rule genuinely has no in-budget
         # option — e.g. the single-option guardrail) the re-resolve stays
         # un-lowered and ``_raise_on_unlowered`` fires below, exactly as before.
         if _unlowered_tiles(terminal, rejections):
             rejections = []
             run = Run(pipeline=self, ctx=ctx, db=db, backend=backend, dump=dump, rejections=rejections)
-            terminal, _ = run.resolve(graph.copy(), greedy_decide(prior=None, price_structural=False))
+            terminal, _ = run.resolve(graph.copy(), greedy_decide(blocked=blocked, prior=None, price_structural=False))
         _raise_on_unlowered(terminal, rejections, ctx)
         logger.info("compile: total %.2fs (deterministic resolve)", time.monotonic() - t_start)
         return terminal

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -113,8 +113,8 @@ def _load_prior_safe():
     ``OfflinePrior`` cold-start fallback), memoized per process on the online
     file's ``(path, mtime)`` — a serve boot compiles ~96 programs and each would
     otherwise ``json.loads`` the 56 MB checkpoint again (the dominant boot-time
-    resolution cost). Best-effort: any load failure → ``None`` → emission order —
-    a bad/missing prior must never break compile."""
+    resolution cost). Best-effort: any load failure → ``None`` → the golden floor
+    plus emission order — a bad/missing prior must never break compile."""
     try:
         from emmy import config  # noqa: PLC0415
 
@@ -551,8 +551,10 @@ def _fork_shape_key(rows: list[dict]):
     from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
 
     key = ShapeKey.from_s_features(rows[0])
-    fams = {k.split("@", 1)[-1] for k in rows[0] if k.startswith("TILE@")}
-    if {"dd", "pj"} <= fams:
+    # ANY row carrying the pair marks the fork (like the cone's sync-STAGE scan below):
+    # the pair may be spelled only on the warp leaves, and row 0 — whichever leaf the
+    # planner emitted first — need not be one of them.
+    if any({"dd", "pj"} <= {k.split("@", 1)[-1] for k in row if k.startswith("TILE@")} for row in rows):
         key = ShapeKey(
             free_prod=key.free_prod,
             reduce_max=0 if key.is_dyn else key.reduce_max,
@@ -672,8 +674,11 @@ def greedy_decide(
     skip ``blocked`` tile identities, and take the prior's ``mean_scores``
     argmin — the ``OnlinePrior`` once trained, the ``OfflinePrior``
     cold-start heuristic otherwise (both behind ``load_prior``'s
-    ``FallbackPrior``). Falls to emission order (option-0, first leaf) only if
-    the prior fails to load entirely. Stamps the pick's predicted µs on
+    ``FallbackPrior``). With no prior at all (a failed load, or the explicit
+    ``prior=None`` emission-order resolve) the card's recorded goldens still
+    floor the pick — the golden tier is prior-independent evidence — and only
+    a fork without a realizable golden falls to emission order (option-0,
+    first leaf). Stamps the pick's predicted µs on
     ``fp.score``, so the resolve trace carries the per-fork price (the
     structural pricing probe reads a kernel's cost off the partition fork's
     trace entry).
@@ -718,7 +723,36 @@ def greedy_decide(
             loaded = True
             the_prior = _load_prior_safe()
         if the_prior is None:
-            return _first_leaf(fp.options[0])  # prior failed to load → emission order
+            # No prior on this resolve — a failed ``load_prior`` (corrupt/unreadable
+            # checkpoint) or ``Pipeline.run``'s explicit emission-order fallback
+            # (``prior=None``). The card's recorded goldens are tier (1) of the
+            # evidence hierarchy and depend on no prior, so they still FLOOR the
+            # pick: a fork whose golden realizes on an offered candidate deploys the
+            # golden, and only the rest falls to emission order. (A blocklisted
+            # tile — one that failed ``validate(ctx)`` earlier — stays excluded, so
+            # the floor can never re-pick a tile the retry loop already rejected.)
+            if golden_state[0] is None:
+                golden_state[0] = _golden_evidence_index(fp.ctx)
+            if golden_state[0]:
+                leaves = [o for o in flatten_leaves(fp.options) if not _is_structural_option(o)]
+                live = [(o, _leaf_knobs(o)) for o in leaves]
+                node_blocked = blocked.get(fp.node_id) if blocked else None
+                if node_blocked is not None:
+                    live = [(o, k) for o, k in live if not _tile_blocked(k, node_blocked)]
+                base = {**fp.ctx.features(), **dict(fp.root_op.knobs)}
+                rows = [{**base, **k} for _, k in live]
+                got = _golden_pick(golden_state[0], rows, fp.node_id) if rows else None
+                if got is not None:
+                    best_i, price = got
+                    logger.warning(
+                        "deploy: node %r resolved WITHOUT a prior (load failure or emission-order fallback), but the "
+                        "golden floor holds — deploying the recorded golden realization (%.1f us) over option-0.",
+                        fp.node_id,
+                        price,
+                    )
+                    fp.score = price
+                    return live[best_i][0]
+            return _first_leaf(fp.options[0])  # no realizable golden → emission order
         # Flatten: greedy benches nothing, so it must pick the globally best
         # COMPLETE tile, not a partial branch — see ``flatten_leaves`` (the
         # prior is blind at a partial ``BM/BN`` branch: ``knob_features``

--- a/tests/compiler/pipeline/search/test_golden_floor.py
+++ b/tests/compiler/pipeline/search/test_golden_floor.py
@@ -1,0 +1,149 @@
+"""The golden FLOOR on prior-less resolves (``policy/greedy.greedy_decide`` with
+``prior=None``): the card's recorded goldens are tier-1 evidence independent of any
+prior, so a fork whose golden still realizes deploys the golden — never option-0.
+
+The prior-loaded path already implements the floor by tier order (the golden tier
+decides before evidence and the model — ``test_golden_evidence_deploy``); these tests
+pin the two paths that resolve WITHOUT a prior and previously skipped the tier
+entirely: a failed ``load_prior`` (corrupt/unreadable online checkpoint), and
+``Pipeline.run``'s last-resort emission-order resolve after the validity-retry
+budget exhausts (where one over-budget node used to cost every OTHER kernel its
+verified golden)."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from emmy import config
+from emmy.compiler.context import Context
+from emmy.compiler.pipeline.search import golden as golden_mod
+from emmy.compiler.pipeline.search.golden import MatmulGoldenConfig
+from emmy.compiler.pipeline.search.policy.greedy import _fork_shape_key, greedy_decide, tile_identity
+
+CARD = "NVIDIA GeForce RTX 4090"
+CAP = (8, 9)
+
+# q_proj-shaped fp16 matmul: M512 x N4096, K3840 — static stamps (S_dtype_f32 absent -> warp tier).
+_SIG = {"S_ext_free_prod": 2097152.0, "S_ext_free_max": 4096.0, "S_ext_reduce_max": 3840.0, "S_ext_reduce_prod": 3840.0}
+
+_STD_TILE = "a:mma_m16n8k16_f16_f32/w2x2/f4x4/k2"
+_W1X1_TILE = "a:mma_m16n8k16_f16_f32/w1x1/f1x1"
+
+# Candidate rows spell the axis-stamped realization (``TILE@a2``) — the golden's bare
+# spelling matches through ``pin_key_matches`` + ``values_equal``.
+_ROW_W1X1 = {"TILE@a2": _W1X1_TILE, "STAGE@a2": "d2/cp/ring", "REDUCE@a2": ""}
+_ROW_GOLD = {"TILE@a2": _STD_TILE, "STAGE@a2": "d2/cp/ring/p2", "REDUCE@a2": ""}
+
+
+def _golden(us=78.0):
+    return MatmulGoldenConfig(
+        name="gemma4_12b.q_proj",
+        M=512,
+        N=4096,
+        K=3840,
+        dtype="fp16",
+        knobs={"TILE": _STD_TILE, "STAGE": "d2/cp/ring/p2", "REDUCE": "", "WSPEC": "", "RASTER": ""},
+        emmy_us=us,
+        gpu_name=CARD,
+        compute_cap=CAP,
+    )
+
+
+class _FakeFP(SimpleNamespace):
+    score = None
+
+
+def _decide_no_prior(monkeypatch, goldens, leaves, blocked=None):
+    monkeypatch.setattr(golden_mod, "GOLDEN_CONFIGS", list(goldens))
+    with config.nvcc_flags_override(""):  # the deployable -O3 regime (H_opt=3) golden consultation is gated on
+        ctx = Context.from_target(CAP, gpu_name=CARD)
+    fp = _FakeFP(ctx=ctx, options=list(leaves), root_op=SimpleNamespace(knobs=dict(_SIG)), node_id="n0", match=None)
+    return greedy_decide(blocked, prior=None)(fp), fp
+
+
+def test_no_prior_resolve_deploys_realizable_golden(monkeypatch, caplog):
+    """A resolve with no prior at all must still land on the recorded golden when it
+    realizes — previously this path fell straight to option-0 (the degenerate w1x1
+    leaf here), silently missing the verified entry. The override is logged loud."""
+    leaves = [SimpleNamespace(knobs=dict(_ROW_W1X1)), SimpleNamespace(knobs=dict(_ROW_GOLD))]
+    with caplog.at_level(logging.WARNING):
+        picked, fp = _decide_no_prior(monkeypatch, [_golden()], leaves)
+    assert picked is leaves[1]
+    assert fp.score == 78.0
+    assert any("golden floor" in r.message for r in caplog.records)
+
+
+def test_no_prior_drift_warns_and_falls_to_option0(monkeypatch, caplog):
+    """A golden keyed to the fork's shape that NO offered candidate realizes is
+    enumeration drift — the loud drift warning fires on this path too (it was silent
+    here before the floor: the tier was never consulted), then emission order."""
+    leaves = [SimpleNamespace(knobs=dict(_ROW_W1X1))]
+    with caplog.at_level(logging.WARNING):
+        picked, fp = _decide_no_prior(monkeypatch, [_golden()], leaves)
+    assert picked is leaves[0]
+    assert fp.score is None
+    assert any("no longer realize" in r.message for r in caplog.records)
+
+
+def test_no_prior_without_goldens_is_pure_emission_order(monkeypatch, caplog):
+    """No golden for the live card ⇒ the old behavior bit-for-bit: option-0, no
+    warnings (parity with ``test_resolve.test_option0_decide_matches_no_prior_greedy``)."""
+    other_card = MatmulGoldenConfig(
+        name="gemma4_12b.q_proj",
+        M=512,
+        N=4096,
+        K=3840,
+        dtype="fp16",
+        knobs={"TILE": _STD_TILE},
+        emmy_us=78.0,
+        gpu_name="NVIDIA GeForce RTX 5090",
+        compute_cap=(12, 0),
+    )
+    leaves = [SimpleNamespace(knobs=dict(_ROW_W1X1)), SimpleNamespace(knobs=dict(_ROW_GOLD))]
+    with caplog.at_level(logging.WARNING):
+        picked, fp = _decide_no_prior(monkeypatch, [other_card], leaves)
+    assert picked is leaves[0]
+    assert fp.score is None
+    assert not caplog.records
+
+
+def test_floor_respects_blocklist(monkeypatch, caplog):
+    """``Pipeline.run``'s last-resort resolve threads ``blocked`` through, so the
+    floor can never re-pick a tile that already failed ``validate(ctx)`` — with the
+    golden's realization blocklisted the shape reads as drift and option-0 stands."""
+    blocked = {"n0": {tile_identity(dict(_ROW_GOLD))}}
+    leaves = [SimpleNamespace(knobs=dict(_ROW_W1X1)), SimpleNamespace(knobs=dict(_ROW_GOLD))]
+    with caplog.at_level(logging.WARNING):
+        picked, fp = _decide_no_prior(monkeypatch, [_golden()], leaves, blocked=blocked)
+    assert picked is leaves[0]
+    assert fp.score is None
+    assert any("no longer realize" in r.message for r in caplog.records)
+
+
+def test_fork_shape_key_flash_sniff_scans_every_row():
+    """The flash OFFER signal (the ``TILE@dd`` + ``TILE@pj`` pair) marks the fork when
+    ANY row carries it — row 0 is whichever leaf the planner emitted first and need
+    not be a warp leaf. A row-0-only sniff mis-keyed such a fork ``kind=""`` (GAP), and
+    the attention goldens were silently skipped in favor of the model. The sig is the
+    RESTRUCTURED twisted op's: re-derived extents only, no histogram — so the stamp
+    classifier cannot fire and the key depends on the offer sniff alone."""
+    flash_sig = {
+        "S_ext_free_prod": 2097152.0,
+        "S_ext_reduce_max": 512.0,
+        "S_ext_n_free_axis": 3.0,
+        "S_ext_n_reduce_axis": 3.0,
+        "S_ext_n_symbolic_axis": 0.0,
+        "H_opt": 3.0,
+    }
+    scalar_row = {**flash_sig, "TILE": "b32x8/f1x1"}  # a bare-TILE non-warp sibling emitted first
+    warp_row = {
+        **flash_sig,
+        "PLACE@fold": "fuse",
+        "TILE@dd": "a:mma_m16n8k16_f16_f32/w4x1/f1x2/k16",
+        "TILE@pj": "a:mma_m16n8k16_f16_f32/w4x1/f1x32",
+        "REDUCE@kv": "",
+        "STAGE@kv": "d2/cp/ring",
+    }
+    assert _fork_shape_key([warp_row, scalar_row]).kind == "flash"
+    assert _fork_shape_key([scalar_row, warp_row]).kind == "flash", "the sniff must not depend on row order"


### PR DESCRIPTION
## What could go wrong before

A greedy deploy is documented as resolving each fork through the evidence hierarchy — the card's recorded goldens first, then measured reservoir/DB evidence, then the prior. In the common path that ordering holds, but the golden tier was implemented *inside* the prior-gated branch of `greedy_decide`, so two paths resolved with the tier silently switched off:

- **Prior load failure** (corrupt / unreadable `online.json`, any `load_prior` exception): every fork of every program in a serve boot fell to emission order (option-0), missing every recorded golden — on the gen-runner serving path that is all ~96 per-layer programs of a boot.
- **`Pipeline.run`'s last-resort emission-order resolve** (after the validity-retry budget exhausts): one over-budget tile anywhere in a program downgraded *every other* fork of that program to option-0, dropping their verified goldens too.

Option-0 is exactly the misdeploy class the goldens exist to pin (degenerate w1x1 tiles, 12–29x off the golden in the cold-gemma findings; `plans/gemma4-m64-decode-goldens-findings.md` measured a 2539.5 µs pick where the seeded golden runs 1215).

A third, latent member of the same class: `_fork_shape_key`'s flash sniff read the `TILE@dd` + `TILE@pj` offer pair off **row 0 only**. A flash fork whose first-emitted leaf isn't a warp leaf would mis-key as `kind=""` → GAP → the attention goldens skipped in favor of the model, silently.

## What the change guarantees

Whenever a recorded golden exists for a fork's shape and its knobs still realize on an offered candidate, the deploy pick is at least as good as that golden — on every resolve path, including the two prior-less ones. Specifically:

- The golden tier is consulted independently of any prior: with `prior=None` (load failure or the explicit emission-order fallback), a realizable golden deploys and the override is **logged loudly** (`golden floor holds — deploying the recorded golden realization`). Only golden-less forks fall to emission order, bit-for-bit as before.
- The drift warning (golden keyed to the shape but no candidate realizes it) now also fires on the prior-less paths — previously silent there because the tier was never consulted.
- `Pipeline.run`'s final option-0 resolve now threads `blocked` through, so the floor can never re-pick a tile that already failed `validate(ctx)` — the escape hatch keeps its lowering guarantee.
- The flash offer sniff scans **every** candidate row (same convention as the computed-A cone's sync-STAGE scan), so the attention-golden join no longer depends on planner emission order.

The prior-loaded path is unchanged — its tier ordering already implements the floor (golden decides before reservoir/DB/model).

## Mechanism found

In `greedy_decide.decide`, the first statement after loading the prior was `if the_prior is None: return _first_leaf(fp.options[0])` — tier (1) of the hierarchy was gated behind tier (3)'s availability. The fix hoists a golden consultation (same flatten → blocklist → row-build → `_golden_pick` as the main path, structural leaves filtered) into that branch; no new abstractions, no config flags.

## Testing

- New `tests/compiler/pipeline/search/test_golden_floor.py` (GPU-free, follows `test_golden_evidence_deploy.py` patterns): floor deploys the golden on a `prior=None` resolve with the override warning; drift warns and falls to option-0; a card without goldens stays pure emission order (parity with `test_option0_decide_matches_no_prior_greedy`); the blocklist keeps the floor off failed tiles; the flash sniff is row-order-invariant. All four behavior tests fail on the pre-fix code.
- `tests/compiler/pipeline/` + `tests/compiler/test_golden_drift_gate.py`: 470 passed, 4 skipped; `tests/compiler/pipeline/search/`: 330 passed (one environment-only failure of `test_selected_kernel_set_identical_across_processes` on the NixOS host — missing `libz` in the spawned subprocess — passes with zlib on `LD_LIBRARY_PATH`; unrelated to this change).
- `ruff check` / `format --check` clean on touched files.

**Pending**: e2e validation on a rented 5090 box — full `make test`, plus a serve boot with a deliberately corrupted `EMMY_ONLINE_FILE` to observe the floor's override warnings on the gen-runner path, and a before/after `emmy eval golden --in-model --model google/gemma-4-12B` (expect MATCH counts unchanged: the audit path already resolves with the offline prior loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQZG4Z6Rsr8mV577b4vfqG