### PR TITLE
Added readability rules with glossary enforcement

### DIFF
--- a/.claude/skills/reproduce-article-benchmarks/SKILL.md
+++ b/.claude/skills/reproduce-article-benchmarks/SKILL.md
@@ -250,6 +250,9 @@ Judge deltas honestly:
   comparisons each deviation weakens. A best-effort reproduction is a legitimate result; an undisclosed one is not.
 - **Say what you did not measure.** Recipes skipped, cells that failed, tables with no backing recipe, a
   command-recipe-only run that never touched the image question. Silence reads as coverage.
+- **Use established terminology only** — terms from the repo-root `GLOSSARY.md`, other established repo/field
+  terms, or plain language. Do not coin labels; before delivering the report, replace any invented term with the
+  correct established term or a plain-word explanation.
 
 ## Common pitfalls
 

--- a/.claude/skills/tune-golden/SKILL.md
+++ b/.claude/skills/tune-golden/SKILL.md
@@ -243,6 +243,10 @@ density of the `tune-model` reports (`plans/*-tune-findings.md`; executed ones a
 `git log --diff-filter=D --name-only -- 'plans/*findings*'` + `git show <commit>^:<path>`). Note friction and findings
 **as they happen** during steps 1–6 — don't reconstruct from memory at the end.
 
+Use established terminology only — terms from the repo-root `GLOSSARY.md`, other established repo/field terms, or
+plain language. Do not coin labels; before saving, re-read the report and replace any invented term with the correct
+established term or a plain-word explanation.
+
 - **Header**: date, GPU, the exact sweep command, wall time, and the category tally (N replaced / N added / N
   unchanged / N worse).
 - **A `## Fork sibling regret` section** (`emmy eval online --dataset nodes`, this card's `-O1` block). The command

--- a/.claude/skills/tune-model/SKILL.md
+++ b/.claude/skills/tune-model/SKILL.md
@@ -211,6 +211,9 @@ doc's structure:
   online ⇒ training data / calibration). Never paste raw eval output or quote an unlabeled "prior" number.
 - **Repro / artifacts** tail: log + dump locations and copy-pasteable repro blocks (compile-only repros that
   need no GPU are the most valuable).
+- **Use established terminology only** — terms from the repo-root `GLOSSARY.md`, other established repo/field
+  terms, or plain language. Do not coin labels; before saving, re-read the report and replace any invented term
+  with the correct established term or a plain-word explanation.
 - Wrap to ~120 chars (repo-wide markdown rule); tables may overflow.
 
 ## Step 6 — workflow retrospective (always include)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ The `README.md` is intentionally short — example-driven, no narrative. For det
   synthesized contraction node — a twisted monoid is a monoid,
   selected structurally not as a distinct kind) →
   [`emmy/compiler/pipeline/passes/ARCHITECTURE.md`](emmy/compiler/pipeline/passes/ARCHITECTURE.md)
+- **Terminology** (the stable vocabulary for comments, docs, reports, and user-facing text) →
+  [`GLOSSARY.md`](GLOSSARY.md)
 
 When the user asks about a CLI flag, recipe field, or matrix combinator, read the relevant ARCHITECTURE.md before
 answering — they hold the detail that is no longer in this file or the README.
@@ -202,6 +204,10 @@ These are invariants — they hold for every doc change, no exceptions:
   and rot immediately. Name a module/symbol only when it is a genuine entry point, and refer to it by name, not line.
 - **CLAUDE.md routes; it does not duplicate.** Each subsystem's detail lives in its nearest `ARCHITECTURE.md`; CLAUDE.md
   points there. Do not re-enumerate the CLI, env vars, or any reference list that already has a canonical home.
+- **Only use established terminology — [`GLOSSARY.md`](GLOSSARY.md) is the stable vocabulary.** In code comments,
+  documentation, reports, commit messages, PR bodies, and when communicating with the user, use glossary terms, other
+  established repo/field terms, or plain language. Never coin new labels; replace any invented term with the correct
+  established term or a plain-word explanation.
 
 **Wrap every `.md` file in the repo to ~120 characters.** This includes `README.md`, every `ARCHITECTURE.md`, every file
 under `docs/`, and any other markdown anywhere in the tree. Do NOT wrap at 70–80 characters — that is the default
@@ -231,12 +237,15 @@ You MUST complete ALL of the following checks before every commit. These are not
 8. **Prune `plans/`**: if the change executed/landed a plan, **delete that plan file**. Then enforce the cap — if
    `plans/` holds more than 10 files, remove the executed/obsolete ones; if all remaining plans are still incomplete,
    remove the oldest. Never add a `plans/*.md` reference to durable docs or code (see Documentation Conventions).
-9. **Run tests**: `make test` — fix any failures before proceeding
-10. **Run linter**: `make lint` — if it fails, run `make format` and re-check
+9. **Check terminology**: review every text this change adds or edits — code comments, docstrings, docs, report
+   text, the commit message and PR body — against [`GLOSSARY.md`](GLOSSARY.md). Remove any invented terms and
+   replace them with the correct established term or a plain-word explanation (see Documentation Conventions).
+10. **Run tests**: `make test` — fix any failures before proceeding
+11. **Run linter**: `make lint` — if it fails, run `make format` and re-check
 
 ### Submitting
 
-11. Push and open a PR
+12. Push and open a PR
 
 # Behavioral Guidelines:
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,193 @@
+# Glossary
+
+This file defines the project-specific and technical language used in the Emmy course and docs. The definitions
+describe how a term is used in Emmy; they are not meant to replace a full textbook definition.
+
+## Machine learning and model serving
+
+- **Large language model (LLM)** — A program trained on a large amount of text to predict or generate language. In
+  this course, an LLM is mainly a chain of tensor operations that must run on a GPU.
+- **Model** — A collection of mathematical operations and learned numbers called weights. The operations describe
+  what to compute; the weights contain information learned during training.
+- **Weight** — A number learned during model training. A real model contains millions or billions of weights,
+  usually stored in tensors.
+- **Tensor** — A rectangular collection of numbers. A scalar is a zero-dimensional tensor, a list is one-dimensional,
+  a table is two-dimensional, and higher-dimensional tensors can represent batches, tokens, or model features.
+- **Shape** — The size of every tensor dimension. A tensor with shape `(2, 8, 16)` has 2 groups, 8 rows per group,
+  and 16 values per row. The meaning of each dimension depends on the operation.
+- **Dtype (data type)** — The format used to store each tensor value, such as 32-bit floating point (`float32`) or
+  16-bit floating point (`float16`). Smaller formats use less memory and can be faster but may lose precision.
+- **Inference** — Using an already-trained model to produce an answer. It is different from training, which changes
+  the weights.
+- **Token** — A small piece of text represented by an integer. A tokenizer converts text into tokens before an LLM
+  processes it.
+- **Embedding** — A list of numbers representing the meaning or features of an input. Similar inputs often have
+  nearby embeddings.
+- **Batch** — Several inputs processed together. Batching often makes better use of a GPU.
+- **vLLM** — An external model-serving system. It owns the HTTP API, request scheduling, tokenization, batching, and
+  other serving work. Emmy can plug compiled model operations into that system.
+- **Transformer** — The neural-network architecture used by most modern LLMs. It processes token representations
+  through repeated layers containing attention and other tensor operations.
+- **KV cache (key/value cache)** — GPU memory that stores attention information for tokens a model has already
+  processed. Reusing it avoids recalculating the entire earlier sequence during text generation. A paged KV cache
+  manages this memory in fixed-size pieces.
+- **Hugging Face** — An ecosystem for publishing and loading models, datasets, and related tools. Emmy can trace
+  compatible models loaded through Hugging Face libraries.
+
+## Compiler concepts
+
+- **Compiler** — A program that translates code from one form into another. Emmy translates PyTorch model operations
+  into CUDA code.
+- **Operation (op)** — One unit of computation, such as add, matrix multiplication, softmax, or RMSNorm.
+- **Graph** — A representation of a program as nodes connected by data-flow edges. A node usually represents an
+  operation; an edge means that one operation uses a value produced by another.
+- **Node** — One item in a graph. In Emmy, it stores an operation, its input node IDs, output tensor information,
+  and optional metadata.
+- **Intermediate representation (IR)** — A compiler's internal description of a program. Emmy uses several IR
+  stages. Early stages resemble PyTorch; later stages explicitly describe loops, GPU threads, memory, and CUDA
+  source.
+- **Dialect** — The vocabulary allowed in one IR stage. For example, Tensor IR uses tensor primitives, while Kernel
+  IR uses hardware-oriented statements.
+- **Frontend / backend** — The frontend reads and represents the source program, such as PyTorch operations. The
+  backend turns a lower-level representation into executable code for a target such as CUDA.
+- **Pass** — One ordered compiler phase. A pass searches for known patterns and rewrites them into a form suitable
+  for the next phase.
+- **Rewrite rule** — A small compiler transformation. It recognizes a pattern, such as RMSNorm, and replaces it with
+  equivalent lower-level operations.
+- **Pipeline** — An ordered sequence of compiler passes. The output of one stage becomes the input to the next.
+- **Decomposition** — Breaking a complex operation into simpler operations. Emmy decomposes recognizable PyTorch
+  operations into a small set of tensor primitives.
+- **Primitive** — A basic operation used as a building block, such as elementwise arithmetic, reduction, or index
+  mapping.
+- **Elementwise operation** — An operation independently applied to corresponding tensor elements, such as adding
+  two tensors.
+- **Reduction** — Combining many values into fewer values, such as summing a row or finding its maximum.
+- **Broadcasting** — Reusing a smaller tensor across a larger shape. For example, one weight per column can be
+  reused for every row.
+- **Index map** — A description of how output coordinates correspond to input coordinates. Emmy uses index maps for
+  broadcasting, transposing, slicing, and reshaping.
+- **Tracing** — Observing a PyTorch program with example inputs to capture the operations and data flow that it
+  performs.
+- **Lowering** — Moving from a high-level representation to a more detailed, machine-oriented one while preserving
+  the program's meaning.
+- **Runtime** — The code and state involved while a compiled program is executing. Emmy's CUDA runtime allocates
+  buffers, resolves dynamic sizes, and launches kernels.
+- **Fusion** — Combining operations so that one GPU kernel performs work that would otherwise require several
+  kernels. Fusion can avoid writing temporary values to slower global memory.
+- **Static shape** — A tensor shape known when compiling, such as exactly 512 tokens.
+- **Dynamic or symbolic shape** — A shape containing a named value, such as `seq_len`, whose actual size is supplied
+  when the program runs.
+- **Provenance** — Metadata that records where generated code came from. It helps connect a final CUDA kernel back
+  to the original model operation when debugging.
+- **Metadata** — Information about program data rather than the data itself, such as a tensor's shape, a kernel's
+  original operation, or the number of threads needed for launch.
+- **Mutable / immutable** — A mutable object can be changed after creation. An immutable object cannot; code creates
+  a replacement instead. Emmy's graph is mutable, while many nested compiler statements are immutable.
+- **Structural identity / structural key** — A fingerprint based on computation and data flow rather than cosmetic
+  names. It lets Emmy recognize equivalent compiler candidates.
+- **Idempotent rule** — A rule that does not keep changing its own output when applied again. Compiler rewrite rules
+  need this property because a pipeline may revisit earlier rules.
+- **JIT compilation (just-in-time compilation)** — Compiling code during program execution, shortly before it is
+  needed.
+
+## GPU and CUDA concepts
+
+- **GPU (graphics processing unit)** — Hardware designed to run many similar calculations in parallel. GPUs were
+  developed for graphics and are now widely used for machine learning.
+- **CUDA** — NVIDIA's platform and programming model for running general-purpose code on NVIDIA GPUs.
+- **Kernel** — A function executed on the GPU by many parallel workers. In this course, "kernel" means a GPU
+  function, not an operating-system kernel.
+- **Thread** — One GPU worker executing a kernel. Threads are organized into blocks.
+- **Block / cooperative thread array (CTA)** — A group of GPU threads that can cooperate using fast shared memory
+  and synchronization.
+- **Warp** — A small group of GPU threads — 32 on current NVIDIA hardware — that execute instructions together.
+- **Grid** — All thread blocks launched for one kernel call.
+- **Shared memory** — Fast memory shared by threads in one block. It is limited in size and must be managed
+  explicitly.
+- **Global memory** — The GPU's large main memory. It has much higher capacity than shared memory but is generally
+  slower to access.
+- **Register** — Very fast storage private to one GPU thread.
+- **Tile** — A small rectangular piece of a larger tensor computation. GPU programs process tiles so data can fit in
+  fast memory and be shared by nearby threads.
+- **Schedule** — The plan for executing correct mathematics on hardware: tile sizes, thread assignments, memory
+  movement, and synchronization. Different schedules can compute the same answer at very different speeds.
+- **Staging** — Moving a piece of data into faster memory before computing with it, often from GPU global memory to
+  shared memory.
+- **Synchronization** — Making workers wait until a required event or memory update is complete. It prevents threads
+  from reading data before other threads have finished producing it.
+- **Contraction** — A multiply-and-combine operation over one or more dimensions. Matrix multiplication is the most
+  familiar example.
+- **Carrier** — The temporary state maintained by a reduction and the rule for combining partial states. A sum's
+  carrier can be one accumulated number; stable softmax needs several related values.
+- **Tensor core** — Specialized GPU hardware for performing small matrix operations efficiently.
+- **nvcc / NVRTC** — Two NVIDIA CUDA compilers. nvcc compiles ahead of execution; NVRTC compiles CUDA source at
+  runtime.
+- **CUDA graph capture** — Recording a sequence of GPU launches so the sequence can be replayed with less CPU
+  overhead.
+- **DLPack** — A standard for sharing tensor memory between libraries without copying the values through CPU memory.
+
+## Deployment and benchmarking
+
+- **CLI (command-line interface)** — The commands and options used from a terminal, such as `emmy compile`.
+- **YAML** — A human-readable configuration format. Emmy recipes are written in YAML.
+- **Recipe** — A version-controlled plan describing what model or command to run, how to deploy it, which hardware
+  and benchmark settings to use, which variants to compare, and how to aggregate results. Commands such as
+  `emmy deploy` and `emmy bench` consume recipes; a recipe does not execute by itself.
+- **Variant** — One concrete combination of recipe settings. A matrix can expand one recipe into many variants.
+- **Matrix** — A recipe section that describes several values to test. `cross` creates every combination; `zip`
+  pairs values by position.
+- **Benchmark** — A controlled measurement of speed, latency, throughput, or resource use.
+- **Latency** — The time needed to complete one operation or request. Lower latency is faster.
+- **Throughput** — The amount of work completed per unit of time, such as requests per second. Higher throughput is
+  better.
+- **VM (virtual machine)** — A computer created by software, often rented from a cloud provider. A GPU VM includes
+  one or more GPUs.
+- **Provisioning** — Obtaining and preparing a machine. This may include creating a cloud VM, installing software,
+  and returning connection details.
+- **Deployment** — Placing and starting the application on a machine that is already available.
+- **Docker container** — An isolated package containing an application and its dependencies.
+- **Docker Compose** — A configuration format and tool for defining and starting several related containers.
+- **Smoke test** — A quick check that the deployed service starts and can answer a basic request before expensive
+  benchmarks begin.
+- **Control plane** — The code that coordinates work — choosing machines, starting services, and collecting
+  results — rather than performing the model computation itself.
+
+## Search and tuning
+
+- **Autotuning** — Trying several valid GPU schedules, measuring them, and keeping evidence about which ones are
+  fast.
+- **Fork** — A compiler decision point with several correct alternatives. Each branch can lead to a different
+  schedule.
+- **Knob** — A named tuning choice, such as a tile size or memory-staging strategy.
+- **Candidate** — One complete set of choices that the compiler could use.
+- **Greedy selection** — Choosing the candidate that currently appears best without exploring alternatives during
+  normal compilation.
+- **MCTS (Monte Carlo tree search)** — A search method that treats decisions as a tree and balances trying promising
+  branches with exploring less-tested ones.
+- **Prior** — In Emmy, a ranker that estimates which schedule will be fast before the current candidate is measured.
+  The offline prior is fixed; the online prior learns from collected measurements.
+- **Golden configuration** — A reviewed, GPU-specific schedule and latency for a standard problem shape. It is
+  trusted deployment evidence and a regression reference.
+- **Evidence** — A compatible recorded measurement used to select between schedule candidates.
+- **Calibration** — A check of whether a learned model ranks measured candidates well enough to influence
+  compilation.
+- **Quarantine** — The state in which an online model may continue learning but is not trusted to choose deployed
+  schedules.
+- **CatBoost** — The machine-learning library Emmy uses for its online schedule-ranking model.
+- **SQLite** — A small database stored in one local file. Emmy uses it to persist tuning measurements.
+
+## Common mathematical terms
+
+- **Matrix multiplication (matmul)** — An operation that combines rows of one matrix with columns of another. It is
+  one of the most important computations in machine learning.
+- **RMSNorm (root mean square normalization)** — An operation that rescales each row according to the root mean
+  square of its values. It helps keep values at a stable scale inside many language models.
+- **Softmax** — An operation that converts a list of scores into positive values that sum to one. Models use it to
+  turn scores into relative weights or probabilities.
+- **Attention** — A mechanism that lets each token combine information from other tokens. It uses matrix
+  multiplication and softmax as major building blocks.
+- **Associative operation** — An operation for which grouping does not change the mathematical result, such as
+  `(a + b) + c = a + (b + c)`. Associativity lets a reduction be split across parallel workers. Floating-point
+  rounding means the bit-level result can still differ slightly.
+- **Numerical precision** — How accurately a number format represents real values. Faster or smaller data types can
+  introduce more rounding error.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -41,8 +41,8 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
 - **Operation (op)** — One unit of computation, such as add, matrix multiplication, softmax, or RMSNorm.
 - **Graph** — A representation of a program as nodes connected by data-flow edges. A node usually represents an
   operation; an edge means that one operation uses a value produced by another.
-- **Node** — One item in a graph. In Emmy, it stores an operation, its input node IDs, output tensor information,
-  and optional metadata.
+- **Node** — One item in a graph. In Emmy, it stores an operation, the names of the input buffers it reads (usually
+  the producing node's ID), one or more output tensors, and optional hints.
 - **Intermediate representation (IR)** — A compiler's internal description of a program. Emmy uses several IR
   stages. Early stages resemble PyTorch; later stages explicitly describe loops, GPU threads, memory, and CUDA
   source.
@@ -165,7 +165,8 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
 - **MCTS (Monte Carlo tree search)** — A search method that treats decisions as a tree and balances trying promising
   branches with exploring less-tested ones.
 - **Prior** — In Emmy, a ranker that estimates which schedule will be fast before the current candidate is measured.
-  The offline prior is fixed; the online prior learns from collected measurements.
+  The offline prior is fitted ahead of time (by `emmy fit`, on the golden dataset) and ships with the repo; the
+  online prior learns from collected measurements.
 - **Golden configuration** — A reviewed, GPU-specific schedule and latency for a standard problem shape. It is
   trusted deployment evidence and a regression reference.
 - **Evidence** — A compatible recorded measurement used to select between schedule candidates.

--- a/emmy/commands/fit.py
+++ b/emmy/commands/fit.py
@@ -1,9 +1,9 @@
 """``emmy fit`` — fit an offline-prior artifact and cross-validate it, writing a per-run
 metrics file.
 
-The Phase-4 fitter entry point: one pipeline, two orthogonal switches — ``--trainer``
-(model class) × ``--data`` (training data). Only the ``linear`` × ``golden`` cell exists
-today (the incumbent trainer on the golden dataset); the other cells arrive with the
+The fitter entry point: one pipeline, two orthogonal switches — ``--trainer``
+(model class) × ``--data`` (training data). Only the ``linear`` × ``golden`` combination exists
+today (the incumbent trainer on the golden dataset); the other combinations arrive with the
 measurement-freeze training work and until then are rejected loudly.
 
 A run writes ``<out>/metrics.json`` — the deterministic, diff-able record two fits are
@@ -104,8 +104,8 @@ def _snippet_rows(snippet: str, ctx: Context) -> list[dict]:
     trace) and capture the RESTORED schedule fork's leaf rows via the same live-fork capture the
     matmul path uses (``golden_eval.enumerate_graph``). A reduce offers its ``REDUCE@<axis>``
     partitions; a pointwise kernel forks nothing today, so its pool is empty and the golden is
-    reported un-enumerable (an honest read of the live space, not a reconstruction of the
-    demolished one)."""
+    reported un-enumerable — reflecting the live search space rather than reconstructing
+    one that no longer exists."""
     from emmy.commands.trace import graph_from_code  # noqa: PLC0415
 
     graph = graph_from_code(snippet)[0]
@@ -125,11 +125,11 @@ def build_golden_groups(features_spec: str = DEFAULT_FEATURES) -> tuple[list[Gro
     pool ``eval offline`` and the greedy deploy rank over (fp32 → thread tier,
     fp16/bf16 → warp tier; the block-DAG rework moved the scalar↔warp choice to a
     structural fork, so a real fp16 matmul ranks within the warp tier alone, no
-    scalar rows in the pool). A dynamic (``.dynM``) golden enumerates its hint-sized
-    static twin's pool and featurizes with the symbolic-axis stamp (its own weight
-    set). Reduce / pointwise goldens trace their snippet and capture the restored
+    scalar rows in the pool). A dynamic (``.dynM``) golden enumerates the pool of its
+    static counterpart at the hint size and featurizes with the symbolic-axis stamp
+    (its own weight set). Reduce / pointwise goldens trace their snippet and capture the restored
     schedule fork's rows (``_snippet_rows``); a regime the live tree doesn't fork
-    (pointwise) reports un-enumerable rather than reconstructing the demolished space.
+    (pointwise) reports un-enumerable rather than reconstructing a search space that no longer exists.
 
     Each golden is reconstructed under its OWN card's context
     (``Context.from_target(cap, gpu_name=…)``, mirroring ``Sample.from_golden``):
@@ -157,7 +157,7 @@ def build_golden_groups(features_spec: str = DEFAULT_FEATURES) -> tuple[list[Gro
             dyn = bool(g.dynamic)
             base = _base(ctx, g.M, g.N, g.K, dynamic=dyn)
             # A fast-math golden's row only exists in the gate-on enumeration (the same
-            # self-gating seam as ``golden_eval.evaluate_golden``) — pin the gate for the
+            # gate pinning ``golden_eval.evaluate_golden`` uses) — pin the gate for the
             # reconstruction so the f16-accumulate rows are present and the fit anchors
             # their ``MMA_acc_bits`` discriminator.
             if g.fast_math:
@@ -177,8 +177,9 @@ def build_golden_groups(features_spec: str = DEFAULT_FEATURES) -> tuple[list[Gro
             continue
         # Match the legacy-recorded golden against the native candidate rows by
         # schema-agnostic structural signature (free-axis slots + reduce decomp +
-        # atom) — the candidates speak native ``MOVE@element``, the golden YAML legacy
-        # GEMM-letters, so a per-key tuple compare never lines up.
+        # atom) — the candidate rows use the native ``MOVE@element`` keys while the
+        # golden YAML records legacy GEMM-letter keys, so comparing key-value tuples
+        # directly never matches.
         want = features.tile_signature(g.knobs)
         gidx = next((i for i, r in enumerate(rows) if features.tile_signature(r) == want), None)
         if gidx is None:

--- a/emmy/commands/tune.py
+++ b/emmy/commands/tune.py
@@ -153,8 +153,8 @@ def _tune_backend(device_id: int | None = None):
     with the worker and the **parent** CUDA stream stays clean. Tight per-variant
     budgets: tune benches isolated single kernels at -Xcicc -O1 (fast), but the
     big-N warp-MMA variants (fp16 N=28672, ``matmul.mlp_gate_up.h4096``) need ~5 s
-    of cicc even then — a 4 s compile budget bench_fail-locks that whole family out
-    of the sweep, hence 12 s; 2 s run is ample and the wall SIGKILLs any runaway
+    of cicc even then — a 4 s compile budget would record that whole family as
+    bench failures and lock it out of the sweep, hence 12 s; 2 s run is ample and the wall SIGKILLs any runaway
     (keeping a ~2 s margin over compile+run). ``device_id`` pins the async bench
     worker to a physical GPU (multi-GPU tune)."""
     from emmy.compiler.backend.cuda.backend import CudaBackend

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Terms used throughout:
 | `search/policy/mcts.py` | The in-memory MCTS (`SearchTree`) colocated with its only reader, `TuningSearch`. |
 | `search/policy/greedy.py` | `greedy_decide` — the no-tree fork resolver used by `compile` / `run`. |
 | `search/two_level.py` | The two-level tuner: outer structural MCTS, inner per-op reward. |
-| `search/prior/` | The ONE ranking path: a `Prior` ABC with the cold `OfflinePrior` and the `OnlinePrior` composed behind `FallbackPrior` (`load_prior`). `diagnostics.py` here backs the `eval` reachability / calibration reports; `fit/` is the offline fitter, split along its seams — `group.py` data representation, `linear.py` trainer+model, `rank.py` rank metrics, `cv.py` fold harness, `run.py` the pure `emmy fit` run harness. |
+| `search/prior/` | The ONE ranking path: a `Prior` ABC with the cold `OfflinePrior` and the `OnlinePrior` composed behind `FallbackPrior` (`load_prior`). `diagnostics.py` here backs the `eval` reachability / calibration reports; `fit/` is the offline fitter, split by responsibility — `group.py` data representation, `linear.py` trainer+model, `rank.py` rank metrics, `cv.py` fold harness, `run.py` the pure `emmy fit` run harness. |
 | `search/data/` | The harmonized read-view over the three data sources (golden configs / DB `perf` rows / prior reservoir): `Sample`, `Dataset`, and `ShapeKey` (the single golden↔measured join key). |
 | `search/golden.py` | `GoldenConfig` and its subclasses (see Part 7, "Golden configs and the A/B integrity gates"). |
 | `search/audit.py` | The golden drift audit: compile graphs with the golden tier as the only evidence, one MATCH / DRIFT / GAP verdict per consulted fork (via `greedy.golden_audit`, the supported sink; records also carry `unrealized`, the per-entry pin-only signal). Backs `emmy eval golden` (the pin-only offer audit), `--in-model`, and the CI gate (see Part 7). |
@@ -193,7 +193,7 @@ The two halves of the one path:
 - **`OfflinePrior`** (cold) — a fit-offline linear *score* over the engineered `D_*` geometry / occupancy features,
   not emission order. The complete scoring function (both weight sets + the scalar params, `feat_ver`-stamped, with a
   `provenance` block) lives in the repo-checked artifact `search/prior/offline_weights.json`, written by the offline
-  fitter — library code in `search/prior/fit/`, split along the trainer/data/harness seams: `group.py` (the `Group`
+  fitter — library code in `search/prior/fit/`, split along trainer / dataset / harness boundaries: `group.py` (the `Group`
   dataset representation — one ndarray-backed candidate pool + its labels — and the `--features` view parser),
   `linear.py` (the linear trainer + fitted model, owner of the loss — the tier-weighted golden-rank objective plus a
   raw-space L2 penalty (`DEFAULT_L2`, CLI `--l2`) whose job is identifiability, not shrinkage: the rank objective is
@@ -213,12 +213,13 @@ The two halves of the one path:
   hard-coded interaction gates ride outside the linear weights: the atomic-free split-K term, and the tensor-core
   preference pair `D_scalar_on_warp_eligible` / `D_splitk_roundtrip` driven by the scheduler's per-kernel
   `S_warp_eligible` row stamp — which stops a warp-eligible f16 contraction deploying a scalar split tile.
-  The linear quality is squashed into a positive latency proxy (`exp(-scale·quality)`) whose exp argument clips only
-  at the float-safety bound (~±700) — **the squash must never saturate over live qualities**. A former ±80 *quality*
-  clip sat inside the live range: every good warp tile collapsed onto one `exp(-8)` plateau, greedy's argmin fell
-  through to emission order (the degenerate-`w1x1` gemma misdeploys, 12–29× off the golden on a real 4090) while the
-  golden-rank eval reported 0 for every tied row. The one consumer needing a bounded value — `FallbackPrior`'s tilt
-  multiplier — clamps to `e**±8` on its own side; ranking consumers get the strictly-ordered proxy.
+  The linear quality is mapped through an exponential into a positive latency proxy (`exp(-scale·quality)`) whose
+  argument clips only at the float-safety bound (~±700) — **the exponential must never saturate over live quality
+  scores**. A former ±80 *quality* clip sat inside the live range: every good warp tile collapsed onto one `exp(-8)`
+  plateau, greedy's argmin fell through to emission order (the degenerate-`w1x1` gemma misdeploys, 12–29× off the
+  golden on a real 4090) while the
+  golden-rank eval reported 0 for every tied row. The one consumer needing a bounded value — `FallbackPrior`'s
+  offline multiplier — clamps to `e**±8` on its own side; ranking consumers get the strictly-ordered proxy.
 - **`OnlinePrior`** (online) — trained from tune measurements (Part 5), composed behind `FallbackPrior`.
 
 A subtlety about features: the `H_*` regime features (GPU / nvcc level) are constant across a pool's siblings, so no
@@ -251,7 +252,7 @@ that ships with a clone — the reservoir and tune DB are machine-local caches w
 machine (every rented box) previously deployed on pure model extrapolation (the gemma 12–29× cold misdeploys). At a
 fork, `greedy_decide` joins the op against the deploy card's recorded goldens — every kind: matmul, attention
 (flash), rms_norm, softmax, reduce, pointwise, norm_linear (the fused RMSNorm→linear computed-A megakernel) — by
-`ShapeKey` (static and dynamic twins never cross; the key's `kind` discriminator, classified off the stamped
+`ShapeKey` (static and dynamic entries never cross; the key's `kind` discriminator, classified off the stamped
 histogram via the sweep identity `S_loop_depth < n_free + n_reduce + n_symbolic`, keeps a flash/norm op apart from
 an extent-coincident contraction — and within the rsqrt family a SECOND reduce axis (`S_ext_n_reduce_axis >= 2`,
 the contraction beside the statistic reduce) marks the `"fused"` computed-A form, `is_warp` forced True since a
@@ -259,7 +260,7 @@ computed-A contraction is a warp mma whose f32 statistic constants would otherwi
 at the DEPLOY fork the flash op is recognized from its offer's `TILE@dd` + `TILE@pj` pair instead — the tile pass's
 restructured twisted op carries re-derived extents only, no histogram, so the stamp classifier cannot fire there; and
 the computed-A norm→linear cone is likewise recognized at the deploy fork from its OFFER — a `d*/sync` STAGE row,
-the mandatory compute-fill only a computed-A contraction enumerates (the catalog spells only gmem-direct/cp/tma) —
+the mandatory compute-fill only a computed-A contraction enumerates (the catalog offers only gmem-direct/cp/tma) —
 since its PRE-SPLIT fork carries only one reduce axis with the rsqrt still buried in the A sub-body, so the histogram
 misreads it as a plain scalar matmul; it is rebuilt to the fused key so the norm→qkv cones join their goldens at cold
 deploy, and a fused golden is schema-required to record a `d*/sync` STAGE so its config can
@@ -271,8 +272,8 @@ satisfied by ANY same-family realization (how a dynamic attention golden's singl
 fork's axis-keyed leaves) — and a fast-math entry self-excludes when its atom isn't offered (gate off). The
 fastest-first pick also grounds the **fm-never-loses invariant** (statically gated in `test_golden_configs.py`):
 within one card's rows of a name, a fast-math entry recording ABOVE the best standard sibling can never realize
-(the std row matches first in either lane), so such rows are dropped — an absent fm row just means the fm lane
-deploys the std config there. Goldens are
+(the std row matches first whether fast-math is on or off), so such rows are dropped — an absent fm row just means a
+fast-math deploy uses the std config there. Goldens are
 **consulted, never trained on**: they enter no reservoir, no checkpoint, no dataset (they are the held-out
 acceptance set). Golden µs is deployable-regime truth and never arbitrates a non--O3 compile. A shape match none of
 whose entries realizes against the offer logs a loud enumeration-drift warning and falls through to the tiers below.
@@ -285,7 +286,7 @@ not merely to pin: `--ab` reproduces configs the enumeration would never choose,
 the isolated golden-reproduction check and only the in-model drift audit (`eval golden --in-model`) catches it.
 The tier depends on **no prior**: a resolve with no prior at all — a failed `load_prior` (corrupt/unreadable online
 checkpoint) or `Pipeline.run`'s last-resort emission-order resolve — still consults the goldens and deploys a
-realizable one (the **golden floor**, logged loudly when it overrides option-0), so a broken checkpoint can never
+realizable one (logged loudly when it overrides option-0), so a broken checkpoint can never
 silently cost a fork its verified golden.
 
 ### `FallbackPrior` and the calibration gate
@@ -297,26 +298,26 @@ in the checkpoint). Below `CALIBRATION_MIN` the model is quarantined: it keeps t
 PUCT, and structural pricing (`greedy._pick_structural`) stay offline, and the verdict is logged.
 
 Why: `fitted` alone let a mis-calibrated model own deploys silently (the 2026-07 RTX 5090 sweeps). In-sample Spearman
-is a lenient tripwire that specifically catches the model-and-rows-don't-share-a-feature-vocabulary collapse (constant
-predictions, worse-than-random ranking).
+is a lenient tripwire that specifically catches the collapse where the model and its rows no longer share feature
+names (constant predictions, worse-than-random ranking).
 
 When trusted: `mean_score` / `mean_scores` / `pick` (deploy + eval) are pure-online + evidence. But `score` — the MCTS
-*selection* signal — tilts the online µs by the offline prior's dimensionless ranking multiplier
+*selection* signal — nudges the online µs by the offline prior's dimensionless ranking multiplier
 (`online · offline**W`, `W = config.offline_tilt`, neutral 1.0), so PUCT still explores regions the cold heuristic
 prices well but the data-poor online model buries.
 
-### Featurizer vocabulary versioning
+### Featurizer versioning
 
 `features.FEATURIZER_VERSION` stamps every persisted training artifact:
 
 - **The prior checkpoint** (`to_json`): `from_json` discards a checkpoint from another version WHOLE — model and
-  reservoir rows alike — since rows spelled in a retired knob vocabulary featurize to garbage and a refit on them
-  collapses to constant predictions.
+  reservoir rows alike — since rows recorded under a retired version's feature names featurize to garbage and a refit
+  on them collapses to constant predictions.
 - **The autotune DB's `node` rows** (a `feat_ver` column, additively migrated): `diagnostics.node_report` excludes
   rows from another version with a printed count. Pre-stamp rows default to version 1 (the retired pre-rebuild
-  vocabulary) and quarantine conservatively.
+  feature names) and quarantine conservatively.
 
-Bump the constant on any incompatible knob-spelling or feature-encoding change; artifacts from the old vocabulary then
+Bump the constant on any incompatible change to knob naming or feature encoding; artifacts from the old version then
 age out instead of poisoning the model.
 
 ## Part 4: The drivers — two ways to run the pipeline
@@ -363,8 +364,8 @@ pinned, so the prior would be blind at the `BM/BN` choice. Instead `greedy_decid
 complete leaves (`fork.flatten_leaves` expands branches depth-first; only knob dicts — materialization stays deferred
 to the chosen leaf) and picks the lowest `Prior.mean_scores` over the full `{H_*, S_*, complete-knob-row}` vector in
 one batched `predict`, invariant to the tree's level order. Cold, the `OfflinePrior` ranks (including a positive
-`MMA_tier` warp preference); if `load_prior` returns nothing entirely the recorded goldens still floor the pick and
-only the golden-less forks fall to option-0 (first leaf, emission order).
+`MMA_tier` warp preference); if `load_prior` returns nothing entirely the recorded goldens still decide the forks
+they match and only the golden-less forks fall to option-0 (first leaf, emission order).
 Greedy benches nothing, so it can only *use* a prior, never train one.
 
 **Every deploy pick breaks ties by candidate content, never enumeration order.** The model can score many
@@ -375,26 +376,26 @@ sorted tuning-knob rendering): the model argmin (`Prior.pick` and the greedy fal
 measured-evidence argmins, and the golden realization pick. An order-broken tie is a per-boot coin flip — leaf order
 can shift across processes — and shipped the 2026-07 RTX 5090 gemma-4 image with a bimodal boot-time cubin set.
 Pinned by `tests/compiler/pipeline/search/test_deploy_pick_determinism.py` (tier-level permutation invariance plus a
-cross-subprocess selected-kernel-set pin, the resolution twin of `test_source_determinism.py`).
+cross-subprocess selected-kernel-set pin, the resolution counterpart of `test_source_determinism.py`).
 
 **Structural options are priced, never raw-scored.** With the trained prior loaded, `greedy_decide`'s
 `_pick_structural` prices each side of a structural fork: a nested `resolve` per kernel over a `lowering/tile`-only
 pipeline, the price being the `score` of the slice-resolve's partition-fork `Decision`, memoized per `op_cache_key`.
 The cheaper kernel set wins, so an unpinned compile deploys the splits `tune` measured best. The nested resolve carries
 the deploy's `db`, so each kernel's price follows the same evidence hierarchy as a knob pick (reservoir -O3, then the
--O1 ranking lane, model prediction only where unmeasured) — a pure sum-of-predictions comparison would be exposed to
-the model's absolute-µs error, which doesn't cancel across different kernel families. Cold, or when a side is
+tune DB's -O1 ranking rows, model prediction only where unmeasured) — a pure sum-of-predictions comparison would be
+exposed to the model's absolute-µs error, which doesn't cancel across different kernel families. Cold, or when a side is
 unpriceable, the structural leaf is filtered — a cold compile never changes kernel sets.
 
 **Evidence joins are drift-tolerant.** `Prior.sig_groups` is one contract for both the reservoir -O3 tier and the DB
 tier: a candidate's fork-time `S_*` base may carry scheduler stamps the persisted perf rows predate (#311's
 `S_warp_eligible` is on no row recorded before it), and a strict-equality signature join would let one added feature
-silently disable the whole evidence lane against every existing DB — the ninth-4090-sweep `mlp_gate_up` misdeploy (the
+silently disable the whole evidence tier against every existing DB — the ninth-4090-sweep `mlp_gate_up` misdeploy (the
 model's `g2k` pick beating the measured-faster fused config it was never allowed to see). The index spans three
-context twins (the deploy's own flags, the `-Xcicc -O1` ranking lane, the `-Xcicc -O3` lane where the tune's deployable
-re-benches land), and the pick is two-tier: a deployable-lane row decides outright; `-O1` rows decide only when no
-candidate has deployable evidence, because an -O1 median is a ranking signal with -O3 inversions and must not override
-a well-trained model on its own.
+context keys (the deploy's own flags, and the same key with `-Xcicc -O1` and with `-Xcicc -O3` — where the tune's
+deployable re-benches land), and the pick is two-tier: a row measured at deployable flags decides outright; `-O1`
+rows decide only when no candidate has deployable evidence, because an -O1 median is a ranking signal with -O3
+inversions and must not override a well-trained model on its own.
 
 **Retries are decide-wrappers over a deterministic re-resolve** — every other choice replays identically (cheap
 non-chronological backtracking, no snapshots). A structural pick that leaves a fragment kernel un-lowered retires
@@ -407,9 +408,10 @@ leaves a node un-lowered, `Pipeline.run` blocklists that tile's `tile_identity` 
 When the retry budget exhausts with the node still un-lowered (an *online* prior can rank many over-budget tiles above
 the first in-budget one), `Pipeline.run` takes one last **option-0 (emission-order) resolve**
 (`greedy_decide(blocked=…, prior=None)`): the planner emits a budget-safe tile first, so it lowers whenever any
-in-budget tile exists. The goldens still floor this resolve — one over-budget node must not cost every *other* kernel
-its verified golden — and the blocklist rides along so the floor can never re-pick a tile that already failed
-`validate(ctx)`. Only when even option-0 overflows does `_raise_on_unlowered` fire the loud `LoweringError`.
+in-budget tile exists. The goldens still decide the forks they match on this resolve — one over-budget node must not
+cost every *other* kernel its verified golden — and the blocklist rides along so this last resolve can never re-pick
+a tile that already failed `validate(ctx)`. Only when even option-0 overflows does `_raise_on_unlowered` fire the
+loud `LoweringError`.
 
 ### `Pipeline.tune_async` — the autotune sweep
 
@@ -541,9 +543,10 @@ There is ONE global `OnlinePrior` across every kernel, GPU, and nvcc setting —
 regime. Op structure (`S_*`) and the host/hardware regime (`H_*` — GPU compute capability + nvcc opt level, from
 `Context.features`) are **features in every row**, not a cache key.
 
-**Value-of-position labels.** Real benches exist only at leaves, but the prior ranks partial-knob siblings at every
-fork level, so the label for any node is the best (min) median latency in µs over its benched descendants
-(`1/best_reward`) — the prior regresses on **latency**, and the `1/û` conversion lives in the MCTS `_select` loop, not
+**Labels credit a partial config with its best completion.** Real benches exist only at leaves, but the prior ranks
+partial-knob siblings at every fork level, so the label for any node is the best (min) median latency in µs over its
+benched descendants (`1/best_reward`) — the prior regresses on **latency**, and the `1/û` conversion lives in the
+MCTS `_select` loop, not
 the stored data. `TuningSearch._collect_rows` walks the live tree and emits `(knobs, label)` for every node with a
 benched descendant:
 
@@ -551,7 +554,7 @@ benched descendant:
   `observe`, so knobs stamped at deterministic non-forking lowering steps (`FK` / `BK` / `SPLITK` / `STAGE`) are
   captured, not just the fork knobs.
 - A **branch** falls back to `_node_knobs` (its partial `fork.knobs` prefix under the op's `S_*` / `H_*` base),
-  carrying the value-of-position label.
+  labeled with the best latency among its benched descendants.
 
 **Why CatBoost** (chosen by `scripts/prior_bakeoff.py`): the model's greedy pick must not run off to a degenerate
 corner. A linear model (the former `BayesianRidgePrior`) is monotone in every knob, so its optimum is always a corner
@@ -560,7 +563,7 @@ off-manifold-safe (an un-benched extreme inherits the nearest leaf's value), and
 to an *untuned* op near-perfectly (leave-one-op-out pick ratio ~1.0 vs xgb/lgbm 1.18, rf 1.31). So one global CatBoost
 prior is good enough on a new op that it is **not refit within an op's own search** — it is a fixed model per run.
 
-**Dataset and checkpoint.** The dataset is bounded + batched (`base.Prior`): each tuned op's value-of-position rows
+**Dataset and checkpoint.** The dataset is bounded + batched (`base.Prior`): each tuned op's training rows
 stream into a reservoir-sampled dataset capped at `MAX_ROWS` (100k, Algorithm R across runs), and the model refits
 (`maybe_refit`) on a dataset-size-tiered cadence (`REFIT_SCHEDULE` — frequently while data-poor, coarsening as it
 grows), then checkpoints. End-of-run does a `maybe_refit(force=True)` so even a small tune ends with a fitted model.

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -113,8 +113,9 @@ def _load_prior_safe():
     ``OfflinePrior`` cold-start fallback), memoized per process on the online
     file's ``(path, mtime)`` — a serve boot compiles ~96 programs and each would
     otherwise ``json.loads`` the 56 MB checkpoint again (the dominant boot-time
-    resolution cost). Best-effort: any load failure → ``None`` → the golden floor
-    plus emission order — a bad/missing prior must never break compile."""
+    resolution cost). Best-effort: any load failure → ``None`` → recorded goldens
+    still decide the forks they match, the rest falls to emission order — a
+    bad/missing prior must never break compile."""
     try:
         from emmy import config  # noqa: PLC0415
 
@@ -139,8 +140,8 @@ def _first_leaf(option: object) -> object:
 def _leaf_knobs(leaf: object) -> dict:
     """A flattened leaf's complete knob row: a leaf ``Fork`` carries it as
     ``knobs``; a concrete ``Op`` carries its own; a ``Graph`` splice has no
-    single row (scored structurally, never by knobs) — empty, matching the
-    ``LazyCandidate.from_option`` lift the drive path used."""
+    single row (scored structurally, never by knobs) — empty, matching how
+    ``LazyCandidate.from_option`` treats it during the tuning search."""
     if isinstance(leaf, Fork):
         return dict(leaf.knobs)
     return dict(getattr(leaf, "knobs", None) or {}) if not isinstance(leaf, Graph) else {}
@@ -171,7 +172,7 @@ def _price_kernel(graph: Graph, nid: str, ctx: Context, prior, memo: dict[str, f
     slice-resolve's trace entry at the partition fork. ``db`` rides into the
     nested decide, so the partition-fork pick follows the same deploy evidence
     hierarchy as a top-level knob pick (reservoir -O3 rows, then the tune DB's
-    -O1 ranking lane, model prediction only where nothing was measured) — the
+    -O1 ranking rows, model prediction only where nothing was measured) — the
     priced µs is a measurement wherever the tune benched this kernel. Memoized
     per ``op_cache_key`` so 28 identical per-layer kernels price once.
     Best-effort: any resolve failure prices as ``None`` (→ the caller keeps
@@ -260,9 +261,9 @@ def _pick_structural(
     return best_split if best_split_us < min(fused_prices) else None
 
 
-# The tune ranking lane's default nvcc flags (``emmy/commands/tune.py``'s
-# ``apply_nvcc_flags(default=...)``) — the deploy-side DB consult queries the
-# perf rows recorded under this lane's ``context_key`` twin beside the deploy's own.
+# The default nvcc flags of the tune ranking pass (``emmy/commands/tune.py``'s
+# ``apply_nvcc_flags(default=...)``) — the deploy-side DB consult also queries the
+# perf rows recorded under a ``context_key`` with these flags, beside the deploy's own.
 _TUNE_RANKING_FLAGS = "-Xcicc -O1"
 
 
@@ -315,14 +316,15 @@ def _db_measured_index_build(db, ctx) -> dict[frozenset, list[tuple[dict, float,
     """The tune DB's measured ``ok`` cuda perf rows, indexed by their ``S_*``
     structural signature (stringified values — perf knobs round-trip JSON) —
     the deploy-side analogue of ``Prior._o3_evidence``. Queries three context
-    keys (``context_key`` folds the nvcc flags): the deploy's own, the
-    ``-Xcicc -O1`` tune ranking twin, and the ``-Xcicc -O3`` twin where the
-    tune's deployable re-benches land. Each entry carries a ``deployable``
-    flag: an -O1-lane median is a *ranking* signal with known -O3 inversions,
-    so the pick must prefer deployable-lane rows wherever they exist (a
-    ranking-lane override of a well-trained model regressed qkv/mlp_down ~15%
-    in the ninth-4090-sweep verification). Best-effort: any failure returns an
-    empty index (deploys fall back to the prior)."""
+    keys (``context_key`` folds the nvcc flags): the deploy's own, and the same
+    key with the ``-Xcicc -O1`` tune ranking flags and with ``-Xcicc -O3``,
+    where the tune's deployable re-benches land. Each entry carries a
+    ``deployable`` flag: an -O1 median is a *ranking* signal with known -O3
+    inversions, so the pick must prefer rows measured at deployable flags
+    wherever they exist (letting -O1 rows override a well-trained model
+    regressed qkv/mlp_down ~15% in the ninth-4090-sweep verification).
+    Best-effort: any failure returns an empty index (deploys fall back to the
+    prior)."""
     from emmy.compiler.pipeline.search.policy.mcts import O3_NVCC_FLAGS  # noqa: PLC0415
 
     index: dict[frozenset, list[tuple[dict, float, bool]]] = {}
@@ -356,8 +358,8 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
     the same prefix-consistency contract as ``Prior.evidence_pick`` (every
     tunable knob the candidate specifies must match the measured row; undecided
     knobs are free). Signature matching is drift-tolerant (:func:`_sig_groups`).
-    Two-tier by lane: deployable-lane rows (the deploy's own + ``-O3`` twin
-    contexts) decide outright; ``-O1`` ranking-lane rows decide only when no
+    Two-tier: rows measured at deployable flags (the deploy's own + ``-O3``
+    context keys) decide outright; ``-O1`` ranking rows decide only when no
     candidate has deployable evidence — an -O1 median is a ranking signal with
     known -O3 inversions, and letting it override a well-trained model regressed
     qkv/mlp_down ~15% in the ninth-4090-sweep verification. Keeps a config the
@@ -391,7 +393,7 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
     groups_memo: dict[frozenset, list[list[tuple[dict, float, bool]]]] = {}
 
     best: tuple[int, float] | None = None  # deployable lane
-    best_rank: tuple[int, float] | None = None  # -O1 ranking-lane fallback
+    best_rank: tuple[int, float] | None = None  # fallback: rows from the -O1 ranking pass
     for i, cand in enumerate(rows):
         sig = frozenset((k, str(v)) for k, v in cand.items() if k.startswith("S_"))
         cand_tun = {k: str(v) for k, v in cand.items() if not k.startswith(("S_", "H_"))}
@@ -399,7 +401,8 @@ def _db_measured_pick(index: dict[frozenset, list[tuple[dict, float, bool]]], ro
             groups_memo[sig] = _sig_groups(index, sig)
         for measured in groups_memo[sig]:
             for row_tun, us, deployable in measured:
-                # Value-of-position join (``evidence_row_vouches``).
+                # A row counts as evidence when it matches every knob the candidate
+                # has decided; undecided knobs are free (``evidence_row_vouches``).
                 if not evidence_row_vouches(cand_tun, row_tun):
                     continue
                 if deployable:
@@ -436,7 +439,7 @@ def _warn_disjoint_evidence(index: dict[frozenset, list[tuple[dict, float, bool]
 def _golden_evidence_index(ctx: Context) -> dict:
     """The deploy card's recorded goldens — every kind: matmul, attention (flash), rms_norm, softmax,
     reduce, pointwise, norm_linear / mlp_geglu (the fused RMSNorm→linear / gate⊗up computed-A), and the
-    fork-nothing rope / embedding regression anchors (which never bind here — no fork) — grouped by
+    rope / embedding entries kept only as regression references (they fork nothing, so they never match here) — grouped by
     :class:`~emmy.compiler.pipeline.search.data.shape.ShapeKey` (whose ``kind``
     discriminator keeps the sweep kinds apart from extent-coincident contractions)
     and sorted fastest-first — the verified-evidence tier a greedy compile consults
@@ -472,12 +475,12 @@ def _golden_evidence_index(ctx: Context) -> dict:
 def _golden_matches_row(golden_knobs: dict, row: dict) -> bool:
     """Prefix-consistency of a golden's recorded tuning knobs against one offered
     candidate row. Keys compare through
-    :func:`~emmy.compiler.pipeline.knob.pin_key_matches` (a bare golden spelling
-    matches the axis-stamped realization) and values through
-    :func:`~emmy.compiler.pipeline.knob.values_equal` (registry-canonical, so an
-    atom-alias TILE spelling matches the canonically-stamped row). A family the
-    candidate hasn't decided at this fork is free — a later pass decides it (the
-    ``evidence_pick`` value-of-position convention).
+    :func:`~emmy.compiler.pipeline.knob.pin_key_matches` (a golden key recorded
+    without an axis suffix matches the axis-stamped realization) and values through
+    :func:`~emmy.compiler.pipeline.knob.values_equal` (registry-canonical, so a
+    TILE value written with an alias atom name matches the canonically-stamped
+    row). A family the candidate hasn't decided at this fork is free — a later
+    pass decides it (the ``evidence_pick`` convention: undecided knobs are free).
 
     An AXIS-KEYED golden key must be satisfied by every candidate key it names — the
     flash all-or-nothing pin contract: a static attention golden records ``TILE@dd``
@@ -521,7 +524,7 @@ def _fork_shape_key(rows: list[dict]):
     ``S_loop_depth``, no op histogram — measured off a live greedy resolve), so the classifier can
     never mark it ``kind="flash"`` there. It is instead unmistakable from its OFFER: only the twisted
     lowering forks the two contractions as ``TILE@dd`` + ``TILE@pj``. When the rows carry that pair,
-    the key is rebuilt flash-kinded, with the masked twin's reduce extent normalized to the stamped
+    the key is rebuilt flash-kinded, with the masked (dynamic) form's reduce extent normalized to the stamped
     final-op convention (the fork-time masked op still shows head_dim as a visible reduce; the golden
     keys — and the diagnostics/A-B joins over final stamped ops — have every reduce axis
     symbolic-excluded, ``reduce_max=0``).
@@ -531,7 +534,7 @@ def _fork_shape_key(rows: list[dict]):
     (``S_ext_n_reduce_axis == 1``) and the rsqrt lives in the nested A-cone sub-body, so the
     histogram can't fire ``kind="fused"`` (which needs ``>= 2`` and a top-level ``S_pw_rsqrt``).
     Like flash, it is unmistakable from its OFFER: only a computed-A contraction enumerates the
-    mandatory ``sync`` compute-fill (``d*/sync`` STAGE rows — ``space.stage_moves`` spells only
+    mandatory ``sync`` compute-fill (``d*/sync`` STAGE rows — ``space.stage_moves`` offers only
     gmem-direct / ``cp`` / ``tma``, and the ``sync`` transport is born in the computed-A resolvers
     alone), so a fork whose rows carry a sync-STAGE candidate IS the cone form. (The earlier
     mixed-dtype sniff — f16/bf16 operands + an f32 statistic constant over an add-reduce — fired on
@@ -546,7 +549,7 @@ def _fork_shape_key(rows: list[dict]):
 
     key = ShapeKey.from_s_features(rows[0])
     # ANY row carrying the pair marks the fork (like the cone's sync-STAGE scan below):
-    # the pair may be spelled only on the warp leaves, and row 0 — whichever leaf the
+    # the pair may appear only on the warp leaves, and row 0 — whichever leaf the
     # planner emitted first — need not be one of them.
     if any({"dd", "pj"} <= {k.split("@", 1)[-1] for k in row if k.startswith("TILE@")} for row in rows):
         key = ShapeKey(
@@ -581,8 +584,8 @@ def _fork_shape_key(rows: list[dict]):
 
 # Optional per-consultation verdict sink for the golden-tier audit (``search/audit.py``).
 # ``None`` (the default) is zero-cost; ``golden_audit`` installs a list that
-# ``_golden_pick`` appends one record per consulted fork to — the supported seam the
-# drift audit reads, replacing the old monkey-patch spy in ``scripts/diagnostics``.
+# ``_golden_pick`` appends one record per consulted fork to — the supported hook the
+# drift audit reads, replacing the old monkey-patch interception in ``scripts/diagnostics``.
 _AUDIT_SINK: list[dict] | None = None
 
 
@@ -684,7 +687,7 @@ def greedy_decide(
     cold-start heuristic otherwise (both behind ``load_prior``'s
     ``FallbackPrior``). With no prior at all (a failed load, or the explicit
     ``prior=None`` emission-order resolve) the card's recorded goldens still
-    floor the pick — the golden tier is prior-independent evidence — and only
+    decide the forks they match — golden evidence needs no prior — and only
     a fork without a realizable golden falls to emission order (option-0,
     first leaf). Stamps the pick's predicted µs on
     ``fp.score``, so the resolve trace carries the per-fork price (the
@@ -734,11 +737,11 @@ def greedy_decide(
             # No prior on this resolve — a failed ``load_prior`` (corrupt/unreadable
             # checkpoint) or ``Pipeline.run``'s explicit emission-order fallback
             # (``prior=None``). The card's recorded goldens are tier (1) of the
-            # evidence hierarchy and depend on no prior, so they still FLOOR the
-            # pick: a fork whose golden realizes on an offered candidate deploys the
+            # evidence hierarchy and depend on no prior, so they still apply:
+            # a fork whose golden realizes on an offered candidate deploys the
             # golden, and only the rest falls to emission order. (A blocklisted
             # tile — one that failed ``validate(ctx)`` earlier — stays excluded, so
-            # the floor can never re-pick a tile the retry loop already rejected.)
+            # this path can never re-pick a tile the retry loop already rejected.)
             if golden_state[0] is None:
                 golden_state[0] = _golden_evidence_index(fp.ctx)
             if golden_state[0]:

--- a/emmy/compiler/pipeline/search/prior/base.py
+++ b/emmy/compiler/pipeline/search/prior/base.py
@@ -3,7 +3,7 @@
 A :class:`Prior` is **one global model** consulted by the MCTS to rank candidates
 via PUCT (``tune``) and by the greedy driver to pick knobs (``compile`` / ``run``).
 Unlike the earlier online-refit-every-few-benches design, it is trained in
-**batches**: every tuned op's value-of-position rows are streamed into a bounded
+**batches**: every tuned op's training rows are streamed into a bounded
 dataset (:meth:`add_rows`), and the model is refit (:meth:`maybe_refit`) on a
 **dataset-size-tiered cadence** (:data:`REFIT_SCHEDULE`) — frequently while the
 model is data-poor, then progressively less often as returns diminish: every
@@ -14,9 +14,10 @@ neither grows without bound nor over-weights recent ops. The model is therefore
 *fixed during a single op's search*, and exploration comes from PUCT's own term,
 not per-bench refitting.
 
-Training signal is **value-of-position**: real benches exist only at leaves, but
-the prior ranks partial-knob siblings at every fork level, so the label for any
-node is the best (min) latency over its benched descendants (``1/best_reward``).
+Training labels credit a partial config with its best completion: real benches
+exist only at leaves, but the prior ranks partial-knob siblings at every fork
+level, so the label for any node is the best (min) latency over its benched
+descendants (``1/best_reward``).
 The search hands :meth:`add_rows` ``(knobs, median_latency_µs)`` rows for leaves
 *and* branches — the prior regresses on latency, and the reward conversion lives
 in the MCTS selection loop. :meth:`score` / :meth:`mean_score` return ``0`` until
@@ -55,8 +56,8 @@ _O3_OPT = 3.0
 # model's own reservoir, :meth:`Prior._reservoir_calibration`) below which :attr:`Prior.trustworthy`
 # is False and ``FallbackPrior`` keeps deploys / PUCT on the offline prior. In-sample Spearman is a
 # deliberately lenient tripwire: a genuinely trained model scores ~+0.85, while the failure class it
-# guards (model and rows not speaking the same feature vocabulary — e.g. a checkpoint that crossed a
-# ``FEATURIZER_VERSION`` bump, RTX 5090 sweep-6 finding 2) collapses to ~0. A model that can't rank
+# guards (model and rows built with different featurizer versions' feature names — e.g. a checkpoint
+# that crossed a ``FEATURIZER_VERSION`` bump, RTX 5090 sweep-6 finding 2) collapses to ~0. A model that can't rank
 # even its own training data must not own decisions.
 CALIBRATION_MIN = 0.5
 # Minimum rows an op group needs to contribute to the calibration median (smaller groups are noise).
@@ -133,13 +134,13 @@ class Prior(ABC):
         default maps element-wise (fine for the cheap offline prior)."""
         return [self.mean_score(k) for k in knobs_list]
 
-    # --- features seam (attribution / ablation / offline fitting) ----------
+    # --- scoring already-featurized rows (attribution / ablation / offline fitting) ----------
 
     def mean_score_features(self, feats: dict) -> float:
         """:meth:`mean_score` on an ALREADY-featurized row (``features.knob_features``
-        output). The seam the attribution diagnostics and the offline fitter score
-        through: they featurize once, then mask / perturb individual features —
-        which have no knob-level spelling — before scoring. Contract:
+        output). The entry point the attribution diagnostics and the offline fitter
+        score through: they featurize once, then mask / perturb individual features —
+        which no knob value maps back to — before scoring. Contract:
         ``mean_score_features(knob_features(knobs)) == mean_score(knobs)``, and a
         DELETED key carries each model's own absent-feature semantics (``0.0`` term
         for the linear offline prior, ``NaN`` routing for CatBoost)."""
@@ -152,7 +153,7 @@ class Prior(ABC):
     def explain_features(self, feats: dict) -> dict[str, float] | None:
         """Signed per-term decomposition of this model's opinion on a featurized row,
         in the model's own ranking-quality units (HIGHER = predicted faster) — the
-        blame view diffs two rows' terms to attribute a misranking to features.
+        attribution report diffs two rows' terms to attribute a misranking to features.
         ``None`` when the model has no decomposition (the default; the offline
         prior returns an exact one, a tree model may return SHAP values). Exactness
         contract, when implemented: the terms sum to the model's full quality score
@@ -165,8 +166,8 @@ class Prior(ABC):
     def sig_groups(index: dict[frozenset, list], sig: frozenset) -> list[list]:
         """The index groups compatible with a candidate's ``S_*`` signature: the
         exact hit when present, else every group agreeing on all *shared* keys.
-        A key present on one side only is featurizer-vocabulary drift, not a
-        shape difference — the deploy candidate's base can carry scheduler
+        A key present on one side only means the featurizer gained or lost a
+        feature between recordings, not a shape difference — the deploy candidate's base can carry scheduler
         stamps neither the reservoir rows nor persisted perf rows have (#311's
         ``S_warp_eligible`` appears in no reservoir/perf row), and a
         strict-equality join lets one added feature silently disable an entire
@@ -208,8 +209,8 @@ class Prior(ABC):
         knob prefix is consistent with the **fastest -O3 reservoir row** of the
         same op (``S_*`` signature). A candidate is consistent with a measured row
         when every tunable knob the candidate specifies matches the row (knobs the
-        candidate hasn't decided yet are free — value-of-position semantics, so a
-        partial fork prefix inherits the best measured outcome under it).
+        candidate hasn't decided yet are free, so a partial fork prefix inherits
+        the best measured outcome among its completions).
 
         Returns ``(index, measured_µs)`` or ``None`` when no candidate has
         evidence. This is what keeps the greedy deploy from preferring an
@@ -230,7 +231,8 @@ class Prior(ABC):
             cand_tun = {k: v for k, v in cand.items() if not k.startswith(("S_", "H_"))}
             for measured in self.sig_groups(index, sig):
                 for row_tun, us in measured:
-                    # Value-of-position join (``evidence_row_vouches``).
+                    # A row counts as evidence when it matches every knob the candidate
+                    # has decided; undecided knobs are free (``evidence_row_vouches``).
                     if not evidence_row_vouches(cand_tun, row_tun):
                         continue
                     # Tie on µs (one measured row matching several candidates) breaks by
@@ -259,7 +261,7 @@ class Prior(ABC):
     # --- dataset + batched refit ------------------------------------------
 
     def add_rows(self, rows: list[tuple[dict, float]]) -> None:
-        """Stream value-of-position rows into the bounded dataset via reservoir
+        """Stream training rows into the bounded dataset via reservoir
         sampling (Algorithm R): under the cap they append; at the cap each new row
         replaces a uniformly-random existing one with the correct probability, so
         ``_dataset`` stays a uniform sample of every row ever seen."""
@@ -320,9 +322,9 @@ class Prior(ABC):
         under :data:`_CALIBRATION_MIN_GROUP` rows skipped. ``None`` when nothing is
         measurable (no fitted model, no big-enough group, scipy absent). In-sample by
         design: it costs one vectorized predict over rows already in memory, never
-        blocks a genuinely trained model, and catches exactly the "model and rows
-        don't speak the same feature language" collapse (constant predictions →
-        ρ ≈ 0)."""
+        blocks a genuinely trained model, and catches exactly the collapse where
+        the model and its rows no longer share feature names (constant
+        predictions → ρ ≈ 0)."""
         if not self.fitted or not self._dataset:
             return None
         try:
@@ -373,9 +375,10 @@ class Prior(ABC):
     # --- end-of-run sanity stats ------------------------------------------
 
     def summary(self, label: str) -> str:
-        """A compact stats block judging the prior by *which picks* it made —
-        silly-pick rate before vs after the model warmed up, and the prior's
-        self-calibration on its post-warmup picks."""
+        """A compact stats block judging the prior by *which picks* it made — how
+        often it picked a config at least 2x slower than the best, before vs after
+        the model's first fit, and the rank correlation between predicted and
+        measured latency on the post-fit picks."""
         oks = [(k, us) for k, us, st in self.trajectory if st == "ok" and us > 0]
         n = len(self.trajectory)
         if not oks:

--- a/emmy/compiler/pipeline/search/prior/fallback.py
+++ b/emmy/compiler/pipeline/search/prior/fallback.py
@@ -24,7 +24,7 @@ learning-to-rank (``emmy fit``) so its ``score`` —
 order is meaningful; its neutral "no opinion" value is exactly ``1.0``). So
 :meth:`score` keeps the online µs as the scale and folds the offline in as a
 dimensionless **multiplier** ``offline**W`` centered at that neutral 1.0 — the
-online half owns the per-shape µs anchor, the offline half contributes only its
+online half sets the per-shape µs scale, the offline half contributes only its
 ranking. ``W`` (``config.offline_tilt``) sizes the nudge: small enough to
 perturb the online order, not replace it. The multiplier is clamped to
 ``e**±8`` before the power: the offline proxy itself is unsaturated (strictly
@@ -75,7 +75,7 @@ class FallbackPrior(Prior):
     def score(self, knobs: dict) -> float:
         # MCTS-selection signal ONLY (deploy/eval go through mean_score/pick).
         # Cold or quarantined: the offline prior IS the ranking. Trusted: keep the
-        # online µs as the scale and tilt it by the offline's dimensionless ranking
+        # online µs as the scale and nudge it by the offline's dimensionless ranking
         # multiplier (``offline**W``, neutral 1.0) so PUCT still explores a region the
         # heuristic prices well but the online model — having never measured it —
         # buries (the fp16 small-BK warp tiles at large squares). ``W=0`` recovers
@@ -88,7 +88,7 @@ class FallbackPrior(Prior):
         online = self.online.score(knobs)
         if w == 0.0 or online <= 0.0:
             return online
-        # The tilt is a bounded NUDGE on the online µs anchor, not a ranking: the
+        # The multiplier is a bounded NUDGE on the online µs prediction, not a re-ranking: the
         # offline proxy is strictly ordered over the full quality range (its exp
         # argument clips only at the float-safety bound), so its raw magnitude can
         # span e**±700 — fed straight into the product it would zero out or blow up
@@ -103,9 +103,9 @@ class FallbackPrior(Prior):
     def mean_scores(self, knobs_list: list[dict]) -> list[float]:
         return self.online.mean_scores(knobs_list) if self.trustworthy else self.offline.mean_scores(knobs_list)
 
-    # Features-seam surface (attribution / ablation) — routed through the same
-    # trustworthy gate as mean_score/mean_scores, so the diagnostics decompose the
-    # model that actually owns decisions.
+    # Scoring of already-featurized rows (attribution / ablation) — routed through
+    # the same trustworthy gate as mean_score/mean_scores, so the diagnostics
+    # decompose the model that actually owns decisions.
     def mean_score_features(self, feats: dict) -> float:
         return self.online.mean_score_features(feats) if self.trustworthy else self.offline.mean_score_features(feats)
 

--- a/emmy/compiler/pipeline/search/prior/fit/cv.py
+++ b/emmy/compiler/pipeline/search/prior/fit/cv.py
@@ -65,7 +65,7 @@ def _median(vals: list[float]) -> float:
 
 def _per_card(entries: list[tuple[Group, tuple[int, int]]]) -> dict:
     """Per-card aggregates over ``(case, (rank, rank_optimistic))`` rows: count, median
-    and top-k coverage in BOTH tie flavors. Cards never pool."""
+    and top-k coverage under both tie conventions. Cards never pool."""
     by_gpu: dict[str, list[tuple[int, int]]] = {}
     for case, ranks in entries:
         by_gpu.setdefault(case.gpu, []).append(ranks)

--- a/emmy/compiler/pipeline/search/prior/fit/group.py
+++ b/emmy/compiler/pipeline/search/prior/fit/group.py
@@ -2,16 +2,16 @@
 
 A group is one shape's featurized candidate pool on one card, with whatever supervision exists for it. Today
 that supervision is a single pinned verified-optimum row (``pinned_idx`` — the golden's index in the pool);
-the freeze-trained cells add per-row measured labels when they land, so builders other than the golden case
-builder can populate groups from measurement sources. Groups are built by plain functions (the golden builder
+the planned measurement-freeze datasets add per-row measured labels when they land, so builders other than the
+golden case builder can populate groups from measurement sources. Groups are built by plain functions (the golden builder
 lives in ``emmy/commands/fit.py`` — case building needs the snippet tracer, which ``pipeline/`` must not
 import) and consumed by trainers and the CV harness through this one shape; there is no iterator/batching
 layer — the whole dataset is a small in-memory list.
 
 Rows are ndarray-backed, not dict-backed: ``feats`` is one float64 matrix (rows × ``feat_names``), packed
 once by :meth:`Group.from_dicts` from the builder's transient per-row feature dicts. A per-row dict of ~63
-floats costs ~4 KB; the full golden dataset is ~2.5 M rows, and the dict spelling (~10 GB) OOM-killed whole
-fit runs — the matrix spelling is ~20× smaller and :meth:`matrix` reproduces ``feats.get(k, 0.0)`` semantics
+floats costs ~4 KB; the full golden dataset is ~2.5 M rows, and the dict representation (~10 GB) OOM-killed whole
+fit runs — the matrix representation is ~20× smaller and :meth:`matrix` reproduces ``feats.get(k, 0.0)`` semantics
 bit-identically (an absent feature is a zero column).
 
 ``key`` is ``"<gpu>/<name>"``, disambiguated by the builder when one name records several parity entries
@@ -67,7 +67,7 @@ class Group:
 
     @classmethod
     def from_dicts(cls, key: str, name: str, tier: str, gpu: str, pinned_idx: int, feats: list[dict[str, float]]) -> Group:
-        """Pack per-row feature dicts into the matrix spelling: ``feat_names`` is the sorted
+        """Pack per-row feature dicts into the matrix representation: ``feat_names`` is the sorted
         union of the pool's keys, the matrix a column per name (absent key = 0.0). Callers
         drop the dicts after this — the matrix is the stored representation."""
         names = tuple(sorted({k for f in feats for k in f}))
@@ -76,7 +76,7 @@ class Group:
     def matrix(self, names: list[str]) -> np.ndarray:
         """The pool projected onto ``names`` — column ``j`` is the stored ``names[j]`` column,
         or zeros when the pool never saw that feature: exactly ``feats.get(k, 0.0)`` per row,
-        so scoring/fitting against any name vocabulary matches the dict spelling bit for bit."""
+        so scoring/fitting against any feature-name list matches the per-dict representation bit for bit."""
         idx = {n: j for j, n in enumerate(self.feat_names)}
         out = np.zeros((len(self.feats), len(names)))
         for j, n in enumerate(names):

--- a/emmy/compiler/pipeline/search/prior/fit/linear.py
+++ b/emmy/compiler/pipeline/search/prior/fit/linear.py
@@ -52,7 +52,7 @@ def eval_weights(mats: list[np.ndarray], gidx: list[int], w: np.ndarray) -> list
 
 def l2_penalty(w: np.ndarray, sd: np.ndarray) -> float:
     """Sum of squared RAW-space weights for a z-space weight vector (raw = w_z / sd, the
-    artifact spelling — see :func:`raw_weights`). Unweighted by any λ: the loss composes
+    format the artifact stores — see :func:`raw_weights`). Unweighted by any λ: the loss composes
     it as ``objective + l2 * l2_penalty``."""
     return float(np.sum((w / sd) ** 2))
 
@@ -131,7 +131,7 @@ def raw_weights(names, best_w, sd) -> dict[str, float]:
 @dataclass
 class TwoStageFit:
     """One trainer invocation's fitted weight sets, in raw-feature space
-    (:func:`raw_weights` — the artifact spelling). ``dyn_raw`` / ``dyn_ranks`` are
+    (:func:`raw_weights` — the format the artifact stores). ``dyn_raw`` / ``dyn_ranks`` are
     ``None`` when the input had no dynamic cases: the CALLER decides the fallback
     (the script carries the incumbent's dynamic set forward; a CV fold treats the
     set as unfittable rather than silently substituting a stale vector)."""
@@ -143,8 +143,8 @@ class TwoStageFit:
 
     def score_rows(self, group: Group) -> np.ndarray | None:
         """The group's per-row linear scores (higher = predicted faster) under the raw
-        weight sets — the artifact-spelling scoring, exactly what the shipped prior
-        ranks with (away from the interaction gates). The static-vs-dynamic weight-set
+        weight sets — scored exactly as the shipped prior ranks, in the format the
+        artifact stores (away from the interaction gates). The static-vs-dynamic weight-set
         selection lives HERE and nowhere else on the fit side. ``None`` when the group
         needs the dynamic set and this fit has none (an unfittable fold — callers
         exclude it up front)."""

--- a/emmy/compiler/pipeline/search/prior/fit/rank.py
+++ b/emmy/compiler/pipeline/search/prior/fit/rank.py
@@ -15,8 +15,9 @@ import numpy as np
 def rank_of_golden(scores: np.ndarray, gidx: int) -> int:
     """0-based rank of the golden by descending score. Ties count AGAINST the golden
     (``>=``): greedy deploy breaks score ties by enumeration order, and option-0 is the
-    per-cell / gmem-direct row — a tie IS a miss at deploy time. (The old ``>`` tie-optimism
-    let a fit with zero ``D_stage_*`` weights report top-1 golden ranks while the deploy pick
+    per-cell / gmem-direct row — a tie IS a miss at deploy time. (The old ``>`` convention,
+    which counted ties in the golden's favor, let a fit with zero ``D_stage_*`` weights
+    report top-1 golden ranks while the deploy pick
     landed on the per-cell row — the 2026-07-02 sweep's 5-15x regressions.)
 
     This is the FIT OBJECTIVE's rank (all ties count, emission order ignored) — the
@@ -31,9 +32,9 @@ def dual_rank(scores, gidx: int) -> tuple[int, int]:
     score-ties earlier in emission order, i.e. exactly the rows a greedy argmin deploys
     ahead of the golden. ``rank_optimistic`` counts strictly-greater rows only — fair when
     tied rows are genuine equivalents. The difference is the tie-plateau width at the
-    golden's score: a large gap flags a saturated/undecided scorer (the 2026-07 exp-squash
-    bug scored "top-1" on the optimistic count while cold deploys shipped emission-order
-    picks 12-29x off)."""
+    golden's score: a large gap flags a saturated/undecided scorer (the 2026-07 bug where
+    the scoring exponential saturated scored "top-1" on the optimistic count while cold
+    deploys shipped emission-order picks 12-29x off)."""
     s = np.asarray(scores, dtype=float)
     g = s[gidx]
     optimistic = int((s > g).sum())

--- a/emmy/compiler/pipeline/search/prior/fit/run.py
+++ b/emmy/compiler/pipeline/search/prior/fit/run.py
@@ -1,5 +1,5 @@
 """The ``emmy fit`` run harness — full-train fit, cross-validation, and metrics/artifact
-assembly as one pure function, the run shape every trainer × data cell shares.
+assembly as one pure function, the run structure shared by every trainer and dataset combination.
 
 :func:`run_fit` owns the *shape* of a fit run and none of its *content*: the trainer
 arrives as two callables (``full_train_fit`` for the shippable model, ``fit_model`` for

--- a/emmy/compiler/pipeline/search/prior/offline.py
+++ b/emmy/compiler/pipeline/search/prior/offline.py
@@ -12,8 +12,8 @@ behind :class:`~emmy.compiler.pipeline.search.prior.fallback.FallbackPrior`.
 ``score`` returns a positive latency *proxy* (``exp(-scale · wᵀfeatures)``),
 **lower is better** — matching ``OnlinePrior``'s polarity. The proxy is not
 calibrated µs; only its ordering (greedy argmin / PUCT relative ``P``) matters.
-Because ordering is the whole contract, the squash must never saturate over live
-qualities: the exp argument is clipped only at the float-safety bound (±700), so
+Because ordering is the whole contract, the exponential must never saturate over
+live quality scores: the exp argument is clipped only at the float-safety bound (±700), so
 equal qualities — and only equal qualities — score equal. (A former ±80 *quality*
 clip sat inside the live range and collapsed every good tile onto one plateau;
 greedy then deployed by emission order.) The proxy's magnitude may therefore span
@@ -28,13 +28,13 @@ pointwise goldens — so one un-gated linear model over the shared ``D_*`` featu
 (plus ``MMA_tier``) ranks them all. Two weight sets, selected at score time on the
 stamped ``S_ext_n_symbolic_axis`` flag: ``weights`` for static shapes,
 ``weights_dynamic`` for symbolic-axis (masked-tile) kernels — a masked tile prices
-differently from its static twin (boundary-guard tax on small tiles, staged
+differently from its static counterpart (boundary-guard tax on small tiles, staged
 prologues locked out, occupancy over a free-dim product that excludes the symbolic
 axis), and the TMA-conditioned ``D_tma_*`` terms are where the one model prices
 Hopper/Blackwell tiles separately. Per-refit history rides the artifact's
 ``provenance`` block and the findings reports, not this docstring. The artifact is
-version-gated on ``feat_ver`` — the weight keys are spelled in the featurizer
-vocabulary, so a cross-version file is meaningless and loading it is a hard error
+version-gated on ``feat_ver`` — the weight keys are that featurizer version's
+feature names, so a cross-version file is meaningless and loading it is a hard error
 (refit, don't guess); a *retired* key inside a same-version file is merely a dead
 term (``feats.get(k, 0.0)``).
 """
@@ -51,8 +51,8 @@ from emmy.compiler.pipeline.search.prior.base import Prior
 
 _DEFAULT_FILE = Path(__file__).parent / "offline_weights.json"
 
-# The artifact's five scalar scoring params, in the spelling shared by the JSON
-# ``params`` block and ``OfflinePrior.__init__`` kwargs.
+# The artifact's five scalar scoring params, named identically in the JSON
+# ``params`` block and the ``OfflinePrior.__init__`` kwargs.
 _PARAM_KEYS = (
     "scale",
     "atomic_free_split_threshold",
@@ -179,9 +179,9 @@ class OfflinePrior(Prior):
         return self.score(knobs)
 
     def mean_score_features(self, feats: dict) -> float:
-        """:meth:`score` from an already-featurized row — the seam the attribution
-        diagnostics mask individual features through (a deleted key scores as its
-        ``0.0`` no-opinion default, which for a linear model is exact term removal)."""
+        """:meth:`score` from an already-featurized row — the entry point the
+        attribution diagnostics use to mask individual features (a deleted key scores
+        as its ``0.0`` no-opinion default, which for a linear model is exact term removal)."""
         w_set = self._w_dyn if feats.get("S_ext_n_symbolic_axis", 0.0) > 0 else self._w
         quality = sum(w * feats.get(k, 0.0) for k, w in w_set.items())
         # Deferred-kernel split-K finalize gate (local term — see __init__). The
@@ -214,7 +214,7 @@ class OfflinePrior(Prior):
     def explain_features(self, feats: dict) -> dict[str, float]:
         """EXACT per-term decomposition of the quality score (higher = predicted
         faster): each nonzero linear term by its feature name, plus the three
-        hardcoded interaction gates as ``gate:*`` pseudo-terms — a blame table that
+        hardcoded interaction gates as ``gate:*`` pseudo-terms — an attribution table that
         omitted the ±40 scalar-on-warp gate would misattribute exactly the misses it
         dominates. Invariant (unit-tested): the terms sum to the same quality
         :meth:`mean_score_features` exponentiates, so a two-row term diff is the

--- a/emmy/compiler/pipeline/search/prior/online.py
+++ b/emmy/compiler/pipeline/search/prior/online.py
@@ -112,8 +112,8 @@ class OnlinePrior(Prior):
         return float(np.exp(self._model.predict(x)[0]))
 
     def mean_scores_features(self, feats_list: list[dict]) -> list[float]:
-        """The featurized half of :meth:`mean_scores` — also the seam the attribution
-        diagnostics mask through: a deleted key fills to ``NaN``, CatBoost's absent
+        """The featurized half of :meth:`mean_scores` — also the entry point the
+        attribution diagnostics mask features through: a deleted key fills to ``NaN``, CatBoost's absent
         semantics. NOTE: masked queries are out-of-distribution for a model trained
         without feature dropout (the attribution caller flags this) — the planned
         offline fitter's masking augmentation is what makes them honest."""
@@ -129,7 +129,7 @@ class OnlinePrior(Prior):
     def to_json(self) -> dict | None:
         """Serialize the CatBoost model (native ``cbm`` blob, base64'd) + the
         reservoir dataset + counters (``None`` when there's nothing yet).
-        ``feat_ver`` stamps the knob vocabulary the rows are spelled in
+        ``feat_ver`` records which featurizer version's feature names the rows use
         (:data:`~emmy.compiler.pipeline.search.features.FEATURIZER_VERSION`);
         ``calibration`` carries the last fit's reservoir Spearman so a loaded
         checkpoint keeps its ``trustworthy`` verdict."""
@@ -150,15 +150,15 @@ class OnlinePrior(Prior):
         """Reconstruct a checkpointed prior from :meth:`to_json` — model (for
         inference / warm-start) plus the reservoir dataset (so a tune keeps
         accumulating). A checkpoint from another ``FEATURIZER_VERSION`` is dropped
-        WHOLE — model and rows alike: its rows are spelled in a knob vocabulary this
-        featurizer can't read, and a model refit on them collapses to constant
+        WHOLE — model and rows alike: its rows use feature names this featurizer
+        version can't read, and a model refit on them collapses to constant
         predictions (worse-than-random ranking; the 2026-07 tile-IR rebuild's
         stale-checkpoint failure). A missing stamp means the retired version 1.
         Otherwise tolerant of a stale checkpoint: an incompatible / corrupt
         model blob is dropped (the rows are still salvaged and a refit rebuilds
         the model), so e.g. a pre-CatBoost prior file migrates instead of crashing."""
         if int(obj.get("feat_ver", 1)) != FEATURIZER_VERSION:
-            return cls()  # cross-vocabulary checkpoint — start fresh
+            return cls()  # checkpoint from another featurizer version — start fresh
         p = cls()
         p._cols = obj.get("cols")
         cal = obj.get("calibration")


### PR DESCRIPTION
Replaced invented terminology, replacing it with established one in glossary file.

- format the course glossary (GLOSSARY.md, repo root) to repo markdown conventions: sections, bolded terms, ~120-char wrap
- replace invented terminology in the offline-prior training pipeline (search/prior/fit/*, emmy fit), the prior classes, the tune command, the greedy compile pick, and pipeline ARCHITECTURE Parts 3-5 with glossary terms or plain language (value-of-position, golden floor, lane/twin, spelling/vocabulary, squash, blame, seam, and friends); comments and docs only, no behavior change
- CLAUDE.md: route to GLOSSARY.md, add the established-terminology invariant, and a mandatory pre-commit terminology check
- add the same rule to the report-writing skills (tune-model, tune-golden, reproduce-article-benchmarks)