### PR TITLE
fusion: restore the multi-load-of-reducer refusal — close the #482 gemma MLP offer drift

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -221,15 +221,14 @@ How to comply:
 - **When generalizing an existing rule, normalize its incidental divergences** (one dtype rule, one index rule)
   and name the behavioral deltas explicitly in the commit — don't preserve two behaviors behind one entry point.
 
-Loop fusion's profitability guard follows the same structural rule. `loop/fusion/010_merge_loop_ops` counts aggregate
-arithmetic and reads, and separately counts transcendental executions. The separate count prevents an expensive
-pointwise producer such as GELU's `tanh`, originally evaluated once per `(M,K)` element, from moving under a
-contraction's `N` loop merely because the contraction's much larger cheap-FMA count hides that duplication. Flash
-attention is the structural exception: a merged softmax-then-P@V offer deliberately streams `exp(score)` without
-materializing the probability matrix, so the tile recognizer owns that composite and the generic transcendental
-brake does not split it. The automatic brake is also limited to unary/single-source activation cones. A multi-source
-gated activation such as GeGLU/SwiGLU remains an evidence-controlled placement choice, preserving its GPU golden
-coverage until that entire cone has been measured.
+Loop fusion's materialization policy follows the same structural rule. `loop/fusion/010_merge_loop_ops` keeps two
+guards: the aggregate compute cap (a merge is refused when summed leaf work grows more than 8× over the region's
+own) and the multi-load-of-reducer refusal (a reduce-heavy producer read through more than one `Load` across the
+rest of the region stays materialized — splicing it would re-execute its reduce per demand site, the boundary that
+keeps a fused normalized-linear/MLP cone realizing its recorded goldens). Flash attention is the structural
+exception: a rowmax-bearing sink may swallow its score producer, because the tile recognizer owns that
+softmax-then-P@V composite and re-synthesizes it without the duplication. Every other historical merge gate is
+gone; those boundaries are placement decisions now.
 
 ## Resolve the hardware-atom binding once, structurally, at the tile level
 

--- a/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
@@ -8,10 +8,16 @@ scope/coordinate demand; no frontend treeification is needed. The splicer also
 handles multiple consumer loads and shared external inputs uniformly
 (first-seen slot assignment + splice-edge routing).
 
-The only materialization-policy guard is aggregate compute growth:
+Two materialization-policy guards remain. Aggregate compute growth:
 ``_total_work`` sums the enclosing free×reduce iteration count of every compute
-leaf, and a merge is refused when that grows by more than
-``_BLOWUP_FACTOR``. Structural region ownership, a real splicer rejection,
+leaf, and a merge is refused when that grows by more than ``_BLOWUP_FACTOR``.
+And the multi-load-of-reducer refusal: a reduce-heavy producer read through
+more than one ``Load`` across the rest of the region stays materialized —
+splicing it re-executes its reduce per demand site, which the work ratio only
+sees when the producer is large relative to the consumer; the refusal catches
+it structurally. A rowmax-bearing sink is exempt: the softmax assembly
+swallowing its score producer is a fused root flash recognition accepts and
+re-synthesizes without the duplication. Structural region ownership, a real splicer rejection,
 and the fence around an already-realized ``__cut_`` workspace remain
 invariants rather than candidate-selection gates.
 
@@ -64,6 +70,51 @@ def _total_work(loop_op: LoopOp) -> int:
     return sum(cost for stmt, cost in _walk_leaf_costs(loop_op) if isinstance(stmt, (Assign, Accum))) or 1
 
 
+# Producers with more than a handful of operations per output element are
+# "reduce-heavy": their output at position p requires non-trivial compute,
+# typically a reduce whose body depends on p. Splicing such a producer at
+# several demand sites re-executes that reduce per site. Pure-elementwise
+# chains sit at roughly 1–3 operations per output and softmax's max + exp at
+# roughly 3, while a contraction sits at its reduce extent; a threshold of 4
+# separates the regimes.
+_REDUCE_HEAVY_WORK_PER_OUTPUT = 4
+
+
+def _output_numel(loop_op: LoopOp) -> int:
+    reduce_names = loop_op.reduce_axis_names
+    numel = 1
+    for axis in loop_op.axes:
+        if axis.name not in reduce_names:
+            numel *= axis.extent.as_static() if axis.extent.is_static else 128
+    return numel
+
+
+def _has_rowmax(loop_op: LoopOp) -> bool:
+    """A ``maximum`` Accum — softmax's rowmax signature."""
+    return any(isinstance(stmt, Accum) and stmt.op.reduce_canon == "maximum" for stmt in loop_op.body.iter())
+
+
+def _reduce_heavy(loop_op: LoopOp) -> bool:
+    """More than ``_REDUCE_HEAVY_WORK_PER_OUTPUT`` operations per output element.
+
+    A softmax assembly (rowmax-bearing body) discounts its ``add`` Assigns:
+    they are the score's mask applications — one predicate-add per mask, not
+    real duplicated compute. Without the discount a multi-mask score (a
+    stamped sliding-window SDPA carries up to three) pushes the cheap
+    max + exp reducer past the threshold and the softmax cone never assembles
+    onto its P@V offer site.
+    """
+    work = _total_work(loop_op)
+    if _has_rowmax(loop_op):
+        work -= sum(cost for stmt, cost in _walk_leaf_costs(loop_op) if isinstance(stmt, Assign) and stmt.op.name == "add")
+    return work > _REDUCE_HEAVY_WORK_PER_OUTPUT * _output_numel(loop_op)
+
+
+def _region_loads_from(graph: Graph, region: set[str], producer_id: str) -> int:
+    """Number of ``Load`` stmts across the other region members reading ``producer_id``'s buffer."""
+    return sum(1 for node_id in region - {producer_id} for load in graph.nodes[node_id].op.body.loads if load.input == producer_id)
+
+
 PATTERN = [Pattern("producer", LoopOp)]
 # Region discovery is dynamic. Watching immediate consumers preserves overlap
 # invalidation when matches are enumerated in batches.
@@ -71,10 +122,18 @@ WATCH_CONSUMERS = True
 
 
 def _merge_region(match: Match, region: set[str], sink: Node) -> Graph:
-    """Splice an owned one- or multi-consumer region, capped only by compute growth."""
+    """Splice an owned one- or multi-consumer region; refuse reduce duplication and compute growth."""
     graph = match.graph
-    if any("__cut_" in node_id for node_id in region - {sink.id}):
+    interior = region - {sink.id}
+    if any("__cut_" in node_id for node_id in interior):
         raise RuleSkipped("region crosses a decided placement cut")
+    # A rowmax-bearing sink is exempt: a softmax assembly's repeated reads are its
+    # two-pass max+exp sweep over the one score it swallows, and flash recognition
+    # accepts that fused root and re-synthesizes the unit without the duplication.
+    if not _has_rowmax(sink.op):
+        for node_id in interior:
+            if _reduce_heavy(graph.nodes[node_id].op) and _region_loads_from(graph, region, node_id) > 1:
+                raise RuleSkipped("reduce-heavy producer read through >1 Load — fusion would duplicate the reduce")
 
     merged = _build_merged_region(graph, region, sink)
     if merged is None:

--- a/tests/compiler/passes/test_fusion_rules.py
+++ b/tests/compiler/passes/test_fusion_rules.py
@@ -1004,3 +1004,80 @@ def test_pending_product_exp_residual_correctness():
     w = rng.standard_normal((6, 8)).astype(np.float32)
     r = rng.standard_normal((4, 6)).astype(np.float32)
     _assert_correctness(_make_pending_product_into_exp_residual_add, {"act": act, "w": w, "r": r})
+
+
+# ===================================================================
+# Multi-load-of-reducer refusal: a reduce-heavy producer read through
+# more than one Load stays materialized
+# ===================================================================
+
+
+def _make_rowstat_scale_into_two_slot_mul():
+    """A reduce-heavy producer read twice at different coordinates.
+
+    Producer: an RMSNorm-shaped per-row normalize (squares under the row
+    reduce, a multi-op sweep — above ``_REDUCE_HEAVY_WORK_PER_OUTPUT``).
+    Consumer: ``z[m, j] = y[m, j] * y[m, j + N/2]`` — two Loads of ``y`` at
+    coordinates the load dedup can never unify. Splicing the producer would
+    re-execute its row reduce per load site (the gemma-4 normalized-linear/MLP
+    cone drift: the RMSNorm inlined into both the gate and up contractions)."""
+    from emmy.compiler.dim import Dim
+    from emmy.compiler.ir.axis import Axis
+    from emmy.compiler.ir.expr import BinaryExpr, Var
+    from emmy.compiler.ir.loop import Load, Loop
+    from emmy.compiler.ir.stmt import Body
+
+    M, N = 4, 8
+    a0 = Var("a0")
+    red = Loop(
+        axis=Axis(name="a2", extent=Dim(N)),
+        body=Body(
+            (
+                Load(name="r0", input="x", index=(a0, Var("a2"))),
+                Assign(name="sq", op="multiply", args=("r0", "r0")),
+                Accum(name="acc", value="sq", op="add", axes=("a2",)),
+            )
+        ),
+    )
+    sweep = Loop(
+        axis=Axis(name="a1", extent=Dim(N)),
+        body=Body(
+            (
+                Load(name="s0", input="x", index=(a0, Var("a1"))),
+                Assign(name="v0", op="multiply", args=("s0", "acc")),
+                Assign(name="v1", op="multiply", args=("v0", "s0")),
+                Assign(name="v2", op="multiply", args=("v1", "s0")),
+                Write(output="y", index=(a0, Var("a1")), value="v2"),
+            )
+        ),
+    )
+    producer = LoopOp(body=Body((Loop(axis=Axis(name="a0", extent=Dim(M)), body=Body((red, sweep))),)))
+
+    b0, b1 = Var("b0"), Var("b1")
+    consumer_cell = Body(
+        (
+            Load(name="c0", input="y", index=(b0, b1)),
+            Load(name="c1", input="y", index=(b0, BinaryExpr("+", b1, Literal(N // 2, "int")))),
+            Assign(name="m0", op="multiply", args=("c0", "c1")),
+            Write(output="z", index=(b0, b1), value="m0"),
+        )
+    )
+    consumer = LoopOp(body=_loops2(consumer_cell, "b0", M, "b1", N // 2))
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (M, N)), node_id="x")
+    g.add_node(producer, ["x"], Tensor("y", (M, N)), node_id="y")
+    g.add_node(consumer, ["y"], Tensor("z", (M, N // 2)), node_id="z")
+    g.inputs, g.outputs = ["x"], ["z"]
+    return g
+
+
+def test_reduce_heavy_producer_behind_two_loads_stays_materialized():
+    result = Pipeline.build(["loop/fusion"]).run(_make_rowstat_scale_into_two_slot_mul())
+    kernels = _kernel_nodes(result)
+    assert len(kernels) == 2, f"the reducer must stay materialized: {[n.id for n in kernels]}"
+
+
+def test_reduce_heavy_producer_behind_two_loads_correctness():
+    x = rng.standard_normal((4, 8)).astype(np.float32)
+    _assert_correctness(_make_rowstat_scale_into_two_slot_mul, {"x": x})


### PR DESCRIPTION
## Summary

#482 removed every merge-loop materialization gate except the 8x compute cap, and landed with a known consequence (its plan's Verification section): gate-free fusion splices the RMSNorm producer of the gemma-4 normalized-linear/MLP cone into BOTH the gate and up contractions, so no offered candidate realizes the recorded `mlp_geglu` goldens (m32/m4096, std + fast-math) and a fresh deploy falls past the golden tier to the cold offline prior. Measured live on a rented 5090 (2026-08-12, fm lane): the boot's roofline audit flags the post twins at 39,623x (decode m32), 15,173x (m1) and 104,464x (chunk m4096) over their weight-streaming floors — the same class as the 2026-08-02 zero-coverage incident.

This restores exactly the exception the experiment plan itself names as the smallest non-placement hardening ("restoring only the refusal for a reduce-heavy producer read through more than one Load"): a reduce-heavy producer read through more than one `Load` across the region stays materialized. A rowmax-bearing sink is exempt, so the softmax assembly still fuses onto its score producer and the #482 flash-recognizer follow-up stands; a mask-add discount keeps multi-mask sliding-window scores under the reduce-heavy threshold.

## Validation

Off-GPU in-model twin audit (gemma-4-12b serving matrix, RTX 5090 card, `audit_card`):

| lane | main (02a94511) | this branch | #483 baseline |
| --- | --- | --- | --- |
| std | MATCH 71 / DRIFT 4 | **MATCH 197 / DRIFT 2** | MATCH 199 / DRIFT 2 |
| fast-math | MATCH 1 / DRIFT 2 | **MATCH 15 / DRIFT 2** | MATCH 15 / DRIFT 2 |

The geglu drifts are gone in both lanes; the residual DRIFT rows are the pre-existing `gate_up_cat.m1024.lin` and `mlp_down.dynM` entries (documented before #482), and std GAP improves 48 → 38 vs #483.

- `tests/compiler/passes/test_fusion_rules.py`: 53 passed, 1 xfailed — includes two new cases (refusal fires for a twice-loaded reduce-heavy producer; correctness of the materialized result)
- `tests/compiler -k "golden or placement or flash or fusion"` on an RTX 4080: 320 passed, 11 skipped, 1 xfailed, no new failures — flash recovery and placement routing intact
- `ruff check` / `format --check`: clean
- Full `make test` on this box carries pre-existing failures from the transformers version squeeze (Laguna tests need >5.12.1 while gemma-4 serving under vLLM 0.23 breaks at 5.15) — independent of this change, fix in flight separately

## Notes

- The 5090 re-baseline bench sweep this incident interrupted is running at #483 (last-good) and can re-validate this branch end-to-end on the same box afterwards if wanted.
- `emmy eval golden --serving-config` on main also fails the #483 realization-matrix pre-check (4,171 missing realizations) — that is a separate gap between the golden file and the stricter gate, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)