### PR TITLE
Add serial std deploy-floor siblings for 4090 mlp_down.m4096(.lin)

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
@@ -906,6 +906,19 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
     emmy_us: 2221.1
     cublas_us: 2915.3
+  # SERIAL std deploy-floor siblings (2026-07-27, vast.ai 4090 580.119.02): as on the 5090, the std
+  # g2k rows above realize only under pin — the un-pinned enumeration offers no split-K here, the
+  # floor fell through, and the prior deployed a 111 ms (canonical) / bench-budget-blowing (.lin)
+  # kernel (0.03x eager, isolated + clean-evidence reproduced). Pinned serial A/B winners recorded.
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.m4096
+    M: 4096
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f2x4/k2', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 3324.9
+    cublas_us: 2915.3
   - kernel: matmul
     name: gemma4_12b.mlp_down.m4096.lin
     M: 4096
@@ -925,6 +938,16 @@ configs:
     trans_b: true
     knobs: {TILE: 'a:mma_m16n8k16_f16_f16/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
     emmy_us: 2154.5
+    cublas_us: 2922.5
+  - kernel: matmul
+    name: gemma4_12b.mlp_down.m4096.lin
+    M: 4096
+    N: 3840
+    K: 15360
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w4x2/f4x8/k4', REDUCE: '', RASTER: '', STAGE: 'd2/cp/ring', WSPEC: ''}
+    emmy_us: 3415.8
     cublas_us: 2922.5
   - kernel: matmul
     name: gemma4_12b.q_proj_global.m4096

--- a/plans/gemma4-attention-s4096-goldens-findings.md
+++ b/plans/gemma4-attention-s4096-goldens-findings.md
@@ -46,6 +46,20 @@ candidates; one 4090 rental died in provisioning) — both cards fell back to va
 - hd512 fm greedy realizes the all-f32 config — no `[fm]` row recorded (would violate nothing, but it would
   be a duplicate std row; `GoldenConfig.fast_math` derives from knobs).
 
+## Follow-up (2026-07-27, full-set 4090 re-bench): mlp_down.m4096 std misdeploy, same offer-gap class
+
+The full 139-name golden-set bench (fresh vast.ai 4090, driver 580.119.02) exposed that the 4090's
+`mlp_down.m4096(.lin)` std lane had NO realizable golden row: the g2k rows realize only under pin (no
+split-K offer — the identical gap as attention.hd512.s4096), the floor fell through, and the clean-evidence
+greedy deployed a **111 ms kernel on the canonical twin (0.03x eager)** and a bench-budget-blowing one on
+`.lin`. Downstream, `mlp_geglu.m4096.cut(.lin)` intermittently FAILED ACCURACY (mean_diff=nan) because its
+cut consumes that pathological down-half. Fixed by recording pinned SERIAL std siblings (canonical
+`w4x2/f2x4/k2` 3324.9 µs, `.lin` `w4x2/f4x8/k4` 3415.8 µs, both d2/cp/ring): floors now decide (3320/3712
+greedy, 0.90x/0.79x) and the geglu accuracy failures disappear. The 5090 file already carried its serial
+sibling — the 4090 port had missed it. Every un-pinnable golden needs a realizable floor sibling; an
+`eval golden` audit that flags pin-only shapes (golden realizes under pin but not in the enumeration)
+would have caught both cases statically.
+
 ## Blog chart regen (the consuming workflow)
 
 - Chart shape set is now **26 per card**: 13 seq-512 base + 13 4K-tier (`.m4096` matmuls incl.


### PR DESCRIPTION
Follow-up to #423, found by the full-set (139-name) golden bench on a fresh vast.ai 4090 (driver 580.119.02):

The 4090's `mlp_down.m4096(.lin)` std lane had **no realizable golden row** — the `REDUCE=g2k` rows realize only under an explicit pin (no split-K offer at this grid, the same enumeration-gap class as `attention.hd512.s4096` in #423), so the golden floor fell through and the clean-evidence greedy deployed:

- canonical twin: a **111 ms kernel (0.03× eager)** — isolated + clean-evidence reproduced,
- `.lin` twin: a variant that blows the 60 s GPU-time bench budget,
- downstream, `mlp_geglu.m4096.cut(.lin)` intermittently **failed accuracy** (`mean_diff=nan`) because the cut consumes that pathological down-half.

Fix: recorded the pinned serial A/B winners as std deploy-floor siblings (canonical `w4x2/f2x4/k2` 3324.9 µs, `.lin` `w4x2/f4x8/k4` 3415.8 µs, both `d2/cp/ring`). Verified on-card: floors now decide (greedy 3320.8 / 3712.0 µs = 0.90×/0.79× vs eager, no fall-through) and the geglu accuracy failures disappear (139/139 golden-set benches pass). The 5090 file already carried its serial sibling — the 4090 port had missed it.

`make test` (2619 passed / 160 skipped) and `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)