### PR TITLE
Release-skill shakedown fixes from the gemma-4 image release

### DIFF
--- a/.claude/skills/release-gemma4-image/SKILL.md
+++ b/.claude/skills/release-gemma4-image/SKILL.md
@@ -28,16 +28,30 @@ Ask only for what the user hasn't already given:
 2. **`HF_TOKEN`** — needed for the gated gemma-4 download during headroom/validate/warm. Local mode with the model
    already in `~/.cache/huggingface` can skip it by pre-seeding (ARCHITECTURE.md "Running it locally").
 3. **Docker Hub credentials for the push** — ask the user for a **short-lived access token** (not their password;
-   `docker login -u <user> --password-stdin`). Never echo it; `docker logout` in teardown regardless of outcome.
+   `docker login -u <user> --password-stdin`) **and, in the same question, the username the token belongs to**: a PAT
+   authenticates only its owning account, which is usually a personal user with push rights to the `cloudriftai` org,
+   not `cloudriftai` itself — the wrong username fails as "incorrect username or password". Never echo the token;
+   `docker logout` in teardown regardless of outcome.
 4. **Env file** (CloudRift creds, rental mode) — default `.env`, per the `start-remote-server` sourcing rules.
 
 ## Step 0 — Provision (rental mode; skip in local mode)
 
 Delegate to the `start-remote-server` skill: `emmy vm create gpu --gpu "NVIDIA GeForce RTX 5090" --gpu-count 1`
-(CloudRift). Capture `REMOTE` and the teardown handle. Then prepare the host (CloudRift image quirks: `apt update`,
-`python3.12-venv`/`python3.12-dev`, `nvcc` via `CUDA_HOME=/usr/local/cuda`; Docker + NVIDIA runtime are preinstalled
-on CloudRift images — verify with `docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi` or the
-vllm-emmy image itself). Rsync the working tree at the **release commit** and `make setup` +
+(CloudRift). On vast.ai instead: rent a **VM instance** template (e.g. "Ubuntu 22.04 VM", vastai/kvm,
+`vms_enabled=true` in search) — plain docker-container templates cannot run the host-level Docker builds; the account
+SSH key may not be injected, self-inject via `--onstart-cmd`. Capture `REMOTE` and the teardown handle. Then prepare
+the host (CloudRift image quirks: `apt update`, `python3.12-venv`/`python3.12-dev`, `nvcc` via
+`CUDA_HOME=/usr/local/cuda`; Docker + NVIDIA runtime are preinstalled on CloudRift images — verify with
+`docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi` or the vllm-emmy image itself). Also
+install `git-lfs` (the repo's hooks require it — a checkout without it dies mid-rebuild) and, when operating as root
+over a synced tree, `git config --global --add safe.directory <repo>` (without it `git rev-parse` returns empty and
+the image tag degrades; `make` now guards this).
+
+**Ship the source at the pinned release commit — never rsync the live working tree.** The working tree is shared
+mutable state: a branch switch in another session mid-release yields a hybrid tree whose wheel fails in confusing,
+distant ways. Pin `origin/main`'s sha up front, get the tree onto the host (fresh clone, or rsync of the
+`git ls-files` list plus `.git`), then `git checkout -f <sha>` there — and re-verify `git rev-parse HEAD` before any
+rebuild. Then `make setup` +
 `./venv/bin/pip install -e ".[serving]"` + cupy (the venv steps back the headroom sweep and the validate script).
 Host toolchain: **CUDA >= 12.9** (FlashInfer refuses sm_120 below it — the misleading error is "requires sm75 or
 higher"); on non-CloudRift hosts verify the NVIDIA container toolkit actually works (`docker run --gpus all ...
@@ -52,7 +66,9 @@ pre-seed the snapshot there, not at the repo root. Budget
 before the bake — nothing after the warm needs it.
 
 **Run every long step detached** (`nohup … > step.log 2>&1 &` or `emmy`'s detached patterns) and poll the log — an
-SSH SIGHUP mid-compile must not kill the step or eat its traceback.
+SSH SIGHUP mid-compile must not kill the step or eat its traceback. Detached means no tty: pass `--batch --yes` to any
+`gpg` in installer snippets or it dies silently. And never `export TOKEN=$(cat …)` inside a `set -x` script — xtrace
+prints the expanded secret into the log; wrap secret reads in `set +x` … `set -x`.
 
 ## Step 1 — Base image
 
@@ -77,6 +93,10 @@ Policy (decode bucket stays at 16): try `--max-model-len`/`--max-num-batched-tok
 `EngineCore encountered a fatal error` (the exit code alone hides tail crashes — a drained bench can die after its
 metrics print; grep the log). It **fails** on CUDA OOM, death before health, or a logged engine fatal. Keep the largest passing N. If even 256 fails with the decode bucket on, retry 256 with
 `EMMY_GEN_DECODE_BUCKET=0` and report that the memory fixes regressed (that is a finding, not a config).
+
+The sweep's first boot compiles every kernel and can exceed `emmy serve`'s 30-min health cap (`_HEALTH_TIMEOUT_S` in
+`emmy/commands/serve.py`) on a slow host — bumping it with a VM-local sed is fine; it does not affect the shipped
+artifacts.
 
 Write the winner into `docker/vllm-emmy-gemma4/config.env`. **The config is sealed from here on** — any later change
 invalidates the warm.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup clean bench bench-force bench-kernels bench-kernels-tune test-compose lint format
+.PHONY: help setup clean bench bench-force bench-kernels bench-kernels-tune test-compose lint format git-sha-guard
 
 help:
 	@echo "Server Benchmark Makefile"
@@ -68,7 +68,14 @@ wheel: setup
 	./venv/bin/pip install --quiet build
 	rm -rf dist build && ./venv/bin/python -m build --wheel -o dist/ .
 
-vllm-emmy-image: wheel
+# Image tags embed the short sha; an empty rev-parse (e.g. root over a synced tree without
+# git safe.directory) would silently tag "...:0.23.0-" — fail loudly instead.
+git-sha-guard:
+	@test -n "$(shell git rev-parse --short HEAD)" || \
+		(echo "ERROR: git rev-parse returned empty — image tag would be malformed."; \
+		 echo "  likely fix: git config --global --add safe.directory $(CURDIR)"; exit 1)
+
+vllm-emmy-image: wheel git-sha-guard
 	docker build -f docker/vllm-emmy/Dockerfile --build-arg VLLM_VERSION=$(VLLM_VERSION) \
 		-t $(VLLM_EMMY_TAG) .
 
@@ -83,7 +90,7 @@ GEMMA4_TAG ?= cloudriftai/vllm-emmy-gemma4:$(patsubst v%,%,$(VLLM_VERSION))-$(sh
 gemma4-warm:
 	BASE_IMAGE=$(VLLM_EMMY_TAG) docker/vllm-emmy-gemma4/warm.sh
 
-gemma4-serve-image:
+gemma4-serve-image: git-sha-guard
 	@test -n "$$(ls -A docker/vllm-emmy-gemma4/warm/hf 2>/dev/null)" -a -n "$$(ls -A docker/vllm-emmy-gemma4/warm/cubin 2>/dev/null)" || \
 		(echo "docker/vllm-emmy-gemma4/warm/ is empty — run 'make gemma4-warm' on the target GPU first"; exit 1)
 	@mkdir -p docker/vllm-emmy-gemma4/warm/pack  # pack is optional (COPY needs the dir); empty → boot falls back to full compile


### PR DESCRIPTION
## Summary

The first real run of the `release-gemma4-image` skill (shipped `cloudriftai/vllm-emmy-gemma4:0.23.0-9ae0683e`,
2026-07-23, RTX 5090 on vast.ai) doubled as its shakedown, per the skill's own failure-handling clause. This PR folds
the process findings back into the skill and the build; the verify.sh gate fix landed separately in #420.

- **Makefile**: new `git-sha-guard` prerequisite on `vllm-emmy-image` and `gemma4-serve-image`. Running as root over a
  synced tree without `git config safe.directory` makes `git rev-parse` return empty, which silently baked a malformed
  `:0.23.0-` tag mid-release. Now the build fails loudly and prints the fix. Both paths tested.
- **SKILL.md**:
  - Inputs: collect the Docker Hub **username together with the token** — a PAT authenticates only its owning account
    (typically a personal user with org push rights, not `cloudriftai`), and the wrong guess costs a user round-trip.
  - Step 0: ship the source as a **pinned-sha checkout, never an rsync of the live working tree** — a branch switch in
    another session mid-release produced a hybrid tree whose wheel failed with a confusing ImportError (~1 h lost).
    Host prep adds `git-lfs` (checkout dies without it; ~40 min lost) and `safe.directory`; documents the vast.ai
    VM-template variant (plain docker templates can't run host-level Docker builds).
  - Detached-run notes: `gpg --batch --yes` under `nohup` (no tty), and never `export TOKEN=$(cat …)` under `set -x`
    (the HF token leaked into a log this way).
  - Step 3: first cold boot exceeds `emmy serve`'s 30-min health cap on slow hosts; a VM-local bump is safe.

## Testing

- `make lint` clean; `make test` 2548 passed, 158 skipped.
- `git-sha-guard` verified in-repo (passes) and with `GIT_DIR=/nonexistent` (fails with the message, exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)