### PR TITLE
Serving: capture-aware no-clone run_device_sym (vLLM integration Milestone A, task 1)

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -185,7 +185,10 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   FULL_DECODE_ONLY` (full cudagraphs need no torch.compile — vLLM wraps the model in its `CUDAGraphWrapper`) and
   `cudagraph_capture_sizes` laddered up to `--max-num-seqs` (sizes at or below the decode bucket run the static
   decode twin; sizes above it capture the device-resident symbolic programs — both paths are capture-validated,
-  `test_gen_capture_gpu` / the two-size live-replay test; over-bucket capture was worth +10.6% req/s at c=64,
+  `test_gen_capture_gpu` / the two-size live-replay test, and BOTH drop their output clones under the outer
+  capture (`run_device_sym` mirrors `run_device`'s captured no-clone branch — the graph's fixed kernel order
+  makes the views safe, and the per-layer clone D2D nodes leave the captured graph; the uncaptured paths keep
+  the clone); over-bucket capture was worth +10.6% req/s at c=64,
   and a decode bucket matched to the concurrency beats riding the symbolic captures — the bucket-64 golden set
   took c=64 TPOT 35.4 → 22.5 ms, and the bucket-8 set (m8 goldens, 2026-07-25) took c=4 TPOT 19.6 → 18.9 and
   c=8 21.4 → 20.6 on the same per-lane-knob rule). The mixed prefill+decode cells take a second per-workload

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -103,7 +103,16 @@ class _Program:
         wall). No per-T graph capture: at prefill widths the dispatch hides behind the GPU work,
         and chunked-prefill ``T`` varies step to step — a per-T graph cache would re-capture
         constantly. Requires the program to have been built with a ``capacity`` feed
-        (:func:`_compile_split`); ``set_sym_values`` raises past it."""
+        (:func:`_compile_split`); ``set_sym_values`` raises past it.
+
+        Under an OUTER capture (an over-bucket decode size in vLLM's capture ladder) the output
+        clones drop, mirroring :meth:`run_device`'s captured branch: the outer graph's fixed
+        kernel order guarantees every consumer (RoPE, attention, the next twin's prefix upload)
+        reads before this program's next-replay overwrite, and each layer runs its own program
+        instance. ``set_sym_values`` stays capture-safe because vLLM's uncaptured per-size warmup
+        has already populated this sym key's TMA descriptor overlay — the descriptor H2D never
+        lands inside the capture window. The uncaptured path keeps the clone: there the buffers
+        may be rewritten before the caller consumes the view."""
         import cupy as cp
         import torch
 
@@ -116,6 +125,8 @@ class _Program:
             self.program.upload_prefix_device(feed)
             self.program.run_once()
             outs = self.program.output_prefix_device({"num_tokens": t})
+            if torch.cuda.is_current_stream_capturing():
+                return [torch.from_dlpack(outs[n]) for n in self.output_names]
             return [torch.from_dlpack(outs[n]).clone() for n in self.output_names]
 
 

--- a/tests/serving/test_gen_capture_gpu.py
+++ b/tests/serving/test_gen_capture_gpu.py
@@ -72,13 +72,16 @@ def test_run_device_sym_inside_outer_capture_replays_live():
     graphs = {}
     ins = {}
     outs = {}
+    out_backing_ptr = prog.program.arrays[prog.output_names[0]].data.ptr
     for t in (24, 40):
         x = torch.randn(t, 16, dtype=torch.float16, device="cuda")
-        warm = prog.run_device_sym([x])[0].clone()  # uncaptured warmup at this exact width
+        warm = prog.run_device_sym([x])[0]  # uncaptured warmup at this exact width
+        assert warm.data_ptr() != out_backing_ptr  # uncaptured path must CLONE (buffer is reused)
         assert torch.allclose(warm, ref_mod(x), rtol=1e-2, atol=1e-2)
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             out = prog.run_device_sym([x])[0]
+        assert out.data_ptr() == out_backing_ptr  # captured path must be a VIEW (A1: no clone nodes)
         graphs[t], ins[t], outs[t] = g, x, out
 
     for t in (24, 40):


### PR DESCRIPTION
First task of the generic vLLM-integration improvement plan's Milestone A (low-risk copy removal — pointer/view changes only, no compiled-graph changes, so all tuned goldens and packs stay valid).

## What

`_Program.run_device_sym` (the symbolic any-width path — over-bucket decode sizes in vLLM's capture ladder) now mirrors `run_device`'s captured branch: under an outer whole-step CUDA-graph capture it returns buffer **views** instead of clones. The per-output clone D2D nodes (q/k/v per layer on pre, hidden on post — ~4/layer/step) drop out of every over-bucket captured decode graph. The uncaptured path keeps the protective clone.

Safety: the outer graph's fixed kernel order guarantees every consumer (RoPE, attention, the next twin's prefix upload) reads before the next replay's overwrite — the same argument already validated for the static twins — and `set_sym_values` never encodes TMA descriptors inside a capture window (vLLM's uncaptured per-size warmup populates the per-sym-key overlay first).

## Validation

- **Unit**: the two-size live-replay test now pins the semantics both ways — captured output must alias the program buffer, uncaptured must not (a future re-added clone fails the test).
- **Local e2e** (RTX 4080, TinyLlama, bucket 4 @ c=8 → every steady decode step rides the changed path): 32/32 requests, TPOT flat at 8.00 ms, capture + live replay clean.
- **RTX 5090 A/B** (gemma-4-12B-it, bucket 16, `--max-num-seqs 64`, c=64, in 8 / out 64, 128 prompts, seed 0, shared pack + cubin cache across arms, 2 runs/arm):

| arm | median TPOT | out tok/s | req/s | greedy chat parity |
| --- | ---: | ---: | ---: | --- |
| main (0ae03cf9) | 59.90 / 60.11 ms | 588.8 | 9.20 | baseline |
| **A1** | **59.74 / 59.57 ms** | **594.3 / 594.7** | **9.29** | **byte-identical** |

No regression; marginally ahead (within noise) — the removed copies are µs-class in-graph nodes at this scale, consistent with the plan's expectation that Milestone A's decode-TPOT effect is small and its value is (a) removing integration overhead ahead of the later milestones and (b) the measurement itself.

Bench-ops footnote: greedy parity probes must use `/v1/chat/completions` — gemma-4-12B-it degenerates on untemplated bare completions (`111...`) identically on stock vLLM in fp16 AND bf16, i.e. a model/prompt-format behavior, not an emmy issue (verified during this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)