### PR TITLE
collect-node-data: optional server rental, all remote work inside tmux

### DIFF
--- a/.claude/skills/collect-node-data/SKILL.md
+++ b/.claude/skills/collect-node-data/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: collect-node-data
-description: Use this skill when the user wants to populate or refresh the autotune DB's node table (the cross-hardware search-tree node store) with data measured on a SPECIFIC GPU — e.g. "collect node data for an H200", "run the node sweep on a rented <GPU> and merge the nodes back", "gather cross-hardware node-store data", "populate / update the node table from <hardware>". Rents a fresh single-GPU server (via start-remote-server), rsyncs + sets up emmy there, runs the budgeted three-slice golden sweep (`remote_node_collect.py` → `golden_neighbor_bench.py`: every golden kind's candidate pool, sliced own-neighborhood / cross-card exchange / uniform tail at 60/25/15 budget shares, kind-stratified within each slice, paired -O1/-O3 pinned benches, ledger-resumed), merges the remote node rows into the local `~/.cache/emmy/autotune.db` (nodes table only, GPU-keyed so cards never collide), backs the DB up locally, and tears the server down.
-version: 0.3.0
+description: Use this skill when the user wants to populate or refresh the autotune DB's node table (the cross-hardware search-tree node store) with data measured on a SPECIFIC GPU — e.g. "collect node data for an H200", "run the node sweep on a rented <GPU> and merge the nodes back", "collect node data on this server", "gather cross-hardware node-store data", "populate / update the node table from <hardware>". Uses an existing GPU server the user provides, or rents a fresh single-GPU one (via start-remote-server); rsyncs + sets up emmy there, runs the budgeted three-slice golden sweep (`remote_node_collect.py` → `golden_neighbor_bench.py`: every golden kind's candidate pool, sliced own-neighborhood / cross-card exchange / uniform tail at 60/25/15 budget shares, kind-stratified within each slice, paired -O1/-O3 pinned benches, ledger-resumed) — all remote processes inside tmux sessions — merges the remote node rows into the local `~/.cache/emmy/autotune.db` (nodes table only, GPU-keyed so cards never collide), backs the DB up locally, and tears the server down (only if it rented it).
+version: 0.4.0
 ---
 
 # Collect node-store data from specific hardware
@@ -12,9 +12,12 @@ dict the prior sees. It is read by `emmy eval prior --dataset nodes` (per-card f
 reachability) and feeds prior diagnostics. Because your dev box (and most of the fleet) has no local CUDA GPU, the
 data for any given card must be **measured on that card** and brought back.
 
-This skill does exactly that for one GPU, in a single budgeted run on the rented box: rent it → set up emmy →
-the golden sweep (`scripts/remote_node_collect.py`, driving `scripts/golden_neighbor_bench.py`) → merge the new card's
-node rows into the local DB → back the DB up → tear the server down.
+This skill does exactly that for one GPU, in a single budgeted run on the box: get a server (an existing one the
+user provides, or rent one) → set up emmy → the golden sweep (`scripts/remote_node_collect.py`, driving
+`scripts/golden_neighbor_bench.py`) → merge the new card's node rows into the local DB → back the DB up → tear the
+server down (only if this run rented it). Everything long-running on the remote — the apt/`make setup` phase and
+the sweep itself — runs inside named tmux sessions (`emmy-node-setup` / `emmy-node-sweep`), so a dropped ssh
+connection never kills the work and a human can attach to watch it.
 
 **Why a budgeted sweep (and not a search-driven tune).** The old flow ran an ε-greedy `emmy tune --dataset golden`
 first: its wall time grew with the golden set (patience-stopped search per shape, no budget knob), and even at
@@ -66,29 +69,38 @@ here.
 The sweep neither needs **`HF_TOKEN` nor downloads models** (golden snippets are pure `torch.randn`) — but it **does**
 need `nvcc` (it compiles CUDA kernels). Budget **~4.5–5.5 h total** for the default 4-hour sweep including env build;
 confirm with the user before starting if they expected a quick run. The budget samples the pool, it doesn't finish
-it — repeated rentals of the same card model resume from the fetched ledger and keep extending coverage.
+it — repeated runs on the same card model (rented or user-provided) resume from the fetched ledger and keep
+extending coverage.
 
 ## Inputs to confirm
 
 Ask only for what the user hasn't already given:
 
-1. **GPU model** — must map to a key in `emmy/hardware.py::GPU_INSTANCE_TYPES` (e.g. "H200" → `"NVIDIA H200
-   141GB"`). If it isn't in the table, stop and say so — don't guess. This card's identity is what the node rows are
-   keyed by.
-2. **Provider** — only ask if the GPU is offered by more than one (e.g. H200 is on CloudRift and GCP). A user-named
-   provider is **binding** (never silently substitute).
-3. **Env file** (CloudRift creds) — default `.env`; if the user named an overlay or wants a non-default cluster, follow
-   the `start-remote-server` sourcing rules (base first, overlay second, same Bash call). H200 on CloudRift often needs
-   a non-default cluster.
-4. **GPU count is fixed at 1.** Node data is per-card; one GPU is all the sweep needs. Don't rent more.
+1. **Server: existing or rented?** If the user provides an existing server (`user@host`, plus port/key if
+   non-default), **skip Step 1 entirely** and never tear it down — a box this run didn't rent is not ours to
+   delete (or otherwise modify beyond the sweep we were asked to run). Requirements for a provided server: ssh key
+   access, an NVIDIA GPU visible (`nvidia-smi`), Ubuntu-ish with `apt` + passwordless `sudo` (the script installs
+   tmux / Python 3.12 / the CUDA toolkit as needed). The card's identity is detected on-box
+   (`Context.hardware_id()`), so the node rows key correctly no matter how the server was obtained.
+2. **GPU model** — needed only when provisioning; must map to a key in
+   `emmy/hardware.py::GPU_INSTANCE_TYPES` (e.g. "H200" → `"NVIDIA H200 141GB"`). If it isn't in the table, stop and
+   say so — don't guess.
+3. **Provider** — provisioning only; ask only if the GPU is offered by more than one (e.g. H200 is on CloudRift and
+   GCP). A user-named provider is **binding** (never silently substitute).
+4. **Env file** (CloudRift creds) — provisioning only; default `.env`; if the user named an overlay or wants a
+   non-default cluster, follow the `start-remote-server` sourcing rules (base first, overlay second, same Bash
+   call). H200 on CloudRift often needs a non-default cluster.
+5. **GPU count is fixed at 1.** Node data is per-card; one GPU is all the sweep needs. Don't rent more. (A provided
+   multi-GPU box works — the sweep just uses one card — but never rent one.)
 
 Don't pass `--billing-exempt` for any rentals — all rentals bill normally (the flag is admin-only and not used by
 any skill flow).
 
-## Step 1 — Provision the server (delegate to `start-remote-server`)
+## Step 1 — Provision the server (skip when the user supplied one)
 
-Provision exactly one GPU using the orchestrator, following the full `start-remote-server` skill (credential sourcing,
-candidate fallback, capacity handling, the binding `--provider` rule). The command shape:
+**Only when the user did not provide an existing server.** Provision exactly one GPU using the orchestrator,
+following the full `start-remote-server` skill (credential sourcing, candidate fallback, capacity handling, the
+binding `--provider` rule). The command shape:
 
 ```bash
 [ -f .env ] && set -a && . ./.env && set +a && \
@@ -102,17 +114,24 @@ Capture from the final `VM ready at <user@host[:port]>` line:
 
 Do not wrap the command in a retry loop — the orchestrator handles fallback itself.
 
+With a user-provided server there is nothing to do here beyond a quick reachability check (`ssh … nvidia-smi -L`)
+— then go straight to Step 2 with the given `user@host` / port / key.
+
 ## Step 2 — Set up, sweep, merge, and back up on the remote (one backgrounded run of one script)
 
-`scripts/remote_node_collect.py` does the whole core in **one process**: ensures the Python 3.12 venv/dev packages +
-`nvcc`, rsyncs your working tree (exact local code, incl. uncommitted changes) to `~/.local/share/emmy/node-collect/`
-(the repo's `REMOTE_DEPLOY_DIR` layout), runs `make setup` (output to `setup.log` in that dir — only a tail returns
-on failure), pushes the resume ledger, launches the sweep detached, **polls the remote log internally** until it
-finishes, then **fetches the ledger and node rows back and merges them** into the local `~/.cache/emmy/autotune.db`
-(`node` table only, GPU-keyed so other cards are untouched), snapshots the DB to `~/.cache/emmy/backups/`, and prints
-the per-card receipt. The robustness traps are baked in: argv-list ssh (no zsh word-split), bracket-pgrep liveness
-(no self-match), one short ssh per poll (no broken-pipe), venv/dev always installed, and a non-tty-safe detached
-launch.
+`scripts/remote_node_collect.py` does the whole core in **one process**: bootstraps tmux, rsyncs your working tree
+(exact local code, incl. uncommitted changes) to `~/.local/share/emmy/node-collect/` (the repo's
+`REMOTE_DEPLOY_DIR` layout), ensures the Python 3.12 venv/dev packages + `nvcc` and runs `make setup` inside the
+`emmy-node-setup` tmux session (output to `setup.log` in that dir — only a tail returns on failure), pushes the
+resume ledger, launches the sweep inside the `emmy-node-sweep` tmux session, **polls the remote log internally**
+until it finishes, then **fetches the ledger and node rows back and merges them** into the local
+`~/.cache/emmy/autotune.db` (`node` table only, GPU-keyed so other cards are untouched), snapshots the DB to
+`~/.cache/emmy/backups/`, and prints the per-card receipt. Every long-running remote process lives in a named tmux
+session — a dropped ssh never kills the work, and `tmux attach -t emmy-node-sweep` on the box shows it live. The
+other robustness traps are baked in: argv-list ssh (no zsh word-split), `tmux has-session` liveness (no pgrep
+self-match), one short ssh per poll (no broken-pipe), and venv/dev always installed. On a box that already has a
+live `emmy-node-sweep` session (possible with a reused / user-provided server) the script **refuses to launch** —
+attach to inspect, or kill that session first.
 
 Run it in the **background** (Bash `run_in_background: true`) — ~4.5 h, past any foreground tool timeout, and you
 want only the final summary in context, not ~20 ssh polls. The harness re-invokes you with the summary when it
@@ -140,7 +159,7 @@ validates imports and the trace path — off-GPU every anchor labels cross and p
 When the run exits you get one compact result:
 
 - **success** → `status: ok`, a `points: neighbor-bench done: <done>/<total> points (<new> new this run)` line plus
-  `ledger: fetched -> …` — **followed by the merge receipt** (the rented card appears as its own line in `node rows
+  `ledger: fetched -> …` — **followed by the merge receipt** (the swept card appears as its own line in `node rows
   per card now: …`; cards already present are unchanged), a `backup: <path>` line, and `status: COMPLETE (sweep +
   merge done)`. Merge and backup are folded in, so there is **no separate step to launch** — the local DB is already
   updated and snapshotted. A run stopped at `--timeout` reports the same way with `sweep stopped at --timeout`
@@ -153,7 +172,7 @@ When the run exits you get one compact result:
   distribution-preserving sample of it and later runs keep going. Don't extend the run past the budget without
   asking the user.
 
-**Re-merge / manual fallback.** If the merge step failed (or you used `--no-merge`), merge the rented card's rows without
+**Re-merge / manual fallback.** If the merge step failed (or you used `--no-merge`), merge the swept card's rows without
 re-sweeping: `./venv/bin/python scripts/merge_node_db.py --remote "<user@host>" [--ssh-key … --port …]` (or `--src
 <snapshot.db>` for an already-fetched file; `--db <path>` to override the destination). Same `node`-only, per-kind
 upsert semantics.
@@ -161,9 +180,11 @@ upsert semantics.
 **Manual debugging** (only if the script fails and you need to poke the box): the harness shell is zsh, so pass ssh
 options as an **array** — `SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -i
 "$HOME/.ssh/id_ed25519")` (a plain string var fails: zsh doesn't word-split it). Then `ssh "${SSH_OPTS[@]}" "$REMOTE"
-'tail -n 40 ~/.local/share/emmy/node-collect/neighbors.log'`; check liveness with `pgrep -f "[g]olden_neighbor_bench"`
-(bracket trick — a plain pattern self-matches the poll's own argv); never run a multi-minute loop inside one ssh
-session.
+'tail -n 40 ~/.local/share/emmy/node-collect/neighbors.log'`; check liveness with `tmux has-session -t
+emmy-node-sweep` (or `tmux capture-pane -pt emmy-node-sweep` for the live screen; the setup phase is
+`emmy-node-setup`). If you ever fall back to pgrep, bracket the pattern (`pgrep -f "[g]olden_neighbor_bench"`) so it
+doesn't self-match. Never run a multi-minute loop inside one ssh session — and if you must start any long-running
+process on the box by hand, start it inside a tmux session, never bare over ssh.
 
 ## Step 3 — Verify
 
@@ -171,13 +192,16 @@ session.
 ./venv/bin/emmy eval prior --dataset nodes
 ```
 
-`node_report` groups by card — confirm a block headed with the rented GPU's name appears (`[<gpu>] <n> nodes`, with fork
+`node_report` groups by card — confirm a block headed with the swept GPU's name appears (`[<gpu>] <n> nodes`, with fork
 sibling-ranking + leaf reachability for that card). `--kernel matmul` / `reduce` / `pointwise` narrows to one op family.
 
-## Step 4 — Tear down the server
+## Step 4 — Tear down the server (only if this run rented it)
 
-The VM bills until deleted, and this skill's job is done once the merge verifies. **Confirm with the user, then delete**
-(never delete a VM without an explicit go-ahead):
+**A user-provided server is never torn down** — it isn't ours. Just report that the sweep is finished, that no
+`emmy-node-sweep` tmux session is left running, and leave the box exactly as it was.
+
+For a server this run provisioned: the VM bills until deleted, and this skill's job is done once the merge
+verifies. **Confirm with the user, then delete** (never delete a VM without an explicit go-ahead):
 
 ```bash
 emmy vm delete cloudrift --instance-id <id>           # CloudRift
@@ -190,17 +214,19 @@ If the user wants to keep the box for more sweeping, leave it up and report the 
 
 Before reporting success:
 
-- [ ] `vm create gpu` exited 0 and an SSH target was captured.
+- [ ] An SSH target was in hand — either provided by the user (reachability checked), or `vm create gpu` exited 0
+      and the target + teardown handle were captured.
 - [ ] The run ended with `status: COMPLETE (sweep + merge done)`, a `neighbor-bench done: <done>/<total> points`
       line, and `ledger: fetched -> …` (a short `<done>` count is fine — the budget samples the pool, it doesn't
       finish it).
 - [ ] The startup log shows per-slice pool counts (`own <o> / cross <c> / tail <t>`) and per-kind `[pool]` lines
       without wholesale anchor-skip storms on a kind (a few `anchor skipped` lines are normal — cross-card configs
       that don't realize here).
-- [ ] The merge receipt shows the rented card as its own per-card line; counts for other cards are unchanged.
+- [ ] The merge receipt shows the swept card as its own per-card line; counts for other cards are unchanged.
 - [ ] A `backup: <path>` line appeared (or the log explains why the backup was skipped).
-- [ ] `eval prior --dataset nodes` shows a block for the rented GPU.
-- [ ] The VM was deleted (or the user explicitly chose to keep it, and has the teardown command).
+- [ ] `eval prior --dataset nodes` shows a block for the swept GPU.
+- [ ] Rented server: the VM was deleted (or the user explicitly chose to keep it, and has the teardown command).
+      User-provided server: left untouched, with no `emmy-node-sweep`/`emmy-node-setup` tmux session still running.
 
 If any check fails, report the failure + raw output instead of claiming success.
 
@@ -214,10 +240,15 @@ If any check fails, report the failure + raw output instead of claiming success.
   kernel compiles hard-fail (there is no NVRTC fallback).
 - **Don't set `HF_TOKEN` or expect model downloads** — the golden snippets are pure torch expressions.
 - **Don't rent more than 1 GPU** — node data is per-card; extra GPUs just burn money.
-- **Don't auto-delete the VM** — confirm teardown with the user first (and never modify a CloudRift server beyond the
-  sweep we explicitly started).
+- **Don't rent a server the user already offered one for** — an existing `user@host` from the user means skip
+  provisioning entirely; renting anyway burns money and splits the run across boxes.
+- **Don't auto-delete the VM** — confirm teardown with the user first; and **never tear down (or otherwise modify) a
+  user-provided server** beyond the sweep we explicitly started — it isn't ours.
+- **Don't run long-lived remote processes outside tmux** — the script already puts setup and the sweep in the
+  `emmy-node-setup` / `emmy-node-sweep` sessions; any manual long-running command you start on the box goes in a
+  tmux session too, never bare over ssh (a dropped connection kills it and strands rented-GPU time).
 - **Don't hand-roll the remote setup/poll loop** — `scripts/remote_node_collect.py` (Step 2) already handles it correctly:
-  argv-list ssh (zsh doesn't word-split a string var), the `[g]olden_neighbor_bench` bracket-pgrep (a plain pattern
-  self-matches the poll's own argv and reports the sweep alive forever), one short ssh per poll, and venv/dev install.
-  Only drop to manual ssh for debugging — and then keep the same precautions (array ssh opts; never name a var
-  `status`/`path`, which are read-only in zsh).
+  argv-list ssh (zsh doesn't word-split a string var), tmux-session launch + `has-session` liveness (no pgrep
+  self-match, no ssh channel held open across a detach), one short ssh per poll, and venv/dev install.
+  Only drop to manual ssh for debugging — and then keep the same precautions (array ssh opts; bracket any pgrep
+  pattern; never name a var `status`/`path`, which are read-only in zsh).

--- a/scripts/remote_node_collect.py
+++ b/scripts/remote_node_collect.py
@@ -3,13 +3,18 @@
 token-heavy middle of the ``collect-node-data`` skill, extracted so the agent makes
 ONE backgrounded tool call instead of ~20 verbose ssh polls.
 
-Given an SSH target it: ensures the Python 3.12 venv/dev packages + ``nvcc``, rsyncs
-the local working tree, runs ``make setup`` (output to a remote logfile — only a tail
-comes back on failure), launches the collection detached, then **polls the remote log
-internally** until it finishes — a run that outlives ``--timeout`` is STOPPED and
-harvested, never abandoned — merges the node rows home, and backs up the local DB.
-All the per-poll ssh chatter happens inside this process, so it never reaches the
-agent's context.
+Given an SSH target (a freshly rented box or any existing server the user provides) it:
+rsyncs the local working tree, ensures the Python 3.12 venv/dev packages + ``nvcc`` and
+runs ``make setup`` (inside the ``emmy-node-setup`` tmux session; output to a remote
+logfile — only a tail comes back on failure), launches the collection inside the
+``emmy-node-sweep`` tmux session, then **polls the remote log internally** until it
+finishes — a run that outlives ``--timeout`` is STOPPED and harvested, never abandoned —
+merges the node rows home, and backs up the local DB. All the per-poll ssh chatter
+happens inside this process, so it never reaches the agent's context.
+
+Every long-running remote process lives in a named tmux session, so a dropped ssh
+connection never kills it and a human can watch or debug with
+``tmux attach -t emmy-node-sweep`` (or ``emmy-node-setup``) on the box.
 
 The collection is ``scripts/golden_neighbor_bench.py`` — the budgeted three-slice sweep
 (own-golden neighborhood / cross-card golden exchange / uniform tail, kind-stratified
@@ -35,11 +40,12 @@ with just the final summary when this exits.
 Then (separately, if ``--no-merge``) merge the node rows home with
 ``scripts/merge_node_db.py --remote``.
 
-Robustness baked in (the four traps the first run hit): all ssh goes through argv
-lists (no shell word-splitting / zsh quirks); liveness uses the
-``[g]olden_neighbor_bench`` bracket-pgrep so it never self-matches; each poll is its
-own short ssh (no long-held session that broken-pipes); and venv/dev are always
-installed before ``make setup``.
+Robustness baked in (the traps earlier runs hit): all ssh goes through argv lists (no
+shell word-splitting / zsh quirks); liveness reads ``tmux has-session`` (no pgrep
+self-match trap, no ssh channel held open across a ``nohup … &``); each poll is its own
+short ssh (no long-held session that broken-pipes); venv/dev are always installed
+before ``make setup``; and a launch refuses to start when a previous sweep session is
+still alive on the box (relevant for user-provided servers).
 """
 
 from __future__ import annotations
@@ -74,9 +80,14 @@ _CUDA_EXPORT = "export PATH=/usr/local/cuda/bin:$PATH CUDA_HOME=/usr/local/cuda"
 _BASE = f"{REMOTE_DEPLOY_DIR}/node-collect"
 _REMOTE_DIR = f"{_BASE}/repo"  # rsync target — the emmy checkout the sweep runs from
 _SETUP_LOG = f"{_BASE}/setup.log"
+_SETUP_STATUS = f"{_BASE}/setup.status"  # one status word (SETUP_OK / SETUP_FAIL / NVCC_MISSING) per setup attempt
 _NEIGHBOR_LOG = f"{_BASE}/neighbors.log"
 _REMOTE_LEDGER = f"{_BASE}/neighbor_ledger.json"
 _REMOTE_RECEIPTS = f"{_BASE}/receipts"
+# Every long-running remote process runs inside one of these named tmux sessions —
+# attachable for debugging, and immune to the launching ssh connection dropping.
+_SETUP_SESSION = "emmy-node-setup"
+_SWEEP_SESSION = "emmy-node-sweep"
 # The driver's final summary line: ``neighbor-bench done: <done>/<total> points (<new> new this run)``.
 # The poll's ``grep -oE`` extracts only the prefix up to ``points`` — match that.
 _NEIGHBOR_DONE_RE = re.compile(r"neighbor-bench done: (\d+)/(\d+) points")
@@ -99,14 +110,13 @@ def _opts(ssh_key: str | None, port: int | None) -> list[str]:
     return out
 
 
-def _run(remote: str, ssh_key: str | None, port: int | None, command: str, *, timeout: int = 600, detach: bool = False) -> tuple[int, str]:
+def _run(remote: str, ssh_key: str | None, port: int | None, command: str, *, timeout: int = 600) -> tuple[int, str]:
     """Run one remote command over a fresh ssh connection; return (rc, combined output).
 
-    ``detach=True`` adds ssh ``-n`` (stdin from /dev/null) — needed when launching a
-    remote background process: without it (plus a ``< /dev/null`` redirect on the
-    command itself) ssh holds the channel open past a ``nohup … &``, so this call
-    times out (rc 124) long *after* the process already started successfully."""
-    argv = ["ssh", *(["-n"] if detach else []), *_opts(ssh_key, port), remote, command]
+    Long-running work never goes through here directly — it is launched into a tmux
+    session (``_tmux_launch``), so no call holds an ssh channel open for the duration
+    of a build or sweep."""
+    argv = ["ssh", *_opts(ssh_key, port), remote, command]
     try:
         p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
         return p.returncode, (p.stdout + p.stderr)
@@ -116,6 +126,66 @@ def _run(remote: str, ssh_key: str | None, port: int | None, command: str, *, ti
 
 def _log(msg: str) -> None:
     print(f"[remote_node_collect] {msg}", flush=True)
+
+
+def _tmux_launch(remote: str, ssh_key: str | None, port: int | None, session: str, body: str, *, pre: str = "") -> bool:
+    """Start ``body`` inside a fresh detached tmux session named ``session`` (killing any
+    stale same-named session first). ``tmux new-session -d`` returns immediately, so the
+    launching ssh never holds a channel open — the old ``nohup``/``ssh -n`` detach dance
+    is gone. Returns True once the launch is confirmed (echo, or the session visible)."""
+    launch = f"{pre}tmux kill-session -t {session} 2>/dev/null; tmux new-session -d -s {session} {shlex.quote(body)} && echo tmux_launched"
+    _, out = _run(remote, ssh_key, port, launch, timeout=60)
+    if "tmux_launched" in out:
+        return True
+    # Belt-and-suspenders: the launch ssh may fail to report after the session started.
+    time.sleep(5)
+    _, chk = _run(remote, ssh_key, port, f"tmux has-session -t {session} 2>/dev/null && echo ALIVE || echo DEAD")
+    if "ALIVE" in chk:
+        _log("launch ssh did not confirm but the tmux session is alive — continuing")
+        return True
+    return False
+
+
+def _run_setup_session(remote: str, ssh_key: str | None, port: int | None, *, wipe_venv: bool) -> str:
+    """Run deps + ``make setup`` inside the ``emmy-node-setup`` tmux session and wait for
+    the status word the session writes to ``_SETUP_STATUS`` (``SETUP_OK`` / ``SETUP_FAIL``
+    / ``NVCC_MISSING``). Returns that word, or '' when the session died without writing
+    one (or the wait timed out). Always (re)installs the venv/dev packages; installs the
+    CUDA toolkit only if ``nvcc`` is genuinely absent. All noisy output → the setup log."""
+    nvcc_probe = "command -v nvcc >/dev/null 2>&1 || ls /usr/local/cuda*/bin/nvcc >/dev/null 2>&1"
+    body = (
+        f"sudo apt-get update -qq >> {_SETUP_LOG} 2>&1; "
+        f"sudo apt-get install -y -qq python3.12 python3.12-venv python3.12-dev >> {_SETUP_LOG} 2>&1; "
+        f"if ! ({nvcc_probe}); then sudo apt-get install -y -qq cuda-toolkit-12-9 >> {_SETUP_LOG} 2>&1; fi; "
+        f"if ! ({nvcc_probe}); then echo NVCC_MISSING > {_SETUP_STATUS}; exit 0; fi; "
+        f"cd {_REMOTE_DIR} && {_CUDA_EXPORT} && "
+        + ("rm -rf venv && " if wipe_venv else "")
+        + f"make setup >> {_SETUP_LOG} 2>&1 && echo SETUP_OK > {_SETUP_STATUS} || echo SETUP_FAIL > {_SETUP_STATUS}"
+    )
+    if not _tmux_launch(remote, ssh_key, port, _SETUP_SESSION, body, pre=f"rm -f {_SETUP_STATUS}; "):
+        return ""
+    deadline = time.monotonic() + 4500  # apt (incl. a possible CUDA toolkit install) + make setup
+    dead_streak = 0
+    while time.monotonic() < deadline:
+        time.sleep(20)
+        _, out = _run(
+            remote,
+            ssh_key,
+            port,
+            f"cat {_SETUP_STATUS} 2>/dev/null; tmux has-session -t {_SETUP_SESSION} 2>/dev/null && echo SESS=ALIVE || echo SESS=DEAD",
+        )
+        word = next((w for w in ("SETUP_OK", "SETUP_FAIL", "NVCC_MISSING") if w in out), "")
+        if word:
+            return word
+        if "SESS=" not in out:
+            continue  # ssh blip this cycle — not evidence the session died
+        if "SESS=DEAD" in out:
+            dead_streak += 1
+            if dead_streak >= 2:  # two confirmed DEADs without a status word ⇒ the session crashed
+                return ""
+        else:
+            dead_streak = 0
+    return ""
 
 
 def _fail(remote: str, ssh_key: str | None, port: int | None, why: str, logfile: str, *, harvest_ledger: str | None = None) -> int:
@@ -178,12 +248,15 @@ def _backup_local_db(keep: int = 5) -> Path | None:
 
 
 def _stop_sweep(remote: str, ssh_key: str | None, port: int | None) -> bool:
-    """Kill the detached sweep (and its in-flight ``emmy run`` bench child) so the harvest
-    reads a quiet node store. The killed batch's points stay non-terminal in the ledger and
-    simply retry next run. Returns True once nothing sweep-related remains."""
+    """Kill the sweep's tmux session (and its in-flight ``emmy run`` bench child) so the
+    harvest reads a quiet node store. The killed batch's points stay non-terminal in the
+    ledger and simply retry next run. Returns True once nothing sweep-related remains."""
     for attempt in range(6):
         sig = "-9 " if attempt >= 2 else ""
-        kill = f"pkill {sig}-f '[g]olden_neighbor_bench' 2>/dev/null; pkill {sig}-f '[e]mmy run --code' 2>/dev/null; true"
+        kill = (
+            f"tmux kill-session -t {_SWEEP_SESSION} 2>/dev/null; "
+            f"pkill {sig}-f '[g]olden_neighbor_bench' 2>/dev/null; pkill {sig}-f '[e]mmy run --code' 2>/dev/null; true"
+        )
         _run(remote, ssh_key, port, kill)
         time.sleep(5)
         _, out = _run(
@@ -255,26 +328,32 @@ def main() -> int:
             return 2
         repo = gp.stdout.strip()
 
-    # 1. make the remote base dir (so the logs + rsync target exist), then deps: always
-    #    install the venv/dev packages (the image ships 3.12 without them); install the CUDA
-    #    toolkit only if nvcc is genuinely absent. All noisy output → the setup log.
-    _log(f"ensuring deps on {remote} (apt; output to {_SETUP_LOG}) ...")
-    deps = (
+    # 1. bootstrap: the remote base dir (so the logs + rsync target exist) and tmux itself —
+    #    the one dependency that can't be installed from inside a tmux session. Everything
+    #    long-running after this point (apt deps, make setup, the sweep) runs inside tmux.
+    _log(f"ensuring tmux on {remote} ...")
+    boot = (
         f"mkdir -p {_BASE}; "
-        f"sudo apt-get update -qq >> {_SETUP_LOG} 2>&1; "
-        f"sudo apt-get install -y -qq python3.12 python3.12-venv python3.12-dev >> {_SETUP_LOG} 2>&1; "
-        "if ! command -v nvcc >/dev/null 2>&1 && ! ls /usr/local/cuda*/bin/nvcc >/dev/null 2>&1; then "
-        f"sudo apt-get install -y -qq cuda-toolkit-12-9 >> {_SETUP_LOG} 2>&1; fi; "
-        "if command -v nvcc >/dev/null 2>&1 || ls /usr/local/cuda*/bin/nvcc >/dev/null 2>&1; "
-        "then echo NVCC_OK; else echo NVCC_MISSING; fi"
+        "if ! command -v tmux >/dev/null 2>&1; then "
+        f"sudo apt-get update -qq >> {_SETUP_LOG} 2>&1; sudo apt-get install -y -qq tmux >> {_SETUP_LOG} 2>&1; fi; "
+        "command -v tmux >/dev/null 2>&1 && echo TMUX_OK || echo TMUX_MISSING"
     )
-    rc, out = _run(remote, key, port, deps, timeout=1800)
-    if rc != 0 or "NVCC_OK" not in out:
-        # rc==0 with NVCC_OK absent means the apt steps ran but nvcc is still missing
-        # (the chain ends in an echo, so rc reflects only that last command); rc!=0 means
-        # the ssh/apt command itself failed. The setup-log tail below carries the detail.
-        reason = "nvcc not found after toolkit install" if rc == 0 else f"ssh/apt rc={rc}"
-        return _fail(remote, key, port, f"deps/nvcc ({reason})", _SETUP_LOG)
+    rc, out = _run(remote, key, port, boot, timeout=900)
+    if "TMUX_OK" not in out:
+        return _fail(remote, key, port, f"tmux bootstrap (rc={rc})", _SETUP_LOG)
+    # Refuse to pile a second sweep onto a box that is still running one (an existing /
+    # user-provided server may have leftovers) — the ledger makes reruns cheap, collisions
+    # on the node store mid-sweep are not.
+    _, out = _run(remote, key, port, f"tmux has-session -t {_SWEEP_SESSION} 2>/dev/null && echo SWEEP=ALIVE || echo SWEEP=DEAD")
+    if "SWEEP=ALIVE" in out:
+        return _fail(
+            remote,
+            key,
+            port,
+            f"a sweep is already running in tmux session {_SWEEP_SESSION} on {remote} — "
+            f"attach with `tmux attach -t {_SWEEP_SESSION}` or kill it first",
+            _NEIGHBOR_LOG,
+        )
 
     # 2. rsync the working tree (exact local code, incl. uncommitted changes).
     _log(f"rsyncing {repo} -> {remote}:{_REMOTE_DIR} ...")
@@ -304,22 +383,20 @@ def main() -> int:
         _log(f"rsync failed: {(rp.stderr or rp.stdout).strip()}")
         return 1
 
-    # 3. make setup (output → the setup log); on failure rebuild a clean venv once.
-    _log(f"running make setup (output to {_SETUP_LOG}) ...")
-    setup = f"cd {_REMOTE_DIR} && {_CUDA_EXPORT} && make setup >> {_SETUP_LOG} 2>&1 && echo SETUP_OK || echo SETUP_FAIL"
-    rc, out = _run(remote, key, port, setup, timeout=2400)
-    if "SETUP_OK" not in out:
+    # 3. deps + make setup, inside the setup tmux session (a dropped ssh no longer kills a
+    #    long apt/CUDA-toolkit install or venv build); on SETUP_FAIL rebuild a clean venv once.
+    _log(f"running deps + make setup in tmux session {_SETUP_SESSION} (output to {_SETUP_LOG}) ...")
+    word = _run_setup_session(remote, key, port, wipe_venv=False)
+    if word != "SETUP_OK" and word != "NVCC_MISSING":
         _log("make setup failed; wiping venv and retrying once ...")
-        setup2 = f"cd {_REMOTE_DIR} && {_CUDA_EXPORT} && rm -rf venv && make setup >> {_SETUP_LOG} 2>&1 && echo SETUP_OK || echo SETUP_FAIL"
-        rc, out = _run(remote, key, port, setup2, timeout=2400)
-        if "SETUP_OK" not in out:
-            return _fail(remote, key, port, "make setup", _SETUP_LOG)
+        word = _run_setup_session(remote, key, port, wipe_venv=True)
+    if word == "NVCC_MISSING":
+        return _fail(remote, key, port, "deps/nvcc (nvcc not found after toolkit install)", _SETUP_LOG)
+    if word != "SETUP_OK":
+        return _fail(remote, key, port, "make setup", _SETUP_LOG)
 
-    # 4. build the sweep's launch command, then launch it detached. Redirect ALL three
-    #    std streams away from the ssh channel (`< /dev/null` + `> <log> 2>&1`) and use
-    #    ssh -n (detach=True), else ssh holds the channel open past the `&` and this
-    #    call times out *after* a successful launch. The bracket-pgrep pattern stops
-    #    the liveness check from matching the poll command's own argv.
+    # 4. build the sweep's launch command, then launch it inside the sweep tmux session
+    #    (stdout/stderr → the log; the session outlives any ssh drop and is attachable).
     # Push the local resume ledger (if any) so the run continues prior coverage.
     local_ledger = Path(args.ledger).expanduser()
     if local_ledger.exists():
@@ -343,25 +420,21 @@ def main() -> int:
             cmd += f" {flag} {val}"
     if args.filter:
         cmd += f" --filter {shlex.quote(args.filter)}"
-    log_file, proc_pat = _NEIGHBOR_LOG, "[g]olden_neighbor_bench"
+    log_file = _NEIGHBOR_LOG
     done_grep, done_re = "neighbor-bench done: [0-9]+/[0-9]+ points", _NEIGHBOR_DONE_RE
-    _log(f"launching `{cmd}` (detached -> {log_file}) ...")
-    launch = f"cd {_REMOTE_DIR} && {_CUDA_EXPORT} && nohup {cmd} > {log_file} 2>&1 < /dev/null & echo run_launched"
-    rc, out = _run(remote, key, port, launch, timeout=60, detach=True)
-    if "run_launched" not in out:
-        # Belt-and-suspenders: if the launch ssh still didn't confirm, the run may
-        # have started anyway — verify the process before declaring failure.
-        time.sleep(5)
-        _, chk = _run(remote, key, port, f"pgrep -f '{proc_pat}' >/dev/null 2>&1 && echo ALIVE || echo DEAD")
-        if "ALIVE" not in chk:
-            return _fail(remote, key, port, f"launch (rc={rc})", log_file)
-        _log("launch ssh did not confirm but the process is alive — continuing")
+    _log(f"launching `{cmd}` in tmux session {_SWEEP_SESSION} (log -> {log_file}) ...")
+    body = f"cd {_REMOTE_DIR} && {_CUDA_EXPORT} && {cmd} > {log_file} 2>&1"
+    # rm the old log at launch: on a reused box a stale ``neighbor-bench done:`` line
+    # would otherwise satisfy the poll's done-grep if the new session dies before
+    # truncating the file.
+    if not _tmux_launch(remote, key, port, _SWEEP_SESSION, body, pre=f"rm -f {log_file}; "):
+        return _fail(remote, key, port, "launch (tmux session did not start)", log_file)
 
     # 5. poll the remote log internally until done / dead / --timeout. Hitting --timeout
     #    is NOT a failure: it stops the sweep and falls through to the same harvest.
     poll = (
         f"echo \"DONE_MARK=$(grep -aoE '{done_grep}' {log_file} 2>/dev/null | tail -1)\"; "
-        f"pgrep -f '{proc_pat}' >/dev/null 2>&1 && echo PROC=ALIVE || echo PROC=DEAD"
+        f"tmux has-session -t {_SWEEP_SESSION} 2>/dev/null && echo PROC=ALIVE || echo PROC=DEAD"
     )
     start = time.monotonic()
     dead_streak = 0


### PR DESCRIPTION
The skill now accepts an existing user-provided server (skipping provisioning and teardown — a box we didn't rent is never deleted or modified beyond the sweep) instead of always renting one via start-remote-server.

remote_node_collect.py runs every long-lived remote process inside a named tmux session: apt/CUDA-toolkit/make setup in emmy-node-setup (previously a held-open ssh a network blip could kill mid-build; completion now reported via a status file) and the sweep in emmy-node-sweep, replacing the nohup/ssh -n detach dance. Liveness polling reads tmux has-session instead of the bracket-pgrep trick, and the timeout stop kills the session. Two reused-box guards: the launch refuses when a sweep session is already running, and the stale sweep log is removed at launch so an old done-marker can't fake completion.