### PR TITLE
Layer-1 IR as ADTs: closed dialect unions, axis type parameter, scoped pyright gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Ruff format check
         run: ./venv/bin/ruff format --check
 
+      - name: Typecheck
+        run: ./venv/bin/pyright
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Quick test models / scripts (for local iteration):
 - `make test` — run `pytest` using the venv (skips `perf`-marked tests; see `tests/perf/ARCHITECTURE.md`). Compiles
   kernels at `-Xcicc -O1` for ~3× faster nvcc (correctness lane; perf tests use `-O3` via `make bench-kernels`)
 - `make lint` — run `ruff check` and `ruff format --check`
+- `make typecheck` — run pyright over the typed Layer-1 IR modules (scope: `[tool.pyright]` in `pyproject.toml`)
 - `make format` — auto-format code and fix lint violations
 - `make bench` — run benchmarks (`emmy bench recipes/*`)
 - `make bench-kernels` — run per-kernel perf comparison vs PyTorch (`tests/perf/`, requires CUDA)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup clean bench bench-force bench-kernels bench-kernels-tune test-compose lint format git-sha-guard
+.PHONY: help setup clean bench bench-force bench-kernels bench-kernels-tune test-compose lint typecheck format git-sha-guard
 
 help:
 	@echo "Server Benchmark Makefile"
@@ -6,6 +6,7 @@ help:
 	@echo "Available targets:"
 	@echo "  setup          - Install system dependencies, create venv, and install Python packages"
 	@echo "  lint           - Run linter and format checks"
+	@echo "  typecheck      - Run pyright over the typed modules (see [tool.pyright] in pyproject.toml)"
 	@echo "  format         - Auto-format code and fix lint violations"
 	@echo "  bench          - Run benchmarks in parallel"
 	@echo "  bench-force    - Run benchmarks in parallel (force re-run, skip cached results)"
@@ -34,6 +35,9 @@ setup-ci:
 lint: setup
 	./venv/bin/ruff check
 	./venv/bin/ruff format --check
+
+typecheck: setup
+	./venv/bin/pyright
 
 format: setup
 	./venv/bin/ruff format

--- a/STYLE.md
+++ b/STYLE.md
@@ -110,6 +110,18 @@ Op subclasses don't have to be frozen (the engine mutates `op.source` / `op.knob
 construction). Just make sure no Op ends up as a *field value* of a Stmt — `Assign.op` / `Accum.op` / `Select.op` take
 an `ElementwiseImpl` (the lightweight value object, already hashable), never an `ElementwiseOp` wrapper.
 
+### Layer-1 op dialects are closed unions
+
+Each Layer-1 IR dialect module exports a closed union alias over its op classes — `FrontendOp`, `TensorOp`,
+`BoundaryOp` — and every variant class is `@final`. Adding an op means: mark it `@final`, add it to the module's
+union, and (for a frontend op) give it a decomposition rule; `tests/compiler/ir/test_dialect_unions.py` fails until
+membership is consistent. In annotations, use the union alias (not `Op`) wherever the dialect is known, and prefer
+`match` with all variants spelled out — the scoped pyright gate (`make typecheck`, config under `[tool.pyright]` in
+`pyproject.toml`) errors on non-exhaustive matches over these unions. Modules in the pyright include list must stay
+error-free; when you touch one, run `make typecheck` before committing. See "Closed Layer-1 unions" in
+`emmy/compiler/ir/ARCHITECTURE.md` for the axis type parameter (`[A: (int, str)]`) and self-specialization
+conventions.
+
 ### Dependency Injection for Testability
 
 Shared logic accepts callable parameters (`run_cmd`, `write_file`) so

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -85,6 +85,28 @@ are NOT frozen — the engine mutates `op.source` / `op.knobs` / `op.inputs` /
 `Assign.op`) must be lightweight value objects (e.g. `ElementwiseImpl`,
 not `ElementwiseOp`) so the surrounding Stmt's hashability isn't poisoned.
 
+## Closed Layer-1 unions (typed dialect views)
+
+The Layer-1 dialects are typed as algebraic datatypes: each module exports a closed union alias over its op classes,
+and every variant is `@final` — `FrontendOp` (`frontend/ir.py`), `TensorOp` (`tensor/ir.py`), `BoundaryOp`
+(`base.py`: `InputOp` / `AuxOutputOp` / `ConstantOp`). Annotate with the alias, not `Op`, whenever a value is known
+to belong to one dialect: a `match` over an alias-typed value is exhaustiveness-checked (`reportMatchNotExhaustive`
+in the scoped pyright config in `pyproject.toml`; `make typecheck` runs it — the include list is the Layer-1
+definition modules only, the first slice of gradual typing). `Op` stays the open cross-dialect base that the
+`Graph` container and the rewrite engine use.
+
+The axis-carrying ops (`ReduceOp` / `ScanOp` / `GatherOp` / `ScatterOp`, and frontend `MeanOp` / `SoftmaxOp`) are
+generic over the axis type: `[A: (int, str)]`, a constrained type parameter, so every instance is either the
+concrete-axis (`int`) or the symbolic-axis (`str`) specialization. A checked caller holding an `int | str` axis
+must branch before constructing — the solver refuses the union, keeping "staticness unknown" unrepresentable. The
+numpy `forward` interpreters are declared with `self` at the `int` specialization (`self: ReduceOp[int]`), so
+checked code cannot run a symbolic-axis op on numpy. `axis` is keyword-only on all six (a typed default for `A`
+needs PEP 696, 3.13+). The parameter is erased at runtime; unchecked callers see no behavior change.
+
+`tests/compiler/ir/test_dialect_unions.py` enforces the runtime side: union membership equals the set of `@final`
+op classes in each module, the unions are disjoint, and every `FrontendOp` variant has a decomposition rule (the
+module contract — after decomposition, none of these ops remain).
+
 ## `base.py`
 
 Cross-cutting root. Imported by every dialect, imports nothing from

--- a/emmy/compiler/ir/base.py
+++ b/emmy/compiler/ir/base.py
@@ -18,7 +18,7 @@ avoids a frontend→tensor dependency for a single function.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, final
 
 import numpy as np
 
@@ -95,6 +95,7 @@ class Op:
         return True
 
 
+@final
 @dataclass
 class InputOp(Op):
     """Sentinel for graph input tensors (no computation)."""
@@ -106,6 +107,7 @@ class InputOp(Op):
         raise NotImplementedError("InputOp is a sentinel; value is supplied by the executor")
 
 
+@final
 @dataclass
 class AuxOutputOp(Op):
     """Sentinel for an AUXILIARY output buffer of its (sole) input node — a second buffer that
@@ -124,6 +126,7 @@ class AuxOutputOp(Op):
         raise NotImplementedError("AuxOutputOp is a sentinel; its buffer is written by the producer node's kernel")
 
 
+@final
 @dataclass
 class ConstantOp(Op):
     """Fixed tensor: weights, RoPE tables, scalars. Not an activation.
@@ -188,6 +191,12 @@ class ConstantOp(Op):
         if self.value is not None:
             return np.array([self.value], dtype=np.float32)
         raise NotImplementedError("ConstantOp with value=None must be supplied by the executor")
+
+
+# The closed set of boundary sentinels. Annotate with this alias (not ``Op``)
+# when a value is known to be a sentinel — the union is closed (every variant
+# is ``@final``), so ``match`` over it can be checked for exhaustiveness.
+type BoundaryOp = InputOp | AuxOutputOp | ConstantOp
 
 
 def _keepdim_axis(shape: tuple, axis: int | str) -> tuple:

--- a/emmy/compiler/ir/elementwise.py
+++ b/emmy/compiler/ir/elementwise.py
@@ -33,7 +33,7 @@ def _erf(x):  # numpy lacks an erf ufunc; scipy ships one and is a torch dep.
     return erf(x)
 
 
-_NAME_TO_FN: dict[str, object] = {
+_NAME_TO_FN: dict[str, Callable[..., object]] = {
     "exp_fast": np.exp,  # the FAST_EXP-lowered exp — host semantics identical, CUDA renders __expf
     "rsqrt": lambda x: 1.0 / np.sqrt(x),
     "relu": lambda x: np.maximum(0.0, x),

--- a/emmy/compiler/ir/expr.py
+++ b/emmy/compiler/ir/expr.py
@@ -175,6 +175,13 @@ def apply_binop(op: str, lv: object, rv: object) -> object:
     raise ValueError(f"Unknown BinOp: {op}")
 
 
+# What ``eval`` consumes and produces: scalars, or numpy arrays when the env
+# binds arrays (vectorized evaluation over whole index grids). numpy scalar
+# types (``np.int64`` …) enter via ``np.ndarray`` element reads and are
+# subsumed under the array/scalar union for typing purposes.
+type Value = int | float | bool | np.ndarray
+
+
 # ---------------------------------------------------------------------------
 # Expression types
 # ---------------------------------------------------------------------------
@@ -186,7 +193,7 @@ class Var(_ExprOps):
 
     name: str
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         return env[self.name]
 
     def pretty(self) -> str:
@@ -228,7 +235,7 @@ class Literal(_ExprOps):
     value: int | float
     dtype: str = "float"
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         return self.value
 
     def pretty(self) -> str:
@@ -283,7 +290,7 @@ class BinaryExpr(_ExprOps):
     left: Expr
     right: Expr
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         # Single source of binary-op semantics: ``apply_binop`` (also used by
         # constant folding) — eval only supplies the evaluated operands.
         return apply_binop(self.op, self.left.eval(env), self.right.eval(env))
@@ -423,7 +430,7 @@ class Builtin(_ExprOps):
 
     name: str
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         raise NotImplementedError(f"Builtin {self.name!r} is GPU-only; cannot eval in numpy")
 
     def pretty(self) -> str:
@@ -459,7 +466,7 @@ class FuncCallExpr(_ExprOps):
     name: str
     args: tuple[Expr, ...]
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         from emmy.compiler.ir.elementwise import ElementwiseImpl
 
         try:
@@ -505,7 +512,7 @@ class TernaryExpr(_ExprOps):
     if_true: Expr
     if_false: Expr
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         return self.if_true.eval(env) if self.cond.eval(env) else self.if_false.eval(env)
 
     def pretty(self) -> str:
@@ -545,7 +552,7 @@ class CastExpr(_ExprOps):
     dtype: str
     expr: Expr
 
-    def eval(self, env: dict[str, object]) -> object:
+    def eval(self, env: dict[str, Value]) -> Value:
         v = self.expr.eval(env)
         if self.dtype == "int":
             return np.asarray(v).astype(np.int64) if hasattr(v, "__array__") else int(v)

--- a/emmy/compiler/ir/frontend/ir.py
+++ b/emmy/compiler/ir/frontend/ir.py
@@ -17,7 +17,8 @@ Two groups:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import final
 
 import numpy as np
 
@@ -29,6 +30,7 @@ from emmy.compiler.ir.base import Op, _keepdim_axis
 # ---------------------------------------------------------------------------
 
 
+@final
 @dataclass
 class TransposeOp(Op):
     """Permute dimensions.
@@ -61,6 +63,7 @@ class TransposeOp(Op):
         return np.transpose(a, self.axes)
 
 
+@final
 @dataclass
 class ReshapeOp(Op):
     """Reshape tensor without changing data."""
@@ -92,10 +95,12 @@ class ReshapeOp(Op):
         return tuple(inferred if d == -1 else d for d in self.shape)
 
     def forward(self, *inputs):
+        # int() also narrows for the checker: a symbolic (str) extent fails
+        # here just as it would inside numpy, only with a clearer error.
+        return np.reshape(inputs[0], tuple(int(d) for d in self.shape))
 
-        return np.reshape(inputs[0], self.shape)
 
-
+@final
 @dataclass
 class SliceOp(Op):
     """Extract a sub-tensor along a dimension.
@@ -136,6 +141,7 @@ class SliceOp(Op):
         return tensor[tuple(slices)]
 
 
+@final
 @dataclass
 class CatOp(Op):
     """Concatenate tensors along a dimension.
@@ -178,6 +184,7 @@ class CatOp(Op):
         return np.concatenate(arrays, axis=dim)
 
 
+@final
 @dataclass
 class UnsqueezeOp(Op):
     """PyTorch aten.unsqueeze: add a size-1 dimension."""
@@ -200,6 +207,7 @@ class UnsqueezeOp(Op):
 # ---------------------------------------------------------------------------
 
 
+@final
 @dataclass
 class LinearOp(Op):
     """PyTorch aten.linear: output = x @ weight.T [+ bias]."""
@@ -219,6 +227,7 @@ class LinearOp(Op):
         return result
 
 
+@final
 @dataclass
 class MatmulOp(Op):
     """PyTorch aten.mm/matmul/addmm: output = A @ B [+ bias]."""
@@ -239,6 +248,7 @@ class MatmulOp(Op):
         return result
 
 
+@final
 @dataclass
 class SdpaOp(Op):
     """PyTorch scaled_dot_product_attention(Q, K, V, ...).
@@ -299,23 +309,29 @@ class SdpaOp(Op):
         return attn @ v
 
 
+@final
 @dataclass
-class MeanOp(Op):
+class MeanOp[A: (int, str)](Op):
     """PyTorch aten.mean.dim: reduction that averages along an axis.
 
     Kept as its own op so the tracer does a faithful 1:1 capture; a
     decomposition rule rewrites it into sum + div.
+
+    ``A`` is the axis type — ``int`` (concrete) or ``str`` (symbolic name);
+    the numpy ``forward`` is declared on the ``int`` specialization only
+    (see ``ir.tensor.ir.ReduceLikeOp`` for the convention).
     """
 
-    axis: int | str = -1
+    axis: A = field(kw_only=True)
 
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         return _keepdim_axis(input_shapes[0], self.axis)
 
-    def forward(self, *inputs):
+    def forward(self: MeanOp[int], *inputs):
         return np.mean(inputs[0], axis=self.axis)
 
 
+@final
 @dataclass
 class RmsNormOp(Op):
     """PyTorch aten.rms_norm: ``x * rsqrt(mean(x*x) + eps) * weight``.
@@ -336,6 +352,7 @@ class RmsNormOp(Op):
         return (x / rms) * weight
 
 
+@final
 @dataclass
 class LayerNormOp(Op):
     """PyTorch aten.layer_norm: ``(x - mean(x)) * rsqrt(var(x) + eps) * weight + bias``.
@@ -363,20 +380,37 @@ class LayerNormOp(Op):
         return out
 
 
+@final
 @dataclass
-class SoftmaxOp(Op):
+class SoftmaxOp[A: (int, str)](Op):
     """PyTorch aten.softmax.int: ``exp(x - max(x, dim)) / sum(exp(...), dim)``.
 
     Decomposed by ``passes/frontend/decomposition/100_softmax.py``.
+
+    ``A`` is the axis type — ``int`` (concrete) or ``str`` (symbolic name);
+    the numpy ``forward`` is declared on the ``int`` specialization only
+    (see ``ir.tensor.ir.ReduceLikeOp`` for the convention).
     """
 
-    axis: int | str = -1
+    axis: A = field(kw_only=True)
 
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         return tuple(input_shapes[0])
 
-    def forward(self, *inputs):
+    def forward(self: SoftmaxOp[int], *inputs):
         x = inputs[0]
         m = np.max(x, axis=self.axis, keepdims=True)
         e = np.exp(x - m)
         return e / np.sum(e, axis=self.axis, keepdims=True)
+
+
+# The closed set of frontend ops — everything the tracer may put in the graph
+# besides the ``ir.base`` sentinels. Annotate with this alias (not ``Op``) when
+# a value is known to be a frontend op; every variant is ``@final``, so the
+# union is closed and ``match`` over it can be checked for exhaustiveness.
+# ``tests/compiler/ir/test_dialect_unions.py`` holds each variant to the
+# module contract: a decomposition rule exists for it under
+# ``pipeline/passes/frontend/decomposition/``.
+type FrontendOp = (
+    TransposeOp | ReshapeOp | SliceOp | CatOp | UnsqueezeOp | LinearOp | MatmulOp | SdpaOp | MeanOp | RmsNormOp | LayerNormOp | SoftmaxOp
+)

--- a/emmy/compiler/ir/tensor/ir.py
+++ b/emmy/compiler/ir/tensor/ir.py
@@ -27,12 +27,14 @@ elementwise, reduce, scan, and accumulator use sites; read straight from
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import final
 
 import numpy as np
 
 from emmy.compiler.dim import Dim, to_dim
 from emmy.compiler.ir.base import Op, _keepdim_axis
 from emmy.compiler.ir.elementwise import _REDUCE_SPELLING, ElementwiseImpl
+from emmy.compiler.ir.expr import Expr
 
 # ---------------------------------------------------------------------------
 # Elementwise / reduce / scan
@@ -65,6 +67,7 @@ class _ElementwiseImplOp(Op):
         return self.op.name
 
 
+@final
 @dataclass
 class ElementwiseOp(_ElementwiseImplOp):
     """Apply a scalar function independently to each element.
@@ -107,12 +110,20 @@ class ElementwiseOp(_ElementwiseImplOp):
 
 
 @dataclass
-class ReduceLikeOp(_ElementwiseImplOp):
+class ReduceLikeOp[A: (int, str)](_ElementwiseImplOp):
     """Shared base for the axis-folding ops (``ReduceOp`` / ``ScanOp``): a ``sum``-default
-    ``ElementwiseImpl`` combine over one ``axis``, resolved to its numpy spelling."""
+    ``ElementwiseImpl`` combine over one ``axis``, resolved to its numpy spelling.
+
+    ``A`` is the axis type: ``int`` for a concrete axis, ``str`` for a symbolic
+    axis name. The numpy ``forward`` methods are declared with ``self`` at the
+    ``int`` specialization (e.g. ``self: ReduceOp[int]``), so type-checked code
+    cannot run a symbolic-axis op on numpy. ``axis`` is keyword-only and has no
+    default — a literal like ``0`` would not typecheck for ``A = str``, and the
+    keyword requirement holds on every axis-carrying op in this dialect.
+    """
 
     op: ElementwiseImpl = field(default_factory=lambda: ElementwiseImpl("sum"))
-    axis: int | str = 0
+    axis: A = field(kw_only=True)
 
     def _spelling(self):
         """The ``ReduceSpelling`` for this combine, or raise if it has none."""
@@ -122,8 +133,9 @@ class ReduceLikeOp(_ElementwiseImplOp):
         return spelling
 
 
+@final
 @dataclass
-class ReduceOp(ReduceLikeOp):
+class ReduceOp[A: (int, str)](ReduceLikeOp[A]):
     """Collapse one or more dimensions via an associative binary op.
 
     ``op`` is the combine (``sum`` / ``max`` / ``prod`` / …); ``axis`` is
@@ -137,18 +149,19 @@ class ReduceOp(ReduceLikeOp):
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         return _keepdim_axis(input_shapes[0], self.axis)
 
-    def forward(self, *inputs):
+    def forward(self: ReduceOp[int], *inputs):
         return self._spelling().np_reduce(inputs[0], axis=self.axis, keepdims=True)
 
 
+@final
 @dataclass
-class ScanOp(ReduceLikeOp):
+class ScanOp[A: (int, str)](ReduceLikeOp[A]):
     """Cumulative application of an associative binary op along an axis."""
 
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         return tuple(input_shapes[0])  # scan preserves shape
 
-    def forward(self, *inputs):
+    def forward(self: ScanOp[int], *inputs):
         spelling = self._spelling()
         if spelling.np_scan is None:
             raise NotImplementedError(f"ScanOp.forward: unknown fn {self.op.name!r}")
@@ -160,18 +173,22 @@ class ScanOp(ReduceLikeOp):
 # ---------------------------------------------------------------------------
 
 
+@final
 @dataclass
-class GatherOp(Op):
-    """Read elements from arbitrary positions along an axis."""
+class GatherOp[A: (int, str)](Op):
+    """Read elements from arbitrary positions along an axis.
 
-    axis: int | str = 0
+    ``A`` is the axis type — ``int`` (concrete) or ``str`` (symbolic name);
+    see :class:`ReduceLikeOp`."""
+
+    axis: A = field(kw_only=True)
 
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         # Output shape = input shape with the gather axis sized by the index input.
         # Conservative fallback: keep input shape (callers should pre-size if needed).
         return tuple(input_shapes[0])
 
-    def forward(self, *inputs):
+    def forward(self: GatherOp[int], *inputs):
 
         data, indices = inputs[0], inputs[1].astype(np.intp)
         axis = self.axis if self.axis >= 0 else data.ndim + self.axis
@@ -187,17 +204,21 @@ class GatherOp(Op):
         return np.take(data, indices, axis=axis)
 
 
+@final
 @dataclass
-class ScatterOp(Op):
-    """Write (or reduce) values into arbitrary positions along an axis."""
+class ScatterOp[A: (int, str)](Op):
+    """Write (or reduce) values into arbitrary positions along an axis.
 
-    axis: int | str = 0
+    ``A`` is the axis type — ``int`` (concrete) or ``str`` (symbolic name);
+    see :class:`ReduceLikeOp`."""
+
+    axis: A = field(kw_only=True)
     reduce_fn: str | None = None  # None = overwrite, "sum" = scatter-add
 
     def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
         return tuple(input_shapes[0])  # scatter preserves the destination shape
 
-    def forward(self, *inputs):
+    def forward(self: ScatterOp[int], *inputs):
 
         dest, indices, values = inputs[0].copy(), inputs[1].astype(np.intp), inputs[2]
         if self.reduce_fn == "sum":
@@ -227,10 +248,11 @@ class IndexSource:
     """
 
     input_idx: int  # position in IndexMapOp's input list
-    coord_map: tuple  # tuple[Expr, ...] — kept untyped to avoid forward-reference clutter
-    select: object | None = None  # Expr | None
+    coord_map: tuple[Expr, ...]
+    select: Expr | None = None
 
 
+@final
 @dataclass
 class IndexMapOp(Op):
     """Compute output by reindexing inputs via affine coord arithmetic.
@@ -287,3 +309,11 @@ class IndexMapOp(Op):
             if not isinstance(c, Var) or c.name != f"{PLACEHOLDER_PREFIX}{i}":
                 return False
         return True
+
+
+# The closed set of tensor-dialect ops — everything a post-decomposition graph
+# may hold besides the ``ir.base`` sentinels. Annotate with this alias (not
+# ``Op``) when a value is known to be a tensor op; every variant is ``@final``,
+# so the union is closed and ``match`` over it can be checked for
+# exhaustiveness.
+type TensorOp = ElementwiseOp | ReduceOp | ScanOp | GatherOp | ScatterOp | IndexMapOp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff"]
+test = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff", "pyright"]
 compile = ["torch", "transformers>=5.10", "cppyy==3.5.0", "safetensors"]
 # vLLM out-of-tree embedding plugin (emmy/serving); vllm pins its own torch.
 # >=0.23: 0.22.1's FlashInfer dispatch cannot run gemma-4's 512-dim global attention
@@ -32,7 +32,7 @@ eval = ["lm-eval[api]>=0.4.9"]
 visualize = ["playwright>=1.40"]
 # flash-attn requires torch at build time, install separately:
 #   pip install flash-attn --no-build-isolation
-dev = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff", "matplotlib", "graphviz", "torch", "transformers>=5.10", "cupy-cuda12x; sys_platform == 'linux'", "cppyy==3.5.0", "safetensors", "playwright>=1.40"]
+dev = ["pytest", "pytest-asyncio", "pytest-xdist", "ruff", "pyright", "matplotlib", "graphviz", "torch", "transformers>=5.10", "cupy-cuda12x; sys_platform == 'linux'", "cppyy==3.5.0", "safetensors", "playwright>=1.40"]
 
 [tool.setuptools.packages.find]
 include = ["emmy*"]
@@ -52,6 +52,34 @@ asyncio_mode = "auto"
 markers = [
     "perf: GPU performance comparison vs PyTorch (deselected by default; run with `pytest -m perf`)",
 ]
+
+[tool.pyright]
+# Typechecking is scoped to the modules that DEFINE the Layer-1 IR (the closed
+# op unions: FrontendOp / TensorOp / BoundaryOp and their support types) — the
+# first slice of gradual typing. Widening include beyond definition modules
+# means burning down that module's pre-existing errors first (see PR #329 for
+# what enabling emmy/compiler wholesale looks like). ir/expr.py is next in
+# line: its ~40 basic-mode errors (mixin self-typing, object arithmetic in
+# apply_binop) need real signature work, not annotation fills.
+include = [
+    "emmy/compiler/ir/base.py",
+    "emmy/compiler/ir/frontend/ir.py",
+    "emmy/compiler/ir/tensor/ir.py",
+    "emmy/compiler/ir/elementwise.py",
+    "emmy/compiler/tensor.py",
+    "emmy/compiler/dim.py",
+    "emmy/compiler/dtype.py",
+]
+venvPath = "."
+venv = "venv"                # resolve imports against ./venv (what `make setup` builds)
+pythonVersion = "3.12"
+# basic (not strict): types-focused correctness lane — None-safety, arg counts,
+# attribute/return mismatches — without strict's whole-program annotation
+# demands (strict's reportUnknown* family fights numpy's partial stubs).
+typeCheckingMode = "basic"
+# The exhaustiveness backstop for the closed op unions: a `match` over
+# FrontendOp / TensorOp / BoundaryOp that misses a variant is an error.
+reportMatchNotExhaustive = "error"
 
 [tool.ruff]
 line-length = 140

--- a/tests/compiler/e2e/test_accuracy.py
+++ b/tests/compiler/e2e/test_accuracy.py
@@ -62,7 +62,7 @@ def test_e2e_pointwise_add(run_graph, dtype):
 def test_e2e_reduce_sum(run_graph, dtype):
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (4, 8), dtype), node_id="x")
-    g.add_node(ReduceOp("sum", -1), ["x"], Tensor("y", (4, 1), dtype), node_id="y")
+    g.add_node(ReduceOp("sum", axis=-1), ["x"], Tensor("y", (4, 1), dtype), node_id="y")
     g.inputs = ["x"]
     g.outputs = ["y"]
 
@@ -78,7 +78,7 @@ def test_e2e_reduce_sum_cooperative(run_graph, dtype):
     smem-cooperative strategy. Verifies the new path matches numpy."""
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (8, 512), dtype), node_id="x")
-    g.add_node(ReduceOp("sum", -1), ["x"], Tensor("y", (8, 1), dtype), node_id="y")
+    g.add_node(ReduceOp("sum", axis=-1), ["x"], Tensor("y", (8, 1), dtype), node_id="y")
     g.inputs = ["x"]
     g.outputs = ["y"]
 
@@ -94,7 +94,7 @@ def test_e2e_reduce_max_cooperative(run_graph, dtype):
     in ``TreeHalve``."""
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (8, 512), dtype), node_id="x")
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("y", (8, 1), dtype), node_id="y")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("y", (8, 1), dtype), node_id="y")
     g.inputs = ["x"]
     g.outputs = ["y"]
 
@@ -231,10 +231,10 @@ def test_e2e_softmax(run_graph, dtype):
     g.add_node(InputOp(), [], Tensor("x", (rows, cols), dtype), node_id="x")
     g.inputs = ["x"]
 
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("mx", (rows, 1), dtype), node_id="mx")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("mx", (rows, 1), dtype), node_id="mx")
     g.add_node(ElementwiseOp("subtract"), ["x", "mx"], Tensor("subtract", (rows, cols), dtype), node_id="subtract")
     g.add_node(ElementwiseOp("exp"), ["subtract"], Tensor("exp", (rows, cols), dtype), node_id="exp")
-    g.add_node(ReduceOp("sum", -1), ["exp"], Tensor("sm", (rows, 1), dtype), node_id="sm")
+    g.add_node(ReduceOp("sum", axis=-1), ["exp"], Tensor("sm", (rows, 1), dtype), node_id="sm")
     g.add_node(ElementwiseOp("divide"), ["exp", "sm"], Tensor("out", (rows, cols), dtype), node_id="out")
     g.outputs = ["out"]
 
@@ -258,10 +258,10 @@ def test_e2e_softmax_cooperative(run_graph, dtype):
     g.add_node(InputOp(), [], Tensor("x", (rows, cols), dtype), node_id="x")
     g.inputs = ["x"]
 
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("mx", (rows, 1), dtype), node_id="mx")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("mx", (rows, 1), dtype), node_id="mx")
     g.add_node(ElementwiseOp("subtract"), ["x", "mx"], Tensor("subtract", (rows, cols), dtype), node_id="subtract")
     g.add_node(ElementwiseOp("exp"), ["subtract"], Tensor("exp", (rows, cols), dtype), node_id="exp")
-    g.add_node(ReduceOp("sum", -1), ["exp"], Tensor("sm", (rows, 1), dtype), node_id="sm")
+    g.add_node(ReduceOp("sum", axis=-1), ["exp"], Tensor("sm", (rows, 1), dtype), node_id="sm")
     g.add_node(ElementwiseOp("divide"), ["exp", "sm"], Tensor("out", (rows, cols), dtype), node_id="out")
     g.outputs = ["out"]
 

--- a/tests/compiler/e2e/test_ops_vs_torch.py
+++ b/tests/compiler/e2e/test_ops_vs_torch.py
@@ -125,7 +125,7 @@ def test_reduce_sum(run_graph):
     x_np = rng.standard_normal((4, 8)).astype(np.float32)
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
-    g.add_node(ReduceOp("sum", -1), ["x"], Tensor("y", (4, 1)), node_id="y")
+    g.add_node(ReduceOp("sum", axis=-1), ["x"], Tensor("y", (4, 1)), node_id="y")
     g.inputs, g.outputs = ["x"], ["y"]
     expected = _torch_to_np(torch.from_numpy(x_np).sum(dim=-1, keepdim=True))
     np.testing.assert_allclose(_run(run_graph, g, {"x": x_np}), expected, rtol=1e-5, atol=1e-5)
@@ -135,7 +135,7 @@ def test_reduce_max(run_graph):
     x_np = rng.standard_normal((4, 8)).astype(np.float32)
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("y", (4, 1)), node_id="y")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("y", (4, 1)), node_id="y")
     g.inputs, g.outputs = ["x"], ["y"]
     expected = _torch_to_np(torch.from_numpy(x_np).amax(dim=-1, keepdim=True))
     np.testing.assert_allclose(_run(run_graph, g, {"x": x_np}), expected, rtol=1e-5, atol=1e-5)
@@ -145,7 +145,7 @@ def test_reduce_sum_keepdim(run_graph):
     x_np = rng.standard_normal((4, 8)).astype(np.float32)
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
-    g.add_node(ReduceOp("sum", -1), ["x"], Tensor("y", (4, 1)), node_id="y")
+    g.add_node(ReduceOp("sum", axis=-1), ["x"], Tensor("y", (4, 1)), node_id="y")
     g.inputs, g.outputs = ["x"], ["y"]
     expected = _torch_to_np(torch.from_numpy(x_np).sum(dim=-1, keepdim=True))
     np.testing.assert_allclose(_run(run_graph, g, {"x": x_np}), expected, rtol=1e-5, atol=1e-5)
@@ -415,10 +415,10 @@ def test_softmax_graph(run_graph):
     x_np = rng.standard_normal((rows, cols)).astype(np.float32)
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (rows, cols)), node_id="x")
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("mx", (rows, 1)), node_id="mx")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("mx", (rows, 1)), node_id="mx")
     g.add_node(ElementwiseOp("subtract"), ["x", "mx"], Tensor("subtract", (rows, cols)), node_id="subtract")
     g.add_node(ElementwiseOp("exp"), ["subtract"], Tensor("exp", (rows, cols)), node_id="exp")
-    g.add_node(ReduceOp("sum", -1), ["exp"], Tensor("sm", (rows, 1)), node_id="sm")
+    g.add_node(ReduceOp("sum", axis=-1), ["exp"], Tensor("sm", (rows, 1)), node_id="sm")
     g.add_node(ElementwiseOp("divide"), ["exp", "sm"], Tensor("out", (rows, cols)), node_id="out")
     g.inputs, g.outputs = ["x"], ["out"]
     expected = _torch_to_np(torch.softmax(torch.from_numpy(x_np), dim=-1))

--- a/tests/compiler/ir/test_dialect_unions.py
+++ b/tests/compiler/ir/test_dialect_unions.py
@@ -1,0 +1,75 @@
+"""The closed Layer-1 dialect unions hold their module contracts.
+
+``FrontendOp`` / ``TensorOp`` / ``BoundaryOp`` are closed union aliases: the checker
+relies on them for exhaustive ``match``, and this file enforces the runtime side —
+membership stays in sync with the classes actually defined in each module, and
+every frontend variant has the decomposition rule its module doc promises.
+"""
+
+from typing import final, get_args
+
+from emmy.compiler.ir import base as base_ir
+from emmy.compiler.ir.base import Op
+from emmy.compiler.ir.frontend import ir as frontend_ir
+from emmy.compiler.ir.tensor import ir as tensor_ir
+from emmy.compiler.pipeline.pipeline import Pass
+
+
+def _variants(alias) -> set[type]:
+    """The member classes of a PEP 695 union alias (lazy — unwrap before get_args)."""
+    return set(get_args(alias.__value__))
+
+
+def _final_ops_defined_in(module) -> set[type]:
+    """All ``@final`` Op subclasses defined (not just imported) in *module*."""
+    return {
+        v
+        for v in vars(module).values()
+        if isinstance(v, type) and issubclass(v, Op) and v.__module__ == module.__name__ and getattr(v, "__final__", False)
+    }
+
+
+# --- union membership ↔ module contents ---
+
+
+def test_union_variants_are_exactly_the_final_op_classes():
+    """Each union lists exactly the ``@final`` op classes of its module — a class
+    added to a module without joining its union (or vice versa) fails here."""
+    for module, alias in (
+        (frontend_ir, frontend_ir.FrontendOp),
+        (tensor_ir, tensor_ir.TensorOp),
+        (base_ir, base_ir.BoundaryOp),
+    ):
+        assert _variants(alias) == _final_ops_defined_in(module), module.__name__
+
+
+def test_unions_are_disjoint():
+    frontend, tensor, boundary = (
+        _variants(frontend_ir.FrontendOp),
+        _variants(tensor_ir.TensorOp),
+        _variants(base_ir.BoundaryOp),
+    )
+    assert not (frontend & tensor or frontend & boundary or tensor & boundary)
+
+
+def test_final_marker_is_importable():
+    # ``@final`` classes carry ``__final__`` per the typing spec — the membership
+    # test above silently weakens if that attribute convention ever changes.
+    @final
+    class Probe: ...
+
+    assert getattr(Probe, "__final__", False)
+
+
+# --- the FrontendOp module contract: everything decomposes ---
+
+
+def test_every_frontend_op_has_a_decomposition_rule():
+    """``ir/frontend/ir.py`` promises every frontend op is rewritten to tensor
+    primitives by a rule under ``passes/frontend/decomposition/``. Enforced
+    exhaustively over the union: a new FrontendOp variant without a rule whose
+    pattern roots on it fails here."""
+    rules = Pass.load("frontend/decomposition", index=0).rules
+    rooted = {p.op_type for rule in rules for p in rule.pattern}
+    missing = _variants(frontend_ir.FrontendOp) - rooted
+    assert not missing, f"frontend ops without a decomposition rule: {sorted(c.__name__ for c in missing)}"

--- a/tests/compiler/passes/test_fusion_rules.py
+++ b/tests/compiler/passes/test_fusion_rules.py
@@ -144,7 +144,7 @@ def _make_rms_norm_like():
     g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
     g.add_node(ConstantOp(name="w"), [], Tensor("w", (4, 8)), node_id="w")
     g.add_node(ElementwiseOp("multiply"), ["x", "x"], Tensor("sq", (4, 8)), node_id="sq")
-    g.add_node(ReduceOp("sum", -1), ["sq"], Tensor("red", (4, 1)), node_id="red")
+    g.add_node(ReduceOp("sum", axis=-1), ["sq"], Tensor("red", (4, 1)), node_id="red")
     g.add_node(ElementwiseOp("multiply"), ["red", "red"], Tensor("sqr", (4, 1)), node_id="sqr")
     g.inputs, g.outputs = ["x", "w"], ["sqr"]
     return g
@@ -182,7 +182,7 @@ def _make_contraction():
     g.add_node(InputOp(), [], Tensor("a", (4, 8)), node_id="a")
     g.add_node(InputOp(), [], Tensor("b", (4, 8)), node_id="b")
     g.add_node(ElementwiseOp("multiply"), ["a", "b"], Tensor("m", (4, 8)), node_id="m")
-    g.add_node(ReduceOp("sum", -1), ["m"], Tensor("y", (4, 1)), node_id="y")
+    g.add_node(ReduceOp("sum", axis=-1), ["m"], Tensor("y", (4, 1)), node_id="y")
     g.inputs, g.outputs = ["a", "b"], ["y"]
     return g
 
@@ -214,7 +214,7 @@ def _make_contraction_with_epilogue():
     g.add_node(InputOp(), [], Tensor("b", (4, 8)), node_id="b")
     g.add_node(InputOp(), [], Tensor("bias", (4, 1)), node_id="bias")
     g.add_node(ElementwiseOp("multiply"), ["a", "b"], Tensor("m", (4, 8)), node_id="m")
-    g.add_node(ReduceOp("sum", -1), ["m"], Tensor("s", (4, 1)), node_id="s")
+    g.add_node(ReduceOp("sum", axis=-1), ["m"], Tensor("s", (4, 1)), node_id="s")
     g.add_node(ElementwiseOp("add"), ["s", broadcast_to(g, "bias", (4, 1))], Tensor("y", (4, 1)), node_id="y")
     g.inputs, g.outputs = ["a", "b", "bias"], ["y"]
     return g
@@ -240,10 +240,10 @@ def test_contraction_epilogue_body_has_add():
 def _make_softmax():
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("mx", (4, 1)), node_id="mx")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("mx", (4, 1)), node_id="mx")
     g.add_node(ElementwiseOp("subtract"), ["x", "mx"], Tensor("subtract", (4, 8)), node_id="subtract")
     g.add_node(ElementwiseOp("exp"), ["subtract"], Tensor("exp", (4, 8)), node_id="exp")
-    g.add_node(ReduceOp("sum", -1), ["exp"], Tensor("sm", (4, 1)), node_id="sm")
+    g.add_node(ReduceOp("sum", axis=-1), ["exp"], Tensor("sm", (4, 1)), node_id="sm")
     g.add_node(ElementwiseOp("divide"), ["exp", "sm"], Tensor("out", (4, 8)), node_id="out")
     g.inputs, g.outputs = ["x"], ["out"]
     return g
@@ -362,8 +362,8 @@ def _make_sibling_reductions():
     with two accumulators sharing one reduce axis."""
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
-    g.add_node(ReduceOp("sum", -1), ["x"], Tensor("s", (4, 1)), node_id="s")
-    g.add_node(ReduceOp("maximum", -1), ["x"], Tensor("m", (4, 1)), node_id="m")
+    g.add_node(ReduceOp("sum", axis=-1), ["x"], Tensor("s", (4, 1)), node_id="s")
+    g.add_node(ReduceOp("maximum", axis=-1), ["x"], Tensor("m", (4, 1)), node_id="m")
     g.add_node(ElementwiseOp("add"), ["s", "m"], Tensor("out", (4, 1)), node_id="out")
     g.inputs, g.outputs = ["x"], ["out"]
     return g
@@ -563,7 +563,7 @@ def _make_gather_into_reduce():
     g.add_node(GatherOp(axis=0), ["w", "idx"], Tensor("emb", (1, S, H)), node_id="emb")
     # RMSNorm-like: variance reduce reads emb, normalize reads emb again.
     g.add_node(ElementwiseOp("multiply"), ["emb", "emb"], Tensor("sq", (1, S, H)), node_id="sq")
-    g.add_node(ReduceOp("sum", -1), ["sq"], Tensor("red", (1, S, 1)), node_id="red")
+    g.add_node(ReduceOp("sum", axis=-1), ["sq"], Tensor("red", (1, S, 1)), node_id="red")
     g.add_node(ElementwiseOp("multiply"), ["emb", broadcast_to(g, "red", (1, S, H))], Tensor("out", (1, S, H)), node_id="out")
     g.inputs, g.outputs = ["w", "idx"], ["out"]
     return g

--- a/tests/compiler/passes/test_matcher.py
+++ b/tests/compiler/passes/test_matcher.py
@@ -20,7 +20,7 @@ def _simple_graph() -> Graph:
     g.add_node(op=InputOp(), inputs=[], output=Tensor("a", (4, 8)), node_id="a")
     g.add_node(op=InputOp(), inputs=[], output=Tensor("b", (8, 4)), node_id="b")
     g.add_node(op=ElementwiseOp("multiply"), inputs=["a", "b"], output=Tensor("m", (4, 8, 4)), node_id="m")
-    g.add_node(op=ReduceOp("sum", 1), inputs=["m"], output=Tensor("o", (4, 4)), node_id="o")
+    g.add_node(op=ReduceOp("sum", axis=1), inputs=["m"], output=Tensor("o", (4, 4)), node_id="o")
     g.inputs = ["a", "b"]
     g.outputs = ["o"]
     return g
@@ -67,8 +67,8 @@ def test_chain_fails_on_fanout():
     g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (4,)), node_id="x")
     g.add_node(op=ElementwiseOp("multiply"), inputs=["x"], output=Tensor("m", (4,)), node_id="m")
     # Two consumers of m, so the chain can't extend.
-    g.add_node(op=ReduceOp("sum", 0), inputs=["m"], output=Tensor("r1", (1,)), node_id="r1")
-    g.add_node(op=ReduceOp("sum", 0), inputs=["m"], output=Tensor("r2", (1,)), node_id="r2")
+    g.add_node(op=ReduceOp("sum", axis=0), inputs=["m"], output=Tensor("r1", (1,)), node_id="r1")
+    g.add_node(op=ReduceOp("sum", axis=0), inputs=["m"], output=Tensor("r2", (1,)), node_id="r2")
     g.inputs = ["x"]
     g.outputs = ["r1", "r2"]
     matches = _match(g, [Pattern("ew", ElementwiseOp), Pattern("red", ReduceOp)])

--- a/tests/compiler/passes/test_move_catalog.py
+++ b/tests/compiler/passes/test_move_catalog.py
@@ -202,7 +202,7 @@ def _reduce_graph() -> Graph:
 
     g = Graph()
     g.add_node(InputOp(), [], Tensor("x", (2048, 2048)), node_id="x")
-    g.add_node(MeanOp(), ["x"], Tensor("y", (2048, 1)), node_id="y")
+    g.add_node(MeanOp(axis=-1), ["x"], Tensor("y", (2048, 1)), node_id="y")
     g.inputs, g.outputs = ["x"], ["y"]
     return g
 


### PR DESCRIPTION
## What

First slice of gradual typing for the compiler: the Layer-1 IR (frontend + tensor dialects and their support
types) is now shaped like algebraic datatypes, with a checker enforcing it.

- **Closed unions per dialect** — `FrontendOp` (`ir/frontend/ir.py`), `TensorOp` (`ir/tensor/ir.py`),
  `BoundaryOp` (`ir/base.py`); every variant `@final`. Annotate with the alias where the dialect is known and
  `match` over it is exhaustiveness-checked. `Op` stays the open cross-dialect base.
- **Axis type parameter** — the six axis-carrying ops (`ReduceOp`/`ScanOp`/`GatherOp`/`ScatterOp`,
  `MeanOp`/`SoftmaxOp`) are generic over `[A: (int, str)]` with keyword-only `axis`: a checked caller must
  resolve concrete-vs-symbolic before constructing, and the numpy `forward` interpreters
  (`self: ReduceOp[int]`) are uncallable on symbolic-axis ops. Erased at runtime; the only caller-visible
  change is the removed axis defaults (all construction sites now name their axis).
- **Scoped pyright gate** — `[tool.pyright]` includes only the Layer-1 definition modules (basic mode +
  `reportMatchNotExhaustive=error`), wired as `make typecheck` and a CI lint step. Green at 0 errors —
  scoped small, unlike #329's all-of-`emmy/compiler` attempt.
- **Runtime enforcement** — `tests/compiler/ir/test_dialect_unions.py` pins union membership to the `@final`
  classes per module, keeps the unions disjoint, and requires a decomposition rule per `FrontendOp` variant.
- Typed on the way: `Expr.eval` (`object` → `Value`), `IndexSource.coord_map`/`select` (bare
  `tuple`/`object` → `Expr`), `ElementwiseImpl`'s name table (`object` → `Callable`).

## Verification

- Guarantees probed for real (per-setup one-time check): unresolved `int | str` axis refused at construction,
  `forward` unbindable on `ReduceOp[str]`, non-exhaustive `match` over `TensorOp` errors, and a fake union
  variant turns both pyright and the coverage test red.
- Full suite on an RTX 4090 box: 2626 passed, 163 skipped (one dry-run test fails only on a `.git`-less rsync
  copy; passes on a real checkout). `make lint` and `make typecheck` green.

## Not included (next slices)

- `ir/expr.py` in the gate (~40 pre-existing basic-mode errors: `_ExprOps` self-typing, `apply_binop` object
  arithmetic — `BinaryExpr.eval`'s `object → Value` mismatch lands there too).
- Stage-boundary narrowing helpers (`as_tensor_op`) + `match`/`assert_never` at dispatch sites.
- The bigger program discussed in-session: op metadata (`source`/`knobs`/IO) off `Op` onto `Node` then frozen
  ops, sealed dialect bases, the scalar-fn enum replacing stringly `ElementwiseImpl` names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AutTCsJwN21NJMUJWsPfV4