### PR TITLE
Fix two #419 regressions breaking Qwen3-embed serving: flash-guard false positive + dtype-blind kernel names

### DIFF
--- a/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
@@ -295,14 +295,42 @@ def _is_flash_offer_shaped(op) -> bool:
     )
 
 
+def _accum_feed_names(op: LoopOp) -> set[str]:
+    """SSA names that transitively FEED an add-``Accum``'s value — the contraction's own
+    dataflow. A post-reduce epilogue operand (a residual add's other input, combined with the
+    finalized accumulator AFTER the reduce loop) never lands in this set."""
+    sources: dict[str, tuple[str, ...]] = {}
+    for s in op.body.iter():
+        if isinstance(s, Assign):
+            sources[s.name] = s.args
+        elif isinstance(s, Select):
+            sources[s.name] = tuple(b.value for b in s.branches)
+    feed: set[str] = set()
+    frontier = [s.value for s in op.body.iter() if isinstance(s, Accum) and s.op.reduce_canon == "add"]
+    while frontier:
+        nm = frontier.pop()
+        if nm in feed:
+            continue
+        feed.add(nm)
+        frontier.extend(sources.get(nm, ()))
+    return feed
+
+
 def _sum_contracts_exp_producer(graph: Graph, consumer: Node, producer: Node) -> bool:
-    """``consumer`` is a sum-contraction one of whose OTHER operands is (or is one producer hop
-    away from) an exp-bearing ``LoopOp`` — the P@V kernel before its softmax fuses in, at any
-    point of the softmax's own assembly. Once it does, the kernel is the flash offer site; a
-    compute producer fused into the V side in the meantime breaks the certification just as
-    surely, so it is deferred the same way. The softmax-side operand itself (``producer``) is
+    """``consumer`` is a sum-contraction one of whose OTHER contraction operands is (or is one
+    producer hop away from) an exp-bearing ``LoopOp`` — the P@V kernel before its softmax fuses
+    in, at any point of the softmax's own assembly. Once it does, the kernel is the flash offer
+    site; a compute producer fused into the V side in the meantime breaks the certification just
+    as surely, so it is deferred the same way. The softmax-side operand itself (``producer``) is
     exempt — that IS the softmax fusing in. A gelu chain feeding a contraction stays fuseable:
-    the gelu IS the producer there, so the other-input scan never sees its exp."""
+    the gelu IS the producer there, so the other-input scan never sees its exp.
+
+    Only operands whose loads feed the add-``Accum`` count (:func:`_accum_feed_names`): a
+    post-reduce EPILOGUE operand is not part of the contraction, so an exp upstream of it says
+    nothing about a future flash site. The residual stream is the load-bearing case — every
+    residual add past layer 0 sits within two producer hops of the previous layer's silu (its
+    sigmoid's exp) or softmax, and treating it as a V operand kept every o_proj product
+    materialized (a (b, s, k, n) gmem scratch per layer)."""
     op = consumer.op
     if not any(isinstance(s, Accum) and s.op.reduce_canon == "add" for s in op.body.iter()):
         return False
@@ -310,9 +338,12 @@ def _sum_contracts_exp_producer(graph: Graph, consumer: Node, producer: Node) ->
     def has_exp(node) -> bool:
         return isinstance(node.op, LoopOp) and any(isinstance(s, Assign) and s.op.name == "exp" for s in node.op.body.iter())
 
+    feed = _accum_feed_names(op)
     for inp in consumer.inputs:
         if inp == producer.id:
             continue
+        if not any(nm in feed for ld in op.body.loads if ld.input == inp for nm in ld.names):
+            continue  # post-reduce epilogue operand — not a contraction operand
         n = graph.producer(inp)
         if n is None or not isinstance(n.op, LoopOp):
             continue

--- a/emmy/compiler/pipeline/passes/loop/stamp/_stamp.py
+++ b/emmy/compiler/pipeline/passes/loop/stamp/_stamp.py
@@ -34,8 +34,18 @@ def name_for_loop(op: LoopOp, node: Node, graph: Graph) -> str:
     """The provenance-derived ``k_…`` kernel label ``010_stamp_loop_names``
     stamps onto ``op``, factored out so fragment builders name their LoopOps
     the same way. Threads the node id + per-node provenance + graph-wide
-    coverage totals into :func:`provenance.name_for`."""
-    return provenance.name_for(op, node.id, provenance.get(node), provenance.totals(graph))
+    coverage totals into :func:`provenance.name_for`, plus the io dtype
+    signature — the body carries no buffer decls, so without it two kernels
+    identical except for an operand/output dtype hash to the same name and the
+    plan's per-name kernel dedup hands one of them the other's code (an
+    f32-writing twin storing f16 bytes)."""
+
+    def _dt(buf: str) -> str:
+        t = graph.buffer(buf)
+        return str(t.dtype) if t is not None else "?"
+
+    dtype_sig = ",".join(_dt(ld.input) for ld in op.body.loads) + "->" + ",".join(_dt(w.output) for w in op.body.writes)
+    return provenance.name_for(op, node.id, provenance.get(node), provenance.totals(graph), dtype_sig=dtype_sig)
 
 
 # ---------------------------------------------------------------------------

--- a/emmy/compiler/provenance.py
+++ b/emmy/compiler/provenance.py
@@ -206,7 +206,7 @@ def _dedup_tokens(name: str) -> str:
     return "_".join(out) if out else name
 
 
-def name_for(loop: LoopOp, base_name: str, node_prov: dict, all_totals: dict[str, set[str]]) -> str:
+def name_for(loop: LoopOp, base_name: str, node_prov: dict, all_totals: dict[str, set[str]], dtype_sig: str = "") -> str:
     """Name the kernel after the original ops it implements (op provenance).
 
     A kernel that fully realizes exactly one meaningful op gets ``k_<op>_<h>``
@@ -243,9 +243,11 @@ def name_for(loop: LoopOp, base_name: str, node_prov: dict, all_totals: dict[str
         if lbl not in labels:
             labels.append(lbl)
     joined = _dedup_tokens("_".join(labels))
-    # ``structural_key`` is a pretty-printed body string; hash it to a short
-    # alphanumeric token (valid in a C identifier; identical bodies → same token).
-    h = hashlib.sha1(loop.body.structural_key().encode()).hexdigest()[:6]
+    # ``structural_key`` is a pretty-printed body string; hash it (with the caller's io
+    # ``dtype_sig`` — buffer decls are outside the body, and two kernels identical except an
+    # operand/output dtype must NOT share a name) to a short alphanumeric token (valid in a C
+    # identifier; identical bodies + dtypes → same token).
+    h = hashlib.sha1((loop.body.structural_key() + "|" + dtype_sig).encode()).hexdigest()[:6]
     cov = coverage(node_prov, all_totals)
     if len(meaningful) == 1 and cov[meaningful[0]][2]:  # single op, fully covered
         return f"k_{joined}_{h}"

--- a/tests/compiler/passes/test_fusion_rules.py
+++ b/tests/compiler/passes/test_fusion_rules.py
@@ -766,3 +766,186 @@ def test_output_reshape_folds_into_reduce_producer():
     before = _run(make_graph(), {"x": x})
     after = _run(fused, {"x": x})
     _assert_close(before, after)
+
+
+# ===================================================================
+# Flash P@V deferral vs residual epilogue: the contraction halves must
+# reunite past an exp-bearing residual stream
+# ===================================================================
+
+
+def _loops2(inner, ax0, ext0, ax1, ext1):
+    from emmy.compiler.dim import Dim
+    from emmy.compiler.ir.axis import Axis
+    from emmy.compiler.ir.loop import Loop
+    from emmy.compiler.ir.stmt import Body
+
+    return Body((Loop(axis=Axis(name=ax0, extent=Dim(ext0)), body=Body((Loop(axis=Axis(name=ax1, extent=Dim(ext1)), body=inner),))),))
+
+
+def _make_pending_product_into_exp_residual_add():
+    """The mid-fusion state the engine reaches on every transformer layer past the first: the
+    decomposed o_proj's sum-reduce already merged into the residual add (which also reads the
+    residual stream ``res``), the bare product ``ew`` still materialized, and ``res`` one
+    producer hop from an exp (the previous layer's silu sigmoid / softmax). The product must
+    still merge into the add's reduce — the flash P@V deferral must not mistake the post-reduce
+    residual operand for a V operand (it kept every o_proj product materialized: a (b, s, k, n)
+    gmem scratch per layer, 17 GB at S=4096 on the Qwen3 embed trunk)."""
+    from emmy.compiler.dim import Dim
+    from emmy.compiler.ir.axis import Axis
+    from emmy.compiler.ir.expr import Var
+    from emmy.compiler.ir.loop import Load, Loop
+    from emmy.compiler.ir.stmt import Body
+
+    S, K, N = 4, 8, 6
+    a0, a1, a2 = Var("a0"), Var("a1"), Var("a2")
+
+    ew_cell = Body(
+        (
+            Loop(
+                axis=Axis(name="a2", extent=Dim(N)),
+                body=Body(
+                    (
+                        Load(name="i0", input="act", index=(a0, a1)),
+                        Load(name="i1", input="w", index=(a2, a1)),
+                        Assign(name="v0", op="multiply", args=("i0", "i1")),
+                        Write(output="ew", index=(a0, a1, a2), value="v0"),
+                    )
+                ),
+            ),
+        )
+    )
+    ew = LoopOp(body=_loops2(ew_cell, "a0", S, "a1", K))
+
+    exp_cell = Body(
+        (
+            Load(name="c0", input="r", index=(a0, a1)),
+            Assign(name="c1", op="exp", args=("c0",)),
+            Write(output="e", index=(a0, a1), value="c1"),
+        )
+    )
+    e = LoopOp(body=_loops2(exp_cell, "a0", S, "a1", N))
+    res_cell = Body(
+        (
+            Load(name="d0", input="r", index=(a0, a1)),
+            Load(name="d1", input="e", index=(a0, a1)),
+            Assign(name="d2", op="add", args=("d0", "d1")),
+            Write(output="res", index=(a0, a1), value="d2"),
+        )
+    )
+    res = LoopOp(body=_loops2(res_cell, "a0", S, "a1", N))
+
+    add_cell = Body(
+        (
+            Loop(
+                axis=Axis(name="a2", extent=Dim(K)),
+                body=Body(
+                    (
+                        Load(name="in0", input="ew", index=(a0, a2, a1)),
+                        Accum(name="acc0", value="in0", op="add", axes=("a2",)),
+                    )
+                ),
+            ),
+            Load(name="in1", input="res", index=(a0, a1)),
+            Assign(name="v1", op="add", args=("acc0", "in1")),
+            Write(output="y", index=(a0, a1), value="v1"),
+        )
+    )
+    add13 = LoopOp(body=_loops2(add_cell, "a0", S, "a1", N))
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("act", (S, K)), node_id="act")
+    g.add_node(InputOp(), [], Tensor("w", (N, K)), node_id="w")
+    g.add_node(InputOp(), [], Tensor("r", (S, N)), node_id="r")
+    g.add_node(ew, ["act", "w"], Tensor("ew", (S, K, N)), node_id="ew")
+    g.add_node(e, ["r"], Tensor("e", (S, N)), node_id="e")
+    g.add_node(res, ["r", "e"], Tensor("res", (S, N)), node_id="res")
+    g.add_node(add13, ["ew", "res"], Tensor("y", (S, N)), node_id="y")
+    # ``res`` doubles as a graph output — the residual stream has other readers in the real
+    # model, so the exp-bearing chain can never be absorbed into the consumer and the guard
+    # decides the product's fate alone.
+    g.inputs, g.outputs = ["act", "w", "r"], ["y", "res"]
+    return g
+
+
+def test_pending_product_reunites_past_exp_residual():
+    fused = Pipeline.build(["loop/fusion"]).run(_make_pending_product_into_exp_residual_add())
+    bare = [n.id for n in _kernel_nodes(fused) if not _has_update(n.op.body) and len(n.output.shape) > 2]
+    assert bare == [], f"bare product left materialized: {bare}"
+
+
+def test_pending_product_exp_residual_correctness():
+    act = rng.standard_normal((4, 8)).astype(np.float32)
+    w = rng.standard_normal((6, 8)).astype(np.float32)
+    r = rng.standard_normal((4, 6)).astype(np.float32)
+    _assert_correctness(_make_pending_product_into_exp_residual_add, {"act": act, "w": w, "r": r})
+
+
+def test_exp_residual_epilogue_is_not_a_flash_site():
+    """Guard-level twin of the fixpoint test: the residual operand rides the post-reduce
+    epilogue, so its upstream exp must not classify the consumer as a future P@V site."""
+    import importlib
+
+    mod = importlib.import_module("emmy.compiler.pipeline.passes.loop.fusion.010_merge_loop_ops")
+    g = _make_pending_product_into_exp_residual_add()
+    assert mod._sum_contracts_exp_producer(g, g.nodes["y"], g.nodes["ew"]) is False
+
+
+def test_pv_mid_assembly_still_deferred():
+    """The flash deferral's true positive survives the epilogue exemption: a sum-contraction
+    whose exp-adjacent operand feeds the accumulate (P@V with its softmax mid-assembly) still
+    defers the V-side compute producer."""
+    import importlib
+
+    from emmy.compiler.dim import Dim
+    from emmy.compiler.ir.axis import Axis
+    from emmy.compiler.ir.expr import Var
+    from emmy.compiler.ir.loop import Load, Loop
+    from emmy.compiler.ir.stmt import Body
+
+    S, K, N = 4, 8, 6
+    a0, a1, a2 = Var("a0"), Var("a1"), Var("a2")
+
+    exp_cell = Body(
+        (
+            Load(name="s0", input="scores", index=(a0, a1)),
+            Assign(name="s1", op="exp", args=("s0",)),
+            Write(output="pw", index=(a0, a1), value="s1"),
+        )
+    )
+    softmax_piece = LoopOp(body=_loops2(exp_cell, "a0", S, "a1", K))
+    vprod_cell = Body(
+        (
+            Load(name="t0", input="vin", index=(a0, a1)),
+            Assign(name="t1", op="multiply", args=("t0", "t0")),
+            Write(output="vbuf", index=(a0, a1), value="t1"),
+        )
+    )
+    vprod = LoopOp(body=_loops2(vprod_cell, "a0", K, "a1", N))
+    pv_cell = Body(
+        (
+            Loop(
+                axis=Axis(name="a2", extent=Dim(K)),
+                body=Body(
+                    (
+                        Load(name="p0", input="pw", index=(a0, a2)),
+                        Load(name="q0", input="vbuf", index=(a2, a1)),
+                        Assign(name="m0", op="multiply", args=("p0", "q0")),
+                        Accum(name="acc0", value="m0", op="add", axes=("a2",)),
+                    )
+                ),
+            ),
+            Write(output="y", index=(a0, a1), value="acc0"),
+        )
+    )
+    pv = LoopOp(body=_loops2(pv_cell, "a0", S, "a1", N))
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("scores", (S, K)), node_id="scores")
+    g.add_node(InputOp(), [], Tensor("vin", (K, N)), node_id="vin")
+    g.add_node(softmax_piece, ["scores"], Tensor("pw", (S, K)), node_id="pw")
+    g.add_node(vprod, ["vin"], Tensor("vbuf", (K, N)), node_id="vbuf")
+    g.add_node(pv, ["pw", "vbuf"], Tensor("y", (S, N)), node_id="y")
+    g.inputs, g.outputs = ["scores", "vin"], ["y"]
+    mod = importlib.import_module("emmy.compiler.pipeline.passes.loop.fusion.010_merge_loop_ops")
+    assert mod._sum_contracts_exp_producer(g, g.nodes["y"], g.nodes["vbuf"]) is True

--- a/tests/compiler/passes/test_loop_naming.py
+++ b/tests/compiler/passes/test_loop_naming.py
@@ -225,3 +225,36 @@ def test_name_for_dedups_repeated_labels():
     # collapses adjacent duplicates so it stays a single ``rms_norm``.
     assert "rms_norm_rms_norm" not in name
     assert name.startswith("k_rms_norm_")
+
+
+def test_name_for_hash_covers_io_dtypes():
+    """Two kernels with identical bodies but a different io ``dtype_sig`` must not share a
+    name: the body carries no buffer decls, and ``plan_from_graph`` dedups kernels per name
+    (first source wins) — an aliased name hands the f32-writing twin the f16 cubin (the
+    last-layer down_proj+residual fused into the final norm's f32 cast wrote f16 bytes into
+    the f32 buffer, garbage embeddings)."""
+    loop = _pointwise_loop()
+    prov_map = {"rms_norm_0": {"kind": "RmsNormOp", "pieces": ["o"]}}
+    totals = {"rms_norm_0": {"o"}}
+    n16 = prov.name_for(loop, "o", prov_map, totals, dtype_sig="f16->f16")
+    n32 = prov.name_for(loop, "o", prov_map, totals, dtype_sig="f16->f32")
+    assert n16 != n32
+    assert n16.startswith("k_rms_norm_") and n32.startswith("k_rms_norm_")
+
+
+def test_name_for_loop_threads_output_dtype_into_name():
+    """``name_for_loop`` reads the io dtypes off the graph decls: the same LoopOp body writing
+    an f16 vs an f32 buffer names apart even when node ids and provenance agree."""
+    from emmy.compiler.pipeline.passes.loop.stamp._stamp import name_for_loop
+
+    def make(out_dtype: str) -> tuple:
+        g = Graph()
+        g.add_node(InputOp(), [], Tensor("x", (4, 8), "f16"), node_id="x")
+        g.add_node(_pointwise_loop(), ["x"], Tensor("o", (4, 8), out_dtype), node_id="o")
+        g.inputs, g.outputs = ["x"], ["o"]
+        prov.seed(g)
+        return g, g.nodes["o"]
+
+    g16, n16 = make("f16")
+    g32, n32 = make("f32")
+    assert name_for_loop(n16.op, n16, g16) != name_for_loop(n32.op, n32, g32)


### PR DESCRIPTION
Both regressions bisect to 2e323599 (#419) and together broke the embedding plugin end to end: a 17.2 GB scratch OOM at engine boot on ≤16 GB cards, and silently garbage embeddings on cards where the slab fit. Diagnosed on the local RTX 4080 via `tests/serving/test_vllm_plugin_gpu.py::test_vllm_plugin_embed_matches_hf_eager`.

## Bug 1 — flash P@V deferral false positive materializes every o_proj product

`010_merge_loop_ops`'s `_sum_contracts_exp_producer` scanned **every** other operand of a sum-contraction for an exp within one producer hop. A residual add whose reduce half already merged in sits within two hops of the previous layer's silu sigmoid (or softmax), so the guard classified every o_proj residual add past layer 0 as a "future flash P@V offer site" and refused the product/reduce halves-merge — the decomposed product stayed materialized as a `(b, s, k, n)` f16 gmem scratch per layer (17.2 GB at S=4096 on the Qwen3-Embedding-0.6B trunk). Layer 0 escaped only because its residual is the embedding.

Fix: only operands whose loads feed the add-`Accum` (a backward dataflow closure, `_accum_feed_names`) get the exp scan; post-reduce epilogue operands are exempt. The true positive — P@V with its softmax mid-assembly, where the exp-adjacent operand feeds the accumulate — still defers (covered by a new test).

## Bug 2 — kernel names blind to buffer dtypes alias f16/f32 twins

`provenance.name_for`'s 6-hex suffix hashed only `body.structural_key()`, which carries no buffer decls. With bug 1 fixed (and pre-fix at smaller S), the last layer's down_proj+residual fuses into the final norm's **f32** cast — algebraically identical to the per-layer **f16** `add_NN` twin — so both hashed to one name, and `plan_from_graph`'s per-name kernel dedup ("first source wins", a debug-level log) handed the f32 node the f16 cubin. The buffer then held f16 byte pairs read as f32: layers 0–26 bit-perfect, final layer garbage (reinterpreting the buffer as contiguous f16 gives cosine +1.0000 vs torch).

Fix: `name_for_loop` threads an io dtype signature from the graph decls into the name hash, restoring the documented contract that distinct kernels never share a name. All kernel-name hash suffixes change, so the cubin cache recompiles once; goldens and the tune DB are keyed by row spelling / op digest, not names, and are unaffected.

## Validation

- `test_vllm_plugin_embed_matches_hf_eager` passes again on the RTX 4080 (was: cupy OOM allocating 17,205,035,008 bytes)
- Runner probe vs HF eager at S=256: last-token cosine 0.99999 (was 0.00)
- Full suite: 2824 passed, 159 skipped; attention/flash e2e coverage green; lint clean
- New regression tests: fixpoint + guard-level (fail pre-fix) in `test_fusion_rules.py`, dtype-naming in `test_loop_naming.py`

Also worth noting for a follow-up: the same collision class exists in `op_cache_key` (term/knob keys carry no output dtype), which can conflate f16/f32 twins' tune-DB evidence — a perf-evidence issue, not correctness, left out of this PR to avoid invalidating existing DB keyings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)