### PR TITLE
tests: re-pin the GQA dynamic warp-chain to the serial REDUCE fork

### DIFF
--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -1429,7 +1429,10 @@ def test_warp_chain_gqa_static_matches_torch(monkeypatch, Hq, Hkv, S, D):
 def test_warp_chain_gqa_dynamic_matches_torch(monkeypatch, seq):
     """Symbolic ``seq_len`` warp-chain flash with **GQA** (``Hq=4 / Hkv=2``, group 2). ``_Gqa`` traces
     as GQA+causal, so this also exercises the causal mask composed with the symbolic boundary mask.
-    ONE cached kernel carrying ``int seq_len``; matches torch GQA+causal SDPA at seq ∈ {8,16,37,64}."""
+    ONE cached kernel carrying ``int seq_len``; matches torch GQA+causal SDPA at seq ∈ {8,16,37,64}.
+    ``REDUCE`` is pinned serial: unpinned, the cold offline pick for this shape is the ``g4k``
+    reduce-partition warp sibling (two kernels) — the fused single-kernel chain is what this case pins."""
+    monkeypatch.setenv("EMMY_REDUCE", "")
     B, Hq, Hkv, D = 1, 4, 2, 32
     sd = torch.export.Dim("seq_len", min=4, max=4096)
     seed = (


### PR DESCRIPTION
## Summary

`test_warp_chain_gqa_dynamic_matches_torch` fails on main (all 4 params) since #446. Bisect + an unpinned
compile A/B showed the compiler is not at fault: the cold pick for this GQA-dynamic shape is byte-identical
before and after #446 — the `REDUCE: 'g4k'` reduce-partition warp sibling, i.e. a `__partial` + finalize
two-kernel plan that trips the one-fused-kernel assertion.

What changed was the test: pre-#446 it pinned `EMMY_PLACE=fuse`; #446 retired the `PLACE` knob and dropped
the pin, assuming the cold offline pick stays warp-fused. That holds for the equal-head dynamic siblings but
not for GQA, where the offline prior has always ranked `g4k` first.

Fix: pin `EMMY_REDUCE=""` (the serial stream, in the live knob namespace — the same pin other cases in the
file use), with a docstring note. The warp-vs-scalar fork stays cold-picked, so the case still asserts the
fused warp chain with one cached kernel carrying `int seq_len`.

Not touched: whether `g4k` actually beats serial-fused for this shape was never benched (relates to the known
attention split-KV offer-gap work), so the prior is left alone.

## Test plan

- `tests/compiler/e2e/test_attention_coverage.py::test_warp_chain_gqa_dynamic_matches_torch` — 4/4 pass (RTX 4080)
- full `test_attention_coverage.py` — 114 passed, 10 skipped (sm_90+ pins)
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)