### PR TITLE
Fix NameError when reloading a kernel-stage dump

### DIFF
--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -297,7 +297,7 @@ def _stmt_eval_scope() -> dict:
 
     from emmy.compiler.dim import Dim
     from emmy.compiler.dtype import DataType
-    from emmy.compiler.ir.axis import Axis, AxisRole
+    from emmy.compiler.ir.axis import Axis, AxisRole, Window
     from emmy.compiler.ir.elementwise import ElementwiseImpl
     from emmy.compiler.ir.expr import (
         BinaryExpr,
@@ -349,6 +349,9 @@ def _stmt_eval_scope() -> dict:
         "StridedLoop": StridedLoop,
         "Cond": Cond,
         "AxisRole": AxisRole,
+        # ``repr(Axis)`` spells its ``window`` field in full, so every kernel-stage dump whose
+        # axes were shrunk (register tiling, cross-CTA reduce slices) carries ``Window(...)``.
+        "Window": Window,
         "StateMerge": StateMerge,
         "Smem": Smem,
         "Sync": Sync,
@@ -375,12 +378,13 @@ def _stmt_eval_scope() -> dict:
     # back. Auto-populate every public class from these modules (``setdefault`` so the
     # explicit stmt/expr entries above win on any name clash) — a new node/knob field
     # needs no edit here.
+    import emmy.compiler.ir.axis as _axis_mod  # noqa: PLC0415
     import emmy.compiler.ir.cuda.ir as _cuda_mod  # noqa: PLC0415
     import emmy.compiler.ir.kernel.ir as _kernel_mod  # noqa: PLC0415
     import emmy.compiler.ir.schedule as _sched_mod  # noqa: PLC0415
     import emmy.compiler.ir.tile.ir as _tile_mod  # noqa: PLC0415
 
-    for _mod in (_sched_mod, _tile_mod, _kernel_mod, _cuda_mod):
+    for _mod in (_axis_mod, _sched_mod, _tile_mod, _kernel_mod, _cuda_mod):
         for _nm in dir(_mod):
             _obj = getattr(_mod, _nm)
             if isinstance(_obj, type):

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -293,6 +293,8 @@ def _stmt_eval_scope() -> dict:
     global _STMT_EVAL_SCOPE
     if _STMT_EVAL_SCOPE is not None:
         return _STMT_EVAL_SCOPE
+    import math as _math
+
     import numpy as _np
 
     from emmy.compiler.dim import Dim
@@ -363,6 +365,10 @@ def _stmt_eval_scope() -> dict:
         # ``repr(np.dtype('float32'))`` is ``dtype('float32')`` — eval needs
         # ``dtype`` in scope to round-trip ``DataType.np``.
         "dtype": _np.dtype,
+        # ``repr(float('-inf'))`` is ``-inf`` — the online-softmax ``Fold.init`` running max, and
+        # any other non-finite literal, needs the bare names in scope to round-trip.
+        "inf": _math.inf,
+        "nan": _math.nan,
         # A dumped ``lift`` lambda is strict for every recognized term (the root stores left
         # for ``TileOp.stores`` at 1q); the raw-loop-IR kernels (escape cells, 030 finalizes)
         # rebuild through the same ``_loop_ir_fn`` arm ``Fold.projection`` uses.

--- a/tests/compiler/ir/test_graph.py
+++ b/tests/compiler/ir/test_graph.py
@@ -152,6 +152,39 @@ def test_cuda_op_tma_descriptors_roundtrip():
     assert descs[0].src_buf == "k" and descs[0].box_extents == (1, 1, 64, 64) and descs[0].swizzle == "B128"
 
 
+def test_kernel_op_windowed_axis_roundtrip():
+    """A dumped kernel-stage graph must rehydrate a ``Tile`` whose axes carry a ``Window``.
+
+    ``repr(Axis)`` spells the ``window`` field in full, so every register-tiled or cross-CTA-split
+    kernel dumps ``Window(parent=Axis(...), base=..., bound=...)`` inside ``KernelOp.body``.
+    ``Window`` lives in ``ir/axis.py``, which the eval scope's auto-populate loop did not cover, so
+    ``Graph.from_dict`` on ``07_lowering_kernel.json`` raised ``NameError: name 'Window' is not
+    defined`` — and with it every ``emmy run --ir <kernel.json>``."""
+    import json
+
+    from emmy.compiler.ir.axis import Axis, Window
+    from emmy.compiler.ir.kernel.ir import KernelOp, Smem, Tile
+
+    parent = Axis(name="a0", extent=512)
+    body = Tile(
+        axes=(Axis(name="a0_b", extent=8, window=Window(parent=parent)),),
+        body=(Smem(name="_a_smem", extents=(128, 32), dtype="__half"),),
+        block_threads=256,
+    )
+    g = Graph()
+    x = g.add_node(op=InputOp(), inputs=[], output=Tensor("x", (512, 4096), "f16"), node_id="x")
+    g.add_node(op=KernelOp(body=(body,), name="k_x"), inputs=[x], output=Tensor("out", (512, 4096), "f16"), node_id="out")
+    g.inputs, g.outputs = [x], ["out"]
+
+    loaded = Graph.from_dict(json.loads(json.dumps(g.to_dict(), default=str)))  # the EMMY_DUMP_DIR disk round-trip
+    op = loaded.nodes["out"].op
+    assert isinstance(op, KernelOp), f"expected KernelOp, got {op!r}"
+    (tile,) = op.body
+    assert isinstance(tile.axes[0].window, Window), f"expected a rehydrated Window, got {tile.axes[0].window!r}"
+    assert tile.axes[0].source_axis.name == "a0"
+    assert op.smem_bytes() == 128 * 32 * 2
+
+
 def test_to_dict_serializes_composite_shape_dim():
     """A node whose output shape carries a COMPOSITE Dim (``BinaryExpr``-backed —
     e.g. the demoted symbolic-N B operand's TMA-padded ``round_up(seq_len, 64)``

--- a/tests/compiler/ir/test_graph.py
+++ b/tests/compiler/ir/test_graph.py
@@ -185,6 +185,18 @@ def test_kernel_op_windowed_axis_roundtrip():
     assert op.smem_bytes() == 128 * 32 * 2
 
 
+def test_stmt_eval_scope_reads_non_finite_literals():
+    """``repr(float('-inf'))`` is the bare token ``-inf``, which does not eval without a name.
+
+    The online-softmax ``Fold.init`` running max dumps ``init=(-inf, 0.0, 0.0)``, so every flash
+    tile-stage dump raised ``NameError: name 'inf' is not defined`` on reload."""
+    from emmy.compiler.graph import _stmt_eval_scope
+
+    scope = _stmt_eval_scope()
+    assert eval("(-inf, 0.0, 0.0)", dict(scope)) == (float("-inf"), 0.0, 0.0)
+    assert eval("nan", dict(scope)) != eval("nan", dict(scope))  # NaN is not equal to itself
+
+
 def test_to_dict_serializes_composite_shape_dim():
     """A node whose output shape carries a COMPOSITE Dim (``BinaryExpr``-backed —
     e.g. the demoted symbolic-N B operand's TMA-padded ``round_up(seq_len, 64)``


### PR DESCRIPTION
`Graph.from_dict()` raises `NameError` on kernel-stage dumps, so a dumped graph cannot be read back in.

Two independent gaps in `_stmt_eval_scope()`, both the same shape — a `repr()` produces a token the eval scope does not name:

- **`Window`.** `repr(Axis)` spells its `window` field in full, so every dump whose axes were shrunk — register tiling, cross-CTA reduce slices — carries `Window(...)`. `ir/axis.py` sits outside the auto-populate loop, so only `Axis` and `AxisRole` were imported.
  ```
  NameError: name 'Window' is not defined
  ```
- **`inf` / `nan`.** `repr(float('-inf'))` is the bare token `-inf`. The online-softmax `Fold.init` running max carries one, so *every* flash tile-stage dump fails, one stage earlier than the above.
  ```
  NameError: name 'inf' is not defined
  ```

## Changes

- `Window` added explicitly, and `emmy.compiler.ir.axis` added to the auto-populate loop so a future axis type needs no edit here.
- `inf` / `nan` bound from `math`.
- A regression test per fix; each fails without its change.

Both are additive to the eval scope — no behaviour changes for graphs that already round-tripped.

## Verification

`tests/compiler/ir`: **506 passed, 13 skipped**.

Reloading all six kernel-stage dumps used by an external consumer now succeeds, and every realized value — grid, block, warps, `smem_bytes`, arithmetic intensity — is unchanged from before the fix, so nothing downstream moves.