### PR TITLE
Onboard Llama 3.1 8B FP16/AWQ on V100 and add AWQ compiler support

### DIFF
--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -610,6 +610,7 @@ def _trace_model(
     from emmy.compiler.loader.safetensors import split_revision
     from emmy.compiler.trace.huggingface import (
         load_architecture_trace_twin,
+        load_quantized_layer_twin,
         load_quantized_trace_twin,
         load_quantized_twin,
         quantized_checkpoint_dir,
@@ -621,10 +622,15 @@ def _trace_model(
     quant_dir = quantized_checkpoint_dir(model_id)
     repo, revision = split_revision(model_id)
     if quant_dir is not None:
-        # Quantized checkpoint (fp8 / EXL3): trace the architecture twin from config,
+        # Quantized checkpoint (FP8 / AWQ / EXL3): trace the architecture twin from config,
         # carrying the decoded real weights (from_pretrained would engage transformers'
         # own quantizer machinery — the trace is quantization-blind; see the FP8 plan).
-        model = load_quantized_trace_twin(quant_dir, dtype, layer) if architecture_only else load_quantized_twin(quant_dir, dtype)
+        if architecture_only:
+            model = load_quantized_trace_twin(quant_dir, dtype, layer)
+        elif layer is not None:
+            model = load_quantized_layer_twin(quant_dir, dtype, layer)
+        else:
+            model = load_quantized_twin(quant_dir, dtype)
     elif architecture_only and layer is not None:
         # Inventory traces need shapes and module structure, not checkpoint
         # values. Constructing from config under ``meta`` avoids downloading or

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -155,7 +155,7 @@ def register_run_command(subparsers):
         dest="strict_correctness",
         action="store_true",
         help=(
-            "With --bench on runnable frontend IR or an embedded golden, fail unless every requested backend, "
+            "With --bench on a traced model, runnable frontend IR, or an embedded golden, fail unless every requested backend, "
             "captured timing, exact pin, and direct Emmy-vs-eager comparison is valid."
         ),
     )
@@ -256,9 +256,6 @@ def _handle_run_once(args):
     if args.strict_correctness and not args.bench:
         logger.error("--strict requires --bench")
         sys.exit(2)
-    if args.strict_correctness and ir_path is None and not hasattr(args, "_golden_graph"):
-        logger.error("--strict currently requires runnable frontend IR or an embedded --golden")
-        sys.exit(2)
     if not torch.cuda.is_available():
         logger.error("CUDA GPU required")
         sys.exit(1)
@@ -356,8 +353,11 @@ def _handle_run_once(args):
         "dynamic": list(args.dynamic) if getattr(args, "dynamic", None) else None,
     }
 
+    strict_correctness = bool(getattr(args, "strict_correctness", False))
+
     async def _bench_session():
-        greedy_fail = results = bench = accuracy_error = ab_ref = golden_benches = greedy_iso = None
+        greedy_fail = results = bench = accuracy_error = correctness = ab_ref = golden_benches = greedy_iso = None
+        greedy_reference_us = None
         captured = True
         try:
             try:
@@ -370,6 +370,7 @@ def _handle_run_once(args):
                     iters=args.iters,
                     accuracy=not skip_accuracy,
                     want_ref=bool(pinned),
+                    strict_accuracy=strict_correctness,
                 )
             except RuntimeError as exc:
                 # Worker SIGKILL (hung kernel), in-child bench budget, EOF — the greedy
@@ -378,6 +379,8 @@ def _handle_run_once(args):
             else:
                 results, bench, captured = resp["results"], resp["result"], resp["captured"]
                 accuracy_error, ab_ref = resp["accuracy_error"], resp["run_io"]
+                correctness = resp.get("correctness")
+                greedy_reference_us = resp.get("reference_run_us")
             if pinned and accuracy_error is None:
                 if greedy_fail:
                     logger.error("%s — greedy row marked bench_fail; pinned rows still bench in the worker", greedy_fail)
@@ -385,9 +388,29 @@ def _handle_run_once(args):
                 golden_benches = await _bench_golden_variants(backend, args.code, pinned, warmup=args.warmup, iters=args.iters, ref=ab_ref)
         finally:
             await backend.aclose_async_worker()
-        return greedy_fail, results, bench, captured, accuracy_error, golden_benches, greedy_iso
+        return (
+            greedy_fail,
+            results,
+            bench,
+            captured,
+            accuracy_error,
+            golden_benches,
+            greedy_iso,
+            greedy_reference_us,
+            correctness,
+        )
 
-    greedy_fail, results, bench, captured, accuracy_error, golden_benches, greedy_iso = asyncio.run(_bench_session())
+    (
+        greedy_fail,
+        results,
+        bench,
+        captured,
+        accuracy_error,
+        golden_benches,
+        greedy_iso,
+        greedy_reference_us,
+        correctness,
+    ) = asyncio.run(_bench_session())
 
     if accuracy_error is not None:
         # Correctness gate: the deployed program computes the wrong answer, so no latency
@@ -404,13 +427,30 @@ def _handle_run_once(args):
         notes = [n for n in (_symbolic_bench_note(_collect_sym_env([compiled])), capture_note) if n]
         _print_table(results, note="\n".join(notes) if notes else None)
     _print_kernel_stats(compiled, bench, golden_benches=golden_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
+    strict_errors = (
+        _strict_benchmark_errors(args, results, bench, captured, correctness, golden_benches) if strict_correctness else None
+    )
     if getattr(args, "json", None):
-        _write_ab_json(args, results or {}, compiled, bench, golden_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
+        _write_ab_json(
+            args,
+            results or {},
+            compiled,
+            bench,
+            golden_benches,
+            greedy_fail=greedy_fail,
+            greedy_iso=greedy_iso,
+            greedy_reference_us=greedy_reference_us,
+            correctness=correctness,
+            strict_errors=strict_errors,
+        )
+    for error in strict_errors or []:
+        logger.error("strict: %s", error)
     _record_bench_nodes(args, golden_benches, greedy_iso)
     if args.profile and greedy_fail is None:
         _run_ncu_profile(args, dump_dir=dump.dir if dump else None)
     if (
-        greedy_fail is not None
+        bool(strict_errors)
+        or greedy_fail is not None
         or (greedy_iso is not None and greedy_iso.status != "ok")
         or any(gb.status != "ok" for gb in golden_benches or [])
     ):

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -427,9 +427,7 @@ def _handle_run_once(args):
         notes = [n for n in (_symbolic_bench_note(_collect_sym_env([compiled])), capture_note) if n]
         _print_table(results, note="\n".join(notes) if notes else None)
     _print_kernel_stats(compiled, bench, golden_benches=golden_benches, greedy_fail=greedy_fail, greedy_iso=greedy_iso)
-    strict_errors = (
-        _strict_benchmark_errors(args, results, bench, captured, correctness, golden_benches) if strict_correctness else None
-    )
+    strict_errors = _strict_benchmark_errors(args, results, bench, captured, correctness, golden_benches) if strict_correctness else None
     if getattr(args, "json", None):
         _write_ab_json(
             args,

--- a/emmy/compiler/backend/cuda/_bench_worker.py
+++ b/emmy/compiler/backend/cuda/_bench_worker.py
@@ -185,19 +185,24 @@ async def _run_job(req: dict) -> dict:
             if bundle is None:
                 raise RuntimeError("trace_args produced no runnable module (embedded or debug IR has none)")
             module, args_t, kwargs = bundle
-            if req.get("accuracy"):
+            if req.get("accuracy") or req.get("strict_accuracy"):
                 # The run path's correctness gate, in-child: bind the rebuilt module's real
                 # inputs, run the emmy program on them, compare vs the eager forward. A
                 # numeric failure skips the bench — the parent aborts on the verdict, so
                 # benching a miscompiling program would be wasted GPU time. ``want_ref``
                 # ships this run's (inputs, outputs) back as the pinned rows' wrong-answer
                 # reference (bounded: pinned rows only exist for --code inputs).
-                from emmy.commands.run import _bind_inputs, _check_accuracy, _eager_output
+                from emmy.commands.run import _bind_inputs, _check_accuracy, _eager_output, _strict_correctness_proof
 
                 input_data = _bind_inputs(req["graph"], module, args_t, kwargs, checkpoint=payload.get("input"))
                 run_result, _ = backend.run(req["graph"], input_data=input_data)
                 eager_out = _eager_output(module, args_t, kwargs)
-                accuracy_error = _check_accuracy(run_result.outputs, eager_out)
+                if req.get("strict_accuracy"):
+                    correctness = _strict_correctness_proof(run_result.outputs, eager_out)
+                    if correctness["status"] != "pass":
+                        accuracy_error = f"strict eager correctness failed: {correctness.get('error', 'tolerance exceeded')}"
+                else:
+                    accuracy_error = _check_accuracy(run_result.outputs, eager_out)
                 if accuracy_error is not None:
                     return {
                         "result": None,

--- a/emmy/compiler/loader/quant.py
+++ b/emmy/compiler/loader/quant.py
@@ -193,9 +193,7 @@ def dequantize_awq4(qweight: np.ndarray, qzeros: np.ndarray, scales: np.ndarray,
     qzeros = np.asarray(qzeros)
     scales = np.asarray(scales)
     if qweight.ndim != 2 or qzeros.ndim != 2 or scales.ndim != 2:
-        raise ValueError(
-            f"AWQ qweight/qzeros/scales must be rank-2, got {qweight.shape}, {qzeros.shape}, {scales.shape}"
-        )
+        raise ValueError(f"AWQ qweight/qzeros/scales must be rank-2, got {qweight.shape}, {qzeros.shape}, {scales.shape}")
     k, packed_n = qweight.shape
     groups, zero_packed_n = qzeros.shape
     n = packed_n * 8
@@ -203,9 +201,7 @@ def dequantize_awq4(qweight: np.ndarray, qzeros: np.ndarray, scales: np.ndarray,
     if effective_group <= 0 or groups * effective_group != k:
         raise ValueError(f"AWQ group geometry {groups} x {effective_group} does not cover input size {k}")
     if zero_packed_n != packed_n or scales.shape != (groups, n):
-        raise ValueError(
-            f"AWQ sibling geometry mismatch: qweight={qweight.shape}, qzeros={qzeros.shape}, scales={scales.shape}"
-        )
+        raise ValueError(f"AWQ sibling geometry mismatch: qweight={qweight.shape}, qzeros={qzeros.shape}, scales={scales.shape}")
     integers = unpack_awq4(qweight).astype(np.float32)
     zeros = np.repeat(unpack_awq4(qzeros), effective_group, axis=0).astype(np.float32)
     scale_values = np.repeat(scales.astype(np.float32), effective_group, axis=0)
@@ -597,9 +593,7 @@ def _spell_awq4_weight(
     )
     graph_scale_dtype = "f32" if scale_dtype == "bf16" else scale_dtype
     scales = frag.add_node(
-        op=ConstantOp(
-            name=f"{op.name}_scales", source_path=base + ".scales", source_shape=scales_shape, source_dtype=scale_dtype
-        ),
+        op=ConstantOp(name=f"{op.name}_scales", source_path=base + ".scales", source_shape=scales_shape, source_dtype=scale_dtype),
         inputs=[],
         output=Tensor(f"{out.name}_scales", scales_shape, graph_scale_dtype),
     )

--- a/emmy/compiler/loader/quant.py
+++ b/emmy/compiler/loader/quant.py
@@ -2,10 +2,11 @@
 
 This module is the ONE place quantization-as-a-concept exists (together with the
 safetensors loader that reads the checkpoint and ``trace/huggingface.py``'s
-architecture-twin construction). Two checkpoint families share the design — FP8
-(scale-paired bits, ``quant_method: "fp8"`` / compressed-tensors) and EXL3
-(trellis-coded sibling tensors, ``quant_method: "exl3"``; decode math in
-``loader/exl3.py``). Per family:
+architecture-twin construction). Three checkpoint families share the design — FP8
+(scale-paired bits, ``quant_method: "fp8"`` / compressed-tensors), AWQ GEMM
+(packed int4 ``qweight`` / ``qzeros`` plus group scales), and EXL3 (trellis-coded
+sibling tensors, ``quant_method: "exl3"``; decode math in ``loader/exl3.py``).
+Per family:
 
 - Pure numpy fp8 math: :func:`decode_f8` (re-exported from
   :mod:`emmy.compiler.dtype`, the leaf module the LUT lives in so the
@@ -66,6 +67,11 @@ F8_SAFETENSORS_DTYPES: dict[str, str] = {"F8_E4M3": "f8e4m3", "F8_E5M2": "f8e5m2
 # selects codebook 1 / 2), and the legacy packed sign words of old checkpoints. ``bias``
 # is NOT here — it is a plain tensor the twin/loader reads by its own key.
 _EXL3_SIBLING_LEAVES = ("suh", "svh", "mcg", "mul1", "su", "sv")
+
+# AutoAWQ GEMM stores eight output-channel nibbles in one i32 word using
+# ``[0, 2, 4, 6, 1, 3, 5, 7]`` as the pack order. Reading the shifts in this
+# inverse order emits logical output channels directly, without a gather.
+_AWQ4_LOGICAL_SHIFTS = (0, 16, 4, 20, 8, 24, 12, 28)
 
 
 def dequantize(weight: np.ndarray, scale: np.ndarray, *, inverse: bool = False) -> np.ndarray:
@@ -138,6 +144,74 @@ def _exl3_quant_config(model_dir: Path) -> dict | None:
     return None
 
 
+def _awq_quant_config(model_dir: Path) -> dict | None:
+    """The checkpoint's AWQ declaration, when it is the GEMM int4 layout.
+
+    Emmy's spelling below implements the canonical AutoAWQ/vLLM GEMM layout:
+    eight output-channel nibbles per i32 word, per-input-channel groups, and
+    explicit zero points. Other AWQ layouts must not be mistaken for it.
+    """
+    cfg_path = model_dir / "config.json"
+    if not cfg_path.exists():
+        return None
+    qc = json.loads(cfg_path.read_text()).get("quantization_config")
+    if not isinstance(qc, dict) or qc.get("quant_method") != "awq":
+        return None
+    bits = int(qc.get("bits", qc.get("w_bit", 0)) or 0)
+    version = str(qc.get("version", "gemm")).lower()
+    if bits != 4 or version != "gemm" or qc.get("zero_point", True) is not True:
+        raise ValueError(
+            "unsupported AWQ checkpoint: Emmy requires GEMM int4 with explicit zero points "
+            f"(bits={bits}, version={version!r}, zero_point={qc.get('zero_point')!r})"
+        )
+    return qc
+
+
+def is_awq_checkpoint(model_dir) -> bool:
+    """Whether the checkpoint declares the supported packed AWQ GEMM scheme."""
+    return _awq_quant_config(Path(model_dir)) is not None
+
+
+def unpack_awq4(packed: np.ndarray) -> np.ndarray:
+    """Unpack AutoAWQ GEMM i32 words to logical int4 output channels.
+
+    The returned shape is ``(*packed.shape[:-1], packed.shape[-1] * 8)``.
+    Unsigned views avoid implementation-defined signed shifts; masking then
+    returns values in ``[0, 15]`` exactly.
+    """
+    words = np.asarray(packed)
+    if words.ndim != 2 or words.dtype not in (np.dtype(np.int32), np.dtype(np.uint32)):
+        raise ValueError(f"AWQ packed tensor must be rank-2 i32/u32, got shape={words.shape}, dtype={words.dtype}")
+    shifts = np.asarray(_AWQ4_LOGICAL_SHIFTS, dtype=np.uint32)
+    unpacked = (words.astype(np.uint32, copy=False)[..., None] >> shifts) & np.uint32(0xF)
+    return unpacked.reshape(words.shape[0], words.shape[1] * 8).astype(np.int8)
+
+
+def dequantize_awq4(qweight: np.ndarray, qzeros: np.ndarray, scales: np.ndarray, group_size: int) -> np.ndarray:
+    """Decode one AutoAWQ GEMM weight to its ``(in, out)`` value matrix."""
+    qweight = np.asarray(qweight)
+    qzeros = np.asarray(qzeros)
+    scales = np.asarray(scales)
+    if qweight.ndim != 2 or qzeros.ndim != 2 or scales.ndim != 2:
+        raise ValueError(
+            f"AWQ qweight/qzeros/scales must be rank-2, got {qweight.shape}, {qzeros.shape}, {scales.shape}"
+        )
+    k, packed_n = qweight.shape
+    groups, zero_packed_n = qzeros.shape
+    n = packed_n * 8
+    effective_group = k if int(group_size) == -1 else int(group_size)
+    if effective_group <= 0 or groups * effective_group != k:
+        raise ValueError(f"AWQ group geometry {groups} x {effective_group} does not cover input size {k}")
+    if zero_packed_n != packed_n or scales.shape != (groups, n):
+        raise ValueError(
+            f"AWQ sibling geometry mismatch: qweight={qweight.shape}, qzeros={qzeros.shape}, scales={scales.shape}"
+        )
+    integers = unpack_awq4(qweight).astype(np.float32)
+    zeros = np.repeat(unpack_awq4(qzeros), effective_group, axis=0).astype(np.float32)
+    scale_values = np.repeat(scales.astype(np.float32), effective_group, axis=0)
+    return (integers - zeros) * scale_values
+
+
 def is_exl3_checkpoint(model_dir) -> bool:
     """Whether the checkpoint declares the EXL3 scheme.
 
@@ -192,6 +266,8 @@ def checkpoint_quant_summary(model_dir) -> str:
         return f"exl3 {qc.get('bits')} bpw (head {qc.get('head_bits')})"
     if (qc := _fp8_quant_config(model_dir)) is not None:
         return f"fp8 {qc.get('fmt') or qc.get('quant_method')}"
+    if (qc := _awq_quant_config(model_dir)) is not None:
+        return f"awq int{qc.get('bits')} g{qc.get('group_size', qc.get('q_group_size'))} {qc.get('version', 'gemm')}"
     return "unquantized"
 
 
@@ -208,7 +284,7 @@ def engine_config_overrides(hf_config) -> dict:
     call site because naming a checkpoint scheme is frontend-band knowledge."""
     scheme = getattr(hf_config, "quantization_config", None)
     method = scheme.get("quant_method") if isinstance(scheme, dict) else getattr(scheme, "quant_method", None)
-    return {"quantization_config": None} if method == "exl3" else {}
+    return {"quantization_config": None} if method in {"exl3", "awq"} else {}
 
 
 def strip_engine_quant_config(hf_config) -> None:
@@ -248,7 +324,7 @@ def _is_skipped(weight_key: str, patterns: list[str]) -> bool:
 
 
 def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
-    """Every checkpoint tensor as numpy VALUES, fp8 weights dequantized by their paired scale.
+    """Every checkpoint tensor as numpy VALUES, including supported coded weights.
 
     Feeds the architecture twin of a quantized checkpoint (see
     ``trace.huggingface.load_quantized_twin``) so the eager / accuracy reference
@@ -267,6 +343,9 @@ def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
     the consumed siblings are dropped. NOTE: whole-dict semantics — the full
     decoded footprint materializes in host memory, so this is for models (or
     config-truncated checkpoints) whose expanded weights fit in RAM.
+
+    AWQ GEMM checkpoints: each ``<module>.qweight`` / ``qzeros`` / ``scales``
+    triplet decodes to ``<module>.weight`` in HF ``(out, in)`` orientation.
     """
     from emmy.compiler.loader.safetensors import _build_index, _read_shard  # noqa: PLC0415
 
@@ -274,6 +353,7 @@ def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
     index = _build_index(model_dir)
     qc = _fp8_quant_config(model_dir)
     exl3 = _exl3_quant_config(model_dir) is not None
+    awq = _awq_quant_config(model_dir)
     patterns = list(qc.get("modules_to_not_convert") or []) + list(qc.get("ignore") or []) if qc else []
 
     by_shard: dict[str, list[str]] = {}
@@ -287,6 +367,16 @@ def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
     out: dict[str, np.ndarray] = {}
     consumed: set[str] = set()
     for key in index:
+        if awq is not None and key.endswith(".qweight"):
+            base = key[: -len(".qweight")]
+            qzeros_key, scales_key = base + ".qzeros", base + ".scales"
+            if qzeros_key not in index or scales_key not in index:
+                raise ValueError(f"AWQ linear {base!r} is missing qzeros or scales")
+            out[base + ".weight"] = dequantize_awq4(
+                sources[key], sources[qzeros_key], sources[scales_key], int(awq.get("group_size", awq.get("q_group_size", -1)))
+            ).T
+            consumed |= {key, qzeros_key, scales_key}
+            continue
         if exl3 and key.endswith(".trellis"):
             base = key[: -len(".trellis")]
             sibs = {leaf for leaf in _EXL3_SIBLING_LEAVES if base + "." + leaf in index}
@@ -299,6 +389,11 @@ def load_dequantized_state_dict(model_dir: str | Path) -> dict[str, np.ndarray]:
             continue
         if key in consumed:
             continue
+        if awq is not None and key.endswith((".qzeros", ".scales")):
+            base = key.rsplit(".", 1)[0]
+            if base + ".qweight" in index:
+                consumed.add(key)
+                continue
         if qc is not None and key in fp8_keys and not _is_skipped(key, patterns):
             scale_key = next((k for k in (key + "_scale", key + "_scale_inv") if k in index), None)
             if scale_key is not None:
@@ -447,8 +542,245 @@ def _spell_one(graph: Graph, nid: str, *, fmt: str, scale_key: str, scale_shape:
     return True
 
 
+def _spell_awq4_weight(
+    graph: Graph,
+    nid: str,
+    *,
+    base: str,
+    qweight_shape: tuple[int, int],
+    qzeros_shape: tuple[int, int],
+    scales_shape: tuple[int, int],
+    scale_dtype: str,
+    group_size: int,
+) -> None:
+    """Replace one logical weight constant with packed AWQ decode algebra."""
+    from emmy.compiler.ir.frontend.ir import ReshapeOp, TransposeOp  # noqa: PLC0415
+    from emmy.compiler.ir.tensor.ir import ElementwiseOp, RangeOp  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.frontend.decomposition._broadcast import broadcast_to  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.frontend.decomposition._helpers import const_bc  # noqa: PLC0415
+    from emmy.compiler.tensor import Tensor  # noqa: PLC0415
+
+    node = graph.nodes[nid]
+    op, out = node.op, node.output
+    if op.load_ops or op.source_parts or op.value is not None or any(not d.is_static for d in out.shape):
+        raise ValueError(f"AWQ weight {nid!r} is not a pristine static checkpoint constant")
+    if len(out.shape) != 2:
+        raise ValueError(f"AWQ weight {nid!r} must be rank-2, got {tuple(out.shape)}")
+
+    n, k = (d.as_static() for d in out.shape)
+    qk, packed_n = qweight_shape
+    groups, zero_packed_n = qzeros_shape
+    effective_group = k if group_size == -1 else group_size
+    if (
+        qk != k
+        or packed_n * 8 != n
+        or zero_packed_n != packed_n
+        or scales_shape != (groups, n)
+        or effective_group <= 0
+        or groups * effective_group != k
+    ):
+        raise ValueError(
+            f"AWQ weight {nid!r} storage geometry qweight={qweight_shape}, qzeros={qzeros_shape}, "
+            f"scales={scales_shape}, group={effective_group} does not reproduce logical {(n, k)}"
+        )
+
+    frag = Graph()
+    qweight = frag.add_node(
+        op=ConstantOp(name=f"{op.name}_qweight", source_path=base + ".qweight", source_shape=qweight_shape, source_dtype="i32"),
+        inputs=[],
+        output=Tensor(f"{out.name}_qweight", qweight_shape, "i32"),
+    )
+    qzeros = frag.add_node(
+        op=ConstantOp(name=f"{op.name}_qzeros", source_path=base + ".qzeros", source_shape=qzeros_shape, source_dtype="i32"),
+        inputs=[],
+        output=Tensor(f"{out.name}_qzeros", qzeros_shape, "i32"),
+    )
+    graph_scale_dtype = "f32" if scale_dtype == "bf16" else scale_dtype
+    scales = frag.add_node(
+        op=ConstantOp(
+            name=f"{op.name}_scales", source_path=base + ".scales", source_shape=scales_shape, source_dtype=scale_dtype
+        ),
+        inputs=[],
+        output=Tensor(f"{out.name}_scales", scales_shape, graph_scale_dtype),
+    )
+    slots = frag.add_node(
+        op=RangeOp(start=0, stop=8, step=1, dtype="i32"),
+        inputs=[],
+        output=Tensor(f"{out.name}_awq4_slots", (8,), "i32"),
+    )
+    slots = frag.add_node(
+        op=ReshapeOp(shape=(1, 1, 8)),
+        inputs=[slots],
+        output=Tensor(f"{out.name}_awq4_slots_view", (1, 1, 8), "i32"),
+    )
+    two = const_bc(frag, name=f"{out.name}_awq4_two", value=2, target_shape=(1, 1, 8), dtype="i32")
+    low_lane = frag.add_node(
+        op=ElementwiseOp(op="remainder"),
+        inputs=[slots, two],
+        output=Tensor(f"{out.name}_awq4_low_lane", (1, 1, 8), "i32"),
+    )
+    high_lane = frag.add_node(
+        op=ElementwiseOp(op="floor_divide"),
+        inputs=[slots, two],
+        output=Tensor(f"{out.name}_awq4_high_lane", (1, 1, 8), "i32"),
+    )
+    sixteen = const_bc(frag, name=f"{out.name}_awq4_sixteen", value=16, target_shape=(1, 1, 8), dtype="i32")
+    four = const_bc(frag, name=f"{out.name}_awq4_four", value=4, target_shape=(1, 1, 8), dtype="i32")
+    low_shift = frag.add_node(
+        op=ElementwiseOp(op="multiply"),
+        inputs=[low_lane, sixteen],
+        output=Tensor(f"{out.name}_awq4_low_shift", (1, 1, 8), "i32"),
+    )
+    high_shift = frag.add_node(
+        op=ElementwiseOp(op="multiply"),
+        inputs=[high_lane, four],
+        output=Tensor(f"{out.name}_awq4_high_shift", (1, 1, 8), "i32"),
+    )
+    shifts = frag.add_node(
+        op=ElementwiseOp(op="add"),
+        inputs=[low_shift, high_shift],
+        output=Tensor(f"{out.name}_awq4_shifts", (1, 1, 8), "i32"),
+    )
+
+    def unpack(packed: str, shape: tuple[int, int], name: str) -> str:
+        rows, words = shape
+        expanded_shape = (rows, words, 8)
+        view = frag.add_node(
+            op=ReshapeOp(shape=(rows, words, 1)),
+            inputs=[packed],
+            output=Tensor(f"{name}_view", (rows, words, 1), "i32"),
+        )
+        words_bc = broadcast_to(frag, view, expanded_shape)
+        shifts_bc = broadcast_to(frag, shifts, expanded_shape)
+        shifted = frag.add_node(
+            op=ElementwiseOp(op="right_shift"),
+            inputs=[words_bc, shifts_bc],
+            output=Tensor(f"{name}_shifted", expanded_shape, "i32"),
+        )
+        mask = const_bc(frag, name=f"{name}_mask", value=15, target_shape=expanded_shape, dtype="i32")
+        nibble = frag.add_node(
+            op=ElementwiseOp(op="bitwise_and"),
+            inputs=[shifted, mask],
+            output=Tensor(f"{name}_nibble", expanded_shape, "i32"),
+        )
+        return frag.add_node(
+            op=ReshapeOp(shape=(rows, words * 8)),
+            inputs=[nibble],
+            output=Tensor(name, (rows, words * 8), "i32"),
+        )
+
+    integers = unpack(qweight, qweight_shape, f"{out.name}_integers")
+    zeros_grouped = unpack(qzeros, qzeros_shape, f"{out.name}_zeros_grouped")
+
+    zeros_view = frag.add_node(
+        op=ReshapeOp(shape=(groups, 1, n)),
+        inputs=[zeros_grouped],
+        output=Tensor(f"{out.name}_zeros_view", (groups, 1, n), "i32"),
+    )
+    zeros_bc = broadcast_to(frag, zeros_view, (groups, effective_group, n))
+    zeros = frag.add_node(
+        op=ReshapeOp(shape=(k, n)),
+        inputs=[zeros_bc],
+        output=Tensor(f"{out.name}_zeros", (k, n), "i32"),
+    )
+    scale_view = frag.add_node(
+        op=ReshapeOp(shape=(groups, 1, n)),
+        inputs=[scales],
+        output=Tensor(f"{out.name}_scales_view", (groups, 1, n), graph_scale_dtype),
+    )
+    scale_bc = broadcast_to(frag, scale_view, (groups, effective_group, n))
+    scale_values = frag.add_node(
+        op=ReshapeOp(shape=(k, n)),
+        inputs=[scale_bc],
+        output=Tensor(f"{out.name}_scale_values", (k, n), graph_scale_dtype),
+    )
+    centered = frag.add_node(
+        op=ElementwiseOp(op="subtract"),
+        inputs=[integers, zeros],
+        output=Tensor(f"{out.name}_centered", (k, n), "i32"),
+    )
+    values = frag.add_node(
+        op=ElementwiseOp(op="copy"),
+        inputs=[centered],
+        output=Tensor(f"{out.name}_values", (k, n), out.dtype),
+    )
+    if graph_scale_dtype != out.dtype.name:
+        scale_values = frag.add_node(
+            op=ElementwiseOp(op="copy"),
+            inputs=[scale_values],
+            output=Tensor(f"{out.name}_scale_values_cast", (k, n), out.dtype),
+        )
+    scaled = frag.add_node(
+        op=ElementwiseOp(op="multiply"),
+        inputs=[values, scale_values],
+        output=Tensor(f"{out.name}_scaled", (k, n), out.dtype),
+    )
+    final = frag.add_node(
+        op=TransposeOp(axes=(1, 0)),
+        inputs=[scaled],
+        output=Tensor(out.name, (n, k), out.dtype),
+    )
+    frag.outputs = [final]
+    graph.splice(frag, consumed=[nid], output=nid)
+
+
+def _spell_awq4_constants(graph: Graph, model_dir: Path, qc: dict) -> int:
+    """Spell supported AWQ GEMM checkpoint constants as packed decode algebra."""
+    from safetensors import safe_open  # noqa: PLC0415
+
+    from emmy.compiler.loader.safetensors import _build_index, _candidate_keys  # noqa: PLC0415
+
+    index = _build_index(model_dir)
+    group_size = int(qc.get("group_size", qc.get("q_group_size", -1)))
+    spelled = 0
+    with ExitStack() as stack:
+        handles: dict[str, object] = {}
+
+        def _slice(key: str):
+            path = str(index[key])
+            handle = handles.get(path)
+            if handle is None:
+                handle = handles[path] = stack.enter_context(safe_open(path, framework="numpy"))
+            return handle.get_slice(key)
+
+        for nid, op in list(graph.loadable_constants()):
+            if op.source_path is None or not op.source_path.endswith(".weight"):
+                continue
+            suffix = len(".weight")
+            base = next(
+                (
+                    candidate[:-suffix]
+                    for candidate in _candidate_keys(op.source_path)
+                    if candidate.endswith(".weight") and candidate[:-suffix] + ".qweight" in index
+                ),
+                None,
+            )
+            if base is None:
+                continue
+            siblings = {leaf: base + "." + leaf for leaf in ("qweight", "qzeros", "scales")}
+            missing = [key for key in siblings.values() if key not in index]
+            if missing:
+                raise ValueError(f"AWQ weight {nid!r} is missing checkpoint siblings {missing}")
+            slices = {leaf: _slice(key) for leaf, key in siblings.items()}
+            shapes = {leaf: tuple(int(d) for d in sl.get_shape()) for leaf, sl in slices.items()}
+            _spell_awq4_weight(
+                graph,
+                nid,
+                base=base,
+                qweight_shape=shapes["qweight"],
+                qzeros_shape=shapes["qzeros"],
+                scales_shape=shapes["scales"],
+                scale_dtype=slices["scales"].get_dtype().lower(),
+                group_size=group_size,
+            )
+            spelled += 1
+    if spelled:
+        logger.info("spelled %d packed AWQ int4 weight constant(s) from %s", spelled, model_dir)
+    return spelled
+
+
 def spell_quantized_constants(graph: Graph, model_id_or_path: str) -> int:
-    """Spell every fp8-stored weight of ``graph`` as in-graph dequant algebra, at birth.
+    """Spell supported compressed weights as in-graph dequant algebra, at birth.
 
     Source of truth is the CHECKPOINT, not the traced module (a quantized
     checkpoint is traced through its bf16 architecture twin, whose module
@@ -472,6 +804,8 @@ def spell_quantized_constants(graph: Graph, model_id_or_path: str) -> int:
 
     model_dir = _resolve_model_dir(model_id_or_path)
     qc = _fp8_quant_config(model_dir)
+    if (awq := _awq_quant_config(model_dir)) is not None:
+        return _spell_awq4_constants(graph, model_dir, awq)
     if qc is None:
         return 0
     patterns = list(qc.get("modules_to_not_convert") or []) + list(qc.get("ignore") or [])

--- a/emmy/compiler/pipeline/search/slice.py
+++ b/emmy/compiler/pipeline/search/slice.py
@@ -36,8 +36,8 @@ def _kernel_compute_types() -> tuple[type, ...]:
 def collect_kernel_ancestors(
     graph: Graph, root_id: str, compute_types: tuple[type, ...], absorb: frozenset[str] = frozenset()
 ) -> tuple[set[str], set[str]]:
-    """Collect ``root_id`` + its transitive ``ConstantOp`` / ``InputOp``
-    ancestors. Compute-op ancestors (another kernel feeding this one) are
+    """Collect ``root_id`` + its transitive Loop / leaf ancestors.
+    Compute-op ancestors (another kernel feeding this one) are
     returned in the ``synthetic`` set — they become synthetic ``InputOp``
     boundaries in the slice and their own producers are NOT walked — EXCEPT
     the ``absorb`` set: a producer a fusion of the root would consume (the
@@ -67,6 +67,14 @@ def collect_kernel_ancestors(
             continue
         if isinstance(node.op, (ConstantOp, InputOp)):
             stack.extend(node.inputs)
+            continue
+        # Cast/layout sentinels can deliberately survive between LoopOps (for
+        # example a compact AWQ integer decode followed by a value cast). Loop
+        # wire format intentionally carries only LoopOp compute, so such a
+        # node becomes a synthetic boundary just like an upstream kernel.
+        # Retaining it without marking it synthetic leaves its own input
+        # unbound and produces an invalid slice.
+        synthetic.add(cur)
     return keep, synthetic
 
 

--- a/emmy/compiler/pipeline/search/working_golden.py
+++ b/emmy/compiler/pipeline/search/working_golden.py
@@ -213,6 +213,12 @@ def _append_trace_inventory(
         origins = tuple(sorted(origin for origin in target_prov if origin in input_graph.nodes))
         inventory.append((node_id, node, folded, origins))
     origin_counts = Counter(origins for _node_id, _node, _folded, origins in inventory if origins)
+    used_names = {
+        realization["name"]
+        for entry in entries
+        for realization in entry.get("realizations", [])
+        if isinstance(realization, dict) and isinstance(realization.get("name"), str)
+    }
 
     for node_id, node, folded, origins in inventory:
         key = node.op.cache_key()
@@ -220,6 +226,20 @@ def _append_trace_inventory(
         name = f"{node.op.name or node_id}.{suffix}"
         if name_prefix:
             name = f"{name_prefix}.{name}"
+        if name in used_names:
+            # One kernel body/cache key can occur at multiple exact Loop
+            # targets whose boundary shapes or checkpoint sources differ.
+            # ``emmy run --golden`` resolves by name, so retaining the bare
+            # duplicate makes the generated file impossible to replay. Node
+            # ids are deterministic within the persisted source program and
+            # distinguish these otherwise same-bodied target sites.
+            base = f"{name}.{node_id}"
+            name = base
+            duplicate = 2
+            while name in used_names:
+                name = f"{base}.{duplicate}"
+                duplicate += 1
+        used_names.add(name)
         if origins and origin_counts[origins] == 1 and not force_loop_targets:
             target = {"origins": list(origins)}
         else:

--- a/emmy/compiler/trace/huggingface.py
+++ b/emmy/compiler/trace/huggingface.py
@@ -452,7 +452,14 @@ def trace_selected_layer(model, layer: int, seq_len: int, dtype, *, dynamic_shap
                         f"got {type(attention_mask).__name__}"
                     )
                 kwargs["attention_mask"] = attention_mask
-            else:
+            elif attention_parameters["attention_mask"].default is inspect.Parameter.empty:
+                # A required declaration still needs an explicit ``None``.
+                # Optional masks must be omitted: torch.export otherwise
+                # retains a scalar placeholder for the non-tensor ``None``,
+                # while the eager input flattener correctly drops it. The
+                # resulting 4-vs-3 phantom input makes direct model benchmarks
+                # impossible even though the default call is semantically
+                # identical.
                 kwargs["attention_mask"] = None
     ple = build_synthetic_ple(block, seq_len, dtype)
     if ple is not None:
@@ -1129,14 +1136,14 @@ class _PassThroughMask:
 
 def _is_quantized_dir(p) -> bool:
     """Whether the checkpoint at ``p`` declares a quantization scheme the loaders ingest
-    (FP8 scale-paired bits, or EXL3 trellis-coded siblings)."""
-    from emmy.compiler.loader.quant import _exl3_quant_config, _fp8_quant_config  # noqa: PLC0415
+    (FP8 scale-paired bits, AWQ GEMM int4, or EXL3 trellis-coded siblings)."""
+    from emmy.compiler.loader.quant import _awq_quant_config, _exl3_quant_config, _fp8_quant_config  # noqa: PLC0415
 
-    return _fp8_quant_config(p) is not None or _exl3_quant_config(p) is not None
+    return _fp8_quant_config(p) is not None or _awq_quant_config(p) is not None or _exl3_quant_config(p) is not None
 
 
 def quantized_checkpoint_dir(model_id_or_path: str, revision: str | None = None):
-    """The local checkpoint dir when the model is a quantized checkpoint (FP8 or EXL3),
+    """The local checkpoint dir when the model is a supported quantized checkpoint,
     else ``None``.
 
     Detection reads only ``config.json`` (for a repo id, a single cached hub
@@ -1420,11 +1427,13 @@ def load_quantized_split(
     from emmy.compiler.loader.exl3 import decode_trellis, fold_hadamard  # noqa: PLC0415
     from emmy.compiler.loader.quant import (  # noqa: PLC0415
         _EXL3_SIBLING_LEAVES,
+        _awq_quant_config,
         _exl3_codebook,
         _exl3_quant_config,
         _fp8_quant_config,
         _is_skipped,
         dequantize,
+        dequantize_awq4,
     )
     from emmy.compiler.loader.safetensors import _build_index  # noqa: PLC0415
 
@@ -1436,6 +1445,7 @@ def load_quantized_split(
         model = _auto_model_from_config(config)
 
     qc = _fp8_quant_config(model_dir) or {}
+    awq = _awq_quant_config(model_dir)
     patterns = list(qc.get("modules_to_not_convert") or []) + list(qc.get("ignore") or [])
     exl3 = _exl3_quant_config(model_dir) is not None
     index = _build_index(model_dir)
@@ -1481,6 +1491,28 @@ def load_quantized_split(
                 continue
             f = _open(shard_path)
             for k in owned_keys:
+                if awq is not None and k.endswith(".qweight"):
+                    base = k[: -len(".qweight")]
+                    qzeros_key, scales_key = base + ".qzeros", base + ".scales"
+                    if qzeros_key not in index or scales_key not in index:
+                        raise ValueError(f"AWQ linear {base!r} is missing qzeros or scales")
+                    model_key = _checkpoint_to_model_key(base + ".weight")
+                    if compress_trunk:
+                        coded_trunk.add(model_key)
+                    else:
+                        values = dequantize_awq4(
+                            f.get_tensor(k).numpy(),
+                            _sibling(qzeros_key).numpy(),
+                            _sibling(scales_key).numpy(),
+                            int(awq.get("group_size", awq.get("q_group_size", -1))),
+                        ).T
+                        state[model_key] = torch.from_numpy(values).to(dtype)
+                    fmt = "awq4"
+                    continue
+                if awq is not None and k.endswith((".qzeros", ".scales")):
+                    base = k.rsplit(".", 1)[0]
+                    if base + ".qweight" in index:
+                        continue
                 slot = _expert_slot(k)
                 if slot is not None:
                     layer, name, expert = slot
@@ -1828,3 +1860,28 @@ def load_quantized_trace_twin(model_dir, dtype, layer: int | None):
     if layer is None:
         return load_quantized_twin(model_dir, dtype)
     return load_architecture_trace_twin(model_dir, dtype, layer)
+
+
+def load_quantized_layer_twin(model_dir, dtype, layer: int):
+    """Value-correct, shard-streamed twin for one quantized decoder layer.
+
+    ``emmy run MODEL --layer N`` needs real eager-reference values, unlike the
+    shape-only inventory path, but decoding the complete checkpoint before
+    selecting one layer wastes almost all work and memory. Reuse the serving
+    split loader with one stage interval, then reconstruct decoder-level
+    non-persistent rotary modules on CPU exactly as the architecture twin does.
+    """
+    model, _store = load_quantized_split(
+        model_dir,
+        dtype,
+        layer_range=(layer, layer + 1),
+        include_embed=False,
+        include_norm=False,
+    )
+    decoder = find_text_decoder(model)
+    rotary_type = type(decoder.rotary_emb)
+    decoder.rotary_emb = rotary_type(decoder.config)
+    if getattr(decoder, "swa_rotary_emb", None) is not None:
+        decoder.swa_rotary_emb = type(decoder.swa_rotary_emb)(decoder.config)
+    model.eval()
+    return model

--- a/emmy/serving/gen_runner.py
+++ b/emmy/serving/gen_runner.py
@@ -410,10 +410,11 @@ def _compile_split(
     would otherwise report no floor at all.
     ``ckpt`` — ``(checkpoint_dir, id_to_key)`` — switches the TRUNK to the checkpoint-sourced
     lane: every traced constant is re-addressed to its checkpoint key
-    (:func:`_retarget_constants`), ``spell_trellis_constants`` then fires on a serving wrapper
-    for the first time (the compressed lane forced, not env-gated), and the constant feed comes
-    from the shards rather than the live module (:func:`_plan_sources`). This is what puts an
-    EXL3 trunk on the card at its CODED size; without it a trunk linear binds decoded values.
+    (:func:`_retarget_constants`), the checkpoint's AWQ/EXL3 constant speller then fires on a
+    serving wrapper for the first time (the compressed lane forced, not env-gated), and the
+    constant feed comes from the shards rather than the live module (:func:`_plan_sources`).
+    This is what puts a coded trunk on the card at its stored size; without it a trunk linear
+    binds decoded values.
     ``plan_cache`` is a session-scoped, binding-neutral plan-template cache. It runs only on the
     cold path (an explicit pack ``plan`` still wins), after every loader spelling and ABI hint has
     reached the graph; each hit returns a fresh plan carrying THIS wrapper's real source paths."""
@@ -433,7 +434,7 @@ def _compile_split(
 
             promote_expert_output_float32(graph)
         if ckpt is not None:
-            from emmy.compiler.loader.quant import spell_trellis_constants
+            from emmy.compiler.loader.quant import spell_quantized_constants, spell_trellis_constants
             from emmy.compiler.trace.huggingface import promote_laguna_exl3_post_float32, promote_shared_expert_float32
 
             _retarget_constants(graph, wrapper, ckpt[1])
@@ -441,6 +442,7 @@ def _compile_split(
                 promote_laguna_exl3_post_float32(graph, kind)
             if getattr(wrapper, "_emmy_shared_expert_float32", False):
                 promote_shared_expert_float32(graph)
+            spell_quantized_constants(graph, ckpt[0])
             spell_trellis_constants(graph, ckpt[0])
         if quant_specs:
             from emmy.compiler.loader.quant import spell_quantized_inputs
@@ -781,16 +783,21 @@ class EmmyGenRunner:
         # dense trunk loaded as real values, expert tensors kept fp8 (``load_quantized_split``).
         qdir = quantized_checkpoint_dir(model_id)
         if qdir is not None:
-            # EXL3 keeps the TRUNK coded too — the whole point of a 2-bit checkpoint is that the
-            # decoded trunk (GLM-4.5-Air: ~14 GiB) does not fit beside the experts. fp8 trunks
-            # stay on the decoded lane, where the values are what the fp8 expert path expects.
-            from emmy.compiler.loader.quant import checkpoint_quant_digest, checkpoint_quant_summary, is_exl3_checkpoint
+            # EXL3 and AWQ keep the TRUNK coded too: expanding either checkpoint before compile
+            # gives back most of its memory savings. fp8 trunks stay on the decoded lane, where
+            # the values are what the fp8 expert path expects.
+            from emmy.compiler.loader.quant import (
+                checkpoint_quant_digest,
+                checkpoint_quant_summary,
+                is_awq_checkpoint,
+                is_exl3_checkpoint,
+            )
             from emmy.compiler.trace.huggingface import load_quantized_split
 
-            # EXL3's generic reconstruction algebra is dissolved before lowering, so its
-            # checkpoint sources can stay coded on the card. FP8 keeps the existing
-            # value-trunk lane; only its routed experts are input-spelled today.
-            coded_trunk = is_exl3_checkpoint(qdir)
+            # Generic EXL3/AWQ reconstruction algebra is dissolved before lowering, so its
+            # checkpoint sources can stay coded on the card. FP8 keeps the existing value-trunk
+            # lane; only its routed experts are input-spelled today.
+            coded_trunk = is_exl3_checkpoint(qdir) or is_awq_checkpoint(qdir)
             # The RESOLVED directory and the scheme summary are logged, not just the requested id:
             # a repo that publishes one rung per branch resolves to a per-commit snapshot, and this
             # line is how a boot proves which rung it actually opened.
@@ -858,8 +865,8 @@ class EmmyGenRunner:
         fp8 bits + scales + biases — in place of the twin's expert params (which stay meta
         on the quantized path); the expert programs are then compiled with the decode + scale
         algebra spelled in-graph (``spell_quantized_inputs`` via ``_compile_split``), one program
-        set per distinct expert SHAPE. A store whose ``trunk`` is ``"codes"`` (EXL3) also puts the
-        TRUNK on the checkpoint-sourced lane, so its coded linears stay compressed on the card."""
+        set per distinct expert SHAPE. A store whose ``trunk`` is ``"codes"`` (AWQ/EXL3) also puts
+        the TRUNK on the checkpoint-sourced lane, so its coded linears stay compressed on the card."""
         import numpy as np
         import torch
 
@@ -994,7 +1001,7 @@ class EmmyGenRunner:
         # A CODED trunk (``load_quantized_split(..., compress_trunk=True)``) binds its constants
         # from the CHECKPOINT rather than from the twin's parameters, which are placeholders
         # there. ``id_to_key`` maps a parameter tensor's identity to its full checkpoint path, so
-        # each wrapper's trace can be re-addressed and the trellis speller can fire (see
+        # each wrapper's trace can be re-addressed and its coded-weight speller can fire (see
         # :func:`_retarget_constants`). Everything else keeps the module lane.
         ckpt = None
         if (expert_store or {}).get("trunk") == "codes":

--- a/experiments/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/serving_v100_sxm2_16gb/recipe.yaml
+++ b/experiments/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/serving_v100_sxm2_16gb/recipe.yaml
@@ -1,0 +1,40 @@
+# Conservative Volta qualification lane for Llama 3.1 8B Instruct AWQ INT4.
+# Start at the checkpoint's native 131072-token context; qualification halves
+# this value after a measured capacity failure and retains the largest context
+# that both starts and completes a materially full request on one 16 GB V100.
+model:
+  huggingface: "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4"
+  revision: db1f81ad4b8c7e39777509fac66c652eb0a52f91
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    context_length: 32768
+    max_concurrent_requests: 8
+    vllm:
+      image: "cloudriftai/1cat-vllm-sm70@sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --attention-backend FLASH_ATTN_V100
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser llama3_json
+
+benchmark:
+  max_concurrency: 8
+  num_prompts: 32
+  random_input_len: 512
+  random_output_len: 256
+  num_warmups: 2
+  repeats: 3
+  seed: 0
+  temperature: 0.0
+  ignore_eos: true
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+  deploy.gpu_count: 1

--- a/experiments/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/serving_v100_sxm3_32gb/recipe.yaml
+++ b/experiments/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/serving_v100_sxm3_32gb/recipe.yaml
@@ -1,0 +1,39 @@
+# Native-context Volta qualification lane for Llama 3.1 8B Instruct AWQ INT4.
+# The target is one V100 SXM3 32 GB; the surrounding eight-card host may be used
+# for compiler search, but this serving lane remains tensor-parallel size one.
+model:
+  huggingface: "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4"
+  revision: db1f81ad4b8c7e39777509fac66c652eb0a52f91
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    context_length: 131072
+    max_concurrent_requests: 8
+    vllm:
+      image: "cloudriftai/1cat-vllm-sm70@sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --attention-backend FLASH_ATTN_V100
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser llama3_json
+
+benchmark:
+  max_concurrency: 8
+  num_prompts: 32
+  random_input_len: 512
+  random_output_len: 256
+  num_warmups: 2
+  repeats: 3
+  seed: 0
+  temperature: 0.0
+  ignore_eos: true
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM3 32GB"
+  deploy.gpu_count: 1

--- a/experiments/Meta-Llama-3.1-8B-Instruct/serving_v100_sxm3_32gb/recipe.yaml
+++ b/experiments/Meta-Llama-3.1-8B-Instruct/serving_v100_sxm3_32gb/recipe.yaml
@@ -1,0 +1,43 @@
+# Conservative FP16 Volta qualification lane for Llama 3.1 8B Instruct.
+# The public NousResearch mirror has byte-identical config and all four
+# safetensor payload hashes relative to Meta's gated checkpoint. The tokenizer
+# is taken from the already-qualified AWQ repository because its tokenizer
+# config is byte-identical to Meta's tool-aware tokenizer config.
+model:
+  huggingface: "NousResearch/Meta-Llama-3.1-8B-Instruct"
+  revision: d10aef7999a2b5ba950ab3974312feeedbfe0b77
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    context_length: 65536
+    max_concurrent_requests: 8
+    vllm:
+      image: "cloudriftai/1cat-vllm-sm70@sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --attention-backend FLASH_ATTN_V100
+        --max-num-batched-tokens 4096
+        --tokenizer hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4
+        --tokenizer-revision db1f81ad4b8c7e39777509fac66c652eb0a52f91
+        --enable-auto-tool-choice
+        --tool-call-parser llama3_json
+
+benchmark:
+  max_concurrency: 8
+  num_prompts: 32
+  random_input_len: 512
+  random_output_len: 256
+  num_warmups: 2
+  repeats: 3
+  seed: 0
+  temperature: 0.0
+  ignore_eos: true
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM3 32GB"
+  deploy.gpu_count: 1

--- a/recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/RESULTS.md
+++ b/recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/RESULTS.md
@@ -44,15 +44,26 @@ the correct answer to `2 + 2`.
 
 ## Compiler qualification
 
-Emmy compiler promotion was evaluated and rejected for this deployment. The loader recognizes FP8 and EXL3 stored
-checkpoint families, but not AWQ's packed 4-bit representation, so a compiler-served path would not preserve the
-qualified checkpoint numerics.
+Emmy's compiler can now recognize this AWQ GEMM checkpoint, stream only the selected layer, preserve packed
+`qweight`/`qzeros`/`scales` tensors, spell their int4 decode algebra into the graph, and feed the packed constants to
+the serving compiler lane. The repair also covers optional attention inputs, non-kernel slice boundaries, unique
+exact-target names, and direct strict eager verification for model-ID runs.
 
-As a diagnostic inventory, layer 0 was traced at sequence lengths 1 and 512. The traces contained 105 and 106 IR
-nodes and produced five and six distinct post-fusion kernel targets. Every target was tuned with an eight-candidate
-budget across all eight V100-SXM2 GPUs. Strict replay failed at both shapes because Emmy returned three outputs where
-eager returned one. At sequence length 512, Emmy also measured 9,137 µs versus 1,438 µs eager; several candidates
-timed out and one attempted a 17.18 GB allocation. No canonical golden or serving integration was retained.
+Layer 0 at sequence length 1 traced to 381 IR nodes. Its seven packed projections fused into four generated kernels.
+The untuned graph passed strict eager comparison at `rtol=atol=1e-3` with 0.000977 maximum absolute error, but took
+941,486 µs versus 1,031 µs eager. All four exact targets were swept with eight candidates across the host's eight
+V100-SXM3 GPUs. Three targets produced winners; every candidate for the dominant attention/linear/reduction target
+exceeded the tuning safety budget. Replaying the usable winners improved Emmy to 797,678 µs versus 1,025 µs eager,
+still 778× slower.
+
+Prefill exposed the remaining structural gap. Sequence length 128 passed the same strict check, but Emmy took
+2,581,686 µs versus 1,197 µs eager. At 256 tokens a generated kernel exceeded the two-second safety limit; at the
+required 512-token shape the execution plan requested a 60.13 GB scratch slab and failed allocation on the 32 GB
+V100. Packed AWQ parsing and correctness are therefore repaired, but the compiler still lacks a bounded,
+tensor-core-friendly fused int4 GEMM schedule. No Emmy golden or Emmy serving promotion was retained.
+
+The serving numbers above do **not** use Emmy-generated kernels. They use the pinned 1Cat/vLLM image's Volta AWQ and
+`FLASH_ATTN_V100` paths, which remain the qualified production backend.
 
 ## Reproduce
 
@@ -73,4 +84,4 @@ The benchmark writes ignored local output. `RESULTS.md` is the only retained mea
 - The exact image is already present on both qualified hosts. A registry pull by this locally resolved digest returned
   `manifest unknown`, so preload or republish that image before using the recipe on a new host.
 - Requalify after changing the image, model revision, driver, context length, or attention backend.
-- Emmy compiler serving is not qualified for this AWQ checkpoint.
+- Emmy compiler serving is not qualified for this AWQ checkpoint; its packed decode path is correct but not deployable.

--- a/recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/RESULTS.md
+++ b/recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/RESULTS.md
@@ -1,0 +1,76 @@
+# Llama 3.1 8B Instruct AWQ on one V100
+
+Status: serving-qualified on single 16 GB and 32 GB V100 profiles with the pinned SM70 1Cat/vLLM runtime.
+
+## Qualified deployments
+
+| Item | 16 GB profile | 32 GB profile |
+| --- | --- | --- |
+| Hardware | 1× Tesla V100-SXM2-16GB, SM70 | 1× Tesla V100-SXM3-32GB, SM70 |
+| Context | 32,768 tokens | 131,072 tokens (native) |
+| Max sequences | 8 | 8 |
+| Tensor parallelism | 1 | 1 |
+| Driver / CUDA | 580.159.03 / 13.0 | 580.159.03 / 13.0 |
+| Model revision | `db1f81ad4b8c7e39777509fac66c652eb0a52f91` | same |
+| Image digest | `sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be` | same |
+| KV capacity reported at boot | 61,760 tokens | 176,864 tokens |
+
+The checkpoint is 4-bit AWQ (`group_size=128`, GEMM packing) with FP16 compute. The image contains 1Cat/vLLM
+`0.1.dev21+g91aca502d.d20260809.cu128` and uses its Volta-native `FLASH_ATTN_V100` path. The 16 GB profile was
+reduced by powers of two: 131,072 needed 16 GiB of KV cache and 65,536 needed 8 GiB, while only 6.86 GiB was
+available. The 32,768-token profile then loaded and served cleanly. The native 131,072-token profile loaded on 32 GB.
+
+## Serving performance
+
+Measured 2026-08-13 with three repeats of 32 requests, 512 input tokens, 256 forced output tokens, concurrency 8,
+greedy decoding, and two warmup requests. All 192 measured requests succeeded.
+
+| Profile | Output tok/s | Total tok/s | Requests/s | Mean TTFT | Mean TPOT / ITL |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| V100 16 GB / 32k | 196.34 ± 11.61 | 589.02 ± 34.81 | 0.763 | 411.77 ms | 39.38 / 39.38 ms |
+| V100 32 GB / 128k | 246.66 ± 14.61 | 739.99 ± 43.84 | 0.963 | 435.06 ms | 30.92 / 30.92 ms |
+
+Cold model load and warmup took 124.56 seconds on 16 GB and 113.07 seconds on 32 GB. Both smoke tests returned
+the correct answer to `2 + 2`.
+
+## Chat, tools, and context
+
+- Both deployments returned valid OpenAI-compatible chat completions.
+- Both emitted a parsed `get_weather` tool call with `{"city":"Paris"}` and `finish_reason="tool_calls"`.
+- The 16 GB profile processed a material 30,041-token prompt and returned `OK.` without OOM.
+- The 32 GB profile processed a material 120,041-token prompt and generated a coherent completion without OOM.
+  That long synthetic prompt hit its requested 16-token output cap rather than obeying the embedded exact-output
+  instruction, so the result qualifies memory/execution at long context, not long-context instruction accuracy.
+
+## Compiler qualification
+
+Emmy compiler promotion was evaluated and rejected for this deployment. The loader recognizes FP8 and EXL3 stored
+checkpoint families, but not AWQ's packed 4-bit representation, so a compiler-served path would not preserve the
+qualified checkpoint numerics.
+
+As a diagnostic inventory, layer 0 was traced at sequence lengths 1 and 512. The traces contained 105 and 106 IR
+nodes and produced five and six distinct post-fusion kernel targets. Every target was tuned with an eight-candidate
+budget across all eight V100-SXM2 GPUs. Strict replay failed at both shapes because Emmy returned three outputs where
+eager returned one. At sequence length 512, Emmy also measured 9,137 µs versus 1,438 µs eager; several candidates
+timed out and one attempted a 17.18 GB allocation. No canonical golden or serving integration was retained.
+
+## Reproduce
+
+```bash
+emmy bench --max-workers 2 \
+  --ssh riftuser@185.165.50.60 \
+  --ssh riftuser@66.172.10.131 \
+  experiments/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/serving_v100_sxm2_16gb \
+  experiments/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/serving_v100_sxm3_32gb
+```
+
+The benchmark writes ignored local output. `RESULTS.md` is the only retained measurement artifact.
+
+## Limits
+
+- The 16 GB profile is qualified only through 32,768 tokens; larger power-of-two contexts failed the boot-time KV fit.
+- The 32 GB long-context probe validates execution and memory, not instruction-following quality at 120k tokens.
+- The exact image is already present on both qualified hosts. A registry pull by this locally resolved digest returned
+  `manifest unknown`, so preload or republish that image before using the recipe on a new host.
+- Requalify after changing the image, model revision, driver, context length, or attention backend.
+- Emmy compiler serving is not qualified for this AWQ checkpoint.

--- a/recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/recipe.yaml
+++ b/recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4/recipe.yaml
@@ -1,0 +1,41 @@
+# Llama 3.1 8B Instruct on one Volta GPU. The two matrix entries are deliberate
+# hardware-specific deployment profiles: 32k context for the 16 GB SXM2 card and
+# the native 128k context for the 32 GB SXM3 card. Both use the same immutable
+# public AWQ checkpoint and SM70-native serving image qualified in RESULTS.md.
+tags:
+  - best-effort
+
+model:
+  huggingface: "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4"
+  revision: db1f81ad4b8c7e39777509fac66c652eb0a52f91
+  rationale: >-
+    Public 4-bit AWQ preserves the Llama 3.1 8B Instruct chat and tool-use contract
+    while fitting one 16 GB V100; the official FP16 checkpoint does not fit there.
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    max_concurrent_requests: 8
+    vllm:
+      image: "cloudriftai/1cat-vllm-sm70@sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --attention-backend FLASH_ATTN_V100
+        --max-num-batched-tokens 4096
+        --enable-auto-tool-choice
+        --tool-call-parser llama3_json
+
+matrices:
+  # 131072 and 65536 both fail the measured KV-cache fit gate on 16 GB.
+  - deploy.gpu: "NVIDIA Tesla V100 SXM2 16GB"
+    deploy.gpu_count: 1
+    engine.llm.context_length: 32768
+
+  # The checkpoint's native context fits on one 32 GB card with 176864 KV tokens.
+  - deploy.gpu: "NVIDIA Tesla V100 SXM3 32GB"
+    deploy.gpu_count: 1
+    engine.llm.context_length: 131072

--- a/recipes/Meta-Llama-3.1-8B-Instruct/RESULTS.md
+++ b/recipes/Meta-Llama-3.1-8B-Instruct/RESULTS.md
@@ -1,0 +1,69 @@
+# Llama 3.1 8B Instruct FP16 on one 32 GB V100
+
+Status: serving-qualified at 65,536 tokens on one Tesla V100-SXM3-32GB with the pinned SM70 1Cat/vLLM runtime.
+
+## Qualified deployment
+
+| Item | Value |
+| --- | --- |
+| Hardware | 1× Tesla V100-SXM3-32GB, SM70 |
+| Context | 65,536 tokens |
+| Max sequences | 8 |
+| Tensor parallelism | 1 |
+| Driver / CUDA | 580.159.03 / 13.0 |
+| Model revision | `d10aef7999a2b5ba950ab3974312feeedbfe0b77` |
+| Image digest | `sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be` |
+| KV capacity reported at boot | 99,120 tokens |
+
+The official Meta repository is gated, so the recipe pins the public NousResearch mirror. Its `config.json` and all
+four safetensor shard SHA-256 values were checked against Meta revision
+`0e9e39f249a16976918f6564b8830bc894c89659` and are identical. The model has 8,030,261,248 parameters and occupies
+about 15 GiB in FP16. The mirror omits Meta's tool-aware tokenizer template, so the recipe pins the tokenizer from
+the qualified AWQ repository; its tokenizer config is byte-identical to Meta's.
+
+The native 131,072-token context failed the measured KV fit gate: 11.42 GiB was available while 16.0 GiB was needed,
+with a boot estimate of 93,584 maximum tokens. Halving to 65,536 loaded with 1.51× reported concurrency.
+
+## Serving performance
+
+Measured 2026-08-13 with three repeats of 32 requests, 512 input tokens, 256 forced output tokens, concurrency 8,
+greedy decoding, and two warmup requests. All 96 measured requests succeeded.
+
+| Output tok/s | Total tok/s | Requests/s | Mean TTFT | Mean TPOT / ITL |
+| ---: | ---: | ---: | ---: | ---: |
+| 280.80 ± 9.64 | 842.40 ± 28.92 | 1.093 ± 0.038 | 333.18 ms | 27.30 / 27.30 ms |
+
+Cold model load and warmup took 108.1 seconds. The three output-throughput repeats were 267.17, 287.98, and
+287.24 tokens/s.
+
+## Chat, tools, and context
+
+- OpenAI-compatible chat completion returned the correct answer to `2 + 2`.
+- Tool use emitted a parsed `get_weather` call with `{"city":"Paris"}`.
+- A material 60,041-token prompt plus three generated tokens completed in 84.93 seconds and returned `OK.` without OOM.
+
+## Emmy compiler qualification
+
+The FP16 layer path was evaluated separately from serving. At sequence length 1, layer 0 compiled into five Emmy
+kernels and passed direct strict eager comparison at `rtol=atol=1e-3` with 0.000977 maximum absolute error. Emmy took
+223,882 µs versus 773 µs eager, a 290× regression. At the required 512-token prefill shape, generated CUDA failed to
+compile because an `f2x26` tiled reduction referenced undefined unrolled-axis variables. Emmy-generated kernels are
+therefore not promoted; the qualified deployment uses the pinned 1Cat/vLLM Volta kernels.
+
+## Reproduce
+
+```bash
+emmy bench --ssh riftuser@66.172.10.131 \
+  experiments/Meta-Llama-3.1-8B-Instruct/serving_v100_sxm3_32gb
+```
+
+The benchmark writes ignored local output. `RESULTS.md` is the only retained measurement artifact.
+
+## Limits
+
+- This FP16 profile is qualified through 65,536 tokens; native 131,072 did not fit the measured KV-cache budget.
+- The tool-aware tokenizer is pinned separately because the byte-identical model mirror lacks Meta's template.
+- The exact image is already present on the qualified host. A registry pull by this locally resolved digest returned
+  `manifest unknown`, so preload or republish it before using the recipe on a new host.
+- Requalify after changing the image, model or tokenizer revision, driver, context length, or attention backend.
+- Emmy compiler serving is not qualified for this model on V100.

--- a/recipes/Meta-Llama-3.1-8B-Instruct/recipe.yaml
+++ b/recipes/Meta-Llama-3.1-8B-Instruct/recipe.yaml
@@ -1,0 +1,35 @@
+# FP16 Llama 3.1 8B Instruct on one 32 GB Volta GPU. The public mirror's
+# config and all four model shards are byte-identical to Meta's gated release.
+tags:
+  - best-effort
+
+model:
+  huggingface: "NousResearch/Meta-Llama-3.1-8B-Instruct"
+  revision: d10aef7999a2b5ba950ab3974312feeedbfe0b77
+  rationale: >-
+    FP16 fits one 32 GB V100 and avoids weight-only quantization. The pinned
+    public mirror is byte-identical to the official Meta model payload.
+  task: generate
+
+engine:
+  llm:
+    tensor_parallel_size: 1
+    pipeline_parallel_size: 1
+    gpu_memory_utilization: 0.88
+    context_length: 65536
+    max_concurrent_requests: 8
+    vllm:
+      image: "cloudriftai/1cat-vllm-sm70@sha256:8405bb60d24610417d0d6da278a753e2c968bfd1e0d7ff7f79cd6601a038b2be"
+      extra_args: >-
+        --dtype half
+        --language-model-only
+        --attention-backend FLASH_ATTN_V100
+        --max-num-batched-tokens 4096
+        --tokenizer hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4
+        --tokenizer-revision db1f81ad4b8c7e39777509fac66c652eb0a52f91
+        --enable-auto-tool-choice
+        --tool-call-parser llama3_json
+
+matrices:
+  deploy.gpu: "NVIDIA Tesla V100 SXM3 32GB"
+  deploy.gpu_count: 1

--- a/tests/compiler/backend/test_bench_worker_compare.py
+++ b/tests/compiler/backend/test_bench_worker_compare.py
@@ -476,6 +476,64 @@ def test_run_job_trace_args_accuracy_gates_the_bench(monkeypatch) -> None:
     assert benched and resp["results"] == {"Emmy": 1.0}
 
 
+def test_run_job_trace_args_strict_accuracy_records_direct_proof(monkeypatch) -> None:
+    """Model-ID runs use the same strict eager proof as runnable frontend IR."""
+    from types import SimpleNamespace
+
+    from emmy.compiler.backend.cuda import _bench_worker
+
+    module = object()
+    monkeypatch.setattr(
+        "emmy.commands.compile.load_or_trace",
+        lambda _args: (object(), "slug", (module, (), {})),
+    )
+    monkeypatch.setattr("emmy.commands.run._bind_inputs", lambda *_args, **_kwargs: {"x": [0.0]})
+    monkeypatch.setattr("emmy.commands.run._eager_output", lambda *_args, **_kwargs: {"n0": [2.0]})
+    monkeypatch.setattr(
+        "emmy.commands.run._strict_correctness_proof",
+        lambda outputs, eager: {
+            "status": "pass",
+            "reference": "eager",
+            "rtol": 1e-3,
+            "atol": 1e-3,
+            "max_abs_error": 0.0,
+            "mean_abs_error": 0.0,
+            "max_rel_error": 0.0,
+        },
+    )
+
+    class Backend:
+        def __init__(self, **_kwargs):
+            pass
+
+        def run(self, *_args, **_kwargs):
+            return SimpleNamespace(outputs={"n0": [2.0]}), None
+
+    monkeypatch.setattr("emmy.compiler.backend.cuda.backend.CudaBackend", Backend)
+
+    async def fake_bench(*_args, **_kwargs):
+        return {"Eager PyTorch": 2.0, "Emmy": 3.0}, SimpleNamespace(captured=True), True
+
+    monkeypatch.setattr("emmy.commands.run.bench_full_model_real", fake_bench)
+    resp = asyncio.run(
+        _bench_worker._run_job(
+            {
+                "graph": object(),
+                "torch_spec": ("trace_args", {"input": "org/model"}),
+                "strict_accuracy": True,
+                "accuracy": False,
+                "want_ref": False,
+                "warmup": 0,
+                "iters": 1,
+                "bench_backends": "eager,emmy",
+            }
+        )
+    )
+    assert resp["accuracy_error"] is None
+    assert resp["correctness"]["status"] == "pass"
+    assert resp["results"] == {"Eager PyTorch": 2.0, "Emmy": 3.0}
+
+
 def test_embedded_reference_survives_later_greedy_timing_failure(monkeypatch) -> None:
     """A completed Loop reference remains usable, but its failed greedy timing remains explicit."""
     from emmy.commands import run as run_mod

--- a/tests/compiler/cli/test_trace.py
+++ b/tests/compiler/cli/test_trace.py
@@ -12,7 +12,7 @@ from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import LinearOp
 from emmy.compiler.ir.loop import LoopOp
-from emmy.compiler.ir.tensor.ir import ElementwiseOp, GatherOp
+from emmy.compiler.ir.tensor.ir import CastOp, ElementwiseOp, GatherOp
 from emmy.compiler.pipeline.search.golden import load_golden_file, load_golden_records
 from emmy.compiler.pipeline.search.working_golden import load_working_targets, write_trace_inventories, write_trace_inventory
 
@@ -315,6 +315,36 @@ def test_trace_inventory_can_force_exact_loop_targets(tmp_path) -> None:
 
     assert record.origins == ()
     assert record.loop_wire is not None
+
+
+def test_exact_loop_targets_disambiguate_same_body_at_distinct_cast_boundaries(tmp_path) -> None:
+    graph = Graph()
+    outputs = []
+    for suffix in ("a", "b"):
+        graph.add_node(InputOp(), [], Tensor(f"left_{suffix}", (16,), "i32"), node_id=f"left_{suffix}")
+        graph.add_node(InputOp(), [], Tensor(f"right_{suffix}", (16,), "i32"), node_id=f"right_{suffix}")
+        graph.add_node(
+            ElementwiseOp("subtract"),
+            [f"left_{suffix}", f"right_{suffix}"],
+            Tensor(f"centered_{suffix}", (16,), "i32"),
+            node_id=f"centered_{suffix}",
+        )
+        graph.add_node(CastOp(dtype="f16"), [f"centered_{suffix}"], Tensor(f"values_{suffix}", (16,), "f16"), node_id=f"values_{suffix}")
+        graph.add_node(InputOp(), [], Tensor(f"scale_{suffix}", (16,), "f16"), node_id=f"scale_{suffix}")
+        graph.add_node(
+            ElementwiseOp("multiply"),
+            [f"values_{suffix}", f"scale_{suffix}"],
+            Tensor(f"scaled_{suffix}", (16,), "f16"),
+            node_id=f"scaled_{suffix}",
+        )
+        graph.inputs.extend((f"left_{suffix}", f"right_{suffix}", f"scale_{suffix}"))
+        outputs.append(f"scaled_{suffix}")
+    graph.outputs = outputs
+
+    path = tmp_path / "working.yaml"
+    write_trace_inventory(graph, path, force_loop_targets=True)
+    names = [record.name for record in load_golden_records(load_golden_file(path))]
+    assert len(names) == len(set(names))
 
 
 def test_combined_trace_inventory_deduplicates_identical_loop_targets(tmp_path) -> None:

--- a/tests/compiler/loader/test_quant.py
+++ b/tests/compiler/loader/test_quant.py
@@ -14,9 +14,11 @@ from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
 from emmy.compiler.loader.quant import (
     decode_f8,
     dequantize,
+    dequantize_awq4,
     spell_dynamic_fp8_activations,
     spell_quantized_constants,
     spell_quantized_inputs,
+    unpack_awq4,
 )
 from emmy.compiler.loader.safetensors import load_constants_from_safetensors
 from tests.compiler.helpers import requires_cuda
@@ -110,6 +112,7 @@ def test_dequantize_rejects_rank_mismatch():
 # ===================================================================
 
 _FP8_QC = {"quant_method": "fp8", "fmt": "e4m3", "activation_scheme": "dynamic", "modules_to_not_convert": []}
+_AWQ_QC = {"quant_method": "awq", "bits": 4, "group_size": 4, "zero_point": True, "version": "gemm"}
 
 
 def _write_checkpoint(dirpath, tensors, quant_config=None):
@@ -145,6 +148,18 @@ def _finite_bits(shape):
     bits[bits == 0x7F] = 0x00
     bits[bits == 0xFF] = 0x80
     return bits
+
+
+def _pack_awq4(values):
+    """AutoAWQ GEMM's output-channel packing, for compact synthetic fixtures."""
+    values = np.asarray(values, dtype=np.int32)
+    assert values.ndim == 2 and values.shape[1] % 8 == 0
+    packed = np.zeros((values.shape[0], values.shape[1] // 8), dtype=np.uint32)
+    order = (0, 2, 4, 6, 1, 3, 5, 7)
+    for word in range(packed.shape[1]):
+        for slot, logical in enumerate(order):
+            packed[:, word] |= values[:, word * 8 + logical].astype(np.uint32) << np.uint32(slot * 4)
+    return packed.view(np.int32)
 
 
 def _spelled(tmp_path, *, scale_shape=(8, 1), fmt="f8e4m3", inverse=False, dtype="f32", qc=_FP8_QC):
@@ -523,6 +538,75 @@ def test_loader_unquantized_checkpoint_unchanged(tmp_path):
     g = _weight_graph()
     assert spell_quantized_constants(g, str(tmp_path)) == 0
     np.testing.assert_array_equal(load_constants_from_safetensors(g, str(tmp_path))["p_w"], w)
+
+
+# ===================================================================
+# AWQ GEMM int4: packed checkpoint algebra and eager-reference decode
+# ===================================================================
+
+
+def _awq_fixture(tmp_path, *, k=8, n=16, group_size=4):
+    integers = (np.arange(k * n, dtype=np.int32).reshape(k, n) * 7 + 3) % 16
+    zeros = (np.arange((k // group_size) * n, dtype=np.int32).reshape(k // group_size, n) * 5 + 1) % 16
+    scales = (np.arange((k // group_size) * n, dtype=np.float32).reshape(k // group_size, n) + 1) / 128
+    qc = dict(_AWQ_QC, group_size=group_size)
+    _write_checkpoint(
+        tmp_path,
+        {
+            "layer.qweight": torch.from_numpy(_pack_awq4(integers)),
+            "layer.qzeros": torch.from_numpy(_pack_awq4(zeros)),
+            "layer.scales": torch.from_numpy(scales).half(),
+        },
+        qc,
+    )
+    stored_scales = scales.astype(np.float16).astype(np.float32)
+    ref = (integers - np.repeat(zeros, group_size, axis=0)) * np.repeat(stored_scales, group_size, axis=0)
+    return integers, zeros, scales, ref
+
+
+def test_unpack_awq4_reverses_gemm_pack_order():
+    values = np.arange(32, dtype=np.int32).reshape(2, 16) % 16
+    np.testing.assert_array_equal(unpack_awq4(_pack_awq4(values)), values)
+
+
+def test_dequantize_awq4_matches_group_formula(tmp_path):
+    integers, zeros, scales, ref = _awq_fixture(tmp_path)
+    got = dequantize_awq4(_pack_awq4(integers), _pack_awq4(zeros), scales.astype(np.float16), 4)
+    np.testing.assert_array_equal(got, ref)
+
+
+def test_load_dequantized_state_dict_awq_emits_hf_weight(tmp_path):
+    from emmy.compiler.loader.quant import load_dequantized_state_dict
+
+    _integers, _zeros, _scales, ref = _awq_fixture(tmp_path)
+    state = load_dequantized_state_dict(tmp_path)
+    assert set(state) == {"layer.weight"}
+    np.testing.assert_array_equal(state["layer.weight"], ref.T)
+
+
+def test_spell_awq4_constants_preserves_packed_sources_and_values(tmp_path):
+    _integers, _zeros, _scales, ref = _awq_fixture(tmp_path)
+    graph = _weight_graph(shape=(16, 8), dtype="f32")
+    assert spell_quantized_constants(graph, str(tmp_path)) == 1
+    graph.validate()
+    sources = {op.source_path for op in _constants(graph).values() if op.source_path is not None}
+    assert sources == {"layer.qweight", "layer.qzeros", "layer.scales"}
+    assert any(n.op.op.name == "right_shift" for n in _ops_by_type(graph, ElementwiseOp))
+    assert any(n.op.op.name == "bitwise_and" for n in _ops_by_type(graph, ElementwiseOp))
+
+    from emmy.compiler.backend.numpy.backend import NumpyBackend
+
+    backend = NumpyBackend()
+    compiled = backend.compile(graph)
+    result, _ = backend.run(compiled, input_data=load_constants_from_safetensors(compiled, str(tmp_path)))
+    np.testing.assert_array_equal(result.outputs[compiled.outputs[0]], ref.T)
+
+
+def test_quantized_checkpoint_dir_detects_awq(tmp_path):
+    from emmy.compiler.trace.huggingface import quantized_checkpoint_dir
+
+    _awq_fixture(tmp_path)
+    assert quantized_checkpoint_dir(str(tmp_path)) == tmp_path
 
 
 # ===================================================================

--- a/tests/compiler/pipeline/search/test_slice.py
+++ b/tests/compiler/pipeline/search/test_slice.py
@@ -19,6 +19,7 @@ from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda.ir import CudaOp
 from emmy.compiler.ir.frontend.ir import MatmulOp
 from emmy.compiler.ir.loop import LoopOp
+from emmy.compiler.ir.tensor.ir import CastOp, ElementwiseOp
 from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pipeline
 from emmy.compiler.pipeline.search.db import SearchDB
 from emmy.compiler.pipeline.search.slice import single_node_graph, topo_order
@@ -134,3 +135,30 @@ def test_flash_slice_absorbs_score_producer() -> None:
     # Without absorb the producer is a synthetic input and the fusion cannot fire — two kernels.
     plain = single_node_graph(fused, consumer)
     assert isinstance(plain.nodes[producer].op, InputOp), "un-absorbed producer is a synthetic input"
+
+
+def test_slice_makes_surviving_cast_a_synthetic_boundary() -> None:
+    """Compact storage algebra can leave a value ``CastOp`` between two LoopOps.
+
+    Loop wire format cannot carry the cast as compute. The cast therefore
+    becomes an input stub, rather than a retained node with an unbound input.
+    """
+    graph = Graph()
+    graph.add_node(InputOp(), [], Tensor("a", (16,), "i32"), node_id="a")
+    graph.add_node(InputOp(), [], Tensor("b", (16,), "i32"), node_id="b")
+    graph.add_node(ElementwiseOp(op="subtract"), ["a", "b"], Tensor("centered", (16,), "i32"), node_id="centered")
+    graph.add_node(CastOp(dtype="f16"), ["centered"], Tensor("values", (16,), "f16"), node_id="values")
+    graph.add_node(InputOp(), [], Tensor("scale", (16,), "f16"), node_id="scale")
+    graph.add_node(ElementwiseOp(op="multiply"), ["values", "scale"], Tensor("scaled", (16,), "f16"), node_id="scaled")
+    graph.inputs, graph.outputs = ["a", "b", "scale"], ["scaled"]
+
+    fused = Pipeline.build(LOOP_PASSES).run(graph, db=SearchDB())
+    loops = [nid for nid, node in fused.nodes.items() if isinstance(node.op, LoopOp)]
+    assert len(loops) == 2
+    producer = next(nid for nid in loops if "centered" in fused.nodes[nid].buffer_names())
+    consumer = next(nid for nid in loops if nid != producer)
+    sub = single_node_graph(fused, consumer, absorb=frozenset({producer}))
+    sub.validate()
+    assert producer not in sub.nodes
+    assert isinstance(sub.nodes["values"].op, InputOp)
+    assert "values" in sub.inputs

--- a/tests/compiler/trace/test_huggingface.py
+++ b/tests/compiler/trace/test_huggingface.py
@@ -311,6 +311,33 @@ def test_static_layer_trace_supplies_declared_attention_inputs(monkeypatch):
     torch.testing.assert_close(kwargs["input_ids"], torch.zeros((1, 8), dtype=torch.long))
 
 
+def test_static_layer_trace_omits_optional_none_attention_mask(monkeypatch):
+    """An optional None is call policy, not a tensor input to compile/bind."""
+    import torch.nn as nn
+
+    transformers = pytest.importorskip("transformers")
+
+    from emmy.commands.compile import _trace_model
+
+    class OptionalMaskAttention(nn.Module):
+        def forward(self, x, position_embeddings, attention_mask=None):
+            assert attention_mask is None
+            return x
+
+    class OptionalMaskBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.self_attn = OptionalMaskAttention()
+
+        def forward(self, x, position_embeddings=None, **kwargs):
+            return self.self_attn(x, position_embeddings=position_embeddings, **kwargs)
+
+    monkeypatch.setattr(transformers.AutoModelForCausalLM, "from_pretrained", lambda model_id, **kw: _fake_causal_lm(OptionalMaskBlock()))
+    graph, (_mod, _args, kwargs) = _trace_model("fake/optional-attention-mask", 0, 8)
+    assert graph.nodes
+    assert "attention_mask" not in kwargs
+
+
 def test_attention_split_rejects_ple_block():
     """The serving carve has no seam for the PLE multiply — it must reject loudly,
     not silently drop the ``per_layer_input`` term."""
@@ -501,6 +528,50 @@ def test_quantized_trace_twin_materializes_only_requested_layer(tmp_path):
     assert next(decoder.layers[0].parameters()).device.type == "meta"
     assert next(decoder.layers[2].parameters()).device.type == "meta"
     assert next(decoder.rotary_emb.buffers()).device.type == "cpu"
+
+
+def test_quantized_layer_twin_streams_only_requested_value_layer(monkeypatch, tmp_path):
+    """The runnable layer lane must not decode the other 31 decoder blocks."""
+    from types import SimpleNamespace
+
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn
+
+    import emmy.compiler.trace.huggingface as huggingface
+
+    class Rotary(nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = config
+            self.register_buffer("inv_freq", torch.ones(2))
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.decoder = nn.Module()
+            self.decoder.layers = nn.ModuleList([nn.Linear(2, 2) for _ in range(3)])
+            self.decoder.config = SimpleNamespace()
+            self.decoder.rotary_emb = Rotary(self.decoder.config)
+            self.config = self.decoder.config
+
+    model = Model()
+    seen = {}
+
+    def split(path, dtype, **kwargs):
+        seen.update(path=path, dtype=dtype, **kwargs)
+        return model, {}
+
+    monkeypatch.setattr(huggingface, "load_quantized_split", split)
+    got = huggingface.load_quantized_layer_twin(tmp_path, torch.float16, 1)
+    assert got is model
+    assert seen == {
+        "path": tmp_path,
+        "dtype": torch.float16,
+        "layer_range": (1, 2),
+        "include_embed": False,
+        "include_norm": False,
+    }
+    assert next(model.decoder.rotary_emb.buffers()).device.type == "cpu"
 
 
 def test_architecture_trace_twin_replaces_laguna_experts_before_materialization(tmp_path):

--- a/tests/serving/generation/test_gen_runner.py
+++ b/tests/serving/generation/test_gen_runner.py
@@ -115,16 +115,19 @@ def test_pipeline_runner_tracks_absolute_layers_and_boundary_ownership():
         runner.final_norm(np.zeros((1, 8), dtype=np.float16))
 
 
-@pytest.mark.parametrize(("quant_method", "coded_trunk"), [("exl3", True), ("fp8", False)])
-def test_create_keeps_only_exl3_trunk_coded(tmp_path, monkeypatch, quant_method, coded_trunk):
-    """EXL3 stays checkpoint-coded; FP8 preserves its decoded trunk lane."""
+@pytest.mark.parametrize(("quant_method", "coded_trunk"), [("exl3", True), ("awq", True), ("fp8", False)])
+def test_create_keeps_storage_coded_trunks_packed(tmp_path, monkeypatch, quant_method, coded_trunk):
+    """EXL3/AWQ stay checkpoint-coded; FP8 preserves its decoded trunk lane."""
     import json
 
     from emmy.compiler.loader import safetensors
     from emmy.compiler.trace import huggingface
     from emmy.serving.gen_runner import EmmyGenRunner
 
-    (tmp_path / "config.json").write_text(json.dumps({"quantization_config": {"quant_method": quant_method}}))
+    quant_config = {"quant_method": quant_method}
+    if quant_method == "awq":
+        quant_config.update(bits=4, version="gemm", zero_point=True)
+    (tmp_path / "config.json").write_text(json.dumps({"quantization_config": quant_config}))
     seen = {}
     fake_model = object()
     fake_store = {"fmt": quant_method}


### PR DESCRIPTION
## Summary

- qualify Llama 3.1 8B Instruct on one V100 in three profiles: AWQ on 16 GB and 32 GB, plus FP16 on 32 GB
- add packed AWQ GEMM support to Emmy's loader, tracer, exact-target inventory, strict model benchmark, and serving compiler lane
- preserve immutable model/tokenizer revisions and the SM70 1Cat/vLLM image digest
- retain only experiment recipes and compact final qualification reports

## Qualified serving profiles

| Weights | GPU | Context | Output throughput | Result |
| --- | --- | ---: | ---: | --- |
| AWQ INT4 | 1× V100 SXM2 16 GB | 32,768 | 196.34 ± 11.61 tok/s | qualified |
| AWQ INT4 | 1× V100 SXM3 32 GB | 131,072 | 246.66 ± 14.61 tok/s | qualified |
| FP16 | 1× V100 SXM3 32 GB | 65,536 | 280.80 ± 9.64 tok/s | qualified |

All serving profiles passed chat, parsed tool-call, and material long-context execution checks. All 288 measured benchmark requests succeeded.

The FP16 recipe pins `NousResearch/Meta-Llama-3.1-8B-Instruct@d10aef7999a2b5ba950ab3974312feeedbfe0b77`; its config and four model shards were verified byte-identical to Meta's gated revision. The tool-aware tokenizer is pinned separately to the byte-identical qualified AWQ tokenizer config.

## Compiler qualification

The compiler now recognizes AWQ GEMM int4 checkpoints, streams selected-layer values, keeps `qweight`/`qzeros`/`scales` packed in graph storage, disambiguates exact targets, handles optional attention inputs and intermediate slice boundaries, and records direct strict eager proofs for model-ID runs.

On V100, AWQ layer-0 decode fused seven packed projections into four kernels and passed strict eager comparison. An eight-candidate sweep of every target across all eight GPUs improved Emmy from 941.5 ms to 797.7 ms, but eager AWQ was 1.025 ms (778× faster). A 128-token prefill also passed strict correctness but was 2,157× slower; 256 tokens exceeded the safety timeout and 512 tokens requested a 60.13 GB scratch slab. FP16 decode passed strict comparison but was 290× slower, and FP16 prefill exposed a separate generated-CUDA unrolled-index bug.

No Emmy compiler golden or serving promotion is included. The qualified deployments use the pinned 1Cat/vLLM Volta AWQ and `FLASH_ATTN_V100` kernels.

## Validation

- `ruff check emmy tests/compiler tests/serving/generation/test_gen_runner.py` — passed
- focused AWQ/trace/slice/strict/serving regressions — 14 passed
- broader affected-module suite — 145 passed; one unrelated existing CUDA FP8 numerical gate remains (`0.0113` max diff vs `0.005`)
- both recipes load through Emmy's recipe parser
- live chat, tools, long-context, throughput, strict decode, prefill-boundary, and eight-GPU tuning runs completed on the target hosts
- temporary workloads and tuning artifacts were removed from both hosts
