### PR TITLE
Add strict command and golden replay integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ emmy run --bench --profile -c "torch.nn.Softmax(dim=-1)(torch.randn(1, 28, 2048,
 emmy trace Qwen/Qwen3-0.6B --layer 0 --dynamic seq_len@x:1 -o _tune/qwen3/working.yaml
 # Measure proposed rows, then spend the remaining per-kernel budget on MCTS
 emmy tune --golden-file _tune/qwen3/working.yaml --devices 0,1 --max-candidates 64
+# Run every working-golden target (add --target NAME to select one)
+emmy run --golden _tune/qwen3/working.yaml --bench --strict --json _tune/qwen3/results
 # Capture one symbolic serving inventory with every release realization, then audit it on the pinned GPU
 emmy trace /models/gemma --serving-twins --serving-config docker/vllm-emmy-serve/models/gemma-4-12b-it.env \
   -o _tune/gemma/working.yaml

--- a/emmy/benchmark/ARCHITECTURE.md
+++ b/emmy/benchmark/ARCHITECTURE.md
@@ -29,6 +29,12 @@ Generic execution integrity is the only automatic acceptance boundary. Process, 
 collection failures are authoritative because they say whether the declared task executed and its evidence was
 collected, not whether the evidence supports a claim.
 
+Every command task records the rendered command, exit code, timing, system information, and declared artifact-transfer
+outcomes in its JSON result. `command.strict` makes three generic integrity requirements fail closed: staged inputs
+must be clean and content-addressed, every declared result file must be retrieved, and source, GPU, and CUDA compiler
+provenance must be present. Dry runs do not require provenance from a host that was never contacted. These checks say
+whether a command measurement is reproducible and complete; they do not interpret its output.
+
 A recipe may declare a short post-processing command directly in its `aggregate.run` block. The command may arrange
 or summarize files mechanically, but must stay readable in the recipe and cannot invoke an external result-analysis
 script. A nonzero command or timeout is an execution failure. Complex interpretation and `RESULTS.md` writing belong

--- a/emmy/benchmark/command_workload.py
+++ b/emmy/benchmark/command_workload.py
@@ -138,14 +138,13 @@ async def run_command_workload(
     logger.info(f"Running command for {task.variant}:\n{rendered}")
     rc, _, _ = await run_cmd(rendered_with_env, log_output=True, timeout=cmd_cfg.timeout)
     success = rc == 0
-    info: dict = {"rendered_command": rendered, "result_paths": []}
+    info: dict = {"rendered_command": rendered, "exit_code": rc, "result_paths": [], "result_errors": []}
 
     if not success:
         logger.error(f"Command failed (rc={rc}) for {task.variant}")
-        return False, info
 
     if dry_run:
-        return True, info
+        return success, info
 
     # Pull back result files (with glob expansion on the remote). Paths stay task_dir-relative
     # until transfer so the local name can keep the subdir spelling.
@@ -154,7 +153,11 @@ async def run_command_workload(
         if any(c in pattern for c in "*?["):
             rel_paths = await _expand_remote_glob(run_cmd, task_dir, pattern)
             if not rel_paths:
-                logger.warning(f"result_files pattern '{pattern}' matched no files in {task_dir}")
+                message = f"result_files pattern '{pattern}' matched no files in {task_dir}"
+                logger.warning(message)
+                info["result_errors"].append(message)
+                if cmd_cfg.strict:
+                    success = False
                 continue
         else:
             rel_paths = [pattern]
@@ -164,8 +167,12 @@ async def run_command_workload(
             local_path.parent.mkdir(parents=True, exist_ok=True)
             rc_scp, stderr = await scp_from_remote(server, ssh_key, ssh_port, f"{task_dir}/{rel}", str(local_path))
             if rc_scp != 0:
-                logger.warning(f"scp_from_remote failed for {task_dir}/{rel}: {stderr}")
+                message = f"scp_from_remote failed for {task_dir}/{rel}: {stderr}"
+                logger.warning(message)
+                info["result_errors"].append(message)
+                if cmd_cfg.strict:
+                    success = False
                 continue
             info["result_paths"].append(str(local_path))
 
-    return True, info
+    return success, info

--- a/emmy/benchmark/execution.py
+++ b/emmy/benchmark/execution.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from emmy.benchmark.bench_logging import _get_group_logger, active_run_dir, add_group_file_handler
 from emmy.benchmark.command_workload import run_command_workload
-from emmy.benchmark.results import compose_json_result
+from emmy.benchmark.results import compose_command_json_result, compose_json_result, missing_command_provenance
 from emmy.benchmark.system_info import collect_system_info
 from emmy.benchmark.workload import capture_server_log, compose_result, run_benchmark_workload
 from emmy.deploy import (
@@ -185,10 +185,12 @@ async def run_execution_group(
                 for p in t.recipe.command.stage:
                     if p not in stage_paths_union:
                         stage_paths_union.append(p)
+        stage_manifest = None
         if stage_paths_union:
             repo_dir_remote = f"{REMOTE_DEPLOY_DIR}/{group_label}/repo"
+            strict_stage = any(t.recipe.command.strict for t in group.tasks if t.recipe.kind == "command" and t.recipe.command is not None)
             try:
-                await stage_to_remote(
+                stage_manifest = await stage_to_remote(
                     Path.cwd(),
                     stage_paths_union,
                     conn.address,
@@ -196,6 +198,7 @@ async def run_execution_group(
                     conn.ssh_port,
                     repo_dir_remote,
                     dry_run=dry_run,
+                    require_clean=strict_stage,
                 )
             except Exception as e:
                 logger.error(f"Staging failed: {e}")
@@ -235,9 +238,10 @@ async def run_execution_group(
                 # local artifacts are easy to correlate when debugging.
                 run_suffix = task.run_dir.name if task.run_dir is not None else "default"
                 task_dir_remote = f"{REMOTE_DEPLOY_DIR}/{group_label}/{task.variant}/{run_suffix}"
+                command_info: dict = {"rendered_command": None, "exit_code": None, "result_paths": []}
                 try:
                     async with task_timer.ameasure(PHASE_COMMAND):
-                        cmd_success, _info = await run_command_workload(
+                        cmd_success, command_info = await run_command_workload(
                             task,
                             run_cmd,
                             repo_dir=repo_dir_remote,
@@ -251,7 +255,26 @@ async def run_execution_group(
                 except Exception as e:
                     task_logger.error(f"Command workload error: {e}")
                     cmd_success = False
-                task_results.append((task, cmd_success, task_timer.as_dict()))
+                    command_info["error"] = str(e)
+                if recipe.command.strict and not dry_run:
+                    if errors := missing_command_provenance(system_info, stage_manifest):
+                        command_info["provenance_errors"] = errors
+                        cmd_success = False
+                if errors := command_info.get("provenance_errors"):
+                    task_logger.error("Required command provenance is missing: %s", ", ".join(errors))
+                timing = task_timer.as_dict()
+                if not dry_run:
+                    command_result = compose_command_json_result(
+                        task,
+                        command_info,
+                        system_info,
+                        success=cmd_success,
+                        timing=timing,
+                        source=stage_manifest,
+                    )
+                    task.json_result_path().write_text(json.dumps(command_result, indent=2) + "\n")
+                    task_logger.info(f"Command result saved to: {task.json_result_path()}")
+                task_results.append((task, cmd_success, timing))
                 await _invoke_callback(on_task_done, task, cmd_success, task_logger)
                 continue
 

--- a/emmy/benchmark/results.py
+++ b/emmy/benchmark/results.py
@@ -55,6 +55,8 @@ class SystemInfo:
     cuda_version: str | None = None
     gpu_count: int | None = None
     docker_version: str | None = None
+    gpu_provenance: list[str] | None = None
+    cuda_compiler: str | None = None
 
 
 # (label in bench output, dataclass field name, type constructor)
@@ -212,6 +214,14 @@ def parse_system_info(raw_text: str) -> SystemInfo:
     if m:
         fields["cuda_version"] = m.group(1)
 
+    gpu_provenance = _get_section(raw_text, "GPU PROVENANCE")
+    if gpu_provenance and gpu_provenance != "N/A":
+        fields["gpu_provenance"] = [line.strip() for line in gpu_provenance.splitlines() if line.strip()]
+
+    cuda_compiler = _get_section(raw_text, "CUDA COMPILER")
+    if cuda_compiler and cuda_compiler != "N/A":
+        fields["cuda_compiler"] = cuda_compiler
+
     # DOCKER VERSION
     docker_section = _get_section(raw_text, "DOCKER VERSION")
     m = re.search(r"Docker version ([\d.]+)", docker_section)
@@ -219,6 +229,16 @@ def parse_system_info(raw_text: str) -> SystemInfo:
         fields["docker_version"] = m.group(1)
 
     return SystemInfo(**fields)
+
+
+def _task_metadata(task) -> dict:
+    return {
+        "recipe_dir": task.recipe_dir,
+        "variant": str(task.variant),
+        "gpu_name": task.gpu_name,
+        "gpu_short": task.gpu_short,
+        "gpu_count": task.gpu_count,
+    }
 
 
 def compose_json_result(
@@ -242,13 +262,7 @@ def compose_json_result(
     repeats = parse_repeat_metrics(benchmark_output)
     mean_metrics, stddev = aggregate_metrics(repeats)
     result = {
-        "task": {
-            "recipe_dir": task.recipe_dir,
-            "variant": str(task.variant),
-            "gpu_name": task.gpu_name,
-            "gpu_short": task.gpu_short,
-            "gpu_count": task.gpu_count,
-        },
+        "task": _task_metadata(task),
         "recipe": asdict(task.recipe),
         "metrics": asdict(mean_metrics),
         "system": asdict(parse_system_info(system_info_raw)),
@@ -261,3 +275,40 @@ def compose_json_result(
     if timing is not None:
         result["timing"] = timing
     return result
+
+
+def compose_command_json_result(
+    task,
+    command_info: dict,
+    system_info_raw: str,
+    *,
+    success: bool,
+    timing: dict[str, float] | None = None,
+    source: dict | None = None,
+) -> dict:
+    """Assemble the standard result for a command-recipe task."""
+    result = {
+        "task": _task_metadata(task),
+        "recipe": asdict(task.recipe),
+        "command": redact_secrets(command_info),
+        "system": asdict(parse_system_info(system_info_raw)),
+        "status": "ok" if success else "failed",
+    }
+    if timing is not None:
+        result["timing"] = timing
+    if source is not None:
+        result["source"] = source
+    return result
+
+
+def missing_command_provenance(system_info_raw: str, source: dict | None) -> list[str]:
+    """Return missing fields required for reproducible command measurements."""
+    system = parse_system_info(system_info_raw)
+    missing = []
+    if not source or not source.get("source_id") or not source.get("files"):
+        missing.append("staged source manifest")
+    if not system.gpu_provenance:
+        missing.append("GPU provenance")
+    if not system.cuda_compiler:
+        missing.append("CUDA compiler provenance")
+    return missing

--- a/emmy/benchmark/system_info.py
+++ b/emmy/benchmark/system_info.py
@@ -38,6 +38,15 @@ echo "=== GPU DETAILS ==="
 nvidia-smi 2>/dev/null || echo "N/A"
 
 echo ""
+echo "=== GPU PROVENANCE ==="
+nvidia-smi --query-gpu=index,name,uuid,driver_version,pstate,temperature.gpu,clocks.sm,clocks.mem,power.draw,power.limit \
+  --format=csv,noheader,nounits 2>/dev/null || echo "N/A"
+
+echo ""
+echo "=== CUDA COMPILER ==="
+(nvcc --version 2>/dev/null || /usr/local/cuda/bin/nvcc --version 2>/dev/null) || echo "N/A"
+
+echo ""
 echo "=== DISK USAGE ==="
 df -h 2>/dev/null || echo "N/A"
 

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -85,7 +85,9 @@ The benchmark library is an experiment-agnostic runner: it records complete clie
 system information, and partial observations after failure. It treats execution and evidence-collection failures as
 authoritative, but does not judge model output, metrics, backend selection, or scientific claims. A recipe may use a
 small self-contained post-processing command, but cannot delegate result interpretation or report generation to a
-script. The complete boundary lives in `emmy/benchmark/ARCHITECTURE.md`.
+script. Command recipes may opt into the single `command.strict` integrity contract for clean/content-addressed staged
+inputs, required declared artifacts, and source/GPU/CUDA provenance. The complete boundary lives in
+`emmy/benchmark/ARCHITECTURE.md`.
 
 `run_benchmark_workload()` drives `vllm bench serve`. Embedding recipes (`model.task: embed`) bench with
 `--backend openai-embeddings --endpoint /v1/embeddings` and drop `--random-output-len` (nothing is generated); the
@@ -122,7 +124,11 @@ They accept a Hugging Face model, debug Graph IR, or inline `--code`; `causal-lm
 keeps the existing Transformers path. `dit` delegates to the Diffusers block adapter in `compiler/trace/dit.py`; it
 requires `--layer`, accepts the checkpoint's layers 0-27, and rejects dynamic shapes in v1. `run --bench` and
 `tune --bench` include the adapter in the isolated worker's reconstruction payload, so eager PyTorch, `torch.compile`,
-and Emmy always rebuild the same module and example inputs. Dynamic-shape parsing, quantized architecture twins and
+and Emmy always rebuild the same module and example inputs. Inductor compiles with
+`fullgraph=True, mode="max-autotune"`; its output must match eager on the same inputs at `rtol=atol=1e-3` before its
+latency is accepted. `run --strict` makes every requested backend, captured timing, exact pin, and direct
+Emmy-vs-eager proof authoritative. It records max/mean/relative error in `--json` and exits
+nonzero on any missing or failed evidence. Dynamic-shape parsing, quantized architecture twins and
 their in-graph storage algebra, sliding-window stamps, and the guarded `trust_remote_code` fallback therefore behave
 identically for all four commands (see `compiler/ARCHITECTURE.md`, "Quantized checkpoints").
 For a single-layer trace, the loader derives a missing attention `layer_type` from
@@ -132,7 +138,7 @@ modules with independent rotary keys (for example DeepSeek V4's `main` / `compre
 The trace/tune handlers delegate working-golden inventory construction, target reconstruction, proposal measurement,
 and atomic ranking persistence to `compiler/pipeline/search/working_golden.py`. Scoped exact knob pins shared by
 `run` and working-golden tuning live beside that search lifecycle in `compiler/pipeline/search/pins.py`; command
-handlers retain only the workflow's argument validation, process orchestration, and user-facing error/reporting.
+handlers retain only the workflow's argument validation and user-facing error/reporting.
 
 `emmy trace MODEL -o PATH` lowers through post-fusion Loop IR and writes one self-contained golden YAML inventory.
 The YAML embeds stable frontend Torch IR programs and emits one target row for every post-fusion kernel occurrence;
@@ -150,7 +156,7 @@ warm shapes, symbolic fallbacks, and standard/precision-trading input pin regime
 `realizations` array with those named bindings and explicit registered input pins; trace no longer accepts an
 independent serving-shape surface. A static-only release is accepted
 only when the same env proves that no wider or symbolic path is reachable. The resulting working file is consumed
-directly by `tune --golden-file` and verified by `run --golden-file --golden NAME`.
+directly by `tune --golden-file` and verified by `run --golden PATH [--target NAME]`.
 
 The in-model audit normally uses those serving twins. An architecture that cannot fit their external-attention ABI is
 dispatched through a sound config-only provider instead: DeepSeek V4 traces one complete representative decoder layer
@@ -178,12 +184,16 @@ With `--bench`, each target's `62_kernel_bench.json` records whether an eager re
 non-fatal accuracy verdict alongside the deployable O3 timings. A null verdict proves correctness only when the
 reference-available field is true; reference-free Loop slices remain timing evidence rather than accuracy evidence.
 
-`emmy compile/run --golden-file PATH --golden NAME` is the verification counterpart: it resolves the name only in
-that explicit working YAML and compiles its exact provenance or Loop IR target, without canonical-corpus or live-card
-filtering. Inventory and proposal rows select the graph but are not trusted as automatic A/B pins; only verified rows
-with paired measurements auto-pin, while a proposal is tested explicitly with `run --bench --ab 'KNOBS…'`. Embedded
-Loop IR stores stable algebra rather than derived structural stamps, so `run --golden` replays it through the full
-compiler pipeline. A direct `run --ir` input remains a stage-complete artifact and runs only the later passes.
+`emmy compile --golden-file PATH --golden NAME` and `emmy run --golden PATH [--target NAME]` are the verification
+counterparts. They resolve targets only in the explicit working YAML and compile its exact provenance or Loop IR,
+without canonical-corpus or live-card filtering. `run` visits every distinct target sequentially in the current
+process unless `--target` narrows the file to one exact or unambiguous substring match. With several targets,
+`--json DIR` writes one readable JSON record per target; there is no repeat or child-process orchestration layer.
+Invoke `emmy run` again when independent process observations are required. Inventory and proposal rows select the
+graph but are not trusted as automatic A/B pins; only verified rows with paired measurements auto-pin, while a
+proposal is tested explicitly with `run --bench --ab 'KNOBS…'`. Embedded Loop IR stores stable algebra rather than
+derived structural stamps, so `run --golden` replays it through the full compiler pipeline. A direct `run --ir` input
+remains a stage-complete artifact and runs only the later passes.
 
 For a fair hybrid-vs-MCTS comparison, both working files start from the same inventory-only trace: do not copy verified
 knob rows into either baseline as proposals. Canonical goldens remain the common implicit deploy context for both runs.

--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -155,7 +155,7 @@ def resolve_golden_arg(args) -> None:
 
     Canonical selection retains every measured sibling on ``args.golden_configs``
     for pinned A/B reporting. ``--golden-file`` instead resolves only inside that
-    working document and retains only its VERIFIED siblings as automatic pins;
+    working document and retains its verified siblings, or its one valid direct tune winner, as automatic pins;
     inventory/proposal siblings still select the target graph. No Python snippet
     is generated and dynamic shapes need no CLI reconstruction: they are already
     in the decoded program.
@@ -235,7 +235,19 @@ def resolve_golden_arg(args) -> None:
 
     pinned = matches
     if document is not None:
-        pinned = [record for record in matches if record.measurements is not None]
+        verified = [record for record in matches if record.measurements is not None]
+        winners = [record for record in matches if record.ranking is not None and record.ranking.get("tune_winner") is True]
+        valid_winner = (
+            len(winners) == 1
+            and winners[0].ranking.get("source") == "tune"
+            and winners[0].ranking.get("status") == "ok"
+            and winners[0].ranking.get("measured_knobs") == winners[0].knobs
+            and bool(winners[0].knobs)
+        )
+        if winners and not valid_winner:
+            logger.error("golden %r must contain one valid direct tune winner with matching measured knobs", name)
+            sys.exit(2)
+        pinned = verified or winners
     args.golden_configs = [Sample.from_golden(match) for match in pinned]
     logger.info(
         "[golden] %s%s → embedded %s target %s (%d matching row%s, %d automatic pin%s)",

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sys
 import uuid
 from collections import namedtuple
@@ -62,9 +63,17 @@ def register_run_command(subparsers):
             "Equivalent to passing the same .json path as the positional input."
         ),
     )
-    from emmy.commands.compile import add_golden_arg
-
-    add_golden_arg(parser)
+    parser.add_argument(
+        "--golden",
+        metavar="PATH",
+        help="Run every embedded target in this working golden YAML. Mutually exclusive with other inputs.",
+    )
+    parser.add_argument(
+        "--target",
+        dest="golden_target",
+        metavar="NAME",
+        help="Run only the matching target from --golden instead of every target.",
+    )
     parser.add_argument(
         "--layer",
         type=int,
@@ -94,7 +103,7 @@ def register_run_command(subparsers):
         help=(
             "Comma-separated subset of backends to time under --bench: any of "
             "``eager``, ``tcompile`` (a.k.a. ``torch.compile`` / ``compile``), "
-            "``emmy``. Falls back to ``EMMY_BENCH_BACKENDS`` env var, "
+            "or ``emmy``. Falls back to ``EMMY_BENCH_BACKENDS`` env var, "
             "then to the default ``eager,emmy`` (drops the ~0.8 s "
             "torch.compile JIT from the per-case cost). ``emmy`` is "
             "implicit even if omitted."
@@ -130,7 +139,8 @@ def register_run_command(subparsers):
         metavar="PATH",
         default=None,
         help=(
-            "With --bench: also write the whole comparison as machine-readable JSON to PATH — the "
+            "With --bench: also write the whole comparison as machine-readable JSON to PATH. When --golden "
+            "runs multiple targets, PATH is an output directory containing one JSON file per target. Records include the "
             "backend table (eager / torch.compile / emmy), the per-kernel greedy rows (plus, when "
             "pinned rows benched, the ``greedy.isolated`` emmy-only re-bench — the pinned-comparable "
             "greedy baseline), and every --golden / --ab A/B row with its integrity flags "
@@ -138,6 +148,15 @@ def register_run_command(subparsers):
             "Each pinned row and the greedy block carry a ``lane`` (fm/std) so the sweep filters to "
             "the greedy's lane — comparing a pinned [fm] latency against a std greedy is a phantom "
             "regression. Retires ad-hoc table parsing in the golden-sweep workflow."
+        ),
+    )
+    parser.add_argument(
+        "--strict",
+        dest="strict_correctness",
+        action="store_true",
+        help=(
+            "With --bench on runnable frontend IR or an embedded golden, fail unless every requested backend, "
+            "captured timing, exact pin, and direct Emmy-vs-eager comparison is valid."
         ),
     )
     parser.add_argument(
@@ -167,7 +186,7 @@ def register_run_command(subparsers):
     from emmy.compiler.target import add_target_arg
 
     add_nvcc_args(parser)
-    add_target_arg(parser)
+    add_target_arg(parser, dest="gpu_arch", option="--gpu-arch")
     parser.set_defaults(func=handle_run)
 
 
@@ -176,7 +195,7 @@ def handle_run(args):
     from emmy.compiler.target import apply_target_arg
 
     apply_nvcc_flags(args, default="")  # run uses nvcc default -O3 (representative codegen)
-    apply_target_arg(args)  # --target sm_NN gates TMA / cp.async like the target GPU would
+    apply_target_arg(args, dest="gpu_arch")
     if args.profile:
         args.bench = True  # --profile re-launches under ncu via the bench path; profiling implies benching
     verbose = getattr(args, "verbose", 0)
@@ -187,6 +206,17 @@ def handle_run(args):
     else:
         logging.getLogger().setLevel(logging.DEBUG)
 
+    if args.golden_target and not args.golden:
+        logger.error("--target requires --golden PATH")
+        sys.exit(2)
+    if args.golden:
+        _run_golden_targets(args)
+        return
+
+    _handle_run_once(args)
+
+
+def _handle_run_once(args):
     try:
         import torch
     except ImportError:
@@ -197,7 +227,10 @@ def handle_run(args):
     from emmy.compiler.backend.cuda.backend import CudaBackend
     from emmy.compiler.pipeline.dump import CompilerDump
 
-    resolve_golden_arg(args)
+    if getattr(args, "golden_file", None):
+        resolve_golden_arg(args)
+    else:
+        args.golden_configs = []
     if sum(x is not None for x in (args.input, args.code, args.ir)) > 1:
         logger.error("input / --code / --ir are mutually exclusive")
         sys.exit(1)
@@ -220,6 +253,12 @@ def handle_run(args):
         except ValueError as exc:
             logger.error("--ab: %s", exc)
             sys.exit(2)
+    if args.strict_correctness and not args.bench:
+        logger.error("--strict requires --bench")
+        sys.exit(2)
+    if args.strict_correctness and ir_path is None and not hasattr(args, "_golden_graph"):
+        logger.error("--strict currently requires runnable frontend IR or an embedded --golden")
+        sys.exit(2)
     if not torch.cuda.is_available():
         logger.error("CUDA GPU required")
         sys.exit(1)
@@ -234,7 +273,7 @@ def handle_run(args):
         return
 
     if args.input is None and args.code is None:
-        logger.error("Either a model ID / .json input, --code, --golden, or --ir is required")
+        logger.error("Either a model ID / .json input, --code, --golden PATH, or --ir is required")
         sys.exit(1)
 
     # Model ID or --code: trace to a frontend graph + keep the runnable module
@@ -378,6 +417,44 @@ def handle_run(args):
         sys.exit(1)  # every row is reported above; any failed row (greedy or pinned) exits non-zero
 
 
+def _run_golden_targets(args) -> None:
+    """Run a working golden's selected targets sequentially in this process."""
+    from copy import copy  # noqa: PLC0415
+
+    from emmy.compiler.pipeline.search.golden import load_golden_file, load_golden_records  # noqa: PLC0415
+
+    if args.input or args.code or args.ir:
+        logger.error("--golden is mutually exclusive with positional input / --code / --ir")
+        sys.exit(2)
+    try:
+        records = load_golden_records(load_golden_file(args.golden))
+    except (OSError, ValueError) as exc:
+        logger.error("cannot load --golden %s: %s", args.golden, exc)
+        sys.exit(2)
+    names = [args.golden_target] if args.golden_target else list(dict.fromkeys(record.name for record in records))
+    if not names:
+        logger.error("--golden contains no targets: %s", args.golden)
+        sys.exit(2)
+
+    output_dir = None
+    if len(names) > 1 and args.json:
+        output_dir = Path(args.json)
+        if output_dir.exists() and (not output_dir.is_dir() or any(output_dir.iterdir())):
+            logger.error("multi-target --json directory must be empty: %s", output_dir)
+            sys.exit(2)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    for index, name in enumerate(names):
+        target_args = copy(args)
+        target_args.golden_file = args.golden
+        target_args.golden = name
+        target_args.golden_target = None
+        if output_dir is not None:
+            safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._") or "target"
+            target_args.json = str(output_dir / f"{index:03d}-{safe_name}.json")
+        _handle_run_once(target_args)
+
+
 def _recordable_bench_leaves(golden_benches, greedy_iso) -> list:
     """The benched rows honest enough to record into the node store: every ``ok`` row
     with NO integrity flag (a flagged ok row measured something untrue — wrong answer,
@@ -518,17 +595,17 @@ def _compare_wall_s(graph, backend, *, base_s: float) -> float:
 
 # One recorded golden config compiled + benched with its knobs pinned this run.
 # ``flags`` are the integrity-gate verdicts (empty = clean): the arithmetic-intensity
-# floor and the wrong-answer check against the greedy run's outputs. ``bench`` is ``None``
+# floor and the output-correctness check against the greedy or eager reference. ``bench`` is ``None``
 # for a row that never benched — ``status`` says why: ``"pin_unmatched"`` (the pinned config
 # didn't realize, so benching would measure the planner's own pick under the pin's name) or
 # ``"bench_fail"`` (compile/bench of the pinned config failed); ``"ok"`` rows carry a bench.
-_GoldenBench = namedtuple("_GoldenBench", "sample graph bench flags status", defaults=("ok",))
+_GoldenBench = namedtuple("_GoldenBench", "sample graph bench flags status correctness", defaults=("ok", None))
 
 
 def _lane(knobs: dict) -> str:
     """The precision REGIME a knob dict realizes: ``"fm"`` (an f16-accumulate mma atom or
     ``FAST_EXP``, :func:`~emmy.compiler.pipeline.search.golden.fast_math_knobs`) else ``"std"``.
-    Derived from the knobs, never a stored flag, so it can't drift. A ``--golden NAME`` sweep
+    Derived from the knobs, never a stored flag, so it can't drift. A working-golden target
     pins BOTH the std and the ``[fm]`` config recorded under one name; comparing a pinned ``[fm]``
     latency against a ``"std"`` greedy manufactures a phantom regression, so every A/B row (and the
     greedy it's compared to) carries its lane and the parser filters to matching lanes."""
@@ -596,6 +673,97 @@ def _wrong_answer_flag(outputs: dict, ref_outputs: dict) -> str | None:
     return None
 
 
+def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, atol: float = 1e-3) -> dict:
+    """Return a direct Emmy-vs-eager tolerance verdict with reproducible error statistics.
+
+    The pass rule is the same elementwise rule used by ``torch.testing.assert_close`` for
+    compiler baselines: ``abs(actual - expected) <= atol + rtol * abs(expected)``. Eager
+    outputs may be tensors, a positional tensor sequence, or an output-name mapping (the
+    latter is what the embedded-golden worker returns to pinned-row replay).
+    """
+    import numpy as np  # noqa: PLC0415
+
+    def _array(value):
+        if hasattr(value, "detach"):
+            value = value.detach().float().cpu().numpy()
+        return np.asarray(value, dtype=np.float64)
+
+    names = list(outputs)
+    if isinstance(eager_out, dict):
+        missing = [name for name in names if name not in eager_out]
+        extra = [name for name in eager_out if name not in outputs]
+        if missing or extra:
+            return {
+                "status": "fail",
+                "reference": "eager",
+                "rtol": rtol,
+                "atol": atol,
+                "max_abs_error": None,
+                "mean_abs_error": None,
+                "max_rel_error": None,
+                "error": f"output names differ: missing={missing}, extra={extra}",
+            }
+        refs = [eager_out[name] for name in names]
+    else:
+        refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
+        if len(refs) != len(names):
+            return {
+                "status": "fail",
+                "reference": "eager",
+                "rtol": rtol,
+                "atol": atol,
+                "max_abs_error": None,
+                "mean_abs_error": None,
+                "max_rel_error": None,
+                "error": f"output count differs: Emmy={len(names)}, eager={len(refs)}",
+            }
+
+    max_abs = 0.0
+    max_rel = 0.0
+    abs_sum = 0.0
+    count = 0
+    failure = None
+    for name, ref in zip(names, refs, strict=True):
+        actual = _array(outputs[name])
+        expected = _array(ref)
+        if actual.shape != expected.shape:
+            failure = f"output {name!r} shape {actual.shape} != eager {expected.shape}"
+            break
+        if not np.isfinite(actual).all() or not np.isfinite(expected).all():
+            failure = f"output {name!r} contains non-finite values"
+            break
+        absolute = np.abs(actual - expected)
+        tolerance = atol + rtol * np.abs(expected)
+        if absolute.size:
+            max_abs = max(max_abs, float(absolute.max()))
+            max_rel = max(max_rel, float((absolute / np.maximum(np.abs(expected), atol)).max()))
+            abs_sum += float(absolute.sum())
+            count += int(absolute.size)
+            if failure is None and not np.all(absolute <= tolerance):
+                failure = f"output {name!r} exceeds rtol={rtol:g}, atol={atol:g}"
+
+    proof = {
+        "status": "fail" if failure else "pass",
+        "reference": "eager",
+        "rtol": rtol,
+        "atol": atol,
+        "max_abs_error": max_abs,
+        "mean_abs_error": abs_sum / count if count else 0.0,
+        "max_rel_error": max_rel,
+    }
+    if failure:
+        proof["error"] = failure
+    return proof
+
+
+def _eager_outputs_by_name(outputs: dict, eager_out) -> dict:
+    """Map positional eager outputs to the lowered graph's stable output names."""
+    refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
+    if len(refs) != len(outputs):
+        return {}
+    return {name: ref.detach().float().cpu().numpy() if hasattr(ref, "detach") else ref for name, ref in zip(outputs, refs, strict=True)}
+
+
 def _cuda_knob_dicts(graph) -> list[dict]:
     """Raw ``op.knobs`` per ``CudaOp`` of a compiled pinned graph, in launch order —
     the realized side of the pin gate."""
@@ -622,7 +790,7 @@ def _sample_replay_knobs(sample) -> dict:
     return {**getattr(sample, "pins", {}), **sample.knobs}
 
 
-async def _bench_golden_variants(backend, source, golden_configs, *, warmup, iters, ref=None):
+async def _bench_golden_variants(backend, source, golden_configs, *, warmup, iters, ref=None, strict_correctness=False):
     """Compile + bench each recorded golden config with its knobs pinned — one
     ``_GoldenBench`` per config so :func:`_print_kernel_stats` can show each as a measured
     row beside the greedy pick. ``golden_configs`` are
@@ -651,16 +819,18 @@ async def _bench_golden_variants(backend, source, golden_configs, *, warmup, ite
     class that misled the hd256 flash sweep (a misspelled pin read as a form refusal).
 
     Two more integrity gates flag (never drop) each benched row: the arithmetic-intensity
-    floor (:func:`_intensity_floor_flag`) and — when ``ref`` carries the greedy run's
-    ``(input_data, outputs)`` — a wrong-answer check: the row's worker job executes the
-    pinned kernel once on the greedy run's inputs and the returned outputs are compared
-    (:func:`_wrong_answer_flag`). Flags render as a ``!`` marker in the table and ride the
-    ``--json`` record."""
+    floor (:func:`_intensity_floor_flag`) and — when ``ref`` carries reference inputs and
+    outputs — an output-correctness check. The default check compares against the greedy
+    Emmy output with :func:`_wrong_answer_flag`; ``strict_correctness`` compares every pinned
+    row directly against eager under rtol=atol=1e-3 and records error statistics. Flags
+    render as a ``!`` marker in the table and ride the ``--json`` record."""
     from emmy.commands.trace import graph_from_code  # noqa: PLC0415
     from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs  # noqa: PLC0415
 
     out = []
     ref_inputs, ref_outputs = ref if ref is not None else (None, None)
+    if strict_correctness and (ref_inputs is None or ref_outputs is None):
+        raise ValueError("strict pinned correctness requires same-input eager reference outputs")
     # Session-unique cache key: the (potentially hundreds-of-MB) reference inputs cross
     # the worker pipe once per child, not once per row (see benchmark_pinned_isolated_async).
     ref_key = uuid.uuid4().hex if ref_inputs is not None else None
@@ -702,17 +872,23 @@ async def _bench_golden_variants(backend, source, golden_configs, *, warmup, ite
             logger.warning("[golden] %s: bench of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
             out.append(_GoldenBench(sample, g_compiled, None, [f"bench_fail: {exc}"], "bench_fail"))
             continue
+        correctness = None
         if run_outputs is not None and ref_outputs is not None:
-            flag = _wrong_answer_flag(run_outputs, ref_outputs)
-            if flag:
-                flags.append(flag)
+            if strict_correctness:
+                correctness = _strict_correctness_proof(run_outputs, ref_outputs)
+                if correctness["status"] != "pass":
+                    flags.append(f"strict eager correctness failed: {correctness.get('error', 'tolerance exceeded')}")
+            else:
+                flag = _wrong_answer_flag(run_outputs, ref_outputs)
+                if flag:
+                    flags.append(flag)
         total_us = (g_bench.min_ms if g_bench.min_ms is not None else g_bench.time_ms) * 1000
         flag = _intensity_floor_flag(sample, total_us)
         if flag:
             flags.append(flag)
         for f in flags:
             logger.warning("[golden] %s: %s — row flagged (marked ! in the table, flagged in --json)", sample.name, f)
-        out.append(_GoldenBench(sample, g_compiled, g_bench, flags))
+        out.append(_GoldenBench(sample, g_compiled, g_bench, flags, "ok", correctness))
     return out
 
 
@@ -757,7 +933,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, gre
     — quick at-a-glance for spotting which kernel dominates, whether
     register pressure is killing occupancy, etc.
 
-    ``golden_benches`` (from ``run --golden NAME``, see :func:`_bench_golden_variants`)
+    ``golden_benches`` (from a selected working-golden target, see :func:`_bench_golden_variants`)
     are each their own live compile+bench of a recorded golden config's pinned
     knobs; their kernels print beneath the greedy kernel of matching shape, labeled
     ``golden NAME [fm|std]`` in the Kernel column (the lane tag so an ``[fm]``-vs-``std``
@@ -945,7 +1121,17 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, gre
             print(f"! {gb.sample.name}: {flag}")
 
 
-def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fail=None, greedy_iso=None) -> None:
+def _write_ab_json(
+    args,
+    results: dict,
+    graph,
+    bench,
+    golden_benches,
+    greedy_fail=None,
+    greedy_iso=None,
+    correctness=None,
+    strict_errors=None,
+) -> None:
     """``--json PATH``: the whole ``--bench`` comparison as one machine-readable record —
     the backend table (eager / torch.compile / emmy), the per-kernel greedy rows, and every
     ``--golden`` / ``--ab`` pinned row with its recorded reference latencies and integrity
@@ -970,7 +1156,7 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
     interleaved (torch-comparable) number, ~7% apart from pinned-row semantics.
 
     Every pinned row and the greedy block carry a ``lane`` (``"fm"`` / ``"std"``, :func:`_lane`):
-    a ``--golden NAME`` sweep pins BOTH lanes recorded under one name, and comparing a pinned
+    a working-golden target pins BOTH lanes recorded under one name, and comparing a pinned
     ``[fm]`` latency against a ``"std"`` greedy is the phantom-regression trap the sweep must not
     fall into — a parser filters ``pinned`` to the rows whose ``lane`` matches ``greedy.lane``
     (which ``greedy.isolated`` shares, being the same graph)."""
@@ -980,12 +1166,15 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
     from emmy.compiler.pipeline.knob import stamp_schedule_families, tuning_knob_items  # noqa: PLC0415
 
     def _kernel_rows(g, b) -> list[dict]:
+        import hashlib  # noqa: PLC0415
+
         if g is None:
             return []
         times = {} if b is None else {lt.idx: (min(lt.samples) if lt.samples else lt.time_ms) * 1000 for lt in (b.per_launch or [])}
         rows = []
         for idx, node in enumerate(_launch_order_cuda_nodes(g)):
             op = node.op
+            source = getattr(op, "kernel_source", None) or ""
             rows.append(
                 {
                     "kernel": op.kernel_name,
@@ -993,14 +1182,29 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
                     "smem_bytes": op.smem_bytes,
                     "knobs": {k: str(v) for k, v in tuning_knob_items(op.knobs or {})},
                     "record_knobs": stamp_schedule_families(op.knobs or {}),
+                    "source_sha256": hashlib.sha256(source.encode()).hexdigest(),
                 }
             )
         return rows
 
-    def _total_us(b) -> float | None:
+    def _timing(b) -> dict:
         if b is None:
-            return None
-        return (b.min_ms if b.min_ms is not None else b.time_ms) * 1000
+            return {"total_us": None, "timing_semantics": None, "captured": None, "num_launches": 0}
+        per_launch = b.per_launch or []
+        num_launches = getattr(b, "num_launches", 0) or len(per_launch)
+        e2e_min_ms = getattr(b, "e2e_min_ms", None)
+        if e2e_min_ms is not None:
+            total_ms = e2e_min_ms
+            semantics = "whole_program_e2e"
+        else:
+            total_ms = b.min_ms if b.min_ms is not None else b.time_ms
+            semantics = "single_launch" if num_launches <= 1 else "per_launch_sum"
+        return {
+            "total_us": total_ms * 1000,
+            "timing_semantics": semantics,
+            "captured": bool(getattr(b, "captured", False)),
+            "num_launches": num_launches,
+        }
 
     pinned = []
     for gb in golden_benches or []:
@@ -1012,9 +1216,10 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
                 "lane": _lane(sample.knobs),
                 "status": gb.status,
                 "pinned_knobs": {k: str(v) for k, v in _sample_replay_knobs(sample).items()},
-                "total_us": _total_us(gb.bench),
+                **_timing(gb.bench),
                 "kernels": _kernel_rows(gb.graph, gb.bench),
                 "flags": list(gb.flags),
+                "correctness": gb.correctness,
                 "recorded_emmy_us": getattr(sample, "latency_us", None),
                 "recorded_ref_us": getattr(sample, "ref_us", None),
             }
@@ -1022,7 +1227,7 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
     greedy = {
         "status": "ok" if greedy_fail is None else "bench_fail",
         "lane": _graph_lane(graph),
-        "total_us": _total_us(bench),
+        **_timing(bench),
         "kernels": _kernel_rows(graph, bench),
     }
     if greedy_fail is not None:
@@ -1030,11 +1235,23 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
     if greedy_iso is not None:
         greedy["isolated"] = {
             "status": greedy_iso.status,
-            "total_us": _total_us(greedy_iso.bench),
+            **_timing(greedy_iso.bench),
             "kernels": _kernel_rows(greedy_iso.graph, greedy_iso.bench),
             "flags": list(greedy_iso.flags),
         }
-    backend_rows = {name: {"latency_us": us} for name, us in (results or {}).items()}
+    captured = bool(getattr(bench, "captured", False))
+    backend_semantics = "captured_whole_forward" if captured else "uncaptured_forward"
+    backend_rows = {
+        name: {
+            "latency_us": us,
+            "captured": captured,
+            "timing_semantics": backend_semantics,
+            **({"correctness": {"status": "pass", "rtol": 1e-3, "atol": 1e-3, "fullgraph": True}} if name == "torch.compile" else {}),
+        }
+        for name, us in (results or {}).items()
+    }
+    if correctness is not None and "Emmy" in backend_rows:
+        backend_rows["Emmy"]["correctness"] = correctness
     eager_us = (results or {}).get("Eager PyTorch")
     if eager_us:
         for name, us in (results or {}).items():
@@ -1051,6 +1268,8 @@ def _write_ab_json(args, results: dict, graph, bench, golden_benches, greedy_fai
         "greedy": greedy,
         "pinned": pinned,
     }
+    if strict_errors is not None:
+        payload["strict"] = {"status": "fail" if strict_errors else "pass", "errors": list(strict_errors)}
     out = Path(args.json)
     out.write_text(_json.dumps(payload, indent=2, default=str))
     print(f"A/B record → {out}")
@@ -1193,20 +1412,21 @@ def _run_ncu_profile(args, *, dump_dir=None):
         "emmy.emmy",
         "run",
     ]
-    if args.code is not None:
+    if getattr(args, "golden_file", None):
+        cmd.extend(["--golden", args.golden_file, "--target", args.golden])
+    elif args.code is not None:
         cmd.extend(["--code", args.code])
     elif args.ir is not None:
         cmd.extend(["--ir", args.ir])
     else:
-        # Positional model ID / .json path (``--golden`` was already rewritten
-        # to ``--code`` by ``resolve_golden_arg``). Forward the trace shape
-        # flags so the child profiles the same graph the parent benched.
+        # Positional model ID / .json path. Forward the trace shape flags so the
+        # child profiles the same graph the parent benched.
         cmd.append(args.input)
         if args.layer is not None:
             cmd.extend(["--layer", str(args.layer)])
         cmd.extend(["--seq-len", str(args.seq_len)])
-    if args.target is not None:
-        cmd.extend(["--target", args.target])
+    if getattr(args, "gpu_arch", None) is not None:
+        cmd.extend(["--gpu-arch", args.gpu_arch])
     # Forward the symbolic-dim specs so the child re-traces the SAME (masked-tile)
     # graph the parent benched. ``args.dynamic`` is the ``NAME@INPUT:AXIS`` CLI form
     # (a dynamic ``--golden`` sets it too, via ``resolve_golden_arg``); without this
@@ -1445,7 +1665,20 @@ def _replay_stage_and_passes(graph, *, embedded_golden: bool) -> tuple[str, list
     return stage, _passes_after_stage(stage)
 
 
-async def bench_lowered_vs_torch(frontend, lowered, backend, *, seed, do_bench, warmup, iters, bench_backends, capture_graphs=True):
+async def bench_lowered_vs_torch(
+    frontend,
+    lowered,
+    backend,
+    *,
+    seed,
+    do_bench,
+    warmup,
+    iters,
+    bench_backends,
+    capture_graphs=True,
+    strict_accuracy=False,
+    return_reference=False,
+):
     """Run + (optionally) benchmark a lowered graph against its torch reference on
     shared random inputs. The common bench primitive behind ``run --ir`` and
     ``tune --bench``.
@@ -1474,7 +1707,9 @@ async def bench_lowered_vs_torch(frontend, lowered, backend, *, seed, do_bench, 
     whether the timings came from graph-captured (pure-GPU) windows, and
     ``accuracy_error`` the non-fatal accuracy verdict (``None`` = passed or no reference;
     also logged here — returned so a worker-side run can ship it back to the parent, whose
-    child logs are invisible). Does no printing / dumping — callers own that."""
+    child logs are invisible). With ``return_reference``, appends the strict correctness
+    proof and ``(input_data, eager_outputs_by_name)`` for same-input pinned replay. Does no
+    printing / dumping — callers own that."""
     import numpy as np
     import torch
 
@@ -1545,22 +1780,34 @@ async def bench_lowered_vs_torch(frontend, lowered, backend, *, seed, do_bench, 
         logger.info("Output %s: shape=%s finite=%s mean=%.4f", nid, arr.shape, bool(finite), float(arr.mean()))
 
     # Build the torch reference from the frontend snapshot, fed the same inputs.
-    torch_fn = torch_inputs = accuracy_error = None
+    torch_fn = torch_inputs = accuracy_error = correctness = reference = None
     if frontend is not None:
         try:
             torch_fn, torch_inputs = torch_ref.build_callable(frontend, input_tensors)
             with torch.no_grad():
                 eager_out = torch_fn(*torch_inputs)
-            accuracy_error = _check_accuracy(result.outputs, eager_out)
+            if strict_accuracy:
+                correctness = _strict_correctness_proof(result.outputs, eager_out)
+                if correctness["status"] != "pass":
+                    accuracy_error = f"strict eager correctness failed: {correctness.get('error', 'tolerance exceeded')}"
+            else:
+                accuracy_error = _check_accuracy(result.outputs, eager_out)
+            reference = (input_data, _eager_outputs_by_name(result.outputs, eager_out))
             if accuracy_error is not None:
-                logger.warning("%s — non-fatal (random-input reproducer); benching anyway", accuracy_error)
+                qualifier = "fatal when strict correctness is requested" if strict_accuracy else "non-fatal (random-input reproducer)"
+                logger.warning("%s — %s; benching anyway", accuracy_error, qualifier)
         except Exception as exc:  # noqa: BLE001 — torch ref is best-effort
             logger.warning("torch reference unavailable (%s) — skipping vs-torch comparison", exc)
             torch_fn = None
+            if strict_accuracy:
+                accuracy_error = f"strict eager correctness unavailable: {exc}"
 
+    if strict_accuracy and frontend is None:
+        accuracy_error = "strict eager correctness unavailable: frontend IR is not runnable"
     torch_available = torch_fn is not None
     if not do_bench:
-        return None, None, torch_available, False, accuracy_error
+        base = (None, None, torch_available, False, accuracy_error)
+        return (*base, correctness, reference) if return_reference else base
 
     if torch_available:
         backends = _resolve_backends(bench_backends)
@@ -1574,11 +1821,13 @@ async def bench_lowered_vs_torch(frontend, lowered, backend, *, seed, do_bench, 
                 torch_fn, torch_inputs, {}, backend, lowered, warmup, iters, torch_fns=torch_fns, capture_graphs=False
             )
             captured = False
-        return results, bench, True, captured, accuracy_error
+        base = (results, bench, True, captured, accuracy_error)
+        return (*base, correctness, reference) if return_reference else base
     # Emmy-only: a capture failure falls back inside ``benchmark_program``
     # (warned + reported via ``bench.captured``) — nothing to de-mix.
     bench = await backend.benchmark_async(lowered, warmup=max(3, warmup // 5), num_iters=max(10, iters // 5), capture_graphs=capture_graphs)
-    return {"Emmy": bench.time_ms * 1000}, bench, False, bench.captured, accuracy_error
+    base = ({"Emmy": bench.time_ms * 1000}, bench, False, bench.captured, accuracy_error)
+    return (*base, correctness, reference) if return_reference else base
 
 
 async def bench_full_model_real(module, args_t, kwargs, lowered, backend, *, warmup, iters, bench_backends):
@@ -1623,6 +1872,67 @@ def _pinned_samples_for_ir(args, embedded):
     return pinned
 
 
+def _strict_benchmark_errors(args, results, bench, captured, correctness, pinned_rows) -> list[str]:
+    """Return every strict verification failure in one ordinary run result."""
+
+    def valid_proof(proof) -> bool:
+        if not isinstance(proof, dict):
+            return False
+        required = {"status": "pass", "reference": "eager", "rtol": 1e-3, "atol": 1e-3}
+        if any(proof.get(key) != value for key, value in required.items()):
+            return False
+        return all(
+            not isinstance(proof.get(metric), bool) and isinstance(proof.get(metric), int | float) and proof[metric] >= 0
+            for metric in ("max_abs_error", "mean_abs_error", "max_rel_error")
+        )
+
+    errors = []
+    display_names = {"eager": "Eager PyTorch", "tcompile": "torch.compile", "emmy": "Emmy"}
+    for backend in _resolve_backends(args.bench_backends):
+        name = display_names[backend]
+        latency = (results or {}).get(name)
+        if isinstance(latency, bool) or not isinstance(latency, int | float) or latency <= 0:
+            errors.append(f"requested backend {name} has no positive latency")
+    if captured is not True:
+        errors.append("backend comparison did not use CUDA graph capture")
+    if bench is None or not bool(getattr(bench, "captured", False)):
+        errors.append("deployed Emmy timing was not captured")
+    if not valid_proof(correctness):
+        errors.append("deployed Emmy row lacks direct strict eager correctness")
+
+    ab_rows = [row for row in pinned_rows or [] if getattr(row.sample, "shape", None) is None]
+    expected_ab_rows = len(args.ab or [])
+    if len(ab_rows) != expected_ab_rows:
+        errors.append(f"expected {expected_ab_rows} exact --ab row(s), got {len(ab_rows)}")
+    exact_rows = ab_rows if expected_ab_rows else list(pinned_rows or [])
+    for row in exact_rows:
+        label = row.sample.name
+        if row.status != "ok" or row.flags:
+            errors.append(f"{label} failed exact-pin integrity: status={row.status}, flags={list(row.flags)}")
+            continue
+        kernels = list(_launch_order_cuda_nodes(row.graph)) if row.graph is not None else []
+        if not kernels:
+            errors.append(f"{label} has no generated kernel inventory")
+        if row.bench is None or not bool(getattr(row.bench, "captured", False)):
+            errors.append(f"{label} timing was not captured")
+        else:
+            num_launches = getattr(row.bench, "num_launches", 0) or len(row.bench.per_launch or [])
+            if num_launches <= 0:
+                errors.append(f"{label} has no measured launches")
+            e2e_ms = getattr(row.bench, "e2e_min_ms", None)
+            if num_launches > 1 and e2e_ms is None:
+                errors.append(f"{label} multi-launch timing is not whole-program end-to-end")
+            total_ms = e2e_ms if e2e_ms is not None else getattr(row.bench, "min_ms", None)
+            if total_ms is None:
+                total_ms = getattr(row.bench, "time_ms", None)
+            if isinstance(total_ms, bool) or not isinstance(total_ms, int | float) or total_ms <= 0:
+                errors.append(f"{label} has no positive whole-program timing")
+        if not valid_proof(row.correctness):
+            errors.append(f"{label} lacks direct strict eager correctness")
+
+    return errors
+
+
 def _handle_run_ir(args, CudaBackend, CompilerDump):
     """Run path: load JSON IR (any stage), finish lowering, execute, bench."""
     import json
@@ -1631,6 +1941,7 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
     from emmy.compiler.graph import Graph
     from emmy.compiler.pipeline import Pipeline
 
+    strict_correctness = bool(getattr(args, "strict_correctness", False))
     embedded = getattr(args, "_golden_graph", None)
     path = Path(args.ir) if embedded is None else None
     if embedded is None:
@@ -1702,8 +2013,9 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         logger.warning("--ab ignored: %s IR is fully lowered (no forks left to pin)", stage)
 
     async def _bench_session():
-        greedy_fail = results = bench = accuracy_error = ab_benches = greedy_iso = None
+        greedy_fail = results = bench = accuracy_error = correctness = ab_ref = ab_benches = greedy_iso = None
         torch_available = captured = False
+        pinned = _pinned_samples_for_ir(args, embedded)
         try:
             try:
                 resp = await backend.benchmark_compare_async(
@@ -1714,14 +2026,16 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                     warmup=args.warmup,
                     iters=args.iters,
                     seed=args.seed,
+                    want_ref=bool(pinned and tail),
+                    strict_accuracy=strict_correctness,
                 )
             except RuntimeError as exc:
                 greedy_fail = f"greedy run/bench failed: {exc}"
             else:
                 results, bench, captured = resp["results"], resp["result"], resp["captured"]
                 torch_available, accuracy_error = resp["torch_available"], resp["accuracy_error"]
-            pinned = _pinned_samples_for_ir(args, embedded)
-            if pinned and tail:
+                correctness, ab_ref = resp.get("correctness"), resp.get("run_io")
+            if pinned and tail and (not strict_correctness or accuracy_error is None):
                 if greedy_fail:
                     logger.error("%s — greedy row marked bench_fail; pinned rows still bench in the worker", greedy_fail)
                 greedy_iso = await _bench_greedy_isolated(backend, graph, warmup=args.warmup, iters=args.iters)
@@ -1731,21 +2045,29 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
                     pinned,
                     warmup=args.warmup,
                     iters=args.iters,
+                    ref=ab_ref,
+                    strict_correctness=strict_correctness,
                 )
-            elif args.ab and tail:
+            elif not pinned and args.ab and tail:
                 if greedy_fail:
                     logger.error("%s — greedy row marked bench_fail; --ab rows still bench in the worker", greedy_fail)
                 greedy_iso = await _bench_greedy_isolated(backend, graph, warmup=args.warmup, iters=args.iters)
                 ab_benches = await _bench_ab_variants_ir(backend, path, tail, args.ab, warmup=args.warmup, iters=args.iters, db=db)
         finally:
             await backend.aclose_async_worker()
-        return greedy_fail, results, bench, torch_available, captured, accuracy_error, ab_benches, greedy_iso
+        return greedy_fail, results, bench, torch_available, captured, accuracy_error, correctness, ab_benches, greedy_iso
 
-    greedy_fail, results, bench, torch_available, captured, accuracy_error, ab_benches, greedy_iso = asyncio.run(_bench_session())
+    greedy_fail, results, bench, torch_available, captured, accuracy_error, correctness, ab_benches, greedy_iso = asyncio.run(
+        _bench_session()
+    )
 
     if accuracy_error is not None:
-        # Non-fatal here (random boundary inputs) — the child's own log is invisible, relay it.
-        logger.warning("%s — non-fatal (random-input reproducer); benched anyway", accuracy_error)
+        # Random boundary-input reproducers keep their historical informational check, while
+        # strict verification aborts after preserving JSON.
+        if strict_correctness:
+            logger.error(accuracy_error)
+        else:
+            logger.warning("%s — non-fatal (random-input reproducer); benched anyway", accuracy_error)
     if dump and bench is not None:
         dump.dump_benchmark(bench)
     if torch_available:
@@ -1759,12 +2081,27 @@ def _handle_run_ir(args, CudaBackend, CompilerDump):
         for line in render_table([Col("Backend"), Col("Latency (us)", "r")], [["Emmy", f"{bench.time_ms * 1000:.0f}"]], rule=True):
             print(line)
     _print_kernel_stats(graph, bench, golden_benches=ab_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
+    strict_errors = _strict_benchmark_errors(args, results, bench, captured, correctness, ab_benches) if strict_correctness else None
     if getattr(args, "json", None):
-        _write_ab_json(args, results or {}, graph, bench, ab_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
+        _write_ab_json(
+            args,
+            results or {},
+            graph,
+            bench,
+            ab_benches,
+            greedy_fail=greedy_fail,
+            greedy_iso=greedy_iso,
+            correctness=correctness,
+            strict_errors=strict_errors,
+        )
+    for error in strict_errors or []:
+        logger.error("strict: %s", error)
     if args.profile and greedy_fail is None:
         _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
     if (
-        greedy_fail is not None
+        (strict_correctness and accuracy_error is not None)
+        or bool(strict_errors)
+        or greedy_fail is not None
         or (greedy_iso is not None and greedy_iso.status != "ok")
         or any(gb.status != "ok" for gb in ab_benches or [])
     ):
@@ -2263,11 +2600,15 @@ def _build_torch_fns(module, args, kwargs, warmup, *, backends: set[str]):
             import torch._dynamo  # noqa: PLC0415
 
             torch._dynamo.reset()
-            compiled_module = torch.compile(module)
+            compiled_torch_module = torch.compile(module, fullgraph=True, mode="max-autotune")
             for _ in range(warmup + 5):
                 with torch.no_grad():
-                    compiled_module(*args, **kwargs)
-            torch_fns["torch.compile"] = lambda: compiled_module(*args, **kwargs)
+                    compiled_torch_module(*args, **kwargs)
+            with torch.no_grad():
+                eager_output = module(*args, **kwargs)
+                compiled_output = compiled_torch_module(*args, **kwargs)
+            torch.testing.assert_close(compiled_output, eager_output, rtol=1e-3, atol=1e-3)
+            torch_fns["torch.compile"] = lambda: compiled_torch_module(*args, **kwargs)
         except Exception as e:  # noqa: BLE001
             logger.warning("torch.compile failed: %s", e)
     return torch_fns

--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -39,6 +39,10 @@ gets the same vs-torch comparison as a static one (benched at the `Dim` hint by
 `commands/run.py::bench_lowered_vs_torch`, which sizes its random inputs by hint-resolving symbolic dims). Used to
 benchmark decoded golden programs and in-memory provenance slices against torch.
 
+The strict run path evaluates Emmy and eager on the same inputs and returns a direct `rtol=atol=1e-3` proof with
+error statistics. The isolated CUDA worker transports that proof and the eager reference outputs back to the parent,
+so exact-pinned rows can be checked against the same reference rather than against another Emmy realization.
+
 ## Backend ABC (`base.py`)
 
 `Backend` is an abstract base class with `compile`, `run`, `benchmark`.

--- a/emmy/compiler/backend/cuda/ARCHITECTURE.md
+++ b/emmy/compiler/backend/cuda/ARCHITECTURE.md
@@ -209,7 +209,9 @@ printed table carries a `benched at seq_len=… (symbolic hint)` note);
 `("frontend_graph", Graph|None)` → `bench_lowered_vs_torch`. A `trace_args` job honors two run-path
 flags: `accuracy` (bind the rebuilt module's real inputs, run the emmy program on them, compare vs
 eager — the verdict rides back as `accuracy_error` and a numeric failure skips the bench) and
-`want_ref` (return that run's `(inputs, outputs)` as `run_io`). Rebuilding the torch side **in the
+`want_ref` (return that run's `(inputs, outputs)` as `run_io`). A frontend-graph job may also request
+`strict_accuracy`; it returns the direct eager proof and same-input eager outputs used to check exact-pinned rows.
+Rebuilding the torch side **in the
 child** (not pickling a live module) is what lets the interleaved comparison — which couldn't cross a
 subprocess boundary before — run isolated. So `tune --bench` (`commands/tune.py` `_run_bench` /
 `_bench_per_kernel`) and every `run --bench` row go through the worker: a hung kernel

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -136,11 +136,12 @@ async def _run_job(req: dict) -> dict:
         # In-process within this child — the parent's SIGKILL is the wall-timeout backstop.
         backend = CudaBackend(bench_compile_timeout_s=60.0, bench_run_timeout_s=60.0)
         kind, payload = spec
-        accuracy_error = run_io = None
+        accuracy_error = run_io = correctness = None
         if kind == "frontend_graph":
             from emmy.commands.run import bench_lowered_vs_torch
 
-            results, bench, avail, captured, accuracy_error = await bench_lowered_vs_torch(
+            want_reference = req.get("want_ref", False) or req.get("strict_accuracy", False)
+            response = await bench_lowered_vs_torch(
                 payload,
                 req["graph"],
                 backend,
@@ -149,7 +150,12 @@ async def _run_job(req: dict) -> dict:
                 warmup=req["warmup"],
                 iters=req["iters"],
                 bench_backends=req["bench_backends"],
+                strict_accuracy=req.get("strict_accuracy", False),
+                return_reference=want_reference,
             )
+            results, bench, avail, captured, accuracy_error = response[:5]
+            if want_reference:
+                correctness, run_io = response[5:]
         elif kind == "trace_args":
             import types
 
@@ -204,6 +210,7 @@ async def _run_job(req: dict) -> dict:
             "captured": captured,
             "accuracy_error": accuracy_error,
             "run_io": run_io,
+            "correctness": correctness,
         }
 
 

--- a/emmy/compiler/backend/cuda/backend.py
+++ b/emmy/compiler/backend/cuda/backend.py
@@ -283,6 +283,7 @@ class CudaBackend(Backend):
         seed: int = 0,
         accuracy: bool = False,
         want_ref: bool = False,
+        strict_accuracy: bool = False,
     ) -> dict:
         """``run --bench``'s greedy-row comparison (eager / torch.compile / emmy, plus the
         optional in-child accuracy verdict and wrong-answer reference) through this
@@ -301,4 +302,5 @@ class CudaBackend(Backend):
             seed=seed,
             accuracy=accuracy,
             want_ref=want_ref,
+            strict_accuracy=strict_accuracy,
         )

--- a/emmy/compiler/backend/cuda/program.py
+++ b/emmy/compiler/backend/cuda/program.py
@@ -1819,6 +1819,7 @@ async def benchmark_compare_worker_async(
     seed: int,
     accuracy: bool = False,
     want_ref: bool = False,
+    strict_accuracy: bool = False,
 ) -> dict:
     """``run --bench``'s greedy-row transport: the same comparison job as
     :func:`benchmark_compare_isolated_async` but over a caller-supplied persistent
@@ -1837,6 +1838,7 @@ async def benchmark_compare_worker_async(
             "seed": seed,
             "accuracy": accuracy,
             "want_ref": want_ref,
+            "strict_accuracy": strict_accuracy,
         },
         wall_timeout_s=wall_timeout_s,
     )
@@ -1847,6 +1849,7 @@ async def benchmark_compare_worker_async(
         "captured": resp.get("captured", False),
         "accuracy_error": resp.get("accuracy_error"),
         "run_io": resp.get("run_io"),
+        "correctness": resp.get("correctness"),
     }
 
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -661,6 +661,12 @@ the partition fork predict for this kernel" are trace queries, never accumulated
 (`Run.resolve`) with the greedy pick (`greedy_decide`) — NOT a search. No frontier, no tree, no benching. The graph is
 copied once per attempt and resolved in place — no per-fork copies.
 
+`emmy run --golden PATH --strict` consumes a working golden rather than changing search. It visits every distinct
+target sequentially in the current process, or one target selected with `--target NAME`. A valid directly measured
+tune winner is an automatic exact pin; verified rows remain automatic pins as before. The ordinary strict run accepts
+only captured whole-forward timing with direct eager correctness at `rtol=atol=1e-3`. Process isolation and repeated
+observations come from independent command invocations, not a second orchestration layer inside `run`.
+
 **Greedy flattens forks before ranking.** The lazy fork tree is an MCTS structure — it stages knob choices across
 levels (`BR` → `BM/BN` → `FM/FN`) so MCTS pays one node per pop. Greedy must NOT walk it level-by-level: a branch
 carries only a *partial* tile, and `features.knob_features` can't compute its area / occupancy until `FM/FN` are

--- a/emmy/compiler/target.py
+++ b/emmy/compiler/target.py
@@ -8,8 +8,8 @@ the compiler emits code for a different architecture than the host —
 useful for ``emmy compile`` on a CPU box that wants to see the
 sm_120 codegen path, or for cross-compiling for a benchmark target.
 
-CLI commands attach the ``--target`` flag with :func:`add_target_arg`
-and resolve it via :func:`apply_target_arg`. Both forms accept the
+CLI commands attach their compute-capability option with :func:`add_target_arg`
+and resolve it via :func:`apply_target_arg`. The options accept the
 canonical NVIDIA spelling (``sm_80``, ``sm_90``, ``sm_120``); the
 optional architecture suffix on Hopper (``sm_90a``) is stripped.
 """
@@ -49,16 +49,15 @@ def set_target(cap: tuple[int, int] | None) -> None:
     compute_capability.cache_clear()
 
 
-def add_target_arg(parser, *, dest: str = "target") -> None:
-    """Add a ``--target sm_NN`` argument to ``parser``.
+def add_target_arg(parser, *, dest: str = "target", option: str = "--target") -> None:
+    """Add a compute-capability argument to ``parser``.
 
-    Commands that produce or run code (``compile``, ``run``, ``bench``)
-    use this so the same flag means the same thing everywhere. The
-    parsed value is a string; pass it to :func:`apply_target_arg` after
-    parsing to install the override.
+    The parsed value is a string; pass it to :func:`apply_target_arg` after parsing
+    to install the override. Most commands use ``--target``; ``run`` reserves that
+    spelling for working-golden selection and uses ``--gpu-arch`` here.
     """
     parser.add_argument(
-        "--target",
+        option,
         dest=dest,
         default=None,
         metavar="sm_NN",

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -72,6 +72,14 @@ is always a hard refusal.
 so every task's result reflects its host's stand-up cost. `vm_provision` is omitted for pre-allocated/fixed/local hosts
 (no VM created). See `emmy/commands/ARCHITECTURE.md` → Timing metrics.
 
+## Command source staging
+
+Command recipes stage only the Git-visible files under their declared paths: tracked and untracked files are included,
+while ignored files are excluded. Staging returns a manifest containing the Git revision, selected paths, per-file
+SHA-256 digests, working-tree status, and a content-derived source ID. `command.strict` rejects dirty selected paths
+before any transfer. The same manifest is retained in the command result, binding a measurement to the bytes sent to
+the remote host without requiring a `.git` directory there.
+
 ## Error contract
 
 `errors.py` defines two exceptions that providers raise to communicate intent:

--- a/emmy/provisioning/staging.py
+++ b/emmy/provisioning/staging.py
@@ -8,7 +8,9 @@ it on the remote without committing first.
 """
 
 import asyncio
+import hashlib
 import io
+import json
 import logging
 import tarfile
 from pathlib import Path
@@ -16,6 +18,11 @@ from pathlib import Path
 from emmy.provisioning.ssh_transport import ssh_base_args
 
 logger = logging.getLogger(__name__)
+
+
+def _source_id(files: dict[str, str]) -> str:
+    payload = json.dumps(files, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 async def enumerate_staged_files(repo_root: Path, stage_paths: list[str]) -> list[str]:
@@ -60,6 +67,39 @@ def build_stage_tar(repo_root: Path, files: list[str]) -> bytes:
     return buf.getvalue()
 
 
+async def _git_output(repo_root: Path, *args: str) -> str:
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        cwd=str(repo_root),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {stderr.decode().strip()}")
+    return stdout.decode().rstrip()
+
+
+async def build_stage_manifest(repo_root: Path, stage_paths: list[str], files: list[str] | None = None) -> dict:
+    """Describe the exact content staged for a command workload."""
+    candidates = files if files is not None else await enumerate_staged_files(repo_root, stage_paths)
+    selected = [relative for relative in candidates if (repo_root / relative).exists()]
+    digests = {relative: hashlib.sha256((repo_root / relative).read_bytes()).hexdigest() for relative in selected}
+    revision = await _git_output(repo_root, "rev-parse", "HEAD")
+    status = await _git_output(repo_root, "status", "--porcelain=v1", "--untracked-files=all", "--", *stage_paths)
+    dirty = [line for line in status.splitlines() if line]
+    return {
+        "schema_version": 1,
+        "source_id": _source_id(digests),
+        "git_revision": revision,
+        "clean": not dirty,
+        "dirty": dirty,
+        "stage_paths": list(stage_paths),
+        "files": digests,
+    }
+
+
 async def stage_to_remote(
     repo_root: Path,
     stage_paths: list[str],
@@ -68,22 +108,26 @@ async def stage_to_remote(
     ssh_port: int,
     remote_dir: str,
     dry_run: bool = False,
-) -> None:
+    require_clean: bool = False,
+) -> dict | None:
     """Stream a tar of staged files into `remote_dir` on the remote VM.
 
     No-op when `stage_paths` is empty.
     """
     if not stage_paths:
-        return
+        return None
 
     files = await enumerate_staged_files(repo_root, stage_paths)
     if not files:
         logger.warning(f"stage_to_remote: no files matched {stage_paths}")
-        return
+        return None
+    manifest = await build_stage_manifest(repo_root, stage_paths, files)
+    if require_clean and not manifest["clean"]:
+        raise RuntimeError(f"command staging requires a clean source tree: {manifest['dirty']}")
 
     if dry_run:
-        logger.info(f"[dry-run] stage {len(files)} files to {server}:{remote_dir}")
-        return
+        logger.info(f"[dry-run] stage {len(files)} files ({manifest['source_id']}) to {server}:{remote_dir}")
+        return manifest
 
     tar_bytes = build_stage_tar(repo_root, files)
 
@@ -105,4 +149,5 @@ async def stage_to_remote(
     _, stderr = await proc.communicate(input=tar_bytes)
     if proc.returncode != 0:
         raise RuntimeError(f"stage_to_remote failed (rc={proc.returncode}): {stderr.decode().strip()}")
-    logger.info(f"Staged {len(files)} files to {server}:{remote_dir}")
+    logger.info(f"Staged {len(files)} files ({manifest['source_id']}) to {server}:{remote_dir}")
+    return manifest

--- a/emmy/recipe/ARCHITECTURE.md
+++ b/emmy/recipe/ARCHITECTURE.md
@@ -239,6 +239,7 @@ command:
     - "*.log"
   timeout: 60
   env: {FOO: bar}                  # optional, prepended as KEY=value to the command
+  strict: true                     # clean source, required artifacts and provenance
 
 matrices:
   deploy.gpu: "NVIDIA GeForce RTX 5090"
@@ -249,6 +250,11 @@ matrices:
 The `run` template uses `string.Template` `$var` syntax. Substitution variables come from variant params (flattened to leaf names: `deploy.gpu` → `gpu`, `marker` → `marker`) plus harness-injected `$task_dir`, `$gpu_device_ids`, and `$repo_dir` (only when `stage` is non-empty). Conflicting leaf names (e.g. two matrix keys flattening to `gpu`) raise at substitution time.
 
 Command recipes skip `validate_extra_args()` since they don't go through engine flag mapping.
+
+Without `strict`, artifact transfer is best effort and staged files may include local edits. With `strict`, the staged
+paths must be clean before execution, their exact file digests and Git revision are recorded, every `result_files`
+entry must be retrieved, and GPU/CUDA provenance must be available. A failed command still attempts to retrieve its
+declared artifacts so partial evidence is not lost.
 
 ### Inline Post-Processing
 

--- a/emmy/recipe/types.py
+++ b/emmy/recipe/types.py
@@ -151,6 +151,8 @@ class CommandConfig:
             matched file is pulled back as {variant}_{basename}.
         timeout: Per-task command timeout in seconds.
         env: Extra environment variables to set on the remote command.
+        strict: Require a clean staged source tree, every declared result file,
+            and complete source/GPU/CUDA provenance.
     """
 
     stage: list[str] = field(default_factory=list)
@@ -158,6 +160,7 @@ class CommandConfig:
     result_files: list[str] = field(default_factory=list)
     timeout: int = 1800
     env: dict[str, str] = field(default_factory=dict)
+    strict: bool = False
 
 
 @dataclass
@@ -269,6 +272,7 @@ class Recipe:
                 result_files=list(cmd_dict.get("result_files", [])),
                 timeout=cmd_dict.get("timeout", 1800),
                 env=dict(cmd_dict.get("env", {})),
+                strict=cmd_dict.get("strict", False),
             )
 
         aggregate = None

--- a/tests/benchmark/test_command_workload.py
+++ b/tests/benchmark/test_command_workload.py
@@ -1,9 +1,13 @@
-"""Unit tests for the command workload module (pure functions)."""
+"""Unit tests for the command workload module."""
+
+from pathlib import Path
 
 import pytest
 
-from emmy.benchmark.command_workload import _local_result_name, build_substitution_map, render_command
+from emmy.benchmark.command_workload import _local_result_name, build_substitution_map, render_command, run_command_workload
+from emmy.planner import BenchmarkTask
 from emmy.planner.variant import Variant
+from emmy.recipe.types import CommandConfig, Recipe
 
 
 def _variant(params):
@@ -72,3 +76,70 @@ def test_render_command_repo_dir_unavailable():
     subs = build_substitution_map(v, [0], repo_dir=None, task_dir="/t")
     with pytest.raises(ValueError, match=r"undefined variable: \$repo_dir"):
         render_command("cd $repo_dir && make", subs)
+
+
+@pytest.mark.asyncio
+async def test_failed_command_still_pulls_preserved_result(monkeypatch, tmp_path):
+    recipe = Recipe(command=CommandConfig(run="false", result_files=["case/artifacts.tar.gz"]))
+    variant = _variant({"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 1})
+    task = BenchmarkTask(recipe_dir="experiment", variant=variant, recipe=recipe, run_dir=tmp_path)
+
+    async def run_cmd(command, **_kwargs):
+        return (7, "", "failed") if command == "false" else (0, "", "")
+
+    async def fake_scp(server, ssh_key, ssh_port, remote, local):
+        del server, ssh_key, ssh_port, remote
+        Path(local).write_bytes(b"archive")
+        return 0, ""
+
+    monkeypatch.setattr("emmy.provisioning.ssh_transport.scp_from_remote", fake_scp)
+    success, info = await run_command_workload(
+        task,
+        run_cmd,
+        repo_dir=None,
+        task_dir="/remote/task",
+        gpu_device_ids=[0],
+        server="host",
+        ssh_key="key",
+        ssh_port=22,
+    )
+
+    assert success is False
+    assert info["exit_code"] == 7
+    assert info["result_paths"] == [str(tmp_path / "rtx5090x1_case_artifacts.tar.gz")]
+    assert (tmp_path / "rtx5090x1_case_artifacts.tar.gz").read_bytes() == b"archive"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["missing", "scp"])
+async def test_strict_result_transfer_fails_closed(monkeypatch, tmp_path, failure):
+    recipe = Recipe(command=CommandConfig(run="true", result_files=["artifacts/*.tar.gz"], strict=True))
+    task = BenchmarkTask(
+        recipe_dir="experiment",
+        variant=_variant({"deploy.gpu": "NVIDIA GeForce RTX 5090", "deploy.gpu_count": 1}),
+        recipe=recipe,
+        run_dir=tmp_path,
+    )
+
+    async def run_cmd(command, **_kwargs):
+        if "for f in" in command:
+            return 0, "" if failure == "missing" else "artifacts/results.tar.gz\n", ""
+        return 0, "", ""
+
+    async def fake_scp(*_args):
+        return 1, "transfer failed"
+
+    monkeypatch.setattr("emmy.provisioning.ssh_transport.scp_from_remote", fake_scp)
+    success, info = await run_command_workload(
+        task,
+        run_cmd,
+        repo_dir=None,
+        task_dir="/remote/task",
+        gpu_device_ids=[0],
+        server="host",
+        ssh_key="key",
+        ssh_port=22,
+    )
+
+    assert success is False
+    assert info["result_errors"]

--- a/tests/benchmark/test_results.py
+++ b/tests/benchmark/test_results.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from emmy.benchmark.results import (
     BenchmarkMetrics,
     SystemInfo,
+    compose_command_json_result,
     compose_json_result,
+    missing_command_provenance,
     parse_benchmark_metrics,
     parse_system_info,
 )
@@ -87,6 +89,12 @@ NVIDIA GeForce RTX 5090, 32607 MiB, 580.65.06, P0, 42, 2 %
 | NVIDIA-SMI 580.65.06              Driver Version: 580.65.06      CUDA Version: 13.0     |
 +-----------------------------------------------------------------------------------------+
 
+=== GPU PROVENANCE ===
+0, NVIDIA GeForce RTX 5090, GPU-1234, 580.65.06, P0, 42, 2400, 1750, 120.0, 575.0
+
+=== CUDA COMPILER ===
+Cuda compilation tools, release 13.0, V13.0.88
+
 === DOCKER VERSION ===
 Docker version 28.5.1, build e180ab8
 """
@@ -160,6 +168,8 @@ def test_parse_system_info():
     assert s.cuda_version == "13.0"
     assert s.gpu_count == 1
     assert s.docker_version == "28.5.1"
+    assert s.gpu_provenance == ["0, NVIDIA GeForce RTX 5090, GPU-1234, 580.65.06, P0, 42, 2400, 1750, 120.0, 575.0"]
+    assert s.cuda_compiler == "Cuda compilation tools, release 13.0, V13.0.88"
 
 
 def test_parse_system_info_empty():
@@ -253,6 +263,32 @@ def test_compose_json_result_with_timing(tmp_path):
     )
     assert result["timing"] == timing
     assert result["timing"]["total"] == 540.5
+
+
+def test_compose_command_json_result_includes_source_and_failure(tmp_path):
+    task = _make_task(tmp_path)
+    result = compose_command_json_result(
+        task,
+        {"rendered_command": "echo test", "exit_code": 7, "result_paths": ["artifact.json"]},
+        SYSTEM_INFO_RAW,
+        success=False,
+        timing={"command": 1.5, "total": 1.5},
+        source={"source_id": "abc", "clean": True},
+    )
+
+    assert result["status"] == "failed"
+    assert result["command"]["exit_code"] == 7
+    assert result["source"] == {"source_id": "abc", "clean": True}
+    assert result["system"]["gpu_name"] == "NVIDIA GeForce RTX 5090"
+
+
+def test_missing_command_provenance_identifies_fields():
+    assert missing_command_provenance(SYSTEM_INFO_RAW, {"source_id": "abc", "files": {"emmy/a.py": "hash"}}) == []
+    assert missing_command_provenance("", None) == [
+        "staged source manifest",
+        "GPU provenance",
+        "CUDA compiler provenance",
+    ]
 
 
 # ── json_result_path ──────────────────────────────────────────────

--- a/tests/compiler/cli/test_golden_file_replay.py
+++ b/tests/compiler/cli/test_golden_file_replay.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
@@ -27,8 +29,15 @@ def _working_loop(path, *, state="inventory"):
     entry = document["configs"][0]
     realization = entry["realizations"][0]
     realization["name"] = "working.relu"
-    if state in {"proposal", "verified"}:
+    if state in {"proposal", "tuned", "verified"}:
         realization["knobs"] = {"WORK": "w1x1"}
+    if state == "tuned":
+        realization["ranking"] = {
+            "source": "tune",
+            "status": "ok",
+            "tune_winner": True,
+            "measured_knobs": {"WORK": "w1x1"},
+        }
     if state == "verified":
         realization["measurements"] = {
             "emmy_us": 1.0,
@@ -139,6 +148,31 @@ def test_working_verified_row_is_automatically_pinned(tmp_path):
     assert args.golden_configs[0].knobs == {"WORK": "w1x1"}
     assert args.golden_configs[0].pins == {"FAST_MATH": False}
     assert _sample_replay_knobs(args.golden_configs[0]) == {"FAST_MATH": False, "WORK": "w1x1"}
+
+
+def test_working_direct_tune_winner_is_automatically_pinned(tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    _working_loop(path, state="tuned")
+    args = _args(path)
+
+    resolve_golden_arg(args)
+
+    assert len(args.golden_configs) == 1
+    assert args.golden_configs[0].knobs == {"WORK": "w1x1"}
+
+
+def test_working_invalid_direct_tune_winner_is_rejected(tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    document = _working_loop(path, state="tuned")
+    document["configs"][0]["realizations"][0]["ranking"]["measured_knobs"] = {"WORK": "w2x2"}
+    dump_golden_file(document, path, overwrite=True)
+
+    with pytest.raises(SystemExit, match="2"):
+        resolve_golden_arg(_args(path))
 
 
 def test_run_replays_embedded_loop_golden_through_structural_stamps(tmp_path):

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -28,6 +28,18 @@ def _randn(shape: str, dtype, scale: float | None = None) -> str:
     return f"torch.randn({shape})"
 
 
+def _working_golden_for_live_gpu(name: str) -> Path:
+    from emmy import gpu
+    from emmy.compiler.pipeline.search import golden
+
+    live_name = gpu.live_name()
+    for path in sorted((Path(golden.__file__).parent / "goldens").glob("*.yaml")):
+        records = golden.load_golden_records(golden.load_golden_file(path))
+        if any(record.name == name and record.gpu_name == live_name for record in records):
+            return path
+    pytest.skip(f"no {name} working golden for {live_name}")
+
+
 def test_run_no_code_errors(run_cli):
     rc, stdout, stderr = run_cli("run")
     assert rc != 0
@@ -198,13 +210,27 @@ def test_build_torch_fns_resets_dynamo_before_compile(monkeypatch):
     assert "Eager PyTorch" in fns
 
 
+def test_build_torch_fns_rejects_wrong_inductor_output(monkeypatch):
+    import torch._dynamo
+
+    from emmy.commands.run import _build_torch_fns
+
+    monkeypatch.setattr(torch._dynamo, "reset", lambda: None)
+    monkeypatch.setattr(torch, "compile", lambda _module, *, fullgraph, mode: lambda: torch.tensor([2.0]))
+
+    fns = _build_torch_fns(lambda: torch.tensor([1.0]), (), {}, warmup=0, backends={"tcompile"})
+
+    assert "torch.compile" not in fns
+
+
 @requires_cuda
 def test_run_golden_bench_shows_benched_golden_row(run_cli):
-    """``run --golden NAME --bench`` compiles + benches the recorded golden (knobs
-    pinned) and prints it as a ``golden NAME``-labeled row in the kernel table, plus the
+    """A selected working-golden target compiles and benches its recorded knobs,
+    then prints it as a ``golden NAME``-labeled row in the kernel table, plus the
     ``greedy (isolated)`` twin — the greedy graph re-benched through the pinned-row path,
     the baseline the golden rows compare against."""
-    rc, stdout, stderr = run_cli("run", "--golden", "matmul.square.512", "--bench")
+    path = _working_golden_for_live_gpu("matmul.square.512")
+    rc, stdout, stderr = run_cli("run", "--golden", str(path), "--target", "matmul.square.512", "--bench")
     assert rc == 0, f"stderr: {stderr}"
     assert "golden matmul.square.512" in stdout, stdout
     assert "greedy (isolated)" in stdout, stdout
@@ -327,6 +353,24 @@ def test_wrong_answer_flag_catches_bad_pinned_output():
     assert "wrong-answer" in _wrong_answer_flag({"o": ref["o"] * 0.5}, ref)
     assert "missing" in _wrong_answer_flag({}, ref)
     assert "shape" in _wrong_answer_flag({"o": np.zeros((2, 2))}, ref)
+
+
+def test_strict_correctness_proof_uses_compiler_baseline_tolerance():
+    import numpy as np
+
+    from emmy.commands.run import _strict_correctness_proof
+
+    eager = {"o": np.array([1.0, 100.0], dtype=np.float32)}
+    passed = _strict_correctness_proof({"o": np.array([1.0015, 100.05], dtype=np.float32)}, eager)
+    assert passed["status"] == "pass"
+    assert passed["reference"] == "eager"
+    assert passed["rtol"] == passed["atol"] == 1e-3
+    assert passed["max_abs_error"] > 0
+    assert passed["mean_abs_error"] > 0
+
+    failed = _strict_correctness_proof({"o": np.array([1.01, 100.0], dtype=np.float32)}, eager)
+    assert failed["status"] == "fail"
+    assert "exceeds" in failed["error"]
 
 
 def test_unreproducible_pin_flag(monkeypatch):
@@ -627,13 +671,27 @@ def test_ab_json_labels_each_row_with_its_lane(tmp_path, monkeypatch):
 
 @requires_cuda
 def test_run_golden_bench_json_record(run_cli, tmp_path):
-    """``run --bench --golden NAME --json PATH`` writes the machine-readable A/B record:
+    """A working-golden benchmark writes the machine-readable A/B record:
     backends, the greedy kernel rows, and one pinned entry per recorded golden config with
     its integrity ``flags`` field and recorded reference latencies."""
     import json
 
     out = tmp_path / "ab.json"
-    rc, stdout, stderr = run_cli("run", "--golden", "matmul.square.512", "--bench", "--warmup", "2", "--iters", "5", "--json", str(out))
+    path = _working_golden_for_live_gpu("matmul.square.512")
+    rc, stdout, stderr = run_cli(
+        "run",
+        "--golden",
+        str(path),
+        "--target",
+        "matmul.square.512",
+        "--bench",
+        "--warmup",
+        "2",
+        "--iters",
+        "5",
+        "--json",
+        str(out),
+    )
     assert rc == 0, f"stderr: {stderr}"
     rec = json.loads(out.read_text())
     assert rec["golden"] == "matmul.square.512"
@@ -745,9 +803,9 @@ def test_run_code_matmul_accuracy(run_cli, dtype):
 
 @requires_cuda
 def test_run_code_target_override(run_cli):
-    """``--target sm_80`` gates lowering to the cp.async path (no TMA); the kernel still runs
+    """``--gpu-arch sm_80`` gates lowering to the cp.async path (no TMA); the kernel still runs
     on the live device and must match eager, so ``rc == 0`` is the accuracy assertion."""
-    rc, _, stderr = run_cli("run", "--code", "torch.matmul(torch.randn(256, 256), torch.randn(256, 256))", "--target", "sm_80")
+    rc, _, stderr = run_cli("run", "--code", "torch.matmul(torch.randn(256, 256), torch.randn(256, 256))", "--gpu-arch", "sm_80")
     assert rc == 0, f"stderr: {stderr}"
 
 
@@ -1398,10 +1456,55 @@ def test_write_ab_json_greedy_isolated_block(tmp_path):
     results = {"Eager PyTorch": 100.0, "torch.compile": 50.0, "Emmy": 25.0}
     _write_ab_json(args, results, greedy, bench, [], greedy_iso=iso)
     rec = json.loads((tmp_path / "ab.json").read_text())
-    assert rec["backends"]["Eager PyTorch"] == {"latency_us": 100.0, "speedup_vs_eager": 1.0}
+    assert rec["backends"]["Eager PyTorch"] == {
+        "latency_us": 100.0,
+        "captured": False,
+        "timing_semantics": "uncaptured_forward",
+        "speedup_vs_eager": 1.0,
+    }
     assert rec["backends"]["torch.compile"]["speedup_vs_eager"] == 2.0
     assert rec["backends"]["Emmy"]["speedup_vs_eager"] == 4.0
     assert rec["greedy"]["total_us"] == 500.0
     iso_rec = rec["greedy"]["isolated"]
     assert iso_rec["status"] == "ok" and iso_rec["total_us"] == 400.0
     assert iso_rec["kernels"][0]["us"] == 400.0 and iso_rec["flags"] == []
+
+
+def test_write_ab_json_uses_whole_program_time_for_multi_launch_pinned_row(tmp_path):
+    import json
+    from types import SimpleNamespace
+
+    from emmy.commands.run import _GoldenBench, _write_ab_json
+
+    greedy, bench, _iso = _iso_bench_fixtures()
+    multi_bench = SimpleNamespace(
+        min_ms=0.8,
+        time_ms=0.9,
+        per_launch=[
+            SimpleNamespace(idx=0, samples=[0.3], time_ms=0.3),
+            SimpleNamespace(idx=1, samples=[0.5], time_ms=0.5),
+        ],
+        num_launches=2,
+        captured=True,
+        e2e_min_ms=0.6,
+    )
+    sample = SimpleNamespace(name="ab TILE=f2x4", knobs={"TILE": "f2x4"}, shape=None, dynamic=None)
+    row = _GoldenBench(sample, greedy, multi_bench, [])
+    args = SimpleNamespace(
+        json=str(tmp_path / "ab.json"),
+        code="torch.matmul(a, b)",
+        input=None,
+        ir=None,
+        golden=None,
+        dynamic=None,
+        warmup=1,
+        iters=1,
+    )
+
+    _write_ab_json(args, {"Emmy": 600.0}, greedy, bench, [row])
+
+    pinned = json.loads((tmp_path / "ab.json").read_text())["pinned"][0]
+    assert pinned["total_us"] == 600.0
+    assert pinned["timing_semantics"] == "whole_program_e2e"
+    assert pinned["captured"] is True
+    assert pinned["num_launches"] == 2

--- a/tests/compiler/cli/test_run_golden.py
+++ b/tests/compiler/cli/test_run_golden.py
@@ -1,0 +1,122 @@
+"""Working-golden execution tests."""
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
+from emmy.commands import run as run_mod
+
+
+def _parser():
+    parser = argparse.ArgumentParser()
+    run_mod.register_run_command(parser.add_subparsers())
+    return parser
+
+
+def test_run_golden_schema_has_no_process_wrapper_flags():
+    args = _parser().parse_args(["run", "--golden", "working.yaml", "--target", "linear.layer0", "--gpu-arch", "sm_90"])
+
+    assert args.golden == "working.yaml"
+    assert args.golden_target == "linear.layer0"
+    assert args.gpu_arch == "sm_90"
+    for removed in ("all_targets", "repeats", "require_kernel_source", "golden_file"):
+        assert not hasattr(args, removed)
+
+
+def test_target_requires_golden(run_cli):
+    rc, stdout, stderr = run_cli("run", "--target", "linear.layer0")
+
+    assert rc == 2
+    assert "--target requires --golden PATH" in stdout + stderr
+
+
+def _args(tmp_path, **updates):
+    values = {
+        "golden": str(tmp_path / "working.yaml"),
+        "golden_target": None,
+        "input": None,
+        "code": None,
+        "ir": None,
+        "json": None,
+    }
+    values.update(updates)
+    return SimpleNamespace(**values)
+
+
+def _patch_records(monkeypatch, names):
+    from emmy.compiler.pipeline.search import golden
+
+    monkeypatch.setattr(golden, "load_golden_file", lambda _path: {})
+    monkeypatch.setattr(golden, "load_golden_records", lambda _document: [SimpleNamespace(name=name) for name in names])
+
+
+def test_golden_runs_every_distinct_target_in_process(monkeypatch, tmp_path):
+    _patch_records(monkeypatch, ["linear.layer0", "linear.layer0", "linear.layer1"])
+    calls = []
+    monkeypatch.setattr(run_mod, "_handle_run_once", calls.append)
+
+    run_mod._run_golden_targets(_args(tmp_path))
+
+    assert [args.golden for args in calls] == ["linear.layer0", "linear.layer1"]
+    assert all(args.golden_file.endswith("working.yaml") for args in calls)
+
+
+def test_target_limits_golden_to_one_match(monkeypatch, tmp_path):
+    _patch_records(monkeypatch, ["linear.layer0", "linear.layer1"])
+    calls = []
+    monkeypatch.setattr(run_mod, "_handle_run_once", calls.append)
+
+    run_mod._run_golden_targets(_args(tmp_path, golden_target="layer1", json=str(tmp_path / "result.json")))
+
+    assert len(calls) == 1
+    assert calls[0].golden == "layer1"
+    assert calls[0].json.endswith("result.json")
+
+
+def test_multi_target_json_uses_one_readable_file_per_target(monkeypatch, tmp_path):
+    _patch_records(monkeypatch, ["linear/layer0", "linear/layer1"])
+    calls = []
+    monkeypatch.setattr(run_mod, "_handle_run_once", calls.append)
+    output = tmp_path / "results"
+
+    run_mod._run_golden_targets(_args(tmp_path, json=str(output)))
+
+    assert [Path(args.json).name for args in calls] == ["000-linear_layer0.json", "001-linear_layer1.json"]
+    assert output.is_dir()
+
+
+def test_strict_result_requires_backends_capture_and_correctness():
+    proof = {
+        "status": "pass",
+        "reference": "eager",
+        "rtol": 1e-3,
+        "atol": 1e-3,
+        "max_abs_error": 0.0,
+        "mean_abs_error": 0.0,
+        "max_rel_error": 0.0,
+    }
+    bench = SimpleNamespace(captured=True, num_launches=1, per_launch=[], e2e_min_ms=None)
+    args = SimpleNamespace(bench_backends="eager,tcompile,emmy", ab=None)
+    results = {"Eager PyTorch": 20.0, "torch.compile": 15.0, "Emmy": 10.0}
+
+    assert run_mod._strict_benchmark_errors(args, results, bench, True, proof, []) == []
+    errors = run_mod._strict_benchmark_errors(args, {"Emmy": 10.0}, bench, True, proof, [])
+    assert "torch.compile" in " ".join(errors)
+
+
+def test_strict_result_requires_every_requested_exact_row():
+    args = SimpleNamespace(bench_backends="emmy", ab=["TILE=f2x4"])
+    proof = {
+        "status": "pass",
+        "reference": "eager",
+        "rtol": 1e-3,
+        "atol": 1e-3,
+        "max_abs_error": 0.0,
+        "mean_abs_error": 0.0,
+        "max_rel_error": 0.0,
+    }
+    bench = SimpleNamespace(captured=True)
+
+    errors = run_mod._strict_benchmark_errors(args, {"Emmy": 10.0}, bench, True, proof, [])
+
+    assert "expected 1 exact --ab row(s), got 0" in errors

--- a/tests/provisioning/test_staging.py
+++ b/tests/provisioning/test_staging.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 
 from emmy.provisioning.staging import (
+    build_stage_manifest,
     build_stage_tar,
     enumerate_staged_files,
+    stage_to_remote,
 )
 
 
@@ -79,3 +81,42 @@ def test_build_stage_tar_roundtrip(repo):
     assert members["scripts/tracked.py"] == "print('hi')\n"
     assert members["scripts/untracked.py"] == "print('new')\n"
     assert "scripts/ignored.log" not in members
+
+
+def test_stage_manifest_records_exact_files_revision_and_dirty_state(repo):
+    manifest = asyncio.run(build_stage_manifest(repo, ["scripts"]))
+
+    assert manifest["schema_version"] == 1
+    assert len(manifest["source_id"]) == 64
+    assert len(manifest["git_revision"]) == 40
+    assert manifest["clean"] is False
+    assert manifest["dirty"] == ["?? scripts/untracked.py"]
+    assert set(manifest["files"]) == {"scripts/tracked.py", "scripts/untracked.py"}
+
+
+def test_stage_manifest_source_id_changes_with_content(repo):
+    before = asyncio.run(build_stage_manifest(repo, ["scripts"]))
+    (repo / "scripts" / "tracked.py").write_text("print('changed')\n")
+    after = asyncio.run(build_stage_manifest(repo, ["scripts"]))
+
+    assert before["source_id"] != after["source_id"]
+    assert after["clean"] is False
+
+
+def test_stage_manifest_excludes_tracked_files_deleted_in_worktree(repo):
+    (repo / "scripts" / "tracked.py").unlink()
+
+    manifest = asyncio.run(build_stage_manifest(repo, ["scripts"]))
+
+    assert "scripts/tracked.py" not in manifest["files"]
+    assert " D scripts/tracked.py" in manifest["dirty"]
+
+
+def test_stage_to_remote_clean_gate_runs_before_dry_run_transfer(repo):
+    with pytest.raises(RuntimeError, match="requires a clean source tree"):
+        asyncio.run(stage_to_remote(repo, ["scripts"], "host", "key", 22, "/remote", dry_run=True, require_clean=True))
+
+    (repo / "scripts" / "untracked.py").unlink()
+    manifest = asyncio.run(stage_to_remote(repo, ["scripts"], "host", "key", 22, "/remote", dry_run=True, require_clean=True))
+    assert manifest is not None
+    assert manifest["clean"] is True

--- a/tests/recipe/test_types.py
+++ b/tests/recipe/test_types.py
@@ -20,6 +20,7 @@ def test_command_config_defaults():
     assert cfg.result_files == []
     assert cfg.timeout == 1800
     assert cfg.env == {}
+    assert cfg.strict is False
 
 
 def test_recipe_kind_inference_default():
@@ -39,6 +40,7 @@ def test_from_dict_command():
             "result_files": ["result.csv", "*.log"],
             "timeout": 60,
             "env": {"FOO": "bar"},
+            "strict": True,
         },
         "deploy": {"gpu": "NVIDIA GeForce RTX 5090", "gpu_count": 1},
     }
@@ -49,6 +51,7 @@ def test_from_dict_command():
     assert r.command.result_files == ["result.csv", "*.log"]
     assert r.command.timeout == 60
     assert r.command.env == {"FOO": "bar"}
+    assert r.command.strict is True
     assert r.deploy.gpu == "NVIDIA GeForce RTX 5090"
 
 


### PR DESCRIPTION
## Summary

- add one `command.strict` recipe field for clean content-addressed staging, required declared artifacts, and source/GPU/CUDA provenance
- preserve command result evidence, including artifacts after command failure, in a generic JSON record
- simplify working-golden replay to `emmy run --golden FILE [--target NAME]`; all targets run by default through the existing in-process path
- remove `--all`, `--repeats`, `--require-kernel-source`, the child-process/manifest wrapper, and its winner-selection helper
- keep strict replay focused on direct eager correctness, full-graph Inductor validity, captured timing, and exact pins
- keep experiment interpretation and report generation outside the benchmark harness

## Validation

- `make test` — 2,959 passed, 646 skipped, 1 xfailed, 1 xpassed
- `make lint`
- focused run/golden suite — 61 passed, 42 skipped