### PR TITLE
serve: make the --bench /health wait window configurable (--health-timeout)

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -273,7 +273,9 @@ emmy serve Qwen/Qwen3-Embedding-0.6B --bench --stock                # raw-vLLM b
 ```
 
 Without `--bench` the process execs `vllm serve` (signals flow to vLLM directly). With `--bench` the server runs as a
-subprocess (logs to a temp file), `/health` is polled (up to 30 min — first boot compiles the model), then
+subprocess (logs to a temp file), `/health` is polled (`--health-timeout` seconds, default 1800 — first boot compiles
+the model; raise it when a fresh-serving-shape compile runs longer, e.g. a new prefill-bucket/max-num-batched-tokens
+combination on a big model, or the kill lands mid-compile and no pack is saved), then
 `vllm bench serve` runs against it (`--max-concurrency` / `--num-prompts` / `--random-input-len` / `--bench-seed`) and
 the server is torn down. The bench backend follows the model: embeddings hit `--backend openai-embeddings --endpoint
 /v1/embeddings`; **`--generate`** hits `--backend openai --endpoint /v1/completions` with `--random-output-len`.

--- a/emmy/commands/serve.py
+++ b/emmy/commands/serve.py
@@ -80,6 +80,13 @@ def _add_own_flags(parser, *, suppress_defaults: bool) -> None:
     parser.add_argument(
         "--bench-seed", type=int, default=d(0), help="Bench prompt-sampling seed (with --bench; `--seed` itself forwards to vllm serve)."
     )
+    parser.add_argument(
+        "--health-timeout",
+        type=int,
+        default=d(_HEALTH_TIMEOUT_S),
+        help="Seconds to wait for /health before killing the server (with --bench; raise it when a "
+        "fresh-shape first boot compiles longer than the default 1800).",
+    )
     parser.add_argument("--dry-run", action="store_true", default=d(False), help="Print the vllm command(s) without running.")
 
 
@@ -363,16 +370,18 @@ def handle_serve(args):
         os.execve(vllm, serve_cmd, env)
 
     bench_cmd[0] = vllm
-    _serve_and_bench(serve_cmd, bench_cmd, port, env=env)
+    _serve_and_bench(serve_cmd, bench_cmd, port, env=env, health_timeout_s=args.health_timeout)
 
 
-def _serve_and_bench(serve_cmd: list[str], bench_cmd: list[str], port: str, *, env: dict | None = None) -> None:
+def _serve_and_bench(
+    serve_cmd: list[str], bench_cmd: list[str], port: str, *, env: dict | None = None, health_timeout_s: int = _HEALTH_TIMEOUT_S
+) -> None:
     log_file = tempfile.NamedTemporaryFile(mode="wb", prefix="emmy-serve-", suffix=".log", delete=False)
     logger.info("Starting server (logs: %s)...", log_file.name)
     logger.info("  %s", shlex.join(serve_cmd))
     server = subprocess.Popen(serve_cmd, stdout=log_file, stderr=subprocess.STDOUT, env=env)
     try:
-        _wait_for_health(server, port, log_file.name)
+        _wait_for_health(server, port, log_file.name, timeout_s=health_timeout_s)
         logger.info("Server healthy — running benchmark...")
         logger.info("  %s", shlex.join(bench_cmd))
         rc = subprocess.run(bench_cmd, env=env).returncode
@@ -389,12 +398,12 @@ def _serve_and_bench(serve_cmd: list[str], bench_cmd: list[str], port: str, *, e
         sys.exit(rc)
 
 
-def _wait_for_health(server: subprocess.Popen, port: str, log_path: str) -> None:
+def _wait_for_health(server: subprocess.Popen, port: str, log_path: str, *, timeout_s: int = _HEALTH_TIMEOUT_S) -> None:
     """Poll /health until the server answers; fail fast if it exits first
     (first boot may compile the whole model — be patient)."""
     import httpx
 
-    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+    deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if server.poll() is not None:
             tail = "".join(open(log_path, errors="replace").readlines()[-15:])
@@ -406,6 +415,6 @@ def _wait_for_health(server: subprocess.Popen, port: str, log_path: str) -> None
         except httpx.HTTPError:
             pass
         time.sleep(3)
-    logger.error("Server did not become healthy within %ds; logs: %s", _HEALTH_TIMEOUT_S, log_path)
+    logger.error("Server did not become healthy within %ds; logs: %s", timeout_s, log_path)
     server.terminate()
     sys.exit(1)

--- a/tests/serving/test_serve_command.py
+++ b/tests/serving/test_serve_command.py
@@ -268,3 +268,20 @@ def test_serve_generate_bench_targets_completions(capsys):
     assert "--runner generate" in out[0]
     assert "--backend openai" in out[1] and "/v1/completions" in out[1]
     assert "--random-output-len" in out[1]  # generative bench needs a generation length
+
+
+def test_health_timeout_default():
+    args = _parse(["serve", MODEL, "--bench"])
+    assert args.health_timeout == 1800
+
+
+def test_health_timeout_after_model_is_extracted_not_forwarded(capsys):
+    # A fresh-shape first boot can compile past the 1800 s default; --health-timeout
+    # widens the --bench /health window. Like every emmy flag it must be extracted
+    # from the REMAINDER, not forwarded to vllm serve.
+    args = _parse(["serve", MODEL, "--bench", "--dry-run", "--health-timeout", "5400"])
+    handle_serve(args)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    assert "--health-timeout" not in out[0] and "--health-timeout" not in out[1]
+    assert args.health_timeout == 5400


### PR DESCRIPTION
## Problem

`emmy serve --bench` hardcoded the `/health` poll window to 1800 s. A fresh-serving-shape gemma-4-12B compile (a new prefill-bucket / max-num-batched-tokens combination, ~35–60 min pipeline-bound) exceeds it: the harness kills the server mid-compile (observed at layer 46/48 on a rented 5090, 2026-08-02), no pack is saved, and the next attempt re-pays the full compile and times out again. The validate script already grew `--health-timeout` for exactly this.

## Change

- `--health-timeout SECONDS` on `emmy serve` (default 1800, the previous constant), threaded `handle_serve` → `_serve_and_bench` → `_wait_for_health`. Like every emmy-side flag it is extracted from the REMAINDER wherever it appears, never forwarded to `vllm serve`.
- Documented in the serve section of `emmy/commands/ARCHITECTURE.md`.
- Two command-construction tests in `tests/serving/test_serve_command.py`: default value, and extraction/non-forwarding of a post-MODEL `--health-timeout 5400`.

## Verification

- `tests/serving/test_serve_command.py`: 31 passed.
- Full `tests/serving/` package: 2 failures in `test_generate_loop.py` reproduce identically on the untouched `main` tree under the same serial invocation (and pass in isolation on both) — pre-existing suite-order flake, unrelated to this diff.
- `ruff check` / `ruff format --check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)