### PR TITLE
CLAUDE.md: Qwen3-0.6B as the generative smoke model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,10 @@ it before answering any CLI-flag question. Quickstart for the common paths:
 
 Quick test models / scripts (for local iteration):
 
-- Ungated Llama-arch smoke model: `TinyLlama/TinyLlama-1.1B-Chat-v1.0`; GPU embedding model (0.6B): `Qwen/Qwen3-Embedding-0.6B`
+- Ungated generative smoke model: `Qwen/Qwen3-0.6B` (Qwen3 arch — same family as the embedding smoke model;
+  serving-validated on a 4080, tuned TPOT 1.28x stock; defaults to thinking mode — pass `enable_thinking: false`
+  in chat probes for terse outputs). `TinyLlama/TinyLlama-1.1B-Chat-v1.0` stays as the ungated **Llama-arch**
+  smoke model. GPU embedding model (0.6B): `Qwen/Qwen3-Embedding-0.6B`
 - Benchmark/profiling helpers live under `scripts/` (`bench_block.py`, `bench_model_kernels.py`, `bench_golden_set.py`,
   `bench_gen_*.py`, `profile_gen_decode.py`, `capture_gen_twins.py`, `new_models.py`, `merge_node_db.py`,
   `remote_node_collect.py`, `golden_neighbor_bench.py`, `digest_kernels.py` — the kernel-source byte-identity


### PR DESCRIPTION
Adopts `Qwen/Qwen3-0.6B` as the ungated generative smoke model for local iteration, keeping TinyLlama only for plain-Llama-arch coverage.

## Validation (local RTX 4080, 2026-07-31)

| run | req/s | out tok/s | median TTFT | median TPOT |
| --- | ---: | ---: | ---: | ---: |
| stock vLLM | 18.76 | 2,402 | 22.5 ms | 3.12 ms |
| emmy cold | 0.81 | 104 | 98.9 ms | 77.0 ms |
| emmy tuned twins | 14.26 | 1,825 | 46.8 ms | **3.99 ms** |

(fp16, mml 512, mns 8, decode bucket 8, c=8, 32 prompts, in 64 / out 128)

- Chat greedy parity vs stock: coherent both arms; 1/3 prompts byte-identical at 64 tokens, the rest diverge only at single near-tie fp16 token flips — the expected cross-kernel greedy behavior.
- The boot roofline audit flagged the cold picks (41–133x over the weight floor) and clears on the tuned decode path — its first end-to-end catch on a never-seen model.
- Twin tune: ~1 h (`capture_gen_twins.py --decode-bucket 8` + 4x `emmy tune` on a twin-local DB); the flagged fused-norm kernel went 73x-over-floor → 19 µs.
- Recorded residuals (all audit-flagged or noted): M=1 and m4096-chunk tiers stay cold (outside this protocol's hot path), and one sym-post `k_linear` search miss at the 512 hint (759 µs vs 33 eager — a tune-model drill-down candidate, contributes to the TTFT gap).

Why: TinyLlama (2023, Llama-2 arch) is obsolete as a representative model; Qwen3-0.6B is ungated, Apache-2.0, exercises the supported Qwen3 path, and pairs with the existing Qwen3-Embedding-0.6B smoke model. It defaults to thinking mode — probes wanting terse output should pass `enable_thinking: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)