### PR TITLE
golden gate: MAJOR-GAP hazard baseline + pins beat routing entries (stacked on #449)

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -59,6 +59,24 @@ def _place_pins() -> dict[str, str]:
     return pins
 
 
+#: The schedule knob families a golden / ``--ab`` row pins. A live pin from any of them marks a
+#: pinned re-record compile, where the pin — not a recorded routing entry — must decide the form.
+_SCHEDULE_FAMILIES = ("TILE", "STAGE", "REDUCE", "WORK", "RASTER", "WSPEC")
+
+
+def _schedule_pins_live() -> bool:
+    """Whether any schedule-family knob pin is live (a bare ``EMMY_<KNOB>`` var or an
+    ``EMMY_KNOBS`` aggregate key). Pins are authoritative over every golden tier — a recorded
+    ROUTING entry must not reroute a pinned compile: the pinned fused row would silently compile
+    the cut's pieces and gate as ``realized (off)`` (the 2026-07-31 fused re-record dead end,
+    where every fused golden replay failed against its own recorded spelling as soon as a
+    same-shape ``.cut`` routing row landed). Bare schedule pins apply compile-wide, so this
+    suppression is compile-wide too — matching ``Knob.narrow``'s bare-pin scope."""
+    if any(config.knob_raw(f) is not None for f in _SCHEDULE_FAMILIES):
+        return True
+    return any(family_of(k) in _SCHEDULE_FAMILIES for k in parse_knob_spec(config.knobs_aggregate()))
+
+
 def _card_has_routing(gpu_name, cap) -> bool:
     """Whether ANY routing golden exists for this card — the cheap gate that keeps the per-kernel
     seam scan off the common compile (no pins, no routing entries → recognition is untouched)."""
@@ -145,7 +163,8 @@ def route_cut(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> S
     """The routing resolution for a freshly-recognized kernel: the cut seam to realize, or
     ``None`` (= fuse, the default — spelled as the ABSENCE of a routing entry). ``PLACE`` pins
     are authoritative over the recorded routing entry (a ``fuse`` pin suppresses a recorded
-    cut); a key that names no seam (or an uncuttable one) on this tree is skipped for a pin (a
+    cut), and so is any live schedule-family pin (a pinned re-record / ``--ab`` compile keeps
+    the recognized form so the pinned row can realize); a key that names no seam (or an uncuttable one) on this tree is skipped for a pin (a
     whole-model pin targets one kernel shape) and falls through with a warning for an entry
     (the drift case — deploy keeps the recognized form). A bare ``PLACE=cut`` pin takes the
     shallowest CUTTABLE seam."""
@@ -168,6 +187,8 @@ def route_cut(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> S
         if site is None or site not in seams:
             continue
         return site if value == _CUT else None  # an explicit fuse pin suppresses any routing entry
+    if _schedule_pins_live():
+        return None  # a pinned compile: the pin decides the form — recorded routing entries do not fire
     entry = _routing_entry(ctx, knobs)
     if entry is None:
         return None

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -4678,25 +4678,79 @@ configs:
     emmy_us: 169.2
     cublas_us: 170.0
 
+  # ---- mlp_down_fused, remaining serving widths (2026-08-02, vast.ai 5090 seeding) ----------------
+  # The last four #446-reopened down keys (m8/m64/m2048/m4096) — un-closable by cut rows (the down
+  # cone is geglu->down in-model, no legal seam) and un-benchable until the route_cut fix made
+  # schedule-family pins authoritative over recorded routing entries (the same-shape .cut rows were
+  # firing inside pinned replay compiles). Tuned + benched via the isolated .lin snippet (one shared
+  # cold DB/prior, small->large); emmy_us is the -O3 greedy A/B, cublas_us the same run's eager
+  # (torch's unfused rms_norm + linear decomposition). The wide widths trail eager (0.58-0.70x) on
+  # the std-lane FP32-accumulate wall — honest pins, not wins; the golden's job here is deploy
+  # pinning (the unseeded fork cold-resolved ~100x off in serving, TPOT ~2760 ms at p2048/c8).
+  # m8/m64 record the m32/m256 rows' spelling (w1x8 f2x2/k4 g4k — the workspace reduce split),
+  # not the snippet greedy's w1x16/g*a winners: those audited DRIFT in-model (the w1x16 + atomic
+  # split rows are not offered on the geglu->down cone), while the g4k twin benches close (m8
+  # 105.4 vs the 84.1 unrealizable winner, m64 133.5 vs 123.6 — partial + finalize summed).
+  # All four dicts DROP the snippet record_knobs' REDUCE@a1='' stamp: the snippet nest spells a
+  # second reduce axis that neither the in-model rows nor the kind's canonical reference tree
+  # carry (the spelling gate rejects the key), and the axis-keyed pin is all-or-nothing, so
+  # keeping it makes the split rows unmatchable in-model (probed: with it 0 rows match).
+  - kernel: norm_linear
+    name: gemma4_12b.mlp_down_fused.m8.lin
+    M: 8
+    H: 15360
+    N: 3840
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w1x8', TILE: 'mma_m16n8k16_f16_f32/f2x2/k4', REDUCE: 'g4k', STAGE: 'd1/sync', LOOPIFY: '0', RASTER: ''}
+    emmy_us: 105.4
+    cublas_us: 100.0
+  - kernel: norm_linear
+    name: gemma4_12b.mlp_down_fused.m64.lin
+    M: 64
+    H: 15360
+    N: 3840
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w1x8', TILE: 'mma_m16n8k16_f16_f32/f2x2/k4', REDUCE: 'g4k', STAGE: 'd1/sync', LOOPIFY: '0', RASTER: ''}
+    emmy_us: 133.5
+    cublas_us: 99.4
+  - kernel: norm_linear
+    name: gemma4_12b.mlp_down_fused.m2048.lin
+    M: 2048
+    H: 15360
+    N: 3840
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w4x2', TILE: 'mma_m16n8k16_f16_f32/f1x4/k4', STAGE: 'd1/sync', LOOPIFY: '0', RASTER: ''}
+    emmy_us: 2066.0
+    cublas_us: 1190.2
+  - kernel: norm_linear
+    name: gemma4_12b.mlp_down_fused.m4096.lin
+    M: 4096
+    H: 15360
+    N: 3840
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w2x4', TILE: 'mma_m16n8k16_f16_f32/f2x4/k2', STAGE: 'd2/sync', LOOPIFY: '0', RASTER: ''}
+    emmy_us: 3238.6
+    cublas_us: 2259.1
+
   # ---- Fused-fork cut routings, remaining serving widths (2026-07-31) -----------------------------
   # The #446 PLACE-knob retirement commented out every fused computed-A golden that spelled a PLACE@
   # placement, reopening the fused norm->linear / down forks at m1/m8/m64/m2048/m4096 (the drift-gate
-  # ratchet's 2026-07-30 block). The prescribed d*/sync fused anchor CANNOT currently be recorded:
-  # since the tile-IR 1s commits (post-0ffea99d) the staged computed-A form no longer realizes in the
-  # ISOLATED GOLDEN SNIPPET — a `STAGE=d1/sync` (or d2/sync) pin reports `realized (off)` on every
-  # width, including a replay of the 2026-07-30 m192/m256/m32 fused rows that snippet-benched it the
-  # day before. The IN-MODEL twins still realize it (the m32/m192 fused rows MATCH in `eval golden
-  # --in-model`), so serving deploys are unaffected; what is broken is the fused rows' isolated
-  # reproduction / re-record path, and the only snippet-realizable fused schedule is the unstaged
-  # gmem-direct one (~13x off eager at m192). So what is recorded here is the PLACE=cut routing
-  # alone: pieces resolve the width's seeded stat/scale/matmul tiers deterministically, the cut fires
+  # ratchet's 2026-07-30 block). What is recorded here is the PLACE=cut routing:
+  # pieces resolve the width's seeded stat/scale/matmul tiers deterministically, the cut fires
   # in-model for the norm->linear cones, and it IS the measured winner at every width where both
-  # forms last benched (m192/m32: fused d1/sync loses 1.6-1.9x to the cut). NO down-cone rows are
-  # added at m8/m64/m2048/m4096: the down cut is in-model-inert (multichannel/geglu residual, the
-  # #389 class — the pre-existing m32/m192/m256 down .cut rows are equally snippet-only, their keys
-  # covered in-model by their realizable fused siblings), and a down fused row cannot be benched
-  # until the snippet-side realization returns — those four keys stay in the drift-gate ratchet.
-  # When the snippet realization is fixed, re-anchor fused rows beside these and re-check the picks.
+  # forms last benched (m192/m32: fused d1/sync loses 1.6-1.9x to the cut).
+  # CORRECTION (2026-08-02): the 2026-07-31 note here blamed the tile-IR 1s commits for the fused
+  # d*/sync anchor's `realized (off)` in the isolated snippet. Bisect exonerated them — the recorded
+  # same-shape .cut ROUTING rows themselves (landed 0ffea99d) were firing inside PINNED replay
+  # compiles (only PLACE pins were authoritative over routing), rerouting the pinned fused row onto
+  # the cut's pieces. route_cut now keeps schedule-family pins authoritative, fused rows bench
+  # honestly again, and the four down keys are seeded above (2026-08-02 block). The down cut stays
+  # in-model-inert (multichannel/geglu residual, the #389 class — the pre-existing m32/m192/m256
+  # down .cut rows are snippet-only, their keys covered in-model by their realizable fused siblings).
   # The m2048/m4096 gate_up cut totals trail eager in the STD lane (the FP32-accumulate half-rate
   # wall on the wide matmul piece); the fm lane's piece tier covers those widths at >=1.0x.
   - kernel: norm_linear

--- a/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx5090_sm120_gemma4.yaml
@@ -4454,6 +4454,10 @@ configs:
   # These rows still trail cuBLAS (1.17x-1.61x) — 192 is a genuinely awkward width and mlp_down's
   # long-K shape wants a family this sweep did not explore. They are recorded because a deterministic
   # 1.2x loss replaces a non-reproducible one that can be 100x.
+  # 2026-07-31 completion: the sweep missed the two attention OUTPUT projections — the in-model audit
+  # (now tracing width 192) flagged o_proj/o_proj_global as the tier's only remaining warp-contraction
+  # gaps, and every MTP c=64 verify step launches both. Seeded below with the same split-to-fill rule;
+  # both beat eager and deploy unpinned.
   - kernel: matmul
     name: gemma4_12b.gate_up_cat.m192.lin
     M: 192
@@ -4524,6 +4528,51 @@ configs:
     knobs: {WORK: 'w1x8', TILE: 'mma_m16n8k16_f16_f32/f2x2/k4', REDUCE: 'g8a', RASTER: 'gm8', STAGE: 'd2/tma/ring'}
     emmy_us: 160.6
     cublas_us: 147.0
+  # o_proj at M=192 (2026-07-31): the two attention output projections were the one matmul family the
+  # 2026-07-30 m192 sweep missed — the in-model audit flagged them as the only remaining warp-contraction
+  # gaps at the MTP c=64 bucket (post192/post192-global). Same tile-M rule as the rest of the tier: the
+  # m64-family w1x8/k2/g8k two-kernel split benches 48.2 (sliding) / 85.7 (global) total; the single-kernel
+  # w2x4 + atomic split + gm8 family wins both. Each reproduced 2x at <1% spread.
+  - kernel: matmul
+    name: gemma4_12b.o_proj.m192.lin
+    M: 192
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w2x4', TILE: 'mma_m16n8k16_f16_f32/f2x2/k2', REDUCE: 'g4a', RASTER: 'gm8', STAGE: 'd2/tma/ring'}
+    emmy_us: 41.8
+    cublas_us: 47.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj.m192.lin
+    M: 192
+    N: 3840
+    K: 4096
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w2x4', TILE: 'mma_m16n8k16_f16_f16/f2x2/k4', REDUCE: 'g4a', RASTER: 'gm8', STAGE: 'd2/tma/ring'}
+    emmy_us: 37.9
+    cublas_us: 47.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj_global.m192.lin
+    M: 192
+    N: 3840
+    K: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w2x4', TILE: 'mma_m16n8k16_f16_f32/f2x2/k2', REDUCE: 'g8a', RASTER: 'gm8', STAGE: 'd2/tma/ring'}
+    emmy_us: 71.9
+    cublas_us: 74.0
+  - kernel: matmul
+    name: gemma4_12b.o_proj_global.m192.lin
+    M: 192
+    N: 3840
+    K: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {WORK: 'w2x4', TILE: 'mma_m16n8k16_f16_f16/f2x2/k2', REDUCE: 'g8a', RASTER: 'gm8', STAGE: 'd2/tma/ring'}
+    emmy_us: 71.3
+    cublas_us: 74.0
   # The FUSED (computed-A) norm->linear cones at this width. These are the rows that matter most
   # here: with no fused golden the cone cold-resolves to the per-cell `fuse`/`b128` scalar config,
   # which is not a mild loss but a ~300x one — measured on-card at m192, std lane, against torch's
@@ -4628,3 +4677,165 @@ configs:
     knobs: {PLACE: 'cut'}
     emmy_us: 169.2
     cublas_us: 170.0
+
+  # ---- Fused-fork cut routings, remaining serving widths (2026-07-31) -----------------------------
+  # The #446 PLACE-knob retirement commented out every fused computed-A golden that spelled a PLACE@
+  # placement, reopening the fused norm->linear / down forks at m1/m8/m64/m2048/m4096 (the drift-gate
+  # ratchet's 2026-07-30 block). The prescribed d*/sync fused anchor CANNOT currently be recorded:
+  # since the tile-IR 1s commits (post-0ffea99d) the staged computed-A form no longer realizes in the
+  # ISOLATED GOLDEN SNIPPET — a `STAGE=d1/sync` (or d2/sync) pin reports `realized (off)` on every
+  # width, including a replay of the 2026-07-30 m192/m256/m32 fused rows that snippet-benched it the
+  # day before. The IN-MODEL twins still realize it (the m32/m192 fused rows MATCH in `eval golden
+  # --in-model`), so serving deploys are unaffected; what is broken is the fused rows' isolated
+  # reproduction / re-record path, and the only snippet-realizable fused schedule is the unstaged
+  # gmem-direct one (~13x off eager at m192). So what is recorded here is the PLACE=cut routing
+  # alone: pieces resolve the width's seeded stat/scale/matmul tiers deterministically, the cut fires
+  # in-model for the norm->linear cones, and it IS the measured winner at every width where both
+  # forms last benched (m192/m32: fused d1/sync loses 1.6-1.9x to the cut). NO down-cone rows are
+  # added at m8/m64/m2048/m4096: the down cut is in-model-inert (multichannel/geglu residual, the
+  # #389 class — the pre-existing m32/m192/m256 down .cut rows are equally snippet-only, their keys
+  # covered in-model by their realizable fused siblings), and a down fused row cannot be benched
+  # until the snippet-side realization returns — those four keys stay in the drift-gate ratchet.
+  # When the snippet realization is fixed, re-anchor fused rows beside these and re-check the picks.
+  # The m2048/m4096 gate_up cut totals trail eager in the STD lane (the FP32-accumulate half-rate
+  # wall on the wide matmul piece); the fm lane's piece tier covers those widths at >=1.0x.
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qkv.m1.lin.cut
+    M: 1
+    H: 3840
+    N: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 15.2
+    cublas_us: 47.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qk_global.m1.lin.cut
+    M: 1
+    H: 3840
+    N: 8704
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 15.9
+    cublas_us: 48.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_gate_up.m1.lin.cut
+    M: 1
+    H: 3840
+    N: 30720
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 142.9
+    cublas_us: 147.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qkv.m8.lin.cut
+    M: 8
+    H: 3840
+    N: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 20.3
+    cublas_us: 21.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qk_global.m8.lin.cut
+    M: 8
+    H: 3840
+    N: 8704
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 20.8
+    cublas_us: 23.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_gate_up.m8.lin.cut
+    M: 8
+    H: 3840
+    N: 30720
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 145.9
+    cublas_us: 151.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qkv.m64.lin.cut
+    M: 64
+    H: 3840
+    N: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 34.5
+    cublas_us: 33.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qk_global.m64.lin.cut
+    M: 64
+    H: 3840
+    N: 8704
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 38.6
+    cublas_us: 33.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qkv.m2048.lin.cut
+    M: 2048
+    H: 3840
+    N: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 676.6
+    cublas_us: 638.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qk_global.m2048.lin.cut
+    M: 2048
+    H: 3840
+    N: 8704
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 701.8
+    cublas_us: 658.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_gate_up.m2048.lin.cut
+    M: 2048
+    H: 3840
+    N: 30720
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 2542.4
+    cublas_us: 2220.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qkv.m4096.lin.cut
+    M: 4096
+    H: 3840
+    N: 8192
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 1322.3
+    cublas_us: 1301.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_qk_global.m4096.lin.cut
+    M: 4096
+    H: 3840
+    N: 8704
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 1382.0
+    cublas_us: 1329.0
+  - kernel: norm_linear
+    name: gemma4_12b.norm_gate_up.m4096.lin.cut
+    M: 4096
+    H: 3840
+    N: 30720
+    dtype: 'fp16'
+    trans_b: true
+    knobs: {PLACE: 'cut'}
+    emmy_us: 7290.4
+    cublas_us: 4398.0

--- a/emmy/serving/twins.py
+++ b/emmy/serving/twins.py
@@ -70,13 +70,15 @@ def capture_twin_graphs(
 
     # Every static width a serving mode deploys gets a twin, so the in-model golden audit
     # sees the SAME forms the packs compile: the decode bucket (32), the documented c=4/c=8
-    # decode-bucket knob (8) and the c=64 one (64), the legacy prefill bucket (256), the
-    # c=4/c=8 chunk-quantum knob (2048 — EMMY_GEN_PREFILL_BUCKET=2048 + mnbt 2056), and the
-    # chunked-prefill static width (4096 — the --max-num-batched-tokens chunk every 4K+ prompt
-    # rides). The 2026-07-23 lane regressions (m64 decode TPOT 74 ms, m4096 TTFT +260 ms) were
-    # merged-key coverage gaps INVISIBLE to the audit precisely because these widths were
-    # missing here — MATCH 74/0/0 while serving cold-resolved.
-    widths = [1, 8, decode_bucket, 64, prefill_bucket, 2048, 4096]  # 1 = the EMMY_GEN_M1_TIER gemv twins
+    # decode-bucket knob (8) and the c=64 one (64), the MTP c=64 verify bucket (192 — the
+    # serving_mtp_rtx5090 depth-2 lane; it had no records of any kind until the 2026-07-30/31
+    # m192 seeding, which is the misdeploy class this list exists to make visible), the legacy
+    # prefill bucket (256), the c=4/c=8 chunk-quantum knob (2048 — EMMY_GEN_PREFILL_BUCKET=2048
+    # + mnbt 2056), and the chunked-prefill static width (4096 — the --max-num-batched-tokens
+    # chunk every 4K+ prompt rides). The 2026-07-23 lane regressions (m64 decode TPOT 74 ms,
+    # m4096 TTFT +260 ms) were merged-key coverage gaps INVISIBLE to the audit precisely
+    # because these widths were missing here — MATCH 74/0/0 while serving cold-resolved.
+    widths = [1, 8, decode_bucket, 64, 192, prefill_bucket, 2048, 4096]  # 1 = the EMMY_GEN_M1_TIER gemv twins
     buckets: list[tuple[str, int | None]] = [(str(m), m) for m in sorted({w for w in widths if w})]
     if symbolic:
         buckets.append(("-sym", None))

--- a/plans/gemma4-serving-golden-coverage-findings.md
+++ b/plans/gemma4-serving-golden-coverage-findings.md
@@ -1,0 +1,123 @@
+# Serving-config golden coverage audit + MTP m192 seeding — RTX 5090, 2026-07-31
+
+Brief: verify every kernel the gemma-4-12B serving configurations deploy has a golden in
+`rtx5090_sm120_gemma4.yaml` — with particular attention to the MTP lanes (`serving_mtp_rtx5090`) and the
+context bump to 16384 — and seed whatever is unseeded. Method: the in-model audit (`search/audit.audit_card`
+over weight-free twins), extended beyond its stock width list with the MTP c=64 verify bucket (192), then
+manual pinned `--ab` seeding on the local 5090 (the manual golden method — no tuner sweep).
+
+## The serving width inventory (what "all kernels from the serving configurations" means)
+
+Emmy-side kernel shapes in generative serving are decided ONLY by the step width (`num_tokens`), never by
+context length. The deployed widths across `serving_rtx5090`, `serving_mtp_rtx5090`, `gsm8k[_mtp]_rtx5090`
+and the baked image (`models/gemma-4-12b-it.env`):
+
+| width | source |
+| --- | --- |
+| m1 | `EMMY_GEN_M1_TIER` gemv twins (true single-token decode) |
+| m8 | decode bucket, c=4/c=8 lanes; MTP c=1 lanes (verify widths 3/4/6 pad into it) |
+| m32 | default decode bucket (baked image); MTP c=4/c=8 depth 2–3 (verify widths 12–32) |
+| m64 | c=64 decode bucket |
+| **m192** | **MTP c=64 depth-2 verify bucket** (64 × (2+1); pinned by the quality gate — 256 fails GSM8K) |
+| m2048 | chunk quantum (`EMMY_GEN_PREFILL_BUCKET=2048`), 4k/4k batched lanes |
+| m4096 | default chunked-prefill width (`--max-num-batched-tokens` chunk) |
+| dynM | the symbolic programs (everything between rungs; over-bucket capture) |
+
+**The 16K context bump changes none of these.** `context_length: 16384` moves vLLM-side artifacts only
+(KV pool, paged attention, rope tables); the twins are `[num_tokens, H]`-parameterized and never see
+`max_model_len`. What 16384 does change: the pack/cubin cache key (the baked image's `.env` is already
+flagged UNVERIFIED at 16384 — the headroom sweep + re-warm remain open, out of scope here).
+
+## Audit result (before edits)
+
+`audit_card` over the full twin set + the 192-width twins, RTX 5090: **MATCH 138 / DRIFT 0 / GAP 77 /
+compile_fail 0**. m32 and m256 audit clean (zero gaps). The gaps split three ways:
+
+1. **MTP m192 majors (NEW, seeded below):** `o_proj` (M=192, N=3840, K=4096) and `o_proj_global`
+   (K=8192) — the only warp-contraction hazards at the MTP c=64 bucket. The 2026-07-30 m192 hand sweep
+   covered the merged QKV/gate⊗up matmuls and the fused cones but missed the attention output projection,
+   and the stock audit never traced width 192, so nothing could see it.
+2. **The #446 fused burn-down (known, closed below):** the PLACE-knob retirement commented out every
+   fused computed-A golden with a `PLACE@` spelling, reopening the fused norm→linear / down forks at
+   m1/m8/m64/m2048/m4096 (18 forks; already tracked in the drift-gate ratchet).
+3. **Aux keys (left open, consistent with the ratchet):** per-head qk-norm rms sweeps, cut-stat rms rows,
+   merged-cat dup-view glue — the greedy-near-optimal class the baseline already accepts at other widths.
+   The m192 members joined `EXPECTED_GAPS`.
+
+## What was recorded
+
+| shape | config | emmy µs | eager µs | ratio |
+| --- | --- | --- | --- | --- |
+| o_proj.m192.lin (std) | `w2x4 f2x2/k2 g4a gm8 d2/tma/ring` | 41.8 | 47 | 1.12× |
+| o_proj.m192.lin (fm) | `w2x4 f2x2/k4 g4a gm8 d2/tma/ring` | 37.9 | 47 | 1.24× |
+| o_proj_global.m192.lin (std) | `w2x4 f2x2/k2 g8a gm8 d2/tma/ring` | 71.9 | 74 | 1.03× |
+| o_proj_global.m192.lin (fm) | `w2x4 f2x2/k2 g8a gm8 d2/tma/ring` | 71.3 | 74 | 1.04× |
+| 14 fused-fork cut routings | `PLACE: cut` | (per-row) | (per-row) | see YAML |
+
+The o_proj rows follow the m192 tile rule from the 2026-07-30 sweep (tile-M-32/64 + a cross-CTA atomic
+split sized to fill the card + `gm8`): the m64-family `w1x8/k2/g8k` two-kernel split benches 48.2 / 85.7
+total against the winners' 41.8 / 71.9. Deployability confirmed unpinned — the greedy pick IS the
+recorded config on both shapes (the g8a/gm8-at-one-tile "benches but cannot deploy" trap from the
+2026-07-30 workflow notes did not bite here).
+
+## Finding — the staged computed-A (fused d*/sync) form no longer realizes in the ISOLATED SNIPPET
+
+The ratchet's prescribed burn-down ("re-record PLACE-free fused rows; the d*/sync anchor") is
+impossible on current main: in the golden SNIPPET compile (`run --bench --golden`), `STAGE=d1/sync`
+(and `d2/sync`) pins report `realized (off)` at every width — **including a replay of the 2026-07-30
+m192/m256/m32 fused rows that snippet-benched that exact spelling the day before** (e.g.
+`norm_gate_up.m192.lin`, recorded 429.3 µs on 2026-07-30). The window is the tile-IR 1s commits
+(`4b947570`/`95b88f9f`, post-`0ffea99d`). The only snippet-realizable fused schedule is the unstaged
+gmem-direct one: ~3725 µs on the m192 gate⊗up cone vs eager 252 — ~15× off.
+
+**The in-model twins are NOT affected**: the audit compiles the serving-twin graphs, and there the
+m32/m192 fused rows (same `d1/sync` spelling) MATCH with zero unrealized entries — serving deploys
+still realize the staged fused form. So this is an eval/re-record-side regression, not a serving one:
+the fused rows' isolated reproduction is dead, no NEW fused row can be honestly benched, and the
+isolated-vs-in-model split is exactly the disagreement class the in-model audit was built for — just
+in the opposite direction (the snippet is the broken half this time). **Recommendation:** restore the
+snippet-side realization of the staged computed-A form (likely the snippet's `F.rms_norm(x) @ w` cone
+recognizing differently after 1s), then re-anchor fused rows at the still-open widths.
+
+## Finding — the down cone's PLACE=cut routing is in-model-inert (all widths)
+
+The `mlp_down_fused` keys could not be closed by cut rows either: a down `.cut` routing row fires in
+the isolated snippet (whose cone is rms→down) but never in-model (where the cone is geglu→down — the
+multichannel/#389 residual; verified: the post8 audit shows the norm_gate_up cut firing while the
+down node stays fused and consults as a GAP). The pre-existing m32/m192/m256 down `.cut` rows are
+equally snippet-only — their keys audit MATCH via their in-model-realizable fused siblings, which is
+also why the gate never noticed. Consequence: at m8/m64/m2048/m4096 the down key has no honest
+closure today (no benchable fused row per the finding above, no in-model cut), so those four keys
+stay in the ratchet with the explanation. No down rows were added.
+
+## Fused-fork cut routings (the #446 closure that IS possible)
+
+The 14 reopened norm→linear forks (norm_qkv / norm_qk_global / norm_gate_up at m1/m8/m64/m2048/m4096)
+now carry `PLACE: 'cut'` routing rows; pieces resolve each width's seeded stat/scale/matmul tiers, the
+cut demonstrably fires in-model (the m8 audit's gate_up node resolves as stat + plain merged matmul),
+and the corresponding ratchet lines are deleted. Notable totals (pieces summed, same-run eager): cut
+beats eager outright at the decode widths — m1 norm_qkv 15.2 vs 47 (3.1×), m8 norm_qkv 20.3 vs 21 —
+and lands within noise at m64/m2048/m4096 except the std-lane wide gate_up (the FP32-accumulate
+half-rate wall; the fm piece tier covers those widths). Full per-row numbers in the YAML.
+
+## Gate/audit changes
+
+- `twins.py`: width 192 joins the audit width list — the MTP bucket was a deployed width the audit
+  could not see (the exact blindness class the 2026-07-24 width extension note warns about).
+- `test_golden_drift_gate.py`: 5090 baseline — 15 fused lines deleted (closed by the cut routings +
+  m192 seeding), the 4 down-fused keys kept with the inert-cut explanation, the 7 m192 aux keys
+  added; 4090 baseline — the 13 m192 keys added (no m192 serving on 24 GB; mirror the 5090 seeding
+  if a 4090 m192 tier is ever wanted).
+
+## Workflow notes
+
+- `--golden NAME` matches by prefix, so a name whose `.cut` sibling exists benches both — and one
+  unrealizable pinned row left the OTHER row unbenched in the same run (the m8 cut row failed alongside
+  the fused row's `realized (off)`, then benched clean solo). Per-name runs are the workaround; a
+  pin-failure that poisons sibling rows is worth a look.
+- The audit's GAP records carry the ShapeKey but not a human name; mapping keys back to
+  `free_prod = M × N` by hand was the most repeated manual step. A `--names` view (nearest golden-name
+  guess per gap key) would cut it.
+- The fused-tier realization loss was invisible to every automated check: the drift gate MATCHes when
+  ANY same-key row realizes, so a cut sibling masks a dead fused arm. A per-ROW realization audit
+  (each golden row must still realize, not each key) would have caught it the day it landed.

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -185,6 +185,25 @@ def test_routing_golden_cuts_without_a_pin(monkeypatch) -> None:
     assert any("__cut_" in k for k in _kernel_ids(out)), "the routing entry cuts with no pin present"
 
 
+def test_schedule_pin_suppresses_the_routing_entry(monkeypatch) -> None:
+    """Any live schedule-family pin marks a pinned re-record / ``--ab`` compile, and pins are
+    authoritative over every golden tier — the recorded routing entry must not reroute it. This
+    is the 2026-07-31 fused re-record dead end: with a same-shape ``.cut`` row recorded, every
+    pinned fused golden replay silently compiled the cut's pieces and gated ``realized (off)``."""
+    from emmy import config
+    from emmy.compiler.pipeline.search import golden as golden_mod
+
+    entry = RmsNormGoldenConfig(
+        name="rms.routing", M=64, K=4096, dtype="fp16", knobs={"PLACE": "cut"}, emmy_us=3.8, gpu_name="NVIDIA GeForce RTX 5090"
+    )
+    monkeypatch.setattr(golden_mod, "GOLDEN_CONFIGS", [entry])
+    monkeypatch.setenv("EMMY_STAGE", "")  # the OFF spelling — any schedule-family pin, PLACE excluded
+    with config.nvcc_flags_override(""):
+        ctx = Context.from_target((12, 0), gpu_name=entry.gpu_name)
+        out = _compile(_rms_graph(), None, monkeypatch, ctx=ctx)
+    assert len(_kernel_ids(out)) == 1, "a live schedule pin is authoritative — the routing entry must not cut"
+
+
 def test_routing_golden_ignored_off_its_card(monkeypatch) -> None:
     from emmy.compiler.pipeline.search import golden as golden_mod
 

--- a/tests/compiler/test_golden_drift_gate.py
+++ b/tests/compiler/test_golden_drift_gate.py
@@ -186,10 +186,13 @@ EXPECTED_MAJOR_GAPS = {
     "NVIDIA GeForce RTX 5090": {
         # 2026-07-31 (#449): the four mlp_down_fused keys (m8/m64/m2048/m4096) are the #446
         # remainder — the down cone's PLACE=cut routing is in-model-inert (the cone is
-        # geglu→down, the multichannel/#389 residual, so the cut never fires in-model), and a
-        # fused row cannot be honestly benched while the staged computed-A form does not
-        # realize in the ISOLATED golden snippet (the tile-IR 1s regression; in-model twins
-        # still realize it). Burn down when either fix lands.
+        # geglu→down, the multichannel/#389 residual, so the cut never fires in-model), and the
+        # fused-row re-record was dead: a same-shape recorded ``.cut`` routing row fired inside
+        # the PINNED replay compile too, so the pinned d*/sync row compiled the cut's pieces and
+        # gated ``realized (off)`` (this was misread as a tile-IR 1s recognition loss; the 1s
+        # commits are exonerated). 2026-08-02: route_cut now keeps schedule-family pins
+        # authoritative over routing entries, so fused rows bench honestly again — burn these
+        # four down by seeding mlp_down_fused rows at the open widths on a 5090.
         ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=245760, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),

--- a/tests/compiler/test_golden_drift_gate.py
+++ b/tests/compiler/test_golden_drift_gate.py
@@ -183,21 +183,12 @@ EXPECTED_GAPS = {
 # fused serving fork and the gate stayed green precisely because those keys blended into a
 # routine baseline edit (``test_no_major_key_hides_in_the_generic_baseline``).
 EXPECTED_MAJOR_GAPS = {
-    "NVIDIA GeForce RTX 5090": {
-        # 2026-07-31 (#449): the four mlp_down_fused keys (m8/m64/m2048/m4096) are the #446
-        # remainder — the down cone's PLACE=cut routing is in-model-inert (the cone is
-        # geglu→down, the multichannel/#389 residual, so the cut never fires in-model), and the
-        # fused-row re-record was dead: a same-shape recorded ``.cut`` routing row fired inside
-        # the PINNED replay compile too, so the pinned d*/sync row compiled the cut's pieces and
-        # gated ``realized (off)`` (this was misread as a tile-IR 1s recognition loss; the 1s
-        # commits are exonerated). 2026-08-02: route_cut now keeps schedule-family pins
-        # authoritative over routing entries, so fused rows bench honestly again — burn these
-        # four down by seeding mlp_down_fused rows at the open widths on a 5090.
-        ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=245760, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=15728640, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=4096),
-    },
+    # 2026-08-02: the 5090 major baseline is EMPTY — the last four #446-reopened keys (the
+    # mlp_down_fused widths, un-closable by cut rows and un-benchable while recorded ``.cut``
+    # routing rows fired inside pinned replay compiles) burned down once route_cut made
+    # schedule-family pins authoritative: fused d*/sync rows benched honestly again and the
+    # four widths were seeded on a vast.ai 5090 (the 2026-08-02 block in the gemma4 YAML).
+    "NVIDIA GeForce RTX 5090": set(),
     "NVIDIA GeForce RTX 4090": {
         # The 4090 majors are all one deferral: the card's mirror re-tune (box lost its GPU at
         # the PCI level; several widths have no 24 GB serving at all — m1, m192 — and the

--- a/tests/compiler/test_golden_drift_gate.py
+++ b/tests/compiler/test_golden_drift_gate.py
@@ -86,27 +86,50 @@ EXPECTED_GAPS = {
         # 2026-07-30: the PLACE-knob retirement (#446) commented out the fused computed-A
         # goldens that recorded a PLACE@ placement, so every fused norm→linear / geglu fork
         # (kind="fused", across the m1/m8/m32/m2048/m4096 audit widths) is uncovered again.
-        # Burn down by re-recording PLACE-free fused rows (manual --ab; the d*/sync anchor).
-        ShapeKey(free_prod=8192, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
-        ShapeKey(free_prod=8704, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
-        ShapeKey(free_prod=30720, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        # 2026-07-31: mostly closed — the reopened norm→linear forks now carry PLACE=cut routing
+        # rows whose pieces resolve each width's seeded stat/scale/matmul tiers (the cut fires
+        # in-model for those cones). The d*/sync fused anchor could NOT be re-recorded: since the
+        # tile-IR 1s commits the staged computed-A form no longer realizes in the ISOLATED golden
+        # snippet (in-model twins still realize it — the m32/m192 fused rows MATCH here), so no
+        # new fused row can be honestly benched. The four mlp_down_fused keys below stay open:
+        # the down cone's PLACE=cut routing is in-model-inert (the multichannel/geglu residual —
+        # the #389 class), so a cut row cannot cover them, and a fused row cannot be benched
+        # until the snippet-side realization returns. Burn down when either fix lands.
         ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=65536, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
-        ShapeKey(free_prod=69632, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
-        ShapeKey(free_prod=245760, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
         ShapeKey(free_prod=245760, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=524288, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
-        ShapeKey(free_prod=557056, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
         ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=15728640, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=4096),
-        ShapeKey(free_prod=16777216, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
-        ShapeKey(free_prod=17825792, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
-        ShapeKey(free_prod=33554432, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
-        ShapeKey(free_prod=35651584, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
-        ShapeKey(free_prod=62914560, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
-        ShapeKey(free_prod=125829120, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        # 2026-07-31: the m192 width (the MTP c=64 verify bucket, serving_mtp_rtx5090) joined
+        # the audit — its aux keys below are the same greedy-near-optimal classes as the other
+        # widths' (per-head qk-norm rms sweeps, the post-attn/cut-stat rms key, the merged-cat
+        # dup-view glue); the m192 matmul/fused/o_proj forks are all golden-covered.
+        ShapeKey(free_prod=737280, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=1572864, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8192),
+        ShapeKey(free_prod=1671168, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
+        ShapeKey(free_prod=393216, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=786432, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=98304, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=1572864, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
     },
     "NVIDIA GeForce RTX 4090": {
+        # 2026-07-31: the m192 width (the MTP c=64 verify bucket) joined the audit. There is no
+        # m192 serving on 24 GB (the 12B does not fit), so the whole m192 fork set is uncovered
+        # here — the merged-cat matmuls/glue, o_proj (reduce 4096/8192), the fused cones, and
+        # the rms/qknorm sweeps. Mirror the 5090's m192 + o_proj + fused-cut seeding if a 4090
+        # m192 tier is ever wanted.
+        ShapeKey(free_prod=1572864, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8192),
+        ShapeKey(free_prod=1572864, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
+        ShapeKey(free_prod=1572864, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=1671168, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
+        ShapeKey(free_prod=1671168, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
+        ShapeKey(free_prod=393216, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=5898240, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        ShapeKey(free_prod=737280, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        ShapeKey(free_prod=737280, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=737280, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        ShapeKey(free_prod=737280, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        ShapeKey(free_prod=786432, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
+        ShapeKey(free_prod=98304, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         # 2026-07-26: the m2048 (chunk-quantum) width joined the audit (parity campaign round
         # 3). The 5090 seeded its m2048 golden set the same day (_tune/m2048/ sweeps); the
         # 4090's rides the same deferred mirror re-tune, so every m2048 fork is uncovered

--- a/tests/compiler/test_golden_drift_gate.py
+++ b/tests/compiler/test_golden_drift_gate.py
@@ -20,7 +20,15 @@ only kernels outside the gate are fork-free deterministic lowerings — rope/emb
 which never consult the golden tier). The per-card baseline must match exactly: a NEW gap
 fails (an uncovered kernel appeared — record a golden or deliberately extend the baseline in
 review); a CLOSED one also fails, asking for its line to be deleted so the ratchet only
-tightens. Warp-contraction gaps (the misdeploy/hang hazard class) are the ones to close first.
+tightens.
+
+Warp-contraction gaps (``major_gap_keys`` — the misdeploy/hang hazard class) are ratcheted
+SEPARATELY through ``EXPECTED_MAJOR_GAPS``, never through the generic baseline: the #446
+PLACE-knob retirement uncovered every fused serving fork on the 5090 and this gate stayed
+green because the 18 keys rode a routine ``EXPECTED_GAPS`` extension. A major-class
+regression must now edit the hazard-labeled list, whose entries each need a dated reason and
+a burn-down condition (``test_no_major_key_hides_in_the_generic_baseline`` keeps the two sets
+disjoint).
 
 Interactive twin: ``emmy eval golden --in-model``.
 """
@@ -34,7 +42,7 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("transformers")
 
-from emmy.compiler.pipeline.search.audit import COMPILE_FAIL, audit_card, gap_keys, summarize
+from emmy.compiler.pipeline.search.audit import COMPILE_FAIL, audit_card, gap_keys, major_gap_keys, summarize
 from emmy.compiler.pipeline.search.data.shape import ShapeKey
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "gemma4_12b"
@@ -85,20 +93,11 @@ EXPECTED_GAPS = {
         ShapeKey(free_prod=17825792, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
         # 2026-07-30: the PLACE-knob retirement (#446) commented out the fused computed-A
         # goldens that recorded a PLACE@ placement, so every fused norm→linear / geglu fork
-        # (kind="fused", across the m1/m8/m32/m2048/m4096 audit widths) is uncovered again.
-        # 2026-07-31: mostly closed — the reopened norm→linear forks now carry PLACE=cut routing
-        # rows whose pieces resolve each width's seeded stat/scale/matmul tiers (the cut fires
-        # in-model for those cones). The d*/sync fused anchor could NOT be re-recorded: since the
-        # tile-IR 1s commits the staged computed-A form no longer realizes in the ISOLATED golden
-        # snippet (in-model twins still realize it — the m32/m192 fused rows MATCH here), so no
-        # new fused row can be honestly benched. The four mlp_down_fused keys below stay open:
-        # the down cone's PLACE=cut routing is in-model-inert (the multichannel/geglu residual —
-        # the #389 class), so a cut row cannot cover them, and a fused row cannot be benched
-        # until the snippet-side realization returns. Burn down when either fix lands.
-        ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=245760, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
-        ShapeKey(free_prod=15728640, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=4096),
+        # (kind="fused", across the m1/m8/m32/m2048/m4096 audit widths) was uncovered.
+        # 2026-07-31: closed for the norm→linear cones — they carry PLACE=cut routing rows
+        # whose pieces resolve each width's seeded stat/scale/matmul tiers (the cut fires
+        # in-model for those cones). The still-open mlp_down_fused keys live in
+        # EXPECTED_MAJOR_GAPS below (the hazard-class baseline), not here.
         # 2026-07-31: the m192 width (the MTP c=64 verify bucket, serving_mtp_rtx5090) joined
         # the audit — its aux keys below are the same greedy-near-optimal classes as the other
         # widths' (per-head qk-norm rms sweeps, the post-attn/cut-stat rms key, the merged-cat
@@ -114,55 +113,41 @@ EXPECTED_GAPS = {
     "NVIDIA GeForce RTX 4090": {
         # 2026-07-31: the m192 width (the MTP c=64 verify bucket) joined the audit. There is no
         # m192 serving on 24 GB (the 12B does not fit), so the whole m192 fork set is uncovered
-        # here — the merged-cat matmuls/glue, o_proj (reduce 4096/8192), the fused cones, and
-        # the rms/qknorm sweeps. Mirror the 5090's m192 + o_proj + fused-cut seeding if a 4090
-        # m192 tier is ever wanted.
+        # here — the merged-cat glue and rms/qknorm sweeps below; the m192 warp-contraction
+        # forks (o_proj, the fused cones) live in EXPECTED_MAJOR_GAPS. Mirror the 5090's m192 +
+        # o_proj + fused-cut seeding if a 4090 m192 tier is ever wanted.
         ShapeKey(free_prod=1572864, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8192),
-        ShapeKey(free_prod=1572864, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
         ShapeKey(free_prod=1572864, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=1671168, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
-        ShapeKey(free_prod=1671168, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
         ShapeKey(free_prod=393216, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=5898240, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
-        ShapeKey(free_prod=737280, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=737280, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=737280, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
-        ShapeKey(free_prod=737280, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
         ShapeKey(free_prod=786432, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=98304, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         # 2026-07-26: the m2048 (chunk-quantum) width joined the audit (parity campaign round
         # 3). The 5090 seeded its m2048 golden set the same day (_tune/m2048/ sweeps); the
         # 4090's rides the same deferred mirror re-tune, so every m2048 fork is uncovered
-        # there — merged/canonical matmuls, fused norm->merged forms, and the rms/qknorm
-        # sweeps below. Burn down with the m8 mirror once a 4090 is back.
+        # there — the glue and rms/qknorm sweeps below; the m2048 warp-contraction forks
+        # (merged/canonical matmuls, fused norm→merged forms) live in EXPECTED_MAJOR_GAPS.
+        # Burn down with the m8 mirror once a 4090 is back.
         ShapeKey(free_prod=1048576, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=16777216, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8192),
-        ShapeKey(free_prod=16777216, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
         ShapeKey(free_prod=16777216, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=17825792, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
-        ShapeKey(free_prod=17825792, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
         ShapeKey(free_prod=4194304, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=62914560, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
-        ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=7864320, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         # 2026-07-25: the m8 (bucket-8 decode) width joined the audit. The 5090 seeded its m8
         # golden set the same day (WS2, serving-next); the 4090's is deferred with the mirror
         # re-tune (box lost its GPU at the PCI level), so EVERY m8 fork is uncovered there —
-        # the merged matmul/fused forms and the per-head/aux rms sweeps below. Burn down by
-        # mirroring the m8 seeding recipe (_tune/decode-m8/) once a 4090 is back.
+        # the glue and per-head/aux rms sweeps below; the m8 warp-contraction forks (merged
+        # matmul/fused forms, o_proj) live in EXPECTED_MAJOR_GAPS. Burn down by mirroring the
+        # m8 seeding recipe (_tune/decode-m8/) once a 4090 is back.
         ShapeKey(free_prod=16384, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=245760, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
-        ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=30720, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=30720, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
-        ShapeKey(free_prod=30720, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
         ShapeKey(free_prod=32768, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=4096, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=65536, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8192),
-        ShapeKey(free_prod=65536, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
         ShapeKey(free_prod=65536, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=69632, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
-        ShapeKey(free_prod=69632, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
         ShapeKey(free_prod=245760, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=262144, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=32768, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
@@ -174,23 +159,74 @@ EXPECTED_GAPS = {
         ShapeKey(free_prod=8388608, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         # 2026-07-24b: the m1 (gemv-tier) width joined the audit — its aux keys (m1
         # pointwise/rope glue, per-head rms at M=1, the small o_proj/lm_head-side forms;
-        # on the 4090 also the fused m1 keys, never seeded there — no m1 serving on 24 GB).
+        # the m1 fused/o_proj warp-contraction keys live in EXPECTED_MAJOR_GAPS — never
+        # seeded here, no m1 serving on 24 GB).
         ShapeKey(free_prod=2048, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=30720, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
         ShapeKey(free_prod=3840, reduce_max=3840, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
-        ShapeKey(free_prod=3840, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
-        ShapeKey(free_prod=3840, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
         ShapeKey(free_prod=4096, reduce_max=256, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=512, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=8192, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8192),
-        ShapeKey(free_prod=8192, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
         ShapeKey(free_prod=8192, reduce_max=512, is_warp=False, is_dyn=False, kind="rms_norm", free_max=0),
         ShapeKey(free_prod=8704, reduce_max=0, is_warp=True, is_dyn=False, kind="", free_max=8704),
+    },
+}
+
+# The warp-contraction hazard baseline — ``major_gap_keys``: warp forks with a real reduce
+# extent (plain matmul, fused computed-A, flash). This is the misdeploy/hang class the goldens
+# exist to pin: an unseeded gemma projection deployed a scalar tile ~770x off cuBLAS, and the
+# 2026-08-02 5090 serving audit (on main, before #449 merged) measured every uncovered fused
+# twin family 114–1014x over the weight-streaming floor with the p2048/c8 chunk cell at TPOT
+# ~2760 ms. The same exact-match ratchet discipline as EXPECTED_GAPS, with a stricter bar for
+# ADDING: every entry needs a dated reason AND a concrete burn-down condition, and a width a
+# card actually serves should be closed (seed a golden or a routing row), not listed. Majors
+# may never ride the generic EXPECTED_GAPS set — the #446 PLACE retirement uncovered every
+# fused serving fork and the gate stayed green precisely because those keys blended into a
+# routine baseline edit (``test_no_major_key_hides_in_the_generic_baseline``).
+EXPECTED_MAJOR_GAPS = {
+    "NVIDIA GeForce RTX 5090": {
+        # 2026-07-31 (#449): the four mlp_down_fused keys (m8/m64/m2048/m4096) are the #446
+        # remainder — the down cone's PLACE=cut routing is in-model-inert (the cone is
+        # geglu→down, the multichannel/#389 residual, so the cut never fires in-model), and a
+        # fused row cannot be honestly benched while the staged computed-A form does not
+        # realize in the ISOLATED golden snippet (the tile-IR 1s regression; in-model twins
+        # still realize it). Burn down when either fix lands.
+        ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        ShapeKey(free_prod=245760, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        ShapeKey(free_prod=15728640, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=4096),
+    },
+    "NVIDIA GeForce RTX 4090": {
+        # The 4090 majors are all one deferral: the card's mirror re-tune (box lost its GPU at
+        # the PCI level; several widths have no 24 GB serving at all — m1, m192 — and the
+        # m8/m2048 sets ride the same rented-card mirror). Burn down per width once a 4090 is
+        # back, mirroring the 5090 seeding recipes (_tune/decode-m8/, _tune/m2048/, the m192 +
+        # fused-cut seeding of 2026-07-31).
+        # m1 (no m1 serving on 24 GB): fused qkv/qk_global/gate_up + o_proj/o_proj_global.
+        ShapeKey(free_prod=8192, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
         ShapeKey(free_prod=8704, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
-        # 2026-07-30: the PLACE-knob retirement (#446) commented out the fused computed-A
-        # goldens that recorded a PLACE@ placement — the m32/m4096 fused forks they covered
-        # are uncovered again (the other widths were already in this set, see above). Burn
-        # down by re-recording PLACE-free fused rows (manual --ab; the d*/sync anchor).
+        ShapeKey(free_prod=30720, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        ShapeKey(free_prod=3840, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        ShapeKey(free_prod=3840, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        # m8 (deferred mirror re-tune): fused qkv/qk_global/gate_up/down + o_proj forms.
+        ShapeKey(free_prod=65536, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
+        ShapeKey(free_prod=69632, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
+        ShapeKey(free_prod=245760, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        ShapeKey(free_prod=30720, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        ShapeKey(free_prod=30720, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        ShapeKey(free_prod=30720, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        # m192 (no m192 serving on 24 GB): fused cones + o_proj/o_proj_global.
+        ShapeKey(free_prod=1572864, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
+        ShapeKey(free_prod=1671168, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
+        ShapeKey(free_prod=5898240, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        ShapeKey(free_prod=737280, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        ShapeKey(free_prod=737280, reduce_max=4096, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        ShapeKey(free_prod=737280, reduce_max=8192, is_warp=True, is_dyn=False, kind="", free_max=3840),
+        # m2048 (deferred mirror re-tune): fused qkv/qk_global/gate_up/down forms.
+        ShapeKey(free_prod=16777216, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
+        ShapeKey(free_prod=17825792, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8704),
+        ShapeKey(free_prod=62914560, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=30720),
+        ShapeKey(free_prod=7864320, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
+        # m32/m4096 #446 remainder (the PLACE@ fused rows the retirement commented out).
         ShapeKey(free_prod=245760, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=3840),
         ShapeKey(free_prod=15728640, reduce_max=15360, is_warp=True, is_dyn=False, kind="fused", free_max=4096),
         ShapeKey(free_prod=33554432, reduce_max=3840, is_warp=True, is_dyn=False, kind="fused", free_max=8192),
@@ -263,7 +299,22 @@ def test_gemma4_goldens_deploy_in_serving_twins(twins, gpu_name, cap):
         f"ratchet tightens: {sorted(fixed_drifts)}"
     )
 
-    gaps = gap_keys(res)
+    majors = major_gap_keys(res)
+    new_major = majors - EXPECTED_MAJOR_GAPS[gpu_name]
+    assert not new_major, (
+        f"NEW uncovered WARP-CONTRACTION fork(s) on {gpu_name}: {sorted(new_major, key=str)}\n"
+        "This is the misdeploy/hang hazard class — an uncovered contraction cold-resolves in serving "
+        "(the #446 regression served the p2048/c8 chunk cell at TPOT ~2760 ms vs the ~20 ms record). "
+        "Close it (seed a golden or a routing row on the card) rather than listing it; extending "
+        "EXPECTED_MAJOR_GAPS needs a dated reason and a concrete burn-down condition in review."
+    )
+    closed_major = EXPECTED_MAJOR_GAPS[gpu_name] - majors
+    assert not closed_major, (
+        f"major gap(s) on {gpu_name} are now covered — delete their EXPECTED_MAJOR_GAPS lines so the "
+        f"ratchet tightens: {sorted(closed_major, key=str)}"
+    )
+
+    gaps = gap_keys(res) - majors
     new = gaps - EXPECTED_GAPS[gpu_name]
     assert not new, (
         f"NEW uncovered kernel fork(s) on {gpu_name}: {sorted(new, key=str)}\n"
@@ -279,3 +330,14 @@ def test_gemma4_goldens_deploy_in_serving_twins(twins, gpu_name, cap):
         f"only {counts['MATCH']} golden matches on {gpu_name} (floor {MIN_MATCH[gpu_name]}) with no DRIFT — "
         "the twins likely re-keyed wholesale (tracer or ShapeKey classifier change), turning matches into GAPs."
     )
+
+
+def test_no_major_key_hides_in_the_generic_baseline():
+    """The warp-contraction hazard class may only be ratcheted through EXPECTED_MAJOR_GAPS —
+    a major key in the generic set would let a coverage loss ride a routine baseline edit,
+    which is exactly how the #446 fused-fork loss stayed green."""
+    for gpu_name, keys in EXPECTED_GAPS.items():
+        leaked = {k for k in keys if k.is_warp and k.reduce_max > 0}
+        assert not leaked, (
+            f"warp-contraction key(s) in EXPECTED_GAPS[{gpu_name}] — move them to EXPECTED_MAJOR_GAPS: {sorted(leaked, key=str)}"
+        )


### PR DESCRIPTION
Stacked on #449 (base branch `feature/gemma4-mtp-golden-coverage`) — two commits. Context: on main the
2026-08-02 5090 serving audit showed every fused twin family cold-resolving (114–1014x over the weight-streaming
floor, p2048/c8 chunk cell at TPOT ~2760 ms) while the drift gate stayed green; #449 closes the coverage, this PR
makes the gate class-aware so the loss can't ride a routine baseline edit again, and unblocks the re-record path
for the four keys #449 had to leave open.

## 1. Drift gate: warp-contraction gaps ratchet through their own `EXPECTED_MAJOR_GAPS` baseline

The #446 PLACE retirement uncovered all 18 fused serving forks and the gate stayed green because the keys were
appended to the generic `EXPECTED_GAPS` — indistinguishable in review from an aux-key edit. Now:

- `major_gap_keys` (warp forks with a real reduce — the misdeploy/hang class) ratchets against its own
  `EXPECTED_MAJOR_GAPS`, exact-match in both directions, with a failure message that says to close (seed a golden
  or a routing row) rather than list.
- Every entry carries a dated reason + a concrete burn-down condition; the 5090 set is exactly the four
  `mlp_down_fused` keys #449 documents, the 4090 set is the known deferred mirror re-tune, grouped by width.
- `test_no_major_key_hides_in_the_generic_baseline` keeps major keys out of `EXPECTED_GAPS` statically.

Verified off-GPU on #449 + current main: RTX 5090 audits MATCH 176 / DRIFT 0 with only the four down majors;
both card gates + the invariant test pass.

## 2. Placement routing: schedule-family pins are authoritative over recorded routing entries

#449's finding "the staged computed-A form no longer realizes in the isolated snippet (the tile-IR 1s window)"
turned out to be misattributed — bisect shows the pinned fused replay already fails at 0ffea99d (the commit that
*recorded* the m192/m256/dynM `.cut` routing rows) and realizes clean at its parent, while the 1s commits change
nothing: the snippet's computed-A cone still binds and offers `d1/sync` on current main. The actual bug:
`route_cut` consulted the recorded same-shape `.cut` ROUTING golden inside pinned compiles too (only `PLACE` pins
were authoritative), so a pinned `d*/sync` fused row silently compiled the cut's pieces and gated
`realized (off)`. Every fused golden replay was failing against its own recorded spelling as soon as a same-shape
`.cut` row landed — and #449's 14 new cut rows extend that lockout to every serving width.

Fix: `route_cut` skips the recorded routing entry whenever any schedule-family pin (TILE/STAGE/REDUCE/WORK/
RASTER/WSPEC; bare `EMMY_<KNOB>` var or `EMMY_KNOBS` aggregate key) is live — matching `Knob.narrow`'s rule that
pins out-rank every golden tier. Explicit `PLACE` pins keep full routing control; the unpinned deploy path is
untouched. New test `test_schedule_pin_suppresses_the_routing_entry` (fails without the fix). Bare schedule pins
apply compile-wide, so the suppression is compile-wide too — same scope as the pins themselves.

Consequence: fused rows bench honestly again — the third commit uses exactly that. The #449 findings-plan section on
the snippet realization loss should be read with this correction (also: at m192 the gate_up fused form is routed
away in-model as well — the in-model fused MATCH at that width comes from the down node, which has no legal cut
seam).

## 3. The four `mlp_down_fused` keys seeded — the 5090 major baseline is EMPTY

With the routing fix in place, the four remaining down keys (m8/m64/m2048/m4096) were tuned + benched on a
vast.ai 5090 (isolated `.lin` snippets, one shared cold DB/prior; `-O3` A/B vs eager): m8 105.4 µs (eager 100),
m64 133.5 (99.4), m2048 2066.0 (1190.2), m4096 3238.6 (2259.1). The wide widths trail eager on the std-lane
FP32-accumulate wall — honest pins, not wins (the unseeded fork cold-resolved ~100x off in serving). Two
record-time findings, both noted in the YAML block: m8/m64 record the `w1x8 f2x2/k4 g4k` spelling (the snippet
greedy's `w1x16`/`g*a` winners are not offered on the in-model geglu→down cone and audited DRIFT), and all four
dicts drop the snippet `record_knobs`' `REDUCE@a1: ''` stamp (a snippet-nest-only axis; the canonical-spelling
gate rejects the key and the axis-keyed pin made the split rows unmatchable in-model). Pinned replays on the
5090 reproduce the records within the noise band (m8 105.2, m2048 2100). `EXPECTED_MAJOR_GAPS` for the 5090 is
now `set()` — the in-model audit reads MATCH 184 / DRIFT 0 with `major_gap_keys` empty.

## Validation

- `make test`: full suite green (2814 passed, incl. the two audit-gate cards and the new routing test).
- `make lint`: clean.
- Off-GPU in-model audit (`emmy eval golden --in-model`): 5090 MATCH 184 / DRIFT 0 / `major_gap_keys` empty.
- On the 5090: pinned replays of the new rows reproduce the recorded µs; the greedy (unpinned) pick now resolves
  through them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
