### PR TITLE
Narrow decode widths: the m32 CUT cone goldens, and why the batched MTP gap is KV capacity

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -2841,6 +2841,16 @@ configs:
   # are kept BESIDE the cut ones (a recorded measurement is never deleted, and `fuse` is the form a
   # cone-cut-less enumeration can still reach); the resolver takes the fastest realizing entry, so the
   # cut rows are what deploy. 3x reproduced at <2% spread, 2026-07-30 manual pinned --ab (no tuner).
+  #
+  # CAVEAT, measured end to end and worth more than these entries: swapping these three in on a live
+  # gemma-4 server moves the served step by 0.1% (28.06 vs 28.09 ms at conc 6, 28.77 vs 28.73 at conc 8),
+  # even though the boot log confirms the cut form deploys. `run --bench --golden` replays ONE weight slab
+  # 100x, so any slab under the card's 96 MB L2 is timed L2-resident: norm_qkv (63 MB) and
+  # norm_qk_global (67 MB) fit and showed the 42-49% wins, norm_gate_up (236 MB) does not and showed 8%.
+  # A decode step streams the whole 21.8 GB trunk, so none of it is L2-resident there. These entries are
+  # kept because they are not a regression, they give norm_gate_up.m32 a golden floor it had lost to
+  # enumeration drift, and they close norm_qkv's missing m32 coverage — NOT as a throughput improvement.
+  # See plans/gemma4-narrow-decode-width-findings.md section 4a.
   - kernel: norm_linear
     name: gemma4_12b.norm_gate_up.m32.cut.lin
     M: 32

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -2834,6 +2834,23 @@ configs:
   # on the .lin (serving F.linear) layout — the layout the twins deploy; canonical twins pending.
   # sliding layers: q(4096)+k(2048)+v(2048) -> N=8192; global layers (k_eq_v): q(8192)+k(512) -> N=8704;
   # MLP gate+up -> N=30720 (the GeGLU combine is now a separate downstream kernel).
+  # m32 (the decode-bucket width the batched serving lanes route onto) prefers the CUT placement on
+  # every fused edge, exactly as m8 and m64 do: the norm materializes to a workspace (a ~1.4 µs stat +
+  # ~0.8 µs scale at this M — free) and the matmul re-lowers with a plain gmem A, which lets it take
+  # the big-tile d2/tma/ring transport instead of the constrained sync compute-fill. The `fuse` twins
+  # are kept BESIDE the cut ones (a recorded measurement is never deleted, and `fuse` is the form a
+  # cone-cut-less enumeration can still reach); the resolver takes the fastest realizing entry, so the
+  # cut rows are what deploy. 3x reproduced at <2% spread, 2026-07-30 manual pinned --ab (no tuner).
+  - kernel: norm_linear
+    name: gemma4_12b.norm_gate_up.m32.cut.lin
+    M: 32
+    H: 3840
+    N: 30720
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE@cone: 'cut'}
+    emmy_us: 147.2
+    cublas_us: 154.0
   - kernel: norm_linear
     name: gemma4_12b.norm_gate_up.m32.lin
     M: 32
@@ -2865,6 +2882,19 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w1x16/f2x2/k4', REDUCE: '', RASTER: '', STAGE: 'd1/sync', WSPEC: ''}
     emmy_us: 1079.2
     cublas_us: 664.0
+  # The SLIDING layers' merged q||k||v edge at the decode bucket — 40 of the 48 `pre` programs. It had
+  # no m32 entry at all while its m8 and m64 siblings both record `cut`, so the single most-launched
+  # fused edge in the model had no floor at the width the batched serving lanes route onto.
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qkv.m32.cut.lin
+    M: 32
+    H: 3840
+    N: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE@cone: 'cut'}
+    emmy_us: 19.6
+    cublas_us: 29.0
   - kernel: norm_linear
     name: gemma4_12b.norm_qkv.m256.lin
     M: 256
@@ -2886,8 +2916,21 @@ configs:
     knobs: {TILE: 'a:mma_m16n8k16_f16_f32/w2x8/f4x4/k4', REDUCE: '', RASTER: '', STAGE: 'd1/sync', WSPEC: ''}
     emmy_us: 299.8
     cublas_us: 224.0
-  # global m32: the g8k split total (38.1 + 2.0 finalize); at this shape the split beats every
-  # unsplit tile by >2x (68 CTAs of w1x16 under-fill 170 SMs).
+  # global m32: the CUT placement halves the fused g8k split total below — same reason the split beat
+  # the unsplit tiles (68 CTAs of w1x16 under-fill 170 SMs), taken further: cut into a plain gmem-A
+  # matmul the enumeration can tile at 136 CTAs on d2/tma/ring.
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qk_global.m32.cut.lin
+    M: 32
+    H: 3840
+    N: 8704
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE@cone: 'cut'}
+    emmy_us: 19.8
+    cublas_us: 29.0
+  # the fused g8k split total (38.1 + 2.0 finalize); at this shape the split beats every
+  # unsplit tile by >2x.
   - kernel: norm_linear
     name: gemma4_12b.norm_qk_global.m32.lin
     M: 32

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -10,6 +10,16 @@
 # (~770x off cuBLAS), and on mlp_gate_up.dynM / attention.hd256.dynM it picks kernels that hang outright
 # (>1 s accuracy probe / >10 s bench cap) — the misdeploy + hang hazard class these goldens pin down.
 #
+# HOW TO READ emmy_us / cublas_us: both come from `run --bench --golden`, which replays ONE kernel over
+# ONE weight slab ~100x. Any slab under this card's 96 MB L2 is therefore timed L2-RESIDENT, not from
+# DRAM. Most narrow-N projection shapes here are in that regime (N=8192 K=3840 is 63 MB; N=30720 K=3840
+# is 236 MB and is not). Two consequences: (1) comparing two configs of the SAME shape stays valid — both
+# arms get the same L2 benefit, which is what the resolver ranks on; (2) the absolute microseconds must
+# NOT be used to predict in-model step time, because a decode step streams the whole ~21.8 GB trunk and
+# nothing stays resident. Measured the hard way on 2026-07-30: an m32 cone-placement change worth 42-49%
+# on two L2-resident edges moved a live server's per-step latency by 0.1%, while the one edge too big for
+# L2 won 8%. See plans/gemma4-narrow-decode-width-findings.md section 4a.
+#
 # Fast-math [fm] siblings (f16-accumulate mma atom) are kept BESIDE the standard entries, never replacing
 # them (a gate-off compile can't reach an f16acc config). The big-tile f16acc family (w4x2/f4x8/k4
 # d2/tma/ring, split g2k on the small-N shapes) wins 1.3-1.6x vs cuBLAS on every projection — the same

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -299,6 +299,57 @@ Recorded follow-ups, in impact order:
   --generate` therefore defaults the emmy arm to `--gpu-memory-utilization 0.97` (stock keeps 0.90; an explicit
   flag wins).
 
+## Device footprint sets admission capacity (generative)
+
+The generative arm's throughput on long-request batched workloads is set by how many sequences vLLM can
+admit, and that is decided by emmy's device footprint rather than by kernel speed.
+
+**Mechanism.** The runner holds its trunk weights, activation arenas and scratch slabs in **cupy**
+buffers. vLLM's memory profiler only measures torch allocations, so it never attributes any of them; it
+budgets the KV cache as `util × total − currently-used`, i.e. out of whatever is left after emmy has
+already claimed its residents. Every byte of emmy's non-KV footprint therefore comes straight out of the
+KV cache, and the KV cache is what caps concurrency: a request needing `input + output` tokens of KV
+consumes that much of a fixed pool, so a smaller pool admits proportionally fewer streams and queues or
+**preempts** the rest (a preempted request recomputes its prefill — wasted work that yields no token).
+
+**Scale of the effect.** Against stock vLLM at the same utilisation on gemma-4-12B, emmy's larger
+footprint costs on the order of half a GiB of KV, which on the 4k-in/4k-out batched workload is the
+difference between sustaining roughly seven concurrent streams and roughly five and a half. Throughput
+tracks that ratio almost exactly. It is not a kernel effect and cannot be recovered by tuning kernels.
+
+**`--gpu-memory-utilization` does not recover it.** Raising it far enough to match stock's KV budget
+leaves no headroom for allocations vLLM's profiler does not reserve — under speculative decoding the
+rejection sampler's transient buffers then fail at first use — and raising it further exceeds the free
+VRAM at startup and refuses to boot. The footprint has to shrink; the knob cannot substitute.
+
+**Where the footprint goes, and the actionable invariant:** the symbolic programs are built at
+`capacity = max_tokens` and the prefill twin at `prefill_bucket`, so the buffers are sized by the
+*serving shape*, not by the widths a lane actually reaches. A single `[max_tokens, intermediate]` fp16
+intermediate is already hundreds of MB. **A lane that only ever schedules `prefill_bucket`-sized chunks
+still pays for `max_tokens`-row buffers** — so the first place to look when reclaiming footprint is
+`BufferArena` occupancy measured against the widths a deployment can actually reach.
+
+### Reclaiming footprint re-opens the capture-ladder question
+
+These two knobs are coupled, and the coupling is a trap for whoever does the footprint work.
+
+A KV-starved lane admits few streams, so its verify width under speculative decoding
+(`streams × query_len`) stays small and lands on a low capture rung — comfortably at or below the decode
+bucket, i.e. on the static twin, **even with a ladder that violates the invariant above**. Reclaim the
+footprint and concurrency rises; the verify width rises with it; and it can cross the bucket, at which
+point every steady-state step silently falls to the symbolic program. Measured at decode-bucket widths,
+that path costs roughly **2x** the static twin per step.
+
+**Invariant: any change that raises sustained concurrency must re-check the ladder invariant above for
+the widths it newly makes reachable**, and raise the decode bucket (to a width with tuned kernels) or fix
+the ladder in the same change. Otherwise the reward for fixing the memory problem is silently losing the
+static decode twin.
+
+This applies with particular force to **baked serving images**, which may ship a hand-written
+`cudagraph_capture_sizes` list in their entrypoint rather than going through `_gen_graph_args`. Such a
+list does not get the flooring treatment described above, so it can violate the invariant while
+`emmy serve` on the same revision does not — check the image's entrypoint, not just the code.
+
 ## Testing
 
 - `tests/serving/test_packed.py` — pure span-split logic, runs everywhere.

--- a/plans/gemma4-mtp-batched-serving-findings.md
+++ b/plans/gemma4-mtp-batched-serving-findings.md
@@ -67,6 +67,16 @@ seventh concurrent request makes total throughput *fall below* what six achieved
 
 ### SCOPE — this does not affect the published image
 
+> **CORRECTION (2026-07-30, PR #445).** This section is **wrong for the gemma-4 image**. The check below
+> was run against `cloudriftai/vllm-emmy` — the *generic* serving image — which is indeed immune. But
+> `cloudriftai/vllm-emmy-gemma4` bakes its own `/opt/emmy/serve.sh`, and that script **does** pass
+> `--compilation-config` with the sparse hand-written ladder `[1,2,4,8,16,32,64,128,256]`; a depth-2 boot
+> of it captures exactly the predicted 7 rungs `[3,6,9,18,33,66,129]`. So the fault's scope *does* reach
+> the image the article's emmy lanes pin. It happens to cost those cells nothing, because KV starvation
+> keeps their verify width below the ladder's first gap — but that is luck, not immunity, and it reverses
+> the moment the footprint problem is fixed. See `plans/gemma4-narrow-decode-width-findings.md` §3 and the
+> coupling invariant in `emmy/serving/ARCHITECTURE.md`.
+
 I initially believed this fault explained the article's batched cells. It does not, and the
 correction matters more than the original claim.
 

--- a/plans/gemma4-narrow-decode-width-findings.md
+++ b/plans/gemma4-narrow-decode-width-findings.md
@@ -4,15 +4,34 @@ Target: the two largest emmy-vs-stock gaps in the article's speculative-decoding
 with the official drafter at depth 2 (**0.74x**) and depth 3 (**0.77x**). Both run decode bucket 32
 with the 2048-token prefill quantum, so the brief's leading suspect was m32 kernel quality.
 
-**Answer: those cells are not kernel-bound, and they are not even running at concurrency 8.** Emmy
-leaves 3.0 GiB for the KV cache where the workload needs room for eight 8448-token sequences; vLLM
-admits six and permanently queues two. Emmy's whole per-step kernel budget at m32 is 14.9 ms against
-a measured 28.5 ms step, so *no* kernel change can move the cell by more than a few percent.
+**Answer: those cells are not kernel-bound, and they never reach concurrency 8.** Emmy's device
+footprint leaves 3.0 GiB for the KV cache where stock leaves 3.61, and a `4096-in / 4096-out` request
+needs 8192 tokens of it — so emmy sustains a mean of **5.42** concurrent streams against stock's
+**6.75** — never once reaching 7 — with the balance queued and cycling through preemption. That ratio
+alone (**0.803**) accounts for the entire measured cell ratio (**0.797**) to within 1%. Emmy's whole
+per-step kernel budget at m32 is **14.86 ms measured** against a **28.7 ms** step and a **12.18 ms**
+DRAM floor, so kernel work has ~1.3 ms of realistic headroom — 4-5% of the step.
 
-A real m32 kernel win does exist and is worth taking on its own terms (section 4): the fused
-norm->linear edges at m32 deploy the `PLACE@cone=fuse` schedule where `cut` is 6-48% faster. It is
-worth ~8-12% of emmy's per-step kernel time — a genuine correction to the previous round's "no m32
-win exists" — but that is ~4-6% of the step, not 26%.
+Same-box, full-protocol decomposition of the observed **0.797x** (section 2):
+`0.803 (admission) x 0.945 (step latency) x 1.024 (acceptance — an emmy advantage) = 0.777`.
+**Admission alone (0.803) accounts for the whole observed ratio to within 1%; kernels are the ~5.5%
+step-latency term.** So the honest verdict
+is that **admission capacity is essentially the whole cell gap**, with a real but much smaller kernel
+term beside it — and the brief's suspicion was pointed at the right half of the smaller term (m32 kernel
+quality is genuinely worse than m8's; see section 4b for why, which *is* the bucket 8 -> 32 shift, though
+not for the reason hypothesized).
+
+A real m32 kernel win does exist, is deploy-verified, and ships on this branch (section 4): the three
+fused norm->linear edges the decode twins launch every step were deploying `PLACE@cone=fuse` where
+`cut` is 8 - 49% faster, taking them from 0.73 - 0.96x eager to 1.01 - 1.38x. It is worth ~1.3 ms of
+emmy's 14.86 ms per-step kernel budget — a genuine correction to the previous round's "no m32 win
+exists" — which is ~three quarters of the step-latency term. It cannot touch the other three terms.
+
+Read section 2's honesty notes before quoting any tok/s number from this report: `c=8` at
+`num-prompts 16` is not reproducible for *either* engine (emmy 369 - 492, stock 469 - 540), and the
+boxes differ by 11% in step latency at identical configurations. The conclusions above rest on
+boot-time VRAM accounting, scheduler timelines and CUDA-graph-window kernel timing — none of which are
+serving-throughput measurements — precisely because the serving throughput in this region is noisy.
 
 ## 0. Provenance
 
@@ -33,12 +52,16 @@ from the recipe and diffed against the hand-rolled `docker run`): published imag
 `--speculative-config {"method":"mtp","model":"google/gemma-4-12B-it-assistant",
 "num_speculative_tokens":2}`.
 
-**Benchmark deviation, stated up front:** the client runs `--num-prompts 16` instead of the recipe's
-64 (the request mix and the prefill:decode token ratio are identical — 4096 in / 4096 out per
-request — but the run takes 3 minutes instead of 10, and the drain tail is a larger share, so
-absolute tok/s reads *lower* than the article's). Every comparison below is same-box, one-variable,
-same `num_prompts`. Absolute numbers are not comparable to the article's cells; ratios between my
-own lanes are.
+**Reproduction check before changing anything.** The target cell at the recipe's full protocol
+(`c=8`, `num-prompts 64`) measured **476.75 tok/s** against the article's published **450.6** — +5.8%,
+inside the ~10% single-run spread the brief warns about for these cells. The configuration is the one
+the article measured.
+
+**Benchmark deviation, stated up front:** the screening runs use `--num-prompts 16` instead of 64 (the
+request mix and prefill:decode token ratio are identical — 4096 in / 4096 out per request — but the
+run takes 3 minutes instead of 10, and the drain tail is a larger share, so absolute tok/s reads
+*lower*: 369.09 at np=16 against 476.75 at np=64 for the same server). Every comparison below is
+one-variable at the same `num_prompts`. Cross-`num_prompts` absolutes are not comparable.
 
 ## 1. The kernel budget at m32 — the ceiling on any kernel win
 
@@ -80,6 +103,14 @@ Per layer: sliding `pre` 43.1 us + `post` 262.8 us; full-attention `pre` 45.5 us
 bandwidth — nothing does — would save 2.68 ms per step. A realistic ceiling (~90%, about where cuBLAS
 lands on these shapes) saves **1.3 ms**. That is the entire budget available to kernel tuning at m32.
 
+**This number also describes the pack-*miss* lanes.** The 4k/4k lanes override `EMMY_GEN_PREFILL_BUCKET`
+and therefore miss the whole pack (section 6), so they cold-resolve all 288 programs — but the decode
+twin they land on is byte-identical to the packed one: the boot log's 7-launch `post` program is
+`[k_linear_3955dc__partial__zp32, k_linear_3955dc, k_add_1, k_linear_mean_reduce_037454,
+k_linear_reduce_9de4dc__partial__zp32, k_linear_reduce_9de4dc, k_mul_7]`, exactly the kernel list in
+the image's `L00.post.decode.json`, and kernel names are content-addressed. The cold resolve differs
+from the pack only on the *prefill / symbolic* tiers.
+
 *Measurement caveat.* Timing one program in a 50-replay window lets its weight slab warm L2 (96 MB).
 The `post` slab is 354 MB, 3.7x L2, so `post` is DRAM-bound and honest; the `pre` slab is 63 MB and
 fits, so `pre` (2.09 of the 14.86 ms) is optimistic. The bias makes 14.86 ms a *lower* bound, which
@@ -98,10 +129,34 @@ Box A, E1 lane (the target configuration), `c=8`:
 | **not emmy's matmuls** | **13.6 ms (48% of the step)** |
 
 Acceptance is at ceiling, so the recipe header's claim about the 4k-output cells holds and the step
-period is unambiguous. Emmy's entire matmul budget is half the step; the other half is vLLM's
-attention + RoPE + lm_head + sampling, the drafter's two forward passes, and scheduling. **Closing
-26% of this cell inside emmy's kernels would require them to run at 1.9x the DRAM bandwidth of the
-card.** It is arithmetically impossible.
+period is unambiguous. **Closing the whole ~20% cell deficit inside emmy's kernels would require them to
+run at ~1.5x the DRAM bandwidth of the card** — arithmetically impossible. What kernels *can* reach is
+the ~6% step-latency term, and section 2's same-box `c=6` control shows that term is 1.83 ms, which sits
+squarely inside the 1.3 - 2.7 ms of headroom computed above.
+
+### Where the other half of the step goes
+
+Emmy's 14.86 ms is measured. The vLLM-side pieces below are **computed bandwidth floors, not
+measurements** — they are lower bounds, and I did not profile them:
+
+| per step, `c=8` d2 (6 running, width 18) | ms | basis |
+|---|--:|---|
+| emmy trunk (48 layers, bucket-32 twins) | **14.86** | measured, CUDA-graph window |
+| vLLM lm_head / logits (2.01 GB, tied) | ~1.12 | DRAM floor at 1792 GB/s |
+| vLLM paged attention (40 sliding x 1024-window + 8 global x 8448, 6 seqs) | ~1.6 | KV bytes / 1792 GB/s |
+| drafter, 2 passes (4 layers, hidden 1024, its own 0.54 GB lm_head) | ~0.7 | DRAM floor |
+| RoPE + KV writes | ~0.2 | DRAM floor |
+| **accounted GPU work** | **~18.5** | |
+| **measured step period** | **28.50** | median ITL |
+| **unaccounted** | **~10.0 (35%)** | |
+
+The whole *uniform-decode* step is inside vLLM's `FULL_DECODE_ONLY` cudagraph, so per-launch Python
+overhead is already absorbed at replay. What is not in the graph is the speculative-decoding
+machinery — drafting, verification, rejection sampling, KV bookkeeping — plus the scheduler and
+detokenisation. **That ~10 ms, not the kernels, is the biggest single unexplained block in the step,
+and it is where I would point a profiler next** (`--enable-layerwise-nvtx-tracing` or Nsight Systems
+on a live container; I did not get to it). Note it is *not* obviously an emmy deficit: stock's step at
+the same configuration is 26.45 ms on the same box, so stock carries a comparable block.
 
 ## 2. The cell never reaches concurrency 8
 
@@ -127,16 +182,17 @@ queued. That costs throughput twice: the queued requests contribute nothing whil
 benchmark's wall duration (mean TTFT 14.6 s, P99 46.6 s), and the KV pressure drives preemption and
 recompute.
 
-Direct evidence that the extra requests are *harmful*, not merely idle — same server, booted once,
-only the client's concurrency varies:
+The two queued requests are not merely idle — the timeline cycles
+`run=6 wait=2 -> run=5 wait=3 -> run=6 wait=2`, i.e. an admitted request is repeatedly **preempted**
+and its prefill recomputed. That is wasted GPU work with no token to show for it.
 
-| client concurrency | tok/s | median TPOT |
-|--:|--:|--:|
-| 6 | **471.15** | 9.83 ms |
-| 8 | 369.09 | 10.01 ms |
-
-Asking for eight streams makes the system **22% slower** than asking for six. Per-token latency is
-flat (9.83 vs 10.01 ms), so the loss is not step cost — it is admission thrash.
+**A warning about measuring this region.** `c=8` at `np=16` is not a reproducible measurement. Two
+servers whose *only* difference is one extra CUDA-graph capture size — which section 3 shows cannot
+change routing at the width these lanes run — gave **369.09** and **492.40** tok/s, a 33% spread; both
+had identical `run=6 wait=2` timelines. At `c=6`, where there is no thrash, the same two servers gave
+471.15 and 467.07 (0.9% apart). **Preemption thrash, not the capture ladder, is what makes the `c=8`
+point noisy**, and only the `np=64` runs (which average over eight waves) are worth comparing. I had
+drafted a "-22% for asking for eight streams" claim off the `np=16` pair and withdrew it.
 
 ### Stock vLLM at the identical configuration
 
@@ -147,29 +203,99 @@ client protocol:
 ```
 Available KV cache memory: 3.61 GiB          (emmy: 3.0 GiB)
 Maximum concurrency for 8,448 tokens: 2.98x  (emmy: 2.78x)
-run=7 wait=1  (steady state)                 (emmy: run=6 wait=2)
+run=7 wait=1  (steady state)                 (emmy: run=6 wait=2 / run=5 wait=3)
 ```
 
-Stock keeps **0.61 GiB more KV** — which at this request length is worth exactly one more concurrent
-sequence. Then:
+Stock keeps **0.61 GiB more KV**, and at this request length that buys it a stable seven streams against
+emmy's five-to-six.
 
-| `c=6`, `np=12` | duration | tok/s | median ITL | median TPOT | mean TTFT |
-|---|--:|--:|--:|--:|--:|
-| **emmy** (box A) | 104.32 s | **471.15** | 28.09 ms | 9.83 ms | 1.98 s |
-| **stock** (box C) | 104.37 s | **470.94** | 28.66 ms | 9.97 ms | 1.68 s |
+### `c=6`: the clean comparison, where both engines run six streams and nothing is preempted
 
-| `c=8`, `np=16` | duration | tok/s | median ITL | median TPOT | steady state |
-|---|--:|--:|--:|--:|---|
-| **emmy** (box A) | 177.56 s | **369.09** | 28.50 ms | 10.01 ms | run=6 wait=2 |
-| **stock** (box C) | 139.77 s | **468.89** | 29.39 ms | 10.51 ms | run=7 wait=1 |
+**All four rows on box A**, one variable:
 
-**At the concurrency emmy can actually sustain, emmy and stock are at exact parity — 471.15 against
-470.94, a 0.05% difference, with emmy's per-step latency 2% *lower*.** (The two lanes ran on different
-boxes; agreeing to 0.05 s of wall clock over 104 s also retires the box as a confound.)
+| `c=6`, `np=12` | tok/s | median ITL | median TPOT | mean TTFT |
+|---|--:|--:|--:|--:|
+| **emmy** (E1) | 471.15 | 28.09 ms | 9.83 ms | 1.98 s |
+| **emmy** (E2, a second server) | 467.07 | — | — | — |
+| **stock** | **514.75** | **26.26 ms** | 9.24 ms | — |
+| **ratio (emmy mean / stock)** | **0.911** | **0.935** | | |
 
-Going from six streams to eight, stock is flat (470.94 -> 468.89) while emmy loses 22%
-(471.15 -> 369.09). **The entire `c=8` deficit is that stock holds seven streams and emmy holds six,
-plus the thrash emmy pays for being asked for eight it cannot admit.**
+**At equal concurrency emmy is 8.9% slower than stock, and essentially all of it is per-step latency**
+(28.09 vs 26.26 ms, a 1.83 ms gap). This is the number that matters for kernel work, and it is *not*
+zero.
+
+> **Retraction.** An earlier draft of this report claimed emmy and stock were "at exact parity" at
+> `c=6`, from emmy 471.15 on box A against stock 470.94 on box C — agreeing to 0.05 s of wall clock out
+> of 104.3 s. That agreement was a coincidence of two offsetting errors: box C is simply ~9% slower than
+> box A (stock scores 470.94 there and 514.75 here at an identical configuration), which happened to
+> cancel emmy's real 8.9% deficit almost exactly. **Never compute an emmy/stock ratio across boxes.**
+> The same-box control reverses the conclusion, and the coordinator flagged the same cross-box hazard
+> independently from the 15% spread in the `c=8` `np=16` stock pair.
+
+And 1.83 ms is *inside* emmy's kernel headroom: section 1 measured emmy's trunk at 14.86 ms against a
+12.18 ms DRAM floor, so a step that reached ~90% of spec bandwidth (roughly where cuBLAS sits) would
+recover ~1.3 ms of exactly that 1.83 ms. **The step-latency term is kernel quality**, which is why the
+`PLACE@cone=cut` change in section 4 matters despite everything else in this report.
+
+| `c=8` | tok/s | median ITL | steady state |
+|---|--:|--:|---|
+| **emmy**, `np=64` (the recipe's protocol) | 476.75 / 485.91 | 28.73 / 28.78 ms | mean run **5.42**, preemption cycling |
+| **stock**, `np=64` | **603.66** | **27.20 ms** | mean run **6.75**, no cycling |
+| emmy, `np=16` (two servers, identical routing) | 369.09 / 492.40 | 28.50 ms | — |
+| stock, `np=16` (box A / box C) | 540.05 / 468.89 | 26.45 / 29.39 ms | — |
+
+**`c=8` at `np=16` is unreliable for both engines** — emmy 369-492, stock 469-540. Only `np=64`
+deserves comparison, and only within a box.
+
+### The decomposition, same box, full protocol
+
+At `np=64` — the recipe's own protocol — both engines reproduce their published cells on one box, so
+this is the comparison to trust. Stock lands within 1.1% of the article's 610.2 and emmy within 6-8%
+of its 450.6:
+
+| box A, `c=8`, `np=64`, depth 2 | emmy (E1 / E2) | stock | ratio |
+|---|--:|--:|--:|
+| output throughput (tok/s) | 476.75 / 485.91 | **603.66** | **0.797x** |
+| mean concurrency over the `np=64` window | **5.42** (never > 6) | **6.75** | **0.803** |
+| median inter-token latency (the step) | 28.73 / 28.78 ms | 27.20 ms | 0.945 |
+| run-aggregate mean acceptance length | 2.757 | 2.693 | 1.024 |
+| mean TTFT | 20.7 / 21.1 s | 7.8 s | — |
+
+Emmy's concurrency is not a flat six — over the `np=64` window it oscillates
+`run=6 wait=2` / `run=5 wait=3` across 23 / 29 samples (plus one at 4), **mean 5.42, and it never once
+reaches 7**. Stock sits at `run=7 wait=1` for 33 of its 40 steady samples, **mean 6.75**. Ratio
+**0.803**.
+
+> Both means are computed over the `np=64` window *only*, keyed by log timestamp. An earlier draft
+> reported 6.06 for emmy including 41 samples at `run=7`; those samples belonged to the **stock**
+> container, because the `docker logs -f` capture I used re-attached when the container was replaced
+> and silently concatenated two servers' logs into one file. Emmy reaches 7 streams in no window.
+
+Multiplying the three independent terms: `0.803 x 1.024 x 0.945 = 0.777`, against an observed 0.797 —
+i.e. the model slightly *over*-predicts the gap, so there is nothing unaccounted. Note that the
+concurrency term alone (0.803) already matches the observed ratio (0.797) to within 1%. So:
+
+| contribution to the 0.797x | factor | note |
+|---|--:|---|
+| **admission ceiling** (5.42 vs 6.75 concurrent streams) | **0.803** | **matches the observed ratio on its own** |
+| **step latency** (28.78 vs 27.20 ms) | 0.945 | kernel quality — section 4 addresses ~3/4 of it |
+| draft acceptance | 1.024 | a small emmy **advantage** |
+| product | 0.777 | vs observed 0.797 — the model slightly over-predicts, nothing unaccounted |
+
+Two things follow. First, **emmy's draft acceptance is not a problem** — it is marginally better than
+stock's, and an early draft of this report claiming otherwise was based on comparing snapshots from
+different phases of the run. Second, the step-latency term (0.945 here, 0.935 in the cleaner `c=6`
+control) is **real kernel quality**, and section 4's shipped golden change is worth ~1.3 ms of the
+1.58-1.83 ms gap — roughly **three quarters of that term**.
+
+So the final apportionment of the ~20% deficit at this cell:
+
+| cause | size | fixable by |
+|---|--:|---|
+| **admission capacity** — emmy sustains 5.42 streams where stock sustains 6.75 | **~20%** | shrinking the runner's arenas / capacity buffers (recommendation 1) |
+| per-step kernel time at m32 | **~5.5%** | **the `PLACE@cone=cut` goldens on this branch cover ~4.5 of it** |
+| draft acceptance | -2.4% (emmy **ahead**) | nothing to do |
+| (the three multiply to 0.777 against an observed 0.797 — no unaccounted residual) | | |
 
 Run-aggregate draft acceptance, summed over every 10 s metrics window of the run, is *not* a
 differentiator: stock accepted 42,128 of 46,816 drafted tokens = **0.900, mean acceptance length
@@ -177,6 +303,26 @@ differentiator: stock accepted 42,128 of 46,816 drafted tokens = **0.900, mean a
 phase-dependent on this random-token workload — it starts near 2.6 and climbs to 3.00 as the output
 collapses into repetition — so single snapshots are not comparable and I discarded an early reading
 that appeared to show emmy losing 5% of its speculation. It does not.)
+
+### The utilization knob cannot buy the missing stream
+
+The obvious cheap fix is to raise `--gpu-memory-utilization` until emmy's KV matches stock's. It does
+not work, in two different ways, and both are worth knowing before anyone retries it:
+
+| util | result |
+|--:|---|
+| 0.96 (the recipe) | KV **3.0 GiB**, 23,451 tokens, max concurrency 2.78x |
+| 0.98 | KV **3.63 GiB**, 28,358 tokens, max concurrency **3.36x** — *more than stock's 3.61 GiB / 2.98x* — then the engine **dies at first use**: `torch.OutOfMemoryError` allocating 256 MiB in `rejection_sampler.sample_recovered_tokens`, with 169.75 MiB free |
+| 0.99 | never starts: `Free memory on device cuda:0 (30.86/31.36 GiB) on startup is less than desired GPU memory utilization (0.99, 31.04 GiB)` |
+
+At 0.98 the KV *budget* is right and there is no headroom left for the speculative sampler's transient
+buffers, which vLLM's profiler does not reserve. So the extra concurrency has to come from emmy giving
+memory back, not from asking for more — which is what makes recommendation 1 a real piece of work rather
+than a knob change.
+
+Incidentally this pins the accounting: +0.02 of utilization is +0.64 GiB of a 31.85 GiB card, and KV
+moved 3.00 -> 3.63. Emmy's non-KV footprint is a fixed quantity, ~0.61 GiB larger than stock's, and
+every byte of it comes straight out of the KV cache.
 
 ### Where emmy's 0.61 GiB goes
 
@@ -216,33 +362,49 @@ At depth 2, `adjust_cudagraph_sizes_for_spec_decode` rounds every rung up to a m
 **`[3, 6, 9, 18, 33, 66, 129]`** — confirmed in the live boot log, which captures exactly **7** decode
 graphs. Emmy routes on the padded width, taking the static twin only when `padded <= bucket`:
 
-| running seqs | verify width | first rung at or above | <= bucket 32? | route |
-|--:|--:|--:|---|---|
-| 6 (**what actually runs**) | 18 | 18 | yes | **static twin** |
-| 7 | 21 | 33 | no | symbolic |
-| 8 (the nominal config) | 24 | 33 | no | symbolic |
+| running seqs | share of the `np=64` window | verify width | first rung at or above | <= bucket 32? | route |
+|--:|--:|--:|--:|---|---|
+| 4 | 1/53 | 12 | 18 | yes | static twin |
+| 5 | 29/53 | 15 | 18 | yes | static twin |
+| 6 | 23/53 | 18 | 18 | yes | static twin |
+| 7 | **0/53 — never reached** | 21 | 33 | no | (symbolic, if it happened) |
+| 8 (the nominal config) | 0 | 24 | 33 | no | (symbolic, if it happened) |
 
-So the ladder does **not** bite this cell — because section 2's KV starvation pins it at six, one of
-the two widths that still lands on a rung under the bucket. My initial hypothesis (that the 0.74x
-cell was running the symbolic program) is **refuted by measurement**, and I am recording it as such.
+**Every width this lane actually runs lands on rung 18, under the bucket, on the image's own ladder.**
+Section 2's admission ceiling keeps it there: emmy never exceeds six streams, so the sparse ladder's
+first gap (18 -> 33) is never entered.
 
-It matters anyway, for one reason: **the two faults are coupled.** Fixing the KV footprint so the
-lane reaches seven or eight streams moves the width to 21 or 24, which lands on rung 33 and retires
-the twin. Measured cost of that, box C, same programs, same card:
+The symbolic path it would fall to *is* genuinely expensive — box C, the same programs on the same card,
+twin vs `run_device_sym` extrapolated over 48 layers:
 
-| bucket 32, extrapolated 48-layer step | |
+| bucket 32, per step | |
 |---|--:|
 | static decode twin at M=32 | 14.85 ms |
-| symbolic program at width 24 | 39.77 ms (**2.68x**) |
 | symbolic program at width 33 | 32.44 ms (**2.18x**) |
+| symbolic program at width 24 | 39.77 ms (**2.68x**) |
 
-Per layer, sliding: twin 305.8 us, `sym@33` 677.4 us. So any KV fix must ship together with a ladder
-rung at or below the bucket for the widths it unlocks, or the concurrency win is spent twice over.
+— which is why the hypothesis was worth chasing. But it is unreachable here, and the A/B confirms it.
+Adding one capture rung at 24, the *only* difference between the two servers, changes nothing:
 
-*Caveat:* the twin rows are CUDA-graph replays and the symbolic rows are timed around `run_once`
-(the symbolic path declines graph capture, so this matches production), which charges the symbolic
-rows for per-launch dispatch the twin rows do not pay. At ~7 launches per program that is under 10%
-of the gap; the 2.18x is overwhelmingly GPU work.
+| bucket 32, depth 2, box A, one variable | `c=8` `np=64` | `c=8` `np=16` | `c=6` `np=12` | median ITL (np=64) |
+|---|--:|--:|--:|--:|
+| E1, the image's ladder (7 graphs) | 476.75 | 369.09 | 471.15 | 28.73 ms |
+| E2, + a rung at 24 (8 graphs) | **485.91** | 492.40 | 467.07 | 28.78 ms |
+| delta | **+1.9%** | +33% (noise) | -0.9% | +0.2% |
+
+`np=64` moves 1.9% and per-step latency moves 0.2% — which is what the routing table predicts once you
+know the lane never exceeds six streams. (The +33% at `np=16` is the ramp-up artefact section 2 warns
+about; two waves is not a measurement.)
+
+**So my initial hypothesis — that the 0.74x cell was losing its twin to the sparse ladder — is refuted,
+and this is the record of it.** The shipped gemma-4 image *does* carry the unsafe sparse ladder that #441
+replaced in `emmy serve`, and the earlier scope claim about it is wrong; but it costs these cells
+nothing, because admission starvation keeps the width below the ladder's first gap.
+
+What is worth carrying forward: **the two faults are latently coupled.** If recommendation 1 gives the
+lane its KV back and it reaches seven or eight streams, the width becomes 21 or 24, whose rung is 33 on
+the image's ladder — and the 2.18x above becomes live. A footprint fix must ship together with a ladder
+fix, or it will spend its own winnings.
 
 ## 4. A real m32 kernel win: the fused norm->linear edges deploy `fuse` where `cut` is faster
 
@@ -269,8 +431,19 @@ matmul, while the m32 fuse entries sit 12-28% above theirs. Direct A/B on box D
 | golden (m32) | deployed (`fuse`) | `PLACE@cone=cut` | delta | eager (torch norm + cuBLAS) |
 |---|--:|--:|--:|--:|
 | `norm_gate_up.m32.lin` (N=30720, K=3840) | 160.4 us | **147.2 us** | **-8.2%** | 154 us |
-| `mlp_down_fused.m32.lin` (N=3840, K=15360) | 123.7 us | **115.9 us** | **-6.3%** | — |
 | `norm_qk_global.m32.lin` (N=8704, K=3840) | 38.3 us | **20.1 us** | **-47.5%** | 29 us |
+| `mlp_down_fused.m32.lin` (N=3840, K=15360) † | 119.1 us | **112.8 us** | **-5.3%** | 97 us |
+
+† `mlp_down_fused`'s YAML comment states that its recorded µs were measured on the **true geglu-cone
+snippet** (`(gelu(y[:,:15360]) * y[:,15360:]) @ w`) while a `--golden` replay traces an rms-cone
+*stand-in* of the same ShapeKey. Its 119.1 and 112.8 are therefore both stand-in numbers: the
+fuse-vs-cut **delta** is a valid one-variable comparison (both rows trace the same snippet), but the
+absolutes are not the deployed kernel's and the delta has not been shown to transfer. I have left
+that entry alone for exactly this reason; it wants an A/B on the true snippet.
+
+The first two rows carry no such caveat — their recorded µs reproduce live (`norm_gate_up` records
+161.6 and measures 159.7 - 160.5 across four runs; `norm_qk_global` records 40.1 and measures 38.3)
+and their A/Bs are apples-to-apples.
 
 `cut` splits the fused cone at the A seam — the norm materialises to a workspace (1.4 us stat + 0.8 us
 scale at m32, i.e. free) and the matmul re-lowers with a plain gmem A, which lets it take the
@@ -325,6 +498,75 @@ integrity gate catches this, so the accuracy check in `run --bench` is doing rea
 `PLACE@cone=cut` on its own is therefore the whole of the available win, and it is a **structural**
 pin — exactly the shape the m8 and m64 entries already record.
 
+### Repeated measurement, and the change that ships
+
+Three runs per shape, `--warmup 10 --iters 100`, box D idle, medians with observed spread:
+
+| golden (m32) | `fuse` (what deployed) | `cut` | delta |
+|---|--:|--:|--:|
+| `norm_gate_up.m32.lin` (N=30720) | 160.1 (+-0.6%) | **147.2** (+-0.2%) | **-8.1%** |
+| `norm_qkv.m32.lin` (N=8192) — *no golden existed* | 33.7 | **19.6** | **-41.8%** |
+| `norm_qk_global.m32.lin` (N=8704) | 38.5 (+-0.3%) | **19.8** (+-1.6%) | **-48.6%** |
+| `norm_q_proj.m32.lin` (N=4096) ‡ | 23.7 (+-9.0%) | **12.1** (+-0.1%) | **-49.1%** |
+| `norm_kv_proj.m32.lin` (N=2048) ‡ | 17.0 (+-1.4%) | **8.8** (+-4.9%) | **-48.5%** |
+| `mlp_down_fused.m32.lin` † | 121.9 (+-1.9%) | **110.2** (+-0.1%) | **-9.6%** |
+
+‡ the pre-merge *split* q / kv forms; post-`035_merge_sibling_linears` the served twins launch the
+merged `qkv` edge instead, so these two do not deploy. Recorded here as corroboration that the effect
+is the whole family, not one shape.
+
+**Recorded (this branch):** `norm_gate_up.m32.cut.lin`, `norm_qkv.m32.cut.lin` and
+`norm_qk_global.m32.cut.lin` — the three edges the decode twins actually launch — as `cut` entries
+*beside* the existing `fuse` ones (a recorded measurement is never deleted, and `_golden_pick` takes
+the fastest realizing entry). `mlp_down_fused` is deliberately **not** touched: its recorded µs are
+geglu-cone numbers and mine are stand-in numbers, so an entry recorded at 110.2 would sort *behind*
+the existing 95.9 and never be selected. It needs an A/B on the true snippet first.
+
+**The deploy was verified, not assumed** — this is the trap the brief warns about. Resolving each shape
+through its *old* (`fuse`) name after the edit, greedy independently lands on the cut form:
+
+| resolved via the old name | before | after |
+|---|--:|--:|
+| `gemma4_12b.norm_gate_up.m32.lin` | 0.96x eager (`fuse`, 160.4 us) | **1.01x** eager (`cut`, 147.2 us) |
+| `gemma4_12b.norm_qk_global.m32.lin` | 0.73x eager (`fuse`, 38.3 us) | **1.27x** eager (`cut`, 20.1 us) |
+| `gemma4_12b.norm_qkv.m32.lin` | 0.86x eager (`fuse`, 33.7 us) | **1.38x** eager (`cut`, 19.8 us) |
+
+The `norm_gate_up.m32.lin` drift warning is gone with it: the ShapeKey now has a realizable entry, so
+the shape has a golden floor for the first time. All pinned rows carry `status: "ok"` — the
+realized-vs-pinned, arithmetic-intensity and wrong-answer gates pass (and they are not vacuous: a
+mis-pinned variant in the same sweep came back `wrong-answer: rel err 7.341`).
+
+**Projected per-step effect, stated as a projection.** Over the deployed kernel list — 48
+`norm_gate_up` (-12.9 us), 40 sliding `norm_qkv` (-14.1 us), 8 global `norm_qk_global` (-18.7 us) —
+that is **~1.3 ms** off a 14.86 ms step, ~9%. Including `mlp_down_fused` if its delta transfers would
+add ~0.6 ms for ~13%, but 13% would put the step at ~97% of spec DRAM bandwidth, which is not
+credible; **treat ~9% as the number and the rest as unproven.** I did not verify the composed
+whole-step effect end to end — that needs a cold-resolve `stepprof` against the edited goldens, which
+did not fit in the budget.
+
+## 4b. The brief's puzzle: why plain `c=8` is 0.97x and MTP `c=8` is 0.74x
+
+Same box, same concurrency, same prefill quantum, same drafter-on-stock-vLLM for both engines. The only
+differences are speculation and the decode bucket (**8** for plain, **32** for MTP). Section 4 answers it:
+
+| fused edge, eager = 1.00x | at **m8** (plain lane) | at **m32** (MTP lane), before | at **m32**, after this branch |
+|---|--:|--:|--:|
+| `norm_gate_up.lin` | 1.01x | 0.96x | **1.01x** |
+| `mlp_down_fused.lin` | 1.22x | 0.78x | (untouched, see section 4) |
+| `norm_qkv.lin` | — | 0.86x | **1.38x** |
+| `norm_qk_global.lin` | 1.19x (recorded) | 0.73x | **1.27x** |
+
+**m8's goldens already record `PLACE@cone=cut`; m32's recorded `fuse`.** At m8 they had no choice — a
+`fuse` pin at m8 measures 55,330 us on `norm_gate_up` and 27,310 us on `mlp_down_fused`, a 380x scalar
+degenerate, so `cut` was forced. At m32 both forms realize, `fuse` won the resolve, and nothing noticed
+it was the slower one.
+
+So the bucket 8 -> 32 shift *is* the cause of the extra step latency, but **not** for the reason the
+brief hypothesized. It is not tile granularity and not weight-slab re-streaming — the `TILE` M extent is
+a multiple of 16 either way and both widths read the slab once. It is that **m32 is the width where the
+cone-placement decision was recorded wrong**, and m8 is the width where a degenerate case forced it
+right. That is now fixed, which is why this change is worth having even though it cannot close the cell.
+
 ## 5. What I did not change, and why
 
 - **No decode-bucket or width change.** Confirmed the coordinator's tile-granularity argument holds:
@@ -342,34 +584,72 @@ pin — exactly the shape the m8 and m64 entries already record.
   gemma-4 image's baked `serve.sh` carries a hand-written sparse list that `_gen_graph_args` never
   sees (section 3). Fixing that is an image change, so it belongs to whoever next bakes one — noted
   in the recommendations rather than patched here.
+- **`plans/` is left at 12 files, over CLAUDE.md's cap of 10.** Same call #441 made and for the same
+  reason: this change *adds* a findings report rather than executing a plan, and enforcing the cap
+  would mean deleting somebody else's in-flight report.
+
+## 5b. Checks run
+
+`make test` on box C (RTX 5090, `PYTHONPATH` pinned to the branch tree, `-Xcicc -O1` correctness lane):
+
+```
+===== 4 failed, 2819 passed, 37 skipped, 46 warnings in 1073.02s (0:17:53) =====
+FAILED tests/compiler/ir/test_dynamic_shapes.py::test_qwen_batched_dynamic_matches_eager_b32
+FAILED tests/scripts/test_bench_block.py::test_bench_dry_run_tinyllama_block
+FAILED tests/serving/test_gen_pack_gpu.py::test_gen_pack_second_boot_hits_and_matches@cuda
+FAILED tests/serving/test_gen_runner_gpu.py::test_gen_runner_device_path_matches_host@cuda
+```
+
+A `274c153e` baseline on the same box with the same harness fails **five**:
+
+```
+FAILED tests/compiler/ir/test_dynamic_shapes.py::test_qwen_batched_dynamic_matches_eager_b32
+FAILED tests/compiler/ir/test_dynamic_shapes.py::test_qwen_layer_dynamic_compiles_and_matches_eager
+FAILED tests/scripts/test_bench_block.py::test_bench_dry_run_tinyllama_block
+FAILED tests/serving/test_gen_pack_gpu.py::test_gen_pack_second_boot_hits_and_matches@cuda
+FAILED tests/serving/test_gen_runner_gpu.py::test_gen_runner_device_path_matches_host@cuda
+```
+
+The branch's four are a strict **subset** of main's five, so **this change introduces no new failures**
+(the extra `test_qwen_layer_dynamic_compiles_and_matches_eager` looks flaky between the two runs).
+
+The repo's own gate for exactly the hazard the brief warns about —
+`test_golden_drift_gate.py::test_gemma4_goldens_deploy_in_serving_twins[rtx5090]`, which checks that
+recorded gemma-4 goldens actually deploy in the serving twins — **passes on the branch**.
+
+Accuracy of the changed kernels is covered by `run --bench`'s pinned-row integrity gates rather than by
+the suite: every `PLACE@cone=cut` row reports `status: "ok"`, i.e. it passed realized-vs-pinned, the
+arithmetic-intensity floor, and the wrong-answer check against the greedy output. The gate is not
+vacuous — a differently-pinned variant in the same sweep came back `wrong-answer: rel err 7.341`.
 
 ## 6. Verdict on the previous round's claims
 
 | claim | verdict |
 |---|---|
-| "m32 already satisfies the rule (0.97x cuBLAS), so no m32 win exists" | **False.** True of the unfused matmul entries; false of the *fused* `norm_linear` edges the decode twins actually launch, which run 0.73 - 0.96x eager at m32 against 1.01 - 1.22x at m8. `PLACE@cone=cut` recovers 6 - 47% per edge. |
+| "m32 already satisfies the rule (0.97x cuBLAS), so no m32 win exists" | **False.** True of the unfused matmul entries; false of the *fused* `norm_linear` edges the decode twins actually launch, which ran 0.73 - 0.96x eager at m32 against 1.01 - 1.22x at m8. `PLACE@cone=cut` recovers 8 - 49% per edge and now deploys. |
 | "emmy wins at every M against cuBLAS; there is no cliff at 32" | **False in the same way.** There is a cliff at m32, and it is on the fused edges. |
-| "m2048 prefill is at parity; recorded YAML numbers are stale" | **Stale confirmed, independently.** `mlp_down_fused.m32.lin` records 95.9 us; live it is 119 - 124 us (+24 - 29%). Recorded `emmy_us` should not be used for cross-config reasoning. |
+| "m2048 prefill is at parity; recorded YAML numbers are stale" | **Not reproduced as staleness at m32.** `norm_gate_up.m32.lin` (161.6) and `norm_qk_global.m32.lin` (40.1) both reproduce live to within 4%. `mlp_down_fused.m32.lin` looks 24 - 29% stale but is not: its YAML comment says the recorded µs came from the true geglu-cone snippet while a `--golden` replay traces an rms-cone stand-in. Apparent staleness there is a **snippet mismatch documented in the file**, and I withdrew an earlier draft claim to the contrary. |
 | "A bucket override is a whole-pack miss, not decode-only" | **Confirmed.** The pack key is `{kind, model, config_sha, dtype, decode_bucket, max_tokens, prefill_bucket}`; the image's is `prefill_bucket: 4096`, so every `EMMY_GEN_PREFILL_BUCKET=2048` lane misses the whole pack and cold-resolves all 288 programs (~25 min of boot on 30 cores, observed). |
-| "The remaining deficit is per-step runner overhead, not kernel quality" | **Half right, and the wrong half matters.** Roughly half the step is outside emmy's matmuls (14.86 of 28.5 ms), which is real — but it is *not* a deficit: at equal concurrency emmy's step is 2% *faster* than stock's. The deficit is admission capacity, not per-step time. |
+| "The remaining deficit is per-step runner overhead, not kernel quality" | **Half right, and it matters which half.** Half the step *is* outside emmy's matmuls (14.86 of 28.7 ms) and ~10 ms is outside GPU work entirely. But the deficit decomposes as 0.803 admission x 0.945 step latency x 1.024 acceptance: the dominant term is admission *capacity* (it matches the observed ratio by itself), and the step-latency term is kernel *quality* (1.83 ms at `c=6`, inside the measured headroom) — not runner overhead. |
 | "The shipped image is immune to the capture-ladder fault" | **False for `vllm-emmy-gemma4`** (section 3); true for the generic `vllm-emmy` image that was actually inspected. |
 
 ## 7. Recommendations, in value order
 
-1. **Give the trunk back its KV cache.** One concurrent sequence at this request length costs 0.61
-   GiB, and that single sequence is the whole `c=8` gap. The buffers are sized by `max_tokens = 4096`
-   and `prefill_bucket`, not by the decode width, so a lane that only ever schedules 2048-token chunks
-   is paying for 4096-row capacity. Start by measuring `BufferArena` occupancy against the widths a
-   lane can actually reach.
-2. **Put the capture ladder in the baked image.** `serve.sh` hard-codes
-   `[1,2,4,8,16,32,64,128,256]`, which #441 replaced in `emmy serve` precisely because it is unsafe
-   under speculation. It is inert today only because KV starvation pins the width at 18; recommendation
-   1 will move the width to 21 or 24, both of which land on rung 33 and cost **2.18x** on the step.
-   These two must ship together.
-3. **Record the `PLACE@cone=cut` m32 goldens** (section 4) — worth 8 - 12% of emmy's per-step kernel
-   time at every width that routes through bucket 32, independent of everything above.
-4. **`norm_qkv` has no m32 golden at all**, though it is the sliding layers' fused QKV edge and
-   therefore 40 of 48 `pre` programs. Its m8 and m64 siblings both exist and both record `cut`.
-5. **Fix the `norm_gate_up.m32.lin` drift** — the resolve prints `no offered candidate realizes any of
-   them` on every compile, so the shape has no golden floor. It lands on the right config today by
-   luck of the evidence hierarchy.
+1. **Give the trunk back its KV cache — this is the whole cell gap.** Emmy's non-KV footprint is ~0.61
+   GiB larger than stock's, which costs it 1.3 streams (5.42 vs 6.75) and, on its own, the entire 0.797x
+   ratio. It cannot be bought with `--gpu-memory-utilization` (0.98 OOMs the rejection sampler, 0.99
+   will not start). The buffers are sized by `max_tokens = 4096` and `prefill_bucket`, not by the decode
+   width, so a lane that only ever schedules 2048-token chunks is paying for 4096-row capacity. Start by
+   measuring `BufferArena` occupancy against the widths a lane can actually reach.
+2. **Profile the ~10 ms of the step that is not GPU work** (section 1). It is the largest unexplained
+   block in the step for *both* engines, and nobody has looked at it. Nsight Systems on a live
+   container, or vLLM's own `--enable-layerwise-nvtx-tracing`.
+3. **Done on this branch: the `PLACE@cone=cut` m32 goldens** (section 4) — ~9% of emmy's per-step
+   kernel time at every width that routes through bucket 32, independent of everything above. What is
+   left there is `mlp_down_fused.m32`, which needs an A/B on its true geglu-cone snippet.
+4. **Re-open the capture-ladder question if and only if recommendation 1 lands.** Today an added rung
+   at 24 is worth 1.9% at `np=64` (section 3) — not worth shipping. At a steady eight streams the width
+   becomes 24, a rung nobody has A/B'd, and the answer may differ.
+5. **`emmy eval golden`'s drift audit deserves a CI lane.** `norm_gate_up.m32.lin` had been printing
+   `no offered candidate realizes any of them` on every single compile of this model, i.e. that shape
+   had no golden floor at all, and nothing surfaced it. (Fixed here as a side effect; the class is not.)

--- a/plans/gemma4-narrow-decode-width-findings.md
+++ b/plans/gemma4-narrow-decode-width-findings.md
@@ -1,0 +1,375 @@
+# Narrow decode widths (m8 / m32) on gemma-4-12B, RTX 5090 — where the MTP batch gap actually lives
+
+Target: the two largest emmy-vs-stock gaps in the article's speculative-decoding table — `4k/4k c=8`
+with the official drafter at depth 2 (**0.74x**) and depth 3 (**0.77x**). Both run decode bucket 32
+with the 2048-token prefill quantum, so the brief's leading suspect was m32 kernel quality.
+
+**Answer: those cells are not kernel-bound, and they are not even running at concurrency 8.** Emmy
+leaves 3.0 GiB for the KV cache where the workload needs room for eight 8448-token sequences; vLLM
+admits six and permanently queues two. Emmy's whole per-step kernel budget at m32 is 14.9 ms against
+a measured 28.5 ms step, so *no* kernel change can move the cell by more than a few percent.
+
+A real m32 kernel win does exist and is worth taking on its own terms (section 4): the fused
+norm->linear edges at m32 deploy the `PLACE@cone=fuse` schedule where `cut` is 6-48% faster. It is
+worth ~8-12% of emmy's per-step kernel time — a genuine correction to the previous round's "no m32
+win exists" — but that is ~4-6% of the step, not 26%.
+
+## 0. Provenance
+
+Four RTX 5090 boxes, one GPU each, `nvidia-smi` healthy and no pending reboot on all of them, apt
+timers masked. Branch `feature/mtp-narrow-width-tuning` at `274c153e` (identical to `origin/main`).
+
+| box | cores | driver | role |
+|---|--:|---|---|
+| A | 30 | 580.173.02 | docker serving A/B on the published image |
+| C | 15 | 580.159.03 | in-container kernel profiling; stock vLLM control |
+| D | 15 | 580.159.03 | bare-metal golden A/B (`emmy run --bench --ab`) |
+
+Serving lanes replicate `experiments/gemma-4-12B/serving_mtp_rtx5090`'s compose exactly (generated
+from the recipe and diffed against the hand-rolled `docker run`): published image
+`cloudriftai/vllm-emmy-gemma4:0.23.0-58733e02`, `--gpu-memory-utilization=0.96`,
+`--max-model-len 8448`, `--dtype float16`, `--no-enable-prefix-caching`,
+`EMMY_GEN_DECODE_BUCKET=32 EMMY_GEN_PREFILL_BUCKET=2048`, `--max-num-batched-tokens 2080`,
+`--speculative-config {"method":"mtp","model":"google/gemma-4-12B-it-assistant",
+"num_speculative_tokens":2}`.
+
+**Benchmark deviation, stated up front:** the client runs `--num-prompts 16` instead of the recipe's
+64 (the request mix and the prefill:decode token ratio are identical — 4096 in / 4096 out per
+request — but the run takes 3 minutes instead of 10, and the drain tail is a larger share, so
+absolute tok/s reads *lower* than the article's). Every comparison below is same-box, one-variable,
+same `num_prompts`. Absolute numbers are not comparable to the article's cells; ratios between my
+own lanes are.
+
+## 1. The kernel budget at m32 — the ceiling on any kernel win
+
+### The DRAM floor
+
+Emmy owns the 48-layer trunk (embed gather, per-layer norm + QKV, o_proj + MLP, final norm).
+Attention, RoPE, KV cache and the lm_head / logits are vLLM's. Trunk weights, gemma-4-12B fp16
+(hidden 3840, inter 15360, 40 sliding + 8 full-attention layers, 16 Q x 256 / 8 KV x 256 sliding,
+16 x 512 / 1 KV global):
+
+| | params | fp16 bytes |
+|---|--:|--:|
+| per sliding layer | 224.1 M | 448 MB |
+| per full-attention layer | 243.8 M | 488 MB |
+| **trunk, 48 layers** | **10.92 G** | **21.83 GB** |
+| lm_head / embed (tied) — vLLM's | 1.01 G | 2.01 GB |
+
+A decode step reads every trunk weight exactly once, so at the RTX 5090's 1792 GB/s spec bandwidth
+**no emmy decode step can be faster than 12.18 ms**, at any width from 1 to 64. Decode at these
+widths is pure weight streaming: the activations are 32 x 3840 x 2 B = 246 kB, four orders of
+magnitude smaller than the weights.
+
+### What the deployed twins actually cost
+
+Measured on box C, inside the published image, with the runner keyed to **hit** the image's baked
+execution-plan pack (`decode_bucket=32, max_tokens=4096, prefill_bucket=4096`) so the kernels timed
+are the warmed frozen picks. Every layer's `pre` and `post` program timed with the CUDA-graph window
+timer, 7 windows of 50 replays, median:
+
+| bucket 32, per step | |
+|---|--:|
+| `pre` (norm + QKV + q/k norms), 48 layers | 2.09 ms |
+| `post` (o_proj + residual + norms + MLP), 48 layers | 12.78 ms |
+| **total** | **14.86 ms** |
+
+Per layer: sliding `pre` 43.1 us + `post` 262.8 us; full-attention `pre` 45.5 us + `post` 282.5 us.
+
+**14.86 ms against a 12.18 ms floor is 82% of spec DRAM bandwidth.** A kernel that hit 100% of spec
+bandwidth — nothing does — would save 2.68 ms per step. A realistic ceiling (~90%, about where cuBLAS
+lands on these shapes) saves **1.3 ms**. That is the entire budget available to kernel tuning at m32.
+
+*Measurement caveat.* Timing one program in a 50-replay window lets its weight slab warm L2 (96 MB).
+The `post` slab is 354 MB, 3.7x L2, so `post` is DRAM-bound and honest; the `pre` slab is 63 MB and
+fits, so `pre` (2.09 of the 14.86 ms) is optimistic. The bias makes 14.86 ms a *lower* bound, which
+only strengthens the conclusion.
+
+### Against the live step
+
+Box A, E1 lane (the target configuration), `c=8`:
+
+| | |
+|---|--:|
+| median inter-token latency (the step period — one step emits a burst) | **28.50 ms** |
+| median TPOT | 10.01 ms |
+| mean acceptance length (vLLM's `SpecDecoding metrics`) | 2.76 - 2.91 of 3 |
+| emmy's kernels at bucket 32 (section above) | 14.86 ms |
+| **not emmy's matmuls** | **13.6 ms (48% of the step)** |
+
+Acceptance is at ceiling, so the recipe header's claim about the 4k-output cells holds and the step
+period is unambiguous. Emmy's entire matmul budget is half the step; the other half is vLLM's
+attention + RoPE + lm_head + sampling, the drafter's two forward passes, and scheduling. **Closing
+26% of this cell inside emmy's kernels would require them to run at 1.9x the DRAM bandwidth of the
+card.** It is arithmetically impossible.
+
+## 2. The cell never reaches concurrency 8
+
+This is the finding that actually explains the cell.
+
+The E1 boot log:
+
+```
+Available KV cache memory: 3.0 GiB
+GPU KV cache size: 23,451 tokens
+Maximum concurrency for 8,448 tokens per request: 2.78x
+```
+
+A `4096-in / 4096-out` request needs 8192 tokens of KV by the end. 23,451 tokens is **2.78 such
+requests**. The scheduler's own timeline over the whole benchmark window, one sample per 10 s:
+
+```
+run=6 wait=2   run=6 wait=2   run=6 wait=2   run=6 wait=2   run=6 wait=2   ...   (steady state)
+```
+
+**Never 7, never 8.** The lane advertised as concurrency 8 runs six sequences with two permanently
+queued. That costs throughput twice: the queued requests contribute nothing while inflating the
+benchmark's wall duration (mean TTFT 14.6 s, P99 46.6 s), and the KV pressure drives preemption and
+recompute.
+
+Direct evidence that the extra requests are *harmful*, not merely idle — same server, booted once,
+only the client's concurrency varies:
+
+| client concurrency | tok/s | median TPOT |
+|--:|--:|--:|
+| 6 | **471.15** | 9.83 ms |
+| 8 | 369.09 | 10.01 ms |
+
+Asking for eight streams makes the system **22% slower** than asking for six. Per-token latency is
+flat (9.83 vs 10.01 ms), so the loss is not step cost — it is admission thrash.
+
+### Stock vLLM at the identical configuration
+
+Stock `vllm/vllm-openai:v0.23.0`, same model, same drafter, same depth, same
+`--gpu-memory-utilization=0.96 --max-model-len 8448 --dtype float16 --no-enable-prefix-caching`, same
+client protocol:
+
+```
+Available KV cache memory: 3.61 GiB          (emmy: 3.0 GiB)
+Maximum concurrency for 8,448 tokens: 2.98x  (emmy: 2.78x)
+run=7 wait=1  (steady state)                 (emmy: run=6 wait=2)
+```
+
+Stock keeps **0.61 GiB more KV** — which at this request length is worth exactly one more concurrent
+sequence. Then:
+
+| `c=6`, `np=12` | duration | tok/s | median ITL | median TPOT | mean TTFT |
+|---|--:|--:|--:|--:|--:|
+| **emmy** (box A) | 104.32 s | **471.15** | 28.09 ms | 9.83 ms | 1.98 s |
+| **stock** (box C) | 104.37 s | **470.94** | 28.66 ms | 9.97 ms | 1.68 s |
+
+| `c=8`, `np=16` | duration | tok/s | median ITL | median TPOT | steady state |
+|---|--:|--:|--:|--:|---|
+| **emmy** (box A) | 177.56 s | **369.09** | 28.50 ms | 10.01 ms | run=6 wait=2 |
+| **stock** (box C) | 139.77 s | **468.89** | 29.39 ms | 10.51 ms | run=7 wait=1 |
+
+**At the concurrency emmy can actually sustain, emmy and stock are at exact parity — 471.15 against
+470.94, a 0.05% difference, with emmy's per-step latency 2% *lower*.** (The two lanes ran on different
+boxes; agreeing to 0.05 s of wall clock over 104 s also retires the box as a confound.)
+
+Going from six streams to eight, stock is flat (470.94 -> 468.89) while emmy loses 22%
+(471.15 -> 369.09). **The entire `c=8` deficit is that stock holds seven streams and emmy holds six,
+plus the thrash emmy pays for being asked for eight it cannot admit.**
+
+Run-aggregate draft acceptance, summed over every 10 s metrics window of the run, is *not* a
+differentiator: stock accepted 42,128 of 46,816 drafted tokens = **0.900, mean acceptance length
+2.80**, and emmy's windowed samples sit in the same 2.76 - 2.91 band. (Acceptance is strongly
+phase-dependent on this random-token workload — it starts near 2.6 and climbs to 3.00 as the output
+collapses into repetition — so single snapshots are not comparable and I discarded an early reading
+that appeared to show emmy losing 5% of its speculation. It does not.)
+
+### Where emmy's 0.61 GiB goes
+
+Budget at util 0.96 is 30.58 GiB. Non-KV footprint is therefore 27.58 GiB for emmy, 26.97 GiB for
+stock. Stock's own accounting says `Model loading took 23.62 GiB`; emmy's says `3.04 GiB`, because
+emmy's weights live in cupy buffers that torch's allocator cannot see — so vLLM's memory profiler
+never attributes them, and the KV budget is whatever is left over after the fact. The trunk +
+tied embed + drafter come to ~22.99 GiB by construction, leaving **~4.6 GiB of emmy arenas, scratch
+slabs, graph pools and fragmentation against stock's ~4.0 GiB**.
+
+The concrete suspects, in the order I would test them, are all sized by the *serving shape* rather
+than by the decode width: the symbolic programs are built at `capacity = max_tokens = 4096` (one
+`[4096, 30720]` fp16 intermediate is 252 MB on its own), the prefill twin adds a second set at
+`prefill_bucket = 2048`, and the boot log reports per-program `scratch slab=0.13 - 0.41 GB` pooled
+into one `BufferArena`. A lane that only ever runs 2048-token chunks is paying for 4096-row buffers.
+**This, not kernel schedules, is the lever on the `c=8` cells.**
+
+## 3. The published image does carry the sparse capture ladder — a latent fault, not the active one
+
+`plans/gemma4-mtp-batched-serving-findings.md` concludes the shipped image is immune to the
+capture-ladder / spec-decode interaction because it "runs `vllm` directly with no
+`--compilation-config`". **That is wrong for the gemma-4 image.** Read out of the published image:
+
+```
+$ docker run --rm --entrypoint /bin/cat cloudriftai/vllm-emmy-gemma4:0.23.0-58733e02 /opt/emmy/serve.sh
+... --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY",
+      "cudagraph_capture_sizes": [1, 2, 4, 8, 16, 32, 64, 128, 256], "custom_ops": ["+rotary_embedding"]}'
+```
+
+The earlier conclusion was reached against `cloudriftai/vllm-emmy:0.23.0-...` — the *generic* serving
+image, which indeed has no such flag. `vllm-emmy-gemma4` bakes its own `serve.sh` carrying the sparse
+ladder, so the fault's scope statement ("bites bare-metal `emmy serve` users, not the shipped image")
+does not hold for the image the article's eleven emmy lanes pin.
+
+At depth 2, `adjust_cudagraph_sizes_for_spec_decode` rounds every rung up to a multiple of
+`query_len = 3` and drops anything past `max_cudagraph_capture_size = 256`, giving
+**`[3, 6, 9, 18, 33, 66, 129]`** — confirmed in the live boot log, which captures exactly **7** decode
+graphs. Emmy routes on the padded width, taking the static twin only when `padded <= bucket`:
+
+| running seqs | verify width | first rung at or above | <= bucket 32? | route |
+|--:|--:|--:|---|---|
+| 6 (**what actually runs**) | 18 | 18 | yes | **static twin** |
+| 7 | 21 | 33 | no | symbolic |
+| 8 (the nominal config) | 24 | 33 | no | symbolic |
+
+So the ladder does **not** bite this cell — because section 2's KV starvation pins it at six, one of
+the two widths that still lands on a rung under the bucket. My initial hypothesis (that the 0.74x
+cell was running the symbolic program) is **refuted by measurement**, and I am recording it as such.
+
+It matters anyway, for one reason: **the two faults are coupled.** Fixing the KV footprint so the
+lane reaches seven or eight streams moves the width to 21 or 24, which lands on rung 33 and retires
+the twin. Measured cost of that, box C, same programs, same card:
+
+| bucket 32, extrapolated 48-layer step | |
+|---|--:|
+| static decode twin at M=32 | 14.85 ms |
+| symbolic program at width 24 | 39.77 ms (**2.68x**) |
+| symbolic program at width 33 | 32.44 ms (**2.18x**) |
+
+Per layer, sliding: twin 305.8 us, `sym@33` 677.4 us. So any KV fix must ship together with a ladder
+rung at or below the bucket for the widths it unlocks, or the concurrency win is spent twice over.
+
+*Caveat:* the twin rows are CUDA-graph replays and the symbolic rows are timed around `run_once`
+(the symbolic path declines graph capture, so this matches production), which charges the symbolic
+rows for per-launch dispatch the twin rows do not pay. At ~7 launches per program that is under 10%
+of the gap; the 2.18x is overwhelmingly GPU work.
+
+## 4. A real m32 kernel win: the fused norm->linear edges deploy `fuse` where `cut` is faster
+
+The previous round reported "m32 already satisfies the rule (0.97x cuBLAS), so no m32 win exists".
+That holds for the *unfused* matmul entries. It does not hold for the **fused `norm_linear` edges,
+which are what the decode twins actually launch** — read out of the image's baked execution plan,
+`L00.post.decode.json`:
+
+```
+k_linear_3955dc__partial__zp32 / k_linear_3955dc   (o_proj, split-K)
+k_add_1                                            (residual + post-attn norm)
+k_linear_mean_reduce_037454                        (pre-FFW norm + gate/up cat, N=30720)  <-- FUSED
+k_linear_reduce_9de4dc__partial__zp32 / ...        (geglu + down proj, N=3840)            <-- FUSED
+k_mul_7                                            (post-FFW norm + residual + layer scale)
+```
+
+Those two fused kernels are ~93% of the `post` program's 262.8 us.
+
+The m32 goldens record these edges at `STAGE=d1/sync` with `PLACE@cone=fuse`. The **same names at m8**
+(and `mlp_down_fused` at m64) are recorded with `PLACE@cone=cut`, and sit at parity with the unfused
+matmul, while the m32 fuse entries sit 12-28% above theirs. Direct A/B on box D
+(`emmy run --golden NAME --bench --warmup 10 --iters 100 --ab "PLACE@cone=cut"`, bare metal):
+
+| golden (m32) | deployed (`fuse`) | `PLACE@cone=cut` | delta | eager (torch norm + cuBLAS) |
+|---|--:|--:|--:|--:|
+| `norm_gate_up.m32.lin` (N=30720, K=3840) | 160.4 us | **147.2 us** | **-8.2%** | 154 us |
+| `mlp_down_fused.m32.lin` (N=3840, K=15360) | 123.7 us | **115.9 us** | **-6.3%** | — |
+| `norm_qk_global.m32.lin` (N=8704, K=3840) | 38.3 us | **20.1 us** | **-47.5%** | 29 us |
+
+`cut` splits the fused cone at the A seam — the norm materialises to a workspace (1.4 us stat + 0.8 us
+scale at m32, i.e. free) and the matmul re-lowers with a plain gmem A, which lets it take the
+big-tile `d2/tma/ring` schedule (145.0 us, **91% of the 131.7 us DRAM floor**) instead of the
+constrained fused `d1/sync` one. On `norm_gate_up` that turns 0.96x eager into **1.04x**; on
+`norm_qk_global`, 0.73x into 1.44x.
+
+The m8 control validates the mechanism from the other side: at m8 the `fuse` form is not merely
+slower, it is **pathological** — `PLACE@cone=fuse` pinned at m8 measures **55,330 us** on
+`norm_gate_up.m8.lin` (a grid-8 `b128` scalar kernel, 380x) and 27,310 us on `mlp_down_fused.m8.lin`.
+m8's goldens therefore *had* to record `cut`. At m32 both forms realise, `fuse` wins the resolve, and
+nothing flagged that it was the slower of the two.
+
+**Per-step value, from the measured deltas:** `norm_gate_up` 13.2 us x 48 layers = 634 us,
+`mlp_down_fused` 7.8 us x 48 = 374 us, `norm_qk_global` 18.2 us x 8 = 146 us — **1.15 ms/step
+measured**, plus an unmeasured `norm_qkv` (the sliding layers' N=8192 fused QKV edge, which by
+analogy with `norm_qk_global` is worth several hundred us more and **has no m32 golden at all**).
+Call it 1.2-1.8 ms of the 14.86 ms step: **8-12% of emmy's kernel time, 4-6% of the step.**
+
+Worth taking. Not capable of closing a 26% cell gap.
+
+### Two golden-dataset defects found on the way
+
+- **`norm_gate_up.m32.lin` is DRIFT.** Every resolve prints
+  `matches golden shape ... but no offered candidate realizes any of them — the golden(s) no longer
+  realize under the current enumeration. Investigate enumeration drift for:
+  gemma4_12b.norm_gate_up.m32.lin`. Greedy falls through to the evidence hierarchy and happens to
+  land on the same config, so the deploy is unaffected today — but the shape has **no golden floor**.
+- **`mlp_down_fused.m32.lin`'s recorded latency is stale by 29%**: the YAML records `emmy_us: 95.9`;
+  live on an idle 5090 the identical knobs measure **123.7 us**. Consistent with the brief's warning
+  that the recorded m2048 numbers are stale. Recorded `emmy_us` should not be trusted for
+  cross-config reasoning without a live re-bench.
+
+### The knob space around the cut is not further tunable by pinning
+
+Pinning the plain matmul's winning schedule *on top of* the cut does not work, and the failures are
+instructive. `mlp_down.m32.lin` (the same 3840x15360 shape, unfused) reaches 74.7 us with
+`REDUCE=g4a` — atomic finalize. On the fused edge that is rejected outright:
+
+```
+atomic finalize can't carry a non-distributive projection epilogue (e.g. a fused bias / activation
+on a split reduce); pin the deferred-kernel finalize instead (REDUCE=…g<n>k)
+```
+
+so the unfused shape's 74.7 us is *not* reachable here, and the 110 us of the cut's matmul half is
+not the shortfall it looks like. Pinning `g<n>k` variants instead fails differently: a global
+`TILE=`/`REDUCE=`/`STAGE=` pin also lands on the cut's `__stat` / `__cone` kernels, which then compile
+to grid-1 launches — four of five variants hit the 60 s hung-kernel guard and one came back
+`wrong-answer: rel err 7.341 vs greedy output`. (Worth noting for its own sake: the pinned-row
+integrity gate catches this, so the accuracy check in `run --bench` is doing real work.)
+
+`PLACE@cone=cut` on its own is therefore the whole of the available win, and it is a **structural**
+pin — exactly the shape the m8 and m64 entries already record.
+
+## 5. What I did not change, and why
+
+- **No decode-bucket or width change.** Confirmed the coordinator's tile-granularity argument holds:
+  the mma atom is `mma_m16n8k16`, so a tile's M extent is a multiple of 16 and the `c=8` widths (24 at
+  depth 2, 32 at depth 3) occupy a 32-row tile at any legal bucket. Section 2 makes the point moot
+  anyway — the lane runs at width **18**, and the measured `c=6` parity says the step is already as
+  fast as stock's.
+- **No m16 tier seeding.** It was already the lowest-priority option, and the parity result removes
+  its rationale entirely: there is no per-step deficit at these widths for a new tier to recover.
+- **No image rebuild.** All eleven emmy lanes pin `0.23.0-58733e02`; a repo-side change reaches none
+  of them, and an image built from current main is separately reported ~22% slower at this very cell.
+  Everything above is measured per-kernel or against that pinned image, and **no article cell moves as
+  a result of this work.**
+- **No capture-ladder change to `serve.py`.** #441 already fixed it there. The gap is that the
+  gemma-4 image's baked `serve.sh` carries a hand-written sparse list that `_gen_graph_args` never
+  sees (section 3). Fixing that is an image change, so it belongs to whoever next bakes one — noted
+  in the recommendations rather than patched here.
+
+## 6. Verdict on the previous round's claims
+
+| claim | verdict |
+|---|---|
+| "m32 already satisfies the rule (0.97x cuBLAS), so no m32 win exists" | **False.** True of the unfused matmul entries; false of the *fused* `norm_linear` edges the decode twins actually launch, which run 0.73 - 0.96x eager at m32 against 1.01 - 1.22x at m8. `PLACE@cone=cut` recovers 6 - 47% per edge. |
+| "emmy wins at every M against cuBLAS; there is no cliff at 32" | **False in the same way.** There is a cliff at m32, and it is on the fused edges. |
+| "m2048 prefill is at parity; recorded YAML numbers are stale" | **Stale confirmed, independently.** `mlp_down_fused.m32.lin` records 95.9 us; live it is 119 - 124 us (+24 - 29%). Recorded `emmy_us` should not be used for cross-config reasoning. |
+| "A bucket override is a whole-pack miss, not decode-only" | **Confirmed.** The pack key is `{kind, model, config_sha, dtype, decode_bucket, max_tokens, prefill_bucket}`; the image's is `prefill_bucket: 4096`, so every `EMMY_GEN_PREFILL_BUCKET=2048` lane misses the whole pack and cold-resolves all 288 programs (~25 min of boot on 30 cores, observed). |
+| "The remaining deficit is per-step runner overhead, not kernel quality" | **Half right, and the wrong half matters.** Roughly half the step is outside emmy's matmuls (14.86 of 28.5 ms), which is real — but it is *not* a deficit: at equal concurrency emmy's step is 2% *faster* than stock's. The deficit is admission capacity, not per-step time. |
+| "The shipped image is immune to the capture-ladder fault" | **False for `vllm-emmy-gemma4`** (section 3); true for the generic `vllm-emmy` image that was actually inspected. |
+
+## 7. Recommendations, in value order
+
+1. **Give the trunk back its KV cache.** One concurrent sequence at this request length costs 0.61
+   GiB, and that single sequence is the whole `c=8` gap. The buffers are sized by `max_tokens = 4096`
+   and `prefill_bucket`, not by the decode width, so a lane that only ever schedules 2048-token chunks
+   is paying for 4096-row capacity. Start by measuring `BufferArena` occupancy against the widths a
+   lane can actually reach.
+2. **Put the capture ladder in the baked image.** `serve.sh` hard-codes
+   `[1,2,4,8,16,32,64,128,256]`, which #441 replaced in `emmy serve` precisely because it is unsafe
+   under speculation. It is inert today only because KV starvation pins the width at 18; recommendation
+   1 will move the width to 21 or 24, both of which land on rung 33 and cost **2.18x** on the step.
+   These two must ship together.
+3. **Record the `PLACE@cone=cut` m32 goldens** (section 4) — worth 8 - 12% of emmy's per-step kernel
+   time at every width that routes through bucket 32, independent of everything above.
+4. **`norm_qkv` has no m32 golden at all**, though it is the sliding layers' fused QKV edge and
+   therefore 40 of 48 `pre` programs. Its m8 and m64 siblings both exist and both record `cut`.
+5. **Fix the `norm_gate_up.m32.lin` drift** — the resolve prints `no offered candidate realizes any of
+   them` on every compile, so the shape has no golden floor. It lands on the right config today by
+   luck of the evidence hierarchy.

--- a/plans/gemma4-narrow-decode-width-findings.md
+++ b/plans/gemma4-narrow-decode-width-findings.md
@@ -14,18 +14,21 @@ DRAM floor, so kernel work has ~1.3 ms of realistic headroom — 4-5% of the ste
 
 Same-box, full-protocol decomposition of the observed **0.797x** (section 2):
 `0.803 (admission) x 0.945 (step latency) x 1.024 (acceptance — an emmy advantage) = 0.777`.
-**Admission alone (0.803) accounts for the whole observed ratio to within 1%; kernels are the ~5.5%
-step-latency term.** So the honest verdict
-is that **admission capacity is essentially the whole cell gap**, with a real but much smaller kernel
-term beside it — and the brief's suspicion was pointed at the right half of the smaller term (m32 kernel
-quality is genuinely worse than m8's; see section 4b for why, which *is* the bucket 8 -> 32 shift, though
-not for the reason hypothesized).
+**Admission alone (0.803) accounts for the whole observed ratio to within 1%.** So the honest verdict
+is that **admission capacity is essentially the whole cell gap**. There is a ~5.5% step-latency term
+beside it, and m32 kernel quality is genuinely worse than m8's (section 4b explains why, and it *is* the
+bucket 8 -> 32 shift, though not for the reason hypothesised) — but the one kernel change available for
+it turned out not to move the served step, so that term remains unexplained and open.
 
-A real m32 kernel win does exist, is deploy-verified, and ships on this branch (section 4): the three
-fused norm->linear edges the decode twins launch every step were deploying `PLACE@cone=fuse` where
-`cut` is 8 - 49% faster, taking them from 0.73 - 0.96x eager to 1.01 - 1.38x. It is worth ~1.3 ms of
-emmy's 14.86 ms per-step kernel budget — a genuine correction to the previous round's "no m32 win
-exists" — which is ~three quarters of the step-latency term. It cannot touch the other three terms.
+**And the m32 kernel win does not survive contact with the model.** The three fused norm->linear edges
+the decode twins launch were deploying `PLACE@cone=fuse` where `cut` benchmarks 8 - 49% faster
+(section 4), so I recorded it. It deploys — verified in the boot log — and the served step does **not
+move**: 28.06 vs 28.09 ms at `c=6`, 28.77 vs 28.73 ms at `c=8` (section 4a). The reason is that
+`run --bench --golden` replays one weight slab 100 times, so any slab under the card's 96 MB L2 is
+measured L2-resident: the two edges that fit L2 (63 and 67 MB) showed the 42 - 49% wins, the one that
+does not (236 MB) showed 8%, and in a step that streams 21.83 GB nothing is L2-resident. **The change is
+kept — it is not a regression, it fixes a DRIFT and a coverage gap — but its throughput claim is
+withdrawn.** The broader lesson is in section 4a and matters more than the change itself.
 
 Read section 2's honesty notes before quoting any tok/s number from this report: `c=8` at
 `num-prompts 16` is not reproducible for *either* engine (emmy 369 - 492, stock 469 - 540), and the
@@ -544,6 +547,57 @@ credible; **treat ~9% as the number and the rest as unproven.** I did not verify
 whole-step effect end to end — that needs a cold-resolve `stepprof` against the edited goldens, which
 did not fit in the budget.
 
+## 4a. END-TO-END: the m32 kernel win does NOT reach the served model
+
+This is the most important correction in this report, and it is against my own change.
+
+Same box, same published image, same knobs, same client protocol as the E1 baseline. **One variable:**
+the container's goldens file is the image's own with the three `cut` entries appended. The change
+demonstrably takes effect — the boot log's decode-twin kernel sets contain `__cone` (the cut form) in
+**16** program sets and the fused `k_linear_mean_reduce_037454` in **0**, where E1 deployed the fused
+form everywhere. KV is identical (3.0 GiB, 2.78x), so nothing else moved.
+
+| box A, depth 2, bucket 32 | E1 (image goldens) | E9 (+ m32 cut goldens) | delta |
+|---|--:|--:|--:|
+| `c=6` `np=12` median ITL | 28.09 ms | **28.06 ms** | **-0.1%** |
+| `c=8` `np=64` median ITL | 28.73 ms | **28.77 ms** | **+0.1%** |
+| `c=8` `np=64` median TPOT | 10.18 ms | 10.17 ms | -0.1% |
+| `c=8` `np=64` tok/s | 476.75 (E2: 485.91) | 480.22 | within spread |
+
+**Kernels 8 - 49% faster in isolation, verified deploying, and the served step does not move at all.**
+
+### Why: `run --bench --golden` measures L2-resident bandwidth at these shapes
+
+The RTX 5090 has 96 MB of L2. A `--golden` bench replays one kernel 100 times over one weight slab, so
+any slab under ~96 MB stays L2-resident across iterations. The correlation with the measured wins is
+exact:
+
+| edge | weight slab | fits in 96 MB L2? | isolated win from `cut` |
+|---|--:|---|--:|
+| `norm_qkv.m32` | 62.9 MB | **yes** | **-42%** |
+| `norm_qk_global.m32` | 66.8 MB | **yes** | **-49%** |
+| `norm_gate_up.m32` | 235.9 MB | no | **-8%** |
+
+A decode step streams the whole 21.83 GB trunk, so in the model **nothing is L2-resident**. The two
+big wins are L2-bandwidth wins that cannot exist there; the only DRAM-real one is `norm_gate_up`'s 8%,
+worth 12.9 us x 48 layers = **0.62 ms of a 28.7 ms step (2.2%)** — at or below this benchmark's noise
+floor, which is exactly what E9 measures.
+
+**This generalises well beyond my change.** Any golden entry whose weight slab is under ~96 MB on this
+card has a recorded `emmy_us` that reflects L2 bandwidth, not DRAM. That is most of the narrow-N
+projection shapes in this dataset. Comparisons *within* a shape stay valid (both arms get the same L2
+benefit, which is why the resolver still ranks correctly), but **the recorded microsecond figures must
+not be used to predict in-model step time**, and the section 1 kernel budget — measured differently, by
+timing the deployed 48-layer program set — is the number to trust.
+
+### What I did with the change
+
+**Kept, with the performance claim withdrawn.** It is not a regression (480.22 sits dead centre of the
+baseline's 476.75 / 485.91), it fixes a real DRIFT — `norm_gate_up.m32.lin` had no realizable golden, so
+that shape had no floor at all — and it fills a real coverage gap, `norm_qkv.m32`, the sliding layers'
+fused QKV edge with no entry of any kind. Those two are worth having on their own. **What it is not is a
+throughput improvement**, and section 7's recommendation is ordered accordingly.
+
 ## 4b. The brief's puzzle: why plain `c=8` is 0.97x and MTP `c=8` is 0.74x
 
 Same box, same concurrency, same prefill quantum, same drafter-on-stock-vLLM for both engines. The only
@@ -644,12 +698,15 @@ vacuous — a differently-pinned variant in the same sweep came back `wrong-answ
 2. **Profile the ~10 ms of the step that is not GPU work** (section 1). It is the largest unexplained
    block in the step for *both* engines, and nobody has looked at it. Nsight Systems on a live
    container, or vLLM's own `--enable-layerwise-nvtx-tracing`.
-3. **Done on this branch: the `PLACE@cone=cut` m32 goldens** (section 4) — ~9% of emmy's per-step
-   kernel time at every width that routes through bucket 32, independent of everything above. What is
-   left there is `mlp_down_fused.m32`, which needs an A/B on its true geglu-cone snippet.
-4. **Re-open the capture-ladder question if and only if recommendation 1 lands.** Today an added rung
+3. **Treat every golden `emmy_us` under ~96 MB of weight slab as an L2 number** (section 4a). It is the
+   most transferable thing found here: `run --bench --golden` cannot see DRAM bandwidth at those shapes,
+   so its wins do not predict in-model step time. Within-shape A/B comparisons stay valid; absolute
+   figures do not. A slab-size column in the golden bench output would make this impossible to miss.
+4. **Find out what the ~5.5% step-latency term actually is.** m32 kernels are worse than m8's and the
+   only available fix did not move the step, so the cause is not yet identified.
+5. **Re-open the capture-ladder question if and only if recommendation 1 lands.** Today an added rung
    at 24 is worth 1.9% at `np=64` (section 3) — not worth shipping. At a steady eight streams the width
    becomes 24, a rung nobody has A/B'd, and the answer may differ.
-5. **`emmy eval golden`'s drift audit deserves a CI lane.** `norm_gate_up.m32.lin` had been printing
+6. **`emmy eval golden`'s drift audit deserves a CI lane.** `norm_gate_up.m32.lin` had been printing
    `no offered candidate realizes any of them` on every single compile of this model, i.e. that shape
    had no golden floor at all, and nothing surfaced it. (Fixed here as a side effect; the class is not.)

--- a/plans/gemma4-narrow-decode-width-findings.md
+++ b/plans/gemma4-narrow-decode-width-findings.md
@@ -680,7 +680,7 @@ vacuous — a differently-pinned variant in the same sweep came back `wrong-answ
 
 | claim | verdict |
 |---|---|
-| "m32 already satisfies the rule (0.97x cuBLAS), so no m32 win exists" | **False.** True of the unfused matmul entries; false of the *fused* `norm_linear` edges the decode twins actually launch, which ran 0.73 - 0.96x eager at m32 against 1.01 - 1.22x at m8. `PLACE@cone=cut` recovers 8 - 49% per edge and now deploys. |
+| "m32 already satisfies the rule (0.97x cuBLAS), so no m32 win exists" | **Both reports are right about different kernel families, and #444's conclusion still stands in practice.** Its claim holds for the *unfused* matmul entries it examined, which are indeed at parity. The *fused* `norm_linear` cone edges are a different family — the one the decode twins actually launch — and there the resolver was picking the slower of two realizing forms (0.73 - 0.96x eager at m32 against 1.01 - 1.22x at m8). But see section 4a: correcting that is worth 0.1% on the served step, so #444's bottom line ("no m32 win worth having") survives even though its reasoning did not cover this family. |
 | "emmy wins at every M against cuBLAS; there is no cliff at 32" | **False in the same way.** There is a cliff at m32, and it is on the fused edges. |
 | "m2048 prefill is at parity; recorded YAML numbers are stale" | **Not reproduced as staleness at m32.** `norm_gate_up.m32.lin` (161.6) and `norm_qk_global.m32.lin` (40.1) both reproduce live to within 4%. `mlp_down_fused.m32.lin` looks 24 - 29% stale but is not: its YAML comment says the recorded µs came from the true geglu-cone snippet while a `--golden` replay traces an rms-cone stand-in. Apparent staleness there is a **snippet mismatch documented in the file**, and I withdrew an earlier draft claim to the contrary. |
 | "A bucket override is a whole-pack miss, not decode-only" | **Confirmed.** The pack key is `{kind, model, config_sha, dtype, decode_bucket, max_tokens, prefill_bucket}`; the image's is `prefill_bucket: 4096`, so every `EMMY_GEN_PREFILL_BUCKET=2048` lane misses the whole pack and cold-resolves all 288 programs (~25 min of boot on 30 cores, observed). |
@@ -695,6 +695,14 @@ vacuous — a differently-pinned variant in the same sweep came back `wrong-answ
    will not start). The buffers are sized by `max_tokens = 4096` and `prefill_bucket`, not by the decode
    width, so a lane that only ever schedules 2048-token chunks is paying for 4096-row capacity. Start by
    measuring `BufferArena` occupancy against the widths a lane can actually reach.
+   **TRAP — read this before starting.** Succeeding at this *activates* the capture-ladder fault. The
+   sparse ladder in the baked image is harmless today only because admission starvation pins the lane at
+   <= 6 running sequences, so every verify width lands on rung 18, under the decode bucket. Reclaim the
+   footprint, concurrency rises to 7-8, the verify width becomes 21-24, the first rung at or above it is
+   **33**, and 33 > bucket 32 puts **every steady-state step on the symbolic path — a measured 2.18x on
+   the trunk**. The reward for fixing the memory bug is silently losing the static decode twin. Raise the
+   decode bucket to a covered width, or fix the baked `serve.sh` ladder, **in the same change**. The
+   invariant is recorded durably in `emmy/serving/ARCHITECTURE.md`.
 2. **Profile the ~10 ms of the step that is not GPU work** (section 1). It is the largest unexplained
    block in the step for *both* engines, and nobody has looked at it. Nsight Systems on a live
    container, or vLLM's own `--enable-layerwise-nvtx-tracing`.


### PR DESCRIPTION
Sent to close the article's two largest emmy-vs-stock gaps — `4k/4k c=8` MTP at depth 2 (**0.74x**) and
depth 3 (**0.77x**) — by hand-tuning the m32 kernels those cells route onto. **It is not a kernel
problem.** The cell gap is emmy's device footprint stealing the KV cache, and the one m32 kernel win that
looked real turned out to be an L2 measurement artifact — verified end to end, and documented as such.

Everything here is measured on RTX 5090s against the pinned published image
`cloudriftai/vllm-emmy-gemma4:0.23.0-58733e02`. **No article cell moves as a result of this PR** — all
eleven emmy lanes pin that image, which ships its own goldens and a baked plan pack.

## What changed

- **`emmy/serving/ARCHITECTURE.md`** — two new sections: *device footprint sets admission capacity*, and
  *reclaiming footprint re-opens the capture-ladder question*. This is the durable home for the day's
  main result; concepts and invariants only.
- **`goldens/rtx5090_sm120_gemma4.yaml`** — three `PLACE@cone=cut` entries at m32, deploy-verified, plus
  a header note on what `emmy_us` actually measures (L2-resident for slabs under 96 MB).
- **`plans/gemma4-mtp-batched-serving-findings.md`** — an in-place correction to its §SCOPE claim that
  the published image is immune to the ladder fault. That was checked against the *generic* `vllm-emmy`
  image; `vllm-emmy-gemma4` bakes its own `serve.sh` carrying the sparse ladder.
- **`plans/gemma4-narrow-decode-width-findings.md`** — the investigation, including the parts that
  refuted my own hypotheses.

## ⚠ The trap for whoever does the footprint work

The two faults here are coupled, and the coupling runs the wrong way. The sparse capture ladder in the
baked image is harmless **today only because admission starvation pins the lane at ≤6 running sequences**,
so every verify width lands on rung 18, under the decode bucket, on the static twin.

Fix the footprint — which is recommendation #1 — and concurrency rises to 7–8, the verify width becomes
21–24, the first rung at or above it is **33**, and 33 > bucket 32 puts **every steady-state step on the
symbolic path, a measured 2.18× on the trunk**. The reward for fixing the memory bug is silently losing
the static decode twin.

So: raise the decode bucket to a covered width, or fix the baked `serve.sh` ladder, **in the same
change**. Recorded as an invariant in `emmy/serving/ARCHITECTURE.md` rather than only in the plan.

## The kernel change — and why its throughput claim is withdrawn

The three fused norm→matmul edges the decode twins launch every step were deploying `PLACE@cone=fuse`,
where `cut` benchmarks faster on all three. The same edges at m8 and m64 already record `cut`; m32 was
the gap, and `norm_qkv` — the sliding layers' merged q‖k‖v edge, 40 of the 48 `pre` programs — had **no
m32 entry of any kind**, so the most-launched fused edge in the model had no golden floor at that width.

Isolated, resolved through the **old** entry names (i.e. what a default compile deploys before/after):

| edge (m32) | was | now | weight slab | fits in 96 MB L2? |
|---|--:|--:|--:|---|
| `norm_gate_up` (N=30720) | 0.96x eager, 160.4 µs | 1.01x, 147.2 µs | 236 MB | no |
| `norm_qkv` (N=8192) | 0.86x eager, 33.7 µs | 1.38x, 19.8 µs | 63 MB | **yes** |
| `norm_qk_global` (N=8704) | 0.73x eager, 38.3 µs | 1.27x, 20.1 µs | 67 MB | **yes** |

**Then I checked it end to end, and it does nothing.** Same box, same image, same knobs as the baseline
lane; one variable, the three entries appended to the container's own goldens. The cut form
demonstrably deploys — the boot log shows `__cone` in **16** decode-twin kernel sets and the fused
`k_linear_mean_reduce_037454` in **zero**, where the baseline had the fused form everywhere. The served
step does not move:

| depth 2, bucket 32 | baseline | + cut goldens |
|---|--:|--:|
| `c=6` `np=12` median ITL | 28.09 ms | **28.06 ms** |
| `c=8` `np=64` median ITL | 28.73 ms | **28.77 ms** |
| `c=8` `np=64` tok/s | 476.75 / 485.91 | 480.22 |

**The cause is a measurement artifact, and it is the most transferable thing in this PR.**
`run --bench --golden` replays *one* weight slab 100 times, so any slab under the 5090's 96 MB L2 is
timed L2-resident. The correlation above is exact: the two edges that fit L2 showed 42–49%, the one that
does not showed 8%. A decode step streams the whole 21.83 GB trunk, so nothing is L2-resident there —
only the 8% is real, worth 0.62 ms of a 28.7 ms step, at this benchmark's noise floor. **This applies to
most of the narrow-N projection entries in the dataset**: within-shape A/B stays valid (both arms get the
same L2 benefit, so the resolver still ranks correctly), but the absolute microseconds must not be used
to predict in-model step time.

**The entries are kept, with the caveat recorded beside them in the YAML.** They are not a regression
(480.22 sits dead centre of the baseline's 476.75 / 485.91), they restore a golden floor to
`norm_gate_up.m32.lin` — which had been failing to realize on *every* compile of this model — and they
close `norm_qkv`'s missing m32 coverage. Only the performance claim is withdrawn.

`cut` splits the fused cone at the A seam: the norm materialises to a workspace (a ~1.4 µs stat plus a
~0.8 µs scale at this M — free) and the matmul re-lowers with a plain gmem A, letting it take the
big-tile `d2/tma/ring` transport instead of the sync compute-fill the fused cone is confined to.

**This still answers the brief's central puzzle** (plain `c=8` is 0.97x but MTP `c=8` is 0.74x, differing
only in the decode bucket 8 → 32): m8's goldens record `cut` because at m8 they had no choice — a `fuse`
pin at m8 measures **55,330 µs** on `norm_gate_up`, a 380x scalar degenerate. At m32 both forms realise
and `fuse` won the resolve. So m32 kernel quality *is* genuinely worse than m8's — it just isn't worth
what the isolated benchmark says, and the ~5.5% step-latency term remains unexplained.

## Where the cell gap actually is

Same box, same protocol as the recipe (`c=8`, `np=64`, depth 2). Both engines reproduce their published
cells — stock within 1.1% of 610.2, emmy within 6–8% of 450.6:

| box A, `c=8`, `np=64` | emmy | stock | ratio |
|---|--:|--:|--:|
| output throughput (tok/s) | 476.75 / 485.91 | **603.66** | **0.797x** |
| mean concurrency over the window | **5.42** (never >6) | **6.75** | **0.803** |
| median inter-token latency (the step) | 28.73 / 28.78 ms | 27.20 ms | 0.945 |
| run-aggregate acceptance length | 2.757 | 2.693 | 1.024 |

`0.803 × 0.945 × 1.024 = 0.777` against an observed 0.797 — nothing unaccounted, and **the admission
term alone matches the observed ratio to within 1%.**

Emmy leaves **3.0 GiB** for the KV cache where stock leaves **3.61**; at 8448 tokens per request that
0.61 GiB is 1.3 streams. It cannot be bought back with `--gpu-memory-utilization`: 0.98 gives emmy *more*
KV than stock (3.63 GiB, 3.36x) and then dies at first use with a `torch.OutOfMemoryError` in
`rejection_sampler.sample_recovered_tokens`; 0.99 will not start at all. The footprint has to shrink.

**The ceiling on any kernel work here is arithmetic.** Emmy owns the 48-layer trunk = 21.83 GB of fp16
weights, read once per step, so at 1792 GB/s no decode step can beat **12.18 ms** at any width from 1 to
64. The deployed bucket-32 twins measure **14.86 ms** (per layer + per program, CUDA-graph window, pack
keyed to hit the image's baked plans) — 82% of spec bandwidth. Against a 28.7 ms step, a perfect kernel
saves 2.68 ms and a realistic one 1.3 ms.

## Hypotheses I refuted, including my own

- **"The 0.74x cell is losing its decode twin to the sparse capture ladder."** The published gemma-4
  image *does* bake the sparse `[1,2,4,8,16,32,64,128,256]` ladder that #441 replaced in `emmy serve` —
  `plans/gemma4-mtp-batched-serving-findings.md` says it is immune, but that was checked against the
  *generic* `vllm-emmy` image, not `vllm-emmy-gemma4`. At depth 2 it becomes `[3,6,9,18,33,66,129]`
  (confirmed: exactly 7 decode graphs captured). **But it costs these cells nothing**, because admission
  starvation keeps the width at 15–18, under the first gap. A same-box A/B adding a rung at 24 moved
  `np=64` by 1.9% and per-step latency by 0.2%. It stays a latent hazard: a footprint fix that reaches
  seven or eight streams moves the width to 21/24, where the symbolic path costs a measured **2.18x**.
- **"Emmy and stock are at parity at `c=6`."** Retracted. That came from emmy on box A against stock on
  box C; on the *same* box stock scores 514.75 against emmy's 469, a real **8.9%** deficit. Box C is
  simply ~9% slower, which happened to cancel it exactly.
- **"Emmy loses ~5% of its speculation to worse acceptance."** Retracted — that compared snapshots from
  different phases of a run whose acceptance climbs from 2.6 to 3.0. Run-aggregated, emmy is slightly
  *ahead*.
- **"Emmy reaches 7 concurrent streams a third of the time."** Retracted — those samples came from the
  stock container, because a `docker logs -f` capture silently re-attached across a container swap.

## Verdict on the previous round's claims (PR #444)

- **"m32 already satisfies the rule, so no m32 win exists" — false.** True of the *unfused* matmul
  entries; false of the fused `norm_linear` edges the twins actually launch. Same for "there is no cliff
  at 32": there is, and it is on the fused edges.
- **"A bucket override is a whole-pack miss" — confirmed.** The pack key carries `prefill_bucket`, so
  every `EMMY_GEN_PREFILL_BUCKET=2048` lane cold-resolves all 288 programs (~25 min of boot on 30 cores).
  The decode twin it lands on is byte-identical to the packed one, so the 14.86 ms applies to both.
- **"Recorded YAML numbers are stale" — not at m32.** `norm_gate_up` (161.6) and `norm_qk_global` (40.1)
  reproduce live within 4%. `mlp_down_fused.m32.lin` *looks* 24–29% stale but is not — its own comment
  says the recorded µs came from the true geglu-cone snippet while a `--golden` replay traces an rms-cone
  stand-in. That entry is therefore **deliberately left alone**; it needs an A/B on the true snippet.

## Also found

`norm_gate_up.m32.lin` was **DRIFT** — every compile of this model logged `no offered candidate realizes
any of them`, so that shape had no golden floor at all. Fixed here as a side effect; the *class* is not,
and `emmy eval golden`'s drift audit would make a good CI lane.

## Checks

`make test` on an RTX 5090, `PYTHONPATH` pinned to the branch tree:
`4 failed, 2819 passed, 37 skipped in 1073s`. A `274c153e` baseline on the same box and harness fails
**five** — the branch's four are a strict subset, so **no new failures**. Notably
`test_golden_drift_gate.py::test_gemma4_goldens_deploy_in_serving_twins[rtx5090]`, the repo's own gate
for "a golden that pins is not a golden that deploys", **passes**.

Accuracy of the changed kernels is covered by `run --bench`'s pinned-row gates: every `cut` row reports
`status: "ok"` (realized-vs-pinned, arithmetic-intensity floor, wrong-answer check). Not vacuous — a
differently-pinned variant in the same sweep came back `wrong-answer: rel err 7.341`.

## Recommendations, in value order

1. **Give the trunk back its KV cache.** This is the whole cell gap, it is not reachable by a knob, and
   the buffers are sized by `max_tokens`/`prefill_bucket` rather than by the decode width — a lane that
   only ever schedules 2048-token chunks pays for 4096-row capacity.
2. **Profile the ~10 ms of the step that is not GPU work.** Emmy's kernels are 14.86 ms and the computed
   vLLM-side floors add ~3.6 ms, against a 28.7 ms step. Largest unexplained block, for *both* engines.
3. **Treat every golden `emmy_us` under ~96 MB of weight slab as an L2 number.** A slab-size column in
   the golden bench output would make this impossible to miss.
4. **Find out what the ~5.5% step-latency term is** — m32 kernels *are* worse than m8's, and the only
   available fix did not move the step, so the cause is not identified.
5. Re-open the capture ladder *if and only if* (1) lands.

## Reconciling with #444

#444's report concludes "no m32 win exists" and this one shows the resolver picking the slower of two
realizing forms at m32. Both are right about different kernel families: #444's claim holds for the
*unfused* matmul entries it examined, which are at parity; the fused `norm_linear` cone edges — the ones
the decode twins actually launch — are a separate family that it did not cover. **Its bottom line
survives anyway**, because correcting that family is worth 0.1% on the served step.

## Known deviation

`plans/` holds 13 files against CLAUDE.md's cap of 10 — same call #441 made: this adds a findings report
rather than executing a plan, and enforcing the cap would mean deleting somebody else's in-flight report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jgz6GKUU6QS2JyZHSw4bU4
