### PR TITLE
pack: fix the env-digest import — record the landed FAST_MATH family

### DIFF
--- a/emmy/compiler/backend/pack.py
+++ b/emmy/compiler/backend/pack.py
@@ -59,8 +59,8 @@ def _environment() -> dict:
     from emmy.compiler.backend.cuda import nvcc  # noqa: PLC0415
     from emmy.compiler.pipeline.search.space import (  # noqa: PLC0415
         F16_MMA_F32_ACC,
-        F16_REDUCE_F32_ACC,
         FAST_EXP,
+        FP8_MMA,
         precision_pin,
     )
 
@@ -69,7 +69,7 @@ def _environment() -> dict:
         "arch": nvcc.device_arch(False),
         "toolkit": nvcc._toolkit_tag(),
         "nvcc_flags": nvcc.effective_flags(),
-        "precision": {k.name: precision_pin(k) for k in (FAST_EXP, F16_MMA_F32_ACC, F16_REDUCE_F32_ACC)},
+        "precision": {k.name: precision_pin(k) for k in (FAST_EXP, F16_MMA_F32_ACC, FP8_MMA)},
     }
 
 


### PR DESCRIPTION
## Summary

PR #478 added `F16_REDUCE_F32_ACC` to `pack._environment()`'s precision record, but that knob never landed on main — the precision-trading family is `FAST_EXP`, `F16_MMA_F32_ACC`, `FP8_MMA`. Since 2026-08-09 any serving boot with `EMMY_PACK_DIR` set crashes with an `ImportError` before compiling anything (found live on a rented 5090 during the gemma-4 re-baseline).

This records `FP8_MMA` instead: it gates fork enumeration exactly like the other family members, so it belongs in the pack validity key. Existing packs keyed with the old field set fall back to a full compile, which is the documented conservative reading.

## Validation

- `tests/compiler/backend/test_pack_gpu.py` (4 tests, RTX 4080): pass — `test_pack_round_trip_runs_identically` calls `pack_path` and reproduces the ImportError before the fix
- `make lint`: clean on the touched file
- Full `make test` on this box has pre-existing failures unrelated to this change (Laguna/GLM tests from #477–#479 require a newer transformers than the locally pinned 5.12.1; verified identical failures on unmodified main via stash-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)