### PR TITLE
eval golden: pin-only offer audit — catch missing deploy-floor siblings at record time

### DIFF
--- a/emmy/commands/eval.py
+++ b/emmy/commands/eval.py
@@ -264,10 +264,13 @@ def handle_eval_online(args) -> None:
 
 def handle_eval_golden(args) -> None:
     """``eval golden`` — the greedy pipeline pick vs recorded golden per config (the
-    actionable "did the pipeline reproduce the golden knobs?" view). Watch it while
-    iteratively tuning golden shapes one at a time (``emmy tune --golden
-    <name>``). Use ``eval offline`` / ``eval online`` for the offline-prior rank and
-    the online rank-under-prior diagnostics."""
+    actionable "did the pipeline reproduce the golden knobs?" view), then the pin-only
+    offer audit (:func:`_emit_offer_audit`: does each recorded entry realize on its
+    shape's UN-PINNED enumeration, or does the shape fall through the deploy's golden
+    floor?). Watch it while iteratively tuning golden shapes one at a time (``emmy tune
+    --golden <name>``). Use ``eval offline`` / ``eval online`` for the offline-prior
+    rank and the online rank-under-prior diagnostics. Exits 1 when the audit finds a
+    fall-through shape."""
     if args.in_model:
         if args.features or args.kernel:
             logger.error("--in-model audits whole serving twins — --features / --kernel apply only to the per-config check")
@@ -280,6 +283,8 @@ def handle_eval_golden(args) -> None:
         _emit_golden_features(args.kernel)
     configs = _golden_configs(args.kernel)
     _emit_prior_golden_check(configs, title=False)
+    if _emit_offer_audit(_offer_audit_configs(args.kernel)):
+        sys.exit(1)
 
 
 def _in_model_audit(model_filter: str | None) -> None:
@@ -908,6 +913,149 @@ def _emit_prior_golden_check(configs: list, *, title: bool = True, perf: dict | 
     entries.append(("total", total_lead, total_cells))
     lead_cols = [Col("kernel"), Col("m/t")] + ([Col("vs gold", "r")] if perf is not None else [])
     _emit_golden_table(lead_cols, entries, "knobs (found/golden)")
+
+
+def _offer_audit_configs(kernel_filter: str | None) -> list:
+    """The live card's golden entries that deploy through a fork — every kind except the
+    fork-nothing regression anchors (rope / embedding gathers never consult the golden tier),
+    optionally name-filtered. Broader than :func:`_golden_configs` (matmul-only): a pin-only
+    row on any forking kind — the 4090 ``attention.hd512.s4096`` split-KV row — falls through
+    the deploy's golden floor exactly like a matmul one."""
+    from emmy.compiler.pipeline.search.golden import EmbeddingGoldenConfig, RopeGoldenConfig, goldens_for_live_gpu  # noqa: PLC0415
+
+    configs = [g for g in goldens_for_live_gpu() if not isinstance(g, (RopeGoldenConfig, EmbeddingGoldenConfig))]
+    if kernel_filter:
+        configs = [g for g in configs if kernel_filter in g.name]
+    return configs
+
+
+def _emit_offer_audit(configs: list) -> bool:
+    """The pin-only offer audit — does each recorded golden realize on its shape's UN-PINNED
+    enumeration? Re-compiles every golden's own snippet greedily under the golden-audit seam
+    (``search/audit.audit_card``: deployable regime, the golden file's own card, no local tune
+    evidence — the enumeration is static given shape+context, so no GPU bench is needed) and
+    reads per-entry realizability off the verdict records:
+
+      PIN-ONLY      the entry's knobs realize only under an explicit pin (``EMMY_KNOBS`` /
+                    ``tune --golden``) — the un-pinned enumeration never offers them, so the
+                    entry never deploys. Legal as a documented lever while an OFFERED sibling
+                    floors the shape.
+      FALL-THROUGH  NO entry of the shape realizes: a deploy logs "no offered candidate
+                    realizes any of them" and falls past the golden tier (the 4090
+                    ``attention.hd512.s4096`` pathology: a 111 ms 0.03x kernel NaN-poisoning
+                    the downstream accuracy check) — the defect this audit catches at record
+                    time. Fix: record an offered deploy-floor sibling (re-tune un-pinned) or
+                    close the enumeration gap.
+
+    Fast-math entries audit under the pinned ``F16_MMA_F32_ACC`` gate (their deploy regime), so
+    each regime's rows judge against their own enumeration. This is the OWN-SNIPPET view — an
+    entry can realize here yet still drift inside a served model's fused graph (the 5090
+    ``mlp_down.m4096`` split-K row on the epilogue-fused twin); ``--in-model`` audits that
+    side. Returns True when any shape falls through (``eval golden`` exits 1 on it)."""
+    import logging as _logging  # noqa: PLC0415
+    from contextlib import nullcontext  # noqa: PLC0415
+
+    from emmy.commands.trace import graph_from_code  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.audit import COMPILE_FAIL, audit_card  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.space import F16_MMA_F32_ACC  # noqa: PLC0415
+    from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs  # noqa: PLC0415
+
+    def label_of(name: str, fm: bool) -> str:
+        return f"{name} [fm]" if fm else name
+
+    def kstr(g) -> str:  # the entry's distinguishing knobs, empty families dropped
+        return ",".join(f"{k}={v}" for k, v in g.knobs.items() if v not in ("", None))
+
+    logger.info("")
+    logger.info("Offer audit — do the recorded knobs realize on the shape's un-pinned enumeration (own snippet, deployable regime)?")
+    cards: dict[tuple, list] = {}
+    for g in configs:
+        cards.setdefault((g.gpu_name, tuple(g.compute_cap)), []).append(g)
+    n_shapes = n_entries = n_pin = 0
+    fell: list[str] = []
+    # Silence the trace/compile chatter — at ERROR, not WARNING: the greedy tier's per-fork
+    # drift warning is this audit's MEASUREMENT (re-reported as FALL-THROUGH below), not news.
+    quiet = [_logging.getLogger(n) for n in ("emmy.compiler", "emmy.commands.trace")]
+    prev = [lg.level for lg in quiet]
+    for lg in quiet:
+        lg.setLevel(_logging.ERROR)
+    try:
+        for (gpu_name, cap), card_cfgs in sorted(cards.items()):
+            if len(cards) > 1:
+                logger.info("  --- %s (sm_%d%d) ---", gpu_name, cap[0], cap[1])
+            for fm in (False, True):
+                groups: dict[str, list] = {}
+                for g in card_cfgs:
+                    if g.fast_math == fm:
+                        groups.setdefault(g.name, []).append(g)
+                graphs: dict[str, object] = {}
+                for name, sub in groups.items():
+                    try:
+                        dyn = sub[0].dynamic_specs()
+                        shapes = build_torch_dynamic_shapes(parse_position_specs(dyn)) if dyn else None
+                        graphs[name], _, _ = graph_from_code(sub[0].snippet(), dynamic_shapes=shapes)
+                    except Exception as e:  # noqa: BLE001 — one shape's error shouldn't abort the audit
+                        logger.info("  %-44s  ERR  %s", label_of(name, fm), " ".join(f"{type(e).__name__}: {e}".split())[:100])
+                if not graphs:
+                    continue
+                with F16_MMA_F32_ACC.pinned("1") if fm else nullcontext():
+                    res = audit_card(graphs, gpu_name, cap)
+                for name, sub in groups.items():
+                    if name not in graphs:
+                        continue  # trace error, already reported
+                    recs = res.get(name, [])
+                    fail = next((r for r in recs if r["verdict"] == COMPILE_FAIL), None)
+                    if fail is not None:
+                        logger.info("  %-44s  ERR  %s", label_of(name, fm), " ".join(str(fail.get("error", "")).split())[:100])
+                        continue
+                    n_shapes += 1
+                    n_entries += len(sub)
+                    key = sub[0].shape_key()
+                    hits = [r for r in recs if r["key"] == key]
+                    if not hits:
+                        logger.warning(
+                            "  %-44s  NO-FORK  no fork of its own snippet keys %s — the golden tier was never "
+                            "consulted at this shape (key drift; `eval golden --in-model` is the deploy-side authority)",
+                            label_of(name, fm),
+                            key,
+                        )
+                        continue
+                    floor = next((r for r in hits if r["verdict"] == "MATCH"), None)
+                    for g in sub:
+                        if any(g not in (r["unrealized"] or ()) for r in hits):
+                            continue  # offered somewhere in its own snippet — deploys un-pinned
+                        n_pin += 1
+                        via = f"deploy floor: {floor['golden']} @ {floor['us']:g}us" if floor else "NO offered sibling"
+                        logger.info("  %-44s  PIN-ONLY  %.1fus  %s  (%s)", label_of(name, fm), g.emmy_us, kstr(g), via)
+                    if all(r["verdict"] == "DRIFT" for r in hits):
+                        fell.append(label_of(name, fm))
+                        logger.error(
+                            "  %-44s  FALL-THROUGH  none of the shape's %d recorded entr%s realizes un-pinned — a deploy "
+                            'logs "no offered candidate realizes any of them" and falls past the golden tier; record an '
+                            "offered deploy-floor sibling or fix the enumeration",
+                            label_of(name, fm),
+                            len(sub),
+                            "y" if len(sub) == 1 else "ies",
+                        )
+    finally:
+        for lg, lv in zip(quiet, prev, strict=True):
+            lg.setLevel(lv)
+    logger.info("")
+    if fell:
+        logger.info(
+            "  offer audit: %d shape(s) FALL THROUGH the golden floor (%s); %d/%d entries pin-only",
+            len(fell),
+            ", ".join(fell),
+            n_pin,
+            n_entries,
+        )
+    elif n_pin:
+        logger.info(
+            "  offer audit: %d/%d entries pin-only across %d shapes — every shape keeps an offered deploy floor", n_pin, n_entries, n_shapes
+        )
+    else:
+        logger.info("  offer audit: all %d entries realize un-pinned across %d shapes", n_entries, n_shapes)
+    return bool(fell)
 
 
 @dataclass(frozen=True)

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -54,7 +54,7 @@ Terms used throughout:
 | `search/prior/` | The ONE ranking path: a `Prior` ABC with the cold `OfflinePrior` and the `OnlinePrior` composed behind `FallbackPrior` (`load_prior`). `diagnostics.py` here backs the `eval` reachability / calibration reports; `fit/` is the offline fitter core (`linear.py`) plus the `emmy fit` cross-validation harness (`cv.py` — fold axes, pooled holdout/train tables, the metrics dict). |
 | `search/data/` | The harmonized read-view over the three data sources (golden configs / DB `perf` rows / prior reservoir): `Sample`, `Dataset`, and `ShapeKey` (the single golden↔measured join key). |
 | `search/golden.py` | `GoldenConfig` and its subclasses (see Part 7, "Golden configs and the A/B integrity gates"). |
-| `search/audit.py` | The golden drift audit: compile graphs with the golden tier as the only evidence, one MATCH / DRIFT / GAP verdict per consulted fork (via `greedy.golden_audit`, the supported sink). Backs `emmy eval golden --in-model` and the CI gate (see Part 7). |
+| `search/audit.py` | The golden drift audit: compile graphs with the golden tier as the only evidence, one MATCH / DRIFT / GAP verdict per consulted fork (via `greedy.golden_audit`, the supported sink; records also carry `unrealized`, the per-entry pin-only signal). Backs `emmy eval golden` (the pin-only offer audit), `--in-model`, and the CI gate (see Part 7). |
 | `keys.py` | `op_cache_key` / `dialect_of` / `source_chain`. |
 | `slice.py` | Isolates one finalized kernel into a standalone graph (used by the inner tune and structural pricing). |
 | `dump.py`, `rule_diff.py` | The dump and `-vv` presentation layers (see the end of this file). |
@@ -758,6 +758,20 @@ baseline means full model coverage is thereafter enforced (only fork-free determ
 gathers — sit outside the gate, having no fork for the golden tier to decide). The twins track the installed `transformers` modeling code by design: a transformers
 bump that changes the forward changes the twins exactly as it changes serving, and the gate goes loudly red.
 `scripts/diagnostics/audit_golden_match.py` is the same audit over explicit graph JSONs on a live box.
+
+**The pin-only offer audit** (`emmy eval golden`, same `search/audit` seam) is the record-time complement: for every
+forking golden entry it re-compiles the shape's OWN snippet un-pinned (deployable regime, the golden file's own card —
+the enumeration is static given shape+context, so no GPU bench) and checks the recorded knobs against the offered
+candidates. An entry only a pin can realize (`EMMY_KNOBS` / `tune --golden` benches it, the enumeration never offers
+it) reports **PIN-ONLY** — legal as a documented lever while an OFFERED sibling floors the shape (the 4090
+`attention.hd512.s4096` split-KV row beside its serial deploy-floor sibling); a shape whose entries are ALL pin-only
+reports **FALL-THROUGH** and exits 1: a deploy logs "no offered candidate realizes any of them" and falls past the
+golden tier — the missing-floor pathology that deployed a 111 ms 0.03x `mlp_down.m4096` kernel and NaN-poisoned the
+downstream accuracy check before the floor-sibling discipline. Fast-math entries audit under the pinned
+`F16_MMA_F32_ACC` gate (their own deploy regime). The own-snippet and in-model views genuinely differ: the 5090
+`mlp_down.m4096` split-K row realizes standalone but not on the serving twin's epilogue-fused down — the offer audit
+passes it and `--in-model` is the authority there, while the s4096 split-KV row fails even standalone, which is what
+this audit catches at record time.
 
 **Live-GPU scoping.** `tune --dataset golden` (and `--golden NAME` resolution) scopes to the **live** card's goldens
 (`goldens_for_live_gpu`) — names repeat across per-GPU golden files with diverging shapes/dtypes, so a flat union

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -602,11 +602,15 @@ _AUDIT_SINK: list[dict] | None = None
 
 @contextmanager
 def golden_audit(records: list[dict]):
-    """Collect one ``{node, key, verdict, golden, us, n_rows}`` record per golden-tier
-    consultation into ``records`` for the duration of the block. Verdicts: ``MATCH``
-    (a recorded golden realized on an offered candidate), ``DRIFT`` (goldens keyed to
-    the fork's shape but none realizes — a graph/enumeration change invalidated them),
-    ``GAP`` (no golden recorded for the shape)."""
+    """Collect one ``{node, key, verdict, golden, us, n_rows, unrealized}`` record per
+    golden-tier consultation into ``records`` for the duration of the block. Verdicts:
+    ``MATCH`` (a recorded golden realized on an offered candidate), ``DRIFT`` (goldens
+    keyed to the fork's shape but none realizes — a graph/enumeration change invalidated
+    them), ``GAP`` (no golden recorded for the shape). ``unrealized`` (MATCH/DRIFT only;
+    ``None`` on GAP) lists the shape's recorded :class:`GoldenConfig` entries that NO
+    offered candidate realizes — the per-entry "pin-only" signal the ``eval golden``
+    offer audit reads (an entry can be individually unrealizable while a sibling still
+    MATCHes and floors the deploy)."""
     global _AUDIT_SINK
     prev = _AUDIT_SINK
     _AUDIT_SINK = records
@@ -616,11 +620,15 @@ def golden_audit(records: list[dict]):
         _AUDIT_SINK = prev
 
 
-def _audit_record(node_id: str, key, verdict: str, golden: str | None, us: float | None, n_rows: int) -> None:
+def _audit_record(
+    node_id: str, key, verdict: str, golden: str | None, us: float | None, n_rows: int, unrealized: list | None = None
+) -> None:
     if _AUDIT_SINK is not None:
         # ``key`` stays the ShapeKey object — coverage policy (major-gap classification)
         # reads its fields; presentation layers stringify at print/JSON time.
-        _AUDIT_SINK.append({"node": node_id, "key": key, "verdict": verdict, "golden": golden, "us": us, "n_rows": n_rows})
+        _AUDIT_SINK.append(
+            {"node": node_id, "key": key, "verdict": verdict, "golden": golden, "us": us, "n_rows": n_rows, "unrealized": unrealized}
+        )
 
 
 def _golden_pick(index: dict, rows: list[dict], node_id: str) -> tuple[int, float] | None:
@@ -647,6 +655,12 @@ def _golden_pick(index: dict, rows: list[dict], node_id: str) -> tuple[int, floa
     if not goldens:
         _audit_record(node_id, key, "GAP", None, None, len(rows))
         return None
+    # Per-entry realizability, computed only under an active audit sink: the ``eval golden``
+    # offer audit reads which recorded entries the un-pinned enumeration never offers
+    # (pin-only rows); the deploy hot path below still stops at the first realizing golden.
+    unrealized = None
+    if _AUDIT_SINK is not None:
+        unrealized = [g for g in goldens if not any(_golden_matches_row(dict(tuning_knob_items(g.knobs)), row) for row in rows)]
     for g in goldens:  # fastest recorded entry first
         gold = dict(tuning_knob_items(g.knobs))
         # Several rows can realize one golden (a golden pins a knob PREFIX); the
@@ -654,9 +668,9 @@ def _golden_pick(index: dict, rows: list[dict], node_id: str) -> tuple[int, floa
         matches = [i for i, row in enumerate(rows) if _golden_matches_row(gold, row)]
         if matches:
             best = min(matches, key=lambda i: canonical_row_key(rows[i]))
-            _audit_record(node_id, key, "MATCH", g.name, float(g.emmy_us or 0.0), len(rows))
+            _audit_record(node_id, key, "MATCH", g.name, float(g.emmy_us or 0.0), len(rows), unrealized=unrealized)
             return best, float(g.emmy_us or 0.0)
-    _audit_record(node_id, key, "DRIFT", ", ".join(g.name for g in goldens), None, len(rows))
+    _audit_record(node_id, key, "DRIFT", ", ".join(g.name for g in goldens), None, len(rows), unrealized=unrealized)
     logger.warning(
         "deploy: node %r matches golden shape %s (%d recorded entr%s), but no offered candidate realizes any of "
         "them — the golden(s) no longer realize under the current enumeration; falling through to the normal "

--- a/tests/compiler/cli/test_eval.py
+++ b/tests/compiler/cli/test_eval.py
@@ -588,3 +588,54 @@ def test_offline_eval_scores_each_golden_under_its_own_card(monkeypatch):
     assert ctx.gpu_name == "NVIDIA GeForce RTX 4090"
     assert ctx.sm_count == 128  # the 4090's registered SM count, regardless of the host GPU
     assert ctx.compute_capability == (8, 9)
+
+
+def test_offer_audit_flags_pin_only_and_fall_through(monkeypatch, caplog):
+    """``eval golden``'s offer audit: an entry no offered candidate realizes is PIN-ONLY
+    (fine while an offered sibling floors the shape); a shape whose entries are ALL
+    pin-only FALLS THROUGH the deploy's golden floor and the audit returns True (the
+    command exits 1) — the 4090 ``attention.hd512.s4096`` split-KV class, caught at
+    record time instead of in production benches. ``PLACE@cone: cut`` is the
+    guaranteed-unrealizable pin here: a plain matmul fork never offers the placement and
+    ``_golden_matches_row`` refuses PLACE as free."""
+    import logging
+
+    import pytest
+
+    pytest.importorskip("torch")
+    import emmy.commands.eval as eval_cmd
+    import emmy.compiler.pipeline.search.golden as golden_mod
+    from emmy.compiler.pipeline.search.golden import MatmulGoldenConfig
+
+    def cfg(name, m, knobs, us):
+        return MatmulGoldenConfig(
+            name=name, M=m, N=32, K=32, dtype="fp32", knobs=knobs, emmy_us=us, gpu_name="NVIDIA GeForce RTX 4090", compute_cap=(8, 9)
+        )
+
+    floored = [
+        cfg("audit.floored", 32, {"PLACE@cone": "cut"}, 10.0),  # pin-only; the sibling below floors the shape
+        cfg("audit.floored", 32, {}, 20.0),  # prefix-consistent with any offered row — the deploy floor
+    ]
+    orphan = [cfg("audit.orphan", 48, {"PLACE@cone": "cut"}, 10.0)]  # ALL pin-only → falls through
+    # The compile-time golden index reads GOLDEN_CONFIGS scoped to the audited card — patch it
+    # so the verdicts are hermetic (no dependence on the repo's real 4090 recordings).
+    monkeypatch.setattr(golden_mod, "GOLDEN_CONFIGS", floored + orphan)
+
+    with caplog.at_level(logging.INFO, logger="emmy.commands.eval"):
+        fell = eval_cmd._emit_offer_audit(floored + orphan)
+
+    assert fell is True
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("PIN-ONLY" in m and "audit.floored" in m and "deploy floor" in m for m in msgs)
+    assert any("PIN-ONLY" in m and "audit.orphan" in m and "NO offered sibling" in m for m in msgs)
+    assert any("FALL-THROUGH" in m and "audit.orphan" in m for m in msgs)
+    assert not any("FALL-THROUGH" in m and "audit.floored" in m for m in msgs)
+
+    # A set whose every entry realizes un-pinned is clean: no flags, audit returns False.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="emmy.commands.eval"):
+        fell = eval_cmd._emit_offer_audit([floored[1]])
+    assert fell is False
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("realize un-pinned" in m for m in msgs)
+    assert not any("PIN-ONLY" in m or "FALL-THROUGH" in m for m in msgs)

--- a/tests/compiler/pipeline/search/test_golden_floor.py
+++ b/tests/compiler/pipeline/search/test_golden_floor.py
@@ -121,6 +121,43 @@ def test_floor_respects_blocklist(monkeypatch, caplog):
     assert any("no longer realize" in r.message for r in caplog.records)
 
 
+def test_audit_sink_records_unrealized_pin_only_entries(monkeypatch):
+    """Under ``golden_audit`` the MATCH record carries ``unrealized`` — the shape's recorded
+    entries NO offered candidate realizes (the ``eval golden`` offer audit's pin-only
+    signal). The deploy outcome is unchanged: the realizable sibling still floors the pick.
+    A shape whose entries are ALL unrealized records DRIFT with every entry listed."""
+    from emmy.compiler.pipeline.search.policy.greedy import golden_audit
+
+    pin_only = MatmulGoldenConfig(
+        name="gemma4_12b.q_proj",
+        M=512,
+        N=4096,
+        K=3840,
+        dtype="fp16",
+        knobs={"TILE": _STD_TILE, "STAGE": "d4/tma/ring"},  # a STAGE these leaves never offer
+        emmy_us=50.0,  # fastest → consulted first; must not decide the pick
+        gpu_name=CARD,
+        compute_cap=CAP,
+    )
+    leaves = [SimpleNamespace(knobs=dict(_ROW_W1X1)), SimpleNamespace(knobs=dict(_ROW_GOLD))]
+    records: list[dict] = []
+    with golden_audit(records):
+        picked, fp = _decide_no_prior(monkeypatch, [pin_only, _golden()], leaves)
+    assert picked is leaves[1], "the realizable sibling floors the deploy exactly as before"
+    assert fp.score == 78.0
+    (rec,) = records
+    assert rec["verdict"] == "MATCH"
+    assert rec["unrealized"] == [pin_only]
+
+    records.clear()
+    with golden_audit(records):
+        picked, _ = _decide_no_prior(monkeypatch, [pin_only], leaves)
+    assert picked is leaves[0]  # nothing realizes → option-0
+    (rec,) = records
+    assert rec["verdict"] == "DRIFT"
+    assert rec["unrealized"] == [pin_only]
+
+
 def test_fork_shape_key_flash_sniff_scans_every_row():
     """The flash OFFER signal (the ``TILE@dd`` + ``TILE@pj`` pair) marks the fork when
     ANY row carries it — row 0 is whichever leaf the planner emitted first and need


### PR DESCRIPTION
## What

`emmy eval golden` now ends with a **pin-only offer audit**: for every forking golden entry it re-compiles the shape's OWN snippet un-pinned through the golden-audit seam (`search/audit.audit_card` — deployable regime, the golden file's own card; the enumeration is static given shape+context, so no GPU bench) and checks the recorded knobs against the offered candidates:

- **PIN-ONLY** — the entry realizes only under an explicit pin (`EMMY_KNOBS` / `tune --golden`); never offered, so it never deploys. Listed with the shape's deploy floor (the sibling a deploy actually lands on) or "NO offered sibling".
- **FALL-THROUGH** — no entry of the shape realizes: a deploy logs `no offered candidate realizes any of them` and falls past the golden tier. Reported as a defect; the command **exits 1**. This is the class that deployed a 111 ms 0.03x `mlp_down.m4096` kernel and NaN-poisoned the downstream `mlp_geglu.m4096.cut` accuracy check before hand-added serial floor siblings (and the 4090 `attention.hd512.s4096` repeat) — now caught at record time instead of in production benches.

Fast-math entries audit under the pinned `F16_MMA_F32_ACC` gate (their own deploy regime); fork-nothing anchors (rope/embedding) are skipped; NO-FORK (own-snippet key drift, e.g. the m32 sink-placement row) warns without failing — `--in-model` remains the deploy-side authority for in-model-only drift (the 5090 `mlp_down.m4096` epilogue-fused case).

Plumbing: `greedy._golden_pick` attaches per-entry realizability (`unrealized`) to `golden_audit` records when a sink is active; the deploy hot path is unchanged.

## Validation

- Live 4090 set (303 entries, ~13 min, off-GPU box): reproduces `attention.hd512.s4096` g2k as PIN-ONLY behind its serial floor (3514.0us pinned lever, floor @ 4587.5us), and with the floor sibling removed reports FALL-THROUGH — the exact regression scenario.
- **Two real findings**: `gemma4_12b.attention.hd512` (s512) and `.s2048` FALL THROUGH — their split-KV g2k rows are each shape's only std entry and don't realize un-pinned (same offer-gap class as s4096). Follow-up: seed serial floor siblings on a rented 4090; until then `eval golden` on a 4090 box exits 1 by design.
- Live 4080 card set: all 10 entries realize un-pinned, exit 0.
- `make test` equivalent: 2632 passed, 158 skipped (includes the golden drift CI gate — the record-shape extension is backward compatible). `ruff check` + `format --check` clean.

Context: `plans/gemma4-attention-s4096-goldens-findings.md` (PR #423's ⚠ OFFER GAP finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)