### PR TITLE
Serving: slice-bound rider outputs (Milestone A, task 3)

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -97,7 +97,10 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   tail chunk routed through it would pay the full-bucket grids for a sliver of real rows), a **rider-carrying full
   chunk step** (`prefill_bucket < num_tokens ≤ prefill_bucket + rider_width`, `rider_width` = the decode bucket when
   both twin families exist) **splits row-wise** across the chunk twin + the decode twin — correct because pre/post are
-  per-token-independent — which is what lets `--max-num-batched-tokens` default to `DYNAMIC_DIM_MAX + bucket`: a full
+  per-token-independent; since A3 both halves copy once into slices of one persistent shared joint destination
+  (`_rider_dest`, cached per column width for gemma-4's heterogeneous layers) instead of clone + `torch.cat`,
+  halving the rider seam bytes and removing the per-layer allocation churn — the caller must consume rider
+  outputs before its next rider call (attention does, within the layer) — which is what lets `--max-num-batched-tokens` default to `DYNAMIC_DIM_MAX + bucket`: a full
   chunk step keeps carrying its decode riders and the previous prompt's 1-token BOS tail instead of freezing every
   decoding request for the whole chunk and deferring first-token sampling (the measured c=4/c=8 TTFT structure), and
   every other width rides the SYMBOLIC programs' `run_device_sym`

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -52,7 +52,7 @@ class _Program:
             out = self.program.outputs({"num_tokens": t})
         return [out[n] for n in self.output_names]
 
-    def run_device(self, arrays):
+    def run_device(self, arrays, out=None):
         """Device-resident captured-replay twin of :meth:`run` for the **static M=bucket** decode
         programs. ``arrays``: torch CUDA tensors aligned to ``input_names`` (each ``[T, …]``,
         ``T <= bucket``). Uploads the ``T`` real rows into the buffer prefix (device-to-device),
@@ -60,6 +60,14 @@ class _Program:
         sliced to ``T`` — no host round-trip. Stale prefix padding rows are safe (pre/post are
         per-token-independent; only ``[:T]`` is read out). All cupy work runs on torch's current
         stream so the upload, replay and output read stay ordered.
+
+        ``out`` (A3, eager only): a list of torch CUDA destination views aligned to
+        ``output_names``, each ``[T, …]``. The single protective copy lands directly in the
+        caller's destination (``dest.copy_(view)``) instead of a freshly allocated clone — the
+        rider path passes slices of one shared joint tensor, so the halves need no
+        ``torch.cat`` (which paid a second full copy plus the allocation). Illegal under an
+        outer capture: the captured branch returns raw views by design (dropping copies is the
+        point there), so ``out`` would silently change semantics — asserted against.
 
         Under an OUTER capture (vLLM's whole-step decode cudagraph — torch's current stream is
         capturing) the program's own graph machinery is illegal (nested stream capture aborts, and
@@ -77,6 +85,7 @@ class _Program:
             feed = {n: cp.from_dlpack(a.detach().contiguous()) for n, a in zip(self.input_names, arrays, strict=True)}
             self.program.upload_prefix_device(feed)
             if torch.cuda.is_current_stream_capturing():
+                assert out is None, "run_device(out=...) is an eager-path contract — captured steps return views"
                 self.program.run_once()
                 # Under the outer whole-step capture the output CLONES are dead weight: the graph's
                 # fixed kernel order guarantees every consumer (RoPE — in-place on the view is fine,
@@ -91,6 +100,10 @@ class _Program:
             self.program.capture_program_graph()  # static graph → one cached entry (empty sym_values)
             self.program.replay_program_graph()
             outs = self.program.output_prefix_device()
+            if out is not None:
+                for o, n in zip(out, self.output_names, strict=True):
+                    o.copy_(torch.from_dlpack(outs[n])[:t])
+                return out
             return [torch.from_dlpack(outs[n])[:t].clone() for n in self.output_names]
 
     def run_device_sym(self, arrays):
@@ -815,6 +828,24 @@ class EmmyGenRunner:
             rows = (rows.float() * scale).to(rows.dtype)
         return rows
 
+    def _rider_dest(self, name, rows, cols, ref):
+        """A3: the shared joint destination for a rider step's combined result — one persistent
+        tensor per ``(name, cols)`` sized ``[prefill_bucket + rider_width, cols]``, sliced to the
+        step's rows. Shared across layers: q/k/v are consumed within their layer (RoPE + paged
+        attention + KV-cache write), and the hidden dest's residual read happens at the NEXT
+        post's upload, before that post's rider halves overwrite the dest. Cached per column
+        width because gemma-4's global layers are wider than its sliding ones."""
+        import torch  # noqa: PLC0415
+
+        dests = getattr(self, "_rider_dests", None)
+        if dests is None:
+            dests = self._rider_dests = {}
+        cap = self._prefill_bucket + self.rider_width
+        d = dests.get((name, cols))
+        if d is None:
+            d = dests[(name, cols)] = torch.empty(cap, cols, dtype=ref.dtype, device=ref.device)
+        return d[:rows]
+
     def forward_layer_pre_device(self, layer, hidden):
         """Device twin of :meth:`forward_layer_pre`: ``hidden[T,H]`` CUDA → un-rotated
         ``(q, k, v)`` CUDA tensors. ``T <= decode_bucket`` rides the static decode twin
@@ -838,12 +869,16 @@ class EmmyGenRunner:
         if self._pre_prefill is not None and t == self._prefill_bucket:
             return tuple(self._pre_prefill[layer].run_device([hidden]))
         if 0 < t - self._prefill_bucket <= self.rider_width:
-            import torch  # noqa: PLC0415
-
+            # A3: both halves copy ONCE, straight into slices of one shared joint destination —
+            # no torch.cat (which allocated 3 tensors and re-copied every row per layer per
+            # rider step). Rider steps are eager by construction, run_device's out= contract.
             pb = self._prefill_bucket
-            head = self._pre_prefill[layer].run_device([hidden[:pb]])
-            tail = self._pre_decode[layer].run_device([hidden[pb:]])
-            return tuple(torch.cat(pair, dim=0) for pair in zip(head, tail, strict=True))
+            hd, nh, nkv, _ = self._attn_meta[layer]
+            widths = (nh * hd, nkv * hd, nkv * hd)
+            dests = [self._rider_dest(nm, t, w, hidden) for nm, w in zip(("q", "k", "v"), widths, strict=True)]
+            self._pre_prefill[layer].run_device([hidden[:pb]], out=[d[:pb] for d in dests])
+            self._pre_decode[layer].run_device([hidden[pb:]], out=[d[pb:] for d in dests])
+            return tuple(dests)
         self._warn_symbolic_decode(t)
         return tuple(self._pre[layer].run_device_sym([hidden]))
 
@@ -859,12 +894,15 @@ class EmmyGenRunner:
         if self._post_prefill is not None and t == self._prefill_bucket:
             return self._post_prefill[layer].run_device([attn_out, residual])[0]
         if 0 < t - self._prefill_bucket <= self.rider_width:
-            import torch  # noqa: PLC0415
-
+            # A3: same slice-bound joint destination as the pre path. The residual reads are
+            # ordered before the overwrites: each half's upload copies its residual slice into
+            # the program's own buffer before that half's kernels run, and the NEXT layer's
+            # post uploads its residual (this dest) before its own halves overwrite it.
             pb = self._prefill_bucket
-            head = self._post_prefill[layer].run_device([attn_out[:pb], residual[:pb]])[0]
-            tail = self._post_decode[layer].run_device([attn_out[pb:], residual[pb:]])[0]
-            return torch.cat((head, tail), dim=0)
+            dest = self._rider_dest("hidden", t, residual.shape[1], residual)
+            self._post_prefill[layer].run_device([attn_out[:pb], residual[:pb]], out=[dest[:pb]])
+            self._post_decode[layer].run_device([attn_out[pb:], residual[pb:]], out=[dest[pb:]])
+            return dest
         return self._post[layer].run_device_sym([attn_out, residual])[0]
 
     def post_attn_backing(self, layer: int, rows: int):

--- a/tests/serving/test_gen_prefill_device_gpu.py
+++ b/tests/serving/test_gen_prefill_device_gpu.py
@@ -75,13 +75,24 @@ def test_run_device_sym_matches_host_path():
     for T in (24, 40, 56):
         hidden = (rng.standard_normal((T, H)) * 0.3).astype(np.float16)
         attn = (rng.standard_normal((T, config.num_attention_heads * 16)) * 0.3).astype(np.float16)
+        # Snapshot each stage to host IMMEDIATELY: rider outputs (T=40) are views of the shared
+        # joint destinations (A3), which the NEXT rider call overwrites — the same consume-
+        # before-next-call discipline the vLLM plugin follows (attention reads q/k/v within the
+        # layer), made explicit here.
         q, k, v = runner.forward_layer_pre_device(0, torch.from_numpy(hidden).cuda())
+        q_np_dev, k_np_dev, v_np_dev = q.cpu().numpy(), k.cpu().numpy(), v.cpu().numpy()
+        q_ptr = q.data_ptr()
         out = runner.forward_layer_post_device(0, torch.from_numpy(attn).cuda(), torch.from_numpy(hidden).cuda())
+        out_np_dev = out.cpu().numpy()
         # Chained layer-to-layer handoff: feed the post output straight back as the next pre
-        # input (what the vLLM plugin does layer to layer). On the eager path the post result
-        # is a clone, so this exercises the upload path against the aliased backing.
+        # input (what the vLLM plugin does layer to layer).
         q2, _, _ = runner.forward_layer_pre_device(0, out)
-        cases.append((T, hidden, attn, q.cpu().numpy(), k.cpu().numpy(), v.cpu().numpy(), out.cpu().numpy(), q2.cpu().numpy()))
+        q2_np_dev = q2.cpu().numpy()
+        if T == 40:
+            # A3 pin: rider outputs are slices of persistent shared joint destinations — the
+            # handoff call above reused the same storage (no per-step allocation, no torch.cat).
+            assert q2.data_ptr() == q_ptr
+        cases.append((T, hidden, attn, q_np_dev, k_np_dev, v_np_dev, out_np_dev, q2_np_dev))
 
     for T, hidden, attn, q, k, v, out, q2 in cases:
         check = np.testing.assert_array_equal if T == 56 else close


### PR DESCRIPTION
Stacked on #456 (A2); GitHub retargets to main when it merges. Task 3 of the vLLM-integration plan's Milestone A.

## What

The rider path (a full chunk step carrying decode riders: chunk-twin head + decode-twin tail in one step) joined its halves with `torch.cat` — clone head + clone tail + cat re-copies every row: 2x the seam bytes and 4 fresh allocations per layer per rider step.

Now:
- `run_device` takes an **eager-only** `out=` destination list: the single protective copy lands directly in the caller's view instead of a fresh clone. Asserted illegal under capture (the captured branch returns views by design — `out=` there would silently change semantics).
- The rider branches pass slices of **one persistent shared joint tensor per output** (`_rider_dest`, cached per column width — gemma-4's global layers are wider than its sliding ones): `head → dest[:pb]`, `tail → dest[pb:t]`. Each half copies once; no cat; no per-step allocation.

Ordering safety (documented in place): each half's upload copies its residual slice out of the destination **before** that half's kernels and `copy_` overwrite it, and the head writes only `[0:pb]` while the tail's upload reads `[pb:]`. The destinations are shared across layers — safe because rider outputs are consumed within their layer (RoPE + paged attention + KV-cache write), the discipline the vLLM plugin already follows, now pinned in the test.

## Validation

- Rider-width (T=40) correctness vs the host path, the chained handoff check, and a storage-reuse pointer pin (`test_gen_prefill_device_gpu.py` — which also had to adopt the consume-before-next-call snapshot discipline itself, a nice demonstration that the contract is real).
- Full suite: 2818 passed, 159 skipped. Lint green.
- Serving-level effect lives on chunk+rider configs (gemma p2048 / mnbt-2056 cells — rider steps are the steady state there); measured in the batched Milestone-A 5090 session after A4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)