### PR TITLE
Add dynamic FP8 checkpoint tracing

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -146,7 +146,8 @@ structurally identical occurrences are not collapsed and a missing cache key nev
 frontend provenance origins when that selector is non-empty and unique. Otherwise the document embeds its standalone
 Loop IR slice in `loops` and selects that fallback by index. Flash score producers absorbed into their consumer are
 stored as part of that one fused target rather than as a second kernel. Trace records neither knobs nor timings,
-refuses replacement, and never writes a traced Graph JSON or provenance sidecar.
+refuses replacement, and never writes a traced Graph JSON or provenance sidecar. Quantized traces store their
+checkpoint-declaration digest in the same YAML.
 
 `emmy trace LOCAL_CHECKPOINT --serving-twins --serving-config PATH -o PATH` is the release inventory variant. It
 calls the config/allocation-metadata-only `serving.twins.capture_twin_graphs` path, combines every distinct

--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -652,12 +652,17 @@ def _trace_model(
         # quantization metadata; only generic tensor algebra enters decomposition.
         # Each speller is a no-op on the other family's checkpoints.
         if quant_dir is not None:
-            from emmy.compiler.loader.quant import spell_quantized_constants, spell_trellis_constants  # noqa: PLC0415
+            from emmy.compiler.loader.quant import (  # noqa: PLC0415
+                spell_dynamic_fp8_activations,
+                spell_quantized_constants,
+                spell_trellis_constants,
+            )
             from emmy.compiler.trace.huggingface import retarget_constants_to_model  # noqa: PLC0415
 
             if wrapper is not None:
                 retarget_constants_to_model(graph, wrapper, model)
             spell_quantized_constants(graph, str(quant_dir))
+            spell_dynamic_fp8_activations(graph, str(quant_dir))
             spell_trellis_constants(graph, str(quant_dir))
         return graph
 

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -1665,6 +1665,32 @@ def _replay_stage_and_passes(graph, *, embedded_golden: bool) -> tuple[str, list
     return stage, _passes_after_stage(stage)
 
 
+def _random_source_values(rng, shape, dtype):
+    """Return nontrivial deterministic values in a constant's declared storage dtype."""
+    import numpy as np  # noqa: PLC0415
+
+    from emmy.compiler.dtype import decode_f8  # noqa: PLC0415
+    from emmy.compiler.dtype import get as get_dtype  # noqa: PLC0415
+
+    canonical = get_dtype(dtype or "f32").name
+    if canonical in {"f8e4m3", "f8e5m2"}:
+        bits = rng.integers(0, 256, shape, dtype=np.uint8)
+        bits[~np.isfinite(decode_f8(bits, canonical))] = np.uint8(0)
+        return bits
+    return rng.standard_normal(shape, dtype=np.float32) * 0.02
+
+
+def _random_input_values(rng, shape, dtype):
+    """Return random runtime values, preserving exact FP8 input storage bits."""
+    import numpy as np  # noqa: PLC0415
+
+    from emmy.compiler.dtype import get as get_dtype  # noqa: PLC0415
+
+    if get_dtype(dtype).name in {"f8e4m3", "f8e5m2"}:
+        return _random_source_values(rng, shape, dtype)
+    return rng.standard_normal(shape, dtype=np.float32)
+
+
 async def bench_lowered_vs_torch(
     frontend,
     lowered,
@@ -1743,19 +1769,19 @@ async def bench_lowered_vs_torch(
                 continue
             if op.source_path and op.source_path not in sources:
                 shp = _static(op.source_shape or node.output.shape)
-                sources[op.source_path] = rng.standard_normal(shp, dtype=np.float32) * 0.02
+                sources[op.source_path] = _random_source_values(rng, shp, op.source_dtype)
             # A merged (source_parts) constant draws one random source PER PART, keyed by the
             # part path — the same tensors the pre-merge frontend reference binds its separate
             # weights from, so emmy's concat and the torch ref stay numerically aligned.
             for path, shp in op.source_parts:
                 if path not in sources:
-                    sources[path] = rng.standard_normal(_static(shp), dtype=np.float32) * 0.02
+                    sources[path] = _random_source_values(rng, _static(shp), op.source_dtype)
 
     input_data: dict[str, object] = {}
     input_tensors: dict[str, object] = {}
     for nid, node in lowered.nodes.items():
         if isinstance(node.op, InputOp):
-            arr = rng.standard_normal(_static(node.output.shape), dtype=np.float32)
+            arr = _random_input_values(rng, _static(node.output.shape), node.output.dtype)
             # Keep the ndarray shape (no flatten) — a symbolic graph's launch
             # reads the runtime seq_len off the input array's shape.
             input_data[nid] = arr

--- a/emmy/commands/trace.py
+++ b/emmy/commands/trace.py
@@ -138,7 +138,21 @@ def handle_trace(args):
     model = args.model_provenance or (
         args.input if input_path is not None and not (input_path.suffix == ".json" and input_path.exists()) else None
     )
-    result = write_trace_inventory(graph, destination, model=model, force_loop_targets=args.loop_targets)
+    model_quant_digest = None
+    if args.input:
+        from emmy.compiler.loader.quant import checkpoint_quant_digest  # noqa: PLC0415
+        from emmy.compiler.trace.huggingface import quantized_checkpoint_dir  # noqa: PLC0415
+
+        quant_dir = quantized_checkpoint_dir(args.input)
+        if quant_dir is not None:
+            model_quant_digest = checkpoint_quant_digest(quant_dir)
+    result = write_trace_inventory(
+        graph,
+        destination,
+        model=model,
+        force_loop_targets=args.loop_targets,
+        model_quant_digest=model_quant_digest,
+    )
     logger.info("Saved golden YAML: %s (%d distinct kernel(s))", result.path, result.target_count)
 
 

--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -142,6 +142,13 @@ buffer into its compute dtype. Scale pairing is the general `<key>_scale` / `<ke
 `.weight` → `.weight_scale` convention and covers non-`.weight` leaves (gpt-oss's 3-D expert params,
 `…experts.gate_up_proj` + `…experts.gate_up_proj_scale`).
 
+When an official FP8 declaration also specifies dynamic activations, `loader.quant.spell_dynamic_fp8_activations`
+wraps each eligible linear input in the checkpoint's per-row amax, zero-safe scale, encode, decode, and scale algebra.
+Linears sharing one projection input share the spelled value. A normal compile retains the model's original outputs;
+working-golden inventory generation alone promotes the marked bits and scale values to auxiliary outputs so fusion
+preserves the materialized W8A8 boundary. Native FP8 tensor-core enumeration remains explicitly gated by `FP8_MMA`,
+and a conservative compile can still execute the same graph algebra without selecting that hardware path.
+
 **Input-sourced fp8.** When the weights are forward-argument `InputOp`s instead of constants (the MoE serving seam's
 expert programs — one program per layer kind, per-expert 2-D slices fed per launch), the constant speller can never
 fire; `loader.quant.spell_quantized_inputs(graph, specs)` is the post-trace twin. Each named input keeps its node id

--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -27,10 +27,12 @@ distinction is whether the graph has been fused yet. See
 
 Not a `Backend` — a small Graph→torch evaluator that runs a frontend-dialect graph through **real PyTorch**, the eager /
 `torch.compile` baseline for `emmy run --ir`. Each frontend / tensor op is mapped to its torch twin
-(`RmsNormOp`→`F.rms_norm`, `LayerNormOp`→`F.layer_norm`, `SdpaOp`→`F.scaled_dot_product_attention`, `LinearOp`→`F.linear`, `ElementwiseOp`/`ReduceOp`→
-the torch elementwise/reduce, layout ops→view/transpose/cat). `is_runnable(graph)` is `True` only when every compute op
-has a mapping — layout/data-dependent ops that appear post-decomposition (`IndexMapOp` / `GatherOp` / `ScatterOp`) are
-unsupported, so `run --ir` falls back to emmy-only benchmarking for non-frontend IR. `build_callable(graph,
+(`RmsNormOp`→`F.rms_norm`, `LayerNormOp`→`F.layer_norm`, `SdpaOp`→`F.scaled_dot_product_attention`,
+`LinearOp`→`F.linear`, `ElementwiseOp`/`ReduceOp`→the torch elementwise/reduce, layout ops→view/transpose/cat).
+FP8 tensors remain exact `uint8` bit carriers; `to_f8*` casts to torch float8 and reinterprets its storage, while
+`from_f8*` performs the inverse reinterpretation before widening. `is_runnable(graph)` is `True` only when every
+compute op and every elementwise operation name has a mapping. Data-dependent `GatherOp` / `ScatterOp` remain
+unsupported, so `run --ir` falls back to emmy-only benchmarking for those graphs. `build_callable(graph,
 input_tensors)` returns a pure `fn(*tensors)` (scalar constants read inline) so `torch.compile` can trace it. Symbolic
 graphs work too: `build_callable` binds every symbolic axis name to its concrete extent read off the supplied tensors
 (the CUDA launch convention) and bakes the env into the per-node callables — shape-resolving sites (`ReshapeOp` target

--- a/emmy/compiler/backend/torch_ref.py
+++ b/emmy/compiler/backend/torch_ref.py
@@ -58,6 +58,11 @@ def torch_dtype(dtype) -> torch.dtype | None:
         "f32": torch.float32,
         "f16": torch.float16,
         "bf16": torch.bfloat16,
+        # Graph FP8 tensors carry the exact checkpoint / encode bit pattern as
+        # uint8.  Only the explicit ``from_f8*`` op decodes those bits to a
+        # numeric torch float8 value.
+        "f8e4m3": torch.uint8,
+        "f8e5m2": torch.uint8,
         "i32": torch.int32,
         "i64": torch.int64,
     }.get(str(dtype))
@@ -67,12 +72,34 @@ def is_runnable(graph: Graph) -> bool:
     """True if every compute op in ``graph`` has a torch mapping."""
     from emmy.compiler.provenance import is_boundary  # noqa: PLC0415
 
-    return all(is_boundary(n.op) or type(n.op).__name__ in SUPPORTED for n in graph.nodes.values())
+    for node in graph.nodes.values():
+        if is_boundary(node.op):
+            continue
+        if type(node.op).__name__ not in SUPPORTED:
+            return False
+        if type(node.op).__name__ == "ElementwiseOp":
+            try:
+                _elementwise_callable(node.op.op.name)
+            except NotImplementedError:
+                return False
+    return True
 
 
 def _build_elementwise_table() -> dict[str, Callable]:
     import torch  # noqa: PLC0415
     import torch.nn.functional as F  # noqa: PLC0415
+
+    def to_f8(bits_dtype):
+        # The Graph dtype is a uint8 bits carrier.  A numeric cast to uint8
+        # would truncate the quantized values; cast to torch float8 first, then
+        # reinterpret that one-byte storage as uint8.
+        return lambda a: a[0].to(bits_dtype).view(torch.uint8)
+
+    def from_f8(bits_dtype):
+        # Reverse the exact storage reinterpretation before widening.  This is
+        # deliberately not ``bits.to(float)``: that would convert codes such as
+        # 0x38 to 56 instead of decoding the FP8 value 1.0.
+        return lambda a: a[0].contiguous().view(bits_dtype).to(torch.float32)
 
     return {
         "add": lambda a: a[0] + a[1],
@@ -103,6 +130,10 @@ def _build_elementwise_table() -> dict[str, Callable]:
         "erf": lambda a: torch.erf(a[0]),
         "gelu": lambda a: F.gelu(a[0]),
         "gelu_tanh": lambda a: F.gelu(a[0], approximate="tanh"),
+        "to_f8e4m3": to_f8(torch.float8_e4m3fn),
+        "to_f8e5m2": to_f8(torch.float8_e5m2),
+        "from_f8e4m3": from_f8(torch.float8_e4m3fn),
+        "from_f8e5m2": from_f8(torch.float8_e5m2),
         "copy": lambda a: a[0],
     }
 

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -584,6 +584,26 @@ class Graph:
         self.inputs = [new_id if i == old_id else i for i in self.inputs]
         self.outputs = [new_id if o == old_id else o for o in self.outputs]
 
+    def replace_input(self, consumer_id: str, old_buf: str, new_buf: str) -> None:
+        """Replace one consumer edge while keeping the buffer indexes consistent.
+
+        Unlike :meth:`replace_node`, this rewires only ``consumer_id``. It is the
+        graph-mutation primitive for birth-time frontend spelling that inserts an
+        explicit value transform in front of selected consumers without redirecting
+        the transform's own input edge.
+        """
+        if consumer_id not in self.nodes:
+            raise KeyError(f"Consumer node {consumer_id!r} not found")
+        if new_buf not in self._producers and new_buf not in self.nodes:
+            raise KeyError(f"Replacement buffer {new_buf!r} not found")
+        consumer = self.nodes[consumer_id]
+        if old_buf not in consumer.inputs:
+            raise ValueError(f"Consumer {consumer_id!r} does not read buffer {old_buf!r}")
+        consumer.inputs = [new_buf if item == old_buf else item for item in consumer.inputs]
+        consumer.op = _rename_buf_in_op(consumer.op, old_buf, new_buf)
+        self._users.get(old_buf, set()).discard(consumer_id)
+        self._users.setdefault(new_buf, set()).add(consumer_id)
+
     def splice(
         self,
         fragment: Graph,

--- a/emmy/compiler/loader/quant.py
+++ b/emmy/compiler/loader/quant.py
@@ -20,6 +20,10 @@ architecture-twin construction). Two checkpoint families share the design — FP
   weight is just constants + algebra, and the cone stays in-graph so the
   compressed device storage reaches the ordinary lowering and scheduling rules
   (``032_fold_constant_subgraphs`` declines every storage-decode cone).
+- :func:`spell_dynamic_fp8_activations`: when the same checkpoint explicitly
+  declares dynamic activation scaling, wrap each eligible linear input in the
+  per-row amax / encode / decode algebra. The graph then carries the checkpoint's
+  W8A8 computation directly; later passes still see only dtypes and tensor algebra.
 - :func:`spell_quantized_inputs`: the input-sourced twin of the constant
   speller for graphs whose weights are forward-argument ``InputOp``s (the MoE
   serving seam's expert programs). Each named input becomes an fp8 bits input
@@ -510,6 +514,188 @@ def spell_quantized_constants(graph: Graph, model_id_or_path: str) -> int:
     if spelled:
         logger.info("spelled %d quantized weight constant(s) from %s", spelled, model_dir)
     return spelled
+
+
+def _dynamic_activation_declaration(qc: dict | None) -> tuple[bool, str | None]:
+    """Return ``(enabled, declared_fmt)`` for a supported dynamic FP8 activation scheme."""
+    if not qc:
+        return False, None
+    if qc.get("quant_method") == "fp8" and qc.get("activation_scheme") == "dynamic":
+        fmt = {"e4m3": "f8e4m3", "e5m2": "f8e5m2", "f8e4m3": "f8e4m3", "f8e5m2": "f8e5m2"}.get(qc.get("fmt"))
+        return fmt is not None, fmt
+    if qc.get("quant_method") == "compressed-tensors":
+        groups = list((qc.get("config_groups") or {}).values())
+        # Fail closed on mixed declarations: without resolving every group's target
+        # selector, one dynamic group must not turn a weight-only group into W8A8.
+        if groups and all(
+            isinstance(group, dict)
+            and isinstance(group.get("weights"), dict)
+            and group["weights"].get("type") == "float"
+            and int(group["weights"].get("num_bits") or 0) == 8
+            and isinstance(group.get("input_activations"), dict)
+            and group["input_activations"].get("type") == "float"
+            and int(group["input_activations"].get("num_bits") or 0) == 8
+            and group["input_activations"].get("dynamic") is True
+            and group["input_activations"].get("strategy") == "token"
+            for group in groups
+        ):
+            return True, None  # the paired weight's concrete f8 storage dtype selects the encode format
+    return False, None
+
+
+def _cone_storage_formats(graph: Graph, start: str) -> set[str]:
+    """Return FP8 storage dtypes reachable upstream from one graph buffer."""
+    pending = [start]
+    seen: set[str] = set()
+    formats: set[str] = set()
+    while pending:
+        buf = pending.pop()
+        node = graph.producer(buf)
+        if node is None or node.id in seen:
+            continue
+        seen.add(node.id)
+        if isinstance(node.op, ConstantOp):
+            dtype = node.output.dtype.name
+            if dtype in F8_SAFETENSORS_DTYPES.values():
+                formats.add(dtype)
+        pending.extend(node.inputs)
+    return formats
+
+
+def _cone_has_fp8_encode(graph: Graph, start: str) -> bool:
+    """Whether an activation buffer is already downstream of an FP8 encode."""
+    from emmy.compiler.ir.tensor.ir import ElementwiseOp  # noqa: PLC0415
+
+    pending = [start]
+    seen: set[str] = set()
+    while pending:
+        buf = pending.pop()
+        node = graph.producer(buf)
+        if node is None or node.id in seen:
+            continue
+        seen.add(node.id)
+        if isinstance(node.op, ElementwiseOp) and node.op.op.name.startswith("to_f8"):
+            return True
+        pending.extend(node.inputs)
+    return False
+
+
+def _fresh_buffer_name(graph: Graph, base: str) -> str:
+    """Return a deterministic unused primary-buffer name."""
+    name = base
+    suffix = 2
+    while name in graph.nodes or graph.buffer(name) is not None:
+        name = f"{base}_{suffix}"
+        suffix += 1
+    return name
+
+
+def _spell_dynamic_activation(graph: Graph, activation: str, fmt: str) -> str:
+    """Spell one shared per-row dynamic FP8 activation value and return its decoded buffer."""
+    from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.frontend.decomposition._helpers import const_bc  # noqa: PLC0415
+    from emmy.compiler.tensor import Tensor  # noqa: PLC0415
+
+    source = graph.buffer(activation)
+    if source is None or not source.shape or source.dtype.name not in {"f16", "bf16", "f32"}:
+        raise ValueError(f"dynamic FP8 activation {activation!r} must be a rank-1+ floating tensor")
+    shape = tuple(source.shape)
+    scale_shape = (*shape[:-1], 1)
+    stem = _fresh_buffer_name(graph, f"{activation}_dynamic_fp8")
+
+    absolute = graph.add_node(
+        op=ElementwiseOp(op="abs"),
+        inputs=[activation],
+        output=Tensor(f"{stem}_abs", shape, "f32"),
+    )
+    amax = graph.add_node(
+        op=ReduceOp(op="maximum", axis=-1),
+        inputs=[absolute],
+        output=Tensor(f"{stem}_amax", scale_shape, "f32"),
+    )
+    floor = const_bc(graph, name=f"{stem}_floor", value=1.0e-12, target_shape=scale_shape, dtype="f32")
+    stable_amax = graph.add_node(
+        op=ElementwiseOp(op="maximum"),
+        inputs=[amax, floor],
+        output=Tensor(f"{stem}_stable_amax", scale_shape, "f32"),
+    )
+    finite_max = 448.0 if fmt == "f8e4m3" else 57344.0
+    denominator = const_bc(graph, name=f"{stem}_finite_max", value=finite_max, target_shape=scale_shape, dtype="f32")
+    scale = graph.add_node(
+        op=ElementwiseOp(op="divide"),
+        inputs=[stable_amax, denominator],
+        output=Tensor(f"{stem}_scale", scale_shape, "f32"),
+    )
+    scale_bc = broadcast_to(graph, scale, shape)
+    normalized = graph.add_node(
+        op=ElementwiseOp(op="divide"),
+        inputs=[activation, scale_bc],
+        output=Tensor(f"{stem}_normalized", shape, "f32"),
+    )
+    bits = graph.add_node(
+        op=ElementwiseOp(op=f"to_{fmt}"),
+        inputs=[normalized],
+        output=Tensor(f"{stem}_bits", shape, fmt),
+    )
+    decoded = graph.add_node(
+        op=ElementwiseOp(op=f"from_{fmt}"),
+        inputs=[bits],
+        output=Tensor(f"{stem}_decoded", shape, source.dtype),
+    )
+    restored = graph.add_node(
+        op=ElementwiseOp(op="multiply"),
+        inputs=[decoded, scale_bc],
+        output=Tensor(f"{stem}_value", shape, source.dtype),
+    )
+
+    # Trace inventories promote these intermediates to auxiliary outputs before
+    # fusion. That preserves the genuine encode/scale boundary needed by a native
+    # W8A8 contraction without changing ordinary model-call outputs.
+    graph.nodes[bits].hints.set("trace.materialize", True)
+    graph.nodes[scale].hints.set("trace.materialize", True)
+    return restored
+
+
+def spell_dynamic_fp8_activations(graph: Graph, model_id_or_path: str) -> int:
+    """Spell checkpoint-declared dynamic FP8 activations in front of eligible linears.
+
+    The official ``quant_method: fp8`` declaration supplies both the activation
+    scheme and format. A linear is eligible only when its already-spelled weight
+    cone contains that same FP8 storage dtype. Shared projection inputs reuse one
+    quantized activation value. The zero-safe per-row scale is ``max(amax(abs(x)),
+    1e-12) / finite_max``. Returns the number of rewired linears; unsupported or
+    weight-only declarations are a no-op.
+    """
+    from emmy.compiler.ir.frontend.ir import LinearOp  # noqa: PLC0415
+    from emmy.compiler.loader.safetensors import _resolve_model_dir  # noqa: PLC0415
+
+    model_dir = _resolve_model_dir(model_id_or_path)
+    enabled, declared_fmt = _dynamic_activation_declaration(_fp8_quant_config(model_dir))
+    if not enabled:
+        return 0
+
+    eligible: list[tuple[str, str, str]] = []
+    for node in list(graph.nodes.values()):
+        if not isinstance(node.op, LinearOp) or len(node.inputs) < 2:
+            continue
+        activation, weight = node.inputs[:2]
+        formats = _cone_storage_formats(graph, weight)
+        if len(formats) != 1 or (declared_fmt is not None and formats != {declared_fmt}) or _cone_has_fp8_encode(graph, activation):
+            continue
+        eligible.append((node.id, activation, next(iter(formats))))
+
+    rewritten: dict[tuple[str, str], str] = {}
+    for linear_id, activation, fmt in eligible:
+        key = (activation, fmt)
+        restored = rewritten.get(key)
+        if restored is None:
+            restored = rewritten[key] = _spell_dynamic_activation(graph, activation, fmt)
+        graph.replace_input(linear_id, activation, restored)
+    if eligible:
+        formats = ", ".join(sorted({fmt for _linear, _activation, fmt in eligible}))
+        logger.info("spelled dynamic %s activation algebra for %d linear(s) from %s", formats, len(eligible), model_dir)
+    return len(eligible)
 
 
 def _trellis_dims(graph: Graph, nid: str, shapes: dict[str, tuple[int, ...]]) -> tuple[int, int, int, int] | None:

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -8,6 +8,7 @@ target identity needed by search consumers directly as data.
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -364,7 +365,11 @@ def validate_golden_file(
 ) -> None:
     if not isinstance(document, Mapping):
         raise ValueError("golden document must be a mapping")
-    _require_keys(document, {"gpu_name", "compute_cap", "model", "programs", "loops", "configs"}, "golden document")
+    _require_keys(
+        document,
+        {"gpu_name", "compute_cap", "model", "model_quant_digest", "programs", "loops", "configs"},
+        "golden document",
+    )
     gpu_name = document.get("gpu_name")
     if gpu_name is not None and (not isinstance(gpu_name, str) or not gpu_name):
         raise ValueError("gpu_name must be a non-empty string")
@@ -375,6 +380,9 @@ def validate_golden_file(
         raise ValueError("repository golden requires gpu_name")
     if document.get("model") is not None and not isinstance(document["model"], str):
         raise ValueError("model must be a string")
+    quant_digest = document.get("model_quant_digest")
+    if quant_digest is not None and (not isinstance(quant_digest, str) or re.fullmatch(r"[0-9a-f]{16}", quant_digest) is None):
+        raise ValueError("model_quant_digest must be a 16-character lowercase hexadecimal digest")
     try:
         programs = validate_program_pool(document.get("programs"))
     except ValueError as exc:

--- a/emmy/compiler/pipeline/search/working_golden.py
+++ b/emmy/compiler/pipeline/search/working_golden.py
@@ -61,6 +61,7 @@ def write_trace_inventory(
     ctx=None,
     force_loop_targets: bool = False,
     realizations: list[dict] | None = None,
+    model_quant_digest: str | None = None,
 ) -> TraceInventoryResult:
     """Lower a trace through fusion and write a self-contained target inventory."""
     destination = preflight_trace_inventory(path)
@@ -79,7 +80,15 @@ def write_trace_inventory(
         force_loop_targets=force_loop_targets,
         realizations=realizations,
     )
-    _dump_trace_inventory(destination, ctx=ctx, model=model, programs=programs, loops=loops, entries=entries)
+    _dump_trace_inventory(
+        destination,
+        ctx=ctx,
+        model=model,
+        model_quant_digest=model_quant_digest,
+        programs=programs,
+        loops=loops,
+        entries=entries,
+    )
     return TraceInventoryResult(path=destination, target_count=len(entries))
 
 
@@ -90,6 +99,7 @@ def write_trace_inventories(
     model: str | None = None,
     ctx=None,
     realizations: list[dict] | None = None,
+    model_quant_digest: str | None = None,
 ) -> TraceInventoryResult:
     """Combine named traces into one exact-Loop-IR working inventory.
 
@@ -121,7 +131,15 @@ def write_trace_inventories(
             seen_loops=seen_loops,
             realizations=realizations,
         )
-    _dump_trace_inventory(destination, ctx=ctx, model=model, programs=programs, loops=loops, entries=entries)
+    _dump_trace_inventory(
+        destination,
+        ctx=ctx,
+        model=model,
+        model_quant_digest=model_quant_digest,
+        programs=programs,
+        loops=loops,
+        entries=entries,
+    )
     return TraceInventoryResult(path=destination, target_count=len(entries))
 
 
@@ -145,6 +163,14 @@ def _append_trace_inventory(
     from emmy.compiler.pipeline.passes.lowering.tile._flash import fused_producer_ids  # noqa: PLC0415
     from emmy.compiler.pipeline.search.slice import single_node_graph  # noqa: PLC0415
     from emmy.compiler.torch_wire import intern_program  # noqa: PLC0415
+
+    # A birth-time speller may mark an internal storage value that has to remain
+    # materialized for a faithful target inventory (dynamic activation bits and
+    # scale are the first use). Promoting only the inventory copy to an auxiliary
+    # graph output preserves the boundary without changing normal model outputs.
+    for traced_node in graph.nodes.values():
+        if traced_node.hints.get("trace.materialize") and traced_node.id not in graph.outputs:
+            graph.outputs.append(traced_node.id)
 
     # Torch tracing and checkpoint spelling may hand us a graph that has already crossed one
     # compiler pipeline and therefore carries implementation-piece provenance. The stable wire
@@ -224,6 +250,7 @@ def _dump_trace_inventory(
     *,
     ctx,
     model: str | None,
+    model_quant_digest: str | None,
     programs: list[dict],
     loops: list[dict],
     entries: list[dict],
@@ -238,6 +265,8 @@ def _dump_trace_inventory(
         document["loops"] = loops
     if ctx.gpu_name:
         document["gpu_name"] = ctx.gpu_name
+    if model_quant_digest:
+        document["model_quant_digest"] = model_quant_digest
     if model:
         document["model"] = model
 

--- a/emmy/compiler/trace/ARCHITECTURE.md
+++ b/emmy/compiler/trace/ARCHITECTURE.md
@@ -216,7 +216,9 @@ shared with CausalLM traces.
   every fold-aware kernel occurrence, and embeds the complete stable Torch IR program once in the golden YAML. Each
   target is selected by unique frontend origins when possible; an empty or ambiguous selector stores the standalone
   post-fusion Loop IR slice instead. The smaller provenance tuning reproducer is derived in memory when the working
-  file is loaded.
+  file is loaded. Quantized model traces also embed the digest of their exact checkpoint declaration. Frontend nodes
+  carrying the generic `trace.materialize` hint become auxiliary outputs only in the inventory copy, preserving an
+  internal storage boundary without changing an ordinary model call.
   `commands.trace` only validates CLI paths and reports that single artifact; traced JSON and sidecars are not outputs.
 - Whole-model trace: `trace_module(build_full_model_wrapper(model, …), (input_ids,))`.
 - Single-layer trace: `trace_module(model.model.layers[N], (x,), kwargs={…})` (static); with `--dynamic`,

--- a/tests/compiler/backend/test_torch_ref.py
+++ b/tests/compiler/backend/test_torch_ref.py
@@ -82,6 +82,64 @@ def test_declared_dtype_cast_is_enforced():
     assert out.dtype == torch.float16
 
 
+def _dynamic_w8a8_graph() -> Graph:
+    """A post-spelling dynamic-activation FP8 projection target."""
+    from emmy.compiler.dtype import F8E4M3, F16, F32
+
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8), F16), node_id="x")
+    g.add_node(InputOp(), [], Tensor("x_scale", (4, 1), F32), node_id="x_scale")
+    g.add_node(ElementwiseOp(op="divide"), ["x", "x_scale"], Tensor("x_normalized", (4, 8), F32), node_id="x_normalized")
+    g.add_node(ElementwiseOp(op="to_f8e4m3"), ["x_normalized"], Tensor("x_bits", (4, 8), F8E4M3), node_id="x_bits")
+    g.add_node(ElementwiseOp(op="from_f8e4m3"), ["x_bits"], Tensor("x_decoded", (4, 8), F16), node_id="x_decoded")
+    g.add_node(ElementwiseOp(op="multiply"), ["x_decoded", "x_scale"], Tensor("x_quantized", (4, 8), F16), node_id="x_quantized")
+    g.add_node(InputOp(), [], Tensor("w_bits", (6, 8), F8E4M3), node_id="w_bits")
+    g.add_node(InputOp(), [], Tensor("w_scale", (6, 1), F32), node_id="w_scale")
+    g.add_node(ElementwiseOp(op="from_f8e4m3"), ["w_bits"], Tensor("w_decoded", (6, 8), F16), node_id="w_decoded")
+    g.add_node(ElementwiseOp(op="multiply"), ["w_decoded", "w_scale"], Tensor("w_quantized", (6, 8), F16), node_id="w_quantized")
+    g.add_node(LinearOp(), ["x_quantized", "w_quantized"], Tensor("o", (4, 6), F16), node_id="o")
+    g.inputs, g.outputs = ["x", "x_scale", "w_bits", "w_scale"], ["o"]
+    return g
+
+
+def _dynamic_w8a8_inputs():
+    from emmy.compiler.dtype import encode_f8
+
+    x = torch.linspace(-2.0, 2.0, 32, dtype=torch.float16).reshape(4, 8)
+    x_scale = x.abs().amax(dim=-1, keepdim=True).float() / 448.0
+    weight = np.linspace(-3.0, 3.0, 48, dtype=np.float32).reshape(6, 8)
+    w_scale = np.max(np.abs(weight), axis=-1, keepdims=True).astype(np.float32) / 448.0
+    w_bits = encode_f8(weight / w_scale, "f8e4m3")
+    return {"x": x, "x_scale": x_scale, "w_bits": torch.from_numpy(w_bits), "w_scale": torch.from_numpy(w_scale)}
+
+
+def test_dynamic_w8a8_eager_preserves_fp8_bit_semantics():
+    g = _dynamic_w8a8_graph()
+    tensors = _dynamic_w8a8_inputs()
+    fn, inputs = torch_ref.build_callable(g, tensors)
+
+    out = fn(*inputs)
+    x_bits = (tensors["x"] / tensors["x_scale"]).to(torch.float8_e4m3fn).view(torch.uint8)
+    x_quantized = (x_bits.view(torch.float8_e4m3fn).to(torch.float16) * tensors["x_scale"]).to(torch.float16)
+    w_quantized = (tensors["w_bits"].view(torch.float8_e4m3fn).to(torch.float16) * tensors["w_scale"]).to(torch.float16)
+    expected = torch.nn.functional.linear(x_quantized, w_quantized)
+
+    assert torch_ref.is_runnable(g)
+    assert tensors["w_bits"].dtype == torch.uint8
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_dynamic_w8a8_torch_compile_is_fullgraph():
+    g = _dynamic_w8a8_graph()
+    fn, inputs = torch_ref.build_callable(g, _dynamic_w8a8_inputs())
+    eager = fn(*inputs)
+
+    compiled = torch.compile(fn, fullgraph=True)
+    actual = compiled(*inputs)
+
+    torch.testing.assert_close(actual, eager, rtol=1e-3, atol=1e-3)
+
+
 def test_matmul_softmax():
     g = Graph()
     g.add_node(InputOp(), [], Tensor("a", (4, 8)), node_id="a")
@@ -179,3 +237,11 @@ def test_is_runnable_accepts_frontend():
     g.add_node(RmsNormOp(), ["x", "w"], Tensor("o", (1, 4, 8)), node_id="o")
     g.inputs, g.outputs = ["x", "w"], ["o"]
     assert torch_ref.is_runnable(g)
+
+
+def test_is_runnable_rejects_unmapped_elementwise():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 8)), node_id="x")
+    g.add_node(ElementwiseOp(op="square"), ["x"], Tensor("o", (4, 8)), node_id="o")
+    g.inputs, g.outputs = ["x"], ["o"]
+    assert not torch_ref.is_runnable(g)

--- a/tests/compiler/cli/test_trace.py
+++ b/tests/compiler/cli/test_trace.py
@@ -196,6 +196,27 @@ def test_trace_writes_deterministic_self_contained_programs(tmp_path) -> None:
     assert all(set(entry["target"]) == {"origins"} for entry in first_doc["configs"])
 
 
+def test_trace_keeps_materialized_storage_outputs_and_quant_digest(tmp_path) -> None:
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("x", (4, 32), "f16"), node_id="x")
+    bits = graph.add_node(ElementwiseOp("to_f8e4m3"), ["x"], Tensor("x_bits", (4, 32), "f8e4m3"), node_id="x_bits")
+    graph.nodes[bits].hints.set("trace.materialize", True)
+    graph.add_node(ElementwiseOp("from_f8e4m3"), [bits], Tensor("out", (4, 32), "f16"), node_id="out")
+    graph.inputs, graph.outputs = ["x"], ["out"]
+
+    path = tmp_path / "working.yaml"
+    result = write_trace_inventory(
+        graph,
+        path,
+        model_quant_digest="0123456789abcdef",
+    )
+    document = load_golden_file(path)
+
+    assert result.target_count == 2
+    assert document["model_quant_digest"] == "0123456789abcdef"
+    assert "x_bits" in document["programs"][0]["outputs"]
+
+
 def test_trace_target_resolves_in_original_multi_op_fusion_context(tmp_path) -> None:
     graph = Graph()
     graph.add_node(InputOp(), [], Tensor("x", (16, 64), "f16"), node_id="x")

--- a/tests/compiler/ir/test_graph.py
+++ b/tests/compiler/ir/test_graph.py
@@ -94,6 +94,22 @@ def test_replace_node():
     assert "red2" in [o for o in g.outputs]
 
 
+def test_replace_input_rewires_only_one_consumer():
+    g = _make_matmul_graph()
+    replacement = g.add_node(
+        op=ElementwiseOp(op="negative"),
+        inputs=["A"],
+        output=Tensor("negative_a", ("M", "K", "N")),
+        node_id="negative_a",
+    )
+
+    g.replace_input("ew", "A", replacement)
+
+    assert g.nodes["ew"].inputs == ["negative_a", "B"]
+    assert g.users("A") == {"negative_a"}
+    assert g.users("negative_a") == {"ew"}
+
+
 def test_remove_node():
     g = _make_matmul_graph()
     g.outputs = []

--- a/tests/compiler/loader/test_quant.py
+++ b/tests/compiler/loader/test_quant.py
@@ -9,9 +9,15 @@ import pytest
 
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import ConstantOp, InputOp
-from emmy.compiler.ir.frontend.ir import ReshapeOp
-from emmy.compiler.ir.tensor.ir import ElementwiseOp
-from emmy.compiler.loader.quant import decode_f8, dequantize, spell_quantized_constants, spell_quantized_inputs
+from emmy.compiler.ir.frontend.ir import LinearOp, ReshapeOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
+from emmy.compiler.loader.quant import (
+    decode_f8,
+    dequantize,
+    spell_dynamic_fp8_activations,
+    spell_quantized_constants,
+    spell_quantized_inputs,
+)
 from emmy.compiler.loader.safetensors import load_constants_from_safetensors
 from tests.compiler.helpers import requires_cuda
 
@@ -236,6 +242,102 @@ def test_spell_is_idempotent(tmp_path):
     nodes_after_first = set(g.nodes)
     assert spell_quantized_constants(g, str(tmp_path)) == 0
     assert set(g.nodes) == nodes_after_first
+
+
+def test_spell_dynamic_activations_reuses_one_shared_w8a8_value(tmp_path):
+    bits = _finite_bits((8, 16))
+    scale = np.ones((8, 1), dtype=np.float32)
+    _write_checkpoint(
+        tmp_path,
+        {
+            "layer.a.weight": _fp8_tensor(bits),
+            "layer.a.weight_scale": torch.from_numpy(scale),
+            "layer.b.weight": _fp8_tensor(bits),
+            "layer.b.weight_scale": torch.from_numpy(scale),
+        },
+        _FP8_QC,
+    )
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 16), "f16"), node_id="x")
+    for name in ("a", "b"):
+        weight = f"p_{name}"
+        g.add_node(
+            ConstantOp(name=weight, source_path=f"layer.{name}.weight", source_shape=(8, 16), source_dtype="f16"),
+            [],
+            Tensor(weight, (8, 16), "f16"),
+            node_id=weight,
+        )
+        g.add_node(LinearOp(), ["x", weight], Tensor(f"y_{name}", (4, 8), "f16"), node_id=f"y_{name}")
+    g.inputs, g.outputs = ["x"], ["y_a", "y_b"]
+
+    assert spell_quantized_constants(g, str(tmp_path)) == 2
+    assert spell_dynamic_fp8_activations(g, str(tmp_path)) == 2
+
+    activation_inputs = {g.nodes[name].inputs[0] for name in ("y_a", "y_b")}
+    assert len(activation_inputs) == 1
+    assert len([node for node in _ops_by_type(g, ElementwiseOp) if node.op.op.name == "to_f8e4m3"]) == 1
+    assert len([node for node in _ops_by_type(g, ReduceOp) if node.op.op.name == "maximum"]) == 1
+    materialized = {node.output.dtype.name for node in g.nodes.values() if node.hints.get("trace.materialize")}
+    assert materialized == {"f32", "f8e4m3"}
+    assert spell_dynamic_fp8_activations(g, str(tmp_path)) == 0
+
+
+def test_spell_dynamic_activations_requires_checkpoint_declaration(tmp_path):
+    qc = {**_FP8_QC, "activation_scheme": "static"}
+    g, _bits, _scale = _spelled(tmp_path, qc=qc)
+    assert spell_dynamic_fp8_activations(g, str(tmp_path)) == 0
+
+
+def test_spell_dynamic_activations_accepts_compressed_tensors_token_scheme(tmp_path):
+    qc = {
+        "quant_method": "compressed-tensors",
+        "format": "float-quantized",
+        "ignore": [],
+        "config_groups": {
+            "group_0": {
+                "weights": {"num_bits": 8, "type": "float", "strategy": "channel", "dynamic": False},
+                "input_activations": {"num_bits": 8, "type": "float", "strategy": "token", "dynamic": True},
+            }
+        },
+    }
+    bits = _finite_bits((8, 16))
+    _write_checkpoint(
+        tmp_path,
+        {"layer.weight": _fp8_tensor(bits), "layer.weight_scale": torch.ones((8, 1), dtype=torch.float32)},
+        qc,
+    )
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4, 16), "f16"), node_id="x")
+    g.add_node(
+        ConstantOp(name="p_w", source_path="layer.weight", source_shape=(8, 16), source_dtype="f16"),
+        [],
+        Tensor("p_w", (8, 16), "f16"),
+        node_id="p_w",
+    )
+    g.add_node(LinearOp(), ["x", "p_w"], Tensor("y", (4, 8), "f16"), node_id="y")
+    g.inputs, g.outputs = ["x"], ["y"]
+
+    assert spell_quantized_constants(g, str(tmp_path)) == 1
+    assert spell_dynamic_fp8_activations(g, str(tmp_path)) == 1
+    assert any(node.op.op.name == "to_f8e4m3" for node in _ops_by_type(g, ElementwiseOp))
+
+
+def test_spell_dynamic_activations_rejects_mixed_compressed_tensor_groups(tmp_path):
+    qc = {
+        "quant_method": "compressed-tensors",
+        "config_groups": {
+            "dynamic": {
+                "weights": {"num_bits": 8, "type": "float"},
+                "input_activations": {"num_bits": 8, "type": "float", "strategy": "token", "dynamic": True},
+            },
+            "weight_only": {
+                "weights": {"num_bits": 8, "type": "float"},
+                "input_activations": None,
+            },
+        },
+    }
+    graph, _bits, _scale = _spelled(tmp_path, qc=qc)
+    assert spell_dynamic_fp8_activations(graph, str(tmp_path)) == 0
 
 
 def test_spell_honors_modules_to_not_convert(tmp_path):
@@ -751,9 +853,18 @@ def test_trace_model_spells_cones_and_binds_dequantized_twin(tmp_path):
     for _nid, op in graph.loadable_constants():
         if op.source_path and ("embed_tokens" in op.source_path or "lm_head" in op.source_path):
             assert op.source_dtype != "f8e4m3", f"unexpected spelling on {op.source_path}"
-    # Each bits constant is consumed by its decode cast in-graph.
+    # Each bits constant and every dynamically encoded activation are consumed
+    # by their matching decode cast in-graph.
     decode_ops = [n for n in graph.nodes.values() if isinstance(n.op, ElementwiseOp) and n.op.op.decodes is not None]
-    assert len(decode_ops) == len(spelled)
+    weight_decodes = [
+        node
+        for node in decode_ops
+        if isinstance(graph.producer(node.inputs[0]).op, ConstantOp) and graph.producer(node.inputs[0]).output.dtype.name == "f8e4m3"
+    ]
+    activation_encodes = [node for node in graph.nodes.values() if isinstance(node.op, ElementwiseOp) and node.op.op.name == "to_f8e4m3"]
+    assert len(weight_decodes) == len(spelled)
+    assert len(decode_ops) == len(spelled) + len(activation_encodes)
+    assert activation_encodes
 
     params = dict(wrapper.named_parameters())
     for name, ref in ref_sd.items():

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -28,6 +28,7 @@
  "tests/compiler/backend/test_bench_worker_recovery.py::test_worker_survives_benign_error": 0.28,
  "tests/compiler/backend/test_emit.py::test_contraction_emits_matmul": 0.18,
  "tests/compiler/backend/test_source_determinism.py::test_kernel_source_identical_across_processes": 7.2,
+ "tests/compiler/backend/test_torch_ref.py::test_dynamic_w8a8_torch_compile_is_fullgraph": 15.1,
  "tests/compiler/cli/test_compare.py::test_compare_full_model_and_kernels": 0.45,
  "tests/compiler/cli/test_compare.py::test_compare_kernel_set_change_listed": 0.39,
  "tests/compiler/cli/test_compare.py::test_compare_missing_dir_errors": 0.42,


### PR DESCRIPTION
## Summary

- spell checkpoint-declared per-token dynamic FP8 activations as ordinary graph algebra before eligible linear ops
- preserve exact FP8 storage bits in eager and `torch.compile` references and in golden replay inputs
- preserve marked internal FP8 bits and scales in working-golden inventory copies and record the quantization declaration digest

This is the reusable compiler support extracted from #486. It contains no conference recipes, serving-model matrices,
benchmark interpretation, corpus-filtering CLI, or report machinery.

## Validation

- `make test`: 2,968 passed, 646 skipped, 1 xfailed, 1 xpassed
- focused compiler suite: 117 passed, 1 skipped
- `make lint`
- `git diff --check`
