### PR TITLE
 Measurement freeze v2: golden-spelled rows, identity captured at collection                                                                                                        

### DIFF
--- a/.claude/skills/collect-node-data/SKILL.md
+++ b/.claude/skills/collect-node-data/SKILL.md
@@ -50,6 +50,13 @@ and `-Xcicc -O3` (`emmy run --bench --ab`, node recording on): the twins share t
 `op_sig` + tunables — the dataset a future "how well does -O1 approximate -O3 on this shape" model fits on. Both
 legs of a pair are measured on the same box in the same session.
 
+**Declarative identity (what makes the rows freezable).** Each batch passes `--record-shape` — the group's
+golden-spelled shape spec — and the recorder stamps it as `shape_spec` on exactly the leaves whose extents key to
+that shape. Only identity-carrying rows enter the goldens-format measurement freeze
+(`scripts/freeze_node_store.py`), so the remote box MUST run this branch's emmy (the rsync step below already
+ensures that); rows collected by an older emmy record identity-less and never freeze. Watch the driver log for the
+`--record-shape ... matched none` warning — it means a shape-key mismatch is silently producing unfreezable rows.
+
 **Why merging into the single local DB is safe (read this once).** The node store is keyed by GPU:
 `node_key = digest(context_key, gpu, op_sig, tunable-knobs)` and the `node` table carries a `gpu` column
 (`Context.hardware_id()` — the canonicalized PCIe product name). Different cards therefore **never collide** — the

--- a/emmy/commands/dataset_args.py
+++ b/emmy/commands/dataset_args.py
@@ -38,7 +38,7 @@ def add_dataset_args(parser, *, default: str, with_min_variants: bool = False) -
     )
     parser.add_argument(
         "--db",
-        help="Tune DB path for --dataset db/nodes — or, for --dataset nodes, a measurement-freeze .jsonl "
+        help="Tune DB path for --dataset db/nodes — or, for --dataset nodes, a measurement-freeze directory "
         "(scripts/freeze_node_store.py). Default: EMMY_TUNE_DB or ~/.cache/emmy/autotune.db.",
     )
     parser.add_argument(

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -141,6 +141,18 @@ def register_run_command(subparsers):
             "(pin mismatch, wrong answer, intensity floor) and the --ir path never record."
         ),
     )
+    parser.add_argument(
+        "--record-shape",
+        default=None,
+        metavar="JSON",
+        help=(
+            "Declarative identity of the benched shape, spelled like a golden YAML entry minus knobs/latencies "
+            '(e.g. \'{"kernel": "matmul", "M": 512, "N": 512, "K": 512, "dtype": "fp16", "trans_b": false, '
+            '"dynamic": false}\'). Recorded rows whose stamped extents match carry it as their shape_spec — the '
+            "identity the goldens-format measurement freeze keeps. Passed by the golden-neighborhood collection "
+            "sweep; no effect with --no-record-nodes."
+        ),
+    )
     parser.add_argument("--dump-dir", default=None, help="Directory to dump intermediate compilation artifacts.")
     parser.add_argument("--debug", action="store_true", help="Per-launch tensor dumps in the emmy backend.")
     parser.add_argument(
@@ -209,6 +221,14 @@ def handle_run(args):
             _ab_samples(args.ab)  # fail fast on a malformed KNOBS spec
         except ValueError as exc:
             logger.error("--ab: %s", exc)
+            sys.exit(2)
+    if args.record_shape is not None:
+        from emmy.compiler.pipeline.search.bench_record import parse_record_shape  # noqa: PLC0415
+
+        try:
+            parse_record_shape(args.record_shape)  # fail fast, before any compile/bench spend
+        except ValueError as exc:
+            logger.error("%s", exc)
             sys.exit(2)
 
     if not torch.cuda.is_available():
@@ -395,7 +415,7 @@ def _record_bench_nodes(args, golden_benches, greedy_iso) -> None:
         return
     from emmy.commands.compile import resolve_tune_db  # noqa: PLC0415
     from emmy.compiler.context import Context  # noqa: PLC0415
-    from emmy.compiler.pipeline.search.bench_record import meets_quality_bar, record_bench_leaves  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.bench_record import meets_quality_bar, parse_record_shape, record_bench_leaves  # noqa: PLC0415
 
     # print, not logger.info: `emmy run` gates the root logger to WARNING at default
     # verbosity, and a default-on WRITE to the user's tune DB must announce itself
@@ -409,8 +429,11 @@ def _record_bench_nodes(args, golden_benches, greedy_iso) -> None:
     leaves = _recordable_bench_leaves(golden_benches, greedy_iso)
     if not leaves:
         return
+    # Re-parse (validated at arg-check time): the declarative identity the sweep passes,
+    # attached per matching leaf inside record_bench_leaves.
+    shape = parse_record_shape(args.record_shape) if getattr(args, "record_shape", None) else None
     db_path = resolve_tune_db()
-    n = record_bench_leaves(db_path, Context.probe(), leaves)
+    n = record_bench_leaves(db_path, Context.probe(), leaves, shape=shape)
     print(f"[record-nodes] {n} bench row(s) recorded into the node store ({db_path}) — opt out with --no-record-nodes")
 
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -627,19 +627,29 @@ incumbent prior preferred and its wall time grew with the golden set, while the 
 of the incumbent and fixed-cost (`tune --explore-eps` survives for interactive tuning).
 
 **Measurement freeze** (`data/freeze.py`, driven by `scripts/freeze_node_store.py`). The node DB is a live store —
-tunes and merges keep writing into it — so a model fit read directly from it is not reproducible. A *freeze* snapshots
-it into one local JSONL file (line 1 a provenance header, then one JSON object per row) whose sha256 digest pins
-exactly which measurements a fit saw. Only **leaves** freeze, filtered by `freeze_reason`: current `feat_ver`, the two
-plausibility predicates above, `bench_fail` leaves kept as negatives ("doesn't build/launch here" is durable); branch
-rows never freeze — a branch's value-of-position bound is one search's coverage artifact over the *historical* tree
-topology, while leaves are complete points in knob space, so prefix rows are re-synthesized at fit time under the
-current fork structure and the freeze stores no tree schema (no `parent_key`/`depth`/`visits`). Freezing the same DB
-twice yields the same digest (rows sorted by `(gpu, op_sig, node_key)`, canonical JSON; the digest covers only the row
-bytes, so the header's `created_at` never perturbs it), and the header reserves both featurizer version axes
-(`knob_ver`/`encoding_ver`, equal today) plus repo commit, source DB, run ids, counts, and a freeform collection-policy
-note. `load_freeze` hard-errors on a foreign file, `feat_ver` mismatch, or digest mismatch — never a silent fallback
-(the offline-artifact loading semantics); `load_node_rows` sniffs a path (sqlite magic vs freeze header) and yields
-`NodeRow`s from either, which is what lets every nodes consumer (`eval online --dataset nodes --db`,
+tunes and merges keep writing into it — so a model fit read directly from it is not reproducible. A *freeze* (v2)
+snapshots it into a local DIRECTORY mirroring the `goldens/` layout: one per-`(gpu, compute_cap)` YAML file
+(`gpu_name`/`compute_cap` header + a `configs` list) beside a `manifest.json` carrying the provenance header and the
+content digests. Each row is **golden-spelled**: the declarative `shape_spec` captured at collection time (`kernel` +
+shape fields + `dynamic` — see the bench-to-node recorder below), the verbatim TUNABLE knobs, and the measurement
+extension block (`value_us`, `opt` — the nvcc cicc lane, `status`, `variance`/`n_samples`, `run_id`/`measured_at`).
+Nothing featurized persists: the loader re-derives `H_*` card-faithfully from the gpu registry
+(`Context.from_target`, `H_opt` overridden from the row's `opt`) and the full `S_*` histogram by re-tracing the
+kind's snippet once per distinct shape (`data/sample.py::traced_s_features`, the kind-generic sibling of
+`compiled_s_features` that selects the traced op keying to the golden's `ShapeKey`; arithmetic fallback with a
+warning) — so an encoding-only featurizer change never quarantines a freeze, and there is deliberately no load-time
+`feat_ver` gate (the stored `feat_ver`/`knob_ver`/`encoding_ver` are provenance). Only identity-carrying **leaves**
+freeze, filtered by `freeze_reason`: a `shape_spec` present (identity-less legacy tune rows stay in the DB but never
+freeze), current `feat_ver` at write time, the two plausibility predicates above, `bench_fail` leaves kept as
+negatives; branch rows never freeze and no tree schema is stored — prefix rows are re-synthesized at fit time under
+the current fork structure. Freezing the same DB twice yields the same digests: every row serializes to one canonical
+JSON line, rows sort by that line, the per-file sha256 covers exactly those lines (content-level — immune to YAML
+style), the manifest's top sha256 folds the sorted per-file digests, and `created_at` enters none of them. A loaded
+row's `op_sig` is the canonical JSON of its `shape_spec` (a stable declarative fold-by-op key — a shape's -O1/-O3
+twins share it). `load_freeze` hard-errors on a missing/foreign/corrupt manifest, `freeze_ver` mismatch, a listed
+file missing, a per-file digest mismatch, or an un-instantiable row — never a silent fallback; `load_node_rows`
+sniffs a path (directory = freeze, sqlite file = DB, a v1 JSONL freeze is refused with a re-freeze pointer) and
+yields `NodeRow`s from either, which is what lets every nodes consumer (`eval online --dataset nodes --db`,
 `Dataset.from_node_rows` / `fold_node_rows`) take a freeze interchangeably with the live DB. Loaded freeze rows are
 parentless with `depth=0` — the marker the diagnostics read as "no tree schema": the fork-regret view skips them and
 the golden-anchored descent renders its loud "no fork-tree data" absence row, so a freeze evaluates through the
@@ -669,6 +679,14 @@ tile-dialect one — the mma tile-lowering preserves no `LoopOp` in `.source`, a
 tensor-core kernel was silently unrecordable (both paths digest to the same tune-written `op_sig`, verified on an
 RTX 4090). A variant's kernels (split-K main + combine) group under one site and record ONE whole-variant leaf; a
 graph whose every kernel loses its site warns loudly instead of recording nothing in silence. Flagged rows (pin mismatch, wrong answer, intensity floor) and the `--ir` path never record.
+The caller may pass a **declarative identity** via `run --bench --record-shape '<json>'` (a golden YAML entry minus
+knobs/latencies — validated by instantiating its golden kind class; the collection sweep passes its group's spec):
+it lands as the node row's `shape_spec` on exactly the leaves whose stamped extents key to the spec's `ShapeKey`
+(`ShapeKey.joins` — tolerant of the sweep kinds' snippet-unstable dtype-derived `is_warp`, strict on contraction
+twins), so a multi-op snippet's secondary ops (a `linear_norm`'s producer matmul) stay identity-less; a spec
+matching zero leaves warns loudly. `shape_spec` is what makes a row freezable in the goldens-format measurement
+freeze, and it is identity-intrinsic in the store: `record_nodes` COALESCE-keeps it in both replacement directions,
+so a later identity-less re-measurement never erases freezability.
 `record_nodes` guards the leaf upsert with **quality-aware replacement**: a newer measurement of unambiguously lower
 quality (fewer `n_samples` AND higher `variance`) never displaces a stored leaf, so a drive-by bench can't overwrite
 tune-grade data, while comparable or unknown quality keeps plain newest-wins (honest re-measurement still heals

--- a/emmy/compiler/pipeline/search/bench_record.py
+++ b/emmy/compiler/pipeline/search/bench_record.py
@@ -22,6 +22,15 @@ floor: the measurement is untrue), and anything from the ``--ir`` path (serializ
 drops ``op.knobs``, so there is no honest feature dict). The caller
 (``emmy/commands/run.py``) owns those exclusions; this module records what it is given.
 
+Declarative identity (``run --bench --record-shape``): the caller may pass a
+golden-spelled shape spec (:func:`parse_record_shape`) naming what the snippet benches.
+It is attached PER LEAF, not blanket: a leaf gets the spec only when its own stamped
+``S_*`` extents key to the spec's :class:`~.data.shape.ShapeKey` — the sanctioned
+golden↔measured join — so the secondary ops a multi-op snippet realizes (a
+``linear_norm`` snippet's producer matmul, an attention trace's plain QKᵀ contraction)
+stay identity-less like legacy rows. Identity-carrying rows are what the goldens-format
+measurement freeze (``data/freeze.py``) keeps.
+
 Pool fidelity: the tune keys a pool by ``op_sig`` — a digest over the **pre-descent**
 offer op's ``S_*`` stamps, NOT the terminal kernel's (descent stamps further ``S_*``
 deltas, so the two differ for most ops). :func:`bench_leaves` recovers the offer site
@@ -39,6 +48,7 @@ provenance.
 
 from __future__ import annotations
 
+import json
 import logging
 import statistics
 from dataclasses import dataclass
@@ -78,6 +88,43 @@ class BenchLeaf:
 def meets_quality_bar(warmup: int, iters: int) -> bool:
     """Whether a ``run --bench`` invocation measures well enough to record."""
     return warmup >= MIN_RECORD_WARMUP and iters >= MIN_RECORD_ITERS
+
+
+@dataclass(frozen=True)
+class RecordShape:
+    """A validated ``--record-shape`` spec: the golden-spelled identity dict verbatim
+    (what lands on ``NodeRow.shape_spec``) plus the :class:`~.data.shape.ShapeKey` the
+    spec's kind class derives — the golden-side half of the per-leaf identity join."""
+
+    spec: dict
+    key: object  # ShapeKey (kept untyped here to avoid a module-level data import)
+
+
+def parse_record_shape(text: str) -> RecordShape:
+    """Parse and validate a ``--record-shape`` JSON spec (the golden YAML entry spelling
+    minus knobs/latencies: ``{"kernel": ..., <shape fields>, "dynamic": ...}``).
+
+    Validation IS instantiation: the spec round-trips through the golden kind dataclass
+    (``_KERNEL_CLASSES``), so unknown kinds, missing/extra fields, and kind-specific
+    ``__post_init__`` invariants (e.g. the dynamic-hint check) all raise here, and the
+    returned ``key`` comes from the same ``shape_key()`` every golden consumer uses.
+    Raises ``ValueError`` with the underlying reason on any invalid spec."""
+    from emmy.compiler.pipeline.search.golden import _KERNEL_CLASSES  # noqa: PLC0415
+
+    try:
+        spec = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"--record-shape is not valid JSON: {e}") from e
+    if not isinstance(spec, dict) or "kernel" not in spec:
+        raise ValueError('--record-shape must be a JSON object with a "kernel" field')
+    cls = _KERNEL_CLASSES.get(spec["kernel"])
+    if cls is None:
+        raise ValueError(f"--record-shape: unknown kernel kind {spec['kernel']!r} (expected one of {sorted(_KERNEL_CLASSES)})")
+    try:
+        cfg = cls(name="record-shape", knobs={}, **{k: v for k, v in spec.items() if k != "kernel"})
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"--record-shape: invalid {spec['kernel']!r} spec: {e}") from e
+    return RecordShape(spec=spec, key=cfg.shape_key())
 
 
 def mint_bench_run_id() -> str:
@@ -200,13 +247,21 @@ def bench_leaves(compiled, bench, *, status: str = "ok") -> list[BenchLeaf]:
     return leaves
 
 
-def record_bench_leaves(db_path: Path | str, ctx: Context, leaves: list[BenchLeaf], *, run_id: str | None = None) -> int:
+def record_bench_leaves(
+    db_path: Path | str, ctx: Context, leaves: list[BenchLeaf], *, run_id: str | None = None, shape: RecordShape | None = None
+) -> int:
     """Key ``leaves`` with the tune's own recipes and upsert them into the node store
     at ``db_path`` — parentless ``depth=0`` leaf rows under the live context's regime
     (``run --bench`` compiles at the deployable flags, so these land in the -O3 lane
     the store is censored in). Returns the number of rows offered to
     :meth:`SearchDB.record_nodes` (its plausibility gate and quality-aware leaf
-    replacement still apply per row)."""
+    replacement still apply per row).
+
+    ``shape`` (from ``--record-shape``) stamps the declarative identity onto exactly
+    the leaves whose stamped ``S_*`` extents key to ``shape.key`` (see the module
+    docstring); a spec that matches NO leaf warns loudly — a systematic key mismatch
+    must not silently produce an identity-less sweep."""
+    from emmy.compiler.pipeline.search.data.shape import ShapeKey  # noqa: PLC0415
     from emmy.compiler.pipeline.search.db import NodeRow, SearchDB  # noqa: PLC0415
     from emmy.compiler.structural import digest  # noqa: PLC0415
 
@@ -215,9 +270,14 @@ def record_bench_leaves(db_path: Path | str, ctx: Context, leaves: list[BenchLea
     run_id = run_id or mint_bench_run_id()
     ctx_key, gpu, h_feats = ctx.structural_key(), ctx.hardware_id(), ctx.features()
     rows = []
+    n_tagged = 0
     for leaf in leaves:
         features = {**h_feats, **leaf.knobs}
         tun = tuple(sorted((k, str(v)) for k, v in features.items() if not k.startswith(("S_", "H_"))))
+        spec = None
+        if shape is not None and ShapeKey.from_s_features(leaf.knobs).joins(shape.key):
+            spec = shape.spec
+            n_tagged += 1
         rows.append(
             NodeRow(
                 node_key=digest(ctx_key, gpu, leaf.op_sig, tun),
@@ -234,7 +294,15 @@ def record_bench_leaves(db_path: Path | str, ctx: Context, leaves: list[BenchLea
                 n_samples=leaf.n_samples,
                 status=leaf.status,
                 run_id=run_id,
+                shape_spec=spec,
             )
+        )
+    if shape is not None and n_tagged == 0:
+        logger.warning(
+            "[record-nodes] --record-shape %s matched none of the %d benched leaf/leaves — rows record "
+            "identity-less and will not enter goldens-format freezes (shape-key mismatch; please report)",
+            shape.spec.get("kernel"),
+            len(rows),
         )
     db = SearchDB(Path(db_path))
     try:

--- a/emmy/compiler/pipeline/search/data/freeze.py
+++ b/emmy/compiler/pipeline/search/data/freeze.py
@@ -1,38 +1,50 @@
-"""Measurement freeze — a digest-pinned, leaf-only snapshot of the tune DB's ``node`` table.
+"""Measurement freeze — a digest-pinned, golden-spelled snapshot of the tune DB's ``node`` table.
 
 The node DB is a live store (tunes and merges write into it), so a model fit directly from
 it is not reproducible: two runs of the same fitter can see different data. A *freeze* is
-one local JSONL file extracted from the DB — line 1 a provenance header, then one JSON
-object per kept leaf row — whose sha256 digest pins exactly which measurements a fit saw.
-The fit becomes a pure function of (repo, freeze digest).
+a local snapshot extracted from the DB whose digest pins exactly which measurements a fit
+saw — the fit becomes a pure function of (repo, freeze digest).
+
+Freeze v2 is a DIRECTORY of per-GPU YAML files mirroring the ``goldens/`` layout — a
+``gpu_name`` / ``compute_cap`` header plus a ``configs`` list — beside a ``manifest.json``
+carrying the provenance header and the content digests. Each row is spelled like a golden
+entry: the declarative ``shape_spec`` captured at collection time (``kernel`` + shape
+fields + ``dynamic`` — ``run --bench --record-shape``, driven by the golden-neighborhood
+sweep), the verbatim TUNABLE knobs, and the measurement extension block (``value_us``,
+``opt`` — the nvcc cicc lane, ``status``, ``variance`` / ``n_samples``, ``run_id`` /
+``measured_at``). Nothing featurized is persisted: the loader re-derives ``H_*`` from the
+gpu registry card-faithfully (``Context.from_target``, ``H_opt`` overridden from ``opt``)
+and the full ``S_*`` histogram by re-tracing the kind's snippet
+(:func:`~..data.sample.traced_s_features`; arithmetic fallback with a warning), so an
+encoding-only featurizer change never quarantines a freeze — re-loading IS the refit's
+re-featurization.
 
 What freezes (see :func:`freeze_reason`): every **leaf** in the current featurizer
-vocabulary that passes the physical-plausibility predicates, ``bench_fail`` leaves
-included (a "doesn't build/launch here" is a durable negative example). Branch rows never
-freeze — a branch's value-of-position bound is a run-artifact of one search's coverage
-over the *historical* fork-tree topology; leaves are complete points in knob space, valid
-under any tree organization, and prefix rows are re-synthesized at fit time under the
-current fork structure. Accordingly a freeze stores **no tree schema**: no ``parent_key``,
-no ``depth``, no ``visits``.
+vocabulary that passes the physical-plausibility predicates AND carries a declarative
+``shape_spec`` — identity-less legacy rows (tune-written, pre-identity benches) stay in
+the DB but never freeze. ``bench_fail`` leaves are kept as durable negatives. Branch rows
+never freeze and no tree schema is stored (no ``parent_key`` / ``depth`` / ``visits``):
+prefix rows are re-synthesized at fit time under the current fork structure.
 
-Determinism contract: freezing the same DB twice yields the same digest. Rows are sorted
-by ``(gpu, op_sig, node_key)`` (total — ``node_key`` is the table's unique key) and
-serialized with sorted keys and fixed separators; the digest covers exactly the raw row
-bytes after the header line, so the header's ``created_at`` never perturbs it and the
-loader catches any corruption by re-hashing the bytes it read. The header reserves both
-featurizer version axes (``knob_ver`` / ``encoding_ver``, equal today) so a future
-knob-spelling vs feature-encoding version split needs no format migration.
+Determinism contract: freezing the same DB twice yields the same digests. Every row
+serializes to one canonical JSON line (sorted keys, fixed separators, ``allow_nan=False``);
+rows within a file sort by that line (total, content-derived order); the per-file
+``sha256`` covers exactly those lines — NOT the YAML bytes, so integrity is content-level
+and immune to YAML style — and the manifest's top-level ``sha256`` folds the sorted
+per-file digests. ``created_at`` never enters any digest.
 
-:func:`load_freeze` hard-errors on a foreign file, a ``feat_ver`` mismatch, or a digest
-mismatch — never a silent fallback (the :mod:`~emmy.compiler.pipeline.search.prior.offline`
-artifact-loading semantics). :func:`load_node_rows` is the interchange seam: it sniffs a
-path and yields ``NodeRow``s from either a live sqlite DB or a freeze, so the nodes-dataset
+:func:`load_freeze` hard-errors — never a silent fallback — on a missing/foreign/corrupt
+manifest, a ``freeze_ver`` mismatch, a manifest-listed file missing, a per-file digest
+mismatch, or a row that fails to instantiate its golden kind class. There is deliberately
+NO load-time ``feat_ver`` gate (the v1 rule): features are re-derived by live code, so the
+stored ``feat_ver`` / ``knob_ver`` / ``encoding_ver`` are provenance, not a contract.
+:func:`load_node_rows` is the interchange seam: it sniffs a path and yields ``NodeRow``s
+from either a live sqlite DB (file) or a freeze (directory), so the nodes-dataset
 consumers (``eval online --dataset nodes``, ``Dataset.from_node_rows`` /
-``fold_node_rows``) accept both. Loaded freeze rows carry ``parent_key=None`` /
-``depth=0`` / ``visits=0``: the fork-regret diagnostics skip parentless rows and the
-golden-anchored descent treats ``depth=0`` rows as tree-less (its absence rule renders
-"no fork-tree data"), so a freeze degrades to the leaf-level metrics instead of
-inventing fork groups.
+``fold_node_rows``) accept both. Loaded rows carry ``parent_key=None`` / ``depth=0`` /
+``visits=0``: the fork diagnostics skip parentless rows and the golden-anchored descent
+treats them as tree-less, so a freeze degrades to the leaf-level metrics. A v1 JSONL
+freeze is refused with a re-freeze pointer — freezes are regenerable from the DB.
 
 Produced by ``scripts/freeze_node_store.py``.
 """
@@ -42,11 +54,15 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
+import shutil
 import subprocess
 from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import yaml
 
 if TYPE_CHECKING:
     from emmy.compiler.pipeline.search.db import NodeRow
@@ -54,18 +70,26 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 FREEZE_KIND = "emmy-node-freeze"
-FREEZE_VER = 1
+FREEZE_VER = 2
+MANIFEST_NAME = "manifest.json"
 
 _SQLITE_MAGIC = b"SQLite format 3\x00"
+
+# The measurement extension block of a freeze row — every payload key that is NOT part of
+# the declarative shape_spec (the loader splits a row back into the two halves by this set).
+_EXTENSION_FIELDS = frozenset({"knobs", "value_us", "opt", "status", "variance", "n_samples", "run_id", "measured_at"})
 
 
 def freeze_reason(row: NodeRow) -> str | None:
     """Why ``row`` is excluded from a measurement freeze, or ``None`` to keep it.
 
-    THE freeze sanity filter, and nothing else — keep every leaf spelled in the current
-    featurizer vocabulary that passes the shared plausibility predicates. ``bench_fail``
-    leaves reach the keep path by construction: both predicates return ``None`` for
-    non-``ok`` rows, so failures are kept as negative examples without a special case."""
+    THE freeze sanity filter, and nothing else — keep every identity-carrying leaf
+    spelled in the current featurizer vocabulary that passes the shared plausibility
+    predicates. ``bench_fail`` leaves reach the keep path by construction: both
+    predicates return ``None`` for non-``ok`` rows, so failures are kept as negative
+    examples without a special case. The ``shape_spec`` requirement is the whole
+    legacy-exclusion mechanism: only rows recorded with a declarative identity
+    (``run --bench --record-shape``) can spell a golden-format freeze row."""
     from emmy.compiler.pipeline.search.db import implausible_value_reason, impossible_kernel_reason  # noqa: PLC0415
     from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION  # noqa: PLC0415
 
@@ -73,6 +97,10 @@ def freeze_reason(row: NodeRow) -> str | None:
         return "non-leaf (branch or pre-enrichment row)"
     if row.feat_ver != FEATURIZER_VERSION:
         return f"stale feat_ver {row.feat_ver} != current {FEATURIZER_VERSION}"
+    if row.shape_spec is None:
+        return "no declarative identity (legacy tune row)"
+    if "H_cc" not in row.features or "H_opt" not in row.features:
+        return "missing H_* regime stamps"
     reason = implausible_value_reason(row)
     if reason is not None:
         return f"implausible value: {reason}"
@@ -82,26 +110,40 @@ def freeze_reason(row: NodeRow) -> str | None:
     return None
 
 
-def _row_line(row: NodeRow) -> bytes:
-    """One freeze row as its canonical JSONL line (bytes) — sorted keys, fixed
-    separators, no NaN tokens (``allow_nan=False`` hard-errors instead of emitting
-    nonstandard JSON): this exact spelling is what makes freeze-twice determinism
-    hold. Bytes end-to-end so the digested bytes ARE the written bytes — no platform
-    newline translation or locale encoding can slip between them."""
-    d = {
-        "node_key": row.node_key,
-        "context_key": row.context_key,
-        "op_sig": row.op_sig,
-        "gpu": row.gpu,
-        "features": row.features,
+def _row_payload(row: NodeRow) -> dict:
+    """One freeze row as its YAML entry dict — the golden-entry spelling: the declarative
+    ``shape_spec`` flattened in, the verbatim tunable knobs, and the measurement
+    extension block. Nothing featurized: ``H_*`` / ``S_*`` are dropped here and
+    re-derived at load."""
+    from emmy.compiler.pipeline.search.data.sample import _split_by_prefix  # noqa: PLC0415
+
+    tunable, _ctx, _s = _split_by_prefix(row.features)
+    return {
+        **row.shape_spec,
+        "knobs": tunable,
         "value_us": row.value_us,
+        "opt": int(row.features["H_opt"]),
+        "status": row.status,
         "variance": row.variance,
         "n_samples": row.n_samples,
-        "status": row.status,
         "run_id": row.run_id,
         "measured_at": row.measured_at,
     }
-    return (json.dumps(d, sort_keys=True, separators=(",", ":"), allow_nan=False) + "\n").encode()
+
+
+def _row_line(payload: dict) -> bytes:
+    """A payload's canonical JSON line (bytes) — sorted keys, fixed separators, no NaN
+    tokens (``allow_nan=False`` hard-errors instead of emitting nonstandard JSON). This
+    exact spelling is the row sort order AND the digested content, so determinism and
+    integrity are content-level, immune to YAML style."""
+    return (json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False) + "\n").encode()
+
+
+def _gpu_filename(gpu_name: str, cap: tuple[int, int]) -> str:
+    """The per-GPU YAML file name, mirroring the ``goldens/`` convention —
+    e.g. ``nvidia_geforce_rtx_4090_sm89.yaml``."""
+    slug = re.sub(r"[^a-z0-9]+", "_", gpu_name.lower()).strip("_") or "unknown_gpu"
+    return f"{slug}_sm{cap[0]}{cap[1]}.yaml"
 
 
 def _repo_commit() -> str:
@@ -120,14 +162,18 @@ def _repo_commit() -> str:
         return "unknown"
 
 
-def write_freeze(db_path: Path | str, out_path: Path | str, *, note: str = "") -> dict:
-    """Read the node DB at ``db_path`` read-only, filter through :func:`freeze_reason`,
-    and atomically write the freeze to ``out_path``. Returns the header dict (so a caller
-    reports counts + digest without re-reading the file). Hard-errors when nothing
-    survives the filter — a zero-row freeze means the wrong DB, not an empty dataset."""
+def write_freeze(db_path: Path | str, out_dir: Path | str, *, note: str = "") -> dict:
+    """Read the node store at ``db_path`` (a live DB or an existing freeze — the
+    :func:`load_node_rows` seam) read-only, filter through :func:`freeze_reason`, and
+    atomically write the freeze DIRECTORY at ``out_dir``: one per-``(gpu, compute_cap)``
+    YAML file plus ``manifest.json``. Returns the manifest dict (so a caller reports
+    counts + digest without re-reading). Hard-errors when nothing survives the filter —
+    a zero-row freeze means the wrong DB (or an identity-less legacy store), not an
+    empty dataset. An existing ``out_dir`` is replaced only when it is itself a freeze
+    (has a manifest) — anything else is refused rather than deleted."""
     from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION  # noqa: PLC0415
 
-    rows = load_node_rows(db_path)  # the one node-reading seam — also lets an existing freeze re-freeze
+    rows = load_node_rows(db_path)
     kept = []
     dropped: Counter[str] = Counter()
     for row in rows:
@@ -140,16 +186,46 @@ def write_freeze(db_path: Path | str, out_path: Path | str, *, note: str = "") -
         logger.info("[freeze] dropped %d row(s): %s", n, reason)
     if not kept:
         raise RuntimeError(
-            f"no freezable leaf rows in {db_path} — wrong DB, or its rows predate the current featurizer vocabulary "
-            f"(re-collect with the collect-node-data flow)"
+            f"no freezable leaf rows in {db_path} — wrong DB, or its rows carry no declarative identity / predate the "
+            f"current featurizer vocabulary (re-collect with the collect-node-data flow)"
         )
-    kept.sort(key=lambda r: (r.gpu, r.op_sig, r.node_key))
-    lines = [_row_line(r) for r in kept]
-    digest = hashlib.sha256()
-    for line in lines:
-        digest.update(line)
+
+    # Group per (gpu, compute_cap) — cap comes off the row's stamped H_cc (major*10+minor),
+    # the same encoding Context.features writes.
+    by_card: dict[tuple[str, tuple[int, int]], list] = {}
+    for row in kept:
+        cap = divmod(int(row.features["H_cc"]), 10)
+        by_card.setdefault((row.gpu, cap), []).append(row)
+
+    out = Path(out_dir)
+    tmp = out.with_name(out.name + ".tmp")
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    tmp.mkdir(parents=True)
+
+    files: dict[str, dict] = {}
+    for (gpu, cap), card_rows in sorted(by_card.items(), key=lambda kv: kv[0]):
+        payloads = sorted((_row_payload(r) for r in card_rows), key=_row_line)
+        digest = hashlib.sha256()
+        for p in payloads:
+            digest.update(_row_line(p))
+        name = _gpu_filename(gpu, cap)
+        if name in files:
+            raise RuntimeError(f"freeze file name collision: {name} (cards {files[name]['gpu_name']!r} and {gpu!r})")
+        doc = {"gpu_name": gpu, "compute_cap": list(cap), "configs": payloads}
+        (tmp / name).write_text(yaml.safe_dump(doc, sort_keys=True, width=120))
+        files[name] = {
+            "gpu_name": gpu,
+            "compute_cap": list(cap),
+            "rows": len(payloads),
+            "sha256": digest.hexdigest(),
+        }
+
+    top = hashlib.sha256()
+    for name in sorted(files):
+        top.update(files[name]["sha256"].encode())
     per_gpu = Counter(r.gpu for r in kept)
-    header = {
+    manifest = {
         "kind": FREEZE_KIND,
         "freeze_ver": FREEZE_VER,
         "feat_ver": FEATURIZER_VERSION,
@@ -165,89 +241,134 @@ def write_freeze(db_path: Path | str, out_path: Path | str, *, note: str = "") -
             "bench_fail": sum(1 for r in kept if r.status == "bench_fail"),
             "per_gpu": {g: per_gpu[g] for g in sorted(per_gpu)},
         },
+        "files": files,
         "created_at": datetime.now(UTC).isoformat(),
-        "sha256": digest.hexdigest(),
+        "sha256": top.hexdigest(),
     }
-    out = Path(out_path)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    tmp = out.with_suffix(out.suffix + ".tmp")
-    # Bytes end-to-end: the digested bytes are exactly the written bytes — no platform
-    # newline translation or locale encoding between the hash and the file.
-    with tmp.open("wb") as fh:
-        fh.write((json.dumps(header, sort_keys=True) + "\n").encode())
-        fh.writelines(lines)
+    (tmp / MANIFEST_NAME).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    if out.exists():
+        if not (out.is_dir() and (out / MANIFEST_NAME).exists()):
+            shutil.rmtree(tmp)
+            raise RuntimeError(f"{out} exists and is not a measurement freeze — refusing to replace it")
+        shutil.rmtree(out)
     tmp.replace(out)
-    return header
+    return manifest
 
 
 def load_freeze(path: Path | str) -> tuple[dict, list[NodeRow]]:
-    """Parse + verify the freeze at ``path`` → ``(header, leaf-only NodeRows)``. Hard
-    ``RuntimeError`` — never a silent fallback — on a foreign/corrupt header, a
-    ``freeze_ver`` or ``feat_ver`` mismatch, or a row-payload digest mismatch. Rows come
-    back with ``parent_key=None`` / ``depth=0`` / ``visits=0`` (a freeze stores no tree
-    schema) and ``feat_ver`` stamped from the header."""
+    """Parse + verify the freeze directory at ``path`` → ``(manifest, leaf-only
+    NodeRows)`` with features RE-DERIVED by live code (see the module docstring). Hard
+    ``RuntimeError`` — never a silent fallback — on any integrity failure. Identity keys
+    of a loaded row: ``op_sig`` is the canonical JSON of its ``shape_spec`` (a stable
+    declarative op id — the ``fold_node_rows(by="op")`` key, shared by a shape's
+    -O1/-O3 twins), ``context_key`` spells ``cap<maj>.<min>-O<opt>``."""
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.data.sample import traced_s_features  # noqa: PLC0415
     from emmy.compiler.pipeline.search.db import NodeRow  # noqa: PLC0415
     from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.golden import _KERNEL_CLASSES  # noqa: PLC0415
+    from emmy.compiler.structural import digest as key_digest  # noqa: PLC0415
 
     p = Path(path)
-    head, _sep, tail = p.read_bytes().partition(b"\n")
-    try:
-        header = json.loads(head)
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        header = None
     regen = "re-freeze with scripts/freeze_node_store.py"
-    if not isinstance(header, dict) or header.get("kind") != FREEZE_KIND:
-        raise RuntimeError(f"{p} is not a measurement freeze (no {FREEZE_KIND!r} header line) — {regen}")
-    if header.get("freeze_ver") != FREEZE_VER:
-        raise RuntimeError(f"measurement freeze {p} has freeze_ver={header.get('freeze_ver')!r}, this code reads {FREEZE_VER} — {regen}")
-    found = header.get("feat_ver")
-    if found != FEATURIZER_VERSION:
-        raise RuntimeError(
-            f"measurement freeze {p} has feat_ver={found!r}, expected {FEATURIZER_VERSION} — its rows are spelled in a "
-            f"different featurizer vocabulary; {regen}"
-        )
-    digest = hashlib.sha256(tail).hexdigest()
-    if digest != header.get("sha256"):
-        raise RuntimeError(f"measurement freeze {p} is corrupt: row payload sha256 {digest} != header {header.get('sha256')!r} — {regen}")
-    rows = []
-    for line in tail.splitlines():
-        if not line:
-            continue
-        d = json.loads(line)
-        rows.append(
-            NodeRow(
-                node_key=d["node_key"],
-                parent_key=None,
-                context_key=d["context_key"],
-                op_sig=d["op_sig"],
-                features=d["features"],
-                value_us=d["value_us"],
-                depth=0,
-                gpu=d["gpu"],
-                visits=0,
-                is_leaf=True,
-                variance=d["variance"],
-                n_samples=d["n_samples"],
-                status=d["status"],
-                run_id=d["run_id"],
-                measured_at=d["measured_at"],
-                feat_ver=found,
+    mpath = p / MANIFEST_NAME
+    if not mpath.exists():
+        raise RuntimeError(f"{p} is not a measurement freeze (no {MANIFEST_NAME}) — {regen}")
+    try:
+        manifest = json.loads(mpath.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"measurement freeze {p} has a corrupt manifest: {e} — {regen}") from e
+    if not isinstance(manifest, dict) or manifest.get("kind") != FREEZE_KIND:
+        raise RuntimeError(f"{p} is not a measurement freeze (manifest kind != {FREEZE_KIND!r}) — {regen}")
+    if manifest.get("freeze_ver") != FREEZE_VER:
+        raise RuntimeError(f"measurement freeze {p} has freeze_ver={manifest.get('freeze_ver')!r}, this code reads {FREEZE_VER} — {regen}")
+
+    rows: list[NodeRow] = []
+    h_cache: dict[tuple[str, tuple[int, int]], dict] = {}
+    s_cache: dict[str, dict] = {}
+    for name in sorted(manifest.get("files", {})):
+        info = manifest["files"][name]
+        fpath = p / name
+        if not fpath.exists():
+            raise RuntimeError(f"measurement freeze {p} is missing {name} (listed in the manifest) — {regen}")
+        doc = yaml.safe_load(fpath.read_text())
+        gpu_name, cap = doc["gpu_name"], tuple(doc["compute_cap"])
+        payloads = doc.get("configs") or []
+        file_digest = hashlib.sha256()
+        for payload in payloads:
+            file_digest.update(_row_line(payload))
+        if file_digest.hexdigest() != info.get("sha256"):
+            raise RuntimeError(f"measurement freeze {p} is corrupt: {name} row digest != manifest — {regen}")
+
+        if (gpu_name, cap) not in h_cache:
+            # Card-faithful H_* off the gpu registry (the Sample.from_golden recipe);
+            # H_opt is overridden per row — from_target reads the ENV nvcc flags.
+            h_cache[(gpu_name, cap)] = Context.from_target(cap, gpu_name=gpu_name).features()
+        h_base = h_cache[(gpu_name, cap)]
+
+        for payload in payloads:
+            spec = {k: v for k, v in payload.items() if k not in _EXTENSION_FIELDS}
+            spec_json = json.dumps(spec, sort_keys=True, separators=(",", ":"))
+            if spec_json not in s_cache:
+                cls = _KERNEL_CLASSES.get(spec.get("kernel"))
+                if cls is None:
+                    raise RuntimeError(f"measurement freeze {p}: {name} row has unknown kernel kind {spec.get('kernel')!r} — {regen}")
+                try:
+                    cfg = cls(
+                        name="freeze", gpu_name=gpu_name, compute_cap=cap, knobs={}, **{k: v for k, v in spec.items() if k != "kernel"}
+                    )
+                except (TypeError, ValueError) as e:
+                    raise RuntimeError(
+                        f"measurement freeze {p}: {name} row does not instantiate {spec.get('kernel')!r}: {e} — {regen}"
+                    ) from e
+                traced = traced_s_features(cfg.snippet(), tuple(cfg.dynamic_specs()), cfg.shape_key())
+                if traced is None:
+                    logger.warning(
+                        "[freeze] %s: no traced op keys to the %s shape — falling back to arithmetic S_* extents", name, spec.get("kernel")
+                    )
+                s_cache[spec_json] = dict(traced) if traced is not None else cfg.shape_key().s_features_arith()
+            knobs = payload["knobs"] or {}
+            opt = int(payload["opt"])
+            features = {**h_base, "H_opt": float(opt), **s_cache[spec_json], **knobs}
+            rows.append(
+                NodeRow(
+                    node_key=key_digest("freeze2", gpu_name, spec_json, opt, tuple(sorted((k, str(v)) for k, v in knobs.items()))),
+                    parent_key=None,
+                    context_key=f"cap{cap[0]}.{cap[1]}-O{opt}",
+                    op_sig=spec_json,
+                    features=features,
+                    value_us=payload["value_us"],
+                    depth=0,
+                    gpu=gpu_name,
+                    visits=0,
+                    is_leaf=True,
+                    variance=payload["variance"],
+                    n_samples=payload["n_samples"],
+                    status=payload["status"],
+                    run_id=payload["run_id"],
+                    measured_at=payload["measured_at"],
+                    feat_ver=FEATURIZER_VERSION,  # features were just derived by live code
+                    shape_spec=spec,
+                )
             )
-        )
-    return header, rows
+    return manifest, rows
 
 
 def load_node_rows(path: Path | str) -> list[NodeRow]:
-    """Node rows from ``path``, whatever it is — a live sqlite tune DB (sniffed by the
-    sqlite magic bytes) or a measurement freeze. The one seam that makes the two
-    interchangeable for every ``Iterable[NodeRow]`` consumer; anything else fails loudly
-    through :func:`load_freeze`'s header check."""
+    """Node rows from ``path``, whatever it is — a live sqlite tune DB (a file, sniffed
+    by the sqlite magic bytes) or a measurement freeze (a directory). The one seam that
+    makes the two interchangeable for every ``Iterable[NodeRow]`` consumer; anything
+    else fails loudly. A v1 JSONL freeze is recognized and refused with a re-freeze
+    pointer — no v1 reader survives (freezes are regenerable from the DB)."""
     p = Path(path)
+    if p.is_dir():
+        return load_freeze(p)[1]
     with p.open("rb") as fh:
-        magic = fh.read(len(_SQLITE_MAGIC))
+        head = fh.read(max(len(_SQLITE_MAGIC), 4096))
     # An empty file IS a valid (empty) sqlite DB — sqlite creates the file empty before
     # the first write (an aborted tune) — so it takes the DB branch and yields no rows.
-    if magic == _SQLITE_MAGIC or not magic:
+    if head[: len(_SQLITE_MAGIC)] == _SQLITE_MAGIC or not head:
         from emmy.compiler.pipeline.search.db import SearchDB  # noqa: PLC0415
 
         db = SearchDB.open_readonly(p)
@@ -255,4 +376,14 @@ def load_node_rows(path: Path | str) -> list[NodeRow]:
             return list(db.iter_nodes())
         finally:
             db.close()
-    return load_freeze(p)[1]
+    first_line = head.partition(b"\n")[0]
+    try:
+        old = json.loads(first_line)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        old = None
+    if isinstance(old, dict) and old.get("kind") == FREEZE_KIND:
+        raise RuntimeError(
+            f"{p} is a v1 JSONL measurement freeze — superseded by the per-GPU YAML freeze directory (freeze_ver "
+            f"{FREEZE_VER}); re-freeze with scripts/freeze_node_store.py"
+        )
+    raise RuntimeError(f"{p} is neither a sqlite node DB nor a measurement freeze directory")

--- a/emmy/compiler/pipeline/search/data/sample.py
+++ b/emmy/compiler/pipeline/search/data/sample.py
@@ -77,6 +77,33 @@ def compiled_s_features(
     return tuple(sorted(s_feats.items()))
 
 
+@lru_cache(maxsize=256)
+def traced_s_features(snippet: str, dynamic: tuple[str, ...], key: ShapeKey) -> tuple[tuple[str, float], ...] | None:
+    """The full ``S_*`` histogram of the ONE traced op keying to ``key`` — the
+    kind-generic sibling of :func:`compiled_s_features` (which merges every node's
+    stamps: correct for a single-op matmul snippet, wrong for the multi-op graphs the
+    other golden kinds trace — a ``linear_norm`` snippet realizes a producer matmul
+    beside the norm op, an attention trace a plain QKᵀ beside the flash op). Per
+    stamped op the histogram keys through :meth:`ShapeKey.from_s_features` — the
+    sanctioned golden↔measured join — and the first match wins (same-key twins carry
+    the same histogram). ``None`` when no op matches: the caller degrades to
+    :meth:`ShapeKey.s_features_arith`. GPU-free (``LOOP_PASSES`` stop before codegen),
+    cached — the goldens-format measurement-freeze loader pays it once per distinct
+    shape. Heavy imports deferred so importing this module stays torch-free."""
+    from emmy.commands.trace import graph_from_code  # noqa: PLC0415
+    from emmy.compiler.pipeline import LOOP_PASSES, Pipeline  # noqa: PLC0415
+    from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs  # noqa: PLC0415
+
+    dynamic_shapes = build_torch_dynamic_shapes(parse_position_specs(list(dynamic))) if dynamic else None
+    graph, _, _ = graph_from_code(snippet, dynamic_shapes=dynamic_shapes)
+    compiled = Pipeline.build(LOOP_PASSES).run(graph)
+    for n in compiled.nodes.values():
+        s = {k: v for k, v in (getattr(n.op, "knobs", {}) or {}).items() if k.startswith(STRUCT_PREFIX)}
+        if s and ShapeKey.from_s_features(s).joins(key):
+            return tuple(sorted(s.items()))
+    return None
+
+
 @dataclass(frozen=True)
 class Sample:
     """One ``(config, latency, identity)`` row, normalized across sources.

--- a/emmy/compiler/pipeline/search/data/shape.py
+++ b/emmy/compiler/pipeline/search/data/shape.py
@@ -140,6 +140,23 @@ class ShapeKey:
             free_max=int(s.get("S_ext_free_max", 0)),
         )
 
+    def joins(self, golden: ShapeKey) -> bool:
+        """Whether this OP-side key (``from_s_features``) names the same shape as a
+        GOLDEN-side key (``shape_key()``) — exact equality, except ``is_warp`` is
+        ignored for the sweep kinds. Rationale: a sweep op's ``is_warp`` derives from
+        the operand-dtype multiset, which is snippet-unstable — an all-fp16 golden
+        snippet stamps fp16-pure (no ``S_dtype_f32`` → ``is_warp=True``) while the
+        same norm in a served graph carries f32 statistic constants (→ ``False``), and
+        the norm-kind goldens all record ``is_warp=False``. Extents + ``kind`` are the
+        discriminating identity there; ``is_warp`` stays load-bearing exactly where it
+        disambiguates real twins — the ``kind == ""`` fp32/fp16 contraction pair — and
+        ``"fused"`` forces ``True`` on both sides already."""
+        if golden.kind not in ("", "fused") and self.kind == golden.kind:
+            from dataclasses import replace  # noqa: PLC0415
+
+            return replace(self, is_warp=golden.is_warp) == golden
+        return self == golden
+
     def s_features_arith(self) -> dict[str, float]:
         """The extent ``S_*`` features derivable without compiling — the exact set
         the cold ``OfflinePrior`` reads (``golden_eval._offline_scorer`` builds the

--- a/emmy/compiler/pipeline/search/db.py
+++ b/emmy/compiler/pipeline/search/db.py
@@ -199,6 +199,11 @@ class NodeRow:
     # version (writers construct rows with live code); rows read back from a pre-stamp DB carry 1
     # and are excluded from prior evaluation (cross-vocabulary features score as garbage).
     feat_ver: int = FEATURIZER_VERSION
+    # Declarative golden-spelled identity of the benched shape (the golden YAML entry minus
+    # knobs/latencies: ``{"kernel": ..., <shape fields>, "dynamic": ...}``), captured at
+    # collection time by ``run --bench --record-shape``. ``None`` = legacy row (tune-written or
+    # pre-identity bench) — kept in the DB but excluded from goldens-format measurement freezes.
+    shape_spec: dict | None = None
 
 
 def implausible_value_reason(row: NodeRow) -> str | None:
@@ -420,7 +425,8 @@ class SearchDB:
             status       TEXT NOT NULL DEFAULT 'ok',
             run_id       TEXT NOT NULL DEFAULT '',
             measured_at  TEXT,
-            feat_ver     INTEGER NOT NULL DEFAULT 1
+            feat_ver     INTEGER NOT NULL DEFAULT 1,
+            shape_spec   TEXT
         )
         """,
         "CREATE INDEX IF NOT EXISTS node_parent ON node (parent_key)",
@@ -488,6 +494,10 @@ class SearchDB:
         # shipped are spelled in the v2 vocabulary yet default to 1 — they quarantine
         # conservatively; re-collect with the ``collect-node-data`` flow.
         ("feat_ver", "INTEGER NOT NULL DEFAULT 1"),
+        # Declarative golden-spelled shape identity (canonical JSON; NULL = legacy row).
+        # See :attr:`NodeRow.shape_spec`; only identity-carrying rows enter goldens-format
+        # measurement freezes (``data/freeze.py``).
+        ("shape_spec", "TEXT"),
     )
 
     def _has_perf_error_column(self) -> bool:
@@ -525,8 +535,8 @@ class SearchDB:
                 magic = fh.read(16)
             if magic and magic != b"SQLite format 3\x00":  # empty file = valid empty DB
                 hint = (
-                    " — this looks like a measurement freeze (.jsonl); freezes are accepted only by the "
-                    "nodes-dataset consumers, e.g. `eval online --dataset nodes --db`"
+                    " — this looks like a v1 JSONL measurement freeze; freezes are now per-GPU YAML directories, "
+                    "accepted only by the nodes-dataset consumers, e.g. `eval online --dataset nodes --db`"
                     if magic.startswith(b"{")
                     else ""
                 )
@@ -812,6 +822,7 @@ class SearchDB:
             feats_json = json.dumps(r.features, sort_keys=True, default=str)
             is_leaf = None if r.is_leaf is None else int(r.is_leaf)
             measured = r.measured_at or now
+            spec_json = json.dumps(r.shape_spec, sort_keys=True) if r.shape_spec is not None else None
             existing = self._conn.execute(
                 "SELECT value_us, n_updates, visits, status, measured_at, variance, n_samples FROM node WHERE node_key = ?",
                 (r.node_key,),
@@ -820,8 +831,8 @@ class SearchDB:
                 self._conn.execute(
                     "INSERT INTO node "
                     "(node_key, parent_key, context_key, op_sig, gpu, features, value_us, depth, n_updates, updated_at, "
-                    " visits, is_leaf, variance, n_samples, status, run_id, measured_at, feat_ver) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    " visits, is_leaf, variance, n_samples, status, run_id, measured_at, feat_ver, shape_spec) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         r.node_key,
                         r.parent_key,
@@ -841,6 +852,7 @@ class SearchDB:
                         r.run_id,
                         measured,
                         r.feat_ver,
+                        spec_json,
                     ),
                 )
                 continue
@@ -873,18 +885,22 @@ class SearchDB:
                 replace = newer and not worse
             else:
                 replace = r.value_us < cur_val  # branch: keep the coverage bound
+            # ``shape_spec`` deliberately deviates from the value-paired-column rule: identity is
+            # config-INTRINSIC (a ``node_key`` has exactly one shape), so it is COALESCE-kept in
+            # both directions — a later identity-less tune re-measurement must not erase
+            # freezability, and a non-replacing identity-carrying bench still proves the shape.
             if replace:
                 self._conn.execute(
                     "UPDATE node SET value_us = ?, features = ?, parent_key = ?, n_updates = ?, updated_at = ?, "
                     "visits = ?, is_leaf = ?, variance = ?, n_samples = ?, status = ?, run_id = ?, measured_at = ?, "
-                    "feat_ver = ? WHERE node_key = ?",
+                    "feat_ver = ?, shape_spec = COALESCE(?, shape_spec) WHERE node_key = ?",
                     (r.value_us, feats_json, r.parent_key, n_upd + 1, now, visits, is_leaf, r.variance, r.n_samples)
-                    + (r.status, r.run_id, measured, r.feat_ver, r.node_key),
+                    + (r.status, r.run_id, measured, r.feat_ver, spec_json, r.node_key),
                 )
             else:
                 self._conn.execute(
-                    "UPDATE node SET n_updates = ?, updated_at = ?, visits = ? WHERE node_key = ?",
-                    (n_upd + 1, now, visits, r.node_key),
+                    "UPDATE node SET n_updates = ?, updated_at = ?, visits = ?, shape_spec = COALESCE(shape_spec, ?) WHERE node_key = ?",
+                    (n_upd + 1, now, visits, spec_json, r.node_key),
                 )
 
     # ------------------------------------------------------------------
@@ -912,10 +928,13 @@ class SearchDB:
         # ``feat_ver`` ships after the enrichment generation, so it needs its own
         # presence check (a read-only open never migrates); absent → 1 (unknown /
         # pre-stamp vocabulary).
-        feat_ver_col = "feat_ver" if any(r[1] == "feat_ver" for r in self._conn.execute("PRAGMA table_info(node)")) else "1"
+        node_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(node)")}
+        feat_ver_col = "feat_ver" if "feat_ver" in node_cols else "1"
+        # ``shape_spec`` ships after ``feat_ver`` — own presence check, absent → NULL (legacy).
+        spec_col = "shape_spec" if "shape_spec" in node_cols else "NULL"
         sql = (
             f"SELECT node_key, parent_key, context_key, op_sig, {gpu_col}, features, value_us, depth, "  # noqa: S608
-            f"{enrich_cols}, {feat_ver_col} FROM node"
+            f"{enrich_cols}, {feat_ver_col}, {spec_col} FROM node"
         )
         clauses: list[str] = []
         params: list = []
@@ -929,11 +948,17 @@ class SearchDB:
             sql += " WHERE " + " AND ".join(clauses)
         for row in self._conn.execute(sql, params):
             node_key, parent_key, ck, sig, gpu, feats_json, value_us, depth = row[:8]
-            visits, is_leaf, var, n_samp, status, run_id, measured, feat_ver = row[8:]
+            visits, is_leaf, var, n_samp, status, run_id, measured, feat_ver, spec_json = row[8:]
             try:
                 features = json.loads(feats_json) if feats_json else {}
             except (TypeError, json.JSONDecodeError):
                 continue
+            try:
+                shape_spec = json.loads(spec_json) if spec_json else None
+                if not isinstance(shape_spec, dict):
+                    shape_spec = None
+            except (TypeError, json.JSONDecodeError):
+                shape_spec = None  # unparseable identity degrades to legacy, never drops the row
             yield NodeRow(
                 node_key=node_key,
                 parent_key=parent_key,
@@ -951,6 +976,7 @@ class SearchDB:
                 run_id=run_id,
                 measured_at=measured,
                 feat_ver=int(feat_ver) if feat_ver is not None else 1,
+                shape_spec=shape_spec,
             )
 
     def merge_nodes(self, src_path: Path | str) -> int:

--- a/plans/analytic-prior-catboost-rework.md
+++ b/plans/analytic-prior-catboost-rework.md
@@ -1,0 +1,749 @@
+# Analytic prior rework: CatBoost + additive fallback, trained on a frozen local measurement snapshot
+
+> Pruned by the plans/ cap on 2026-07-21 (commit 3c000f1f) while still active; restored and brought current
+> 2026-07-23 — see the Update 2026-07-23 section and the STATUS stamps for what is done vs open.
+
+## Goal
+
+Replace the linear `AnalyticPrior` (`emmy/compiler/pipeline/search/prior/analytic.py`; its weight sets live in the
+repo-checked `analytic_weights.json` since 2026-07-10, `_W_A` / `_W_A_DYN` in older notes below) with a nonlinear,
+CatBoost-based cold-start prior that (a) handles feature interactions and per-regime structure
+the linear form cannot, and (b) is **at least as resilient** to code / feature / search-space changes as the current
+setup. "Analytic prior" here means the *shipped, cold-start* ranking used when the learned online `CatBoostPrior` is
+absent, cold, or quarantined — it must work on a fresh clone with zero measurements.
+
+Success criteria: on the k-fold held-out sets used during training (grouped leave-one-op-family-out /
+leave-one-card-out folds, applied identically to BOTH data assemblies — goldens-only and goldens+freeze; goldens are
+training data, NOT a reserved held-out set — corrected 2026-07-23, history in decision 5), the new prior beats the
+linear baseline on golden rank, per-depth fork sibling-ranking, and golden path-descent; a real-hardware A/B (cold
+greedy deploy + cold tune efficiency) confirms it; and a breaking featurizer change costs one GPU-free refit command,
+not a data campaign.
+
+## Why (the problem with the current linear prior)
+
+- **Interactions get hardcoded back in as escape hatches.** `AnalyticPrior.__init__` carries
+  `atomic_free_split_threshold` / `atomic_free_weight` with a comment saying a linear weight can't express the
+  interaction. That's the old rule-based prior sneaking back, one special case at a time.
+- **The nonlinearity lives in the featurizer.** Band/target features (`D_bm_band`, `D_near_waves`, `D_w_near_bk`)
+  hand-encode thresholds someone must re-derive when hardware or the enumeration changes — the old rule prior's
+  brittleness, relocated.
+- **Two disjoint weight sets** (`_W_A` vs `_W_A_DYN`, selected on `S_ext_n_symbolic_axis`) is a manual regime split a
+  tree model handles with one split.
+- **Additive scoring is architecture-blind by construction — confirmed by the 2026-07-09 golden sweeps.** The
+  featurizer already carries the arch identity (`Context.features()`: `H_cc`, `H_tc_gen`, `H_sm_count`, `H_smem_*`,
+  `H_total_mem`), but those are constant across a pool's siblings, so on a linear model — or ANY additive one, a
+  depth-1 stump included — they shift every candidate equally and never change the ranking. Consistently,
+  `_W_A`/`_W_A_DYN` carry zero `H_*` weights, and the only hardware sensitivity in the `D_*` block is `H_sm_count`
+  feeding the occupancy terms; every other target (warp-BK≈2, tile-area, BM/BN bands) is an arch-independent
+  constant. The one weight set therefore prices warp tiles for whichever card dominated the fit: analytic TILE fork
+  regret 3.62× (sm_89) vs **11.49×** (sm_120), golden TILE match 5/17 vs **0/17**, and the learned prior inherits
+  the censoring (1.48× vs 7.20×) — see `plans/golden-sweep-rtx4090-findings.md` /
+  `plans/golden-sweep-rtx5090-findings.md`. Arch-differentiation is an *interactions* problem (`H_* × D_*`), which
+  trees express natively and additive tables must get via declared pair terms (decision 11).
+- The codebase already made this argument once: `prior/catboost.py`'s docstring on why the linear `BayesianRidgePrior`
+  was replaced (monotone-in-every-knob → corner-seeking) applies to the analytic prior too.
+
+## Context for a fresh agent
+
+Read `emmy/compiler/pipeline/ARCHITECTURE.md` (sections: "Forks and the one ranking path", "Learned prior",
+"Featurizer vocabulary versioning", the `SearchDB` / node-table paragraphs) before touching anything. Key modules:
+
+- `search/prior/analytic.py` — the linear prior being replaced (the hardcoded interaction gates + the artifact
+  loader). Since 2026-07-10 the weights are NOT source literals: they live in the repo-checked, `feat_ver`-stamped
+  `search/prior/analytic_weights.json` (params + provenance included), written by the fitter, overridable via
+  `EMMY_ANALYTIC_FILE` / `eval --analytic-file` for A/Bs, hard-error on version mismatch — the artifact format +
+  loading/quarantine path Phase 5's tier-1 artifact extends.
+- `search/prior/base.py` — the `Prior` ABC: reservoir, refit cadence, `evidence_pick`, the **calibration gate**
+  (`trustworthy`, `CALIBRATION_MIN`) added on branch `feature/prior-calibration-gate`. The quarantine pattern there
+  (measure after fit → gate ownership of decisions → log the verdict) is the template this plan's promotion gate mirrors.
+- `search/prior/catboost.py` — the learned online prior (NaN-fill semantics, `feat_ver`-stamped JSON checkpoint,
+  discard-whole on version mismatch). Its training loop is NOT touched by this plan.
+- `search/prior/fallback.py` — `FallbackPrior` composition; `score()` folds the analytic in as a dimensionless
+  multiplier `analytic**W` centered at neutral 1.0 (`config.analytic_tilt`).
+- `search/features.py` — `knob_features` (THE one featurization), `FEATURIZER_VERSION`, `tile_signature`.
+- `search/db.py` — the `node` table (`NodeRow`): leaf vs branch semantics, per-kind upsert, label-quality columns,
+  `merge_nodes` (cross-hardware accumulation, driven by the `collect-node-data` skill).
+- `search/policy/mcts.py` — `_collect_node_records` (what writes node rows), PUCT `_select` (scores *partial* prefixes).
+- `search/prior/diagnostics.py` — `node_report` (fork sibling-ranking eval), backing `emmy eval`.
+- `search/analytic.py` — golden-eval glue: `enumerate_graph` (live-fork candidate capture), `evaluate_golden`.
+- `search/golden.py` + per-GPU golden YAMLs — the curated verified-optimum configs.
+- `scripts/golden_knob_heuristics.py` — the current offline fitter (random search + coordinate descent over linear
+  weights, golden-rank objective). Superseded by the Phase-4 fitter.
+- `search/data/` — `Sample` / `Dataset` / `ShapeKey`; `Dataset.fold_node_rows` (group-holdout folds by op_sig / gpu).
+
+Vocabulary: **leaf** = complete knob config with a direct bench; **branch** = partial knob prefix, value-of-position
+label (min over benched descendants); **pool** = one op's candidate enumeration on one card/regime; **goldens** =
+verified-best configs (tuned + A/B'd with integrity gates), committed per-GPU.
+
+## Decisions made, and why
+
+1. **CatBoost (tier 1) + machine-fit additive table (tier 2) + option-0. No linear model; no hand-written rule prior.**
+   The fallback chain is: repo-checked CatBoost artifact → additive table → option-0 emission order. The user explicitly
+   rejected keeping the linear model. The tier-2 additive table replaces BOTH the linear weights and the earlier
+   "hand-written physics rules" idea: a boosted **depth-1 (stump) ensemble is exactly additive** — `Σ_k shape_k(x_k)` —
+   exported at fit time to a plain per-feature table (the `analytic_weights.json` artifact — since 2026-07-10 the
+   linear weights already ship there rather than as source literals; CatBoost JSON dump → collapse stumps). Scoring is
+   ~20 lines of `shape_k(feats[k]) if k in feats else 0`. Each shape function reads as a fitted rule
+   ("`D_near_waves`: +8 in [1.5, 2.5]") — the old rule prior's legibility without its bit-rot, regenerated by one script.
+2. **Resilience is a property of the fit pipeline, not the artifact.** The linear prior survives churn because (a) the
+   fitter regenerates candidate pools from the live enumeration, (b) goldens store raw knobs + shape matched
+   schema-agnostically (`tile_signature`), (c) missing features degrade gracefully (`feats.get(k, 0.0)`). Keep all three
+   properties; swap the model class. Never persist feature matrices — always re-featurize raw knob dicts at fit time.
+3. **Graceful degradation semantics per tier.** Tier 2 gets the linear model's locality *by construction* (additivity +
+   skip-if-missing: a retired feature deletes one term, the rest stand). Tier 1 (depth 4–6, interactions → non-local
+   damage possible) gets it *statistically*: per-**pool** masking augmentation (features NaN'd with p≈0.05–0.15, K
+   replicas + one clean copy; `nan_mode="Min"` trains real absent-feature routing) plus `rsm < 1.0` for split-level
+   redundancy. Caveats: masking must be per-pool, not per-row (a retired feature is absent for the WHOLE pool at
+   inference; per-row masking teaches a ranking loss that missingness discriminates siblings — exactly wrong). And
+   dropout does NOT cover semantic drift (same name, new meaning/scale) — distribution fingerprints do (decision 9).
+4. **NaN vocabulary is preserved.** Absent feature = "not-yet-decided" (partial fork prefix); explicit OFF value =
+   "decided unused" (the knob-stamp invariant). The masking augmentation therefore masks the structural side
+   (`S_*`/`H_*`/`D_*`) at pool level only; knob-side missingness in training comes from REAL prefix rows (decision 6),
+   so the not-yet-decided semantics stay honest.
+5. **Training data = a frozen, LEAF-ONLY local extract of the fleet node DB; ~~goldens are the held-out acceptance
+   set~~ goldens train too — held-out evaluation is the k-fold splits (corrected 2026-07-23; reversal history
+   below).** RESCOPED 2026-07-09 — was "a committed, curated snapshot". With no second consumer of the dataset the
+   commit bought nothing: row-level PR review of thousands of leaves was never real, and the reproducibility /
+   verifiability properties survive as a digest pin. The data stays local; distribution (HF dataset repo, GCS,
+   git LFS) is deferred until sharing matters.
+   - Why frozen (not fit-from-DB): the DB is a live store — tunes and merges write into it — so fitting from it
+     directly makes fits non-reproducible and fitter A/Bs (CV folds, loss choices, masking rates on identical data)
+     incomparable. One command extracts → writes one local file → sha256s it; the fit is a pure function of
+     (repo, pinned freeze), and the tier-1 artifact stamps the digest. CI keeps every data-free check (feat_ver,
+     column vocabulary, fingerprints, golden gate) — none need the freeze present.
+   - Why leaf-only: a leaf is a durable fact about (config, GPU, compiler version). A branch row is a run-artifact — a
+     policy-dependent coverage bound (min over whatever that search benched), possibly stale/non-monotone vs its own
+     re-measured leaves, and **path-structure-fragile** (its identity is a prefix in the *historical* fork-tree topology;
+     level reorders / knob moves orphan it, and no spelling migration fixes that). Leaves are complete points in knob
+     space — valid under any tree organization.
+   - ~~Why goldens never train: they are the only *verified-optimum* labels (tune-golden A/B + integrity gates).
+     Training on them makes the promotion gate measure memorization. Their value is spent as the eval set.~~
+     **REVERSED 2026-07-15: goldens DO train, as a fit-time union.** The search data is censored exactly where the
+     verified optimum sits (the -O1 lane inversion, the post-swizzle fm optima found only by manual sweeps): a golden
+     the search never reached has NO nearby training rows in the freeze at all, so excluding goldens starves the fit
+     in the one region we know the answer. The fitter unions `Dataset.from_golden()` (source-marked, card-faithful
+     context, deployable-regime latency — must group with `H_opt=3` pools per decision 7, never the -O1 lane) with the
+     freeze rows at data-assembly time; the freeze file itself stays a pure DB extract (goldens are repo-checked, so
+     the fit's `(repo commit, freeze digest)` pin already covers them — baking copies in would only go stale). Gate
+     integrity lives in the k-fold holdouts used during training (decision 13): grouped leave-one-op-family-out /
+     leave-one-card-out folds, the same mechanism for the goldens-only and goldens+freeze assemblies — each golden
+     is scored held-out by the fold model that never trained on it, and full-train vs held-out is the memorization
+     split. *(Corrected 2026-07-23: an earlier version of this note also reserved "the next newly-onboarded model's
+     goldens" as a standing unseen acceptance set — dropped; no golden set is held out of training.)*
+   - Freeze contents: ok leaves + **fail leaves** (negative examples — "doesn't build/launch here" is durable) + all
+     regime rows (-O1 and -O3 both; no size budget — keep EVERY leaf passing the sanity filter). Raw knob dicts +
+     shape/context/gpu + bench stats + provenance (measured_at, run_id; the freeze header stamps the repo commit and a
+     collection-policy note at freeze time — per-row commit/policy aren't recorded in the DB). No `parent_key`, no
+     `visits`, no tree schema.
+   - Durability: local-only means `~/.cache/emmy/autotune.db` is the SOLE copy of data that cost rented-GPU money (a
+     `.bak-pre-wipe` neighbor shows cache wipes happen). After each `collect-node-data` merge, copy the DB (or the
+     freeze) somewhere durable; re-collection is possible but costs rental hours per card. *(Partially automated
+     2026-07-22: `remote_node_collect.py` backs up the local autotune DB after each merge; an off-laptop copy is
+     still an open question below.)*
+6. **Branch training rows are SYNTHESIZED at fit time, not stored.** Group the freeze's leaves by prefix under the
+   **current** code's fork structure; label = min over the group (value-of-position); confidence weight = descendant
+   count. Strictly better than stored branch rows: consistent with today's tree (what PUCT will actually score),
+   consistent with the kept leaves (no stale bounds), and it doubles as the principled prefix-masking augmentation.
+   Favorable error structure: shallow prefixes aggregate many leaves → tight labels exactly where a misranking costs
+   the most; deep sparse prefixes get loose labels where errors cost least.
+7. **Loss = grouped ranking (per fork sibling set, per level), not µs regression.** The analytic prior's contract is
+   ordinal — µs calibration is the learned prior's job, and `FallbackPrior`'s tilt needs the dimensionless neutral-1.0
+   multiplier. Emit one ranking group per fork node (its children with value-of-position labels), depth-weighted so
+   shallow levels dominate; also group per `(pool, H_opt)` so -O1 ranking-lane rows and -O3 deployable rows never pool.
+   Wrap the raw score in the monotone `exp(-scale·s)` squash to preserve the multiplier convention, with the special
+   case: no `D_*` features → exactly 1.0 (no opinion).
+8. **Monotone constraints are the durable home for physics rules.** Declared per feature name next to the feature list
+   (e.g. `D_splitk_excess` can only hurt); survive refactors legibly; bound damage from degraded inputs; a renamed
+   feature loudly fails the constraint mapping instead of silently misfiring.
+9. **Promotion gate + CI, mirroring the calibration-gate pattern — TWO quality metrics only.** Metric minimalism is a
+   deliberate decision: one metric per question the prior answers, each denominated so a threshold is meaningful.
+   (a) **Flattened golden rank** (exists today) — "would a cold greedy deploy find the golden?"; (b) **fork sibling
+   value regret**, bucketed by the knob FAMILY of the fork's delta (TILE / REDUCE / STAGE / structural), on held-out
+   node data — "does the prior steer the search into fast subtrees?": median of `value_us(predicted-best child) /
+   value_us(true-best child)` per fork group, gated hardest on the shallow families. Family bucketing, not raw
+   `depth` — depth is rule-step distance (renumbers on pass changes; live store shows forks only at depths 4–8/11–15
+   with a 75-child bulge at the tile fork), family is the stable semantic level. Rejected as gate metrics: golden
+   path-descent (presumes the golden's branch must win every level — a sibling branch may hold a near-equal config;
+   sibling regret over measured values answers the same question honestly), top-1/top-k rates and Spearman (proxies
+   for regret). A **feature-ablation robustness check** (mask each feature/family, measure metric collapse) is part
+   of the gate as a resilience verification, not a quality metric — built in Phase 2 (blame + ablation tooling) and consumed by the Phase-8 gate.
+   Promote only if ≥ incumbent; otherwise keep the old artifact and log the
+   quarantine. CI: artifact `feat_ver == FEATURIZER_VERSION`, model cols ⊆ live featurizer keys, golden median rank ≤
+   threshold, per-feature **distribution fingerprints** (training quantiles vs live golden-enumeration featurization —
+   catches same-name-new-meaning drift, the class dropout can't).
+10. **Refit workflow (two clocks).** Steady state: no refit (deterministic fit, pinned artifact, CI green).
+    *Code events* (frequent, GPU-free): featurizer/encoding change → measurements untouched, re-featurize the freeze,
+    one-command refit; search-space growth → old configs remain valid at the new knob's OFF value, refit immediately as
+    a bridge (model neutral on the new dimension via NaN), then schedule a collection sweep for coverage.
+    *Data events* (rare, GPU-spend): codegen drift — detected by the golden gate degrading against freshly re-tuned
+    goldens — or new hardware → collection sweep → merge → re-freeze → refit. The learned prior stays the
+    *online* model (freshest local data); the analytic prior is a *release artifact* on the repo clock.
+11. **Arch-differentiation is an interactions problem; every tier gets an explicit answer (added 2026-07-09, from
+    the cross-card golden sweeps).** `H_*` features are constant within a sibling pool, so they carry zero marginal
+    ranking signal — they act only through `H_* × knob` interactions. Tier 1: keep `H_*` in the training columns,
+    depth ≥ 2 (never stumps-only), and gate on the leave-one-card-out fold so a learned arch split is verified, not
+    assumed — the per-pool ranking groups mean per-arch *coverage* in the freeze, not row volume, decides whether
+    the split is learnable (the 5090's golden-tile region is censored today; Finding 3's pollution filter is a
+    prerequisite). Tier 2: additive ⇒ arch-blind unless arch×knob pair terms are declared — seed the whitelist with
+    `H_tc_gen × warp-aspect`, `H_tc_gen × splitk-need`, and TMA/WSPEC staging × tile geometry (the 5090 sweep's
+    exact miss directions: wide warps over-weighted, split-K under-weighted on sm_120). Featurizer: add the
+    engineered features the sweeps showed missing on BOTH cards — masked warp aspect (`wNxM` under a symbolic axis;
+    today no feature separates those siblings, the 4090's Finding 1) and TMA/WSPEC-conditioned tile pricing.
+    Vocabulary additions are code events (decision 10): GPU-free refit, no new collection required.
+    **STATUS (2026-07-09): the featurizer additions + analytic refit LANDED** (branch
+    `feature/prior-arch-features`): `D_w_grid_m/n/aspect` (warp-grid arrangement over the canonical free slots —
+    same-tile different-grid siblings were byte-identical before) and `D_tma_{grid_m,grid_n,aspect,log2_area,
+    l2_splitk}` (geometry mirrored onto TMA-staged rows — the per-candidate arch key). Two findings along the way:
+    (a) `S_masked_m/n/k` have NO producers left (`masked_axis_features` is orphaned — the `D_neg_masked_*` weights
+    are dead everywhere), so the masked-warp-aspect axis rides the dyn weight-set split instead (the regime split IS
+    the masking condition); (b) the fitter's random-restart stage overfits the golden objective while trashing
+    node-store calibration (4090 Spearman +0.46 → +0.18) — the landed weights are coordinate-descent-from-seed only
+    (`--samples 0`), which Phase 4's fitter should keep as a lesson (regularize toward the incumbent). Results:
+    `eval analytic` top1 31 → 40/53, top50 41 → 47/53, every sweep `.dynM` miss to rank 0 (mlp_down 2358 → 0,
+    square.512 1198 → 0, qkv 780 → 0, o_proj 663 → 0); 4090 TILE fork regret 3.62x → 2.31x, calibration +0.46 →
+    +0.53; the 5090 node table is unadjudicable until the Phase-3 roofline floor lands (its regressed rows sit on
+    physically-impossible baselines). The dyn set's divergence is exactly the predicted axis: `D_tma_grid_m/n`
+    +4.75 vs static +2.49, `D_tma_l2_splitk` +3.15 vs −0.68 (the 5090's split-K-under-TMA wins). NEXT: re-run the
+    golden sweep on a rented 4090/5090 to confirm the cold search now reaches the goldens (tune-golden skill).
+12. **Naming: the two priors are named by role/clock, not model class — `OfflinePrior` / `OnlinePrior` (settled
+    2026-07-11).** Once both priors are CatBoost-backed, implementation names stop differentiating them (and
+    "analytic" becomes factually wrong — the shipped prior is machine-fit). `AnalyticPrior` → `OfflinePrior`
+    (offline-fit release artifact, repo clock); learned `CatBoostPrior` → `OnlinePrior` (online-updated local
+    model). The tier chain (CatBoost → additive table → option-0) hides behind the ONE public `OfflinePrior`
+    class — its loader picks the best valid artifact via the existing `kind` field, so `FallbackPrior` stays a
+    two-way composition (`online µs × offline**W`). Rename surface: `prior/analytic.py` → `prior/offline.py`,
+    `prior/catboost.py` → `prior/online.py`, `search/analytic.py` (golden-eval glue — shares the doomed name),
+    config vars (`EMMY_ANALYTIC_FILE` / `analytic_tilt` / `EMMY_PRIOR_FILE` → offline/online spellings; old env
+    names stay as accepted aliases with a deprecation warning — they live in shell profiles), `eval analytic`,
+    artifact filenames, docs/skills. Unchanged: the `Prior` ABC, `FallbackPrior`, DB schema, checkpoint keys.
+    Lands as its OWN mechanical PR BEFORE the Phase-4 extraction so the fitter and its artifacts are born with
+    the new vocabulary. (Prose elsewhere in this plan predates the rename and says "analytic" / "learned".)
+    **STATUS: LANDED 2026-07-13 (#355)** — `prior/offline.py` / `prior/online.py`, `offline_weights.json`,
+    `EMMY_OFFLINE_FILE` / `EMMY_ONLINE_FILE` (old spellings accepted as aliases), `eval offline` / `eval online`.
+13. **Phase-4 fitter: one pipeline, two orthogonal switches — model class × training data (settled 2026-07-11).**
+    "Current vs new training" differs on two independent axes, so the fitter exposes both:
+    `--trainer {linear,catboost}` × `--data {golden,freeze:<path>}` (trainers declare which data kinds they
+    support; catboost is freeze-only). Three cells get run and compared: linear×golden (the incumbent process,
+    preserved), linear×freeze (isolates the data/objective effect), catboost×freeze (the target) — and for
+    cell 3 vs cell 2 to isolate the model class, the linear freeze trainer optimizes the SAME grouped pairwise
+    loss CatBoost does (the coordinate-descent optimizer with its objective parameterized), with everything else
+    held fixed: one featurization, same eval folds, same seed policy. Preservation is verified, not promised:
+    `golden_knob_heuristics.py` becomes a thin wrapper over the extracted fit module (`search/prior/fit/`),
+    pinned by two regression tests — same seed + same incumbent → byte-identical artifact, and the incumbent
+    artifact through the new eval path reproduces today's `eval analytic` numbers exactly. Entry point: an
+    `emmy fit` subcommand (the command layer owns the snippet-tracing golden-case builder — `pipeline/` never
+    imports `commands/`). Every fit run writes a per-run METRICS FILE (JSON, in a `_tune/fits/…` run dir, not
+    repo-checked): a header (trainer, data kind + digest, feat_ver, seed, fold spec, repo commit, augmentation
+    params — two runs are comparable iff their headers differ only in the axis under test), per-fold blocks keyed
+    by held-out group with both gate metrics per card (never pooled), golden rank reported both ways (full-train
+    vs leave-that-op-out — the memorization split), and per-card aggregates. Keys are stable identifiers (golden
+    name, family, card), so comparison = joining two files; a side-by-side renderer can come later. Deterministic:
+    same header inputs → identical metrics content, so an A/B diff contains only real differences. Fold-trained
+    models plug into the eval as stub priors via the Phase-2 features seam, so the eval suite has zero
+    per-trainer branches. Masking augmentation is trainer-owned, not a shared prepare stage (tier-1 needs it,
+    linear would only gain noise).
+
+14. **The freeze adopts the goldens' declarative row spelling (settled 2026-07-23).** The landed v1 freeze dumps
+    `NodeRow`s: identity as digests (`node_key` / `context_key` / `op_sig`) and the persisted `features` dict —
+    the featurizer's encoded `S_*`/`H_*` output — which is exactly what decision 2 forbids ("never persist feature
+    matrices"): the shape is unrecoverable from a row, and every encoding-only featurizer change quarantines the
+    file (`feat_ver`). Goldens got this right: declarative kind + shape fields + verbatim TUNABLE knobs, with
+    `S_*`/`H_*`/pools re-derived at load/fit time. Settled shape of the rework:
+    - **Rows are golden-entry-shaped**: kernel kind, declarative shape fields, `knobs` = verbatim tunable knobs
+      only, measured µs, grouped per GPU — plus a measured-row extension block with no golden equivalent:
+      `status` (`bench_fail` negatives), `variance` / `n_samples` (confidence weighting + quality-aware
+      replacement), the nvcc opt lane (the -O1/-O3 twins), `run_id` / `measured_at`. No `cublas_us` — sweep
+      points bench emmy-only; it is NOT the literal `GoldenConfig` schema, but the same spelling.
+    - **Declarative identity is captured at COLLECTION time, not reverse-engineered at freeze time.** The
+      three-slice sweep already holds (kind, shape fields, gpu, knob row, opt level) per benched point — its
+      ledger is keyed `(gpu, shape, knob signature)` — so the bench-to-node recorder carries the identity
+      (`ShapeKey` in `search/data/shape.py` is the carrier). Tune-written rows have no such identity today:
+      either `ShapeKey` gets recorded at tune time too, or they are excluded from goldens-format freezes.
+    - **The freeze's provenance contract survives unchanged**: sorted rows, digest over the row payload,
+      provenance header, hard-error loading — orthogonal to row spelling.
+    - **Payoff**: one data-assembly path in the fitter — the case builder snippet-traces each distinct shape
+      once, enumerates the pool, and joins golden entries AND freeze rows into it by shape + knob spelling
+      (`ShapeKey` / `tile_signature`), no `op_sig`-digest bridging; encoding-only featurizer changes stop
+      quarantining freezes (re-derive at load — most of Phase 9's motivation dissolves); the k-fold group keys
+      (op family, gpu) read directly off every row.
+    **STATUS (2026-07-23): IMPLEMENTED on `feature/golden-neighbor-collect`** (CPU-tested; GPU smoke pending the
+    next rented card). Landed: `NodeRow.shape_spec` + node column (COALESCE-kept both replacement directions),
+    `run --bench --record-shape` with the per-leaf `ShapeKey.joins` gate in `bench_record.py` (`joins` tolerates
+    the sweep kinds' snippet-unstable dtype-derived `is_warp` — found implementing this: an all-fp16 norm snippet
+    flips it vs the goldens' recorded `False`), the sweep passing its group spec, `traced_s_features` (kind-generic
+    multi-op `S_*` re-derivation), and freeze v2 (`FREEZE_VER=2`): per-GPU YAML dir + manifest, content-level
+    digests, loader re-derivation, v1 JSONL refused with a re-freeze pointer, load-time `feat_ver` gate dropped.
+
+## Constraints and requirements
+
+- **ONE featurization**: everything (both tiers, synthesis, evals) reads `features.knob_features`. No private feature
+  views (that's what killed the old rule prior).
+- **ONE ranking path**: both tiers implement the `Prior` ABC and compose behind `FallbackPrior`. No policy special-cases.
+- Analytic contract: lower-is-better latency *proxy*, ordinal only, neutral exactly 1.0 when it has no opinion, usable
+  with zero measurements on a fresh clone, cheap enough for greedy's ~1k-row flattened batches (vectorize tier 1's
+  predict like `CatBoostPrior.mean_scores`).
+- Tier-1 artifact: repo-checked, stamped `feat_ver` + training-data digest + fingerprints, discarded WHOLE on version
+  mismatch (the `CatBoostPrior.from_json` semantics), deterministic refit (seeded).
+- Freeze: leaf-only, raw-knob spelling, digest-stamped, keep-everything (no row budgets — the file is local and never
+  reviewed row-by-row; curation is one shared sanity filter: current `feat_ver`, degenerate-bench latency floor, fails
+  kept as negatives).
+- Train/inference representation identity: synthesized partial rows NaN out undecided knobs exactly as the live
+  descent featurization does.
+- Code-event refits must need no GPU. ~~Goldens must never enter training.~~ (Reversed 2026-07-15 — decision 5:
+  goldens join training via the fit-time union; held-out integrity comes from the k-fold splits alone — corrected
+  2026-07-23, the earlier "+ the next new model's goldens" reservation is dropped.)
+- Repo conventions: knobs declared only in `search/space.py`; `pipeline/` never imports `backend/`; markdown wrapped
+  ~120 chars; plans are ephemeral (this file gets deleted when the work lands — durable content goes to ARCHITECTURE.md).
+
+## Do NOT change
+
+- The `Prior` ABC surface (`score` / `mean_score` / `mean_scores` / `pick` / `trustworthy` / `evidence_pick`) and
+  `FallbackPrior`'s blend semantics (learned µs × `analytic**W`, neutral 1.0; evidence-pick precedence).
+- The learned `CatBoostPrior`'s online loop: reservoir sampling, `REFIT_SCHEDULE`, checkpoint format, calibration gate.
+  Different clock, different job — this plan only touches the *analytic* half of the composition.
+- The knob-stamp invariant and OFF-value / NaN semantics (`tests/compiler/passes/test_knob_stamp_invariant.py`).
+- The `node` table schema semantics (per-kind upsert, newest-leaf-wins, `merge_nodes`) — the freeze step is a
+  read-only consumer. ~~The `collect-node-data` flow keeps working unchanged (ε-greedy 0.25 collection stays; it's
+  the provenance the freeze prefers).~~ *(Overtaken 2026-07-22: the ε-greedy tune phase was retired and
+  `collect-node-data` is now the three-slice golden-anchored sweep — see the Update 2026-07-23 section. The table
+  schema semantics above still hold.)*
+- Golden dataset role/format and `tile_signature` matching; the golden A/B integrity gates.
+- Greedy mechanics: `flatten_leaves` (complete-leaf scoring), validity blocklist retries, option-0 last resort.
+- Existing `emmy eval` subcommands keep working (new evals are additive).
+
+## Phases
+
+Each phase is independently verifiable; 1–4 need no GPU; hardware spend concentrates in 7. Dependencies: 1 → {2, 3};
+3 → 4 → {5, 6} → 7 → 8; 9 floats; the decision-12 rename PR precedes 4's extraction. Phase 3 shrank in the 2026-07-09 rescope to a thin freeze step — effectively step 0
+of Phase 4. Phase 2 is diagnostic tooling — parallel with 3, consumed by 4's fitter loop and 8's gate.
+
+1. **Evaluation harness + incumbent baseline.** Exactly the two gate metrics (decision 9): flattened golden rank
+   (exists — `eval analytic`) and family-bucketed fork sibling value regret (rework `node_sibling_ranking`:
+   regret instead of top-1/Spearman, bucket by the fork delta's knob family). NO comparison runner — comparing
+   priors = diffing two report files (the golden-sweep findings already track progress across dates this way);
+   the Phase-4 fitter emits the same report per CV fold. May add a `Prior`-internal score-on-features seam
+   (both priors already featurize-then-predict) — needed by the Phase-2 attribution tooling and the Phase-4 fitter; no
+   behavior change, equivalence-tested. **Prerequisite (SATISFIED 2026-07-09 — see assumptions): one fresh ε-greedy
+   `collect-node-data` sweep on a rented card** — the 2026-07-06 audit found the local node store 100% retired-vocabulary (see assumptions), so no
+   nodes-based metric has usable data until then; the sweep doubles as Phase-2/3 seed data. Deliverable: baseline
+   findings report (plans/) following the house report conventions (title + card + date; context header defining
+   the numbers; data tables FIRST with a per-row link to the numbered finding each bad row motivates; numbered
+   findings each ending in a "Next:" action; artifacts/workflow notes last). Report layout: per-KERNEL rows ×
+   per-FAMILY columns — golden table one row per golden (`name | rank/pool | → finding#`); regret table one row
+   per op label (`kernel | TILE | REDUCE | STAGE | structural | n_forks`) with a per-family aggregate line at the
+   bottom, which IS the gate number; the per-kernel rows are the diagnostic view feeding the findings. Verify:
+   read-only vs live DBs; unit tests on synthetic `NodeRow` sets + stub priors; `make test` green; no behavior
+   change to compile/tune.
+   **STATUS: DONE.** The two-metric harness landed as #361; the metrics only became *honest* with #364
+   (de-saturated squash + tie-pessimistic golden rank) and #363 (card-faithful eval contexts) — see the 07-15
+   Update. Baseline reports exist (`plans/analytic-blame-ablation-baseline-findings.md`, the golden-sweep
+   findings series); the family-bucketed regret is a projection of the shared `ForkRecord` builder (Phase 2).
+2. **Per-feature regret attribution — blame decomposition + ablation Δ (diagnostic, NOT gate).** Two output modes
+   over the per-fork records the regret metric already produces. (a) **Blame**: for each missed fork, the
+   per-feature signed contribution to the pick-vs-best score gap — EXACT for the linear analytic prior
+   (`Σ_k w_k · (f_k(picked) − f_k(best))` sums to the gap by construction), SHAP-difference for CatBoost —
+   aggregated per family, regret-weighted: "which feature caused this misranking". (b) **Ablation Δ**: re-pick with
+   one feature/family masked; `Δregret = regret_masked − regret_full` per family — a negative Δ flags an actively
+   misleading feature. Motivation (2026-07-07): both headline baseline discoveries were manual instances of these
+   views — the identical-vector REDUCE blindness is blame's degenerate case ("no feature varies across siblings"),
+   and the post-#318 `_W_A` serial preference on reduce forks took a hand decomposition to find; the pending `_W_A`
+   reduce refit consumes the blame table directly. Deliverables: the linear blame table first (exact, ~small),
+   CatBoost SHAP mode + ablation Δ after; run for the incumbent on the fresh sweep data; and wire the new views
+   into the tune-golden / tune-model skill report templates (their finding-evidence lists — the regret block was
+   added there when it landed; blame replaces their hand-derived "per-knob misses" attribution step). STRICTLY diagnostic — the
+   gate stays two numbers (decision 9): attribution among correlated features is non-unique (ablation double-counts
+   redundancy, SHAP splits it arbitrarily), so never threshold on it. NaN-mask ablation is a fair proxy only once
+   the fitter's dropout training (phase 4) makes masked queries in-distribution — flag that in the output until
+   then. Verify: unit tests with stub priors (a planted weight's blame is recovered; the linear decomposition sums
+   exactly to the score gap); read-only against the node store.
+   **STATUS (2026-07-07): LANDED except the CatBoost SHAP mode** (deferred until a trained artifact exists to test
+   against — decided with the user; the out-of-distribution caveat flag ships now and fires for any non-analytic
+   prior). Shipped: `eval prior --dataset nodes --blame/--ablate` over a shared `ForkRecord` builder (the regret
+   metric is now a projection of it), the `Prior` features seam (`mean_score[s]_features` + exact
+   `explain_features`, the hardcoded interactions as `gate:*` pseudo-terms), the skill-template wiring, and the
+   incumbent run — `plans/analytic-blame-ablation-baseline-findings.md` (headline: 42/43 REDUCE misses BLIND at
+   ~89% of total regret-weight; `D_l2_reuse` actively misleading on TILE forks, Δ −0.56x).
+   **Re-run 2026-07-08 post-#322 + refit sweeps (same report, before/after): the acceptance check passed** —
+   REDUCE blind 42 → 0, regret-weight 1670 → 84, per-card medians 34–68x → 1.00–1.13x (PRO 6000 on re-featurized
+   old rows alone); `D_l2_reuse` rehabilitated by the refit; the worst class moved to the 4090's big-K TILE
+   goldens (215x — a Phase-4 priority test case), and `D_l2_bm` / the splitk-roundtrip gate are the new
+   misleading shortlist.
+3. **Local measurement freeze (RESCOPED 2026-07-09 — was "committed measurement snapshot"; effectively step 0 of
+   Phase 4).** One command: read the node DB read-only → sanity filter (leaf-only, current `feat_ver`, the
+   degenerate-bench latency floor, fails kept as negatives — a shared ~20-line predicate, not an exporter with
+   policy) → write ONE local file (JSONL of leaf rows or a `VACUUM INTO` sqlite copy; no format ambition — it is
+   regenerated from the DB) → sha256 + provenance header (repo commit, run_ids, policy note). The latency floor is
+   **load-bearing for sm_120**: the 5090 sweep found physically-impossible leaves in the node store (9.17 µs on a
+   ~60 GFLOP fp16 matmul ⇒ ~6700 TFLOP/s vs the card's ~210 peak; up to 24643× fake fork regret) — floor each leaf
+   at a per-shape FLOP roofline from its `S_ext_*` extents and the card's peak (derivable from the `H_*` regime),
+   and drop rows below it; without this the 5090 rows poison both training and the regret gate. Loader: freeze →
+   leaf-only `NodeRow`s (`parent_key=None`, `feat_ver` from the header) so `Dataset.from_node_rows` /
+   `fold_node_rows` and the Phase-1/2 evals work unchanged. Dropped with the commit: pool-grouped per-card repo
+   files, row budgets, coverage-quota curation, in-repo manifest, CI data loading, the format doc. Deferred until a
+   second consumer exists: HF dataset / GCS / git LFS distribution. Verify: freeze-twice determinism (same DB → same
+   digest); round-trip vs `iter_nodes`; evals accept a freeze path interchangeably with the live DB.
+   **STATUS (2026-07-15): LANDED** (branch `feature/measurement-freeze`; merged as #382, 2026-07-16, together with
+   the item-5 bench-to-node recorder): `search/data/freeze.py`
+   (`freeze_reason` / `write_freeze` / `load_freeze` / the sniffing `load_node_rows`) + `scripts/freeze_node_store.py`;
+   JSONL, header line with both version axes reserved (`knob_ver`/`encoding_ver`), digest over sorted row payload
+   only; `eval online --dataset nodes --db` takes a freeze via the sniff seam. Verified on the real store: 5,990
+   leaves frozen (5,963 ok + 27 bench_fail; 10,787 branch rows excluded), freeze-twice digest identical, eval
+   degrades to leaf metrics as designed. `load_node_rows` is the seam the Phase-4 `emmy fit --data freeze:<path>`
+   consumes.
+   **FORMAT REWORKED (decision 14; implemented 2026-07-23 on `feature/golden-neighbor-collect`):** the v1 row
+   spelling (a `NodeRow` dump — digest identity + persisted featurization) is superseded by the goldens-format
+   freeze v2 (per-GPU YAML dir + manifest, identity captured at collection time, features re-derived at load);
+   v1 files are refused with a re-freeze pointer. The determinism/digest contract and the `load_node_rows` seam
+   carried over. See decision 14's STATUS for the landed pieces.
+4. **Training pipeline.** Prefix-row synthesis under the current fork structure, sibling-group ranking datasets,
+   pool-level masking augmentation, group-holdout k-fold (leave-one-op-out AND leave-one-card-out via
+   `Dataset.fold_node_rows`), candidate CatBoost rankers with monotone constraints; every fold reported through the
+   Phase-1 suite. Deliverable: the fitter (successor to `golden_knob_heuristics.py`) + CV report vs the linear
+   baseline on identical folds. **This is where old-vs-new comparison lives.** Offline only.
+   Settled design in decision 13 (trainer × data switches, extract-and-wrap, per-run metrics files, `emmy fit`).
+   Build order: (0) the decision-12 rename PR; (1) extraction + wrapper + the two preservation tests (pure
+   refactor, no behavior change); (2) the Phase-3 freeze command + loader; (3) metrics file + fold harness → run
+   linear×golden — the first held-out numbers the current process has ever had (golden-case folds:
+   leave-one-op-family-out and leave-one-card-out; small-n, so the card axis is the meaningful one; node folds
+   need no per-fold retraining for this cell — the incumbent trains on goldens, so any node fold is
+   out-of-sample); (4) prefix synthesis + ranking groups → linear×freeze; (5) catboost×freeze — the open Phase-4
+   questions below (loss, masking p/K, monotone list, depth budget) get decided empirically here, each candidate
+   config just another metrics file. `--folds both` = the union of the two fold axes (two report sections), not
+   nested op×gpu — nesting starves training at this dataset size.
+   **STATUS (2026-07-23): build-order steps 0–3 LANDED; steps 4–5 are the open frontier.**
+   - (0) rename — #355 (07-13). (1) extraction + wrapper + preservation tests — #383 (07-20): fit core in
+     `search/prior/fit/` (`linear.py`), `golden_knob_heuristics.py` is the thin legacy wrapper. (2) freeze
+     command + loader — #382 (07-16, Phase 3 below). (3) metrics file + fold harness + **linear×golden** —
+     #404 (07-20): `emmy fit` (`emmy/commands/fit.py` owns the snippet-tracing case builder; `fit/cv.py` owns
+     the folds/metrics). **This cell is the CURRENT training pipeline, and it trains on goldens only** — no
+     freeze/node rows enter any fit yet. Shape as landed: `--trainer {linear,catboost} × --data
+     {golden,freeze:<path>}` with every cell except linear×golden rejected loudly; `--folds
+     {op_family,gpu,both,none}`, each golden held out exactly once per axis, holdout vs train rank + per-card
+     gap (overfit vs weak-model split), aggregates per card ONLY, fold models seeded from ZEROS (incumbent
+     seeding would leak each golden into its own holdout model — the full-train shippable artifact keeps
+     incumbent seeding, recorded in the header); writes `metrics.json` + `weights.json` (the shipped
+     `offline_weights.json` format). Coverage caveat: attention / rms_norm / softmax goldens have no case
+     builder — counted `out_of_scope` per card, so the goldens-only fit is also kind-limited.
+   - (4) prefix synthesis + ranking groups → linear×freeze and (5) catboost×freeze — NOT STARTED. Their
+     training data is what the 07-2x collection rework (Update 2026-07-23) is gathering.
+   Data assembly unions the freeze with
+   `Dataset.from_golden()` rows (decision 5 as reversed 2026-07-15): source-marked so folds can exclude them for the
+   memorization split, joined into pools by shape (`ShapeKey`/`tile_signature`), grouped with the deployable-regime
+   (`H_opt=3`) lane — never the -O1 ranking lane.
+   Arch generalization is a first-class output (decision 11): the leave-one-card-out fold directly tests the
+   2026-07-09 cross-card failure (analytic TILE regret 3.62× sm_89 → 11.49× sm_120), so report both gate metrics
+   **per card, never pooled**; verify tier 1 actually learned an `H_* × knob` interaction (interaction
+   strength / SHAP on `H_tc_gen`/`H_cc`) rather than averaging the cards. Decision 11's featurizer additions
+   (masked warp aspect, TMA/WSPEC-conditioned tile pricing) land here, each justified by its fold-level metric Δ.
+5. **Tier-1 artifact.** Format (feat_ver, cols, digest, fingerprints), the new prior class (contract per constraints),
+   loading/quarantine path, one-command refit make target. Not yet the default. Verify: Phase-1 suite; refit-twice
+   determinism; version-mismatch quarantine.
+6. **Tier-2 additive fallback.** Depth-1 fit stage + declared pair terms (atomic-free × split-width, plus decision
+   11's arch×knob seeds: `H_tc_gen × warp-aspect`, `H_tc_gen × splitk-need`, TMA/WSPEC × tile geometry — without
+   these the additive table is arch-blind by construction), export into the `analytic_weights.json` artifact
+   (`kind` field distinguishes it from the linear weights it replaces), skip-if-missing scorer; drop the linear
+   weight sets from the artifact once parity is shown. Verify: suite ≥ linear baseline on goldens **per card** (a
+   pooled win that trades one arch against the other repeats today's failure) before removal; locality check (mask
+   any feature → bounded, term-local degradation).
+7. **Integration + real-hardware A/B.** Wire tier-1 → tier-2 → option-0 into `FallbackPrior` / `load_prior` (greedy +
+   PUCT + structural pricing paths), quarantine rules. Verify on a rented card: cold greedy deploy A/B (old vs new
+   analytic prior, golden A/B harness), cold-tune search-efficiency A/B (benches-to-best, wall time), full `make test`.
+8. **Promotion gate + CI.** Formalize refit → eval → promote-or-keep; the CI checks from decision 9; ARCHITECTURE.md
+   updates (the two-clock refit workflow). Verify: break it on purpose in a branch (rename a feature) → CI trips →
+   refit target → green.
+9. **(Optional, deferrable) Version split.** Split `FEATURIZER_VERSION` into knob-spelling vs feature-encoding axes so
+   encoding-only changes stop quarantining node rows / freezes (most changes are encoding-only; raw knob dicts stay
+   readable and a refit fully recovers). Touches `features.py`, the DB `feat_ver` stamp, checkpoint + freeze formats.
+   The freeze header should reserve both axes from day one (currently equal) so this split needs no format migration.
+
+## Update 2026-07-23 — collection strategy reworked (three-slice golden-anchored sweep); first real fitter, goldens only
+
+Two things moved since 07-16: the data-collection strategy was replaced end to end, and the Phase-4 fitter now
+exists — but only its goldens-only cell.
+
+- **The ε-greedy `collect-node-data` tune phase is RETIRED; the ONE collection flow is now a budgeted
+  golden-anchored enumeration sweep.** Base collector merged as #414 (07-23, from `feature/golden-neighbor-collect`);
+  the three-slice rework + hardening ride the same branch (in review; skill rewritten to the single-phase flow,
+  v0.3.0). Mechanism (`remote_node_collect.py` → `golden_neighbor_bench.py` on the box): every shape with a recorded
+  golden — matmul AND the non-matmul kinds, which enumerate via the fit's snippet-trace path — builds its candidate
+  pool on the live card; the pool splits into three slices sampled at configurable 60/25/15 budget shares:
+  `own` (rows within `--max-dist` knob families of the live card's own golden anchors — dense label support where
+  its deploy decisions land), `cross` (rows near OTHER cards' anchors that realize here — transfer signal and the
+  arch-disagreement rows decision 11's `H_* × knob` interactions train on), `tail` (a deterministic hash-ordered
+  subsample of the rest — landscape support so the fit also sees the bad tail). Within a slice the batch draw is
+  kind-stratified (the 07-23 4090 run showed matmul, 87% of selectable points, starving attention / softmax /
+  pointwise / linear_norm to ZERO benches in 4 h), then shape-proportional to remaining points. Every sampled point
+  is benched at BOTH `-Xcicc -O1` and `-O3`, pinned via `emmy run --bench --ab` with the #382 default bench-to-node
+  recording (integrity gates for free: `pin_unmatched` / flagged / failed rows go ledger-terminal, never recorded
+  clean). A JSON ledger keyed by (gpu, shape, knob signature) makes runs resumable across boxes; the remote driver
+  harvests the ledger + node rows even on timeout/failure and backs up the local DB after each merge. Why the
+  replacement: search-driven collection over-samples the branches the incumbent prior already likes (coverage
+  correlated with the thing being retrained — the 07-15 Update's complaint), and its wall time grew with the golden
+  set; a budgeted enumeration sample gives clean leaf rows at fixed cost.
+- **What the new collection changes in this plan's economics:** (a) deployable-regime labels by construction —
+  every point gets a pinned -O3 measurement, so the item-1 `-O1` lane inversion no longer censors *collection*
+  (the tuner-internal per-family re-bench floor stays open but drops in priority; the re-bench gate in
+  `policy/mcts.py` is still the global `EMMY_O3_TOL` band today); (b) the item-4 offset dataset falls out for
+  free — a point's -O1/-O3 twins share the knob set and join on `op_sig` + tunables; (c) coverage is golden-anchored
+  by design, exactly the "one verified point, no neighborhood" censoring item 5 diagnosed, with the `cross` slice
+  feeding decision 11's cross-card interaction data and the `tail` slice keeping the fit honest off-anchor;
+  (d) the freeze (Phase 3) picks the rows up unchanged — same store, same `freeze_reason` filter.
+- **Sweep data status:** first stratified 4090 run 2026-07-23 (it surfaced the kind-starvation fix); the 5090 side
+  is still pending — as are the retirement of its poisoned checkpoint (07-13 item 2) and enough merged volume to
+  assemble the first freeze-trained cells.
+- **The current training pipeline is `emmy fit`, and it trains on GOLDENS ONLY.** #404 landed Phase-4 build steps
+  0–3 (see the Phase-4 STATUS): the linear trainer fit on the golden dataset — the incumbent process, now with
+  cross-validated held-out reporting (op_family / gpu axes, per-card-only aggregates, zero-seeded fold models) and
+  a deterministic per-run metrics file. No measured node/freeze row enters any fit yet; the freeze-trained cells
+  (linear×freeze, catboost×freeze — the point of this plan) are the open frontier, waiting on sweep volume.
+- **Held-out evaluation clarified: goldens are NOT a held-out set.** Goldens are ordinary training data in every
+  cell; held-out integrity is the k-fold mechanism during training — grouped folds (leave-one-op-family-out /
+  leave-one-card-out), each golden scored held-out by the fold model that never trained on it — applied the same
+  way to the goldens-only assembly (already live in `emmy fit`'s CV harness) and to the goldens+freeze assembly
+  when the freeze cells land. The earlier ideas of reserving goldens (pre-07-15) or "the next new model's goldens"
+  (07-15) as a standing never-trained acceptance set are both dropped; the affected passages above carry dated
+  correction stamps.
+- **Freeze format decision:** freeze rows adopt the goldens' declarative spelling — kind + shape fields + verbatim
+  tunable knobs + µs with a measured-row extension block (status, variance/n_samples, opt lane, provenance),
+  identity captured at collection time via `ShapeKey`, digest/header contract unchanged. Full rationale and scope
+  in decision 14; Phase 3's landed v1 format is stamped superseded accordingly.
+- **Deploy-surface context keeps narrowing** (extends the 07-15 "#368" note): #396 made deploy picks
+  content-tie-deterministic, and #417's golden floor lets a realizable golden decide even prior-less resolves.
+  The offline prior's live surface is ever more concentrated on cold UNSEEDED shapes + PUCT steering — weighting
+  Phase 4's fold-based generalization gate over seeded-shape golden rank, as the 07-15 Update already argued.
+
+## Update 2026-07-15 — what the saturation arc changed (status of the 07-13 items below, and new inputs to Phase 4+)
+
+A week of landed work (#361 harness, #363 card-faithful eval contexts, #364 de-saturation + tie-pessimistic golden
+rank + a linear refit, #368 golden evidence tier at deploy, #369 golden-anchored descent diagnostics + a full 4090
+golden sweep) changes this plan's context materially:
+
+- **The historical eval numbers adjudicating refits were wrong twice over.** The offline prior's exp-squash clipped
+  quality at ±80, collapsing the whole good-tile region into a tie at `exp(-8)`: greedy fell through to emission
+  order (the 12–29x gemma cold misdeploys) while the strictly-greater rank metric reported 0 for every tied row
+  ("27/28 top-1" was a plateau artifact). Separately, `eval offline`/`eval online` built golden contexts from the
+  host GPU, not the golden's card. Both fixed (#364, #363); every pre-07-14 golden-rank number in this plan's
+  history is unreliable. The honest baseline: OLD weights median rank 461/top-100 30 of 122; the #364 refit 79/68.
+- **The refit's honest profile, measured on fresh sweep data** (`plans/offline-prior-old-vs-new-on-sweep-data.md`):
+  decisive on gemma (median 1422→90) and "everything else" (476→37); the fp16-square regression is real, exactly
+  the promotion-time size, and confined — those rows stay this plan's tier-1 acceptance cases. Critically,
+  **fork-level steering was a wash** (TILE regret 1.88x vs 1.95x): the linear refit reshaped the flattened-pool
+  ranking greedy uses, not the within-fork ordering PUCT uses. Phase 4's grouped per-fork ranking loss is therefore
+  not redundant with the refit — it targets the axis the refit provably did not move.
+- **The offline prior's deployment surface narrowed (#368).** Recorded goldens now decide cold deploys directly
+  (all golden kinds, verified on a 4090 incl. the attention hang-class shapes at 37–44 µs vs 143–158 prior picks),
+  and warm deploys are owned by measured evidence. The offline prior's remaining live surface is cold UNSEEDED
+  shapes and PUCT steering — which weights Phase 4's fold-based generalization gate even more heavily, and golden
+  rank on seeded shapes less.
+- **The gemma goldens are SPENT as the held-out unseen-shape set** — the #364 refit trained on them (item 3 below,
+  as amended). ~~The Phase-4 gate needs a replacement: the next newly-onboarded model's goldens (record them BEFORE
+  any refit sees them), plus the leave-one-op-family-out fold as the standing proxy.~~ *(Corrected 2026-07-23: no
+  replacement unseen golden set — the gate is the k-fold holdout during training, on both data assemblies; goldens
+  are not a held-out set at all.)* Report memorization vs generalization splits both ways, as decision 13 already
+  requires.
+- **New diagnostics exist for the gate** (#369): the golden-anchored descent section makes reachability explicit
+  (matched fork levels per golden, loud NO TREE DATA absence, per-family divergence, -O3 endpoints) — the
+  store-conditioned blind spot that hid the saturation bug is now a rendered metric. Phase 1's metric set should
+  treat divergence between the store-conditioned view and the enumeration-wide view as itself reportable.
+- **Data status**: one fresh 4090 golden-tune store exists locally (16.7k current-vocabulary rows + online
+  checkpoint at `_tune/golden-tune-4090-2026-07-14/`, NOT yet merged into the canonical DB) — but it was a plain
+  tune, not ε-greedy, so its coverage correlates with the incumbent priors; the ε-greedy collection sweeps (item 2)
+  and the -O3 re-bench family floor (item 1) remain open prerequisites for training data. The 5090 side has no
+  post-swizzle data at all and its poisoned checkpoint still needs retiring. Sweep-observed search behavior
+  reinforces item 1: matmul bests were found at bench #112–159 of 233–255 — exploration is paying for ranking the
+  -O1 lane censors.
+
+## Added 2026-07-13 — data prerequisites from the golden/gemma sweeps, and the -O1→-O3 offset model
+
+Motivated by the 07-12/07-13 sweep findings (the manual 5090/4090 golden sweeps, the post-swizzle 4090 refresh, the
+gemma-4 golden seeding): the immediate goal is making the tune-golden skill trustworthy again, and the sweeps showed
+the training data feeding this plan is censored and stale in ways the plan didn't yet account for. Ordered items:
+
+1. **-O3 re-bench floor per tile family in the tuner (prerequisite for every retraining step in this plan).**
+   *(STATUS 2026-07-23: NOT LANDED in the tuner — the re-bench gate is still the global `EMMY_O3_TOL` band in
+   `policy/mcts.py` — but DEMOTED from prerequisite to improvement: the three-slice collection sweep benches every
+   sampled point at both opt levels, so training data no longer routes through the tuner's -O1 band at all.)* The
+   `-Xcicc -O1` ranking lane systematically inverts the big-register-tile f16-accumulate family ~5× (measured
+   directly on the 5090: 2008 vs 392 µs at -O1 for configs ~32% *faster* at -O3), so those configs never land in
+   the `EMMY_O3_TOL` band, the node store holds zero measurements in the winning region, and every fit inherits the
+   censoring — the fm-lane optima were only found by manual sweeps. Change: grant the deployable -O3 re-bench to
+   the top-K per (atom, tile-size family) bucket, not only the global -O1 top band; raise the tuner's per-kernel
+   compile budget for the -O3 lane (the big tiles already trip the 12 s cap at -O1). Cost with coarse buckets
+   (accumulator type × tile-area band) and K=1–2 is roughly +10–30% collection wall time — acceptable on rented
+   collection boxes; before implementing, size K and the bucket definition by replaying the rule against the
+   existing autotune DB's -O1 rows (read-only, no GPU) to count the extra re-benches it would have triggered.
+2. **Fresh post-swizzle collection sweeps; retire the poisoned checkpoints.** *(STATUS 2026-07-23: the ε-greedy
+   sweep as specified here is OBSOLETE — collection is now the three-slice golden-anchored sweep (Update
+   2026-07-23), which replaces both this item's mechanism and its bias complaint. First stratified 4090 run done
+   07-23; the 5090 sweep and the poisoned-checkpoint retirement remain open.)* *(STATUS 2026-07-15: partial — one
+   plain-tune 4090 store exists locally (see the Update section); the ε-greedy sweeps and the 5090 side remain.)*
+   The node store has NO post-swizzle
+   measurements and the cp.async slab swizzle moved the fm optima (07-12 4090 refresh: "a region no prior trained
+   on old data would revisit"); the 5090 sweep checkpoint (`_tune/golden-sweep-5090/prior.json`) is trained on the
+   pre-purge fake rewards and must not be reused (already flagged in the assumptions above). After item 1 lands:
+   one ε-greedy `collect-node-data` sweep per card (4090 + 5090 at minimum), then discard or predicate-filter the
+   poisoned checkpoint. These sweeps produce both the Phase-3 freeze contents and the -O1/-O3 measurement pairs
+   item 4 trains on.
+3. **Phase-4 gate addition: the gemma-4 goldens are the held-out unseen-shape acceptance set.** *(SUPERSEDED
+   2026-07-15: the #364 refit trained on them — spent; ~~the next new model's goldens replace them~~. Corrected
+   2026-07-23: no unseen golden acceptance set exists — the gate is the k-fold holdout during training, see the
+   07-15 Update bullet as corrected.)* They were recorded
+   manually (07-13, 5090 + 4090 files), never trained on, and are the first goldens off the h4096 shape family —
+   "rank the gemma entries well from a fit that never saw gemma shapes" is exactly the generalization test whose
+   absence let the incumbent process score 27/28 top-1 while cold greedy misdeployed every unseeded gemma shape
+   (kv_proj ~770× off, two shapes picking hangs). Do NOT re-run the incumbent `golden_knob_heuristics` refit as a
+   stopgap — it was attempted and rejected on 07-12 (top-1 27→20, one shape to rank 3449); the Phase-4 fitter with
+   held-out folds is the only sanctioned refit path.
+4. **New artifact: the -O1→-O3 offset model.** *(STATUS 2026-07-23: the model is still untouched, but its
+   training data now arrives by construction — the collection sweep benches each point at both opt levels with a
+   shared knob set, joinable on `op_sig` + tunables, and the pairs are NOT band-censored since the sweep never
+   routes through the tuner's -O1 band.)* *(STATUS 2026-07-15: untouched; the 4090 sweep store adds fresh
+   -O1/-O3 pairs for the retrodiction test, still band-censored until item 1 lands.)* A small model (same
+   featurization, same freeze/fit pipeline — one
+   more cell in the Phase-4 fitter matrix) trained on same-config measurement pairs, label = log(-O3/-O1) latency
+   ratio. The ratio is dimensionless, so it transfers across shapes and cards, and most absolute-latency variance
+   cancels out of it. Go/no-go before any integration work: retrodiction — trained on pre-07-12 pairs only, it
+   must place the big-tile f16-accumulate family into the re-bench band; if it fails, run one more item-2 sweep
+   and refit before proceeding. Integration points, in payoff order:
+   - **The -O3 re-bench gate**: rank candidates for the deployable re-bench by offset-corrected -O1 (measured -O1 ×
+     predicted ratio), not raw -O1 — this is where the inversion actually gets fixed. Item 1's unconditional
+     per-family floor stays regardless, so the offset never gates its own training data.
+   - **PUCT selection**: a multiplicative term on the prior score via the `FallbackPrior` dimensionless-multiplier
+     convention (neutral 1.0) — steering only, so a wrong offset costs wasted benches, never wrong data.
+   - **Training-label translation**: convert the -O1-rich node labels into estimated deploy-regime labels for
+     offline-prior ranking groups, weighted down as model-corrected rather than measured.
+   Hard rules: never fold the offset into observed rewards / Q-values — measurements stay ground truth; and the
+   offset is the SOLE owner of cross-regime translation (keep the priors regime-conditional via per-`(pool, H_opt)`
+   grouping, decision 7) so the learned `H_opt` feature and the offset never double-correct.
+
+5. **Golden-neighborhood sweep collector (added 2026-07-15).** The 07-12 manual `--ab` sweeps found the fm-lane
+   optima, but NONE of those ~120 pinned benches reached the node store: the tune engine (`two_level.py` →
+   `record_nodes`) is the table's only writer — `run --bench --ab/--golden` results go to the printed table and
+   `--json` only. So the region around each golden stays censored in the training data even after the goldens
+   themselves join training (decision 5 as reversed) — one verified point, no neighborhood. Fix: a repeatable
+   collector that benches each golden's knob neighborhood and records it. Preferred mechanism (investigated
+   2026-07-15): a script that (1) enumerates the shape's offer space via `golden_eval.enumerate_graph` (gate pinned
+   for fm goldens), (2) filters to rows differing from the golden's `stamp_schedule_families` spelling in ≤ k
+   families (k≥2 — the fm headline was a joint atom × geometry move a k=1 star misses), (3) benches pinned at -O3
+   via the `_bench_golden_variants` harness (pin-match + intensity-floor + wrong-answer flags for free), and
+   (4) writes leaf `NodeRow`s through `record_nodes` with a dedicated `run_id` (freeze picks them up unchanged;
+   -O3 labels dodge the item-1 lane inversion by construction). Zero-code alternative for a first campaign:
+   per-family pinned-subspace tunes (`EMMY_KNOBS="<all but F pinned>" emmy tune --golden NAME --explore-eps 0.25`
+   with `EMMY_NVCC_FLAGS=""`), at higher GPU cost. ~1k benches ≈ a day on one rented card for the full golden set.
+   **SETTLED 2026-07-15 — the recorder is `run --bench` itself, DEFAULT-ON behind a quality bar.** Whenever a
+   bench meets the tuner's measurement standard (warmup/iters at the tune bench level; an opt-out flag covers the
+   rest), `run --bench` records into the canonical node store: every clean pinned golden/`--ab` row as an `ok`
+   leaf; a realized config's compile/launch failure as a `bench_fail` negative; and the greedy pick itself via its
+   `greedy (isolated)` re-bench (branch `feature/greedy-isolated-rebench` — re-benches the greedy graph emmy-only
+   through the same pinned-row worker, so the number is pinned-comparable; the documented ~7% skew was measurement
+   position, not config), which makes every benched pool self-anchoring: the prior's argmax gets a measured value
+   (the bench-the-argmax anchor for unconditional regret). Never recorded: `pin_unmatched` rows (the claimed
+   config never ran; "not offered" is not "doesn't launch"), wrong-answer- or intensity-floor-flagged rows, and
+   the whole `--ir` path (serialization drops `op.knobs` — no honest feature dict). Rows are parentless deployable
+   -O3 leaves keyed with the tune's own recipes (same pools), `run_id` `bench-<UTC ts>`. Write protection beyond
+   the plausibility gate: `record_nodes` gains quality-aware leaf replacement — a materially lower-quality
+   measurement (fewer `n_samples`, higher variance) never replaces a stored leaf; newest-wins among comparable
+   quality (keep-min stays wrong for leaves: min over re-measurements noise-mines, and a fake-fast row would be
+   unrepairable). With this, the neighborhood collector reduces to spec steps (1)–(3) driving
+   `run --bench --golden NAME --ab … --json`; step (4) is the default recorder. **LANDED 2026-07-15** (this
+   branch; the isolated re-bench merged as #376): `search/bench_record.py` (offer-site pool keying via
+   `source_chain` — validated byte-identical against the store's tune-written `op_sig`s; whole-variant leaf per
+   site), the `run --bench` default-on wiring (`--no-record-nodes` opts out), and `record_nodes`' quality-aware
+   leaf replacement. **GPU-verified 2026-07-16 on a rented CloudRift 4090**, which caught one real bug (fixed +
+   regression-tested): the mma tile-lowering preserves no `LoopOp` in `.source`, so the loop-only offer-site
+   predicate silently dropped every tensor-core kernel — a golden sweep recorded zero rows; the tile-dialect
+   fallback digests to the identical tune `op_sig`. Quality guard, opt-out/quality-bar, freeze pickup, and the
+   leaf-only eval degrade all passed on-device. A second on-device pass caught and fixed two more: (a) the split-K
+   COMBINE kernel carries no `S_*` provenance anywhere in its chain, so it was silently dropped and the leaf held
+   a partial-only value (~14% fast-biased vs the tune's whole-slice leaves in the same pool) — orphan kernels now
+   attribute to their nearest sited producer through the graph edges, verified on the 4090 (leaf 8.71 → 10.18 µs
+   = the kernel table's sum); (b) the record confirmation was `logger.info`, invisible at `emmy run`'s default
+   WARNING verbosity — a default-on DB write must announce itself, so the record-nodes notices print like the
+   rest of the bench output. Known deviation: bench rows key under the probe context, which is a DIFFERENT
+   `context_key` than the tune's -O3 re-bench context (flag-spelling difference; same `H_opt=3.0`) — grouping per
+   `(pool, H_opt)` is unaffected, but a bench row never dedups against its tune -O3 twin; fix would be
+   compile-flag canonicalization in `Context.structural_key`, deferred.
+   **STATUS 2026-07-23: the collector spec above SHIPPED and then GREW into the whole collection strategy.**
+   Steps (1)–(3) landed as `scripts/golden_neighbor_bench.py` driving `run --bench --golden/--ab --json` (base
+   collector merged #414); step (4) is the default recorder as settled. It then absorbed the rest of collection:
+   the own-neighborhood star became one of three slices (own / cross-card exchange / uniform tail), sampling went
+   kind-stratified, runs became ledger-resumable across boxes, and the ε-greedy tune phase it was meant to
+   *supplement* was retired outright — full detail in the Update 2026-07-23 section.
+
+The golden A/B harness fixes decided alongside these (bench survives a greedy-row bench_fail; a pin matching no
+offered row fails loudly; recorder-side schedule-family stamping; the dynM FLOP-floor overcount) are NOT part of
+this plan — they land independently on `feature/golden-ab-harness-fixes`.
+
+## Open questions and assumptions
+
+Assumptions (verify early, Phase 3–4):
+- ~~The merged fleet node DB has enough leaf volume/coverage at the current `feat_ver`~~ **VERIFIED FALSE
+  (2026-07-06 audit)**: the local store (`~/.cache/deplodock/autotune.db`) holds 23,971 nodes / ~536 multi-child
+  forks across RTX 4090 + RTX 5090 — structurally enough — but 100% in the retired pre-tile-IR-rebuild knob
+  vocabulary (`SPLIT@a0`, old `REDUCE` codec; pre-enrichment schema → migrates to `feat_ver=1`, fully quarantined
+  at `FEATURIZER_VERSION=2`). No `prior.json` checkpoint exists locally either. Consequence: fresh ε-greedy
+  collection sweeps are a hard prerequisite for every nodes-based step (Phase 1 baseline regret, Phase 3 freeze,
+  Phase 4 training); golden-based metrics are unaffected (live enumeration + committed goldens).
+  **RESOLVED 2026-07-09: two ε-greedy `collect-node-data` sweeps landed** — 16,958 `feat_ver=2` rows / 6,036 leaves
+  (6,009 ok + 27 `bench_fail`, 39% at `H_opt=3`) across RTX 4090 + RTX 5090, 42–43 op_sigs, 4 context regimes.
+  Nodes-based phases are unblocked for these two cards; the old "-O3 rows are scarce" worry is moot (the deployable
+  re-bench lane produces plenty). ~~CAVEAT: the 5090 rows include degenerate-fast leaves~~ **ROOT-CAUSED AND FIXED
+  (2026-07-10)**: the impossible leaves were pre-#330 split-K variants whose over-budget staged main kernel was
+  rejected at materialize — the bench saw only the shared combine kernel and cache-hit its ~9 µs row as the whole
+  matmul (`ok`), min-propagated up the ancestries. #330 killed the mechanism; `SearchDB.record_nodes` now gates
+  every write on physical plausibility (`implausible_value_reason` — work certified by the stamp identity
+  `S_loop_depth == n_free + n_reduce + n_symbolic`, which exactly separates contraction/reduce kinds from
+  norm/softmax/attention where free×red overcounts), and `scripts/purge_node_store.py` purged the local store
+  (44 leaves + 129 dead branches deleted, 19 branch bounds repaired). Post-purge the node metrics are trustworthy
+  on BOTH cards: 5090 TILE fork regret 11.49× → 2.70×, reachability mean 10.96× → 1.73×, calibration +0.59
+  (with the 2026-07-09 arch-features refit in place); 4090 TILE 2.24×, reachability mean 1.31×. Phase 3's freeze
+  sanity filter can now simply reuse `implausible_value_reason`. A residual small-shape class needed a SECOND
+  predicate (`impossible_kernel_reason`): on `square.512.dynM` the combine-only ~2 µs implied a *legal* 133 TFLOP/s,
+  so only kernel validity catches it — a cp.async-staged slab over the card's dynamic-smem cap cannot have launched
+  (8 more rows purged; the 512² regret denominators are honest now, learned reachability there 11.76× → 2.89×).
+  **Follow-ups from the 2026-07-10 clean-data regret run (analytic + both sweep-trained checkpoints):**
+  - **The 5090 sweep checkpoint (`_tune/golden-sweep-5090/prior.json`) is itself poisoned** — trained on the fake
+    rewards, it still steers into the purged region: TILE fork regret 379.9× (qkv.dynM) / 524.4× (mlp_down.dynM)
+    on an otherwise-healthy 1.89× median. Do NOT reuse it; retrain from clean data (next sweep, or filter its
+    reservoir with the shared predicates). The 4090 checkpoint shows no spikes (TILE worst 2.73×).
+  - **The learned prior's reservoir feed (`record_bench` / `add_rows`) bypasses the node-store gate** — the bug
+    mechanism is dead (#330), but the training path has no plausibility defense-in-depth; add one when touching
+    the online loop (needs the card identity, which the reservoir rows don't carry today).
+  - **The now-real analytic targets, by size:** structural PLACE on small matmuls (5090 128²/64² at 5.5×/4.2× —
+    the keep-vs-cut pricing the learned model gets right at 1.03×), WSPEC 2.91×, the TILE/REDUCE K-heavy residuals
+    (mlp_down family 4.4–5.3× TILE with 2.5× REDUCE co-misses), and the 5090 512² TILE (7.1×).
+  - **Learned cross-card transfer quantified**: own-card TILE 1.48×/1.89× degrades to ~2.0× judging the other card,
+    calibration +0.90/+0.77 → ~+0.5 — the decision-11 `H_* × knob` interaction gap, now with clean numbers.
+- Known gap inherited from today: the reduce/pointwise tiers enumerate zero rows through the live-fork capture
+  (`analytic.py`'s own comment) — path-descent/golden eval coverage for those tiers is limited until that's fixed.
+- CatBoost's JSON model dump is stable enough to mechanically collapse a stump ensemble into the tier-2 table.
+
+Open questions (each owned by its phase's detail discussion):
+- Phase 3 (settled by the 2026-07-09 rescope): format is trivial and regenerable, no size caps / per-regime budgets
+  (keep everything), no staleness policy v1 (the DB keeps newest-per-leaf, re-freezing IS the refresh; codegen drift
+  stays on the data-event clock).
+- Phase 4: exact ranking loss (YetiRank vs QueryRMSE vs PairLogit — whichever wins, the linear freeze trainer mirrors
+  the same pairwise formulation, decision 13), depth-weighting scheme, masking rate p and replica
+  count K, monotone-constraint list (features + directions), tier-1 depth/regularization budget. Also golden-shape
+  leakage: `collect-node-data` tunes the golden dataset, so the freeze's pools ARE the golden shapes' pools (the
+  golden config itself may sit there as an ordinary leaf) and the gate's golden rank partly measures memorization —
+  arguably fine for a cold-start prior, but decide deliberately; report golden rank both ways (full-train artifact vs
+  the leave-that-op-out fold artifact) so memorization vs generalization stays visible.
+- Phase 5: artifact location/format in-repo (base64 JSON vs `.cbm` binary — diff noise vs size), the exp-squash scale /
+  normalization for the neutral-1.0 contract, how tier-1 quarantine composes with the learned prior's `trustworthy`
+  (three-model precedence in `FallbackPrior` — needs a small design note).
+- Phase 6: pair-term whitelist beyond the decision-11 seeds (atomic-free × split-width + the arch×knob terms); bin
+  cap per shape function (legibility budget); whether tier 2 should instead select among per-`H_tc_gen` tables (the
+  5090 report's "per-arch weight set" recommendation) — equivalent expressiveness, different legibility trade.
+- Phase 8: promotion thresholds (golden median rank, per-family sibling regret — hardest on shallow families,
+  ablation-collapse tolerance); where the gate runs (CI-only vs also at artifact load).
+- Phase 9: do it as part of this effort or defer; low-risk either way now — the freeze header reserves both version
+  axes from day one (see phase 9), so deferring costs no format migration.
+
+Needs further discussion / planning (beyond per-phase details):
+- Freeze refresh + DB backup cadence and ownership — what triggers a golden re-tune + sweep (tie to the tune-golden
+  skill?); where the durable off-laptop copy of the node DB lives (decision 5's durability note).
+- Whether the tier-1 artifact should ALSO warm-start the learned prior's reservoir on fresh machines (out of scope
+  here, but the freeze makes it possible — flag when designing Phase 4).
+- Golden set growth: the acceptance gate is only as good as golden coverage (flash forks, WSPEC, structural splits
+  have no goldens today). Decide whether golden expansion is a prerequisite for trusting the gate or a parallel track.

--- a/scripts/freeze_node_store.py
+++ b/scripts/freeze_node_store.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python
-"""Freeze the autotune DB's ``node`` table into one digest-pinned JSONL file.
+"""Freeze the autotune DB's ``node`` table into a digest-pinned per-GPU YAML directory.
 
 The node DB is a live store (tunes and merges write into it), so a prior fit from it is
 not reproducible. This wraps the tested core
 :func:`emmy.compiler.pipeline.search.data.freeze.write_freeze`: read the DB read-only,
-keep every leaf in the current featurizer vocabulary that passes the plausibility
-predicates (``bench_fail`` leaves kept as negatives; branch rows never freeze), write
-one JSONL file — a provenance header line, then one row per leaf — whose sha256 pins
-exactly which measurements a fit saw. Freezing the same DB twice yields the same digest.
+keep every identity-carrying leaf in the current featurizer vocabulary that passes the
+plausibility predicates (``bench_fail`` leaves kept as negatives; branch rows and
+identity-less legacy rows never freeze), and write a freeze DIRECTORY mirroring the
+``goldens/`` layout — one golden-spelled YAML per (gpu, compute_cap) plus a
+``manifest.json`` whose sha256s pin exactly which measurements a fit saw. Freezing the
+same DB twice yields the same digests.
 
     ./venv/bin/python scripts/freeze_node_store.py                    # freeze the local store
-    ./venv/bin/python scripts/freeze_node_store.py --db /path/autotune.db --out /path/freeze.jsonl
-    ./venv/bin/python scripts/freeze_node_store.py --note "eps-greedy 0.25 sweeps, 4090+5090"
+    ./venv/bin/python scripts/freeze_node_store.py --db /path/autotune.db --out /path/freeze/
+    ./venv/bin/python scripts/freeze_node_store.py --note "three-slice sweep, 4090+5090"
 
 The source DB is never modified. Evals accept the freeze wherever they accept the DB:
-``emmy eval online --dataset nodes --db <freeze.jsonl>``.
+``emmy eval online --dataset nodes --db <freeze-dir>``.
 """
 
 from __future__ import annotations
@@ -32,23 +34,23 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")  # surface the drop-reason tally
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--db", help="Autotune DB to freeze (default: EMMY_TUNE_DB or ~/.cache/emmy/autotune.db).")
-    p.add_argument("--out", help="Freeze file to write (default: <db-stem>-freeze.jsonl next to the DB).")
-    p.add_argument("--note", default="", help="Freeform collection-policy note stamped into the header.")
+    p.add_argument("--out", help="Freeze directory to write (default: <db-stem>-freeze/ next to the DB).")
+    p.add_argument("--note", default="", help="Freeform collection-policy note stamped into the manifest.")
     args = p.parse_args()
 
     db_path = Path(args.db).expanduser() if args.db else resolve_tune_db()
     if not db_path.exists():
         p.error(f"no autotune DB at {db_path}")
-    out = Path(args.out).expanduser() if args.out else db_path.with_name(f"{db_path.stem}-freeze.jsonl")
+    out = Path(args.out).expanduser() if args.out else db_path.with_name(f"{db_path.stem}-freeze")
 
-    header = write_freeze(db_path, out, note=args.note)
-    counts = header["counts"]
+    manifest = write_freeze(db_path, out, note=args.note)
+    counts = manifest["counts"]
     per_gpu = ", ".join(f"{gpu or '(unknown card)'}: {n}" for gpu, n in counts["per_gpu"].items())
     print(f"[freeze_node_store] froze {counts['rows']} leaf row(s) ({counts['ok']} ok + {counts['bench_fail']} bench_fail) from {db_path}")
     print(f"[freeze_node_store]   per card: {per_gpu}")
-    print(f"[freeze_node_store]   commit {header['repo_commit']}, {len(header['run_ids'])} run id(s)")
-    print(f"[freeze_node_store]   sha256 {header['sha256']}")
-    print(f"[freeze_node_store]   -> {out}")
+    print(f"[freeze_node_store]   commit {manifest['repo_commit']}, {len(manifest['run_ids'])} run id(s)")
+    print(f"[freeze_node_store]   sha256 {manifest['sha256']} over {len(manifest['files'])} per-GPU file(s)")
+    print(f"[freeze_node_store]   -> {out}/")
 
 
 if __name__ == "__main__":

--- a/scripts/golden_neighbor_bench.py
+++ b/scripts/golden_neighbor_bench.py
@@ -224,6 +224,7 @@ class ShapeGroup:
     snippet: str
     dynamic_specs: list[str]
     fast_math: bool  # any anchor entry is fast-math → pin the fm enumeration gate
+    shape_spec: dict  # declarative identity passed to emmy run --record-shape (see shape_spec_of)
     names: list[str] = field(default_factory=list)  # golden entry names, for --filter / logs
     points: list[tuple[str, str, str]] = field(default_factory=list)  # (point_key, spec, slice)
 
@@ -240,6 +241,16 @@ def _group_id(kind: str, g, base_fields: frozenset[str]) -> str:
         return f"M{g.M}xN{g.N}xK{g.K}_{g.dtype}{dyn}{tb}"
     parts = "_".join(f"{f.name}{getattr(g, f.name)}" for f in fields(type(g)) if f.name not in base_fields)
     return f"{kind}_{parts}" + ("_dyn" if g.dynamic else "")
+
+
+def shape_spec_of(kind: str, g, base_fields: frozenset[str]) -> dict:
+    """The group's declarative identity for ``emmy run --record-shape`` — the golden YAML
+    entry spelling minus knobs/latencies: ``kernel`` + every kind-own shape field (all
+    written explicitly) + ``dynamic``. Safe to build from any one golden in the group:
+    ``_group_id`` derives from exactly these fields, so a group's entries spell the
+    identical spec (they differ only in knobs/latencies/card)."""
+    own = {f.name: getattr(g, f.name) for f in fields(type(g)) if f.name not in base_fields}
+    return {"kernel": kind, **own, "dynamic": g.dynamic}
 
 
 def build_groups(max_dist: int, name_filter: str | None, tail_cap: int) -> tuple[list[ShapeGroup], str]:
@@ -328,6 +339,7 @@ def build_groups(max_dist: int, name_filter: str | None, tail_cap: int) -> tuple
                 snippet=rep.snippet(),
                 dynamic_specs=rep.dynamic_specs(),
                 fast_math=fast_math,
+                shape_spec=shape_spec_of(kind, rep, base_fields),
                 names=names,
                 points=points,
             )
@@ -353,6 +365,9 @@ def run_batch(group: ShapeGroup, specs: list[str], opt: str, args, receipt: Path
     cmd = [args.emmy, "run", "--code", group.snippet, "--bench", "--bench-backends", "emmy"]
     cmd += ["--warmup", str(args.warmup), "--iters", str(args.iters)]
     cmd += ["--nvcc-flags", OPT_FLAGS[opt], "--json", str(receipt)]
+    # Declarative identity: recorded rows matching this shape carry it as shape_spec —
+    # the goldens-format measurement freeze keeps only identity-carrying rows.
+    cmd += ["--record-shape", json.dumps(group.shape_spec, sort_keys=True)]
     for d in group.dynamic_specs:
         cmd += ["--dynamic", d]
     for s in specs:

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -13,7 +13,7 @@ tests/
 ├── test_hardware.py         # emmy.hardware (top-level module)
 ├── test_redact.py           # emmy.redact (secret redaction)
 ├── test_new_models.py       # scripts/new_models.py (model discovery: base-key match, dedup, arena linking)
-├── test_golden_neighbor_bench.py # scripts/golden_neighbor_bench.py (knob distance, point keys, slice assignment/shares, sampling, resume ledger)
+├── test_golden_neighbor_bench.py # scripts/golden_neighbor_bench.py (knob distance, point keys, slice assignment/shares, sampling, resume ledger, shape specs)
 ├── benchmark/
 │   ├── test_bench_dryrun.py # bench CLI dry-run
 │   ├── test_code_hash.py    # BenchmarkTask.compute_code_hash()

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -370,28 +370,38 @@ def test_prior_nodes_smoke(run_cli, tmp_path):
 
 
 def test_prior_nodes_accepts_freeze_path(run_cli, tmp_path):
-    """``eval online --dataset nodes --db`` takes a measurement freeze interchangeably
-    with the live DB (``load_node_rows`` sniffs which it got). Only the two leaves
-    survive the leaf-only freeze filter, and the loaded rows carry no tree schema —
-    the report degrades gracefully to the leaf metrics instead of inventing forks."""
+    """``eval online --dataset nodes --db`` takes a measurement freeze (a per-GPU YAML
+    directory) interchangeably with the live DB (``load_node_rows`` sniffs which it
+    got). Only the two identity-carrying leaves survive the freeze filter (the branch
+    row never freezes), and the loaded rows carry no tree schema — the report degrades
+    gracefully to the leaf metrics instead of inventing forks."""
     from emmy.compiler.pipeline.search.data.freeze import write_freeze
     from emmy.compiler.pipeline.search.db import NodeRow, SearchDB
 
     db_path = tmp_path / "n.db"
     db = SearchDB(db_path)
-    s = {"S_ext_free_prod": 1024.0, "S_reduce_add": 1.0, "S_pw_multiply": 1.0, "S_n_distinct_input": 2.0}
+    spec = {"kernel": "matmul", "M": 64, "N": 64, "K": 64, "dtype": "fp32", "trans_b": False, "dynamic": False}
+    s = {
+        "H_cc": 120.0,
+        "H_opt": 3.0,
+        "S_ext_free_prod": 1024.0,
+        "S_reduce_add": 1.0,
+        "S_pw_multiply": 1.0,
+        "S_n_distinct_input": 2.0,
+    }
+    gpu = "NVIDIA GeForce RTX 5090"
     db.record_nodes(
         [
-            NodeRow("P", None, "ctx", "mm", s, 1.0, 1, is_leaf=False),
-            NodeRow("c8", "P", "ctx", "mm", {**s, "BN": 32, "BM": 8}, 1.0, 2, is_leaf=True),
-            NodeRow("c64", "P", "ctx", "mm", {**s, "BN": 32, "BM": 64}, 3.0, 2, is_leaf=True),
+            NodeRow("P", None, "ctx", "mm", s, 1.0, 1, gpu=gpu, is_leaf=False),
+            NodeRow("c8", "P", "ctx", "mm", {**s, "BN": 32, "BM": 8}, 1.0, 2, gpu=gpu, is_leaf=True, shape_spec=spec),
+            NodeRow("c64", "P", "ctx", "mm", {**s, "BN": 32, "BM": 64}, 3.0, 2, gpu=gpu, is_leaf=True, shape_spec=spec),
         ]
     )
     db.close()
-    freeze_path = tmp_path / "freeze.jsonl"
-    write_freeze(db_path, freeze_path)
+    freeze_dir = tmp_path / "freeze"
+    write_freeze(db_path, freeze_dir)
     rc, stdout, stderr = run_cli(
-        "eval", "online", "--dataset", "nodes", "--db", str(freeze_path), "--online-file", str(tmp_path / "missing.json")
+        "eval", "online", "--dataset", "nodes", "--db", str(freeze_dir), "--online-file", str(tmp_path / "missing.json")
     )
     assert rc == 0, f"stderr: {stderr}"
     assert "=== offline prior" in stdout

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -211,6 +211,13 @@ def test_run_ab_rejects_malformed_spec(run_cli):
     assert "missing '='" in (stdout + stderr)
 
 
+def test_run_record_shape_rejects_bad_spec(run_cli):
+    """``--record-shape`` fails fast (before any compile/bench spend) on an invalid spec."""
+    rc, stdout, stderr = run_cli("run", "--code", "torch.zeros(4)", "--record-shape", '{"kernel": "warp_drive"}')
+    assert rc == 2
+    assert "unknown kernel kind" in (stdout + stderr)
+
+
 def test_ab_samples_parse_label_and_shape():
     """``_ab_samples`` parses each spec with the ``EMMY_KNOBS`` grammar, labels
     the row with the raw spec, and marks it shapeless (the ``_print_kernel_stats``

--- a/tests/compiler/pipeline/search/test_bench_record.py
+++ b/tests/compiler/pipeline/search/test_bench_record.py
@@ -18,6 +18,7 @@ from emmy.compiler.pipeline.search.bench_record import (
     bench_leaves,
     meets_quality_bar,
     mint_bench_run_id,
+    parse_record_shape,
     record_bench_leaves,
 )
 from emmy.compiler.pipeline.search.data.freeze import freeze_reason
@@ -143,7 +144,7 @@ def test_record_round_trip_into_node_store(compiled_matmul, tmp_path) -> None:
     ctx = Context.from_target((12, 0), gpu_name=_GPU)
     leaves = bench_leaves(compiled_matmul, _fake_bench(_n_cuda_kernels(compiled_matmul), time_ms=0.5))
     db_path = tmp_path / "tune.db"
-    n = record_bench_leaves(db_path, ctx, leaves)
+    n = record_bench_leaves(db_path, ctx, leaves, shape=parse_record_shape(_MM_SPEC))
     assert n == len(leaves)
     db = SearchDB.open_readonly(db_path)
     try:
@@ -164,7 +165,7 @@ def test_record_round_trip_into_node_store(compiled_matmul, tmp_path) -> None:
 def test_record_fail_leaf_kept_as_negative(compiled_matmul, tmp_path) -> None:
     ctx = Context.from_target((12, 0), gpu_name=_GPU)
     leaves = bench_leaves(compiled_matmul, None, status="bench_fail")
-    record_bench_leaves(tmp_path / "tune.db", ctx, leaves)
+    record_bench_leaves(tmp_path / "tune.db", ctx, leaves, shape=parse_record_shape(_MM_SPEC))
     db = SearchDB.open_readonly(tmp_path / "tune.db")
     try:
         rows = list(db.iter_nodes())
@@ -178,6 +179,65 @@ def test_quality_bar_and_run_id() -> None:
     assert meets_quality_bar(5, 20) and meets_quality_bar(10, 100)
     assert not meets_quality_bar(4, 100) and not meets_quality_bar(10, 19)
     assert mint_bench_run_id().startswith("bench-")
+
+
+# ---------------------------------------------------------------------------
+# --record-shape: spec parsing + the per-leaf identity gate
+# ---------------------------------------------------------------------------
+
+_MM_SPEC = '{"kernel": "matmul", "M": 512, "N": 512, "K": 512, "dtype": "fp16", "trans_b": false, "dynamic": false}'
+
+
+def test_parse_record_shape_round_trips_through_kind_class() -> None:
+    from emmy.compiler.pipeline.search.data.shape import ShapeKey
+
+    rs = parse_record_shape(_MM_SPEC)
+    assert rs.spec["kernel"] == "matmul" and rs.spec["M"] == 512
+    assert rs.key == ShapeKey.from_matmul(512, 512, 512, "fp16")
+
+
+@pytest.mark.parametrize(
+    ("text", "match"),
+    [
+        ("not json", "not valid JSON"),
+        ('["matmul"]', 'JSON object with a "kernel" field'),
+        ('{"kernel": "warp_drive"}', "unknown kernel kind"),
+        ('{"kernel": "matmul", "M": 512}', "invalid 'matmul' spec"),  # missing N/K
+    ],
+)
+def test_parse_record_shape_rejects_bad_specs(text: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        parse_record_shape(text)
+
+
+def test_record_shape_tags_matching_leaves(compiled_matmul, tmp_path) -> None:
+    """The benched op's stamped extents key to the spec's ShapeKey → the leaf carries the
+    declarative identity, spelled exactly as passed."""
+    ctx = Context.from_target((12, 0), gpu_name=_GPU)
+    leaves = bench_leaves(compiled_matmul, _fake_bench(_n_cuda_kernels(compiled_matmul), time_ms=0.5))
+    record_bench_leaves(tmp_path / "tune.db", ctx, leaves, shape=parse_record_shape(_MM_SPEC))
+    db = SearchDB.open_readonly(tmp_path / "tune.db")
+    try:
+        rows = list(db.iter_nodes())
+    finally:
+        db.close()
+    assert rows and all(r.shape_spec == parse_record_shape(_MM_SPEC).spec for r in rows)
+
+
+def test_record_shape_mismatch_stays_identity_less_and_warns(compiled_matmul, tmp_path, caplog) -> None:
+    """A spec whose ShapeKey matches no benched leaf records identity-less rows (the
+    legacy treatment) and warns — silence must never read as a tagged sweep."""
+    wrong = parse_record_shape('{"kernel": "matmul", "M": 64, "N": 64, "K": 64, "dtype": "fp32", "trans_b": false, "dynamic": false}')
+    ctx = Context.from_target((12, 0), gpu_name=_GPU)
+    leaves = bench_leaves(compiled_matmul, _fake_bench(_n_cuda_kernels(compiled_matmul), time_ms=0.5))
+    with caplog.at_level("WARNING"):
+        record_bench_leaves(tmp_path / "tune.db", ctx, leaves, shape=wrong)
+    assert any("matched none" in r.message for r in caplog.records)
+    db = SearchDB.open_readonly(tmp_path / "tune.db")
+    try:
+        assert all(r.shape_spec is None for r in db.iter_nodes())
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/compiler/pipeline/search/test_data.py
+++ b/tests/compiler/pipeline/search/test_data.py
@@ -90,6 +90,38 @@ def test_golden_dynamic_compile_s_feats_mirror() -> None:
     assert ShapeKey.from_s_features(full) == s.shape
 
 
+def test_traced_s_features_matmul_parity_and_no_match() -> None:
+    """The kind-generic ``traced_s_features`` agrees with ``compiled_s_features`` on a
+    single-op matmul snippet (same trace, selection is a no-op there), and returns
+    ``None`` for a key no traced op matches — the caller's arith-fallback signal."""
+    from emmy.compiler.pipeline.search.data.sample import compiled_s_features, traced_s_features
+    from emmy.compiler.pipeline.search.golden import MatmulGoldenConfig
+
+    g = MatmulGoldenConfig(name="matmul.square.512", M=512, N=512, K=512, dtype="fp16")
+    traced = traced_s_features(g.snippet(), (), g.shape_key())
+    assert traced == compiled_s_features(512, 512, 512, "fp16", g.compute_cap)
+    assert traced_s_features(g.snippet(), (), ShapeKey.from_matmul(3, 5, 7, "fp32")) is None
+
+
+def test_traced_s_features_selects_the_keyed_op_in_multi_op_graphs() -> None:
+    """A ``linear_norm`` snippet traces a producer matmul BESIDE the norm op — the
+    selection must return the norm's histogram (the golden's key), not the matmul's
+    and not a cross-op merge."""
+    from emmy.compiler.pipeline.search.data.sample import traced_s_features
+    from emmy.compiler.pipeline.search.golden import LinearNormGoldenConfig
+
+    cfg = LinearNormGoldenConfig(name="ln.key", M=64, K=64, H=64, dtype="fp16")
+    traced = traced_s_features(cfg.snippet(), (), cfg.shape_key())
+    assert traced is not None
+    s = dict(traced)
+    op_key = ShapeKey.from_s_features(s)
+    assert op_key.kind == "rms_norm"  # the norm op, not the producer matmul
+    # The fp16-pure snippet flips the sweep op's dtype-derived is_warp (no f32 constants,
+    # unlike a served graph) — exactly what ShapeKey.joins tolerates for sweep kinds.
+    assert op_key.joins(cfg.shape_key())
+    assert not op_key.joins(ShapeKey.from_matmul(64, 64, 64, "fp16"))  # never the producer's key
+
+
 # --- Sample round-trips (the acceptance gates) ------------------------------
 
 

--- a/tests/compiler/pipeline/search/test_db.py
+++ b/tests/compiler/pipeline/search/test_db.py
@@ -383,6 +383,59 @@ def test_node_feat_ver_defaults_to_legacy_on_pre_stamp_db(tmp_path) -> None:
     assert n.feat_ver == 1
 
 
+_SPEC = {"kernel": "matmul", "M": 64, "N": 64, "K": 64, "dtype": "fp32", "trans_b": False, "dynamic": False}
+
+
+def test_record_nodes_shape_spec_roundtrips(tmp_path) -> None:
+    """The declarative identity round-trips as a dict; identity-less rows read back ``None``."""
+    db = SearchDB(tmp_path / "t.db")
+    db.record_nodes([_node_row("tagged", 5.0, shape_spec=_SPEC), _node_row("legacy", 6.0)])
+    by_key = {n.node_key: n for n in db.iter_nodes()}
+    assert by_key["tagged"].shape_spec == _SPEC
+    assert by_key["legacy"].shape_spec is None
+
+
+def test_shape_spec_readonly_pre_column_degrades(tmp_path) -> None:
+    """A read-only open of a pre-``shape_spec`` DB degrades the field to ``None`` (legacy)
+    rather than raising — the additive ALTER is writer-side only."""
+    path = tmp_path / "ro.db"
+    con = sqlite3.connect(path)
+    con.executescript(_PRE_GPU_NODE_SCHEMA)
+    con.commit()
+    con.close()
+    assert list(SearchDB.open_readonly(path).iter_nodes())[0].shape_spec is None
+
+
+def test_shape_spec_survives_identity_less_replacement() -> None:
+    """Identity is config-intrinsic: a newer identity-less leaf re-measurement replaces the
+    value but COALESCE keeps the stored ``shape_spec`` — freezability is never erased."""
+    db = SearchDB()
+    db.record_nodes([_node_row("n1", 5.0, is_leaf=True, measured_at="2026-07-01T00:00:00", shape_spec=_SPEC)])
+    db.record_nodes([_node_row("n1", 4.0, is_leaf=True, measured_at="2026-07-02T00:00:00")])
+    (n,) = list(db.iter_nodes())
+    assert n.value_us == 4.0  # newer measurement won
+    assert n.shape_spec == _SPEC  # identity kept
+
+
+def test_shape_spec_filled_by_non_replacing_row() -> None:
+    """A non-replacing identity-carrying bench (older measurement, value untouched) still
+    proves the config's shape: the NULL ``shape_spec`` fills in."""
+    db = SearchDB()
+    db.record_nodes([_node_row("n1", 5.0, is_leaf=True, measured_at="2026-07-02T00:00:00")])
+    db.record_nodes([_node_row("n1", 9.0, is_leaf=True, measured_at="2026-07-01T00:00:00", shape_spec=_SPEC)])
+    (n,) = list(db.iter_nodes())
+    assert n.value_us == 5.0  # stale measurement never resurrects
+    assert n.shape_spec == _SPEC  # but its identity lands
+
+
+def test_merge_nodes_carries_shape_spec(tmp_path) -> None:
+    src = SearchDB(tmp_path / "src.db")
+    src.record_nodes([_node_row("n1", 5.0, gpu="NVIDIA GeForce RTX 4090", shape_spec=_SPEC)])
+    dst = SearchDB(tmp_path / "dst.db")
+    assert dst.merge_nodes(tmp_path / "src.db") == 1
+    assert list(dst.iter_nodes())[0].shape_spec == _SPEC
+
+
 _PRE_GPU_NODE_SCHEMA = (
     "CREATE TABLE node (node_key TEXT PRIMARY KEY, parent_key TEXT, context_key TEXT NOT NULL, "
     "op_sig TEXT NOT NULL, features TEXT NOT NULL DEFAULT '{}', value_us REAL NOT NULL, "

--- a/tests/compiler/pipeline/search/test_freeze.py
+++ b/tests/compiler/pipeline/search/test_freeze.py
@@ -1,21 +1,32 @@
-"""The measurement freeze — leaf-only sanity filter, freeze-twice determinism, the
+"""The measurement freeze (v2) — the golden-spelled sanity filter, freeze-twice
+determinism over the per-GPU YAML directory, load-time feature re-derivation, the
 loader's hard-error contract, and the DB/freeze interchange seam (``load_node_rows``).
 
 The freeze is Phase 3 of the offline-prior rework: a fit must be a pure function of
 (repo, pinned data), so one command snapshots the live node DB into a digest-pinned
-JSONL file. These tests never touch a GPU — the plausibility physics itself is covered
-by ``test_node_gate.py``; here the fixtures only need one plausible and one implausible
-latency on a registry-known card."""
+directory of golden-spelled per-GPU YAML files. These tests never touch a GPU — the
+plausibility physics itself is covered by ``test_node_gate.py``; the specs here are
+small fp32 matmuls so the loader's snippet re-trace stays cheap (and lru-cached)."""
 
 from __future__ import annotations
 
-import dataclasses
+import hashlib
 import json
 
 import pytest
+import yaml
 
 from emmy.compiler.pipeline.search.data import Dataset
-from emmy.compiler.pipeline.search.data.freeze import FREEZE_KIND, FREEZE_VER, freeze_reason, load_freeze, load_node_rows, write_freeze
+from emmy.compiler.pipeline.search.data.freeze import (
+    FREEZE_KIND,
+    FREEZE_VER,
+    MANIFEST_NAME,
+    freeze_reason,
+    load_freeze,
+    load_node_rows,
+    write_freeze,
+)
+from emmy.compiler.pipeline.search.data.shape import ShapeKey
 from emmy.compiler.pipeline.search.db import SearchDB
 from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
 from tests.compiler.pipeline.search.conftest import GPU_5090 as _GPU
@@ -24,40 +35,79 @@ from tests.compiler.pipeline.search.conftest import node_row as _row
 
 _GPU2 = "NVIDIA GeForce RTX 4090"
 
+# Small declarative identities — the loader re-traces each DISTINCT shape once (cached).
+_SPEC_A = {"kernel": "matmul", "M": 64, "N": 64, "K": 64, "dtype": "fp32", "trans_b": False, "dynamic": False}
+_SPEC_B = {"kernel": "matmul", "M": 64, "N": 64, "K": 128, "dtype": "fp32", "trans_b": False, "dynamic": False}
+
+
+def _feats(*, opt: float = 3.0, cc: float = 120.0, **knobs) -> dict:
+    """Write-time features consistent with ``_SPEC_A``-sized shapes: the regime stamps the
+    freeze needs (``H_cc`` / ``H_opt``), plausible extents, and the tunable knobs that
+    must survive the round trip verbatim."""
+    return {
+        "H_cc": cc,
+        "H_opt": opt,
+        "S_ext_free_prod": 4096.0,
+        "S_ext_reduce_max": 64.0,
+        "S_ext_n_free_axis": 2.0,
+        "S_ext_n_reduce_axis": 1.0,
+        "S_loop_depth": 3.0,
+        "S_dtype_f32": 3.0,
+        "TILE": "n16x16/f2x2",
+        **knobs,
+    }
+
 
 # ---------------------------------------------------------------------------
 # freeze_reason — the sanity filter
 # ---------------------------------------------------------------------------
 
 
-def test_reason_keeps_plausible_ok_leaf() -> None:
-    assert freeze_reason(_row("k", value_us=500.0)) is None
+def test_reason_keeps_identity_carrying_ok_leaf() -> None:
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), shape_spec=_SPEC_A)) is None
 
 
 def test_reason_keeps_bench_fail_leaf_as_negative() -> None:
     # A fail's value_us is the watchdog sentinel — absurd as a latency, but the row is
     # a durable "doesn't build/launch here" negative and must freeze.
-    assert freeze_reason(_row("k", value_us=9.17, status="bench_fail")) is None
+    assert freeze_reason(_row("k", value_us=9.17, features=_feats(), shape_spec=_SPEC_A, status="bench_fail")) is None
+
+
+def test_reason_drops_identity_less_legacy_rows() -> None:
+    # THE legacy-exclusion mechanism: tune-written / pre-identity rows stay in the DB
+    # but can never spell a golden-format freeze row.
+    assert "no declarative identity" in freeze_reason(_row("k", value_us=500.0, features=_feats()))
+
+
+def test_reason_drops_rows_without_regime_stamps() -> None:
+    feats = {k: v for k, v in _feats().items() if k != "H_cc"}
+    assert "missing H_" in freeze_reason(_row("k", value_us=500.0, features=feats, shape_spec=_SPEC_A))
 
 
 def test_reason_drops_non_leaves() -> None:
-    assert freeze_reason(_row("k", value_us=500.0, is_leaf=False)) is not None
-    assert freeze_reason(_row("k", value_us=500.0, is_leaf=None)) is not None  # pre-enrichment unknown
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), shape_spec=_SPEC_A, is_leaf=False)) is not None
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), shape_spec=_SPEC_A, is_leaf=None)) is not None
 
 
 def test_reason_drops_stale_feat_ver() -> None:
-    assert freeze_reason(_row("k", value_us=500.0, feat_ver=FEATURIZER_VERSION - 1)) is not None
+    stale = FEATURIZER_VERSION - 1
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), shape_spec=_SPEC_A, feat_ver=stale)) is not None
     # ... including fail rows: a negative spelled in a retired vocabulary is unreadable too.
-    assert freeze_reason(_row("k", value_us=9.17, status="bench_fail", feat_ver=FEATURIZER_VERSION - 1)) is not None
+    assert freeze_reason(_row("k", value_us=9.17, features=_feats(), shape_spec=_SPEC_A, status="bench_fail", feat_ver=stale)) is not None
 
 
 def test_reason_drops_implausible_value() -> None:
-    assert "implausible value" in freeze_reason(_row("k", value_us=9.17))  # ~6500 TFLOP/s
+    # The conftest f16 mlp_down extents at 9.17 µs imply ~6500 TFLOP/s.
+    from tests.compiler.pipeline.search.conftest import F16_MATMUL_FEATS
+
+    feats = {"H_cc": 120.0, "H_opt": 3.0, **F16_MATMUL_FEATS}
+    assert "implausible value" in freeze_reason(_row("k", value_us=9.17, features=feats, shape_spec=_SPEC_A))
 
 
 def test_reason_drops_impossible_kernel() -> None:
     # The square.512 residue: over-cap cp.async slab -> legal-looking latency, invalid kernel.
-    assert "impossible kernel" in freeze_reason(_row("k", value_us=2.02, features=impossible_staged_feats()))
+    feats = {"H_cc": 120.0, "H_opt": 3.0, **impossible_staged_feats()}
+    assert "impossible kernel" in freeze_reason(_row("k", value_us=2.02, features=feats, shape_spec=_SPEC_A))
 
 
 # ---------------------------------------------------------------------------
@@ -72,65 +122,93 @@ def _seed_db(path, rows) -> None:
 
 
 _SEED = [
-    _row("leaf-a", value_us=500.0, op_sig="mm1", run_id="run-a"),
-    _row("leaf-b", value_us=480.0, op_sig="mm1", gpu=_GPU2, run_id="run-b"),
-    _row("leaf-fail", value_us=60000.0, op_sig="mm2", status="bench_fail", run_id="run-a"),
-    _row("branch", value_us=480.0, op_sig="mm1", is_leaf=False),
-    _row("leaf-stale", value_us=500.0, op_sig="mm1", feat_ver=FEATURIZER_VERSION - 1),
+    # _SPEC_A's -O3/-O1 twins on the 5090 — same declarative op, two lanes.
+    _row("leaf-a3", value_us=500.0, op_sig="mm1", features=_feats(), shape_spec=_SPEC_A, run_id="run-a"),
+    _row("leaf-a1", value_us=900.0, op_sig="mm1", features=_feats(opt=1.0), shape_spec=_SPEC_A, run_id="run-a"),
+    _row("leaf-b", value_us=480.0, op_sig="mm2", gpu=_GPU2, features=_feats(cc=89.0), shape_spec=_SPEC_B, run_id="run-b"),
+    _row("leaf-fail", value_us=60000.0, op_sig="mm2", features=_feats(), shape_spec=_SPEC_B, status="bench_fail", run_id="run-a"),
+    _row("branch", value_us=480.0, op_sig="mm1", features=_feats(), shape_spec=_SPEC_A, is_leaf=False),
+    _row("leaf-stale", value_us=500.0, op_sig="mm1", features=_feats(), shape_spec=_SPEC_A, feat_ver=FEATURIZER_VERSION - 1),
+    _row("leaf-legacy", value_us=500.0, op_sig="mm1", features=_feats()),  # no identity — never freezes
 ]
-_KEPT_KEYS = {"leaf-a", "leaf-b", "leaf-fail"}
+_N_KEPT = 4
 
 
 def test_write_freeze_round_trip(tmp_path) -> None:
     db_path = tmp_path / "autotune.db"
     _seed_db(db_path, _SEED)
-    out = tmp_path / "freeze.jsonl"
-    header = write_freeze(db_path, out, note="unit-test policy")
+    out = tmp_path / "freeze"
+    manifest = write_freeze(db_path, out, note="unit-test policy")
 
-    assert header["kind"] == FREEZE_KIND
-    assert header["freeze_ver"] == FREEZE_VER
-    assert header["feat_ver"] == header["knob_ver"] == header["encoding_ver"] == FEATURIZER_VERSION
-    assert header["counts"] == {"rows": 3, "ok": 2, "bench_fail": 1, "per_gpu": {_GPU2: 1, _GPU: 2}}
-    assert header["run_ids"] == ["run-a", "run-b"]
-    assert header["policy_note"] == "unit-test policy"
-    assert header["source_db"] == str(db_path.resolve())
+    assert manifest["kind"] == FREEZE_KIND
+    assert manifest["freeze_ver"] == FREEZE_VER
+    assert manifest["feat_ver"] == manifest["knob_ver"] == manifest["encoding_ver"] == FEATURIZER_VERSION
+    assert manifest["counts"] == {"rows": _N_KEPT, "ok": 3, "bench_fail": 1, "per_gpu": {_GPU2: 1, _GPU: 3}}
+    assert manifest["run_ids"] == ["run-a", "run-b"]
+    assert manifest["policy_note"] == "unit-test policy"
+    assert manifest["source_db"] == str(db_path.resolve())
+    # One YAML per (gpu, cap), goldens-style header + configs; nothing featurized persists.
+    assert set(manifest["files"]) == {"nvidia_geforce_rtx_5090_sm120.yaml", "nvidia_geforce_rtx_4090_sm89.yaml"}
+    doc = yaml.safe_load((out / "nvidia_geforce_rtx_5090_sm120.yaml").read_text())
+    assert doc["gpu_name"] == _GPU and doc["compute_cap"] == [12, 0]
+    assert all(set(c) & {"H_cc", "H_opt"} == set() for c in doc["configs"])
+    assert all(not any(k.startswith(("S_", "H_")) for k in c["knobs"]) for c in doc["configs"])
 
-    loaded_header, rows = load_freeze(out)
-    assert loaded_header == header
-    assert {r.node_key for r in rows} == _KEPT_KEYS
-    # Field-for-field identical to the DB's filter-passing leaves, minus the tree schema.
-    db = SearchDB.open_readonly(db_path)
-    try:
-        db_rows = {r.node_key: r for r in db.iter_nodes() if freeze_reason(r) is None}
-    finally:
-        db.close()
-    for r in rows:
-        assert r.parent_key is None and r.depth == 0 and r.visits == 0 and r.is_leaf is True
-        expected = dataclasses.replace(db_rows[r.node_key], parent_key=None, depth=0, visits=0)
-        assert r == expected
+    loaded_manifest, rows = load_freeze(out)
+    assert loaded_manifest == manifest
+    assert len(rows) == _N_KEPT
+    by_run_value = {(r.run_id, r.value_us): r for r in rows}
+    a3 = by_run_value[("run-a", 500.0)]
+    a1 = by_run_value[("run-a", 900.0)]
+    fail = by_run_value[("run-a", 60000.0)]
+    # The measurement extension block survives verbatim; identity is the declarative spec.
+    assert a3.shape_spec == _SPEC_A and a3.status == "ok" and a3.measured_at == "2026-07-09T00:00:00+00:00"
+    assert fail.shape_spec == _SPEC_B and fail.status == "bench_fail"
+    # Features are RE-DERIVED: card-faithful H_* (H_cc from the file cap), the opt lane
+    # from the row's own field, full traced S_* keying to the spec, tunables verbatim.
+    assert a3.features["H_cc"] == 120.0 and a3.features["H_opt"] == 3.0
+    assert a1.features["H_opt"] == 1.0
+    assert a3.features["TILE"] == "n16x16/f2x2"
+    assert ShapeKey.from_s_features(a3.features).joins(ShapeKey.from_matmul(_SPEC_A["M"], _SPEC_A["N"], _SPEC_A["K"], _SPEC_A["dtype"]))
+    assert a3.feat_ver == FEATURIZER_VERSION
+    # Treeless contract + identity keys: op_sig is the canonical spec JSON — the -O1/-O3
+    # twins share it (one fold-by-op group), distinct shapes never do.
+    assert all(r.parent_key is None and r.depth == 0 and r.visits == 0 and r.is_leaf is True for r in rows)
+    assert a3.op_sig == a1.op_sig == json.dumps(_SPEC_A, sort_keys=True, separators=(",", ":"))
+    assert a3.op_sig != fail.op_sig and a3.node_key != a1.node_key
     # The existing consumers work unchanged on freeze rows.
-    assert len(Dataset.from_node_rows(rows)) == 3
-    folds = Dataset.fold_node_rows(rows, by="gpu")
-    assert {g: len(rs) for g, rs in folds.items()} == {_GPU: 2, _GPU2: 1}
+    assert len(Dataset.from_node_rows(rows)) == _N_KEPT
+    assert {g: len(rs) for g, rs in Dataset.fold_node_rows(rows, by="gpu").items()} == {_GPU: 3, _GPU2: 1}
+    assert {sig: len(rs) for sig, rs in Dataset.fold_node_rows(rows, by="op").items()} == {a3.op_sig: 2, fail.op_sig: 2}
 
 
 def test_freeze_twice_same_digest(tmp_path) -> None:
     db_path = tmp_path / "autotune.db"
     _seed_db(db_path, _SEED)
-    h1 = write_freeze(db_path, tmp_path / "f1.jsonl")
-    h2 = write_freeze(db_path, tmp_path / "f2.jsonl")
-    assert h1["sha256"] == h2["sha256"]
-    tail1 = (tmp_path / "f1.jsonl").read_bytes().partition(b"\n")[2]
-    tail2 = (tmp_path / "f2.jsonl").read_bytes().partition(b"\n")[2]
-    assert tail1 == tail2  # only the header (created_at) may differ
+    m1 = write_freeze(db_path, tmp_path / "f1")
+    m2 = write_freeze(db_path, tmp_path / "f2")
+    assert m1["sha256"] == m2["sha256"]
+    assert m1["files"] == m2["files"]
+    for name in m1["files"]:
+        assert (tmp_path / "f1" / name).read_bytes() == (tmp_path / "f2" / name).read_bytes()
 
 
 def test_freeze_digest_insertion_order_independent(tmp_path) -> None:
     _seed_db(tmp_path / "fwd.db", _SEED)
     _seed_db(tmp_path / "rev.db", list(reversed(_SEED)))
-    h_fwd = write_freeze(tmp_path / "fwd.db", tmp_path / "fwd.jsonl")
-    h_rev = write_freeze(tmp_path / "rev.db", tmp_path / "rev.jsonl")
-    assert h_fwd["sha256"] == h_rev["sha256"]
+    m_fwd = write_freeze(tmp_path / "fwd.db", tmp_path / "fwd")
+    m_rev = write_freeze(tmp_path / "rev.db", tmp_path / "rev")
+    assert m_fwd["sha256"] == m_rev["sha256"]
+
+
+def test_refreezing_a_freeze_is_stable(tmp_path) -> None:
+    # write_freeze reads through load_node_rows, so a freeze re-freezes: the loaded rows
+    # carry re-derived features + their shape_spec, and the digests must not drift.
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    m1 = write_freeze(db_path, tmp_path / "f1")
+    m2 = write_freeze(tmp_path / "f1", tmp_path / "f2")
+    assert m1["sha256"] == m2["sha256"]
 
 
 # ---------------------------------------------------------------------------
@@ -141,43 +219,79 @@ def test_freeze_digest_insertion_order_independent(tmp_path) -> None:
 def _frozen(tmp_path):
     db_path = tmp_path / "autotune.db"
     _seed_db(db_path, _SEED)
-    out = tmp_path / "freeze.jsonl"
+    out = tmp_path / "freeze"
     write_freeze(db_path, out)
     return out
 
 
 def test_load_freeze_digest_mismatch_hard_error(tmp_path) -> None:
     out = _frozen(tmp_path)
-    head, sep, tail = out.read_bytes().partition(b"\n")
-    out.write_bytes(head + sep + tail.replace(b'"status":"ok"', b'"status":"OK"', 1))
+    f = out / "nvidia_geforce_rtx_4090_sm89.yaml"
+    f.write_text(f.read_text().replace("value_us: 480.0", "value_us: 4.0"))
     with pytest.raises(RuntimeError, match="corrupt"):
         load_freeze(out)
 
 
-def test_load_freeze_feat_ver_mismatch_hard_error(tmp_path) -> None:
-    # Rewriting the header alone doesn't trip the digest (it covers only the rows) —
-    # the version gate must catch it on its own.
+def test_load_freeze_missing_listed_file_hard_error(tmp_path) -> None:
     out = _frozen(tmp_path)
-    head, sep, tail = out.read_bytes().partition(b"\n")
-    header = json.loads(head)
-    header["feat_ver"] = FEATURIZER_VERSION - 1
-    out.write_bytes(json.dumps(header, sort_keys=True).encode() + sep + tail)
-    with pytest.raises(RuntimeError, match="feat_ver"):
+    (out / "nvidia_geforce_rtx_4090_sm89.yaml").unlink()
+    with pytest.raises(RuntimeError, match="missing"):
         load_freeze(out)
 
 
-def test_load_freeze_foreign_file_hard_error(tmp_path) -> None:
-    garbage = tmp_path / "notes.txt"
-    garbage.write_text("hello\nworld\n")
+def test_load_freeze_ver_mismatch_hard_error(tmp_path) -> None:
+    out = _frozen(tmp_path)
+    manifest = json.loads((out / MANIFEST_NAME).read_text())
+    manifest["freeze_ver"] = FREEZE_VER + 1
+    (out / MANIFEST_NAME).write_text(json.dumps(manifest))
+    with pytest.raises(RuntimeError, match="freeze_ver"):
+        load_freeze(out)
+
+
+def test_load_freeze_foreign_dir_hard_error(tmp_path) -> None:
+    plain = tmp_path / "not-a-freeze"
+    plain.mkdir()
     with pytest.raises(RuntimeError, match="not a measurement freeze"):
-        load_freeze(garbage)
+        load_freeze(plain)
+
+
+def test_load_freeze_uninstantiable_row_hard_error(tmp_path) -> None:
+    out = _frozen(tmp_path)
+    name = "nvidia_geforce_rtx_5090_sm120.yaml"
+    doc = yaml.safe_load((out / name).read_text())
+    for c in doc["configs"]:
+        c["kernel"] = "warp_drive"
+    (out / name).write_text(yaml.safe_dump(doc, sort_keys=True, width=120))
+    manifest = json.loads((out / MANIFEST_NAME).read_text())
+    # Keep the digest honest so the kind check (not the digest) is what trips.
+    from emmy.compiler.pipeline.search.data.freeze import _row_line
+
+    digest = hashlib.sha256()
+    for c in doc["configs"]:
+        digest.update(_row_line(c))
+    manifest["files"][name]["sha256"] = digest.hexdigest()
+    (out / MANIFEST_NAME).write_text(json.dumps(manifest))
+    with pytest.raises(RuntimeError, match="unknown kernel kind"):
+        load_freeze(out)
 
 
 def test_write_freeze_nothing_survives_hard_error(tmp_path) -> None:
+    # An identity-less (legacy) store has leaves, but none can spell a v2 row.
     db_path = tmp_path / "autotune.db"
-    _seed_db(db_path, [_row("branch-only", value_us=480.0, is_leaf=False)])
+    _seed_db(db_path, [_row("legacy", value_us=500.0, features=_feats())])
     with pytest.raises(RuntimeError, match="no freezable leaf rows"):
-        write_freeze(db_path, tmp_path / "freeze.jsonl")
+        write_freeze(db_path, tmp_path / "freeze")
+
+
+def test_write_freeze_refuses_to_replace_non_freeze_dir(tmp_path) -> None:
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    target = tmp_path / "precious"
+    target.mkdir()
+    (target / "notes.txt").write_text("do not delete\n")
+    with pytest.raises(RuntimeError, match="refusing to replace"):
+        write_freeze(db_path, target)
+    assert (target / "notes.txt").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -193,12 +307,21 @@ def test_load_node_rows_zero_byte_file_is_empty_db(tmp_path) -> None:
     assert load_node_rows(empty) == []
 
 
-def test_open_readonly_rejects_freeze_with_pointer(tmp_path) -> None:
-    # A freeze handed to a perf-table consumer (eval variants/knobs/failures --db) must
-    # fail at open with a named reason, not a bare sqlite DatabaseError inside a PRAGMA.
-    out = _frozen(tmp_path)
+def test_load_node_rows_refuses_v1_jsonl_freeze(tmp_path) -> None:
+    v1 = tmp_path / "freeze.jsonl"
+    header = {"kind": FREEZE_KIND, "freeze_ver": 1, "sha256": "deadbeef"}
+    v1.write_text(json.dumps(header) + "\n" + '{"node_key": "k"}\n')
+    with pytest.raises(RuntimeError, match="superseded"):
+        load_node_rows(v1)
+
+
+def test_open_readonly_rejects_v1_freeze_with_pointer(tmp_path) -> None:
+    # A v1-style JSON file handed to a perf-table consumer (eval variants/knobs/failures
+    # --db) must fail at open with a named reason, not a bare sqlite DatabaseError.
+    v1 = tmp_path / "freeze.jsonl"
+    v1.write_text(json.dumps({"kind": FREEZE_KIND, "freeze_ver": 1}) + "\n")
     with pytest.raises(RuntimeError, match="nodes-dataset"):
-        SearchDB.open_readonly(out)
+        SearchDB.open_readonly(v1)
     garbage = tmp_path / "notes.txt"
     garbage.write_text("hello\n")
     with pytest.raises(RuntimeError, match="not a sqlite database"):
@@ -218,10 +341,8 @@ def test_anchor_walk_treats_freeze_rows_as_treeless(tmp_path) -> None:
         def mean_scores_features(self, fvecs):
             return [0.0] * len(fvecs)
 
-    db_path = tmp_path / "autotune.db"
-    _seed_db(db_path, _SEED)
-    write_freeze(db_path, tmp_path / "freeze.jsonl")
-    _header, rows = load_freeze(tmp_path / "freeze.jsonl")
+    out = _frozen(tmp_path)
+    _manifest, rows = load_freeze(out)
     matched, steps, descriptor = diagnostics._anchor_walk(_Flat(), rows, {})
     assert (matched, steps) == (0, [])
     assert "no fork-tree data" in descriptor
@@ -230,16 +351,16 @@ def test_anchor_walk_treats_freeze_rows_as_treeless(tmp_path) -> None:
     assert matched_live == 1 and "followed" in descriptor_live
 
 
-def test_load_node_rows_sniffs_db_and_freeze(tmp_path) -> None:
+def test_load_node_rows_sniffs_db_and_freeze_dir(tmp_path) -> None:
     db_path = tmp_path / "autotune.db"
     _seed_db(db_path, _SEED)
-    out = tmp_path / "freeze.jsonl"
+    out = tmp_path / "freeze"
     write_freeze(db_path, out)
     from_db = load_node_rows(db_path)
     from_freeze = load_node_rows(out)
-    assert {r.node_key for r in from_db} == _KEPT_KEYS | {"branch", "leaf-stale"}  # raw iter_nodes view
-    assert {r.node_key for r in from_freeze} == _KEPT_KEYS
-    with pytest.raises(RuntimeError, match="not a measurement freeze"):
-        garbage = tmp_path / "notes.txt"
-        garbage.write_text("hello\n")
+    assert len(from_db) == len(_SEED)  # raw iter_nodes view — everything
+    assert len(from_freeze) == _N_KEPT
+    garbage = tmp_path / "notes.txt"
+    garbage.write_text("hello\n")
+    with pytest.raises(RuntimeError, match="neither a sqlite node DB nor"):
         load_node_rows(garbage)

--- a/tests/compiler/pipeline/search/test_shape_key_kinds.py
+++ b/tests/compiler/pipeline/search/test_shape_key_kinds.py
@@ -177,3 +177,19 @@ def test_sweep_classifier_from_measured_stamps():
     assert ShapeKey.from_s_features(matmul).kind == ""
     # Bare rows without stamps (arithmetic bases, old reservoir rows) stay plain.
     assert ShapeKey.from_s_features({"S_ext_free_prod": 512.0, "S_ext_reduce_max": 4096.0}).kind == ""
+
+
+def test_joins_tolerates_sweep_dtype_flip_but_stays_strict_on_contractions():
+    """``ShapeKey.joins``: a sweep op's ``is_warp`` derives from the operand-dtype
+    multiset, which flips between an all-fp16 golden snippet (fp16-pure stamps) and the
+    same norm in a served graph (f32 statistic constants) — so for sweep kinds the join
+    ignores it. For ``kind == ""`` it stays exact: ``is_warp`` is the fp32/fp16
+    contraction-twin discriminator."""
+    golden_rms = ShapeKey(free_prod=4096, reduce_max=64, is_warp=False, kind="rms_norm")
+    op_rms_fp16 = ShapeKey(free_prod=4096, reduce_max=64, is_warp=True, kind="rms_norm")
+    assert op_rms_fp16.joins(golden_rms)
+    assert not ShapeKey(free_prod=4096, reduce_max=128, is_warp=True, kind="rms_norm").joins(golden_rms)  # extents still bind
+    assert not ShapeKey(free_prod=4096, reduce_max=64, is_warp=True, kind="softmax").joins(golden_rms)  # kind still binds
+    mm_fp16 = ShapeKey.from_matmul(512, 512, 512, "fp16")
+    mm_fp32 = ShapeKey.from_matmul(512, 512, 512, "fp32")
+    assert mm_fp16.joins(mm_fp16) and not mm_fp16.joins(mm_fp32)  # the real twin pair never merges

--- a/tests/compiler/test_golden_configs.py
+++ b/tests/compiler/test_golden_configs.py
@@ -559,3 +559,29 @@ def test_neighbor_bench_group_id_covers_every_recorded_kind():
         kind = kind_of[type(g)]
         gid = gnb._group_id(kind, g, base_fields)
         assert gid and (kind == "matmul" or gid.startswith(kind))
+
+
+def test_neighbor_bench_shape_spec_covers_every_recorded_kind():
+    """Every recorded golden's ``shape_spec_of`` output must survive the full identity
+    round trip the sweep relies on: JSON-serializable, accepted by ``parse_record_shape``
+    (i.e. it re-instantiates through ``_KERNEL_CLASSES``), and keying to the SAME
+    ``ShapeKey`` as the golden itself — that key equality is the per-leaf gate that
+    decides whether a benched row carries the identity at all."""
+    import json
+    import sys
+    from dataclasses import fields
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+    import golden_neighbor_bench as gnb
+
+    from emmy.compiler.pipeline.search.bench_record import parse_record_shape
+
+    kind_of = {cls: kind for kind, cls in _KERNEL_CLASSES.items()}
+    base_fields = frozenset(f.name for f in fields(GoldenConfig))
+    for g in GOLDEN_CONFIGS:
+        kind = kind_of[type(g)]
+        spec = gnb.shape_spec_of(kind, g, base_fields)
+        rs = parse_record_shape(json.dumps(spec, sort_keys=True))
+        assert rs.spec == spec
+        assert rs.key == g.shape_key(), f"{g.name}: spec keys to {rs.key}, golden keys to {g.shape_key()}"

--- a/tests/test_golden_neighbor_bench.py
+++ b/tests/test_golden_neighbor_bench.py
@@ -129,6 +129,30 @@ class TestGroupId:
         assert gid != gnb._group_id("novel_kind", Novel(rows=8), _BASE_FIELDS)
 
 
+class TestShapeSpecOf:
+    def test_matmul_spelling_with_dynamic_and_trans_b(self):
+        @dataclass
+        class Matmul(_FakeBase):
+            M: int = 2048
+            N: int = 512
+            K: int = 3840
+            dtype: str = "fp16"
+            trans_b: bool = True
+
+        spec = gnb.shape_spec_of("matmul", Matmul(dynamic=True), _BASE_FIELDS)
+        assert spec == {"kernel": "matmul", "M": 2048, "N": 512, "K": 3840, "dtype": "fp16", "trans_b": True, "dynamic": True}
+
+    def test_generic_kind_derives_from_own_fields(self):
+        spec = gnb.shape_spec_of("reduce", _FakeReduce(), _BASE_FIELDS)
+        assert spec == {"kernel": "reduce", "M": 4096, "K": 512, "dtype": "fp32", "dynamic": False}
+
+    def test_group_entries_spell_the_identical_spec(self):
+        # A group's entries share _group_id, which derives from exactly the spec fields —
+        # so any representative yields the same spec (they differ only in knobs/latencies).
+        a, b = _FakeReduce(name="a"), _FakeReduce(name="b")
+        assert gnb.shape_spec_of("reduce", a, _BASE_FIELDS) == gnb.shape_spec_of("reduce", b, _BASE_FIELDS)
+
+
 class TestAssignSlice:
     def test_own_wins_even_when_cross_is_closer(self):
         assert gnb.assign_slice(2, 0, max_dist=2) == "own"


### PR DESCRIPTION
                                                                                                                                                                                     
  The v1 freeze dumped NodeRows — digest identity plus the persisted feature dict — so a row's shape was unrecoverable and every encoding-only featurizer change quarantined the     
  file. Freeze v2 stores rows the way the goldens files do, and captures the identity where it exists: at collection time.                                                           
                                                                                                                                                                                     
  - Collection: the sweep passes each group's declarative shape spec via the new emmy run --bench --record-shape; the recorder stamps it as NodeRow.shape_spec on exactly the leaves 
  whose stamped extents key to the spec's ShapeKey (per-leaf gate — a multi-op snippet's secondary ops stay identity-less; zero matches warn). record_nodes COALESCE-keeps the       
  identity in both replacement directions; merge_nodes carries it.                                                                                                                   
  - Freeze v2 (FREEZE_VER=2): a directory mirroring goldens/ — one YAML per (gpu, compute_cap) with golden-spelled rows (kernel + shape fields + verbatim tunable knobs +            
  value_us/opt/status/bench stats/provenance) beside a manifest.json with content-level sha256s. Nothing featurized persists: the loader re-derives H_* card-faithfully and full S_* 
  via the new kind-generic traced_s_features, so featurizer encoding changes stop quarantining freezes (the load-time feat_ver gate is dropped by design). A loaded row's op_sig is  
  its spec's canonical JSON — the -O1/-O3 twins share one fold-by-op group. Identity-less legacy rows never freeze; v1 JSONL files are refused with a re-freeze pointer.             
  - Fix found en route: the golden↔measured ShapeKey join broke for fp16 sweep-kind snippets (a sweep op's dtype-derived is_warp flips between an fp16-pure snippet and a served     
  graph's f32 statistic constants). New ShapeKey.joins tolerates the flip for sweep kinds only; contraction twins stay strict. Used only by the two new consumers.                   
                                                                                                                                                                                     
  GPU-verified on a rented 4090: a filtered sweep recorded 75 identity-carrying rows (both opt lanes, mma path included, zero gate misses), the freeze dropped 4,278 legacy rows with
  the named reason and produced a loadable, freeze-twice-deterministic YAML dataset. Implements decision 14 of plans/analytic-prior-catboost-rework.md.                              
                           