### PR TITLE
CloudRift rental controls: node pinning and tags

### DIFF
--- a/.claude/skills/start-remote-server/SKILL.md
+++ b/.claude/skills/start-remote-server/SKILL.md
@@ -104,7 +104,7 @@ Terminal errors (auth 401/403, malformed 400, "Unknown GPU" `ValueError`, missin
 
 ## Manual Overrides
 
-Use the provider-specific commands **only** when the user explicitly asks for a specific instance type / machine type that doesn't match a hardware-table entry, or when debugging a provisioning bug. For normal "give me a server" requests, always prefer `vm create gpu`.
+Use the provider-specific commands **only** when the user explicitly asks for a specific instance type / machine type that doesn't match a hardware-table entry, when the user pins a specific CloudRift node, or when debugging a provisioning bug. For normal "give me a server" requests, always prefer `vm create gpu`.
 
 ### CloudRift (single-shot, exact instance type)
 
@@ -115,6 +115,10 @@ emmy vm create cloudrift \
 ```
 
 This command requires the **public** key path (`.pub`), unlike `vm create gpu`. It does not retry across bases/zones — one attempt, then exit.
+
+Add `--node <id-or-hostname>` when the user names a specific node: the rental then uses the `ByNodeId` selector.
+Hostname resolution goes through the operator-only node-list endpoint, so non-operator accounts must pass the node
+UUID. A pinned node has no fallback — if the rent fails, report it; do not retry elsewhere.
 
 Image is auto-selected from the instance type: `mi*` (AMD Instinct) → ROCm image; everything else → NVIDIA driver image. Override with `--image-url` only when the user explicitly asks — the wrong image leaves the GPU unusable.
 

--- a/emmy/commands/vm/cloudrift.py
+++ b/emmy/commands/vm/cloudrift.py
@@ -52,6 +52,7 @@ async def _handle_create(args):
             dry_run=args.dry_run,
             billing_exempt=args.billing_exempt,
             network=args.network,
+            node=args.node,
         )
     except (CapacityExhausted, TerminalProvisionError) as exc:
         logger.error(f"{exc}")
@@ -104,6 +105,11 @@ def register_create_target(subparsers):
         "--network",
         default=None,
         help="Network name to attach the instance to (must exist in the target datacenter; default: provider picks a public network)",
+    )
+    parser.add_argument(
+        "--node",
+        default=None,
+        help="Pin the rental to one node, by node ID or hostname (hostname resolution requires operator access)",
     )
     parser.set_defaults(func=handle_create)
 

--- a/emmy/commands/vm/cloudrift.py
+++ b/emmy/commands/vm/cloudrift.py
@@ -53,6 +53,7 @@ async def _handle_create(args):
             billing_exempt=args.billing_exempt,
             network=args.network,
             node=args.node,
+            tags=args.tag,
         )
     except (CapacityExhausted, TerminalProvisionError) as exc:
         logger.error(f"{exc}")
@@ -110,6 +111,12 @@ def register_create_target(subparsers):
         "--node",
         default=None,
         help="Pin the rental to one node, by node ID or hostname (hostname resolution requires operator access)",
+    )
+    parser.add_argument(
+        "--tag",
+        action="append",
+        default=None,
+        help="Rental tag, repeatable (default: EMMY_RENTAL_TAGS, else 'emmy')",
     )
     parser.set_defaults(func=handle_create)
 

--- a/emmy/config.py
+++ b/emmy/config.py
@@ -59,6 +59,7 @@ GEN_PREFILL_BUCKET = "EMMY_GEN_PREFILL_BUCKET"
 GEN_PREFILL_CAPACITY = "EMMY_GEN_PREFILL_CAPACITY"
 GEN_EMBED_HOST = "EMMY_GEN_EMBED_HOST"
 READABLE = "EMMY_READABLE"
+RENTAL_TAGS = "EMMY_RENTAL_TAGS"
 
 _CACHE_ROOT = Path.home() / ".cache" / "emmy"
 
@@ -164,6 +165,17 @@ def _str(name: str, default: str = "") -> str:
 
 
 # --- Typed getters (read os.environ live) ----------------------------------
+
+
+def rental_tags() -> list[str]:
+    """Tags attached to cloud VM rentals: ``EMMY_RENTAL_TAGS`` (comma-separated)
+    → ``["emmy"]``. The env override lets a caller label a whole rental lane —
+    e.g. an experiment run or a GitHub workflow job — without plumbing a flag
+    through every provisioning path."""
+    raw = _str(RENTAL_TAGS)
+    if not raw:
+        return ["emmy"]
+    return [tag.strip() for tag in raw.split(",") if tag.strip()]
 
 
 def tune_db_path() -> Path:

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -40,6 +40,11 @@ The orchestrator tries candidates in this order until one succeeds or all are ex
 fallback follows the hardware table across providers. An explicit `--provider` restricts the entire candidate list,
 so callers that request CloudRift are never silently relocated to GCP.
 
+CloudRift rentals can also be pinned to one node (`vm create cloudrift --node <id-or-hostname>`): the rent request
+then uses the `ByNodeId` selector instead of `ByInstanceTypeAndLocation`, and `resolve_node_id()` turns a hostname
+into the node UUID via `/api/v1/nodes/list` (an operator-only endpoint — customers pass the UUID). A pinned node has
+no placement fallback, so the pin lives on the single-shot provider command, not the candidate orchestrator.
+
 For each candidate, the orchestrator makes up to `SAME_CANDIDATE_RETRIES` (= 2) attempts on transient errors. On the contracted exceptions it short-circuits:
 
 | Provider raises | Orchestrator does |

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -45,6 +45,10 @@ then uses the `ByNodeId` selector instead of `ByInstanceTypeAndLocation`, and `r
 into the node UUID via `/api/v1/nodes/list` (an operator-only endpoint — customers pass the UUID). A pinned node has
 no placement fallback, so the pin lives on the single-shot provider command, not the candidate orchestrator.
 
+Every CloudRift rental carries free-form tags for later filtering on listings. `create_instance` resolves them
+through `emmy.config.rental_tags()` — repeatable `--tag` flags win, else the comma-separated `EMMY_RENTAL_TAGS` env
+var (how an experiment run or CI job labels its whole rental lane), else the default `emmy` tag.
+
 For each candidate, the orchestrator makes up to `SAME_CANDIDATE_RETRIES` (= 2) attempts on transient errors. On the contracted exceptions it short-circuits:
 
 | Provider raises | Orchestrator does |

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -8,6 +8,7 @@ import uuid
 
 import httpx
 
+from emmy import config
 from emmy.provisioning.errors import CapacityExhausted, TerminalProvisionError
 from emmy.provisioning.ssh import wait_for_ssh
 from emmy.provisioning.types import VMConnectionInfo
@@ -85,6 +86,7 @@ async def _rent_instance(
     billing_exempt=False,
     network=None,
     node_id=None,
+    tags=None,
 ):
     """Rent a new CloudRift VM instance.
 
@@ -94,6 +96,7 @@ async def _rent_instance(
         ssh_public_keys: list of public key strings (e.g. ["ssh-ed25519 AAAA..."])
         node_id: optional node UUID; when set, rents on exactly that node via the
             ``ByNodeId`` selector instead of letting the provider place the instance.
+        tags: optional list of free-form labels attached to the rental.
     """
     vm_config = {
         "ssh_key": {"PublicKeys": ssh_public_keys},
@@ -117,6 +120,8 @@ async def _rent_instance(
         data["billing_exempt"] = True
     if network is not None:
         data["network"] = network
+    if tags:
+        data["tags"] = list(tags)
     return await _api_request("POST", "/api/v1/instances/rent", data, api_key, api_url, dry_run)
 
 
@@ -405,6 +410,7 @@ async def create_instance(
     extra_public_keys=None,
     allocation_observer=None,
     node=None,
+    tags=None,
 ):
     """Create a CloudRift VM instance.
 
@@ -414,6 +420,8 @@ async def create_instance(
         ssh_key_path: path to the SSH **public** key file.
         node: optional node UUID or hostname to pin the rental to (see
             :func:`resolve_node_id`); placement fallback does not apply to a pinned node.
+        tags: rental labels; ``None`` resolves through :func:`emmy.config.rental_tags`
+            (``EMMY_RENTAL_TAGS`` override, default ``["emmy"]``).
         extra_public_keys: optional list of additional SSH public key strings to
             install in the VM's authorized_keys alongside the key from
             ``ssh_key_path`` (e.g. ["ssh-ed25519 AAAA bob@host"]).
@@ -439,6 +447,9 @@ async def create_instance(
         node_id = await resolve_node_id(api_key, node, api_url=api_url, dry_run=dry_run)
         logger.info(f"Pinning rental to node {node} (id={node_id}).")
 
+    if tags is None:
+        tags = config.rental_tags()
+
     ssh_key_path = os.path.expanduser(ssh_key_path)
     if dry_run and not os.path.exists(ssh_key_path):
         public_key = "dry-run-placeholder"
@@ -460,6 +471,7 @@ async def create_instance(
             billing_exempt=billing_exempt,
             network=network,
             node_id=node_id,
+            tags=tags,
         )
     except httpx.HTTPStatusError as exc:
         code = exc.response.status_code

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import uuid
 
 import httpx
 
@@ -83,6 +84,7 @@ async def _rent_instance(
     dry_run=False,
     billing_exempt=False,
     network=None,
+    node_id=None,
 ):
     """Rent a new CloudRift VM instance.
 
@@ -90,6 +92,8 @@ async def _rent_instance(
 
     Args:
         ssh_public_keys: list of public key strings (e.g. ["ssh-ed25519 AAAA..."])
+        node_id: optional node UUID; when set, rents on exactly that node via the
+            ``ByNodeId`` selector instead of letting the provider place the instance.
     """
     vm_config = {
         "ssh_key": {"PublicKeys": ssh_public_keys},
@@ -98,12 +102,12 @@ async def _rent_instance(
     }
     if ports:
         vm_config["ports"] = [str(p) for p in ports]
+    if node_id is not None:
+        selector = {"ByNodeId": {"node_id": node_id, "instance_type": instance_type}}
+    else:
+        selector = {"ByInstanceTypeAndLocation": {"instance_type": instance_type}}
     data = {
-        "selector": {
-            "ByInstanceTypeAndLocation": {
-                "instance_type": instance_type,
-            },
-        },
+        "selector": selector,
         "config": {
             "VirtualMachine": vm_config,
         },
@@ -114,6 +118,38 @@ async def _rent_instance(
     if network is not None:
         data["network"] = network
     return await _api_request("POST", "/api/v1/instances/rent", data, api_key, api_url, dry_run)
+
+
+async def resolve_node_id(api_key, node, api_url=DEFAULT_API_URL, dry_run=False):
+    """Resolve a node reference (UUID or hostname) to the node UUID used by the rent API.
+
+    A value that parses as a UUID is returned unchanged. Anything else is treated as a
+    hostname and looked up via POST /api/v1/nodes/list, which the API restricts to
+    operator accounts (admin or the node's provider); customers must pass the UUID.
+    """
+    try:
+        return str(uuid.UUID(node))
+    except ValueError:
+        pass
+    if dry_run:
+        logger.info(f"[dry-run] Would resolve node hostname {node!r} via /api/v1/nodes/list.")
+        return node
+    try:
+        result = await _api_request("POST", "/api/v1/nodes/list", {"selector": "All"}, api_key, api_url)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            raise TerminalProvisionError(
+                f"Node listing returned {exc.response.status_code}: resolving a hostname requires operator "
+                f"access — pass the node UUID instead of {node!r}."
+            ) from exc
+        raise
+    nodes = result.get("nodes", [])
+    matches = [entry["id"] for entry in nodes if entry.get("hostname") == node]
+    if not matches:
+        raise TerminalProvisionError(f"No node with hostname {node!r} among the {len(nodes)} nodes visible to this account.")
+    if len(matches) > 1:
+        raise TerminalProvisionError(f"Hostname {node!r} is ambiguous: nodes {matches}.")
+    return matches[0]
 
 
 async def _terminate_instance(api_key, instance_id, api_url=DEFAULT_API_URL, dry_run=False):
@@ -368,6 +404,7 @@ async def create_instance(
     network=None,
     extra_public_keys=None,
     allocation_observer=None,
+    node=None,
 ):
     """Create a CloudRift VM instance.
 
@@ -375,6 +412,8 @@ async def create_instance(
         image_url: VM image URL. If ``None``, auto-picks ROCm for ``mi*`` instance
             types and NVIDIA otherwise via :func:`select_image_url`.
         ssh_key_path: path to the SSH **public** key file.
+        node: optional node UUID or hostname to pin the rental to (see
+            :func:`resolve_node_id`); placement fallback does not apply to a pinned node.
         extra_public_keys: optional list of additional SSH public key strings to
             install in the VM's authorized_keys alongside the key from
             ``ssh_key_path`` (e.g. ["ssh-ed25519 AAAA bob@host"]).
@@ -394,6 +433,11 @@ async def create_instance(
         logger.info(f"Creating CloudRift instance (type={instance_type}, auto-selected image={image_url})...")
     else:
         logger.info(f"Creating CloudRift instance (type={instance_type}, image={image_url})...")
+
+    node_id = None
+    if node is not None:
+        node_id = await resolve_node_id(api_key, node, api_url=api_url, dry_run=dry_run)
+        logger.info(f"Pinning rental to node {node} (id={node_id}).")
 
     ssh_key_path = os.path.expanduser(ssh_key_path)
     if dry_run and not os.path.exists(ssh_key_path):
@@ -415,6 +459,7 @@ async def create_instance(
             dry_run=dry_run,
             billing_exempt=billing_exempt,
             network=network,
+            node_id=node_id,
         )
     except httpx.HTTPStatusError as exc:
         code = exc.response.status_code

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -322,6 +322,21 @@ def _instance_fully_ready(info):
     return True
 
 
+def _vm_username(instance):
+    """VM login username from virtual_machines[].login_info, default "user".
+
+    login_info is a single-variant enum dict; every variant carries a username
+    (UsernameAndPassword, and HiddenPassword for callers without the
+    view-credentials permission), so read it variant-agnostically.
+    """
+    vms = instance.get("virtual_machines") or []
+    if not vms:
+        return "user"
+    login_info = vms[0].get("login_info") or {}
+    creds = next(iter(login_info.values()), None) or {}
+    return creds.get("username") or "user"
+
+
 def _extract_connection_info(instance, delete_info=()):
     """Extract connection info from an instance dict into a VMConnectionInfo.
 
@@ -330,14 +345,7 @@ def _extract_connection_info(instance, delete_info=()):
     """
     host = instance.get("host_address", "")
     port_mappings = instance.get("port_mappings", [])
-
-    # Extract login credentials from VM info
-    username = "user"
-    vms = instance.get("virtual_machines", [])
-    if vms:
-        login_info = vms[0].get("login_info", {})
-        creds = login_info.get("UsernameAndPassword", {})
-        username = creds.get("username", username)
+    username = _vm_username(instance)
 
     # Find SSH port mapping: each mapping is [internal_port, external_port]
     ssh_port = 22
@@ -363,14 +371,7 @@ def _log_connection_info(instance):
     """
     host = instance.get("host_address")
     port_mappings = instance.get("port_mappings", [])
-
-    # Extract login credentials from VM info
-    username = "user"
-    vms = instance.get("virtual_machines", [])
-    if vms:
-        login_info = vms[0].get("login_info", {})
-        creds = login_info.get("UsernameAndPassword", {})
-        username = creds.get("username", username)
+    username = _vm_username(instance)
 
     # Find SSH port mapping: each mapping is [internal_port, external_port]
     ssh_ext_port = None

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -17,6 +17,7 @@ from emmy.provisioning.cloudrift import (
     _add_ssh_key,
     _api_request,
     _ensure_ssh_key,
+    _extract_connection_info,
     _get_instance_info,
     _instance_fully_ready,
     _list_ssh_keys,
@@ -283,6 +284,14 @@ async def test_create_instance_pins_resolved_node(mock_wait, mock_resolve, mock_
     assert conn is not None
     mock_resolve.assert_awaited_once_with(API_KEY, "cato-ubuntu-66-172-10-7", api_url=API_URL, dry_run=False)
     assert mock_rent.call_args.kwargs["node_id"] == "2cb28df8-86fe-11f0-b32f-3b150b0bc471"
+
+
+def test_extract_connection_info_hidden_password_username():
+    """v062 HiddenPassword login_info still names the user; don't fall back to "user"."""
+    instance = dict(INSTANCE_ACTIVE_RESPONSE["instances"][0])
+    instance["virtual_machines"] = [{"login_info": {"HiddenPassword": {"username": "riftuser"}}, "ready": True}]
+
+    assert _extract_connection_info(instance).username == "riftuser"
 
 
 # ── rental tags ───────────────────────────────────────────────────

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -6,6 +6,7 @@ Response fixtures are captured from real CloudRift API calls.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from emmy.provisioning.cloudrift import (
     API_VERSION,
@@ -23,6 +24,7 @@ from emmy.provisioning.cloudrift import (
     _rent_instance,
     _terminate_instance,
     create_instance,
+    resolve_node_id,
     select_image_url,
     wait_for_status,
 )
@@ -202,6 +204,85 @@ async def test_rent_instance_no_billing_exempt_by_default(mock_api):
 
     call_data = mock_api.call_args[0][2]
     assert "billing_exempt" not in call_data
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_node_id_selector(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(
+        API_KEY,
+        "rtx49-7c-kn.1",
+        ["ssh-ed25519 AAAA user@host"],
+        DEFAULT_IMAGE_URL_NVIDIA,
+        api_url=API_URL,
+        node_id="2cb28df8-86fe-11f0-b32f-3b150b0bc471",
+    )
+
+    call_data = mock_api.call_args[0][2]
+    assert call_data["selector"] == {"ByNodeId": {"node_id": "2cb28df8-86fe-11f0-b32f-3b150b0bc471", "instance_type": "rtx49-7c-kn.1"}}
+
+
+# ── resolve_node_id ───────────────────────────────────────────────
+
+NODES_LIST_RESPONSE = {
+    "nodes": [
+        {"id": "2cb28df8-86fe-11f0-b32f-3b150b0bc471", "hostname": "cato-ubuntu-66-172-10-7"},
+        {"id": "f8c403e6-7101-11ee-b00d-63f746883a19", "hostname": "atlas-ubuntu-1"},
+    ]
+}
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_node_id_uuid_passthrough(mock_api):
+    node_id = await resolve_node_id(API_KEY, "2cb28df8-86fe-11f0-b32f-3b150b0bc471", api_url=API_URL)
+
+    assert node_id == "2cb28df8-86fe-11f0-b32f-3b150b0bc471"
+    mock_api.assert_not_called()
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_node_id_hostname(mock_api):
+    mock_api.return_value = NODES_LIST_RESPONSE
+
+    node_id = await resolve_node_id(API_KEY, "cato-ubuntu-66-172-10-7", api_url=API_URL)
+
+    assert node_id == "2cb28df8-86fe-11f0-b32f-3b150b0bc471"
+    assert mock_api.call_args[0][1] == "/api/v1/nodes/list"
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_node_id_unknown_hostname(mock_api):
+    mock_api.return_value = NODES_LIST_RESPONSE
+
+    with pytest.raises(TerminalProvisionError, match="no-such-host"):
+        await resolve_node_id(API_KEY, "no-such-host", api_url=API_URL)
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_node_id_forbidden_is_terminal(mock_api):
+    response = MagicMock(status_code=403, text="forbidden")
+    mock_api.side_effect = httpx.HTTPStatusError("forbidden", request=MagicMock(), response=response)
+
+    with pytest.raises(TerminalProvisionError, match="operator"):
+        await resolve_node_id(API_KEY, "cato-ubuntu-66-172-10-7", api_url=API_URL)
+
+
+@patch("emmy.provisioning.cloudrift._rent_instance", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.resolve_node_id", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.wait_for_status", new_callable=AsyncMock)
+async def test_create_instance_pins_resolved_node(mock_wait, mock_resolve, mock_rent, tmp_path):
+    key_path = tmp_path / "id_ed25519.pub"
+    key_path.write_text("ssh-ed25519 AAAA user@host")
+    mock_resolve.return_value = "2cb28df8-86fe-11f0-b32f-3b150b0bc471"
+    mock_rent.return_value = RENT_RESPONSE
+    mock_wait.return_value = INSTANCE_ACTIVE_RESPONSE["instances"][0]
+
+    conn = await create_instance(API_KEY, "rtx49-7c-kn.1", str(key_path), api_url=API_URL, node="cato-ubuntu-66-172-10-7")
+
+    assert conn is not None
+    mock_resolve.assert_awaited_once_with(API_KEY, "cato-ubuntu-66-172-10-7", api_url=API_URL, dry_run=False)
+    assert mock_rent.call_args.kwargs["node_id"] == "2cb28df8-86fe-11f0-b32f-3b150b0bc471"
 
 
 @patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -285,6 +285,73 @@ async def test_create_instance_pins_resolved_node(mock_wait, mock_resolve, mock_
     assert mock_rent.call_args.kwargs["node_id"] == "2cb28df8-86fe-11f0-b32f-3b150b0bc471"
 
 
+# ── rental tags ───────────────────────────────────────────────────
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_tags_payload(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(
+        API_KEY,
+        "rtx49-7c-kn.1",
+        ["ssh-ed25519 AAAA user@host"],
+        DEFAULT_IMAGE_URL_NVIDIA,
+        api_url=API_URL,
+        tags=["emmy", "experiment:mpk"],
+    )
+
+    call_data = mock_api.call_args[0][2]
+    assert call_data["tags"] == ["emmy", "experiment:mpk"]
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_no_tags_field_when_untagged(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(API_KEY, "rtx49-7c-kn.1", ["ssh-ed25519 AAAA user@host"], DEFAULT_IMAGE_URL_NVIDIA, api_url=API_URL)
+
+    assert "tags" not in mock_api.call_args[0][2]
+
+
+def _tagged_create(tmp_path, mock_rent, mock_wait, **kwargs):
+    key_path = tmp_path / "id_ed25519.pub"
+    key_path.write_text("ssh-ed25519 AAAA user@host")
+    mock_rent.return_value = RENT_RESPONSE
+    mock_wait.return_value = INSTANCE_ACTIVE_RESPONSE["instances"][0]
+    return create_instance(API_KEY, "rtx49-7c-kn.1", str(key_path), api_url=API_URL, **kwargs)
+
+
+@patch("emmy.provisioning.cloudrift._rent_instance", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.wait_for_status", new_callable=AsyncMock)
+async def test_create_instance_tags_default_to_emmy(mock_wait, mock_rent, tmp_path, monkeypatch):
+    monkeypatch.delenv("EMMY_RENTAL_TAGS", raising=False)
+
+    await _tagged_create(tmp_path, mock_rent, mock_wait)
+
+    assert mock_rent.call_args.kwargs["tags"] == ["emmy"]
+
+
+@patch("emmy.provisioning.cloudrift._rent_instance", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.wait_for_status", new_callable=AsyncMock)
+async def test_create_instance_tags_env_override(mock_wait, mock_rent, tmp_path, monkeypatch):
+    monkeypatch.setenv("EMMY_RENTAL_TAGS", "experiment:mpk, gh:job-7")
+
+    await _tagged_create(tmp_path, mock_rent, mock_wait)
+
+    assert mock_rent.call_args.kwargs["tags"] == ["experiment:mpk", "gh:job-7"]
+
+
+@patch("emmy.provisioning.cloudrift._rent_instance", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.wait_for_status", new_callable=AsyncMock)
+async def test_create_instance_explicit_tags_win(mock_wait, mock_rent, tmp_path, monkeypatch):
+    monkeypatch.setenv("EMMY_RENTAL_TAGS", "ignored")
+
+    await _tagged_create(tmp_path, mock_rent, mock_wait, tags=["experiment:mpk"])
+
+    assert mock_rent.call_args.kwargs["tags"] == ["experiment:mpk"]
+
+
 @patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
 async def test_rent_instance_network(mock_api):
     mock_api.return_value = RENT_RESPONSE


### PR DESCRIPTION
## Summary

`emmy vm create cloudrift --node <id-or-hostname>` pins the rental to one node via the CloudRift `ByNodeId` rent
selector. A UUID is used directly; a hostname is resolved through `/api/v1/nodes/list`, which the API restricts to
operator accounts (non-operators pass the UUID). The pin lives on the single-shot provider command rather than the
`vm create gpu` orchestrator because a pinned node has no placement fallback.

- `_rent_instance` gains `node_id` and switches selector accordingly.
- New `resolve_node_id()` with UUID passthrough, hostname lookup, and terminal errors on 401/403, unknown, or
  ambiguous hostnames.
- Docs: provisioning ARCHITECTURE.md and the start-remote-server skill.

## Testing

- 6 new unit tests (selector payload, UUID passthrough, hostname resolution, unknown/forbidden errors,
  `create_instance` plumb-through); `tests/provisioning/` 167 passed; ruff clean.
- Real-rental verification on a pinned A100 node is queued in the MPK comparison campaign (#502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)