### PR TITLE
Serving: post→pre buffer chaining for symbolic and prefill-chunk families (Milestone A, task 2)

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -120,8 +120,11 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   self-copy-skips on pointer equality, dropping the per-layer D2D seam copy from the captured decode graph.
   **Post→pre chaining covers EVERY program family** (decode twins, M=1, symbolic, prefill-chunk — the vLLM
   integration plan's Milestone A2): each family's post OUTPUT array is rewired at build onto its pre twins'
-  shared hidden-INPUT backing, so the between-layer upload self-copy-skips — the seam copy leaves eager chunk
-  steps and captured over-bucket sym steps alike. Safe because the residual upload copies the previous hidden
+  shared hidden-INPUT backing, so the between-layer upload self-copy-skips on pointer equality. The skip pays
+  where the caller holds a VIEW of the post output — under an outer capture (the no-clone branch) — so the seam
+  copy node drops from captured over-bucket sym decode graphs; EAGER steps still clone (the pointer-breaker), so
+  the chunk-twin chaining activates only once chunk steps are whole-step captured (recorded future work). Safe
+  because the residual upload copies the previous hidden
   out of the backing before post overwrites it, rider steps (all tiers alias one backing base) are eager by
   construction with the chunk head CLONED before the decode tail runs, and the host `rebind` path — which
   re-takes arena views and unwinds the rewire — is never mixed with the device path on one runner (the oracle

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -118,6 +118,15 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   routes true single-token decode onto gemv-class matvec programs, and `EMMY_GEN_ALIAS_ATTN` (default off) lets
   vLLM's paged attention write directly into the M=1 post twin's `attn_out` input backing — the prefix upload
   self-copy-skips on pointer equality, dropping the per-layer D2D seam copy from the captured decode graph.
+  **Post→pre chaining covers EVERY program family** (decode twins, M=1, symbolic, prefill-chunk — the vLLM
+  integration plan's Milestone A2): each family's post OUTPUT array is rewired at build onto its pre twins'
+  shared hidden-INPUT backing, so the between-layer upload self-copy-skips — the seam copy leaves eager chunk
+  steps and captured over-bucket sym steps alike. Safe because the residual upload copies the previous hidden
+  out of the backing before post overwrites it, rider steps (all tiers alias one backing base) are eager by
+  construction with the chunk head CLONED before the decode tail runs, and the host `rebind` path — which
+  re-takes arena views and unwinds the rewire — is never mixed with the device path on one runner (the oracle
+  and the device server are separate runners; `tests/serving/test_gen_prefill_device_gpu.py` pins both the
+  pointers and the two-phase discipline).
   **Multimodal wrappers:** the trunk is resolved through `language_model` (gemma-4 "unified" nests the decoder stack +
   embed/norm there) and the text dims come from `config.text_config`.
   **Tuning what serving actually runs.** The deploy pick reads the golden tier, then box-local `perf`/reservoir

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -630,14 +630,16 @@ class EmmyGenRunner:
                     prog.program.arrays[out_name] = cp.ndarray(m1_shared.shape, dtype=m1_shared.dtype, memptr=m1_shared.data)
         # A2: the same chaining for the SYMBOLIC programs (capacity-view buffers — device path
         # only, `max_tokens` set; the oracle's host `rebind` re-takes arena views per call and
-        # neither needs nor keeps the rewire) and for the static prefill-chunk twins. Every
-        # family's post output now aliases its pre twins' shared hidden-INPUT backing, so the
-        # between-layer seam copy self-skips on eager chunk steps (the measured ~0.9 ms/layer
-        # host+copy chunk overhead's copy share) and drops out of captured over-bucket sym
-        # steps. Rider steps stay safe under the cross-tier aliasing (all tiers' views share
-        # one backing base): they are eager by construction (prefill is never captured), and
-        # `run_device`'s uncaptured path CLONES the chunk-twin head before the decode-twin
-        # tail overwrites the shared rows.
+        # neither needs nor keeps the rewire) and for the static prefill-chunk twins. The skip
+        # fires on pointer equality, so it pays exactly where the caller receives a VIEW of the
+        # post output — i.e. under an outer capture (the A1 no-clone branch): the per-layer seam
+        # copy node drops from captured over-bucket sym decode graphs. On EAGER steps the
+        # protective output clone breaks pointer equality and the upload still copies — the
+        # chunk-twin chaining is groundwork that activates when chunk steps get whole-step
+        # captured (the recorded future work), not an eager win today. Rider steps stay safe
+        # under the cross-tier aliasing (all tiers' views share one backing base): they are
+        # eager by construction (prefill is never captured), and `run_device`'s uncaptured path
+        # CLONES the chunk-twin head before the decode-twin tail overwrites the shared rows.
         if max_tokens is not None and pre_programs and post_programs:
             sym_in = pre_programs[0].input_names[0]
             sym_shared = pre_programs[0].program.arrays[sym_in]

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -628,6 +628,30 @@ class EmmyGenRunner:
                 cur = prog.program.arrays[out_name]
                 if cur.shape == m1_shared.shape and cur.dtype == m1_shared.dtype:
                     prog.program.arrays[out_name] = cp.ndarray(m1_shared.shape, dtype=m1_shared.dtype, memptr=m1_shared.data)
+        # A2: the same chaining for the SYMBOLIC programs (capacity-view buffers — device path
+        # only, `max_tokens` set; the oracle's host `rebind` re-takes arena views per call and
+        # neither needs nor keeps the rewire) and for the static prefill-chunk twins. Every
+        # family's post output now aliases its pre twins' shared hidden-INPUT backing, so the
+        # between-layer seam copy self-skips on eager chunk steps (the measured ~0.9 ms/layer
+        # host+copy chunk overhead's copy share) and drops out of captured over-bucket sym
+        # steps. Rider steps stay safe under the cross-tier aliasing (all tiers' views share
+        # one backing base): they are eager by construction (prefill is never captured), and
+        # `run_device`'s uncaptured path CLONES the chunk-twin head before the decode-twin
+        # tail overwrites the shared rows.
+        if max_tokens is not None and pre_programs and post_programs:
+            sym_in = pre_programs[0].input_names[0]
+            sym_shared = pre_programs[0].program.arrays[sym_in]
+            for prog in post_programs:
+                out_name = prog.output_names[0]
+                if prog.program.arrays[out_name].nbytes == sym_shared.nbytes:
+                    prog.program.arrays[out_name] = sym_shared
+        if prefill_ok and pre_prefill and post_prefill:
+            pf_in = pre_prefill[0].input_names[0]
+            pf_shared = pre_prefill[0].program.arrays[pf_in]
+            for prog in post_prefill:
+                out_name = prog.output_names[0]
+                if prog.program.arrays[out_name].nbytes == pf_shared.nbytes:
+                    prog.program.arrays[out_name] = pf_shared
 
         embed_weight = trunk.embed_tokens.weight.detach().cpu().to(torch.float32).numpy().astype(np_dtype, copy=False)
         # Gemma scales embeddings by sqrt(hidden) (a ``Gemma3TextScaledWordEmbedding`` carries it as

--- a/tests/serving/test_gen_capture_gpu.py
+++ b/tests/serving/test_gen_capture_gpu.py
@@ -131,3 +131,39 @@ def test_run_device_aliased_input_backing_replays_live():
     g.replay()
     torch.cuda.synchronize()
     assert torch.allclose(out, ref2, rtol=1e-2, atol=1e-2)
+
+
+def test_run_device_sym_aliased_input_backing_replays_live():
+    """The A2 chained-seam primitive on the SYMBOLIC path: the caller writes INTO the sym
+    program's own input backing (what the previous layer's chained post output is, after A2),
+    so ``upload_prefix_device`` self-copy-skips — and a captured graph over ``run_device_sym``
+    must still replay LIVE through the aliased backing."""
+    pytest.importorskip("cupy")
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+
+    from emmy.serving.gen_runner import _compile_split
+
+    torch.manual_seed(0)
+    wrapper = torch.nn.Linear(16, 16, bias=False).to(torch.float16).eval()
+    prog, _ = _compile_split(wrapper, [torch.zeros(4, 16, dtype=torch.float16)], ["input"], np.dtype("float16"), capacity=64)
+
+    ref_mod = wrapper.cuda()
+    t = 24
+    # The alias: a torch prefix view of the sym program's OWN capacity input buffer.
+    x = torch.from_dlpack(prog.program.arrays[prog.input_names[0]])[:t]
+    x.copy_(torch.randn(t, 16, dtype=torch.float16, device="cuda"))
+    warm = prog.run_device_sym([x])[0]  # uncaptured warmup at this width (self-copy-skips)
+    assert torch.allclose(warm, ref_mod(x), rtol=1e-2, atol=1e-2)
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        out = prog.run_device_sym([x])[0]
+    x2 = torch.randn(t, 16, dtype=torch.float16, device="cuda")
+    ref2 = ref_mod(x2)
+    x.copy_(x2)
+    g.replay()
+    torch.cuda.synchronize()
+    assert torch.allclose(out, ref2, rtol=1e-2, atol=1e-2)

--- a/tests/serving/test_gen_prefill_device_gpu.py
+++ b/tests/serving/test_gen_prefill_device_gpu.py
@@ -43,6 +43,21 @@ def test_run_device_sym_matches_host_path():
     assert runner.prefill_bucket == 32
     assert runner.rider_width == 16  # chunk twin + decode twin -> split coverage above the chunk
 
+    # A2 chaining pins: every family's post OUTPUT array aliases its pre twins' hidden-INPUT
+    # backing, so the next layer's pre upload self-copy-skips. Checked BEFORE any host-path
+    # call — the host ``rebind`` re-takes arena views at the call's shape, which unwinds the
+    # rewire for that program (correct, just copies again; serving never runs the host path).
+    def _ptr(prog, name):
+        return prog.program.arrays[name].data.ptr
+
+    assert _ptr(runner._post[0], runner._post[0].output_names[0]) == _ptr(runner._pre[0], runner._pre[0].input_names[0])
+    assert _ptr(runner._post_prefill[0], runner._post_prefill[0].output_names[0]) == _ptr(
+        runner._pre_prefill[0], runner._pre_prefill[0].input_names[0]
+    )
+    assert _ptr(runner._post_decode[0], runner._post_decode[0].output_names[0]) == _ptr(
+        runner._pre_decode[0], runner._pre_decode[0].input_names[0]
+    )
+
     rng = np.random.default_rng(0)
     H = config.hidden_size
     close = lambda dev, host: np.testing.assert_allclose(dev, host, rtol=2e-2, atol=2e-3)  # noqa: E731
@@ -52,20 +67,29 @@ def test_run_device_sym_matches_host_path():
     # the chunk+decode twin row SPLIT (different kernels from the host's symbolic program,
     # so fp16 accumulation order may differ by rounding). T=56: past the rider window
     # (48 = pb + rider is still split) — the SYMBOLIC device regime, same program as the
-    # host path (bit-exact).
-    for T, check in (
-        (24, close),
-        (40, close),
-        (56, np.testing.assert_array_equal),
-    ):
+    # host path (bit-exact). TWO PHASES, all device calls first: the host ``rebind`` both
+    # unwinds the chaining rewire AND re-sizes the shared capacity buffers to each call's
+    # shape (a later device call at a larger T would then refuse on capacity) — serving never
+    # mixes the two paths on one runner, and neither may this test.
+    cases = []
+    for T in (24, 40, 56):
         hidden = (rng.standard_normal((T, H)) * 0.3).astype(np.float16)
-        q_np, k_np, v_np = runner.forward_layer_pre(0, hidden)  # host rebind path
+        attn = (rng.standard_normal((T, config.num_attention_heads * 16)) * 0.3).astype(np.float16)
         q, k, v = runner.forward_layer_pre_device(0, torch.from_numpy(hidden).cuda())
+        out = runner.forward_layer_post_device(0, torch.from_numpy(attn).cuda(), torch.from_numpy(hidden).cuda())
+        # Chained layer-to-layer handoff: feed the post output straight back as the next pre
+        # input (what the vLLM plugin does layer to layer). On the eager path the post result
+        # is a clone, so this exercises the upload path against the aliased backing.
+        q2, _, _ = runner.forward_layer_pre_device(0, out)
+        cases.append((T, hidden, attn, q.cpu().numpy(), k.cpu().numpy(), v.cpu().numpy(), out.cpu().numpy(), q2.cpu().numpy()))
+
+    for T, hidden, attn, q, k, v, out, q2 in cases:
+        check = np.testing.assert_array_equal if T == 56 else close
+        q_np, k_np, v_np = runner.forward_layer_pre(0, hidden)  # host rebind path
         for host, dev in ((q_np, q), (k_np, k), (v_np, v)):
             assert dev.shape[0] == T
-            check(dev.cpu().numpy().astype(np.float32), host.astype(np.float32))
-
-        attn = (rng.standard_normal((T, config.num_attention_heads * 16)) * 0.3).astype(np.float16)
+            check(dev.astype(np.float32), host.astype(np.float32))
         out_np = runner.forward_layer_post(0, attn, hidden)
-        out = runner.forward_layer_post_device(0, torch.from_numpy(attn).cuda(), torch.from_numpy(hidden).cuda())
-        check(out.cpu().numpy().astype(np.float32), out_np.astype(np.float32))
+        check(out.astype(np.float32), out_np.astype(np.float32))
+        q2_np, _, _ = runner.forward_layer_pre(0, out)
+        check(q2.astype(np.float32), q2_np.astype(np.float32))


### PR DESCRIPTION
Task 2 of the vLLM-integration plan's Milestone A (low-risk copy removal). Same pattern as the landed decode/M=1 chaining, extended to the remaining two program families: at build time, each post program's OUTPUT array is rewired onto its pre twins' shared hidden-INPUT backing, so the next layer's `upload_prefix_device` can self-copy-skip on pointer equality.

## What it actually removes (corrected during review discussion)

The skip fires on **pointer equality**, and the eager path's protective output clone breaks it. So, honestly:

- **Captured over-bucket sym decode steps: real recurring win.** Under an outer capture, A1's no-clone branch hands the next layer a *view* of the post output — with A2's aliasing that view IS the pre input buffer, so the per-layer seam copy node (~48/step) drops from the captured graph and stays gone at every replay.
- **Eager chunk/prefill steps: no copy removed today.** The eager clone is the pointer-breaker. The chunk-twin chaining is correctness-neutral groundwork that activates when chunk steps get whole-step captured (the future work the parity campaign already recommended) — not an eager win now.

The rewire itself is one-time at boot (the programs and their capacity buffers are persistent and reused every step, which is what makes pointer rewiring pay repeatedly at all). Pointer changes only — no compiled-graph changes; goldens and packs stay valid.

## Safety argument (documented at the rewire site)

- The residual upload copies the previous hidden out of the shared backing **before** post's kernels overwrite it (the protective copy stays — same argument as the landed decode chaining).
- All tiers' views share one backing base, so **rider steps** interleave two families in one step: safe because riders are eager by construction (prefill is never captured) and `run_device`'s uncaptured path clones the chunk-twin head before the decode-twin tail overwrites the shared rows.
- The **host `rebind` path unwinds the rewire** (it re-takes arena views) and also re-sizes the shared capacity buffers — mixing host and device paths on one runner was already invalid, and the prefill test now pins the two-phase discipline explicitly (this restructure surfaced the invariant).

## Validation

- Pointer pins for the sym / prefill-chunk / decode chains + a chained layer-to-layer handoff correctness check (`test_gen_prefill_device_gpu.py`).
- New captured live-replay test for the sym-aliased-input primitive — what a captured over-bucket step does post-A2 (`test_gen_capture_gpu.py`).
- Full suite: 2818 passed, 159 skipped. Lint green.
- Local tuned Qwen3-0.6B serving smoke: 14.19 req/s / TTFT 46.52 ms / TPOT 4.00 ms vs pre-A2 baseline 14.26 / 46.79 / 3.99 — no regression, and per the corrected accounting no eager win was expected. The captured-path effect at real scale (gemma-12B) lands in the batched Milestone-A 5090 measurement after A3/A4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)