### PR TITLE
Separate fusion, placement, and schedule search for H200 tuning

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -173,9 +173,12 @@ is a per-tuned-kernel budget: every supplied proposal reserves one slot, while a
 remaining live-measurement slot. A traced target normally maps to one post-fusion kernel, but lowering may materialize
 several CudaOps; conflicting multi-CudaOp knob rows are reported as ambiguous instead of being assigned an invented
 winner. Proposal feedback is written immediately after measurement, before MCTS, so an interruption preserves it.
-The final winner annotation is emitted only when one directly searched observation supplies both the knobs and cost;
-the later greedy deploy replay cannot be paired with the search reward. The ranking pass stays at tune's fast compile
-flags and never writes the trusted
+The final winner annotation is emitted only from directly searched observations that supply both exact replay data
+and cost; the later greedy deploy replay cannot be paired with the search reward. A scalar target retains the flat
+knob wire.
+A target with several kernels uses `ranking.kernel_set`: exact placement plus each operation cache key's multiplicity,
+direct schedule pins, direct latency, and ordered realized CudaOp knob rows. The ranking pass stays at tune's fast
+compile flags and never writes the trusted
 `emmy_us` / `cublas_us` fields. With multiple homogeneous `--devices`, independent working-file targets share one
 event loop, backend-slot queue, DB, and prior, so a file of one-kernel trace entries can use every selected GPU.
 When the file has multiple targets, `--dump-dir` receives one stable indexed subdirectory per target; `--output` is
@@ -184,6 +187,9 @@ rejects any `--golden-file` inside the canonical repository `search/goldens/` tr
 With `--bench`, each target's `62_kernel_bench.json` records whether an eager reference was available and the
 non-fatal accuracy verdict alongside the deployable O3 timings. A null verdict proves correctness only when the
 reference-available field is true; reference-free Loop slices remain timing evidence rather than accuracy evidence.
+If tuning produced no exact scalar or kernel-set winner, tune writes one target-scoped `no_exact_pin` marker, retires
+any stale unverified winner, and leaves no automatic pin. A later strict run expects that missing exact row and fails
+rather than treating an unchanged inventory as publication evidence.
 
 `emmy compile --golden-file PATH --golden NAME` and `emmy run --golden PATH [--target NAME]` are the verification
 counterparts. They resolve targets only in the explicit working YAML and compile its exact provenance or Loop IR,
@@ -204,6 +210,8 @@ Repeated names that resolve to different embedded targets remain ambiguous;
 qualification scopes a temporary working YAML to one target rather than guessing. A direct `run --ir` input remains a
 stage-complete artifact and runs only the later passes. JSON records whole-program end-to-end timing for multi-kernel
 rows, so promotion compares aggregate execution rather than a sum of isolated launch windows.
+For a working target, strict mode checks automatic golden rows and explicit shape-less `--ab` rows as separate
+obligations and validates every returned row; satisfying one set can never hide a missing or failed row in the other.
 
 For a fair hybrid-vs-MCTS comparison, both working files start from the same inventory-only trace: do not copy verified
 knob rows into either baseline as proposals. Canonical goldens remain the common implicit deploy context for both runs.

--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -47,7 +47,9 @@ _DEFAULT_PASSES = LOOP_PASSES
 # ``>>> t:005_blockify_launch``); the canonical mapping lives in
 # ``compiler/pipeline/rule_diff.PASS_SHORTHAND`` so the engine can build
 # the marker names without depending on the CLI layer.
-_PASS_SHORTCUTS = {short: full for full, short in PASS_SHORTHAND.items()}
+_PASS_SHORTCUTS: dict[str, list[str]] = {}
+for _full_pass, _short_pass in PASS_SHORTHAND.items():
+    _PASS_SHORTCUTS.setdefault(_short_pass, []).append(_full_pass)
 
 
 def resolve_tune_db() -> Path:
@@ -145,7 +147,7 @@ def add_golden_arg(parser) -> None:
         help=(
             "Resolve the required --golden NAME from this explicit working YAML instead of the "
             "canonical live-GPU corpus. Replays the file's exact provenance or Loop IR target; "
-            "only verified rows are automatically A/B-pinned."
+            "verified rows or one valid direct tune winner are automatically A/B-pinned."
         ),
     )
 
@@ -170,6 +172,7 @@ def resolve_golden_arg(args) -> None:
     name = getattr(args, "golden", None)
     golden_file = getattr(args, "golden_file", None)
     args.golden_configs = []
+    args.expected_golden_pins = 0
     if golden_file and not name:
         logger.error("--golden-file requires --golden NAME")
         sys.exit(2)
@@ -237,17 +240,37 @@ def resolve_golden_arg(args) -> None:
     if document is not None:
         verified = [record for record in matches if record.measurements is not None]
         winners = [record for record in matches if record.ranking is not None and record.ranking.get("tune_winner") is True]
-        valid_winner = (
+        unresolved = [
+            record
+            for record in matches
+            if record.ranking is not None and record.ranking.get("source") == "tune" and record.ranking.get("status") == "no_exact_pin"
+        ]
+        scalar_winner = (
             len(winners) == 1
             and winners[0].ranking.get("source") == "tune"
             and winners[0].ranking.get("status") == "ok"
+            and "kernel_set" not in winners[0].ranking
             and winners[0].ranking.get("measured_knobs") == winners[0].knobs
             and bool(winners[0].knobs)
         )
-        if winners and not valid_winner:
-            logger.error("golden %r must contain one valid direct tune winner with matching measured knobs", name)
+        kernel_set_winner = False
+        if len(winners) == 1 and "kernel_set" in winners[0].ranking:
+            try:
+                from emmy.compiler.pipeline.search.working_golden import parse_kernel_set_ranking  # noqa: PLC0415
+
+                parse_kernel_set_ranking(winners[0].ranking)
+                kernel_set_winner = not winners[0].knobs and "measured_knobs" not in winners[0].ranking
+            except ValueError as exc:
+                logger.error("golden %r has an invalid exact kernel-set winner: %s", name, exc)
+                sys.exit(2)
+        if winners and not (scalar_winner or kernel_set_winner):
+            logger.error("golden %r must contain one valid direct tune winner", name)
+            sys.exit(2)
+        if len(unresolved) > 1 or (unresolved and winners):
+            logger.error("golden %r must contain one current direct tune result", name)
             sys.exit(2)
         pinned = verified or winners
+        args.expected_golden_pins = len(verified) if verified else (1 if winners or unresolved else 0)
     args.golden_configs = [Sample.from_golden(match) for match in pinned]
     logger.info(
         "[golden] %s%s → embedded %s target %s (%d matching row%s, %d automatic pin%s)",
@@ -456,7 +479,7 @@ def resolve_passes(args) -> list[str]:
         raw = args.passes.strip()
         # Shorthand: no commas AND every character is a known pass letter.
         if "," not in raw and raw and all(c in _PASS_SHORTCUTS for c in raw):
-            return [_PASS_SHORTCUTS[c] for c in raw]
+            return [name for c in raw for name in _PASS_SHORTCUTS[c]]
         return [p.strip() for p in raw.split(",") if p.strip()]
     if args.ir is not None:
         return _IR_STAGES[args.ir][0]

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -796,6 +796,10 @@ def _strict_correctness_proof(outputs: dict, eager_out, *, rtol: float = 1e-3, a
 
 def _eager_outputs_by_name(outputs: dict, eager_out) -> dict:
     """Map positional eager outputs to the lowered graph's stable output names."""
+    if isinstance(eager_out, dict):
+        if set(eager_out) != set(outputs):
+            return {}
+        return {name: ref.detach().float().cpu().numpy() if hasattr(ref, "detach") else ref for name, ref in eager_out.items()}
     refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
     if len(refs) != len(outputs):
         return {}
@@ -826,6 +830,15 @@ def _ab_samples(specs, dynamic=None):
 def _sample_replay_knobs(sample) -> dict:
     """All knob pins needed to reproduce a golden winner or explicit A/B row."""
     return {**getattr(sample, "pins", {}), **sample.knobs}
+
+
+def _sample_lane(sample) -> str:
+    """The scalar row's lane, or the union lane of an exact kernel set."""
+    kernel_set = getattr(sample, "kernel_set", None)
+    if kernel_set is None:
+        return _lane(sample.knobs)
+    rows = (row for kernel in kernel_set["kernels"] for row in kernel["cuda_record_knobs"])
+    return "fm" if any(_lane(row) == "fm" for row in rows) else "std"
 
 
 async def _bench_golden_variants(backend, source, golden_configs, *, warmup, iters, ref=None, strict_correctness=False):
@@ -863,6 +876,7 @@ async def _bench_golden_variants(backend, source, golden_configs, *, warmup, ite
     row directly against eager under rtol=atol=1e-3 and records error statistics. Flags
     render as a ``!`` marker in the table and ride the ``--json`` record."""
     from emmy.commands.trace import graph_from_code  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.pins import KernelSetReplayError, lower_exact_kernel_set  # noqa: PLC0415
     from emmy.compiler.trace.dynamic import build_torch_dynamic_shapes, parse_position_specs  # noqa: PLC0415
 
     out = []
@@ -886,7 +900,13 @@ async def _bench_golden_variants(backend, source, golden_configs, *, warmup, ite
                     graph, _, _ = graph_from_code(source, dynamic_shapes=dynamic_shapes)
                 else:
                     graph = source.copy()
-                g_compiled = backend.compile(graph)
+                kernel_set = getattr(sample, "kernel_set", None)
+                g_compiled = lower_exact_kernel_set(graph, kernel_set) if kernel_set is not None else backend.compile(graph)
+        except KernelSetReplayError as exc:
+            flag = f"kernel-set pin mismatch: {exc} — row NOT benched"
+            logger.error("[golden] %s: %s", sample.name, flag)
+            out.append(_GoldenBench(sample, None, None, [flag], "pin_unmatched"))
+            continue
         except Exception as exc:  # noqa: BLE001 — a bad pin must not abort the run's own bench table
             logger.warning("[golden] %s: compile of the pinned config failed (%s) — row kept as bench_fail", sample.name, exc)
             out.append(_GoldenBench(sample, None, None, [f"compile failed: {exc}"], "bench_fail"))
@@ -1079,7 +1099,7 @@ def _print_kernel_stats(graph, bench, golden_benches=None, greedy_fail=None, gre
         kernels with ``--`` timings (a compile failure has no kernels — one bare
         label row keeps the failure visible)."""
         label = f"golden {gb.sample.name}" if gb.sample.shape is not None else gb.sample.name
-        label = f"{label} [{_lane(gb.sample.knobs)}]"  # so an [fm]-vs-std A/B can't be misread
+        label = f"{label} [{_sample_lane(gb.sample)}]"  # so an [fm]-vs-std A/B can't be misread
         if gb.flags:
             label = f"! {label}"
         if gb.graph is None:
@@ -1252,22 +1272,24 @@ def _write_ab_json(
     pinned = []
     for gb in golden_benches or []:
         sample = gb.sample
-        pinned.append(
-            {
-                "name": sample.name,
-                "kind": "golden" if sample.shape is not None else "ab",
-                "lane": _lane(sample.knobs),
-                "status": gb.status,
-                "pinned_knobs": {k: str(v) for k, v in _sample_replay_knobs(sample).items()},
-                **_timing(gb.bench),
-                "e2e_us": _e2e_us(gb.bench),
-                "kernels": _kernel_rows(gb.graph, gb.bench),
-                "flags": list(gb.flags),
-                "correctness": gb.correctness,
-                "recorded_emmy_us": getattr(sample, "latency_us", None),
-                "recorded_ref_us": getattr(sample, "ref_us", None),
-            }
-        )
+        row = {
+            "name": sample.name,
+            "kind": "golden" if sample.shape is not None else "ab",
+            "lane": _sample_lane(sample),
+            "status": gb.status,
+            "pinned_knobs": {k: str(v) for k, v in _sample_replay_knobs(sample).items()},
+            **_timing(gb.bench),
+            "e2e_us": _e2e_us(gb.bench),
+            "kernels": _kernel_rows(gb.graph, gb.bench),
+            "flags": list(gb.flags),
+            "correctness": gb.correctness,
+            "recorded_emmy_us": getattr(sample, "latency_us", None),
+            "recorded_ref_us": getattr(sample, "ref_us", None),
+        }
+        if getattr(sample, "kernel_set", None) is not None:
+            row["winner_kind"] = "kernel_set"
+            row["pinned_kernel_set"] = sample.kernel_set
+        pinned.append(row)
     greedy = {
         "status": "ok" if greedy_fail is None else "bench_fail",
         "lane": _graph_lane(graph),
@@ -1990,12 +2012,16 @@ def _strict_benchmark_errors(args, results, bench, captured, correctness, pinned
     if not valid_proof(correctness):
         errors.append("deployed Emmy row lacks direct strict eager correctness")
 
-    ab_rows = [row for row in pinned_rows or [] if getattr(row.sample, "shape", None) is None]
+    pinned_rows = list(pinned_rows or [])
+    ab_rows = [row for row in pinned_rows if getattr(row.sample, "shape", None) is None]
+    automatic_rows = [row for row in pinned_rows if getattr(row.sample, "shape", None) is not None]
+    expected_automatic_rows = int(getattr(args, "expected_golden_pins", 0) or 0)
+    if len(automatic_rows) != expected_automatic_rows:
+        errors.append(f"expected {expected_automatic_rows} exact working-golden row(s), got {len(automatic_rows)}")
     expected_ab_rows = len(args.ab or [])
     if len(ab_rows) != expected_ab_rows:
         errors.append(f"expected {expected_ab_rows} exact --ab row(s), got {len(ab_rows)}")
-    exact_rows = ab_rows if expected_ab_rows else list(pinned_rows or [])
-    for row in exact_rows:
+    for row in pinned_rows:
         label = row.sample.name
         if row.status != "ok" or row.flags:
             errors.append(f"{label} failed exact-pin integrity: status={row.status}, flags={list(row.flags)}")
@@ -2521,7 +2547,12 @@ def _check_accuracy(outputs, eager_out) -> str | None:
     # output against its positional eager counterpart (graph-output order).
     # Historic single-output behavior (every output vs THE eager tensor) is the
     # degenerate case of the fallback-to-first pairing below.
-    eager_refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
+    if isinstance(eager_out, dict):
+        if set(eager_out) != set(outputs):
+            return f"CORRECTNESS FAIL: output names differ: Emmy={list(outputs)}, eager={list(eager_out)}"
+        eager_refs = [eager_out[name] for name in outputs]
+    else:
+        eager_refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
     eager_flats = [t.detach().cpu().flatten().tolist() for t in eager_refs]
     if any(e != e for flat in eager_flats for e in flat):
         return "eager reference contains NaN (reproducer inputs out of domain)"
@@ -2661,7 +2692,7 @@ def _check_accuracy(outputs, eager_out) -> str | None:
                     budget,
                 )
         else:
-            logger.warning("Output size %d does not match eager %d; skipping accuracy", len(values), len(eager_flat))
+            failures.append(f"output {buf_name}: size {len(values)} does not match eager {len(eager_flat)}")
     return f"accuracy check failed vs eager: {'; '.join(failures)}" if failures else None
 
 

--- a/emmy/commands/tune.py
+++ b/emmy/commands/tune.py
@@ -568,7 +568,7 @@ def _tune_working_multi(args, targets, document, *, backends, db, ctx, run_id) -
                         html_dir=(dump.dir if dump and tmp_dump is None else None),
                         device_id=backends[0].device_id,
                     )
-            winner = result.best_reward.searched_winner() if result.best_reward is not None else None
+            winner = result.searched_winner()
             persist_tune_winner(args.golden_file, document, target, winner, compile_flags=config.nvcc_flags())
         for block in results[0].prior_summaries if results else []:
             sys.stderr.write(block + "\n")
@@ -750,7 +750,7 @@ def handle_tune(args):
                         device_id=backends[0].device_id,
                     )
             if working_document is not None:
-                winner = result.best_reward.searched_winner() if result.best_reward is not None else None
+                winner = result.searched_winner()
                 persist_tune_winner(
                     args.golden_file,
                     working_document,

--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -72,7 +72,8 @@ autotuning cache doesn't bust on cosmetic edits.
 | `ir/`                 | Op-type definitions per dialect         | `ir/ARCHITECTURE.md`         |
 | `trace/`              | PyTorch/HuggingFace → Graph IR          | `trace/ARCHITECTURE.md`      |
 | `pipeline/`           | Rewrite engine, passes, dump hooks      | `pipeline/ARCHITECTURE.md`   |
-| `pipeline/passes/lowering/tile/` | LoopOp → TileOp; **purely algebraic moveset, no specializations** (dispatch on fold algebra) | `pipeline/passes/ARCHITECTURE.md` |
+| `pipeline/passes/lowering/tile/` | maximal algebra recognition + structural placement; no target or shape specializations | `pipeline/passes/ARCHITECTURE.md` |
+| `pipeline/passes/lowering/schedule/` | capability-compatible schedule enumeration and graph-level schedule realization | `pipeline/passes/ARCHITECTURE.md` |
 | `backend/`            | Execution (numpy / loop / cuda)         | `backend/ARCHITECTURE.md`    |
 | `loader/`             | Bind constants (safetensors / `nn.Module` → `input_data`) | —              |
 | `pipeline/search/`    | Autotune DB + MCTS tree (see below)     | `pipeline/ARCHITECTURE.md`   |
@@ -87,11 +88,15 @@ autotuning cache doesn't bust on cosmetic edits.
 - **Layer 2** — operates on `Graph` + Loop IR only. Every `LoopOp`'s
   `__post_init__` canonicalizes (`ir/stmt/normalize.py`) and simplifies
   (`ir/stmt/passes.py`) its body. Fusion forms the maximal reasonable algebraic region without consulting hardware,
-  schedules, or profitability; kernel partitioning is the later `PLACE` structural fork.
+  schedules, or profitability; recognition certifies that algebra without `Context`; kernel partitioning is the
+  later `PLACE` structural fork. Placement retains the certified Tile-IR terms on both sides of a cut and reaches a
+  graph-level fixpoint before schedule enumeration begins.
 - **Layer 3** — hardware instruction spelling and launch mechanics live in Kernel IR and backends. Compiler passes
   remain target-portable: they receive hardware facts through `Context`, recognize only structure, and gate schedule
-  or lowering choices on named primitive capabilities rather than GPU names or repeated SM-number thresholds. The
-  pass-authoring contract and its executable guardrail live in `pipeline/passes/ARCHITECTURE.md`.
+  or lowering choices on named primitive capabilities and atom requirements rather than GPU names or repeated
+  SM-number thresholds. A measured GPU-specific golden can select a generic choice; it cannot create a recognition,
+  schedule, or lowering path. The pass-authoring contract and its executable guardrail live in
+  `pipeline/passes/ARCHITECTURE.md`.
 
 ## Shared invariants
 

--- a/emmy/compiler/ARCHITECTURE.md
+++ b/emmy/compiler/ARCHITECTURE.md
@@ -86,8 +86,12 @@ autotuning cache doesn't bust on cosmetic edits.
   implement `infer_output_shape(input_shapes)` and a numpy `forward()`.
 - **Layer 2** — operates on `Graph` + Loop IR only. Every `LoopOp`'s
   `__post_init__` canonicalizes (`ir/stmt/normalize.py`) and simplifies
-  (`ir/stmt/passes.py`) its body.
-- **Layer 3** — backends are the only place GPU specifics live.
+  (`ir/stmt/passes.py`) its body. Fusion forms the maximal reasonable algebraic region without consulting hardware,
+  schedules, or profitability; kernel partitioning is the later `PLACE` structural fork.
+- **Layer 3** — hardware instruction spelling and launch mechanics live in Kernel IR and backends. Compiler passes
+  remain target-portable: they receive hardware facts through `Context`, recognize only structure, and gate schedule
+  or lowering choices on named primitive capabilities rather than GPU names or repeated SM-number thresholds. The
+  pass-authoring contract and its executable guardrail live in `pipeline/passes/ARCHITECTURE.md`.
 
 ## Shared invariants
 

--- a/emmy/compiler/backend/ARCHITECTURE.md
+++ b/emmy/compiler/backend/ARCHITECTURE.md
@@ -33,8 +33,11 @@ FP8 tensors remain exact `uint8` bit carriers; `to_f8*` casts to torch float8 an
 `from_f8*` performs the inverse reinterpretation before widening. `is_runnable(graph)` is `True` only when every
 compute op and every elementwise operation name has a mapping. Data-dependent `GatherOp` / `ScatterOp` remain
 unsupported, so `run --ir` falls back to emmy-only benchmarking for those graphs. `build_callable(graph,
-input_tensors)` returns a pure `fn(*tensors)` (scalar constants read inline) so `torch.compile` can trace it. Symbolic
-graphs work too: `build_callable` binds every symbolic axis name to its concrete extent read off the supplied tensors
+input_tensors)` returns a pure `fn(*tensors)` (scalar constants read inline) so `torch.compile` can trace it. The
+callable returns every graph output, using a tensor for the common single-output case and an output-name mapping
+otherwise; the accuracy gate pairs names exactly and treats a missing output or output-size mismatch as a
+failure. Symbolic graphs work too: `build_callable` binds every symbolic axis name to its concrete extent read off the
+supplied tensors
 (the CUDA launch convention) and bakes the env into the per-node callables — shape-resolving sites (`ReshapeOp` target
 shape, `IndexMapOp` out-shape and coord/select exprs) eval through it, so a dynamic frontend provenance slice
 gets the same vs-torch comparison as a static one (benched at the `Dim` hint by

--- a/emmy/compiler/backend/torch_ref.py
+++ b/emmy/compiler/backend/torch_ref.py
@@ -361,7 +361,8 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
     """Build a torch callable for ``graph`` plus its positional input list.
 
     The returned ``fn(*tensors)`` runs the frontend ops in topological order and
-    returns the graph's first output; the input list is the ``tensors`` to call
+    returns every graph output (one tensor for a single-output graph, otherwise an
+    output-name mapping); the input list is the ``tensors`` to call
     it with (drawn from ``input_tensors`` in boundary topo order). Scalar
     constants are read inline from the graph (so ``fn`` is a pure function of
     its tensor inputs and ``torch.compile`` can trace it).
@@ -410,7 +411,7 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
         else:
             op_callable = (lambda n: lambda ins: _eval(n, ins, sym_env))(node)
         compute_steps.append((nid, op_callable, list(node.inputs), torch_dtype(node.output.dtype)))
-    out_id = graph.outputs[0]
+    out_ids = tuple(graph.outputs)
 
     def fn(*tensors):
         env = dict(scalars)
@@ -418,6 +419,8 @@ def build_callable(graph: Graph, input_tensors: dict[str, torch.Tensor]) -> tupl
         for nid, op_callable, in_ids, out_dtype in compute_steps:
             v = op_callable([env[i] for i in in_ids])
             env[nid] = v if out_dtype is None else v.to(out_dtype)
-        return env[out_id]
+        if len(out_ids) == 1:
+            return env[out_ids[0]]
+        return {out_id: env[out_id] for out_id in out_ids}
 
     return fn, [input_tensors[i] for i in tensor_ids]

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -410,13 +410,13 @@ def _stmt_eval_scope() -> dict:
 # don't carry a ``Body``. ``name`` is an instance label; ``source`` is the
 # rewrite-chain predecessor on the base ``Op`` (attribution metadata only,
 # stamped automatically by the engine — see ``Op.source``).
-_STRUCTURAL_SKIP_FIELDS = frozenset({"name", "source", "meta"})
+_STRUCTURAL_SKIP_FIELDS = frozenset({"name", "source", "decision_knobs", "meta"})
 
 # Op dataclass fields excluded from JSON serialization in :meth:`Graph.to_dict`:
 # pure runtime state (``source`` / ``knobs`` chain metadata, ``inputs`` /
 # ``outputs`` snapped by the matcher) — none of it belongs in the persisted
 # IR.
-_SERIALIZE_SKIP_FIELDS = frozenset({"source", "knobs", "inputs", "outputs", "meta"})
+_SERIALIZE_SKIP_FIELDS = frozenset({"source", "knobs", "decision_knobs", "inputs", "outputs", "meta"})
 
 
 class Graph:
@@ -1255,7 +1255,7 @@ def _rename_buf_in_op(op, old: str, new: str):
     """Rewrite ``Load.source`` / ``Write.output`` references inside a
     ``LoopOp`` body from ``old`` to ``new`` (recursively into nested Loops).
     Pass-through for op types without internal buf refs. Preserves the op's
-    ``name`` / ``knobs`` / ``source`` identity — a rename after
+    ``name`` / ``knobs`` / ``decision_knobs`` / ``source`` identity — a rename after
     ``991_stamp_loop_names`` / ``992_stamp_structural_features`` (e.g. the
     splice id-promotion of a lowering-phase fragment like the demoted-matmul
     split) must not strip the stamped kernel name, the ``S_*`` features, or
@@ -1277,6 +1277,7 @@ def _rename_buf_in_op(op, old: str, new: str):
     renamed = LoopOp(body=op.body.map(fn))
     renamed.name = op.name
     renamed.knobs = dict(op.knobs)
+    renamed.decision_knobs = dict(op.decision_knobs)
     renamed.source = op.source
     return renamed
 

--- a/emmy/compiler/graph.py
+++ b/emmy/compiler/graph.py
@@ -410,13 +410,13 @@ def _stmt_eval_scope() -> dict:
 # don't carry a ``Body``. ``name`` is an instance label; ``source`` is the
 # rewrite-chain predecessor on the base ``Op`` (attribution metadata only,
 # stamped automatically by the engine — see ``Op.source``).
-_STRUCTURAL_SKIP_FIELDS = frozenset({"name", "source", "decision_knobs", "meta"})
+_STRUCTURAL_SKIP_FIELDS = frozenset({"name", "source", "source_is_graph_splice", "decision_knobs", "meta"})
 
 # Op dataclass fields excluded from JSON serialization in :meth:`Graph.to_dict`:
 # pure runtime state (``source`` / ``knobs`` chain metadata, ``inputs`` /
 # ``outputs`` snapped by the matcher) — none of it belongs in the persisted
 # IR.
-_SERIALIZE_SKIP_FIELDS = frozenset({"source", "knobs", "decision_knobs", "inputs", "outputs", "meta"})
+_SERIALIZE_SKIP_FIELDS = frozenset({"source", "source_is_graph_splice", "knobs", "decision_knobs", "inputs", "outputs", "meta"})
 
 
 class Graph:

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -74,6 +74,12 @@ keep working unchanged. `source` is excluded from
 `Graph.structural_key` and from `Op.cache_key` — kernels rendered
 along different lowering paths still dedup in the tuning cache.
 
+`Op.knobs` and `Op.decision_knobs` have distinct ownership. `knobs` is the realized configuration of this kernel and
+participates in its tuning/cache identity. `decision_knobs` records a structural fork that changed which kernels
+exist, such as `PLACE@a=cut`; the engine propagates it for decision replay, but graph serialization, structural keys,
+kernel cache keys, and per-kernel schedule evidence exclude it. Search still carries the structural row on the fork
+lineage, so an end-to-end measurement remains attributable to the placement decision.
+
 **Stmt subclasses are `@dataclass(frozen=True)`** — every concrete Loop-IR
 / Tile-IR / Kernel-IR statement (`Loop`, `Cond`, leaves, `Tile`, `Smem`, `Sync`,
 `CpAsyncCopy`, `TmaDescriptor`, …) is immutable + hashable. `Body` is a `tuple[Stmt, ...]`
@@ -82,7 +88,7 @@ subclass, so a full body tree hashes structurally end-to-end. This makes
 without a try/except fallback for unhashable stmts. To "edit" a frozen
 Stmt, return a fresh instance via `dataclasses.replace(stmt, field=value)`;
 `__post_init__` coercions use `object.__setattr__`. Ops, by contrast,
-are NOT frozen — the engine mutates `op.source` / `op.knobs` / `op.inputs` /
+are NOT frozen — the engine mutates `op.source` / `op.knobs` / `op.decision_knobs` / `op.inputs` /
 `op.outputs` post-construction. Op fields stored inside Stmts (e.g.
 `Assign.op`) must be lightweight value objects (e.g. `ElementwiseImpl`,
 not `ElementwiseOp`) so the surrounding Stmt's hashability isn't poisoned.
@@ -317,6 +323,9 @@ Construction never fails: unresolved names are data, and chaining scope levels m
 matching escape check (may the cone be cut out, with only the designated consumers reading its roots?). This is
 the shared substrate behind the rules that slice cones (the demoted-operand producer cut in
 `lowering/tile/030_split_reduce`) — eligibility judgments stay in the rules, per `pipeline/passes/ARCHITECTURE.md`. The
+scope-sensitive companion `lexical_free_values` preserves statement order, nested value scope, and accumulator
+exports; placement and recognition use it when a global `reads - definitions` difference would incorrectly close an
+open term. The
 `classify_fragment_epilogue` walk (`ir/stmt/algebra.py`) deliberately does NOT use it: it is a single pass
 interleaving reduce-scope flags with its negative-form blocker reporting, a different operator than the cone's
 any-dep taint.

--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -65,7 +65,7 @@ top-level layer/pass picture see `compiler/ARCHITECTURE.md`.
   `CudaOp` carrying rendered source.
 
 `Op.source` is the rewrite-chain predecessor — the engine's
-`_apply_one` stamps it on every 1:1 in-place rebind, so a fully
+`Candidate.apply` stamps it on every 1:1 in-place rebind, so a fully
 lowered `CudaOp` carries the full chain back to its originating
 `LoopOp` (`cuda.source.source.source`) without any rule needing to
 pass it explicitly. The base-class field is keyword-only and
@@ -73,12 +73,22 @@ pass it explicitly. The base-class field is keyword-only and
 keep working unchanged. `source` is excluded from
 `Graph.structural_key` and from `Op.cache_key` — kernels rendered
 along different lowering paths still dedup in the tuning cache.
+`Op.source_is_graph_splice` classifies the source edge created when one same-dialect op becomes a multi-op `Graph`
+fragment. The fragments retain the predecessor for structural-decision replay, but persistence excludes each
+fragment's individual launch time from ordinary per-kernel lowering evidence for that predecessor. Like `source`,
+the flag is excluded from structural identity and serialization.
 
 `Op.knobs` and `Op.decision_knobs` have distinct ownership. `knobs` is the realized configuration of this kernel and
 participates in its tuning/cache identity. `decision_knobs` records a structural fork that changed which kernels
 exist, such as `PLACE@a=cut`; the engine propagates it for decision replay, but graph serialization, structural keys,
 kernel cache keys, and per-kernel schedule evidence exclude it. Search still carries the structural row on the fork
-lineage, so an end-to-end measurement remains attributable to the placement decision.
+lineage, so the outer search's derived sum of independently measured kernel times remains attributable to the
+placement decision. That sum is search evidence, not an assembled whole-program measurement.
+
+`Op.meta` is ephemeral rule state, excluded from equality, structural identity, cache keys, and serialization. A pass
+may use it to mark an in-memory phase fact such as “this recognized root has resolved placement”; it must never carry
+algebra, a user-visible decision, or evidence. The canonical pass sequence reaches placement fixpoint before schedule,
+so cut pieces retain their `Fold` trees and receive their own marker rather than inheriting a schedule shortcut.
 
 **Stmt subclasses are `@dataclass(frozen=True)`** — every concrete Loop-IR
 / Tile-IR / Kernel-IR statement (`Loop`, `Cond`, leaves, `Tile`, `Smem`, `Sync`,
@@ -322,7 +332,8 @@ Construction never fails: unresolved names are data, and chaining scope levels m
 `backward_cone` with the previous one's `external_reads`. `Body.defs_die_at(members, roots=…, allowed=…)` is the
 matching escape check (may the cone be cut out, with only the designated consumers reading its roots?). This is
 the shared substrate behind the rules that slice cones (the demoted-operand producer cut in
-`lowering/tile/030_split_reduce`) — eligibility judgments stay in the rules, per `pipeline/passes/ARCHITECTURE.md`. The
+`lowering/schedule/030_split_reduce`) — eligibility judgments stay in the rules, per
+`pipeline/passes/ARCHITECTURE.md`. The
 scope-sensitive companion `lexical_free_values` preserves statement order, nested value scope, and accumulator
 exports; placement and recognition use it when a global `reads - definitions` difference would incorrectly close an
 open term. The
@@ -597,6 +608,7 @@ directly (no separate AST class).
 | `TreeHalve`        | Cross-thread tree reduction over a smem buffer.                   |
 | `RegFragment`      | Per-thread `mma.sync` register array declaration, zero-initialized for C. The established m16n8k16 layout uses A/B/C counts 4/2/4 for f16/f16/f32; the Volta m8n8k4 layout carries explicit 2/2/8 counts because one instruction realizes four PTX cells arranged as one logical 16×16 tile. Carries instruction shape, dtype, and an optional explicit register count. The opaque `nvcuda::wmma` nodes remain retired. |
 | `LdmatrixLoad`     | Load one operand into a `RegFragment`. The m16n8k16 layout can use `ldmatrix.sync.aligned.m8n8.x{4,trans}.b16` from shared memory or a global-memory-direct gather with the same lane map. SM70 has no `ldmatrix`, so the Volta m8n8k4 layout uses its cooperative gather for both address spaces: a global pointer for the direct path or a shared-slab pointer after synchronous-copy staging; its four computation groups duplicate the appropriate A or B quadrant. `b_trans=True` marks a `[N, K]` weight and selects the corresponding transposed gather. Guards clamp M/N lanes and zero masked K elements in both layouts. |
+| `FragmentLoad`     | Load a materialized tensor directly into the absolute row/column lane map of an mma C fragment. The materialized-score flash path uses it before the ordinary fragment softmax and C→A repack; f16/bf16 inputs promote to f32 on assignment. |
 | `MmaSyncPtx`       | Inline PTX for either `mma.sync.aligned.m8n8k4.row.col.f32.f16.f16.f32` on the Volta fragment layout or the established `mma.sync.aligned.m16n8k16.row.col.{f32,f16}.{f16,bf16}.{f16,bf16}.{f32,f16}` family. The renderer includes only the selected family's prelude, so SM70 never parses newer `ldmatrix` or m16n8k16 assembly. |
 | `FragmentPromote`  | Fold a packed f16-accumulate C fragment into its f32 shadow fragment and rezero it (`emmy_mma_promote_f16acc`: PTX `cvt.f32.f16` + add per element) — the chunked-accumulation promote pairing the f16-acc `MmaSyncPtx`. The mma chain accumulates in f16 at full rate; each K chunk (the staged bk slab, every `_F16ACC_STEPS` gmem-direct atom steps, or the flash streaming KV block) folds into the f32 shadow, bounding the f16 rounding to one chunk while the store/epilogue read f32. |
 | `RegStore`         | Layout-aware per-lane epilogue store: four C elements for m16n8k16 or eight elements covering the four Volta output quadrants for m8n8k4. Stores f32 directly or downconverts to f16. Optional `RegEpilogue` loads and pointwise chains are evaluated at each element's own coordinates; guarded tails predicate every load and store. |

--- a/emmy/compiler/ir/base.py
+++ b/emmy/compiler/ir/base.py
@@ -55,6 +55,11 @@ class Op:
     via ``_STRUCTURAL_SKIP_FIELDS`` — pure attribution metadata, not
     part of dataflow identity.
 
+    ``decision_knobs`` carries kernel-set decisions separately from ``knobs``. A structural fork
+    must remain replayable after its pieces are scheduled, but its placement choice is not a
+    per-kernel schedule realization. The rewrite engine propagates this metadata through the
+    source chain without folding it into cache keys or schedule evidence.
+
     ``inputs`` / ``outputs`` are per-op-instance buffer maps populated by
     the matcher (``_match_at``) just after a match is built — the matcher
     calls :meth:`populate_io` on every matched node, snapping in real
@@ -74,6 +79,7 @@ class Op:
     # autotune knob picked along the chain. Excluded from structural
     # identity and equality — pure attribution metadata.
     knobs: dict = field(default_factory=dict, kw_only=True, repr=False, compare=False)
+    decision_knobs: dict = field(default_factory=dict, kw_only=True, repr=False, compare=False)
     inputs: dict[str, Tensor] = field(default_factory=dict, kw_only=True, repr=False, compare=False)
     outputs: dict[str, Tensor] = field(default_factory=dict, kw_only=True, repr=False, compare=False)
 

--- a/emmy/compiler/ir/base.py
+++ b/emmy/compiler/ir/base.py
@@ -47,13 +47,17 @@ class Op:
 
     ``source`` is the predecessor op in any rewrite chain — the engine
     stamps it automatically on every 1:1 in-place rebind
-    (``_apply_one`` Op branch), so a fully-lowered ``CudaOp`` keeps the
+    (the ``Candidate.apply`` Op branch), so a fully-lowered ``CudaOp`` keeps the
     full path back through ``KernelOp → TileOp → LoopOp`` (or any other
     chain a future pipeline introduces) via repeated ``.source``
     traversals. Keyword-only so positional construction of subclass
     fields keeps working; excluded from :meth:`Graph.structural_key`
     via ``_STRUCTURAL_SKIP_FIELDS`` — pure attribution metadata, not
     part of dataflow identity.
+
+    ``source_is_graph_splice`` classifies an edge minted by a same-dialect ``Graph`` splice. The fragments retain
+    their shared predecessor for decision replay, but their individual launch times cannot price that predecessor as
+    ordinary per-kernel lowering evidence. Like ``source``, the flag is attribution metadata rather than IR identity.
 
     ``decision_knobs`` carries kernel-set decisions separately from ``knobs``. A structural fork
     must remain replayable after its pieces are scheduled, but its placement choice is not a
@@ -72,14 +76,21 @@ class Op:
     """
 
     source: Op | None = field(default=None, kw_only=True, repr=False, compare=False)
+    # Classifies the edge to ``source``. A Graph splice can mint several same-dialect kernels from
+    # one op; each fragment keeps the predecessor for decision replay, but its individual latency
+    # must not become an ordinary lowering edge for the pre-splice op.
+    source_is_graph_splice: bool = field(default=False, kw_only=True, repr=False, compare=False)
     # Free-form metadata dict for rules to stamp the knobs they used
     # (e.g. ``{"BN": 64, "BM": 64}`` from ``005_blockify_launch``). The
-    # engine's ``_apply_one`` merges the predecessor's knobs forward on
+    # engine's 1:1 rebind path merges the predecessor's knobs forward on
     # every 1:1 rebind, so a fully-lowered ``CudaOp`` carries every
     # autotune knob picked along the chain. Excluded from structural
     # identity and equality — pure attribution metadata.
     knobs: dict = field(default_factory=dict, kw_only=True, repr=False, compare=False)
     decision_knobs: dict = field(default_factory=dict, kw_only=True, repr=False, compare=False)
+    # Ephemeral rule state. Excluded from structural identity and persistence; a rule may use it
+    # to mark an in-memory phase boundary without turning that marker into compiler IR.
+    meta: dict = field(default_factory=dict, kw_only=True, repr=False, compare=False)
     inputs: dict[str, Tensor] = field(default_factory=dict, kw_only=True, repr=False, compare=False)
     outputs: dict[str, Tensor] = field(default_factory=dict, kw_only=True, repr=False, compare=False)
 

--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -1183,6 +1183,56 @@ class FragmentMask(Stmt):
 
 
 @dataclass(frozen=True)
+class FragmentLoad(Stmt):
+    """Per-element gmem load into an mma C-fragment at absolute row/column coordinates.
+
+    The index is a template over :data:`FRAG_ROW` / :data:`FRAG_COL`; ``row_base`` and
+    ``col_base`` place each lane-owned element through the C-fragment layout. Source f16/bf16
+    values convert to the f32 fragment algebra on assignment."""
+
+    frag: str
+    buf: str
+    index: tuple[Expr, ...]
+    col_base: Expr
+    row_base: Expr
+    layout: FragLayout = M16N8
+
+    def deps(self) -> tuple[str, ...]:
+        return (self.frag,)
+
+    def defines(self) -> tuple[str, ...]:
+        return (self.frag,)
+
+    def external_reads(self) -> tuple[str, ...]:
+        return (self.buf,)
+
+    def exprs(self) -> tuple[Expr, ...]:
+        return (*self.index, self.col_base, self.row_base)
+
+    def pretty(self, indent: str = "") -> list[str]:
+        idx = ", ".join(e.pretty() for e in self.index)
+        return [f"{indent}FragmentLoad({self.frag} = {self.buf}[{idx}])"]
+
+    def render(self, ctx: RenderCtx) -> list[str]:
+        from emmy.compiler.ir.stmt import render_index  # noqa: PLC0415
+
+        pad = _pad(ctx.indent)
+        lay = self.layout
+        conv = {"f16": "__half2float({})", "bf16": "__bfloat162float({})"}
+        dt = ctx.buffer_dtypes.get(self.buf, "f32")
+        lines = _lane_preamble(ctx, pad, lay.lane_decl)
+        for i in range(lay.n_elems):
+            sub: dict[str, Expr] = {
+                FRAG_COL: BinaryExpr("+", self.col_base, lay.col_off[i]),
+                FRAG_ROW: BinaryExpr("+", self.row_base, lay.row_off[lay.elem_row[i]]),
+            }
+            idx = tuple(e.substitute(sub) for e in self.index)
+            flat = render_index(self.buf, idx, ctx)
+            lines.append(f"{pad}{self.frag}[{i}] = {conv.get(dt, '{}').format(f'{self.buf}[{flat}]')};")
+        return lines
+
+
+@dataclass(frozen=True)
 class FragmentBiasAdd(Stmt):
     """Per-element **additive gmem bias** over an mma C-fragment — the fragment-tier realization of
     the explicit additive score mask (SDPA's ``attn_mask`` float bias: the HF precomputed causal /
@@ -2644,5 +2694,20 @@ def _(s: FragmentMask, rename, sigma, axis_fn):
         col_base=sigma.apply(s.col_base),
         row_base=sigma.apply(s.row_base) if s.row_base is not None else None,
         fill=s.fill,
+        layout=s.layout,
+    )
+
+
+@_rewrite.register
+def _(s: FragmentLoad, rename, sigma, axis_fn):
+    # Like the gmem-direct LdmatrixLoad, this assigns an already-declared fragment. Route the
+    # fragment name through SSA replication and the load-index template plus tile origins through
+    # the axis substitution; the backing buffer is an external name and stays unchanged.
+    return FragmentLoad(
+        frag=rename(s.frag),
+        buf=s.buf,
+        index=tuple(sigma.apply(e) for e in s.index),
+        col_base=sigma.apply(s.col_base),
+        row_base=sigma.apply(s.row_base),
         layout=s.layout,
     )

--- a/emmy/compiler/ir/stmt/__init__.py
+++ b/emmy/compiler/ir/stmt/__init__.py
@@ -62,7 +62,7 @@ from emmy.compiler.ir.stmt.base import (
     _pad as _pad,  # re-export for ir.kernel.ir
 )
 from emmy.compiler.ir.stmt.blocks import Cond, Loop, StridedLoop
-from emmy.compiler.ir.stmt.body import Body, Lambda
+from emmy.compiler.ir.stmt.body import Body, Lambda, lexical_free_values
 from emmy.compiler.ir.stmt.leaves import (
     Accum,
     Assign,
@@ -124,6 +124,7 @@ __all__ = [
     "eval_lambda",
     "foldmap_eval",
     "hoist_loop_invariants",
+    "lexical_free_values",
     "normalize_body",
     "op_to_expr",
     "pretty_body",

--- a/emmy/compiler/ir/stmt/body.py
+++ b/emmy/compiler/ir/stmt/body.py
@@ -99,6 +99,50 @@ def _member_reads(s: Stmt) -> frozenset[str]:
     return frozenset(reads - defs)
 
 
+def lexical_free_values(stmts: Iterable[Stmt], *, bound: Iterable[str] = ()) -> frozenset[str]:
+    """Value and expression names read outside their lexical statement scope.
+
+    Unlike a global ``reads - definitions`` set difference, this respects statement order and
+    nested-body scope. Assignments and loads are local to their body, while accumulator state and
+    explicit initializers cross a block boundary exactly as Loop IR validation specifies. Carried
+    accumulators are visible throughout their body because a twisted fold may read its running
+    state before the statement that updates it.
+
+    ``bound`` supplies names owned by the caller, normally enclosing iteration axes. The result is
+    an analysis, not validation: unresolved names are returned so the caller can decide whether a
+    capture is legal in that context.
+    """
+    from emmy.compiler.ir.stmt.leaves import Accum, Init  # noqa: PLC0415
+
+    def walk(body: Body, visible: set[str]) -> tuple[set[str], set[str]]:
+        local = set(visible)
+        local.update(s.name for s in body if isinstance(s, Accum))
+        free: set[str] = set()
+        exported: set[str] = set()
+        for stmt in body:
+            reads = set(stmt.deps())
+            for expr in stmt.exprs():
+                reads.update(expr.free_vars())
+            free.update(reads - local)
+
+            nested_exports: set[str] = set()
+            child_visible = local | set(stmt.binds_axes())
+            for child in stmt.nested():
+                child_free, child_exported = walk(Body.coerce(child), child_visible)
+                free.update(child_free)
+                nested_exports.update(child_exported)
+            local.update(nested_exports)
+            exported.update(nested_exports)
+
+            local.update(stmt.defines())
+            if isinstance(stmt, (Accum, Init)):
+                exported.update(stmt.defines())
+        return free, exported
+
+    free, _ = walk(Body.coerce(stmts), set(bound))
+    return frozenset(free)
+
+
 class Body(tuple[Stmt, ...]):
     """Immutable Stmt sequence. Tuple-subclass so existing tuple-shaped
     APIs accept Body for free; preserves its own type through

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -77,10 +77,11 @@ positionally per scope with the cross-scope aliasing pattern kept). Consumed by 
 MATERIALIZED (a gmem `Load`) or COMPUTED (the node itself, stored INLINE; the cone built by `_atomize.make_cone`).
 
 **Edge iff closed** holds BY CONSTRUCTION — operands bind positionally, so a subtree that reads a name from its
-enclosing body cannot be one. The closure SCAN survives only as the validation reading, living with its one consumer
-in `passes/lowering/tile/_cut.py`, where it decides cut legality: closed subtrees may hoist to edges, while combine's
-derived material — flash's PV, whose `P` reads the running state — sits BELOW the seam lattice as a derived schedule
-site excluded from PLACE (`Site.derived`). Flash's QK operand edge IS a PLACE site.
+enclosing body cannot be one. Recognition binds every channel of a product operand and rejects a constructed root
+projection with unbound value reads. The same order- and scope-aware closure reading decides cut legality in
+`passes/lowering/tile/_cut.py`: closed subtrees may hoist to edges, while combine's derived material — flash's PV,
+whose `P` reads the running state — sits BELOW the seam lattice as a derived schedule site excluded from PLACE
+(`Site.derived`). Flash's QK operand edge IS a PLACE site.
 
 A cone's SOURCE is the row-invariant prologue (the per-row statistic) and its body the per-cell normalize, so the K
 seam is the node boundary (`ops.cone_seam`). The A/B asymmetry that is real — A M-resident and compute-fillable, B

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -55,9 +55,10 @@ Loops carry NO algebra — `Loop` / `StridedLoop` hold only their `AxisRole`. Th
 
 There is no `step` sequence. The composed evaluations DERIVE:
 
-- flash's kv stream λ-spells with its QK score a HOISTED operand edge and its PV synthesized and memoized inside the
-  derived blocked evaluation — `Fold.step_stmts()` is the one consumer read, and `ops.stream_pair` the one reading of
-  the `(score, expectation)` pair that walk produces;
+- flash's kv stream λ-spells with its score as a HOISTED operand edge (a QK `Fold`, or the `Load` left when PLACE
+  materializes that edge) and its PV synthesized and memoized inside the derived blocked evaluation —
+  `Fold.step_stmts()` is the one consumer read, and `ops.stream_pair` the one reading of the `(score, expectation)`
+  pair that walk produces;
 - split-K's outer reduce is the identity-lift composition — `Fold.composed` is the one read.
 
 `Fold.from_loop` reconstructs the algebra from the loop BODY alone (degenerate facts off its `Accum`s; a twisted merge
@@ -116,7 +117,7 @@ lift through the one `_loop_ir_fn` arm.
 | softmax / RMSNorm | `Fold.projection(body=<per-cell normalize>, operands=(<the stat fold>,))` + a sweep `Store` |
 | fused norm→linear / gate⊗up | a zero-axis fold over the product contraction (a fork sibling of its coop-reduce form) |
 | a pure pointwise cell | `Fold.projection(body=…)` with no operands + its root `Store`s |
-| flash | the `TWISTED` fold on the streaming schedule — QK a hoisted operand edge, PV the derived evaluation's synthesized node |
+| flash | the `TWISTED` fold on the streaming schedule — the score is a hoisted QK edge or its materialized `Load`; PV is the derived evaluation's synthesized node |
 
 A twisted monoid is a monoid, selected structurally rather than as a distinct kind.
 
@@ -130,6 +131,8 @@ ONE walker plus one resolver, short-path-canonical: bare for the primary node, `
 and written through `ops.Sched`, which is also the one home of the `(m, n)` binding rule (`Sched.placed` /
 `Sched.tile_of`). The path codec spells `map` / `fold` / `a` / `b` segments off the derived readings — `PLACE@a`'s
 golden rows depend on it. A sliced axis's window is the one `Axis.window`.
+When PLACE materializes flash's score edge, the stream becomes the primary score site and spells bare `TILE` beside
+the surviving P@V site's `TILE@pj`; the algebraic fold and codec rules are otherwise unchanged.
 
 Since step 7 the wire forms are SITE-LOCAL: the worker inventory is spelled once in `WORK`
 (`w<M>x<N>[+p<np>]` / `t<N>[x<M>]`, the producer band riding `+p`), and `TILE` / `REDUCE` values shed their worker

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 from emmy.compiler.ir.axis import AxisRole
 from emmy.compiler.ir.schedule import ReducePlan
-from emmy.compiler.ir.stmt import Loop, StridedLoop
+from emmy.compiler.ir.stmt import Load, Loop, StridedLoop
 from emmy.compiler.ir.stmt.base import Stmt
-from emmy.compiler.ir.tile.ir import Fold, deep_defines, deep_reads, effect_tail, is_contraction, stmt_axis_names
+from emmy.compiler.ir.tile.ir import Fold, _operand_result_names, deep_defines, deep_reads, effect_tail, is_contraction, stmt_axis_names
 
 
 def cone_seam(cone) -> tuple[tuple, tuple, tuple[str, ...]]:
@@ -132,6 +132,12 @@ class Sched:
         site = next((s for s in self._all_sites() if s.node is node), None)
         if site is None:
             return None
+        score, pv = stream_pair(node)
+        if isinstance(score, Load) and pv is not None:
+            if len(free) < 2:
+                return None
+            ax = node.axis.window.parent if node.axis.window is not None else node.axis
+            return (free[-2], ax)
         if site.depth == 1:
             return self.place.root_mn
         if len(free) < 2:
@@ -248,13 +254,14 @@ def head(op):
 
 
 def stream_pair(node) -> tuple:
-    """The ``(score, expectation)`` contractions a STREAMING fold schedules through — flash's
-    hoisted ``Σ Q·K`` edge at the head of its derived evaluation and the synthesized ``Σ_j P·V``
-    below the merge — or ``(None, None)`` for any other node.
+    """The ``(score edge, expectation contraction)`` a STREAMING fold schedules through — the
+    hoisted score operand (COMPUTED ``Σ Q·K`` or its MATERIALIZED ``Load`` cut terminal) and the
+    synthesized ``Σ_j P·V`` below the merge — or ``(None, None)`` for any other node.
 
-    Found by POSITION, because position is what tells them apart: the score is a hoisted operand
-    edge, so it leads the step; the expectation is synthesized under the merge stmts that produce
-    the softmax weight it reads, which is exactly why it cannot be hoisted above them.
+    Found from the injection algebra rather than a name: string-valued non-pivot lift components
+    bind the expectation operand edges, leaving the score as the one other operand. The expectation
+    contraction is the derived contraction distinct from that score edge. This remains true when
+    PLACE materializes the score and replaces its ``Fold`` edge with a ``Load``.
 
     ONE reading for a question five readers were asking on their own — and asking two different
     ways, ``is_contraction`` in the tile and kernel layers against ``role is AxisRole.CONTRACTION``
@@ -262,9 +269,17 @@ def stream_pair(node) -> tuple:
     spellings of one rule stay equal only until one of them is edited."""
     if not isinstance(node, Fold) or node.axis is None:
         return None, None  # a zero-axis fold has no monoid, so no derived step to read
-    steps = list(node.step_stmts())
-    score = steps[0] if steps and is_contraction(steps[0]) else None
-    return score, next((s for s in steps[1:] if is_contraction(s)), None)
+    bindings = {}
+    for edge in node.operands:
+        for name in _operand_result_names(edge):
+            bindings[name] = edge
+    expectation = {id(bindings[term]) for term in node.lift.results[1:] if isinstance(term, str) and term in bindings}
+    scores = [edge for edge in node.operands if id(edge) not in expectation and isinstance(edge, (Fold, Load))]
+    if len(scores) != 1:
+        return None, None
+    score = scores[0]
+    pv = next((s for s in node.step_stmts() if is_contraction(s) and s is not score), None)
+    return (score, pv) if pv is not None else (None, None)
 
 
 def reduce_loop(op):

--- a/emmy/compiler/ir/tile/path.py
+++ b/emmy/compiler/ir/tile/path.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from emmy.compiler.ir.stmt import Load
 from emmy.compiler.ir.tile.ir import Fold, is_contraction
 
 #: The knob families whose keys address a tree site (``WORK`` / ``RASTER`` / ``LOOPIFY`` stay
@@ -195,6 +196,12 @@ def family_sites(family: str, all_sites: tuple[Site, ...]) -> tuple[Site, ...]:
             continue
         if s.node.axis is not None and is_contraction(s.node):
             out.append(s)
+        elif s.node.axis is not None:
+            from emmy.compiler.ir.tile.ops import stream_pair  # noqa: PLC0415 — ops imports this walker lazily
+
+            score, pv = stream_pair(s.node)
+            if isinstance(score, Load) and pv is not None:
+                out.append(s)  # the materialized score's fragment geometry lives on its stream
         elif s.node.axis is None and not s.node.operands and s.depth == 1 and not _is_escape(s.node):
             out.append(s)
     return tuple(out)

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -494,11 +494,12 @@ schedule domain or expose a realizable `PLACE` cut, then measure the choice.
 
 A **routing** golden is the durable measured form of that decision: its knobs are `PLACE` keys only. The loader
 rejects records that mix placement and schedule knobs, and `_golden_evidence_index` skips routing entries. A matching
-routing golden or authoritative pin collapses the structural fork before ranking. Each cut piece is recognized afresh
-and resolves its own placement and schedule choices recursively. `Op.decision_knobs` carries structural rows across
-lowering for replay, while `Op.knobs` remains the schedule realization of one kernel. The two-level tuner trains
-placement only from outer, whole-kernel-set Σ rows (`PLACE_sites` / `PLACE_cut`); those features never enter the
-per-kernel schedule rows, tune DB node keys, or O3 signatures.
+routing golden or authoritative pin collapses the structural fork before ranking. Each cut piece retains its
+recognized `Fold` tree and resolves its own placement and schedule choices recursively. `Op.decision_knobs` carries
+structural rows across lowering for replay, while `Op.knobs` remains the schedule realization of one kernel. The
+two-level tuner trains placement only from outer, derived whole-kernel-set Σ rows. `PLACE_sites` / `PLACE_cut` pool the
+row, while `PLACE_cut_site_<path>` preserves which canonical seam was selected so distinct one-cut kernel sets cannot
+alias. Those features never enter the per-kernel schedule rows, tune DB node keys, or O3 signatures.
 
 **Both file-backed inputs to that pick are built once per process.** The parsed online prior and the DB perf index are
 memoized on the source file's `(path, mtime)` — the online file, and the DB file plus its `-wal` sidecar. A generative
@@ -681,9 +682,18 @@ copied once per attempt and resolved in place — no per-fork copies.
 
 `emmy run --golden PATH --strict` consumes a working golden rather than changing search. It visits every distinct
 target sequentially in the current process, or one target selected with `--target NAME`. A valid directly measured
-tune winner is an automatic exact pin; verified rows remain automatic pins as before. The ordinary strict run accepts
-only captured whole-forward timing with direct eager correctness at `rtol=atol=1e-3`. Process isolation and repeated
-observations come from independent command invocations, not a second orchestration layer inside `run`.
+tune winner is an automatic exact pin; verified rows remain automatic pins as before. A scalar winner keeps the flat
+knob wire. A multi-kernel winner records placement and one component per operation cache key with multiplicity, direct
+schedule pins and latency, and ordered CudaOp knob rows. Replay resolves placement first, then selects each schedule by
+that pre-schedule cache key. It rejects placement or kernel-count drift, checks each component's CudaOp order in its
+single-kernel slice, and checks the whole graph's exact CudaOp-row inventory without imposing order across independent
+components. The ordinary strict run accepts only captured whole-forward timing with direct eager correctness at
+`rtol=atol=1e-3`. Process isolation and repeated observations come from independent command invocations, not a second
+orchestration layer inside `run`.
+When tune cannot encode an exact scalar or kernel-set winner, the working target carries `status: no_exact_pin` and
+strict replay expects one automatic row that cannot be produced. This intentional failure closes the gap between "tune
+completed" and "the selected kernel set has a replayable publication row"; inventory-only targets still have no
+automatic-row obligation.
 
 **Greedy flattens forks before ranking.** The lazy fork tree is an MCTS structure — it stages knob choices across
 levels (`BR` → `BM/BN` → `FM/FN`) so MCTS pays one node per pop. Greedy must NOT walk it level-by-level: a branch
@@ -781,23 +791,24 @@ The two kinds are **op-variant** forks, which choose tile / pad / stage settings
 forks, which choose whether a closed seam in an already-recognized algebraic region becomes a kernel boundary. Because
 the two have opposite structure, `two_level.py` gives placement to the outer search and scheduling to the inner search.
 
-**Outer search** (`run_two_level_tune`) drives `frontend` + `loop` and `lowering/tile/010_recognize`, then stops before
-`020_schedule`. Fusion is deterministic and maximal; recognition is algebraic and offers the structural
-`PLACE@<path>=fuse|cut` rows. An outer **terminal** has every placement decision resolved and every resulting kernel
-represented by an unmapped `TileOp`. Its **reward** is `1 / Σ best-per-kernel time` from the inner search,
-backpropagated by the reused `TuningSearch`.
+**Outer search** (`run_two_level_tune`) drives `frontend` + `loop`, then runs `lowering/tile/010_recognize` and
+`015_place` to a graph-level fixpoint. Fusion is deterministic and maximal; recognition is algebraic; placement
+offers the structural `PLACE@<path>=fuse|cut` rows without lowering either side back through recognition. An outer
+**terminal** has every placement decision resolved and every resulting kernel represented by an unmapped `TileOp`.
+Its **reward** is `1 / Σ best-per-kernel time` from the inner search, backpropagated by the reused `TuningSearch`.
 
 Within one trajectory, structurally identical fork points all take the same side: `Run.drive` replays the first
 decision, read off the trajectory's own graph (`_replay_structural_decision`), so the outer tree grows with the number
 of *unique* kernels rather than as `2^n` in the number of such points. A term with no realizable seam yields one outer
 terminal and reduces to "tune each kernel once, sum, assemble". The global prior drives the outer PUCT too: each
 terminal emits a whole-kernel-set Σ row with context features, the offer kernel's structural `S_*` features, and
-pooled placement features (`PLACE_sites`, `PLACE_cut`). The row does not contain any resulting kernel's schedule
-realization.
+placement features (`PLACE_sites`, `PLACE_cut`, and the selected seam's `PLACE_cut_site_<path>` identity). Its latency
+is the multiplicity-weighted sum of independently measured per-kernel medians, not an assembled whole-program
+measurement. The row does not contain any resulting kernel's schedule realization.
 
 **Inner search** (`_inner_reward_async`) tunes each recognized kernel **independently** in its own single-node slice
 (`single_node_graph`, `slice.py`) with a plain `TuningSearch` beginning at schedule enumeration
-(`schedule → kernel → cuda`):
+(`lowering/schedule → kernel → cuda`):
 
 - The slice keeps the root kernel + its leaf-op closure and turns every other kernel-input into a synthetic `InputOp`.
   The root op is shared **by reference**, so its body — and thus `Op.cache_key` — is byte-for-byte the full-graph op's.
@@ -997,8 +1008,9 @@ don't invent a third:
 
 - **Four op-inventory tables** — one row per op encountered along any lowering chain, keyed by `Op.cache_key`.
 - **A `lowering` edge table** — one row per rewrite hop carrying the knob delta plus a best-median upsert
-  (`best_per_op_time` walks the chain to resolve a pre-final op's measured cost; loop→loop source hops are skipped as
-  structural/decision hops).
+  (`best_per_op_time` walks the chain to resolve a pre-final op's measured cost; graph-splice source edges and
+  loop→loop structural hops are skipped). A multi-kernel fragment's individual launch time never prices its shared
+  predecessor; the two-level search owns that kernel set's aggregate Σ.
 - **A backend-partitioned `perf` table** — full stats + `backend` + `status` + `knobs` + `captured`.
 - **A `node` table** — one row per **search-tree node**, meaning every partly-decided branch and every leaf of a
   per-kernel search. It is keyed by `digest(context_key, gpu, op_sig, tunable-knob set)` and carries the full feature
@@ -1372,22 +1384,25 @@ attribution POOLS GPUs and flag settings, which is safe because regret is a rati
 
 ## Part 9: Tile lowering at the pipeline level
 
-`lowering/tile/` lowers each fused `LoopOp` to a kernel-ready `TileOp` over the block-DAG Tile IR (`ir/tile/ir.py`):
+`lowering/tile/` turns each fused `LoopOp` into a resolved kernel set over the block-DAG Tile IR (`ir/tile/ir.py`):
 `010_recognize` lifts `LoopOp` → `TileOp`, recognizes the flash / softmax streaming forms, annotates each reduce
-`Loop` with its `AxisRole`, binds every algebraic operand channel, and offers `PLACE` at every realizable closed seam;
-`020_schedule` maps the selected kernel set and chooses among capability-compatible hardware atoms;
-`030_split_reduce` realizes a selected cross-CTA reduction.
-The pass **never dispatches on a named shape or GPU product** — every decision follows the stored fold and named
-capability predicates. The full design lives in
+`Loop` with its `AxisRole`, and binds every algebraic operand channel; `015_place` then offers `PLACE` at every
+realizable closed seam until the graph reaches a placement fixpoint. A cut preserves the recognized child and parent
+`Fold` trees. `lowering/schedule/020_schedule` maps that fixed kernel set and chooses among capability-compatible
+hardware atoms; `030_split_reduce` realizes a selected cross-CTA reduction.
+When recognition returns a graph fragment, its output `TileOp` enters placement in the full graph, so constants and
+internal producers remain intact around either result. These passes **never dispatch on a named shape or GPU
+product** — recognition follows stored algebra, and schedule/lowering gate generic paths on named capabilities. The
+full design lives in
 [`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md).
 
-The step BETWEEN those two — schedule enumeration: mapping the free axes onto the grid and forking the per-node
+The following pass — schedule enumeration: mapping the free axes onto the grid and forking the per-node
 `TILE` / `REDUCE` / `STAGE` / `WORK` / `RASTER` families — is ONE recursive row enumerator over the term's own site
 tree (the `020_schedule` rule). It covers every single-site term, the COMPUTED `a` edge (the fused norm→linear /
 gate⊗up cone) and the flash streaming pair — the two-site families are why it recurses. A term it cannot schedule
 enumerates NO rows and stays unmapped rather than being guessed at — the guardrail contract, with any coverage gap
 riding `tests/xfail_registry.py`. A schedule coverage or profitability gap must not become a fusion exception. If a
-closed seam makes independently schedulable kernels, recognition exposes it through `PLACE`; the outer tuner compares
+closed seam makes independently schedulable kernels, placement exposes it through `PLACE`; the outer tuner compares
 the maximal and cut kernel sets by their measured sum. Otherwise the repair belongs in the generic schedule domain.
 See the leading section of [`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md) for the design.
 
@@ -1466,7 +1481,8 @@ cross-CTA split is the `g<n>` field (GRID stage), and the
 carriers only; both tiers — an mma partial's C fragment rides `RegStore.atomic`, the packed f16x2/bf16x2 red, at the
 cost of one output-dtype rounding per partition), `g<n>k` = deferred `__partial` workspace + a sibling combine kernel
 (any carrier; the only legal arm for the twisted flash `(m, l, O)` split-KV and for a multi-channel ⊗-combine). Pin
-via `EMMY_REDUCE=g2k` (one flat knob — no per-axis `EMMY_REDUCE_<axis>`, no `EMMY_FINALIZE`). The split is consumed by `lowering/tile/030_split_reduce` as a graph rewrite (partial + finalize); the
+via `EMMY_REDUCE=g2k` (one flat knob — no per-axis `EMMY_REDUCE_<axis>`, no `EMMY_FINALIZE`). The split is consumed by
+`lowering/schedule/030_split_reduce` as a graph rewrite (partial + finalize); the
 letter round-trips through `ReducePlan.parse`/`spell` and reads back as `ReducePlan.finalize`. The atomic finalize
 applies the kernel's projection epilogue **per partition** before the `atomicAdd`, so it is only correct when that
 projection *distributes* over the add (`Σ φ(xₛ) = φ(Σ xₛ)`): a constant scale like `mean`'s `×1/N` distributes and
@@ -1588,8 +1604,8 @@ re-spell deliberately and retires only when symbolic-trace keyed resolution exis
 
 Pass files are numerically prefixed so `sorted()` picks them up deterministically. Pick a fresh prefix when adding a
 rule; the loader ignores the prefix itself — it only makes the ordering readable. Per-pass authoring invariants are in
-[`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md); the tile passes (`010_recognize` → `030_split_reduce`) and the set
-of algebraic rewrites they may apply are documented there too.
+[`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md); the structural tile pass (`010_recognize` → `015_place`) and the
+following schedule pass (`020_schedule` → `030_split_reduce`) are documented there too.
 
 | Pass                      | What rules do                                                                                |
 |---------------------------|----------------------------------------------------------------------------------------------|
@@ -1599,7 +1615,8 @@ of algebraic rewrites they may apply are documented there too.
 | `loop/fusion/`            | `split_shared_indexmap` dissolves a fan-out pure-indexmap into separate consumers when its branches do not reconverge; `merge_loop_ops` uses the same N-way splicer for adjacent pairs and closed reconvergent producer DAGs, preserving shared SSA definitions instead of treeifying them; `dedup_loads` drops identical `(input, index)` Loads; `fold_output_reshape` retargets a producer's `Write` through a graph-output memcpy-identity flatten (verified exactly over the finite domain; clean affine re-decomposition onto the output strides) — the copy kernel the splicer cannot take (a producer that carries a reduce, read through a div/mod index map). Folding scalar-constant broadcasts into consumers cuts Qwen3-Embedding-0.6B from 394 → 337 kernels. |
 | `loop/recognize/`         | Empty (retired) — flash / online-softmax recognition moved into `lowering/tile/010_recognize` (the `_flash` / `_softmax` helpers), so the loop dialect carries no pattern recognizers. |
 | `loop/stamp/`             | `stamp_loop_names` (`provenance.name_for`, e.g. `k_rms_norm_3f2a1b`) + `stamp_structural_features` (the `S_*` dict). Runs last in the loop dialect — after fusion and recognition — so every kernel is named / stamped against its final body. |
-| `lowering/tile/`          | `LoopOp → TileOp` over the block-DAG Tile IR: `010_recognize` reads the algebra, offers post-fusion `PLACE`, and emits an unmapped `TileOp` → `020_schedule` enumerates one generic product over term sites → `030_split_reduce` realizes a selected cross-CTA reduction. Dispatch is on structural fold readings and roles, never a named shape or GPU product. |
+| `lowering/tile/`          | `LoopOp → TileOp` over the block-DAG Tile IR: `010_recognize` reads maximal algebra; `015_place` resolves post-fusion kernel boundaries to a graph-level fixpoint while preserving each term. Recognition is target-independent and never dispatches on a named shape or GPU product. |
+| `lowering/schedule/`      | `020_schedule` enumerates one generic product over every resolved term's sites; `030_split_reduce` realizes a selected cross-CTA reduction. Capability predicates and atom metadata decide which generic primitives the target can execute. |
 | `lowering/kernel/`        | `010_materialize` is a `TileOp → KernelOp` tier dispatcher (scalar / `_reduce`). A tiled `CONTRACTION` arrives as a `Fold` already **built recognize-side** in the bilinear shape (`is_contraction` is the reading, not a kind) (`lowering/tile/010_recognize._nodify_contraction` — one flat node splitting the algebra params (axes / operands / acc / epilogue) from the schedule, which the fork places onto the grid), so materialize only synthesizes its bare grid-`Write` and **expands** it through the one atom-generic `_factor.factorize` over the shared tiling layer (in `_factor.py`) (the geometry is derived on the PLACED `TilePlan` slice, the algebra on the node; `_atom.reduce_codegen` emits the shared K-loop and a swappable `store` sink, dispatched off the atom). Then the Kernel-IR peepholes: `030_stamp_types` (+ `040_demote_to_write_dtype`) resolve dtypes, `050_vectorize_loads` / `080_vectorize_stores` / `095_interleave_loads` pack/reorder memory ops, `110_drop_redundant_syncs`. See [`passes/lowering/kernel/ARCHITECTURE.md`](passes/lowering/kernel/ARCHITECTURE.md). |
 | `lowering/cuda/`          | `delegate_zero_init` (first) moves an atomic accumulator's per-launch zero-init off the runtime memset and into a dataflow-predecessor kernel as a `ZeroPrologue` stmt (CTA 0 writes zero words; stream order guarantees happen-before) — one CUDA-graph MEMSET node saved per site; the capture's first launch, symbolic-shaped accumulators, and accumulators past the one-CTA break-even cap (`_MAX_DELEGATED_WORDS`, 64 KB — CTA 0 zeroes serially, so a large buffer costs more than the MEMSET node it replaces) keep their memset, and the slab planner starts the buffer's live interval at the delegating launch (`CudaOp.zero_prologues`). `lower_kernelop` then renders the `KernelOp` body to a `__global__` source string (`ir/kernel/render.py::render_kernelop`) and mutates the node's op to `CudaOp` in place. |
 

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -199,6 +199,9 @@ def rewrite(ctx: Context, graph: Graph, match: Match) -> Graph | Op | list[Graph
 - The dispatcher binds `rewrite`'s parameters **by name**. Reserved names: `graph`, `match`, `root`, `out`, `ctx`.
   Pattern names from `PATTERN` bind to their matched `Node` objects. Anything else binds positionally to
   `root.inputs[i]`. Take only what you need — `ctx` is optional.
+- A hardware-dependent rule takes `ctx` and asks a named primitive-capability predicate. Passes never import the
+  process-global target probe or compare `ctx.compute_capability` to an SM threshold; the executable contract is in
+  [`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md).
 - Files starting with `_` (e.g. `_broadcast.py`) are **not** loaded as rules — they're shared helpers.
 - Raise `RuleSkipped(reason)` to decline a match; the engine logs the reason at DEBUG and moves on.
 
@@ -470,7 +473,7 @@ yet supported; today `emmy fit` trains on goldens only).
 
 **Whichever tier decides, the µs of the winning row is written onto the fork's trace entry** (`Decision.score`): a
 measured µs when a golden or an evidence row decided, the model's predicted µs otherwise. That number is what the
-structural cost estimate reads off the partition fork (Part 4), so the Σ compared there mixes measured and predicted
+structural cost estimate reads off the placement fork (Part 4), so the Σ compared there mixes measured and predicted
 µs — measured wherever the tune benched that kernel, predicted only where nothing was.
 
 **How to see which tier answered.** There is no flag that reports, per fork, which tier decided it; a live compile
@@ -481,19 +484,21 @@ audits — `emmy eval golden` re-runs the golden-tier consultations and prints a
 Part 7). Answering "which tier decided this fork, and did I expect that one?" means correlating those three, not
 flipping one switch.
 
-**Where the kernel gets cut is settled before any of this.** Ahead of the schedule pick, a separate decision splits —
-or does not split — the recognized work into kernels. A **routing** golden entry is how that decision is recorded: an
-entry whose knobs are only `PLACE@<label>` values, where the label names an edge inside the recognized kernel.
-`PLACE@cone = cut`, for instance, says "split at the edge labelled `cone`, so that sub-computation becomes its own
-kernel". The loader rejects an entry that mixes `PLACE` with schedule knobs, and `_golden_evidence_index` skips
-routing entries. They are consulted during recognition (`lowering/tile/_cut.py`, joined by `ShapeKey.joins` against
-the live GPU, and restricted to `-O3` like the golden tier itself). Each resulting piece is then recognized afresh and
-resolves its OWN `(kind, shape)` through the same hierarchy above; see the tile-lowering ARCHITECTURE's
-placement-routing section. Keeping the work in one kernel is the default and is what an absent entry means; cutting
-happens only from recorded evidence or a hand-forced pin. That makes routing one of exactly two ways a greedy compile
-can change which kernels exist: a routing golden (or pin) cuts with no prior involved, while a structural fork
-(Part 4) needs the trusted online prior to estimate its cost. Everything else — offline prior and option-0
-included — keeps the default kernel set.
+**Where the kernel gets cut is settled after fusion and recognition, before scheduling.** Fusion first forms the
+largest reasonable algebraic region subject only to semantic preservation and general work-duplication brakes. It
+does not consult hardware, schedule coverage, or profitability evidence. `PLACE@<label>` then names an edge inside
+the recognized term. With no authoritative decision, placement offers a structural fork: the maximal region first,
+plus one `Graph` fragment per realizable seam. Tuning compares those kernel sets; a cold prior or option-0 keeps the
+maximal region. A schedule that cannot realize that region does not justify weakening fusion: extend the generic
+schedule domain or expose a realizable `PLACE` cut, then measure the choice.
+
+A **routing** golden is the durable measured form of that decision: its knobs are `PLACE` keys only. The loader
+rejects records that mix placement and schedule knobs, and `_golden_evidence_index` skips routing entries. A matching
+routing golden or authoritative pin collapses the structural fork before ranking. Each cut piece is recognized afresh
+and resolves its own placement and schedule choices recursively. `Op.decision_knobs` carries structural rows across
+lowering for replay, while `Op.knobs` remains the schedule realization of one kernel. The two-level tuner trains
+placement only from outer, whole-kernel-set Σ rows (`PLACE_sites` / `PLACE_cut`); those features never enter the
+per-kernel schedule rows, tune DB node keys, or O3 signatures.
 
 **Both file-backed inputs to that pick are built once per process.** The parsed online prior and the DB perf index are
 memoized on the source file's `(path, mtime)` — the online file, and the DB file plus its `-wal` sidecar. A generative
@@ -771,51 +776,48 @@ lowest measured latency.
 ### Two-level search: outer structural MCTS + inner per-op tuning
 
 `emmy tune` does **not** run one MCTS over the whole graph. The pipeline applies rules one after another, so the two
-kinds of fork would nest and multiply out under a single patience budget, starving the ops deepest in the graph. The
-two kinds are **op-variant** forks, which choose tile / pad / stage settings inside one kernel, and **structural**
-forks, which change which kernels exist — how ops are grouped into kernels, and the split taken by a demoted matmul
-(one whose shape makes the compiler handle it as a plain reduction rather than as a contraction). Because the two have
-opposite structure, `two_level.py` separates them by the fork's *effect*, reusing the `Op`-rebind vs `Graph`-splice
-classification made where the children are pushed.
+kinds of fork would nest and multiply out under a single patience budget, starving the kernels deepest in the graph.
+The two kinds are **op-variant** forks, which choose tile / pad / stage settings inside one kernel, and **placement**
+forks, which choose whether a closed seam in an already-recognized algebraic region becomes a kernel boundary. Because
+the two have opposite structure, `two_level.py` gives placement to the outer search and scheduling to the inner search.
 
-**Outer search** (`run_two_level_tune`) drives the graph-changing passes: `frontend` + `loop`, plus the part of
-`lowering/tile` that runs before `partition_loops`. A **terminal** here is the state in which the cursor reaches
-`partition_loops` with every structural fork resolved. Each terminal is one candidate grouping of ops into kernels;
-its **reward** is `1 / Σ best-per-op time` from the inner search, backpropagated by the reused `TuningSearch`.
+**Outer search** (`run_two_level_tune`) drives `frontend` + `loop` and `lowering/tile/010_recognize`, then stops before
+`020_schedule`. Fusion is deterministic and maximal; recognition is algebraic and offers the structural
+`PLACE@<path>=fuse|cut` rows. An outer **terminal** has every placement decision resolved and every resulting kernel
+represented by an unmapped `TileOp`. Its **reward** is `1 / Σ best-per-kernel time` from the inner search,
+backpropagated by the reused `TuningSearch`.
 
 Within one trajectory, structurally identical fork points all take the same side: `Run.drive` replays the first
 decision, read off the trajectory's own graph (`_replay_structural_decision`), so the outer tree grows with the number
-of *unique* kernels rather than as `2^n` in the number of such points. Fusion itself is still deterministic (no rule
-offers a multi-option fusion fork), so a graph with no structural forks yields exactly one terminal and the whole
-thing reduces to "tune each op once, sum, assemble". The global prior drives the outer PUCT too: each terminal emits
-one combined Σ row per structural decision it took (features `{ctx, op knobs before the decision, the decision's knob
-delta}`, label = the Σ of that side's per-kernel bests), so a re-tune on a warm machine descends into the kernel set
-predicted to be cheaper first.
+of *unique* kernels rather than as `2^n` in the number of such points. A term with no realizable seam yields one outer
+terminal and reduces to "tune each kernel once, sum, assemble". The global prior drives the outer PUCT too: each
+terminal emits a whole-kernel-set Σ row with context features, the offer kernel's structural `S_*` features, and
+pooled placement features (`PLACE_sites`, `PLACE_cut`). The row does not contain any resulting kernel's schedule
+realization.
 
-**Inner search** (`_inner_reward_async`) tunes each finalized kernel **independently** in its own single-node slice
-(`single_node_graph`, `slice.py`) with a plain `TuningSearch` over the lowering passes only (`tile → kernel → cuda`):
+**Inner search** (`_inner_reward_async`) tunes each recognized kernel **independently** in its own single-node slice
+(`single_node_graph`, `slice.py`) with a plain `TuningSearch` beginning at schedule enumeration
+(`schedule → kernel → cuda`):
 
 - The slice keeps the root kernel + its leaf-op closure and turns every other kernel-input into a synthetic `InputOp`.
   The root op is shared **by reference**, so its body — and thus `Op.cache_key` — is byte-for-byte the full-graph op's.
   It filters the graph's canonical topological order rather than iterating its set-backed ancestor closure, so slice
   inputs and persisted Loop programs stay byte-identical across fresh Python processes.
-- One fold-aware exception: a flash fold offer site's slice CARRIES the score producer its fusion consumes
-  (`_flash.fused_producer_ids` → `single_node_graph(absorb=…)`), and the absorbed producer loses its own slice. A
-  synthetic-input boundary would make `try_flash` unfusable in-slice, silently degrading every tune trajectory to the
-  cut (benching fragment kernels greedy deploy never picks) and leaving the fused flash fork unreachable under tune.
+- The LoopOp guardrail retains one fold-aware exception: a flash offer site's slice carries the score producer its
+  recognition consumes (`_flash.fused_producer_ids` → `single_node_graph(absorb=…)`). Normal outer terminals have
+  already recognized this algebra into `TileOp`, so the inner search does not revisit that decision.
 - Because the inner tree holds one op, MCTS explores only that op's forks with `patience` as the op's own budget —
   `Σ_k n_k` benches total, never the product.
-- **Leaves are deduped by `Op.cache_key`**: 24 RMSNorm LoopOps across 24 layers collapse to one work unit, and the
+- **Leaves are deduped by `Op.cache_key`**: 24 equivalent kernels across 24 layers collapse to one work unit, and the
   outer `total_us` accumulates `best * multiplicity` so the reward stays multiplicity-weighted. The progress
   denominator is the deduped count, so Qwen3-Embedding-0.6B's ~14 unique kernels show as 14/14, not 14/337.
 
-**Separability + the structural handoff.** Op-variant forks are separable: every multi-option fork is an in-place `Op`
-rebind that leaves the graph unchanged, so whole-graph time is `Σ_k t_k`. Results key structurally (`Op.cache_key` =
-name-invariant body+knobs digest), so a kernel tuned in its slice transfers to the assembled graph unchanged **and**
-is shared across outer terminals — two fusion candidates sharing an identical op reuse its tuning (a DB hit). After
-the best fusion is picked, the assembled `Graph[CudaOp]` is benched **once** for the real in-context whole-graph
-latency; comparing it to the `Σ` estimate is the **separability check** — a gap exposes L2 / clock / launch coupling
-the isolated benches can't see (in practice <2% for small graphs).
+**Separability + the placement handoff.** Op-variant forks are separable: every multi-option schedule fork is an
+in-place `Op` rebind that leaves the kernel set unchanged, so the outer estimate is `Σ_k t_k`. Results key
+structurally (`Op.cache_key` = name-invariant body+knobs digest), so a kernel tuned in its slice transfers to the
+assembled graph unchanged and is shared across outer terminals. Placement lives only in `Op.decision_knobs` for
+structural replay; inner node rows, schedule prior rows, O3 signatures, and kernel cache keys exclude it. The winning
+outer terminal is lowered directly, so an unfitted prior cannot replay a different kernel set during assembly.
 
 **Always re-run, replay from the cache.** The inner search runs for **every** op on every pass — it is never skipped
 on prior effort. Replay is cheap, not gated: each benched terminal hits the per-variant `perf` cache, so an
@@ -1371,13 +1373,12 @@ attribution POOLS GPUs and flag settings, which is safe because regret is a rati
 ## Part 9: Tile lowering at the pipeline level
 
 `lowering/tile/` lowers each fused `LoopOp` to a kernel-ready `TileOp` over the block-DAG Tile IR (`ir/tile/ir.py`):
-`010_recognize` (lift `LoopOp` → `TileOp`, recognize the flash / softmax streaming forms, annotate each reduce
-`Loop` with its `AxisRole` — the only loop annotation; the algebra is the body — and **atomize**: resolve the
-algebra→hardware-atom binding structurally onto the node, so an unbindable atom never becomes one; `_atomize.py`) →
-`030_split_reduce` (cross-CTA split-K as a graph rewrite). It **never dispatches on a named
-shape** — every decision is gated on the derived role of the stored fold (`PLANAR` / `CONTRACTION` / `TWISTED`; flash
-attention is the `TWISTED` fold on the streaming schedule, a twisted monoid is a monoid, selected structurally), not
-on a matmul / pointwise / attention archetype. The full design lives in
+`010_recognize` lifts `LoopOp` → `TileOp`, recognizes the flash / softmax streaming forms, annotates each reduce
+`Loop` with its `AxisRole`, binds every algebraic operand channel, and offers `PLACE` at every realizable closed seam;
+`020_schedule` maps the selected kernel set and chooses among capability-compatible hardware atoms;
+`030_split_reduce` realizes a selected cross-CTA reduction.
+The pass **never dispatches on a named shape or GPU product** — every decision follows the stored fold and named
+capability predicates. The full design lives in
 [`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md).
 
 The step BETWEEN those two — schedule enumeration: mapping the free axes onto the grid and forking the per-node
@@ -1385,8 +1386,10 @@ The step BETWEEN those two — schedule enumeration: mapping the free axes onto 
 tree (the `020_schedule` rule). It covers every single-site term, the COMPUTED `a` edge (the fused norm→linear /
 gate⊗up cone) and the flash streaming pair — the two-site families are why it recurses. A term it cannot schedule
 enumerates NO rows and stays unmapped rather than being guessed at — the guardrail contract, with any coverage gap
-riding `tests/xfail_registry.py`. See the leading section of [`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md) for
-the design.
+riding `tests/xfail_registry.py`. A schedule coverage or profitability gap must not become a fusion exception. If a
+closed seam makes independently schedulable kernels, recognition exposes it through `PLACE`; the outer tuner compares
+the maximal and cut kernel sets by their measured sum. Otherwise the repair belongs in the generic schedule domain.
+See the leading section of [`passes/ARCHITECTURE.md`](passes/ARCHITECTURE.md) for the design.
 
 ## Tunable knobs
 
@@ -1596,7 +1599,7 @@ of algebraic rewrites they may apply are documented there too.
 | `loop/fusion/`            | `split_shared_indexmap` dissolves a fan-out pure-indexmap into separate consumers when its branches do not reconverge; `merge_loop_ops` uses the same N-way splicer for adjacent pairs and closed reconvergent producer DAGs, preserving shared SSA definitions instead of treeifying them; `dedup_loads` drops identical `(input, index)` Loads; `fold_output_reshape` retargets a producer's `Write` through a graph-output memcpy-identity flatten (verified exactly over the finite domain; clean affine re-decomposition onto the output strides) — the copy kernel the splicer cannot take (a producer that carries a reduce, read through a div/mod index map). Folding scalar-constant broadcasts into consumers cuts Qwen3-Embedding-0.6B from 394 → 337 kernels. |
 | `loop/recognize/`         | Empty (retired) — flash / online-softmax recognition moved into `lowering/tile/010_recognize` (the `_flash` / `_softmax` helpers), so the loop dialect carries no pattern recognizers. |
 | `loop/stamp/`             | `stamp_loop_names` (`provenance.name_for`, e.g. `k_rms_norm_3f2a1b`) + `stamp_structural_features` (the `S_*` dict). Runs last in the loop dialect — after fusion and recognition — so every kernel is named / stamped against its final body. |
-| `lowering/tile/`          | `LoopOp → TileOp` over the block-DAG Tile IR: `010_recognize` (structural — reads the algebra off the `LoopOp` body and emits an UNMAPPED `TileOp`) → the schedule step (REMOVED — see Part 9) → `030_split_reduce`. Dispatch is on the fold's derived role (`Fold.role` — `FREE` / `PLANAR` / `CONTRACTION` / `TWISTED`), never a named shape. |
+| `lowering/tile/`          | `LoopOp → TileOp` over the block-DAG Tile IR: `010_recognize` reads the algebra, offers post-fusion `PLACE`, and emits an unmapped `TileOp` → `020_schedule` enumerates one generic product over term sites → `030_split_reduce` realizes a selected cross-CTA reduction. Dispatch is on structural fold readings and roles, never a named shape or GPU product. |
 | `lowering/kernel/`        | `010_materialize` is a `TileOp → KernelOp` tier dispatcher (scalar / `_reduce`). A tiled `CONTRACTION` arrives as a `Fold` already **built recognize-side** in the bilinear shape (`is_contraction` is the reading, not a kind) (`lowering/tile/010_recognize._nodify_contraction` — one flat node splitting the algebra params (axes / operands / acc / epilogue) from the schedule, which the fork places onto the grid), so materialize only synthesizes its bare grid-`Write` and **expands** it through the one atom-generic `_factor.factorize` over the shared tiling layer (in `_factor.py`) (the geometry is derived on the PLACED `TilePlan` slice, the algebra on the node; `_atom.reduce_codegen` emits the shared K-loop and a swappable `store` sink, dispatched off the atom). Then the Kernel-IR peepholes: `030_stamp_types` (+ `040_demote_to_write_dtype`) resolve dtypes, `050_vectorize_loads` / `080_vectorize_stores` / `095_interleave_loads` pack/reorder memory ops, `110_drop_redundant_syncs`. See [`passes/lowering/kernel/ARCHITECTURE.md`](passes/lowering/kernel/ARCHITECTURE.md). |
 | `lowering/cuda/`          | `delegate_zero_init` (first) moves an atomic accumulator's per-launch zero-init off the runtime memset and into a dataflow-predecessor kernel as a `ZeroPrologue` stmt (CTA 0 writes zero words; stream order guarantees happen-before) — one CUDA-graph MEMSET node saved per site; the capture's first launch, symbolic-shaped accumulators, and accumulators past the one-CTA break-even cap (`_MAX_DELEGATED_WORDS`, 64 KB — CTA 0 zeroes serially, so a large buffer costs more than the MEMSET node it replaces) keep their memset, and the slab planner starts the buffer's live interval at the delegating launch (`CudaOp.zero_prologues`). `lower_kernelop` then renders the `KernelOp` body to a `__global__` source string (`ir/kernel/render.py::render_kernelop`) and mutates the node's op to `CudaOp` in place. |
 
@@ -1619,7 +1622,7 @@ prefix is the single-letter shorthand from `PASS_SHORTHAND` (`d` / `o` / `l` / `
 letters the CLI accepts in `--passes dolft` (`commands/compile.py` imports `PASS_SHORTHAND` so the flag and the marker
 prefix can't drift). Skipped rules collapse to a one-liner. The bracketing makes per-rule / per-pass slicing trivial
 via `awk`; ANSI color is applied only inside the diff body so the markers stay plain ASCII. Color follows
-`compile --color`. Body-carrying ops render through their own `pretty_body` (the in-flight `TileGraphOp` pretty-prints
+`compile --color`. Body-carrying ops render through their own `pretty_body` (the in-flight `TileOp` pretty-prints
 its block-DAG), so a tile-pass diff reads as a readable block-DAG delta. The structured `.rules.json` dump is
 unaffected — the diff is purely presentation.
 

--- a/emmy/compiler/pipeline/__init__.py
+++ b/emmy/compiler/pipeline/__init__.py
@@ -17,7 +17,7 @@
   dispatch that routes post-pass dumps by pass name.
 - :mod:`.passes` — pass directories grouped by IR level:
   ``frontend/{decomposition,optimization}``, ``loop/{lifting,fusion}``,
-  ``lowering/{tile,kernel,cuda}``. Each leaf contains ``NNN_<name>.py``
+  ``lowering/{tile,schedule,kernel,cuda}``. Each leaf contains ``NNN_<name>.py``
   rule modules picked up by ``Pass.load``.
 """
 
@@ -42,7 +42,7 @@ from emmy.compiler.pipeline.search import (
 # and tests should reference these rather than re-listing pass names.
 TENSOR_PASSES = ["frontend/decomposition", "frontend/optimization"]
 LOOP_PASSES = [*TENSOR_PASSES, "loop/lifting", "loop/fusion", "loop/stamp"]
-TILE_PASSES = [*LOOP_PASSES, "lowering/tile"]
+TILE_PASSES = [*LOOP_PASSES, "lowering/tile", "lowering/schedule"]
 KERNEL_PASSES = [*TILE_PASSES, "lowering/kernel"]
 CUDA_PASSES = [*KERNEL_PASSES, "lowering/cuda"]
 

--- a/emmy/compiler/pipeline/knob.py
+++ b/emmy/compiler/pipeline/knob.py
@@ -87,11 +87,12 @@ class Knob:
     hints: tuple = ()
     help: str = ""
     # Optional custom featurizer for the online-prior feature vector: maps this
-    # knob's value to a ``dict[str, float]`` of sub-features. Declared at the
+    # knob's concrete key and value to a ``dict[str, float]`` of sub-features. The key lets a
+    # scoped family preserve the structural site selected by ``FAMILY@path``. Declared at the
     # knob (e.g. ``MMA`` expands an atom kind into physical cell/dtype props) so
     # ``knob_features`` needs no per-knob special-casing. ``None`` → encode by
     # ``type`` (INT → float, BOOL → 0/1, BINMASK → popcount/width/frac).
-    features: Callable[[Any], dict[str, float]] | None = None
+    features: Callable[[str, Any], dict[str, float]] | None = None
     # The "unused / declined" OFF value. When a knob doesn't apply to a variant
     # (a tier-foreign knob like ``WM`` on a scalar kernel) or its owning pass
     # declines / is skipped, :func:`apply_off_defaults` stamps this value so the

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -9,6 +9,28 @@ walk; the derived `Fold.role` for the loop annotation the materializer reads), n
 flash attention is the `TWISTED` fold on the streaming schedule (a twisted monoid is a monoid), selected
 structurally, not a distinct kind.
 
+## Hardware portability is a compiler invariant
+
+Recognition describes algebra and dataflow; it never names a GPU, model, operator provenance, or workload shape.
+Scheduling may ask whether a primitive is available, but that fact has one source: a named capability predicate on
+the per-compilation `Context` (`has_cp_async`, `has_tma`, an MMA-family predicate, and so on). Lowering consumes the
+primitive selected by the schedule and may validate the same named capability; it must not rediscover eligibility
+from an SM-number threshold or a product name. A path therefore applies to every target whose `Context` advertises
+the primitives it needs, including future targets, without adding a sibling target-specific branch.
+
+Physical product identity is allowed only where measurement identity matters: golden and node evidence may key on
+`Context.hardware_id` / `gpu_name`, and device limits such as shared-memory size may be carried as context facts.
+Product identity may select measured placement evidence in `_cut.py`; it may not define an implementation path.
+Neither identity nor a physical limit may decide whether an algebraic form is recognized or whether an instruction
+family is legal. Profitability comes from measured evidence and the prior; primitive legality comes from capability
+predicates.
+
+This boundary is executable. `tests/compiler/passes/test_hardware_capability_contract.py` scans every pass module and
+rejects process-global target probes and direct comparisons against `Context.compute_capability`. When a new
+instruction family lands, add its predicate to `Context`, test the predicate across the architectural boundary, and
+exercise recognition plus schedule/lowering with synthetic contexts on both sides. Do not add an exception to the
+guardrail; move the hardware fact to `Context`.
+
 ## Quantization is not a concept past the decomposition band
 
 A quantized checkpoint is spelled as generic in-graph algebra at BIRTH (`loader.quant`, immediately post-trace).
@@ -207,6 +229,10 @@ How to comply:
   bound as the shared A value by value-tree equality, however many fold channels read it). Norm→linear, gate/up +
   SwiGLU, scale→matmul, SDPA P@V, and rotary QK^T are *instances* of that one rule, not branches — and a shape
   nobody designed for (a weight-side decode cone) is covered for free.
+- **Preserve the primitive's structural laws.** A tensor-core A fragment is stationary across N and B is stationary
+  across M. A load indexed by both output axes and K is valid scalar contraction algebra, but it is not a matrix
+  atom operand; recognition declines that atom binding and the term remains on the PLANAR guardrail path. Do not
+  patch its emitted index for one reshape — state the stationary-operand law once.
 - **Gate in the negative.** Enumerating admissible shapes is shape matching by another name. Walk the body and
   report the first thing the transform *fundamentally cannot do*, like `ir/stmt/algebra.classify_fragment_epilogue`
   (the epilogue folds unless it has an ineligible op/dependency) — the eligible set then grows with the renderer
@@ -220,6 +246,29 @@ How to comply:
   condition. See the dependence-cones section of `compiler/ir/ARCHITECTURE.md`.
 - **When generalizing an existing rule, normalize its incidental divergences** (one dtype rule, one index rule)
   and name the behavioral deltas explicitly in the commit — don't preserve two behaviors behind one entry point.
+
+Fusion and placement have separate ownership. Loop fusion forms the largest reasonable algebraic region subject to
+semantic preservation and its general work-duplication brakes; it never asks which GPU will run it, which schedule is
+available, or whether one kernel will be faster than two. Once recognition has built that region's term, the
+`PLACE@<path>` structural fork may keep it fused or materialize a closed subtree. Every resulting kernel then enters
+the same recognition and schedule paths independently. A scheduling gap is therefore repaired by extending the
+schedule domain or its placement choices, never by adding a profitability exception to fusion.
+
+Recognition is total over the algebra it accepts: a product contraction binds every additive channel sharing its A
+edge, and a root projection must bind every value it reads. If an optimized reading cannot preserve that complete
+term, recognition declines it and retains the general `Fold` spelling. A `PLACE` cut may expose a simpler term, but
+it cannot make a partial or open term legal. These are target-independent formation rules; hardware capabilities are
+consulted only when schedule and lowering choose a realizable primitive.
+
+This ownership boundary is executable: the pass contract test rejects context, hardware, search, schedule, and
+placement dependencies from `loop/fusion`. A new fusion condition must be justified only by algebraic correctness or
+bounded work duplication. Product names, workload provenance, schedule families, and placement keys belong later.
+
+The two-level tuner enforces the same boundary operationally. Its outer pipeline ends after `010_recognize`, where
+`PLACE` changes the kernel set; each terminal is a set of unmapped `TileOp`s priced by the sum of independently tuned
+kernels. The inner pipeline begins at `020_schedule`. Placement rows train the outer prior only, while schedule rows,
+node-store keys, O3 signatures, and kernel cache keys contain no `PLACE` metadata. Assembly lowers the measured outer
+winner directly rather than asking a later greedy schedule replay to reconstruct the kernel set.
 
 Loop fusion first keeps a contraction producer materialized when it fans out into the statistic and value paths of a
 downstream normalization. The N-way splicer shares repeated equal-coordinate demands, but this fan-out would duplicate
@@ -240,21 +289,19 @@ Fusion also lets a decomposed contraction's pointwise product reunite with its s
 upstream activation-bearing cone is spliced into the product. Otherwise pass order can materialize the full M×K×N
 product, whose work-growth then prevents the reduction merge; ordinary softmax/attention reduction order is unchanged.
 
-## Resolve the hardware-atom binding once, structurally, at the tile level
+## Resolve algebraic roles once; select hardware from the schedule
 
 The same invariant applies *across* the tile→kernel boundary: the kernel materializer must not re-recognize structure
-the tile IR already holds. The **atomize** step (`lowering/tile/_atomize.py`, called when a warp / register-tiled
-option is built — *not* a standalone pass) resolves the algebra→hardware-atom binding once at
-RECOGNIZE time (`010_recognize._nodify_contraction` / `_atomize.bind_prologue_contraction`) and feeds it into the
-contraction-shaped `Fold`, so materialize reads the operands /
-`acc` off the node and only `factorize`s (the projection is peeled off the wrapping zero-axis fold's `lift` — its one
-home). Resolving it before the schedule means an atom that **cannot** be
-bound (e.g. a non-`Load` operand — a computed-cone / demoted matmul) never gets built in the bilinear shape: its
-loads stay INLINE in a fold's lift, so the contraction reading (and with it the placed tiers) declines it instead of
+the tile IR already holds. The **atomize** helper (`lowering/tile/_atomize.py`, called by recognition rather than as a
+standalone pass) resolves target-independent operand roles once
+(`010_recognize._nodify_contraction` / `_atomize.bind_contraction_channels`) and feeds them into the
+contraction-shaped `Fold`. It does not select an instruction. Schedule enumeration later pairs that algebra with
+each hardware atom whose declared capabilities and operand laws fit; materialize reads the chosen pair and only
+`factorize`s it. An algebraic form that cannot be bound completely stays in the general `Fold` spelling instead of
 failing several passes later:
 
-- a `CONTRACTION` contraction → the `(a, b, acc, projection)` operand→role facts
-  (`_atomize.bind_contraction`): the operands are named by the ⊗ **lift** (the `Assign` the fold accumulates) — B is its
+- a `CONTRACTION` contraction → the shared A edge, every `(b_i, acc_i)` channel, and the projection
+  (`_atomize.bind_contraction_channels`): operands are named by each ⊗ **lift** — B is its
   (n, k)-indexed `Load`, A is the lift's other argument, either a plain `Load` (clean gmem-direct) or, when loop fusion
   has inlined an operand cone, the cone as a zero-axis `Fold` stored INLINE on an operand edge (`_atomize.make_cone`
   — a STAT-FREE computed A, which rides the `sync` compute-fill like the norm→linear cone but carries
@@ -272,9 +319,9 @@ failing several passes later:
   no let table, no reference arm, and no resolve step:
   every downstream reader takes the cone's K seam straight off the view's `a` edge (`ops.cone_seam`); `lower`
   flattens it once, at the point of use. **Edge iff closed holds by construction**: operands bind POSITIONALLY to
-  lift params, so an operand cannot see the fold's state or its siblings — the closure scan is demoted to the
-  validation reading (1q) and lives with its one consumer, the cut (`_cut._captured_values`); closure is the precondition for lifting any subtree into its own kernel (a placement
-  cut). Flash's `P = exp(s − m)` is `combine`'s derived singleton-specialization internals — material BELOW the seam
+  lift params, so an operand cannot see the fold's state or its siblings. The same lexical closure analysis validates
+  cut eligibility and the constructed root projection; closure is the precondition for lifting any subtree into its
+  own kernel. Flash's `P = exp(s − m)` is `combine`'s derived singleton-specialization internals — material BELOW the seam
   lattice, never a cut target — and flash's QK score is a hoisted operand edge of the kv stream (step 7): closed by
   construction, reading only the enclosing iteration var, never state. The derived PV contraction's A edge is
   precisely where "no reference arm" becomes visible: `P` is already in a register, and since an edge is a `Load` or
@@ -480,35 +527,25 @@ The fragment idiom's re-entry semantics are the rule's own: `030` opts its halve
 that emits plain un-mapped `LoopOp`s hands them back to `010_recognize` on the pass-scan restart. The shared fixpoint
 is what lets such rules compose without knowing about each other.
 
-**Placement routing (phase 4).** `PLACE@<child-path> = cut | fuse` is the per-seam edge property on the recognized
+**Placement (phase 4).** `PLACE@<child-path> = cut | fuse` is the per-seam edge property on the recognized
 tree — a `PLACE` site is every NON-ROOT node (the child names its parent↔child seam; the cone edge spells `PLACE@a`
-through the view-role label), spelled/resolved by the same tree-path codec as the schedule families. Resolution is
-TWO-LEVEL and RECURSIVE, decided BEFORE any schedule fork exists (`010_recognize` consults it right after the lift /
-prologue bind): a ROUTING golden entry — an ordinary kind entry whose knobs are `PLACE` keys ONLY (the cut set,
-never a schedule; the loader rejects a mixed entry, and the schedule golden tier skips routing entries, so the
-retired single-namespace hazards — a cut row tying its knob-identical fused twin — cannot return) — or an
-authoritative `PLACE` pin picks a cut seam; the realizer (`lowering/tile/_cut.py`) splits the tree there: the child
-subtree becomes a plain un-mapped `LoopOp` computing the seam value into a `…__cut_…` workspace over its DERIVED
-index space (the enclosing axes its lowered body reads, loop-invariantly nested; a fold child — one that FOLDS AN
-AXIS — bridges carrier state as **f32** per the split-reduce workspace rule, while a zero-axis projection child is
-the value seam and keeps its leaf operand dtype: in the one-kind IR every node is a `Fold`, so the axis is the
-discriminator, not the class), and the parent
-consumes a plain workspace `Load` (every edge admits `Load` — the cut terminal). Both pieces re-recognize as fresh
-roots on the pass-scan restart and resolve their OWN `(kind, shape)` entries through the full deploy hierarchy —
-recursively: the cone piece re-recognizes as the rms_norm shape and its own entry (or a bare pin) cuts the statistic
-out, yielding the cascade statistic + scale + plain matmul, every piece joining an EXISTING golden kind's evidence.
-Computed-A routing uses the fused-key convention on both sides: the live tree supplies the computed-A fact before a
-schedule offer exists, while a persisted `PLACE@a` supplies it for a stat-free activation cone with no second reduce
-axis. Keeping one key prevents the routing entry from recursively matching its own materialized producer.
-**Fuse is the default by ABSENCE** — no routing entry and no pin leaves recognition byte-untouched (digest-verified),
-and cut is evidence/pin-only. Cut legality is structural: single-component CLOSED children only (`_captured_values`
-in its demoted validation role — flash's state-capturing `P` is simply not cuttable), and the pure-copy degenerate
-(cutting an empty-body root projection's only operand, whose parent would merely copy the workspace out — the
-non-terminating case) is refused. Loop fusion brakes on `__cut_` workspace producers — a decided placement is not
-fusion's to undo (tune-mode slicing re-enters fusion with the pieces as ordinary pairs). The old `020_cut_edge` /
-`025_sink_row_reduce` / `032_fuse_finalize` realizers stay retired; their non-default placements return only as
-routing entries re-seeded by fresh `--ab` evidence (phase 5 — the 020-era `cut_cone_*` schedule entries stamp the
-OLD piece shapes' keys and are re-seeded rather than joined).
+through the view-role label), spelled/resolved by the same tree-path codec as the schedule families. Placement runs
+after algebra recognition and before schedule enumeration. With no authoritative evidence, `_cut.py` offers one
+structural fork containing the fused form first and one option for every realizable single-seam cut; all options spell
+the same seam-key set, with exactly one `cut` on each fragment choice. A cold deploy therefore preserves the maximal
+fused region, tuning measures both kernel sets, and a trusted deploy prior prices a cut as the sum of its kernels.
+
+A ROUTING golden (a `PLACE`-only record) or an authoritative pin collapses that fork before search. Routing records
+remain separate from schedule goldens: the loader rejects mixed records and the schedule tier skips routing entries.
+The structural choice persists in `Op.decision_knobs`, not `Op.knobs`, so it can replay across the source chain without
+polluting any resulting kernel's cache identity or schedule evidence.
+
+The realizer splits the selected child into a plain un-mapped `LoopOp` writing a `…__cut_…` workspace and a parent
+`LoopOp` consuming a workspace `Load`. The workspace index space is derived from enclosing axes; a fold-axis child
+bridges carrier state as f32, while a zero-axis value child keeps its leaf operand dtype. Both pieces re-recognize and
+schedule as fresh roots, recursively offering their own placement choices. Cut legality is structural: the child is
+single-component and closed, the parent is closed after substitution, the pure-copy non-terminating seam is refused,
+and a materialized fragment that fails Loop-IR SSA validation is not offered. Fusion never revisits this decision.
 
 The atom spec is subtyped by kind (`ir/atom.py`: `AtomKind` is the fixed mma cell selected by name; `ScalarAtom`
 is the plain scalar fma cell). The contraction binder (`bind_contraction`) is loop-addressable so warp-flash can later

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -163,12 +163,13 @@ enumeration cannot schedule yields NO rows and stays unmapped: the guardrail con
 still compile on the materializer's per-cell path, so what is missing is schedule coverage, never a compile.
 
 **The streaming pair, site by site.** A fold whose DERIVED evaluation contracts (`_schedule._streams` — structural,
-never the `TWISTED` role) keeps its children as sites: the hoisted QK score edge and the synthesized P@V. Each
-enumerates its own half of `twisted_warp_moves`' free geometry — the key-atom / query-tile pair, since `warps_m` is
-the inventory and lives once in `WORK` — and the pair is reconciled at the STREAM (`_legality.twisted_sites_agree`:
-the P@V rows are the score's rows, its K-chunk is the streamed key block). That reconciliation is the whole reason
-the enumeration recurses: two sites that must agree cannot be a product over one node's families. The stream itself
-then decides what only it can see — the K/V transport, sized against the geometry its children chose
+never the `TWISTED` role) keeps its score and synthesized P@V as sites. The score is normally the hoisted QK edge; if
+PLACE materialized that edge, the stream itself is the score site and reads its `(m, kv)` `Load`. Each enumerates its
+own half of `twisted_warp_moves`' free geometry — the key-atom / query-tile pair, since `warps_m` is the inventory and
+lives once in `WORK` — and the pair is reconciled at the STREAM (`_legality.twisted_sites_agree`: the P@V rows are
+the score's rows, its K-chunk is the streamed key block). That reconciliation is the whole reason the enumeration
+recurses: two sites that must agree cannot be a product over one node's families. The stream itself then decides
+what only it can see — the K/V transport, sized against the geometry its children chose
 (`_legality.resolve_twisted_stage`, including the `split` per-edge groups that also stage Q), and the cross-CTA
 split-KV `030_split_reduce` realizes as partial + LSE finalize. The **chain** is the same P@V site under the `""`
 inventory (the value axis leaves the grid for a per-thread register vector); the **per-cell / cooperative** forms are
@@ -251,8 +252,9 @@ Fusion and placement have separate ownership. Loop fusion forms the largest reas
 semantic preservation and its general work-duplication brakes; it never asks which GPU will run it, which schedule is
 available, or whether one kernel will be faster than two. Once recognition has built that region's term, the
 `PLACE@<path>` structural fork may keep it fused or materialize a closed subtree. Every resulting kernel then enters
-the same recognition and schedule paths independently. A scheduling gap is therefore repaired by extending the
-schedule domain or its placement choices, never by adding a profitability exception to fusion.
+the same placement and schedule paths independently while retaining its recognized algebra. A scheduling gap is
+therefore repaired by extending the schedule domain or its placement choices, never by adding a profitability
+exception to fusion.
 
 Recognition is total over the algebra it accepts: a product contraction binds every additive channel sharing its A
 edge, and a root projection must bind every value it reads. If an optimized reading cannot preserve that complete
@@ -261,14 +263,20 @@ it cannot make a partial or open term legal. These are target-independent format
 consulted only when schedule and lowering choose a realizable primitive.
 
 This ownership boundary is executable: the pass contract test rejects context, hardware, search, schedule, and
-placement dependencies from `loop/fusion`. A new fusion condition must be justified only by algebraic correctness or
-bounded work duplication. Product names, workload provenance, schedule families, and placement keys belong later.
+placement dependencies from `loop/fusion`, and rejects hardware capabilities from recognition. A new fusion
+condition must be justified only by algebraic correctness or bounded work duplication. Product names, workload
+provenance, schedule families, placement keys, and GPU identities belong later. Recognition may describe primitive
+requirements structurally, but only schedule/lowering may ask `Context` whether the target supplies them. Those
+checks use named capabilities and atom metadata, never a product name or an isolated SM-number branch; measured
+GPU-specific goldens may select among generic paths but may not define one.
 
-The two-level tuner enforces the same boundary operationally. Its outer pipeline ends after `010_recognize`, where
-`PLACE` changes the kernel set; each terminal is a set of unmapped `TileOp`s priced by the sum of independently tuned
-kernels. The inner pipeline begins at `020_schedule`. Placement rows train the outer prior only, while schedule rows,
-node-store keys, O3 signatures, and kernel cache keys contain no `PLACE` metadata. Assembly lowers the measured outer
-winner directly rather than asking a later greedy schedule replay to reconstruct the kernel set.
+The two-level tuner enforces the same boundary operationally. Its outer pipeline runs `010_recognize` and then
+`015_place` to a graph-level fixpoint; each terminal is a resolved set of unmapped `TileOp`s priced by the sum of
+independently tuned kernels. This derived sum selects placement during search; it is not an assembled whole-program
+latency. The inner pipeline begins at `lowering/schedule/020_schedule`. Placement rows train the outer prior only,
+while schedule rows, node-store keys, O3 signatures, and kernel cache keys contain no `PLACE` metadata. Assembly
+lowers the selected outer terminal directly rather than asking a later greedy schedule replay to reconstruct the
+kernel set.
 
 Loop fusion first keeps a contraction producer materialized when it fans out into the statistic and value paths of a
 downstream normalization. The N-way splicer shares repeated equal-coordinate demands, but this fan-out would duplicate
@@ -516,16 +524,17 @@ grammar it read).
 
 ## The divide rule: `split` an iteration axis
 
-`lowering/tile` carries one one-kernel→graph-fragment rule:
+`lowering/schedule` carries one schedule-realization one-kernel→graph-fragment rule:
 
 - **`030_split_reduce`** splits the **reduce axis** (the REDUCE codec's `g<w>` cross-CTA shard): the SAME
   computation, its K partitioned across CTAs into a partial + finalize. It runs AFTER its decision — the `g` row was
   chosen FOR the split form — so the partial carries the decided knob row verbatim and the finalize is deliberately
   `_mapped`: both **opt out** of re-recognition, because re-entering would discard the very decision being realized.
 
-The fragment idiom's re-entry semantics are the rule's own: `030` opts its halves OUT of recognition, while a rule
-that emits plain un-mapped `LoopOp`s hands them back to `010_recognize` on the pass-scan restart. The shared fixpoint
-is what lets such rules compose without knowing about each other.
+The fragment idiom's re-entry semantics are the rule's own: `030` emits already mapped halves, so neither placement
+nor scheduling revisits the selected split. Placement emits unmapped recognized pieces instead; the structural pass
+reaches its graph-level fixpoint before `lowering/schedule` begins. A schedule therefore cannot race ahead of a newly
+created placement piece.
 
 **Placement (phase 4).** `PLACE@<child-path> = cut | fuse` is the per-seam edge property on the recognized
 tree — a `PLACE` site is every NON-ROOT node (the child names its parent↔child seam; the cone edge spells `PLACE@a`
@@ -534,18 +543,22 @@ after algebra recognition and before schedule enumeration. With no authoritative
 structural fork containing the fused form first and one option for every realizable single-seam cut; all options spell
 the same seam-key set, with exactly one `cut` on each fragment choice. A cold deploy therefore preserves the maximal
 fused region, tuning measures both kernel sets, and a trusted deploy prior prices a cut as the sum of its kernels.
+Recognition rules that return a graph fragment obey the same boundary: its output `TileOp` is matched in the full
+graph by `015_place`, while constants and other internal producers remain intact around either result.
 
 A ROUTING golden (a `PLACE`-only record) or an authoritative pin collapses that fork before search. Routing records
 remain separate from schedule goldens: the loader rejects mixed records and the schedule tier skips routing entries.
 The structural choice persists in `Op.decision_knobs`, not `Op.knobs`, so it can replay across the source chain without
 polluting any resulting kernel's cache identity or schedule evidence.
 
-The realizer splits the selected child into a plain un-mapped `LoopOp` writing a `…__cut_…` workspace and a parent
-`LoopOp` consuming a workspace `Load`. The workspace index space is derived from enclosing axes; a fold-axis child
-bridges carrier state as f32, while a zero-axis value child keeps its leaf operand dtype. Both pieces re-recognize and
-schedule as fresh roots, recursively offering their own placement choices. Cut legality is structural: the child is
-single-component and closed, the parent is closed after substitution, the pure-copy non-terminating seam is refused,
-and a materialized fragment that fails Loop-IR SSA validation is not offered. Fusion never revisits this decision.
+The realizer splits the selected child into an unmapped `TileOp` writing a `…__cut_…` workspace and a parent `TileOp`
+consuming a workspace `Load`. The workspace index space is derived from enclosing axes; a fold-axis child bridges
+carrier state as f32, while a zero-axis value child keeps its leaf operand dtype. Both pieces preserve their existing
+`Fold` trees, recursively offer their own placement choices, and then schedule as independent roots. Placement never
+lowers a term to Loop IR and asks recognition to rediscover it: doing so can erase a contraction with computed
+operands and turn a schedulable tensor-core term into a scalar fold. Cut legality is structural: the child is
+single-component and closed, the parent is closed after substitution, and the pure-copy non-terminating seam is
+refused. Fusion never revisits this decision.
 
 The atom spec is subtyped by kind (`ir/atom.py`: `AtomKind` is the fixed mma cell selected by name; `ScalarAtom`
 is the plain scalar fma cell). The contraction binder (`bind_contraction`) is loop-addressable so warp-flash can later
@@ -607,12 +620,13 @@ conservative one-warp / `2·atom_n` block / one tile; the third dimension is the
 each warp streams `fm` independent `(m, l, O)` chains against shared K/V fragments, FA-2's in-flight ILP; the Q@K /
 P@V mma `TilePlan`s are the two sites' own values, reconciled at the stream), the scalar
 register-vector CHAIN (the FA-2 shared-score form), then the cooperative / per-cell reduce-partition escapes — every
-leaf row spelling the same `TILE@dd` / `TILE@pj` key pair plus the BARE `REDUCE` / `STAGE` the stream is primary for,
+leaf row spelling the same `TILE@dd` / `TILE@pj` key pair plus the BARE `REDUCE` / `STAGE` the stream is primary for
+(`TILE` / `TILE@pj` after PLACE materializes the score and makes the stream the primary score site),
 and its ONE `WORK` inventory (decided-empty where a form doesn't tile). The **flash split-KV** rows are fork siblings
 of the un-split warp rows on an under-occupied grid (the occupancy read is the warp row's OWN launch grid — the
 shrunk query axis, the value axis gone), and a cross-CTA `REDUCE=g<n>k` pin selects them: the plan stamps
-onto each row's `Fold` node and `030_split_reduce` realizes it as a fragment-resident partial (the kv stream windowed to
-the CTA's slice, its absolute base/bound on the sliced axis's `Axis.window`; raw `(m, l, O)` state to an f32
+onto each row's `Fold` node and `030_split_reduce` realizes it as a fragment-resident partial (the kv stream windowed
+to the CTA's slice, its absolute base/bound on the sliced axis's `Axis.window`; raw `(m, l, O)` state to an f32
 `__partial` workspace) plus
 an LSE-combine finalize — kernel finalize only (the twisted `e^{Δm}` rescale can't be an atomic). A static kv must be
 block-divisible; a **symbolic kv splits too**: the slice width is the bn-aligned runtime `ceil(S/(cta·bn))·bn` (a

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/050_fold_into_constant.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/050_fold_into_constant.py
@@ -23,6 +23,7 @@ Companion rule ``060_fold_reshape_into_constant`` does the same for
 
 from __future__ import annotations
 
+from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Node, Tensor
 from emmy.compiler.ir.frontend.ir import TransposeOp
 from emmy.compiler.pipeline import Match, Pattern
@@ -31,6 +32,6 @@ from emmy.compiler.pipeline.passes.frontend.decomposition._fold_constant import 
 PATTERN = [Pattern("root", TransposeOp)]
 
 
-def rewrite(match: Match, root: Node, inp_x: Node, out: Tensor) -> Graph | None:
+def rewrite(match: Match, root: Node, inp_x: Node, out: Tensor, ctx: Context) -> Graph | None:
     graph = match.graph
-    return fold_into_constant(graph, root, inp_x, out)
+    return fold_into_constant(graph, root, inp_x, out, ctx)

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/060_fold_reshape_into_constant.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/060_fold_reshape_into_constant.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Node, Tensor
 from emmy.compiler.ir.frontend.ir import ReshapeOp
 from emmy.compiler.pipeline import Match, Pattern
@@ -11,6 +12,6 @@ from emmy.compiler.pipeline.passes.frontend.decomposition._fold_constant import 
 PATTERN = [Pattern("root", ReshapeOp)]
 
 
-def rewrite(match: Match, root: Node, inp_x: Node, out: Tensor) -> Graph | None:
+def rewrite(match: Match, root: Node, inp_x: Node, out: Tensor, ctx: Context) -> Graph | None:
     graph = match.graph
-    return fold_into_constant(graph, root, inp_x, out)
+    return fold_into_constant(graph, root, inp_x, out, ctx)

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/_fold_constant.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/_fold_constant.py
@@ -29,11 +29,11 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Node, Tensor
 from emmy.compiler.ir.base import ConstantOp
 from emmy.compiler.pipeline import RuleSkipped
 from emmy.compiler.pipeline.passes.frontend.decomposition._helpers import open_fragment
-from emmy.compiler.target import compute_capability
 
 
 def _feeds_only_matvecs(graph: Graph, root: Node) -> bool:
@@ -70,7 +70,7 @@ def _feeds_only_matvecs(graph: Graph, root: Node) -> bool:
     return bool(verdicts) and all(verdicts)
 
 
-def fold_into_constant(graph: Graph, root: Node, inp_x: Node, out: Tensor) -> Graph | None:
+def fold_into_constant(graph: Graph, root: Node, inp_x: Node, out: Tensor, ctx: Context) -> Graph | None:
     """Append ``root.op`` to ``inp_x.op.load_ops`` and rebuild the constant.
 
     Skips scalar constants (``value is not None``) — the loader never
@@ -79,8 +79,8 @@ def fold_into_constant(graph: Graph, root: Node, inp_x: Node, out: Tensor) -> Gr
     """
     from emmy.compiler.ir.frontend.ir import TransposeOp  # noqa: PLC0415
 
-    if compute_capability() < (9, 0) and not (isinstance(root.op, TransposeOp) and _feeds_only_matvecs(graph, root)):
-        raise RuleSkipped("TMA path inactive (compute capability < sm_90) and not an M=1 matvec weight — fold not needed")
+    if not ctx.has_tma and not (isinstance(root.op, TransposeOp) and _feeds_only_matvecs(graph, root)):
+        raise RuleSkipped("TMA path inactive and not an M=1 matvec weight — fold not needed")
     if not isinstance(inp_x.op, ConstantOp):
         raise RuleSkipped("input is not a ConstantOp")
     if inp_x.op.value is not None:

--- a/emmy/compiler/pipeline/passes/lowering/_reduction.py
+++ b/emmy/compiler/pipeline/passes/lowering/_reduction.py
@@ -4,7 +4,7 @@ dtypes)``. This is a LOWERING helper, not IR vocabulary: the stored term keeps e
 program (the flat ``combine``), and everything here — the state⊕state re-emission, the one-shot
 :class:`~emmy.compiler.ir.stmt.algebra.StateMerge`, the per-component seeds, the twist facts —
 is derived on demand at the two consumers, the kernel materializer (``lowering/kernel/_factor``
-and friends) and the cross-CTA split (``lowering/tile/030_split_reduce``). Nothing else reads it.
+and friends) and the cross-CTA split (``lowering/schedule/030_split_reduce``). Nothing else reads it.
 
 Leading ``_`` so the pass loader skips this module."""
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -23,7 +23,7 @@ kind, sealed through the one `grid_tile` finalizer (the article's "schedule sepa
   (mma / scalar). An unbindable contraction (a non-`Load` operand) keeps the `Map` form and falls through to the
   degenerate arm here. (This build was a separate `005_contract` pass, then folded into materialize, and now lives
   recognize-side so the node exists before scheduling; the schedule only PLACES it, and declines with
-  `LoweringError` when there is no `(m, n)` grid pair to place onto.)
+  no output-tile row when there is no `(m, n)` grid pair to place onto.)
 - **REDUCE-tiled** (`_tile_reduce_axis`, a `PLANAR` / `TWISTED` reduce — or a non-output-tiled `CONTRACTION` — whose
   `ReducePlan` cooperates / register-folds) — the reduce axis is tiled instead: `coop` lanes across the CTA's threads
   (its unit level) and `reg` ILP chains across per-thread accumulators (its register level), then a REG-tree fold, the
@@ -34,8 +34,10 @@ kind, sealed through the one `grid_tile` finalizer (the article's "schedule sepa
 
 ### The recursive node walk (`_emit`) — one hierarchical emitter
 
-Two recursions cooperate. The **root** recursion `_factorize(op, ctx, tail, out_val)` binds a node to the grid: a `Map`
-with a `source` recurses (projection → `tail`), the leaf binds via the one `_bind` pipeline. The **body**
+Two recursions cooperate. The **root** recursion `_factorize(op, ctx, tail, out_val)` binds a node to the grid: a
+zero-axis projection over a structural node recurses (projection → `tail`), while one whose placement edge terminates
+at a materialized `Load` flattens that load into the per-cell projection body; the leaf binds via the one `_bind`
+pipeline. The **body**
 recursion `_emit(op, ctx) -> Frag` builds the per-cell loop-IR — over the `Map` / `Fold` tree,
 through **`source` AND `partial`** — threading a `Ctx` **down** (the ambient cell environment: the grid axes, operand
 `inputs`, `stage`, output buffer) and returning a `Frag` **up** (the per-cell `body` this node contributes, the produced
@@ -349,14 +351,16 @@ is the placement-keyed fold's **fragment row**: where the scalar tier folds in-t
 fold is a `FragmentRowReduce` `__shfl` butterfly over the C-fragment lanes. The fold MOVE itself is never re-decided
 per site: `ReduceStage.combine` (`ir/schedule.py`) is the ONE placement-keyed selector — within-warp → `SHFL`,
 within-block → `SHFL`+`SMEM` tree, cross-CTA → `ATOMIC`/`KERNEL` — and every emitter consumes its output
-(`emit_combine` at scalar residence, this realizer at fragment residence, `030_split_reduce` as the graph rewrite); only the
-residence-specific realization differs. Everything realizes from structure — the
-head contraction's `ldmatrix`/`mma.sync` off its node geometry (`_frag_contraction`); the score prologue stmt-by-stmt
+(`emit_combine` at scalar residence, this realizer at fragment residence, `030_split_reduce` as the graph rewrite);
+only the residence-specific realization differs. Everything realizes from structure — the head contraction's
+`ldmatrix`/`mma.sync` off its node geometry (`_frag_contraction`), or a PLACE-materialized score's gmem `Load` into
+the identical C-fragment lane map (`FragmentLoad`, with staging decided empty); the score prologue stmt-by-stmt
 (`Assign` → `FragmentApply`, a coordinate `Select` → `FragmentMask` with the keep-predicate negated, an
 `(m, kv)`-indexed additive bias `Load` + `add` — SDPA's explicit `attn_mask`, the HF precomputed causal /
 sliding-window band — → a per-fragment `FragmentBiasAdd` reading the mask at each element's absolute coordinates
 (previously the whole kernel demoted to the scalar tier — every real-model gemma attention layer at seq > window),
-loop-invariant constant `Load`s hoisted); the streaming merge REGENERATED from the carrier's channel spec (pivot → rowmax + running
+loop-invariant constant `Load`s hoisted); the streaming merge REGENERATED from the carrier's channel spec (pivot →
+rowmax + running
 stats + α-rescale; denom → rowsum; the expect channel's ⊗ `lift` IS the P@V node, the register-resident P converted
 straight into its A-operand fragments by the **C→A register repack** (`FragmentRepack` — the `AtomKind.c_to_a_repack`
 lane-map compatibility: the m16n8 C fragment is elementwise lane-aligned with the m16k16 A fragment's k-halves, so

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -252,12 +252,19 @@ state component: O rides the normal fragment store into the f32 `__partial` work
 **Inline operands — the mma tier's `sync` transport.** A matmul with a pure producer cone on either operand reaches
 the warp tier through a COMPUTED edge: recognition stores the producer tree inline on that edge
 (`_atomize.make_cone`), and the schedule offers a MANDATORY resolved `sync` `Stage` (there is no gmem-direct sibling —
-a copy transport cannot evaluate a cone). `_staged` builds a `SyncTransport` whose computed A or B fill evaluates
+a copy transport cannot evaluate a cone). A multi-channel product uses the same mandatory transport even when all
+edges are materialized, because the direct emitters carry one B/C channel while `sync` allocates one slab and
+fragment chain per channel. `_staged` builds a `SyncTransport` whose computed A or B fill evaluates
 ordinary scalar tensor algebra per shared-memory slab cell, feeding the unchanged `ldmatrix` drain. A is stored in
 canonical `(tile_m × bk)` geometry and B in canonical `(bk × tile_n)` geometry. Materialized peer operands use the
 same vectorized `cp.async` path as ordinary staged matmul, so a generic compact-storage B producer can be evaluated
 directly into Tensor Core fragments without first constructing its expanded dense matrix. This facility is defined
 entirely in generic tensor/loop IR; checkpoint formats are already dissolved before it is selected.
+
+Any materialized edge under `sync` requires the target's `cp.async` capability because that is the transport's copy
+lane. If the capability, exact-cover geometry, dtype, or shared-memory budget declines the warp row, the product's
+demoted `Fold` reading remains schedulable by the general reduce path. Lowering assertions remain backstops; an
+unsupported transport is never emitted as a schedule candidate.
 
 The compute fill assigns each thread a contiguous run of slab cells (the row/col derivation hoists out of the
 per-cell code and the cone replicates with a `__c<j>` SSA suffix). A materialized canonical B uses the K-major

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_factor.py
@@ -235,6 +235,11 @@ def _factorize(op, ctx: Ctx, tail: tuple, out_val: str, store=None, stores: tupl
     P@V contractions and its streaming reduce factorize through this one walk (scalar block=1
     today; a nested warp-tiled contraction routes through the ``_emit`` contraction seam). A
     bespoke emitter would be a divergent codegen path the mandate forbids."""
+    if (isinstance(op, Fold) and op.axis is None) and op.operands and all(isinstance(edge, Load) for edge in op.operands):
+        # A placement cut may terminate every projection edge at a workspace Load. The stored
+        # zero-axis Fold explicitly permits that edge, so flatten those loads into the cell before
+        # binding instead of recursing as though the edge were another structural node.
+        op = Fold.projection(body=Body((*op.operands, *op.body)))
     if (isinstance(op, Fold) and op.axis is None) and op.operands:
         proj = _emit_body(op.body, ctx)
         if stores:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -60,6 +60,7 @@ from emmy.compiler.ir.kernel.ir import (
     TmaLoad,
 )
 from emmy.compiler.ir.stmt import Body, Cond, Load, Loop, Stmt, StridedLoop, Write
+from emmy.compiler.ir.tile.ir import deep_defines
 
 
 def _mul(a: Expr, b: Expr) -> Expr:
@@ -553,7 +554,7 @@ class SyncTransport:
                 plans.append("vector")
             else:
                 plans.append("cell")
-            cell_defs |= set(a.defines())
+            cell_defs |= deep_defines(a)
         return plans
 
     def fill(self, *, k0: Expr, slot: Expr, k0_cur: Expr | None = None) -> list[Stmt]:
@@ -606,7 +607,7 @@ class SyncTransport:
             # binding every cell's suffixed name (one 16 B ld like the cp.async fill, instead of V
             # scalar loads — the compute fill issued 3.6x cuBLAS's LSU instructions). Everything
             # else replicates per cell as before.
-            local = {nm for p, st in enumerate(cell_stmts[0]) if plans[p] != "hoist" for nm in st.defines()}
+            local = {nm for p, st in enumerate(cell_stmts[0]) if plans[p] != "hoist" for nm in deep_defines(st)}
             for p in range(len(cell_stmts[0])):
                 if plans[p] == "hoist":
                     body.append(cell_stmts[0][p])

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_twist.py
@@ -1,15 +1,16 @@
 """The fragment realizer — a TWISTED carrier realized at WARP-FRAGMENT residence.
 
 The one ``_bind`` pipeline calls :func:`realize_warp_twist` when the reduce arm's tree carries a
-warp tile (:func:`warp_source` — the stream's head contraction stamped with an mma
+warp tile (:func:`warp_source` — the stream's score site stamped with an mma
 :class:`TilePlan` by the schedule): the streaming reduce keeps its per-step values in mma
 C-fragments instead of scalars, so every piece of the scalar lowering is *realized* at the new
 residence — the fragment row of the placement-keyed fold (a within-warp ``FragmentRowReduce``
 ``__shfl`` move where the scalar tier folds in-thread):
 
-- the head contraction (Q@K) emits ``ldmatrix`` + ``mma.sync`` into score C-fragments off its node
-  geometry (:func:`_frag_contraction` — operands / ``b_trans`` / guards from the node, the atom
-  counts from its stamped ``TilePlan``);
+- a computed head contraction (Q@K) emits ``ldmatrix`` + ``mma.sync`` into score C-fragments off
+  its node geometry (:func:`_frag_contraction` — operands / ``b_trans`` / guards from the node,
+  the atom counts from its stamped ``TilePlan``); a PLACE-materialized score loads the workspace
+  into the identical C-fragment lane map with :class:`FragmentLoad`;
 - the score prologue (the scale ``Assign``, the causal ``Select``, the explicit additive mask) is
   realized stmt-by-stmt (:func:`_realize_prologue`): a pointwise ``Assign`` → :class:`FragmentApply`,
   a coordinate-predicated ``Select`` → :class:`FragmentMask` (the keep-predicate negated), an
@@ -27,7 +28,7 @@ residence — the fragment row of the placement-keyed fold (a within-warp ``Frag
   no smem round-trip, no sync; gated at schedule time);
 - the projection tail (``O / l``) realizes as an in-place ``FragmentApply`` + the ``RegStore``
   output close;
-- a resolved K/V ``Stage`` on the streaming ``Fold`` node (resolved schedule-side,
+- a resolved K/V ``Stage`` on a computed-score streaming ``Fold`` node (resolved schedule-side,
   cp.async or TMA over a block-divisible-or-symbolic kv) re-parents the streaming step under the same
   ``staged_kloop`` skeleton the matmul tier runs: the K/V slabs fill per KV block (each in its
   operand's own layout — verbatim row copies, so staged stays bit-identical to gmem-direct) and
@@ -57,6 +58,7 @@ from emmy.compiler.ir.kernel.ir import (
     UNIFORM,
     FragmentApply,
     FragmentBiasAdd,
+    FragmentLoad,
     FragmentMask,
     FragmentPromote,
     FragmentRepack,
@@ -70,7 +72,7 @@ from emmy.compiler.ir.kernel.ir import (
 from emmy.compiler.ir.schedule import FoldMove, Level, ReduceStage, TilePlan
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Assign, Body, Cond, Init, Load, Select, Stmt, StridedLoop, Write
-from emmy.compiler.ir.tile.ir import Fold, is_contraction
+from emmy.compiler.ir.tile.ir import Fold, is_contraction, operand_name
 from emmy.compiler.ir.tile.ops import head, stream_pair
 from emmy.compiler.pipeline.passes.lowering._addr import gmem_row_stride
 from emmy.compiler.pipeline.passes.lowering.kernel._atom import _clamp_last, _f16acc, unroll_ok
@@ -114,21 +116,20 @@ _NEGATE = {"<=": ">", "<": ">=", ">=": "<", ">": "<=", "==": "!="}
 
 
 def warp_source(op, sched):
-    """The warp-tiled stream-head fold of a ``TWISTED`` :class:`Fold` tree
-    (``op`` bare or under a projecting :class:`Fold`), or ``None`` — the structural schedule read
-    the one binder keys the fragment realization on (like ``plan.coop`` keys the lane tiling).
-    Returns the STORED ``role=CONTRACTION`` fold — its warp tile is a schedule slice
-    (``sched`` — the ``TileOp.schedule`` view, 1r), never a node field;
-    :func:`realize_warp_twist` derives the full views itself."""
+    """The schedule site carrying a warp-tiled score of a streaming :class:`Fold`, or ``None``.
+
+    A computed score carries the slice on its contraction edge; after PLACE materializes that
+    edge, the stream carries the same score-fragment geometry. Both are schedule slices, never
+    node fields, and :func:`realize_warp_twist` derives the full views itself."""
     red = head(op)  # the compute node through the projection wrapper — ONE accessor, not a ternary
     if red is None:
         return None
-    stmts = red.step_stmts()
-    first = stmts[0] if stmts else None
-    if first is not None and is_contraction(first):
-        htile = sched.tile_of(first)
+    score, pv = stream_pair(red)
+    site = red if isinstance(score, Load) else score
+    if site is not None and pv is not None:
+        htile = sched.tile_of(site)
         if htile is not None and htile.is_warp:
-            return first
+            return site
     return None
 
 
@@ -301,19 +302,17 @@ def _frag_contraction(
     return out
 
 
-def _realize_prologue(stmts, qk: Fold, tile: TilePlan, frags: tuple[str, ...], col_bases, row_base: Expr, state) -> tuple[list, list]:
+def _realize_prologue(stmts, score: str, tile: TilePlan, frags: tuple[str, ...], col_bases, row_base: Expr, state) -> tuple[list, list]:
     """Realize the score prologue (the plain stmts between the head contraction and the carrier's
     streaming merge) at fragment residence, stmt kind by stmt kind. Returns ``(hoisted, stream)`` —
     the loop-invariant scalar ``Load``\\ s (hoisted above the stream when a realized stmt reads
     them) and the in-stream fragment stmts. Stops at the first stmt touching a carrier state name —
     from there the merge is REGENERATED from the channel spec, not walked.
 
-    Node and slice travel as a PAIR, like everywhere else in this layer: the value name the walk
-    threads is the score's own accumulator (algebra — the node's), while the coordinates it
-    substitutes are the placed geometry's (the slice's)."""
+    ``score`` is the algebraic score edge's bound value name — a computed contraction accumulator
+    or a materialized Load result. The coordinates come from the placed score slice."""
     hoisted: list[Load] = []
     stream: list[Stmt] = []
-    score = qk.acc
     m_name, n_name = tile.axes[0].name, tile.axes[1].name
     # An additive score bias (the explicit SDPA ``attn_mask``): a per-``(m, kv)`` tensor ``Load``
     # awaiting its ``add`` — realized as a :class:`FragmentBiasAdd` per score fragment when the add
@@ -420,13 +419,16 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
     output fragments + hoisted scalars; fold = the streaming :class:`StridedLoop`; close = the
     realized projection + the fragment output store). See the module docstring for the walk."""
     red: Fold = head(op)
-    partial = list(red.step_stmts())
-    # The stored steps are contraction folds; the realizer works on their DERIVED views. Both
+    prologue = list(red.lift.body)
+    # The realizer works on the stream's score edge and derived P@V view. Both
     # slices arrive ALREADY PLACED from ``Sched.tile_of`` — the query / value axes off the
     # placement's free axes, the score's stream axis off its parent fold read through a slice
     # partial's window PARENT — so this reader states no placement rule of its own.
-    qk, pv = stream_pair(red)
-    qk_t: TilePlan = ctx.sched.tile_of(qk)
+    score, pv = stream_pair(red)
+    materialized_score = isinstance(score, Load)
+    qk = score if isinstance(score, Fold) else None
+    score_name = operand_name(score)
+    qk_t: TilePlan = ctx.sched.tile_of(red if materialized_score else qk)
     pv_t: TilePlan = ctx.sched.tile_of(pv)
     atom = qk_t.atom
     shape = atom.shape
@@ -486,7 +488,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
     # subtracted; an above-the-diagonal slice goes negative and the loop runs zero steps).
     kv_end: Expr | None = local_kv_end  # a symbolic slice stops at its own end even un-causal
     cta_rows = Literal(um * fm * shape[0], "int")
-    if _causal_stream(partial[1:], qk_t):
+    if _causal_stream(prologue, qk_t):
         causal_rows = BinaryExpr("*", BinaryExpr("+", Var(grid[-1].name), Literal(1, "int")), cta_rows)
         if kv_off is not None:
             causal_rows = BinaryExpr("-", causal_rows, kv_off)
@@ -501,7 +503,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
     # start is slice-local (base subtracted; a below-the-band slice floors past its own end and the
     # loop runs zero steps). Truncating '/' on a negative pre-max value is dodged by the ternary.
     kv_start: Expr | None = None
-    window = _banded_stream(partial[1:], qk_t)
+    window = _banded_stream(prologue, qk_t)
     if window is not None:
         start_rows: Expr = BinaryExpr("-", BinaryExpr("*", Var(grid[-1].name), cta_rows), Literal(window - 1, "int"))
         if kv_off is not None:
@@ -539,11 +541,11 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
                 row_base=_row_base(i),
                 pivot=f"{pivot_name}{sfx}",
                 denom=f"{denom_name}{sfx}",
-                sfrags=tuple(f"{qk.acc}{sfx}_f{t}" for t in range(nt)),
+                sfrags=tuple(f"{score_name}{sfx}_f{t}" for t in range(nt)),
                 pfrags=tuple(f"_p{sfx}_f{t}" for t in range(nt)),
                 ofrags=tuple(f"{expect_name}{sfx}_f{j}" for j in range(nd)),
                 ohfrags=tuple(f"{expect_name}{sfx}_h{j}" for j in range(nd)) if pv_f16acc else (),
-                qa=tuple(f"_{qk.acc}{sfx}_a{s}" for s in range(qk_t.bk)),
+                qa=tuple(f"_{score_name}{sfx}_a{s}" for s in range(qk_t.bk)) if qk is not None else (),
                 pa=tuple(f"_pa{sfx}{s}" for s in range(pv_bk)) if pv_bk > 1 else (f"_pa{sfx}",),
             )
         )
@@ -555,23 +557,26 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
     # once, its A fragments ldmatrix'd per atom-K chunk INSIDE the stream — the freed resident
     # registers are what make the wide (64-key) block fit.
     stage = ctx.sched.get("STAGE", red)
+    assert not materialized_score or stage is None, "materialized-score warp streams are gmem-direct"
     split = stage is not None and stage.split
     is_tma = stage is not None and stage.transport == "tma"
     elem_bytes = atom.operand_dtype("b").nbytes
     kv_pad = 0 if is_tma else _PAD
-    k_swz = pick_swizzle_atom(qk.axis.extent.as_static(), elem_bytes)[1] if is_tma else "NONE"
+    k_swz = pick_swizzle_atom(qk.axis.extent.as_static(), elem_bytes)[1] if is_tma and qk is not None else "NONE"
     v_swz = pick_swizzle_atom(d_v, elem_bytes)[1] if is_tma else "NONE"
-    head_dim_s = qk.axis.extent.as_static()
+    head_dim_s = qk.axis.extent.as_static() if qk is not None else 0
     q_ldm = head_dim_s + _PAD  # the staged-Q slab row stride (padded, like the cp.async K/V rows)
     # Gmem-direct fragment ROW strides, derived from each operand's load index + buffer shape
     # (``gmem_row_stride``) — NOT the trailing-axis extent: an un-transposed ``(B, S, H, D)``
     # trace strides its rows by ``H·D``, and the old ``head_dim`` assumption read the wrong rows
     # (the gemma layer-0 NaN). Canonical ``(batch…, row, dd)`` layouts derive the same values as
     # before (bit-identical). The schedule gate guarantees derivability.
-    q_gmem_ldm = gmem_row_stride(qk.a, qk_t.axes[0].name, ctx.inputs)
-    k_gmem_ldm = gmem_row_stride(qk.b, qk_t.axes[1].name if qk.b_trans else qk.axis.name, ctx.inputs)
+    q_gmem_ldm = gmem_row_stride(qk.a, qk_t.axes[0].name, ctx.inputs) if qk is not None else None
+    k_gmem_ldm = gmem_row_stride(qk.b, qk_t.axes[1].name if qk.b_trans else qk.axis.name, ctx.inputs) if qk is not None else None
     v_gmem_ldm = gmem_row_stride(pv.b, pv_t.axes[1].name if pv.b_trans else kv_axis.name, ctx.inputs)
-    assert q_gmem_ldm and k_gmem_ldm and v_gmem_ldm, "warp twist: underivable gmem row stride (schedule-gate breach)"
+    assert v_gmem_ldm and (materialized_score or (q_gmem_ldm and k_gmem_ldm)), (
+        "warp twist: underivable gmem row stride (schedule-gate breach)"
+    )
 
     def _q_frag_stmts(qt, i: int) -> list[Stmt]:
         """The query tile's ``bk`` A-fragment declarations + loads. Resident form (default): gmem
@@ -579,6 +584,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
         from the staged Q slab (slab-local rows — the tile's offset within the CTA's query block),
         block-scoped so the registers die each step. Same values either way: bit-identical."""
         stmts: list[Stmt] = []
+        assert qk is not None, "a materialized score has no resident query fragments"
         if split:
             rel = Literal(i * shape[0], "int")
             if um > 1:
@@ -622,7 +628,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
             state.append(Init(name=f"{qt.denom}{c}", identity=0.0, dtype=F32))
         for f in qt.ofrags:
             state.append(RegFragment(name=f, role="c", shape=shape, dtype=F32))
-        if not split:
+        if not split and qk is not None:
             state.extend(_q_frag_stmts(qt, i))
 
     # ---- the streaming step (a builder — the staged path re-parents it under the ring drain; the
@@ -641,35 +647,52 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
                 # The per-block packed f16 P@V targets — zero-inited per step (block-scoped, like
                 # the score fragments); the promote below folds them into the f32 ``ofrags`` shadows.
                 stream.append(RegFragment(name=f, role="c", shape=shape, dtype=pv_t.atom.operand_dtype("c")))
-        qk_mask: dict[str, tuple] = {}
-        if symbolic_k:
-            # The guard bound is ABSOLUTE — ``_frag_contraction``'s gmem guards compare the
-            # operand's own (absolute) coordinates (``col_bases`` / ``_abs_kv(kv0)``), so a slice
-            # partial bounds at its absolute end, not the window-local one.
-            qk_mask[qk_t.axes[1].name] = (kv0_var, abs_kv_end)
-        if qk.axis.extent.as_static() % atom.atom_k:
-            qk_mask[qk.axis.name] = (Literal(0, "int"), _ext(qk.axis))
-        stream += _frag_contraction(
-            qk,
-            qk_t,
-            [(qt.sfrags, qt.qa) for qt in qtiles],
-            # Staged: the K slab is slot-local (its rows are this block's keys), so the score
-            # column origin is the in-block offset; the absolute ``col_bases`` still name the
-            # score columns for the masks below.
-            n_sub=(lambda t: Literal(t * atom_n, "int")) if staged else (lambda t: col_bases[t]),
-            k_sub=Literal(0, "int"),
-            mask=qk_mask,
-            b_slab="_k_smem" if staged else None,
-            b_slot=k_slot,
-            b_ldm=qk.axis.extent.as_static() + kv_pad if staged else 0,
-            b_gmem_ldm=k_gmem_ldm,
-            b_swizzle=k_swz if staged else "NONE",
-            reg_depth=stage.reg_depth if staged else 1,
-        )
+        if materialized_score:
+            assert isinstance(score, Load)
+            m_name, kv_name = qk_t.axes[0].name, qk_t.axes[1].name
+            row_coord: Expr = Var(FRAG_ROW) if not symbolic_q else _clamp_last(Var(FRAG_ROW), _ext(qk_t.axes[0]))
+            col_coord: Expr = Var(FRAG_COL) if not symbolic_k else _clamp_last(Var(FRAG_COL), abs_kv_end)
+            index = tuple(e.substitute({m_name: row_coord, kv_name: col_coord}) for e in score.index)
+            for qt in qtiles:
+                for t, frag in enumerate(qt.sfrags):
+                    stream.append(
+                        FragmentLoad(
+                            frag=frag,
+                            buf=score.input,
+                            index=index,
+                            col_base=col_bases[t],
+                            row_base=qt.row_base,
+                        )
+                    )
+        else:
+            assert qk is not None
+            qk_mask: dict[str, tuple] = {}
+            if symbolic_k:
+                # The guard bound is ABSOLUTE — ``_frag_contraction``'s gmem guards compare the
+                # operand's own (absolute) coordinates (``col_bases`` / ``_abs_kv(kv0)``), so a
+                # slice partial bounds at its absolute end, not the window-local one.
+                qk_mask[qk_t.axes[1].name] = (kv0_var, abs_kv_end)
+            if qk.axis.extent.as_static() % atom.atom_k:
+                qk_mask[qk.axis.name] = (Literal(0, "int"), _ext(qk.axis))
+            stream += _frag_contraction(
+                qk,
+                qk_t,
+                [(qt.sfrags, qt.qa) for qt in qtiles],
+                # Staged: K is slot-local, while ``col_bases`` remains absolute for masks.
+                n_sub=(lambda t: Literal(t * atom_n, "int")) if staged else (lambda t: col_bases[t]),
+                k_sub=Literal(0, "int"),
+                mask=qk_mask,
+                b_slab="_k_smem" if staged else None,
+                b_slot=k_slot,
+                b_ldm=qk.axis.extent.as_static() + kv_pad if staged else 0,
+                b_gmem_ldm=k_gmem_ldm,
+                b_swizzle=k_swz if staged else "NONE",
+                reg_depth=stage.reg_depth if staged else 1,
+            )
         qk_seg, stream = stream, []
 
         for qi, qt in enumerate(qtiles):
-            hoisted, pro = _realize_prologue(partial[1:], qk, qk_t, qt.sfrags, col_bases, qt.row_base, set(names))
+            hoisted, pro = _realize_prologue(prologue, score_name, qk_t, qt.sfrags, col_bases, qt.row_base, set(names))
             if qi == 0:  # the hoisted scalar constants (the 1/√d scale) are tile-invariant
                 state.extend(hoisted)
             stream += pro
@@ -750,6 +773,7 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
         return [s for stmts, _reads in _stream_segments(k_slot, v_slot, staged) for s in stmts]
 
     if stage is not None:
+        assert qk is not None, "only computed-score streams have a staged tier"
         # The staged K/V stream: the resolved ``Stage`` (resolved schedule-side —
         # block-divisible or symbolic kv) rides the SAME ``staged_kloop`` skeleton the matmul tier
         # runs, the streaming step as its drain. The K slab keeps K's own N-major layout (``bn`` key
@@ -949,7 +973,10 @@ def realize_warp_twist(op, ctx, tail: tuple) -> tuple[list[Stmt], list[Stmt], li
     store_tmpl = tail[-1] if tail and isinstance(tail[-1], Write) else None
     proj_tail = tail[:-1] if store_tmpl is not None else tail
     close: list[Stmt] = []
-    batch_idx = tuple(qk.a.index[:-2])  # (batch…, head) — passthrough grid vars (fallback)
+    # Preserve the computed-score fallback's original Q index exactly (including affine GQA head
+    # maps). A materialized score has no Q operand, so its placement passthrough axes are the only
+    # structural batch/head coordinates available.
+    batch_idx = tuple(qk.a.index[:-2]) if qk is not None else tuple(Var(a.name) for a in ctx.free[:-2])
     for qt in qtiles:
         for s in proj_tail:
             if isinstance(s, Assign) and expect_name in s.args:

--- a/emmy/compiler/pipeline/passes/lowering/schedule/020_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/schedule/020_schedule.py
@@ -8,7 +8,7 @@ THIS rule picks that up and decides the schedule — the free-axis → grid mapp
 helper's ONE recursive row enumerator over the term's own site tree.
 
 Splitting the two halves is what makes the fork ONE thing: a kernel reaches scheduling by three
-routes — the ordinary lift, flash's graph rewrite, and a placement cut's re-recognized pieces — and
+routes — the ordinary lift, flash's graph rewrite, and a placement cut's recognized pieces — and
 all three converge here. The engine restarts its rule scan after every functional rewrite, so a
 ``TileOp`` this pass's ``010`` just emitted is matched here on the next sweep, exactly as
 ``030_split_reduce`` already matches the ``TileOp``\\ s this rule produces.

--- a/emmy/compiler/pipeline/passes/lowering/schedule/030_split_reduce.py
+++ b/emmy/compiler/pipeline/passes/lowering/schedule/030_split_reduce.py
@@ -291,10 +291,11 @@ def _split_twisted_warp(match: Match, root: Node, tile: TileOp, op: Fold, plan: 
     projection (``O/l`` + the layout-aware store) per output element. Deferred-kernel finalize
     only — the twisted ``e^{Δm}`` rescale can't be an atomic."""
     (red,) = op.operands
-    score, _ = stream_pair(red)  # the score fold (the hoisted operand edge) — its tile is the schedule read
+    score, _ = stream_pair(red)
     cta = plan.cta
     src_sched = sched_of(tile)
-    head_tile = src_sched.tile_of(score)
+    score_site = red if isinstance(score, Load) else score
+    head_tile = src_sched.tile_of(score_site)
     atom_n = head_tile.atom.shape[1]
     bn = head_tile.regs[1] * atom_n
     # What a split-KV partition demands is stated ONCE, in ``_legality.splitkv_slice`` — the
@@ -349,7 +350,7 @@ def _split_twisted_warp(match: Match, root: Node, tile: TileOp, op: Fold, plan: 
     p_sched = Sched(partial_map, {})
     sliced_head, sliced_pv = stream_pair(sliced)
     _, orig_pv = stream_pair(red)
-    p_sched.put("TILE", sliced_head, head_tile)
+    p_sched.put("TILE", sliced if isinstance(sliced_head, Load) else sliced_head, head_tile)
     p_sched.put("TILE", sliced_pv, src_sched.tile_of(orig_pv))
     p_sched.put("STAGE", sliced, src_sched.get("STAGE", red))
     stripped = _strip_grid(plan)
@@ -429,9 +430,10 @@ def rewrite(match: Match, root: Node) -> TileOp | Graph | None:
         and isinstance(op.operands[0], Fold)
         and op.operands[0].role is AxisRole.TWISTED
     ):
-        red_stmts = op.operands[0].step_stmts()
-        score = red_stmts[0] if len(red_stmts) else None
-        head_tile = sched_of(tile).tile_of(score) if isinstance(score, Fold) else None
+        red = op.operands[0]
+        score, _ = stream_pair(red)
+        score_site = red if isinstance(score, Load) else score
+        head_tile = sched_of(tile).tile_of(score_site)
         if head_tile is not None and head_tile.is_warp:
             # A symbolic kv splits too: ``_split_twisted_warp`` builds the bn-aligned runtime slice
             # width and the absolute ``bound`` the realizer stops/masks against.

--- a/emmy/compiler/pipeline/passes/lowering/schedule/__init__.py
+++ b/emmy/compiler/pipeline/passes/lowering/schedule/__init__.py
@@ -1,0 +1,6 @@
+"""Schedule a resolved kernel set and realize graph-level schedule decisions.
+
+``020_schedule`` maps each recognized ``TileOp`` independently and enumerates its typed schedule
+slices. ``030_split_reduce`` then realizes a selected cross-CTA reduction as partial/finalize graph
+nodes. Structural placement has already reached a graph-level fixpoint in ``lowering/tile``.
+"""

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -10,10 +10,10 @@ That op IS the rewrite's result. The schedule picks it up on the next rule sweep
 axes onto the grid and offers the scheduling forks; materialization back to loop IR happens in
 ``lowering/kernel``.
 
-Algebra recognition reads no hardware or profitability signal. After the recognized tree exists,
-step 3.5 offers placement as a separate structural ``PLACE`` fork: keep the maximal region fused or
-cut one closed seam into un-mapped ``LoopOp`` pieces. A routing golden or pin may collapse that fork.
-Placement must run before ``020`` because every piece needs its own schedule enumeration.
+Algebra recognition reads no hardware, placement, schedule, or profitability signal. The next rule,
+``015_place``, owns the structural ``PLACE`` fork over the recognized tree. Keeping that boundary
+separate ensures fusion and recognition remain maximal while a cut preserves the algebra already
+certified here.
 
 All recognition lives in THIS one rule (no separate flash / softmax pass), in order (each
 step unconditional — no knobs):
@@ -77,11 +77,9 @@ from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
 from emmy.compiler.pipeline.passes.lowering._reduction import loop_state_head
 from emmy.compiler.pipeline.passes.lowering.tile._atomize import (
     bind_contraction_channels,
-    bind_prologue_contraction,
     make_cone,
     map_cone,
 )
-from emmy.compiler.pipeline.passes.lowering.tile._cut import placement_options
 from emmy.compiler.pipeline.passes.lowering.tile._flash import is_flash_score_producer, try_flash
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
 from emmy.compiler.pipeline.passes.lowering.tile._softmax import _fuse
@@ -412,7 +410,7 @@ def _order_free_by_output(node: Fold, free: list, stores: tuple = ()) -> tuple:
     return tuple(sorted(free, key=lambda ax: pos[ax.name]))
 
 
-def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | list | None:
+def rewrite(match: Match, root: Node) -> TileOp | Graph | None:
     # (1) Flash attention — a graph rewrite that fuses a softmax-then-P@V kernel with its
     # scaled-QK producer. Tried first on every node; flash precedes online-softmax precedes
     # normalize, each consuming the Accums the next would match. The fusion is unconditional:
@@ -446,20 +444,6 @@ def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | list | None:
     # the scheduler can read operand shapes (the shared-row stage detection); the matcher refreshes
     # it from the graph again when a later pass matches the scheduled op.
     map_tile = TileOp(op=node, name=loop.name, place=Placement(free=free), inputs=dict(loop.inputs), stores=stores)
-    pro = bind_prologue_contraction(node, free)
-    # (3.5) PLACEMENT (phase 4) — a structural PLACE fork is offered before the schedule fork:
-    # the fused form plus every structurally legal single-seam cut. Each cut piece re-recognizes
-    # and schedules independently, so recursive cuts remain possible. An authoritative pin or
-    # routing golden collapses the fork to its recorded side; a cold deploy keeps fused option 0.
-    # The computed-A reading is the reference tree when it binds, because its `a` cone edge is a
-    # placement seam even though schedule may later choose the ordinary map reading.
-    route_tree, route_free, route_stores = (pro[0], (*free, pro[1]), pro[2]) if pro is not None else (node, free, stores)
-    placed = placement_options(ctx, dict(loop.knobs or {}), match, root, route_tree, route_free, route_stores, map_tile)
-    if isinstance(placed, list):
-        return placed
-    if isinstance(placed, Graph):
-        return placed
-    map_tile = placed
     # Recognition ends here: the UNMAPPED tile is the fused rewrite's result. The MONOID-producer
     # composition (``pro``) is re-derived by the schedule — it is a decision about the SCHEDULE
     # (which of the two readings of this one loop each fork row realizes), not about the structure,

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -10,10 +10,10 @@ That op IS the rewrite's result. The schedule picks it up on the next rule sweep
 axes onto the grid and offers the scheduling forks; materialization back to loop IR happens in
 ``lowering/kernel``.
 
-Nothing here reads a knob or a pin — recognition is structure, and every choice it makes is
-unconditional. (The one exception is PLACEMENT ROUTING, step 3.5: a routing golden / ``PLACE`` pin
-cuts the recognized tree into a fragment of un-mapped ``LoopOp``\\ s, and it must resolve BEFORE any
-schedule fork exists, so it cannot wait for ``020``.)
+Algebra recognition reads no hardware or profitability signal. After the recognized tree exists,
+step 3.5 offers placement as a separate structural ``PLACE`` fork: keep the maximal region fused or
+cut one closed seam into un-mapped ``LoopOp`` pieces. A routing golden or pin may collapse that fork.
+Placement must run before ``020`` because every piece needs its own schedule enumeration.
 
 All recognition lives in THIS one rule (no separate flash / softmax pass), in order (each
 step unconditional — no knobs):
@@ -64,19 +64,24 @@ from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.axis import AxisRole
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.loop import LoopOp
-from emmy.compiler.ir.stmt import Accum, Assign, Body, Init, Load, Loop, Write
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Init, Load, Loop, Write, lexical_free_values
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.tile import (
-    Channel,
     Fold,
     Placement,
     TileOp,
     split_effects,
 )
+from emmy.compiler.ir.tile.ops import axis_names
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
 from emmy.compiler.pipeline.passes.lowering._reduction import loop_state_head
-from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_contraction, bind_prologue_contraction, make_cone, map_cone
-from emmy.compiler.pipeline.passes.lowering.tile._cut import realize_cut, route_cut
+from emmy.compiler.pipeline.passes.lowering.tile._atomize import (
+    bind_contraction_channels,
+    bind_prologue_contraction,
+    make_cone,
+    map_cone,
+)
+from emmy.compiler.pipeline.passes.lowering.tile._cut import placement_options
 from emmy.compiler.pipeline.passes.lowering.tile._flash import is_flash_score_producer, try_flash
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
 from emmy.compiler.pipeline.passes.lowering.tile._softmax import _fuse
@@ -319,22 +324,35 @@ def _nodify_contraction(node, free: tuple):
     projection = Body(tuple(node.body[1:]))
     if len(free) >= 2:
         try:
-            a_load, b_load, acc, epi = bind_contraction(rloop, free[-2].name, free[-1].name, projection)
+            a_load, channels, epi = bind_contraction_channels(rloop, free[-2].name, free[-1].name, projection)
         except LoweringError:
             pass
         else:
             con = Fold.contraction(
                 k_axis=rloop.axis,
                 a=a_load if isinstance(a_load, Load) else make_cone(a_load, rloop.axis.name),
-                # A computed B is a closed zero-axis operand node. Unlike A's norm/activation
-                # cone it has no row-statistic seam to split; its whole generic MAP tree is
-                # evaluated at each (k, n) slab cell by the sync compute-fill.
-                channels=(Channel(b=b_load if isinstance(b_load, Load) else Fold.projection(body=Body(tuple(b_load))), acc=acc),),
+                channels=channels,
             )
             # ONE home for the projection: the wrapping zero-axis fold's lift body, never a node field. The
             # STORED form is the contraction itself (1s) — pure algebra; the
             # output axes / tile / stage are caller facts, stamped at the point of use.
-            return _project(con, epi)
+            candidate, stores = _project(con, epi)
+            # A root projection has no enclosing value scope beyond the free grid and boundary
+            # store sweeps: every other value read by its lift must be bound by an operand result.
+            # This closes the recognition boundary generically; a future binder that omits a
+            # product channel declines to the complete fold below instead of emitting undefined
+            # CUDA. A swept store's axis is bound when ``effect_tail`` reconstitutes its loop.
+            captures = lexical_free_values(
+                candidate.lift.body,
+                bound={
+                    *candidate.lift.params,
+                    *axis_names(candidate),
+                    *(a.name for a in free),
+                    *(store.sweep.name for store in stores if store.sweep is not None),
+                },
+            )
+            if not captures:
+                return candidate, stores
     red = fold_from_loop(rloop)  # loads stay inline in the lift — the fold derives PLANAR
     if red is None:  # not λ-representable — the raw-loop-IR escape (the flat zero-axis fold)
         return Fold.projection(body=(rloop, *projection)), ()
@@ -394,7 +412,7 @@ def _order_free_by_output(node: Fold, free: list, stores: tuple = ()) -> tuple:
     return tuple(sorted(free, key=lambda ax: pos[ax.name]))
 
 
-def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | None:
+def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | list | None:
     # (1) Flash attention — a graph rewrite that fuses a softmax-then-P@V kernel with its
     # scaled-QK producer. Tried first on every node; flash precedes online-softmax precedes
     # normalize, each consuming the Accums the next would match. The fusion is unconditional:
@@ -429,18 +447,20 @@ def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | None:
     # it from the graph again when a later pass matches the scheduled op.
     map_tile = TileOp(op=node, name=loop.name, place=Placement(free=free), inputs=dict(loop.inputs), stores=stores)
     pro = bind_prologue_contraction(node, free)
-    # (3.5) PLACEMENT ROUTING (phase 4) — resolved FIRST, before any schedule fork exists: a
-    # ROUTING golden (PLACE-only knobs for this kernel's (kind, shape)) or an authoritative
-    # PLACE pin cuts the recognized tree into a fragment of un-mapped LoopOps; each piece
-    # re-recognizes as a fresh root on the pass-scan restart and resolves its OWN entry
-    # (recursive — a piece's entry may itself cut). No entry / no pin = fuse = the recognized
-    # form, by absence. The fused (computed-A) reading is the routing reference tree when it
-    # binds — its seams (the `a` cone edge) are the ones a routing entry spells.
+    # (3.5) PLACEMENT (phase 4) — a structural PLACE fork is offered before the schedule fork:
+    # the fused form plus every structurally legal single-seam cut. Each cut piece re-recognizes
+    # and schedules independently, so recursive cuts remain possible. An authoritative pin or
+    # routing golden collapses the fork to its recorded side; a cold deploy keeps fused option 0.
+    # The computed-A reading is the reference tree when it binds, because its `a` cone edge is a
+    # placement seam even though schedule may later choose the ordinary map reading.
     route_tree, route_free, route_stores = (pro[0], (*free, pro[1]), pro[2]) if pro is not None else (node, free, stores)
-    seam = route_cut(ctx, dict(loop.knobs or {}), route_tree, route_stores, route_free)
-    if seam is not None:
-        return realize_cut(match, root, route_tree, route_free, route_stores, seam)
-    # Recognition ends here: the UNMAPPED tile is the rewrite's result. The MONOID-producer
+    placed = placement_options(ctx, dict(loop.knobs or {}), match, root, route_tree, route_free, route_stores, map_tile)
+    if isinstance(placed, list):
+        return placed
+    if isinstance(placed, Graph):
+        return placed
+    map_tile = placed
+    # Recognition ends here: the UNMAPPED tile is the fused rewrite's result. The MONOID-producer
     # composition (``pro``) is re-derived by the schedule — it is a decision about the SCHEDULE
     # (which of the two readings of this one loop each fork row realizes), not about the structure,
     # and it needs the schedule results to arbitrate (a warp ``TILE`` pin keeps the contraction

--- a/emmy/compiler/pipeline/passes/lowering/tile/015_place.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/015_place.py
@@ -1,0 +1,38 @@
+"""Resolve structural placement on recognized, unmapped tile algebra.
+
+Recognition always builds the maximal algebraic region. This rule then offers the generic
+``PLACE`` fork before scheduling: keep that region or materialize one closed child seam. Cut pieces
+remain recognized ``TileOp`` trees, so placement cannot erase a contraction or other reading and
+each piece reaches the same schedule enumerator independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from emmy.compiler.graph import Node
+from emmy.compiler.ir.tile import TileOp
+from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
+from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_prologue_contraction
+from emmy.compiler.pipeline.passes.lowering.tile._cut import placement_options
+
+PATTERN = [Pattern("root", TileOp)]
+
+_RESOLVED = "placement_resolved"
+
+
+def rewrite(match: Match, root: Node, ctx=None):
+    tile: TileOp = root.op
+    if tile.op is None or tile.place.is_mapped or tile.meta.get(_RESOLVED):
+        raise RuleSkipped("placement already resolved / nothing to place")
+
+    tree = tile.op
+    free = tuple(tile.place.free)
+    stores = tuple(tile.stores)
+    prologue = bind_prologue_contraction(tree, free)
+    if prologue is not None:
+        tree, n_axis, stores = prologue
+        free = (*free, n_axis)
+
+    fused = replace(tile, meta={**tile.meta, _RESOLVED: True})
+    return placement_options(ctx, dict(tile.knobs or {}), match, root, tree, free, stores, fused)

--- a/emmy/compiler/pipeline/passes/lowering/tile/__init__.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/__init__.py
@@ -1,39 +1,13 @@
-"""Tile-IR lowering: ``LoopOp`` → ``TileOp``.
+"""Algebra recognition and structural placement: ``LoopOp`` → resolved kernel set.
 
-1. **Recognize** (``010_recognize``) — the Loop-IR → Tile-IR boundary. Fuse flash attention, fuse
-   online softmax, annotate each reduce ``Loop`` with its ``AxisRole`` (the algebra is the body),
-   then **lift** the kernel to a ``TileOp`` carrying ONE op-tree — a ``Fold`` /
-   contraction term — with an **unmapped** placement (its parallel ``free`` axes). After this
-   nothing downstream traffics in ``LoopOp``. The ``_flash`` / ``_softmax`` helpers hold the
-   pattern matchers, ``_atomize`` the algebra→atom binding, ``_cut`` the placement cut.
-2. **Schedule** (``020_schedule``) — decide that op's ``place`` (free axes → grid) and its per-node
-   ``schedule`` slices, and offer them as a fork. ONE generic row enumerator (``_schedule``): the
-   kernel's single ``WORK`` inventory is CHOSEN first, then a recursive walk of the site tree hands
-   each family its typed candidate slices — dispatched on two stored-param predicates of the node
-   (``axis is None`` / ``is_contraction``), NEVER the ``AxisRole``, which stays a loop annotation
-   and a materializer read — the domain being the ``search/space.py`` move catalog. Each row spells
-   every family ONCE at its canonical path key, and one ``build_fork_tree`` turns them into the lazy
-   fork. Every role emits rows; none builds a ``TileOp`` directly.
-3. **Split** (``030_split_reduce``) — consume a cross-CTA ``GRID`` stage (``ReducePlan.needs_split``)
-   as a **graph rewrite**: a partial kernel reduces each CTA's slice of the reduce axis and
-   either ``atomicAdd``\\ s its (additive) state into the output (one kernel) or writes it to a
-   ``__partial`` workspace folded by a sibling finalize kernel (the carrier's
-   ``combine_states`` over the split axis — additive ``sum`` / split-K matmul AND the twisted
-   flash ``(m, l, O)`` split-KV). The schedule carries the partition; the graph carries the
-   kernel count, so ``lowering/kernel`` only ever sees single-launch kernels.
+1. **Recognize** (``010_recognize``) — certify the maximal algebraic region and lift it to an
+   unmapped ``TileOp``. Flash, online-softmax, and contraction recognition are algebra-only; no
+   target capability or profitability signal enters this rule.
+2. **Place** (``015_place``) — keep that maximal region or materialize one closed child seam. Cut
+   pieces remain recognized ``TileOp`` trees and re-enter this pass until every kernel's placement
+   is resolved.
 
-**The schedule step is INCOMPLETE.** It covers every term whose operand edges are all MATERIALIZED —
-the pointwise cell + the register-strip term reading, the reduce partition, and the contraction
-(scalar + warp tiers, staging, split-K, raster) — plus the COMPUTED operand edge (the fused
-norm→linear / gate⊗up cone), which arrives as a ``_site_values`` entry under the term-reading union
-rather than as an emitter of its own — the flash streaming pair included, whose two sites
-(the hoisted score edge and the derived P@V) enumerate their own halves of the twisted geometry and
-reconcile at the stream. A term the enumeration cannot schedule yields NO rows and ``020`` leaves it
-unmapped — the guardrail contract, ``[]`` and never a raise. The knob / path codec, the move catalog
-and the whole ``lowering/kernel`` materializer are frozen — they are the contract the enumerator
-meets.
-
-Recognition reads algebraic structure; scheduling is geometry; materialization back to
-loop IR happens in ``lowering/kernel`` — so the tile passes work purely with algebra
-primitives.
+The following ``lowering/schedule`` pass maps the fixed kernel set. The schedule implementation
+remains in ``_schedule`` because it consumes the same Tile-IR predicates, but placement always
+reaches a graph-level fixpoint before any schedule row is enumerated.
 """

--- a/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
@@ -58,8 +58,10 @@ def _idx_vars_deep(stmts) -> set:
 
 def map_cone(body: list, root: str) -> list | None:
     """The backward cone of SSA ``root`` within ``body`` — the fused producer's compute, in body
-    order. ``None`` unless every cone stmt is a scalar ``Load`` or a pointwise ``Assign`` (a pure
-    MAP cone — a reduce-bearing cone, e.g. an rmsnorm scale, is not compute-fillable per cell)."""
+    order. ``None`` unless every cone stmt is a pure, non-scoped value binding (a MAP cone — a
+    reduce-bearing cone, e.g. an rmsnorm scale, is not compute-fillable per cell). The shared
+    ``Stmt.pure`` trait includes coordinate ``Select`` as well as ``Load`` / ``Assign``; recognizing
+    the trait instead of a class list keeps every algebraic pointwise spelling on the same path."""
     defs: dict[str, Stmt] = {}
     for st in body:
         for d in st.defines():
@@ -71,20 +73,15 @@ def map_cone(body: list, root: str) -> list | None:
         if st is None or id(st) in seen:
             continue
         seen.add(id(st))
-        if isinstance(st, Load):
+        if st.pure and not st.nested():
             cone.append(st)
-            # A data-dependent gather/index load consumes SSA values through its INDEX rather
-            # than through ``Assign.args``. Those definitions are part of the producer cone too;
-            # dropping them leaves an apparently pure map with undefined index temporaries once
-            # the operand is compute-filled. Axis names are harmless here because ``defs.get``
-            # simply ignores names not defined by the body.
+            # Loads consume SSA through their index expressions, Select consumes branch values
+            # and coordinate predicates, and future pure leaves may expose either surface. Axis
+            # names are harmless because ``defs.get`` ignores names not defined by this body.
             need.extend(st.deps())
+            need.extend(v for expr in st.exprs() for v in expr.free_vars())
             continue
-        if isinstance(st, Assign):
-            cone.append(st)
-            need.extend(st.args)
-            continue
-        return None  # an Accum / Loop / Select in the cone — not a pure MAP producer
+        return None  # an Accum / Loop / Write / effect — not a pure MAP producer
     order = {id(st): i for i, st in enumerate(body)}
     return sorted(cone, key=lambda st: order[id(st)])
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
@@ -1,12 +1,13 @@
 """Atomize — resolve the algebra→hardware-atom binding structurally.
 
 The warp matmul materializer needs to know which operand is the mma ``a`` vs ``b`` (by
-axis-in-index), the fold accumulator, and the projection epilogue.
-:func:`bind_contraction` reads them **structurally** off the annotated ``CONTRACTION`` reduce loop
-— the operand ``Load``\\ s indexed over the K axis, the fold ``Accum`` target — and returns them as
-the ``(a_load, b_load, acc, epilogue)`` facts ``010_recognize._nodify_contraction`` stamps onto the
-contraction structural node at RECOGNIZE time (the node
-is then the single source of truth — it re-derives ``b_trans`` off ``b`` itself). Reading the
+axis-in-index), every fold accumulator, and the projection epilogue.
+:func:`bind_contraction_channels` reads them **structurally** off the annotated ``CONTRACTION``
+reduce loop — the operand ``Load``\\ s indexed over the K axis and its additive ``Accum`` targets —
+and returns one shared A edge plus every ``(b, accumulator)`` channel for
+``010_recognize._nodify_contraction`` to stamp onto the contraction structural node at RECOGNIZE
+time (the node is then the single source of truth — it re-derives ``b_trans`` off ``b`` itself).
+The one-channel form delegates to :func:`bind_contraction`. Reading the
 binding **structurally** off the annotated loop — not a stored node kind — is what keeps the ⊗/⊕
 algebra a property of the loop, so no per-algebra op-tree node class is needed. The cooperative reduce
 needs no binding here — its accumulator dtype + shuffle/tree
@@ -231,8 +232,12 @@ def bind_contraction(loop: Loop, m_name: str, n_name: str, epilogue: Body) -> tu
     k_name = loop.axis.name
     body = list(loop.body)
     loads = [s for s in body if isinstance(s, Load) and k_name in _idx_vars(s.index)]
-    a_leaf = next((ld for ld in loads if m_name in _idx_vars(ld.index)), None)
-    b_leaf = next((ld for ld in loads if n_name in _idx_vars(ld.index)), None)
+    # A fragment is stationary across N and a B fragment is stationary across M. Merely
+    # containing the expected axis is insufficient: a reshaped/broadcast contraction can expose
+    # one load indexed by (m, n, k), which is valid scalar algebra but cannot be shared by an mma
+    # output tile. Declining the binding keeps that form on the general PLANAR path.
+    a_leaf = next((ld for ld in loads if m_name in _idx_vars(ld.index) and n_name not in _idx_vars(ld.index)), None)
+    b_leaf = next((ld for ld in loads if n_name in _idx_vars(ld.index) and m_name not in _idx_vars(ld.index)), None)
     fold = next((s for s in body if isinstance(s, Accum)), None)
     if fold is None:
         raise LoweringError("warp tier: contraction loop has no fold accumulator")
@@ -287,6 +292,80 @@ def bind_contraction(loop: Loop, m_name: str, n_name: str, epilogue: Body) -> tu
     if a_leaf is None or b_leaf is None:
         raise LoweringError("warp tier: could not bind A/B operands by grid (m, n) axis")
     return a_leaf, b_leaf, acc, epilogue
+
+
+def bind_contraction_channels(loop: Loop, m_name: str, n_name: str, epilogue: Body) -> tuple[Load | list, tuple[Channel, ...], Body]:
+    """Bind every additive channel of one bilinear reduce loop.
+
+    A one-channel loop delegates to :func:`bind_contraction`, retaining its computed-operand and
+    multiplicative-factor handling. A product loop is the general sibling form: every accumulated
+    lift must be a multiply, every channel must share the same A value tree, and the B edges must
+    agree on layout so one staged slab can serve the group. The result is independent of target
+    hardware; schedule selection later decides whether any available atom can realize the product.
+    """
+    body = list(loop.body)
+    folds = [s for s in body if isinstance(s, Accum)]
+    if not folds:
+        raise LoweringError("warp tier: contraction loop has no fold accumulator")
+    if len(folds) == 1:
+        a, b, acc, epi = bind_contraction(loop, m_name, n_name, epilogue)
+        edge = b if isinstance(b, Load) else Fold.projection(body=Body(tuple(b)))
+        return a, (Channel(b=edge, acc=acc),), epi
+    if any(fold.op.name != "add" for fold in folds):
+        raise LoweringError("warp tier: product contraction channels must use additive folds")
+
+    k_name = loop.axis.name
+    loads = {s.name: s for s in body if isinstance(s, Load) and s.is_scalar}
+    defs = {s.name: s for s in body if isinstance(s, (Load, Assign))}
+    a_edges: list[Load | list] = []
+    a_keys: list[tuple] = []
+    channels: list[Channel] = []
+    covered: set[int] = {id(fold) for fold in folds}
+
+    for fold in folds:
+        lift = defs.get(fold.value)
+        if not isinstance(lift, Assign) or lift.op.name != "multiply" or len(lift.args) != 2:
+            raise LoweringError("warp tier: every product channel must fold one multiply lift")
+        b_name = next(
+            (
+                arg
+                for arg in lift.args
+                if (ld := loads.get(arg)) is not None
+                and k_name in _idx_vars(ld.index)
+                and n_name in _idx_vars(ld.index)
+                and m_name not in _idx_vars(ld.index)
+            ),
+            None,
+        )
+        if b_name is None:
+            raise LoweringError("warp tier: product channel has no materialized B edge stationary across M")
+        b = loads[b_name]
+        a_name = next(arg for arg in lift.args if arg != b_name)
+        a = loads.get(a_name)
+        if a is not None:
+            used = _idx_vars(a.index)
+            if k_name not in used or m_name not in used or n_name in used:
+                raise LoweringError("warp tier: product A edge is not stationary across N")
+            a_edge: Load | list = a
+        else:
+            cone = map_cone(body, a_name)
+            if not cone or any(isinstance(st, Load) and n_name in _idx_vars(st.index) for st in cone):
+                raise LoweringError("warp tier: product A cone does not bind")
+            a_edge = cone
+        a_edges.append(a_edge)
+        a_keys.append(_cone_value_key(a_name, defs))
+        channels.append(Channel(b=b, acc=fold.name))
+        covered.add(id(lift))
+        covered.update(id(st) for st in map_cone(body, a_name) or ())
+        covered.add(id(b))
+
+    if len(set(a_keys)) != 1:
+        raise LoweringError("warp tier: product channels do not share one A value")
+    if len({k_name in channel.b.index[-1].free_vars() for channel in channels}) != 1:
+        raise LoweringError("warp tier: product B edges disagree on layout")
+    if any(isinstance(st, (Load, Assign)) and id(st) not in covered for st in body):
+        raise LoweringError("warp tier: product contraction has an unbound value")
+    return a_edges[0], tuple(channels), epilogue
 
 
 def _cone_value_key(name: str, defs: dict) -> tuple:
@@ -442,4 +521,4 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Fold, Axis, tuple] | Non
     return Fold.projection(body=Body((*prefix, *tail_ops)), operands=(node,)), n_ax, (Store(write=write),)
 
 
-__all__ = ["bind_contraction", "bind_prologue_contraction", "make_cone", "map_cone"]
+__all__ = ["bind_contraction", "bind_contraction_channels", "bind_prologue_contraction", "make_cone", "map_cone"]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -1,15 +1,14 @@
-"""The placement CUT realizer (phase 4) — routing entries partition the recognized tree.
+"""The post-recognition placement fork and cut realizer.
 
 ``PLACE@<child-path> = cut`` on an in-tree parent↔child seam splits the kernel: the child
 subtree becomes its own graph node (a plain un-mapped ``LoopOp``, re-entering recognition as a
 fresh tree), the seam value materializes to a workspace buffer, and the parent consumes a plain
-``Load`` where the child was. Resolution is TWO-LEVEL and RECURSIVE: the ROUTING entry (a golden
-whose knobs are ``PLACE`` keys only — cuts, never schedules) or an authoritative ``PLACE`` pin
-decides the cut BEFORE any schedule fork is built; every resulting piece then re-recognizes on
-the pass-scan restart and resolves its OWN ``(kind, shape)`` entry through the full deploy
-hierarchy — a piece's entry may itself cut (the cone piece re-recognizes as the rms_norm shape
-and its routing entry cuts the statistic out). NO routing entry = fuse = the recognized form —
-the deployment-safety default, spelled as absence.
+``Load`` where the child was. With no authoritative pin or routing entry, every structurally legal
+seam is offered beside the maximal form as a structural ``PLACE`` fork. Outer search measures those choices;
+a cold deploy keeps the first, fused option, while trusted evidence can price the fragment as the sum
+of its independently scheduled kernels. This happens before ``020_schedule``. Resolution is recursive:
+every cut piece re-enters recognition
+and may offer its own placement fork.
 
 The realizer is seam-agnostic by design: the two seam shapes (a zero-axis ``Fold`` projection seam, a fold
 operand edge) fall out of the node kinds — the child's index space is DERIVED (the enclosing
@@ -24,6 +23,7 @@ construction); an open seam cannot be spelled because ``PLACE`` sites are tree c
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, replace
 
 from emmy import config
 from emmy.compiler.dtype import F32
@@ -32,20 +32,19 @@ from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.loop import LoopOp
-from emmy.compiler.ir.stmt import Body, Load, Loop, Write
+from emmy.compiler.ir.stmt import Body, Load, Loop, Write, lexical_free_values
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.stmt.body import _member_reads
 from emmy.compiler.ir.tile.ir import (
     Fold,
     _operand_result_names,
-    deep_defines,
-    deep_reads,
     effect_tail,
     is_contraction,
     operand_name,
 )
 from emmy.compiler.ir.tile.ops import axis_names
 from emmy.compiler.ir.tile.path import Site, family_sites, resolve, sites, spell
+from emmy.compiler.pipeline.fork import OptionFork
 from emmy.compiler.pipeline.knob import SCHEDULE_FAMILIES, family_of, parse_knob_spec
 from emmy.compiler.pipeline.passes.loop.stamp._stamp import restamp_structural_features
 from emmy.compiler.pipeline.pipeline import RuleSkipped
@@ -54,6 +53,17 @@ logger = logging.getLogger(__name__)
 
 #: The one value that routes a rewrite; ``fuse`` (or absence) is the recognized form.
 _CUT = "cut"
+_FUSE = "fuse"
+
+
+@dataclass(frozen=True)
+class _PlacementDecision:
+    """An authoritative placement result, or the undecided seam set to enumerate."""
+
+    decided: bool
+    seam: Site | None
+    seams: tuple[Site, ...]
+    knobs: dict
 
 
 def _place_pins() -> dict[str, str]:
@@ -84,19 +94,6 @@ def _schedule_pins_live() -> bool:
     if any(config.knob_raw(f) is not None for f in SCHEDULE_FAMILIES):
         return True
     return any(family_of(k) in SCHEDULE_FAMILIES for k in parse_knob_spec(config.knobs_aggregate()))
-
-
-def _card_has_routing(gpu_name, cap) -> bool:
-    """Whether ANY routing golden exists for this card — the cheap gate that keeps the per-kernel
-    seam scan off the common compile (no pins, no routing entries → recognition is untouched)."""
-    if not gpu_name:
-        return False
-    try:
-        from emmy.compiler.pipeline.search.golden import GOLDEN_RECORDS  # noqa: PLC0415
-
-        return any(g.is_routing and g.gpu_name == gpu_name and tuple(g.compute_cap) == cap for g in GOLDEN_RECORDS)
-    except Exception:  # noqa: BLE001
-        return False
 
 
 def _has_computed_a(node) -> bool:
@@ -167,11 +164,7 @@ def _captured_values(root, axes: set[str]) -> tuple[str, ...]:
     scope it captures from) — which is why that seam is not cuttable.
 
     Returned sorted, so callers can put it straight into an error message."""
-    stmts = list(root.lower())
-    defs: set[str] = set()
-    for s in stmts:
-        defs |= deep_defines(s)
-    return tuple(sorted(deep_reads(stmts) - defs - axes))
+    return tuple(sorted(lexical_free_values(root.lower(), bound=axes)))
 
 
 def _cuttable(root, site: Site, stores: tuple, free: tuple) -> bool:
@@ -209,39 +202,41 @@ def _cuttable(root, site: Site, stores: tuple, free: tuple) -> bool:
     return True
 
 
-def route_cut(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> Site | None:
-    """The routing resolution for a freshly-recognized kernel: the cut seam to realize, or
-    ``None`` (= fuse, the default — spelled as the ABSENCE of a routing entry). ``PLACE`` pins
-    are authoritative over the recorded routing entry (a ``fuse`` pin suppresses a recorded
-    cut), and so is any live schedule-family pin (a pinned re-record / ``--ab`` compile keeps
-    the recognized form so the pinned row can realize); a key that names no seam (or an uncuttable one) on this tree is skipped for a pin (a
-    whole-model pin targets one kernel shape) and falls through with a warning for an entry
-    (the drift case — deploy keeps the recognized form). A bare ``PLACE=cut`` pin takes the
-    shallowest CUTTABLE seam."""
+def _placement_decision(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> _PlacementDecision:
+    """Resolve authoritative placement evidence, otherwise expose every legal seam.
+
+    Pins and routing goldens decide one path before schedule enumeration. Without either, the
+    result is deliberately undecided so :func:`placement_options` can build the structural fork.
+    A schedule-family pin keeps the fused form because it is an exact re-record of that kernel.
+    """
     pins = _place_pins()
-    if not pins and not _card_has_routing(getattr(ctx, "gpu_name", None), tuple(getattr(ctx, "compute_capability", ()) or ())):
-        return None  # nothing could ever route — skip the seam scan (the common compile)
     all_sites = sites(root)
-    seams = [s for s in family_sites("PLACE", all_sites) if _cuttable(root, s, stores, free)]
+    seams = tuple(s for s in family_sites("PLACE", all_sites) if _cuttable(root, s, stores, free))
     if not seams:
-        return None  # a bare fold / flat cell has no in-tree seam (or none is legal)
-    for key, value in pins.items():
-        if key == "PLACE":
-            if value == _CUT:
-                return min(seams, key=lambda s: s.depth)
-            return None  # bare fuse pin — authoritative
-        try:
-            site = resolve(root, key, all_sites=all_sites)
-        except ValueError:
-            continue  # the pin names no seam on THIS tree (a whole-model pin targets one kernel)
-        if site is None or site not in seams:
-            continue
-        return site if value == _CUT else None  # an explicit fuse pin suppresses any routing entry
+        return _PlacementDecision(True, None, (), {})
+    if pins:
+        bare = pins.get("PLACE")
+        if bare is not None:
+            seam = min(seams, key=lambda s: s.depth) if bare == _CUT else None
+            return _PlacementDecision(True, seam, seams, {"PLACE": bare})
+        matched: list[tuple[str, str, Site]] = []
+        for key, value in pins.items():
+            try:
+                site = resolve(root, key, all_sites=all_sites)
+            except ValueError:
+                continue  # a whole-model pin may name a seam on another kernel
+            if site is not None and site in seams:
+                matched.append((key, value, site))
+        cuts = [(key, site) for key, value, site in matched if value == _CUT]
+        if len(cuts) > 1:
+            raise NotImplementedError(f"placement pin: exactly one cut per recognized tree, got {[key for key, _ in cuts]}")
+        seam = cuts[0][1] if cuts else None
+        return _PlacementDecision(True, seam, seams, {key: value for key, value, _ in matched})
     if _schedule_pins_live():
-        return None  # a pinned compile: the pin decides the form — recorded routing entries do not fire
+        return _PlacementDecision(True, None, seams, {})
     entry = _routing_entry(ctx, knobs, root)
     if entry is None:
-        return None
+        return _PlacementDecision(False, None, seams, {})
     cuts = [k for k, v in entry.knobs.items() if str(v) == _CUT]
     if len(cuts) != 1:
         raise NotImplementedError(f"routing golden {entry.name!r}: exactly ONE cut per entry for now, got {sorted(cuts)}")
@@ -252,16 +247,61 @@ def route_cut(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> S
         # warp-form tree a suffixed key was recorded against; the recursion reaches the same
         # cascade from whichever legal seam goes first, so the shallowest-cuttable rule is the
         # tree-robust reading of a bare entry (measured: the cone-cut A/Bs ran exactly this).
-        return min(seams, key=lambda s: s.depth)
+        return _PlacementDecision(True, min(seams, key=lambda s: s.depth), seams, dict(entry.knobs))
     try:
         site = resolve(root, cuts[0], all_sites=all_sites)
     except ValueError as e:
         logger.warning("routing golden %r: %s — the recorded cut no longer names a seam; deploying the recognized form", entry.name, e)
-        return None
+        return _PlacementDecision(True, None, seams, dict(entry.knobs))
     if site not in seams:
         logger.warning("routing golden %r: %s names an uncuttable seam — deploying the recognized form", entry.name, cuts[0])
-        return None
-    return site
+        return _PlacementDecision(True, None, seams, dict(entry.knobs))
+    return _PlacementDecision(True, site, seams, dict(entry.knobs))
+
+
+def route_cut(ctx, knobs: dict, root, stores: tuple = (), free: tuple = ()) -> Site | None:
+    """Compatibility view of authoritative placement: the selected cut seam, if any."""
+    return _placement_decision(ctx, knobs, root, stores, free).seam
+
+
+def placement_options(ctx, knobs: dict, match, root: Node, tree, free: tuple, stores: tuple, fused):
+    """Return the authoritative placement, or the fused-plus-every-cut structural fork.
+
+    The fork row carries the offer kernel's structural ``S_*`` features and gives every legal seam
+    an explicit ``cut``/``fuse`` value. Uniform keys make structural-decision replay independent of
+    option order. ``decision_knobs`` persists only the placement values across later lowering,
+    without mixing them with any individual kernel's schedule knobs.
+    """
+    decision = _placement_decision(ctx, knobs, tree, stores, free)
+    if decision.decided:
+        if decision.seam is not None:
+            return realize_cut(match, root, tree, free, stores, decision.seam, decision_knobs=decision.knobs)
+        return replace(fused, decision_knobs={**fused.decision_knobs, **decision.knobs}) if decision.knobs else fused
+
+    realized: list[tuple[Graph, str]] = []
+    for seam in decision.seams:
+        selected = spell(tree, "PLACE", seam.node, all_sites=sites(tree))
+        try:
+            cut = realize_cut(match, root, tree, free, stores, seam)
+        except (RuleSkipped, ValueError) as exc:
+            logger.debug("placement: seam %s is not realizable: %s", selected, exc)
+            continue
+        realized.append((cut, selected))
+    if not realized:
+        return fused
+
+    labeled = [selected for _, selected in realized]
+    structural = {key: value for key, value in knobs.items() if key.startswith("S_")}
+    fuse_row = {key: _FUSE for key in labeled}
+    fused = replace(fused, decision_knobs={**fused.decision_knobs, **fuse_row})
+    options = [OptionFork(option=fused, knobs={**structural, **fuse_row})]
+    for cut, selected in realized:
+        row = {key: (_CUT if key == selected else _FUSE) for key in labeled}
+        for node in cut.nodes.values():
+            if isinstance(node.op, LoopOp):
+                node.op.decision_knobs.update(row)
+        options.append(OptionFork(option=cut, knobs={**structural, **row}))
+    return options
 
 
 def _child_axes(child, free: tuple, ancestors: tuple) -> list[Axis]:
@@ -360,7 +400,7 @@ def _replace_edge(node, child, load: Load):
     return _dc_replace(node, operands=tuple(_replace_edge(e, child, load) if isinstance(e, Fold) else e for e in node.operands))
 
 
-def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Site) -> Graph:
+def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Site, *, decision_knobs: dict | None = None) -> Graph:
     """Split the recognized tree at ``site``'s seam into a two-kernel fragment: the CHILD piece
     computes the seam value into a workspace over its derived index space; the PARENT piece is
     the same tree with the seam edge replaced by a plain workspace ``Load``. Both pieces are
@@ -385,14 +425,14 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
     # --- the CHILD piece: the seam subtree, its value stored to the workspace ------------------
     child_stmts = [*child.lower(), Write(output=ws, index=ws_index, value=child_name)]
     child_body = _nest(child_stmts, axes)
-    child_op = LoopOp(body=Body(tuple(child_body)))
+    child_op = LoopOp(body=Body(tuple(child_body)), decision_knobs=dict(decision_knobs or {}))
 
     # --- the PARENT piece: the tree with the seam edge → a workspace Load ----------------------
     load = Load(name=child_name, input=ws, index=ws_index)
     parent_tree = _replace_edge(tile_op, child, load)
     parent_cell = effect_tail(parent_tree.lower(), stores)
     parent_body = _nest(list(parent_cell), list(free))
-    parent_op = LoopOp(body=Body(tuple(parent_body)))
+    parent_op = LoopOp(body=Body(tuple(parent_body)), decision_knobs=dict(decision_knobs or {}))
 
     frag = Graph()
     for inp in root.inputs:
@@ -417,4 +457,4 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
     return frag
 
 
-__all__ = ["realize_cut", "route_cut"]
+__all__ = ["placement_options", "realize_cut", "route_cut"]

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -1,14 +1,13 @@
 """The post-recognition placement fork and cut realizer.
 
 ``PLACE@<child-path> = cut`` on an in-tree parent↔child seam splits the kernel: the child
-subtree becomes its own graph node (a plain un-mapped ``LoopOp``, re-entering recognition as a
-fresh tree), the seam value materializes to a workspace buffer, and the parent consumes a plain
+subtree becomes its own graph node (an un-mapped ``TileOp`` retaining its recognized algebra), the
+seam value materializes to a workspace buffer, and the parent consumes a plain
 ``Load`` where the child was. With no authoritative pin or routing entry, every structurally legal
 seam is offered beside the maximal form as a structural ``PLACE`` fork. Outer search measures those choices;
 a cold deploy keeps the first, fused option, while trusted evidence can price the fragment as the sum
 of its independently scheduled kernels. This happens before ``020_schedule``. Resolution is recursive:
-every cut piece re-enters recognition
-and may offer its own placement fork.
+every cut piece may offer its own placement fork without re-recognizing structure.
 
 The realizer is seam-agnostic by design: the two seam shapes (a zero-axis ``Fold`` projection seam, a fold
 operand edge) fall out of the node kinds — the child's index space is DERIVED (the enclosing
@@ -31,12 +30,14 @@ from emmy.compiler.graph import Graph, Node, Tensor
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.expr import Var
-from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.stmt import Body, Load, Loop, Write, lexical_free_values
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.stmt.body import _member_reads
 from emmy.compiler.ir.tile.ir import (
     Fold,
+    Placement,
+    Store,
+    TileOp,
     _operand_result_names,
     effect_tail,
     is_contraction,
@@ -46,7 +47,7 @@ from emmy.compiler.ir.tile.ops import axis_names
 from emmy.compiler.ir.tile.path import Site, family_sites, resolve, sites, spell
 from emmy.compiler.pipeline.fork import OptionFork
 from emmy.compiler.pipeline.knob import SCHEDULE_FAMILIES, family_of, parse_knob_spec
-from emmy.compiler.pipeline.passes.loop.stamp._stamp import restamp_structural_features
+from emmy.compiler.pipeline.passes.loop.stamp._stamp import structure_features
 from emmy.compiler.pipeline.pipeline import RuleSkipped
 
 logger = logging.getLogger(__name__)
@@ -252,10 +253,10 @@ def _placement_decision(ctx, knobs: dict, root, stores: tuple = (), free: tuple 
         site = resolve(root, cuts[0], all_sites=all_sites)
     except ValueError as e:
         logger.warning("routing golden %r: %s — the recorded cut no longer names a seam; deploying the recognized form", entry.name, e)
-        return _PlacementDecision(True, None, seams, dict(entry.knobs))
+        return _PlacementDecision(True, None, seams, {})
     if site not in seams:
         logger.warning("routing golden %r: %s names an uncuttable seam — deploying the recognized form", entry.name, cuts[0])
-        return _PlacementDecision(True, None, seams, dict(entry.knobs))
+        return _PlacementDecision(True, None, seams, {})
     return _PlacementDecision(True, site, seams, dict(entry.knobs))
 
 
@@ -298,7 +299,7 @@ def placement_options(ctx, knobs: dict, match, root: Node, tree, free: tuple, st
     for cut, selected in realized:
         row = {key: (_CUT if key == selected else _FUSE) for key in labeled}
         for node in cut.nodes.values():
-            if isinstance(node.op, LoopOp):
+            if isinstance(node.op, TileOp):
                 node.op.decision_knobs.update(row)
         options.append(OptionFork(option=cut, knobs={**structural, **row}))
     return options
@@ -403,12 +404,11 @@ def _replace_edge(node, child, load: Load):
 def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Site, *, decision_knobs: dict | None = None) -> Graph:
     """Split the recognized tree at ``site``'s seam into a two-kernel fragment: the CHILD piece
     computes the seam value into a workspace over its derived index space; the PARENT piece is
-    the same tree with the seam edge replaced by a plain workspace ``Load``. Both pieces are
-    plain un-mapped ``LoopOp``\\ s — the pass-scan restart hands them back to ``010_recognize``,
-    so each re-recognizes as a fresh root, resolves its OWN routing/schedule entries, and the
-    recursion terminates because trees strictly shrink. Structural features are re-stamped per
-    piece (a cut consumer is a plain matmul that must join the matmul evidence, not the fused
-    kind)."""
+    the same tree with the seam edge replaced by a plain workspace ``Load``. Both pieces remain
+    recognized, un-mapped ``TileOp``\\ s, so each resolves its OWN placement and schedule entries
+    without a lossy round trip through loop IR. Recursion terminates because trees strictly shrink.
+    Structural features are re-stamped per piece (a cut consumer is a plain matmul that must join
+    the matmul evidence, not the fused kind)."""
     out = root.output
     child = site.node
     child_name = operand_name(child)
@@ -425,20 +425,34 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
     # --- the CHILD piece: the seam subtree, its value stored to the workspace ------------------
     child_stmts = [*child.lower(), Write(output=ws, index=ws_index, value=child_name)]
     child_body = _nest(child_stmts, axes)
-    child_op = LoopOp(body=Body(tuple(child_body)), decision_knobs=dict(decision_knobs or {}))
+    child_loop = Body(tuple(child_body))
+    child_op = TileOp(
+        op=child,
+        name=ws,
+        place=Placement(free=tuple(axes)),
+        stores=(Store(write=Write(output=ws, index=ws_index, value=child_name)),),
+        decision_knobs=dict(decision_knobs or {}),
+    )
 
     # --- the PARENT piece: the tree with the seam edge → a workspace Load ----------------------
     load = Load(name=child_name, input=ws, index=ws_index)
     parent_tree = _replace_edge(tile_op, child, load)
     parent_cell = effect_tail(parent_tree.lower(), stores)
     parent_body = _nest(list(parent_cell), list(free))
-    parent_op = LoopOp(body=Body(tuple(parent_body)), decision_knobs=dict(decision_knobs or {}))
+    parent_loop = Body(tuple(parent_body))
+    parent_op = TileOp(
+        op=parent_tree,
+        name=getattr(root.op, "name", "") or out.name,
+        place=Placement(free=tuple(free)),
+        stores=tuple(stores),
+        decision_knobs=dict(decision_knobs or {}),
+    )
 
     frag = Graph()
     for inp in root.inputs:
         frag.add_node(op=InputOp(), inputs=[], output=match.graph.buffer(inp), node_id=inp)
-    child_reads = {ld.input for ld in child_op.body.loads if ld.input != ws}
-    parent_reads = {ld.input for ld in parent_op.body.loads if ld.input != ws}
+    child_reads = {ld.input for ld in child_loop.loads if ld.input != ws}
+    parent_reads = {ld.input for ld in parent_loop.loads if ld.input != ws}
     frag.add_node(
         op=child_op,
         inputs=[i for i in root.inputs if i in child_reads],
@@ -452,8 +466,8 @@ def realize_cut(match, root: Node, tile_op, free: tuple, stores: tuple, site: Si
         node_id=out.name,
     )
     frag.outputs = [out.name]
-    for nid in (ws, out.name):
-        restamp_structural_features(frag.nodes[nid].op, frag)
+    child_op.knobs.update(structure_features(child_loop, frag))
+    parent_op.knobs.update(structure_features(parent_loop, frag))
     return frag
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_flash.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_flash.py
@@ -917,6 +917,22 @@ class _FlashMatch:
     v_inline: tuple[Loop, tuple[Stmt, ...], str, Load] | None = None
 
 
+@dataclass(frozen=True)
+class _InlineQk:
+    """Canonical computed Q/K edges recovered from one inlined score cell.
+
+    ``q_id`` / ``k_id`` are declaration anchors only; the edges retain every exact external
+    load. Their logical shapes come from the SDPA iteration space rather than either anchor's
+    physical storage shape, which may be one packed projection buffer.
+    """
+
+    q_id: str
+    k_id: str
+    q_edge: Load | Fold
+    k_edge: Load | Fold
+    head_dim: Dim
+
+
 def _pv_loads(graph: Graph, node: Node) -> tuple[Load, Load, Loop, tuple[Stmt, ...], str] | None:
     """Return the probability load and V cone for a bare P×V root.
 
@@ -1139,12 +1155,14 @@ def _qk_cell(rowmax: Loop, m_var: str, kv_var: str) -> tuple[Loop, list[Stmt], s
     """Recover one Q×K contraction cell nested under ``rowmax``.
 
     Returns the contraction loop plus each product argument's pure backward cone, value name,
-    and sequence-bearing leaf load. A K-normalization statistic is not mistaken for Q×K because
-    it has no query-indexed side.
+    and one declaration anchor. Classification uses each WHOLE cone's axis dependence: a packed
+    affine view, coordinate ``Select``, normalization weight, and rotary inputs may contribute
+    several sequence-bearing loads while still defining one closed scalar Q or K value. A
+    K-normalization statistic is not mistaken for Q×K because it has no query-indexed side.
     """
 
-    def index_vars(stmts: list[Stmt]) -> set[str]:
-        return {v for st in stmts if isinstance(st, Load) for expr in st.index for v in expr.free_vars()}
+    def expr_vars(stmts: list[Stmt]) -> set[str]:
+        return {v for st in stmts for expr in st.exprs() for v in expr.free_vars()}
 
     found = []
     for lp in rowmax.body.iter_of_type(Loop):
@@ -1159,13 +1177,15 @@ def _qk_cell(rowmax: Loop, m_var: str, kv_var: str) -> tuple[Loop, list[Stmt], s
             cone = map_cone(list(lp.body), value)
             if not cone:
                 break
-            vars_ = index_vars(cone)
+            vars_ = expr_vars(cone)
             leaves = [
                 s
                 for s in cone
-                if isinstance(s, Load) and _slot_of(s.index, lp.axis.name) is not None and ((m_var in vars_) or (kv_var in vars_))
+                if isinstance(s, Load)
+                and lp.axis.name in {v for expr in s.index for v in expr.free_vars()}
+                and ({m_var, kv_var} & {v for expr in s.index for v in expr.free_vars()})
             ]
-            if len(leaves) != 1:
+            if not leaves or lp.axis.name not in vars_:
                 break
             sides.append((cone, value, leaves[0], m_var in vars_, kv_var in vars_))
         if len(sides) != 2:
@@ -1234,7 +1254,7 @@ def _inline_operand_edge(
         return None
     members = [stmt for group in reversed(groups) for stmt in group]
     loops = [stmt for stmt in members if isinstance(stmt, Loop)]
-    if any(not isinstance(stmt, (Load, Assign, Loop)) for stmt in members):
+    if any(not (stmt.pure or isinstance(stmt, Loop)) for stmt in members):
         return None
     if len(loops) > 1:
         return None
@@ -1270,29 +1290,29 @@ def _inline_operand_edge(
 
 def _extract_inline_qk(
     score: Node,
+    root: Node,
     m_var: str,
     kv_var: str,
     rowmax: Loop,
-) -> tuple[tuple[str, tuple[int, int], Load | Fold], tuple[str, tuple[int, int], Load | Fold]] | None:
-    """Recover canonical Q/K operand edges from an inlined softmax producer."""
+) -> _InlineQk | None:
+    """Recover canonical Q/K operand edges from an inlined softmax producer.
+
+    Logical attention axes come from the consumer's iteration space. A physical declaration
+    anchor cannot supply them when Q and K are affine views of one packed projection buffer.
+    """
     found = _qk_cell(rowmax, m_var, kv_var)
     if found is None:
         return None
     qk_loop, q_cone, q_value, q_load, k_cone, k_value, k_load = found
-    q_layout = (_slot_of(q_load.index, m_var), _slot_of(q_load.index, qk_loop.axis.name))
-    k_layout = (_slot_of(k_load.index, kv_var), _slot_of(k_load.index, qk_loop.axis.name))
-    if None in (*q_layout, *k_layout):
+    writes = [stmt for stmt in root.op.body.iter() if isinstance(stmt, Write)]
+    if len(writes) != 1 or len(writes[0].index) != len(root.output.shape) or _var_at(writes[0].index, -2) != m_var:
         return None
-    q_layout = (q_layout[0], q_layout[1])
-    k_layout = (k_layout[0], k_layout[1])
 
-    # Canonical batch variables are learned from Q's non-(seq,last) slots. K may carry the
-    # same head variable through an affine GQA ``head // group`` access, which substitution
-    # then preserves exactly on its computed edge.
+    # The root write spells canonical ``(batch…, m, d)``. Its batch/head variables bind Q's
+    # logical batch axes; K may carry the same head variable through affine GQA ``head/group``.
     outer_sigma: dict[str, Var] = {m_var: Var("m"), kv_var: Var("kv")}
-    batch_pos = [i for i in range(len(q_load.index)) if i not in q_layout]
-    for i, pos in enumerate(batch_pos):
-        expr = q_load.index[pos]
+    batch_rank = len(root.output.shape) - 2
+    for i, expr in enumerate(writes[0].index[:-2]):
         if isinstance(expr, Var):
             outer_sigma[expr.name] = Var(f"b{i}")
         elif expr.free_vars():
@@ -1305,12 +1325,12 @@ def _extract_inline_qk(
     k_edge = _inline_operand_edge(score.op, qk_loop, path, k_cone, k_value, prefix="flash_k", outer_sigma=outer_sigma)
     if q_edge is None or k_edge is None:
         return None
-    allowed = {*(f"b{i}" for i in range(len(batch_pos))), "m", "kv", "dd"}
+    allowed = {*(f"b{i}" for i in range(batch_rank)), "m", "kv", "dd", "flash_q_stat", "flash_k_stat"}
     for edge in (q_edge, k_edge):
         for stmt in Body(tuple(edge.lower() if isinstance(edge, Fold) else (edge,))).iter():
-            if isinstance(stmt, Load) and any(expr.free_vars() - allowed - {"flash_q_stat", "flash_k_stat"} for expr in stmt.index):
+            if any(expr.free_vars() - allowed for expr in stmt.exprs()):
                 return None
-    return (q_load.input, q_layout, q_edge), (k_load.input, k_layout, k_edge)
+    return _InlineQk(q_load.input, k_load.input, q_edge, k_edge, qk_loop.axis.extent)
 
 
 def _extract_inline_v(root: Node, found: tuple[Loop, tuple[Stmt, ...], str, Load]) -> tuple[tuple[int, int], Fold] | None:
@@ -1391,7 +1411,7 @@ def try_flash(graph: Graph, root: Node) -> Graph | None:
     inline_qk = None
     if found.inline is not None:
         m_var, kv_var, rowmax = found.inline
-        inline_qk = _extract_inline_qk(score_producer, m_var, kv_var, rowmax)
+        inline_qk = _extract_inline_qk(score_producer, root, m_var, kv_var, rowmax)
         qk = None
     else:
         qk = _extract_qk(score_producer)
@@ -1416,7 +1436,9 @@ def try_flash(graph: Graph, root: Node) -> Graph | None:
         q_layout = k_layout = v_layout = None
         access_indices = (q_idx, k_idx, v_idx)
     elif inline_qk is not None:
-        (q_id, q_layout, q_edge), (k_id, k_layout, k_edge) = inline_qk
+        q_id, k_id = inline_qk.q_id, inline_qk.k_id
+        q_edge, k_edge = inline_qk.q_edge, inline_qk.k_edge
+        q_layout = k_layout = None  # computed edges already carry exact canonicalized accesses
         if graph.buffer(q_id) is None or graph.buffer(k_id) is None:
             return None
     else:
@@ -1444,9 +1466,16 @@ def try_flash(graph: Graph, root: Node) -> Graph | None:
         # Shapes canonicalize to (batch…, seq, last) per each operand's traced layout — the
         # eligibility predicates and the fragment's grid work on canonical shapes; the LOAD
         # indices permute back to each operand's own slot order (``_permute_idx``).
-        q_shape = _canon_shape(graph.buffer(q_id).shape, q_layout)
-        k_shape = _canon_shape(graph.buffer(k_id).shape, k_layout)
         v_shape = _canon_shape(graph.buffer(v_id).shape, v_layout)
+        if inline_qk is not None:
+            # Q's batch/head + query axes are the consumer output's leading dimensions; K
+            # shares V's batch/kv-head + sequence axes. Replace only the value dimension with
+            # the score contraction's D. Physical q_id/k_id storage may be one packed buffer.
+            q_shape = (*root.output.shape[:-1], inline_qk.head_dim)
+            k_shape = (*v_shape[:-1], inline_qk.head_dim)
+        else:
+            q_shape = _canon_shape(graph.buffer(q_id).shape, q_layout)
+            k_shape = _canon_shape(graph.buffer(k_id).shape, k_layout)
         if materialized_v is not None:
             v_id = f"{root.output.name}__flash_v"
             v_layout = None  # the recognizer-minted workspace is canonical by construction

--- a/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
@@ -220,6 +220,19 @@ def stage_target(stage: Stage, ctx) -> str | None:
     return None
 
 
+def sync_stage_target(c: Fold, ctx) -> str | None:
+    """Whether the generic ``sync`` transport can fill every contraction edge on ``ctx``.
+
+    Computed edges are filled synchronously by ordinary CTA threads. Materialized peers use the
+    transport's vectorized ``cp.async`` copy lane, so any such edge requires that named primitive.
+    This is a property of the transport and edge inhabitants, not of a GPU product or workload.
+    """
+    materialized = isinstance(c.a, Load) or any(isinstance(ch.b, Load) for ch in c.channels)
+    if materialized and not ctx.has_cp_async:
+        return "the sync transport copies materialized contraction edges with cp.async, which requires sm_80 or newer"
+    return None
+
+
 def warp_atom_stage(atom, stage: Stage) -> str | None:
     """Whether ``atom`` has a shared-memory fragment drain for ``stage``."""
     if atom.materialized_edges_only and not (stage.transport == "sync" and atom.sync_copy_staging):
@@ -504,10 +517,12 @@ def computed_a_cover(c: Fold, tile: TilePlan) -> str | None:
 
 
 def resolve_sync_stage(c: Fold, tile: TilePlan, budget: int, want_depth: int = 1) -> Stage | None:
-    """The ``sync`` compute-fill :class:`Stage` for a computed-operand warp contraction under ``tile``
-    — MANDATORY for this form (the gmem-direct mma leaf refuses a computed A, and cp.async / TMA are
-    copy transports that cannot evaluate a producer cone), so it has no gmem-direct ``""`` sibling
-    and a ``STAGE`` pin can only choose its DEPTH. ``None`` when the slabs exceed ``budget``: one A
+    """The mandatory ``sync`` :class:`Stage` for a computed-operand or product contraction.
+
+    A computed edge needs the synchronous fill, while a multi-channel product needs the transport
+    that allocates and drains every B/C channel. Neither form has a gmem-direct or copy-transport
+    sibling, and a ``STAGE`` pin can only choose its DEPTH. ``None`` when the slabs exceed
+    ``budget``: one A
     slab, one B slab per channel, and one fp32 row per bridged statistic (``ops.cone_seam``'s
     ``stats`` — the same node boundary the materializer fills through).
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -114,8 +114,8 @@ from emmy.compiler.structural import digest
 logger = logging.getLogger(__name__)
 
 #: The per-site schedule families this enumeration decides, IN THE ORDER their keys lead the fork
-#: levels. ``WORK`` and ``RASTER`` are kernel-global and bracket them; ``PLACE`` is the seam
-#: family — resolved from routing goldens / pins, never enumerated here.
+#: levels. ``WORK`` and ``RASTER`` are kernel-global and bracket them; ``PLACE`` is the separate
+#: structural seam fork, enumerated before each resulting kernel reaches this schedule enumerator.
 #:
 #: Not a copy of ``path.SLICE_FAMILIES`` even though the members match: that one answers "which
 #: families key a slice" (a set) and this one "in what order do their levels nest" (a sequence).
@@ -462,11 +462,10 @@ class _Term:
         atoms = _warp_atoms(self, node)
         warp = [p for p in warp_tile_moves(atoms) if _tile_ok(self, node, p)] if atoms else []
         self.warp_eligible = self.warp_eligible or bool(warp)
-        # A COMPUTED ``a`` edge is warp-ONLY: the fill that evaluates a producer cone is the mma
-        # tier's compute fill, and a per-cell / scalar expansion would re-run the cone on every K
-        # step. The reduce tiers stay reachable — through the COLLAPSE reading, whose spliced fold
-        # computes the whole body per cell (:func:`_readings`).
-        scalar = scalar_tile_moves() if not _has_computed_operand(node) else []
+        # A term that requires the generic sync transport is warp-ONLY: the fill evaluates a
+        # producer cone or carries every channel of a product, while both direct emitters are
+        # single-channel. The reduce tiers stay reachable through the COLLAPSE reading.
+        scalar = scalar_tile_moves() if not _requires_sync_stage(node) else []
         grouped: dict[str, list[TilePlan]] = {}
         for plan in scalar + warp:
             w = plan_workers(plan)
@@ -644,7 +643,7 @@ def _readings(tile: TileOp, ctx) -> list[_Term]:
     node = head(tile.op)
     if node is None or not is_contraction(node):
         return [base]
-    if _has_computed_operand(node):
+    if _requires_sync_stage(node):
         return [base, _reading(tile, _rewrap(tile.op, node.demoted()), ctx, ref=base.sched)]
     promoted = _promoted(node, tile.inputs, ctx)
     if promoted is None:
@@ -672,6 +671,11 @@ def _has_computed_operand(node) -> bool:
     return eligible(node.a) or any(eligible(ch.b) for ch in node.channels)
 
 
+def _requires_sync_stage(node) -> bool:
+    """Whether direct contraction emitters cannot realize the complete algebraic term."""
+    return _has_computed_operand(node) or len(node.channels) > 1
+
+
 def _tile_ok(term: _Term, node, plan: TilePlan) -> bool:
     """Whether a warp tile candidate is realizable on ``node`` — the K-step divisibility every warp
     row needs, plus the exact-cover geometry a COMPUTED ``a`` edge's compute fill adds. Both are
@@ -684,13 +688,15 @@ def _tile_ok(term: _Term, node, plan: TilePlan) -> bool:
         return False
     if not legal.enforce(legal.warp_k_step(node, plan), pinned=False):
         return False
-    if not _has_computed_operand(node):
+    if not _requires_sync_stage(node):
         return True
     placed = plan.placed_on(term.place)
     if placed.axes is None:
         return False  # no (m, n) pair on the grid — nothing to place a compute-filled tile on
-    return legal.enforce(legal.computed_operand_cover(node, placed), pinned=False) and legal.enforce(
-        legal.computed_operand_copy_dtype(node, placed, term.tile.inputs), pinned=False
+    return (
+        legal.enforce(legal.sync_stage_target(node, term.ctx), pinned=False)
+        and legal.enforce(legal.computed_operand_cover(node, placed), pinned=False)
+        and legal.enforce(legal.computed_operand_copy_dtype(node, placed, term.tile.inputs), pinned=False)
     )
 
 
@@ -960,7 +966,7 @@ def _resolve_stage(term: _Term, node, tile: TilePlan, want: Stage | None) -> Sta
         return None
     if want is not None and tile.is_warp and legal.warp_atom_stage(tile.atom, want) is not None:
         return None
-    if _has_computed_operand(node):
+    if _requires_sync_stage(node):
         return legal.resolve_sync_stage(node, tile, budget, want.depth if want is not None else 1)
     if want is None or (want.transport == "tma" and not term.ctx.has_tma):
         return None
@@ -989,9 +995,11 @@ def _resolved(moves, resolve, *, gmem_direct: bool = True) -> list[Stage | None]
 
 
 def _sync_values(term: _Term, node, tile: TilePlan) -> list[Stage | None]:
-    """The RESOLVED compute-fill stages a COMPUTED operand offers — its depths, and nothing else:
-    the fill is MANDATORY (there is no gmem-direct ``None`` sibling and no copy transport can
-    evaluate a cone), so a ``STAGE`` pin can only choose the depth. ``d1`` and the asynchronous-peer
+    """The resolved stages for a term that requires the complete ``sync`` transport.
+
+    A computed operand needs evaluation and a product needs one B/C slab per channel. The stage is
+    MANDATORY (there is no complete gmem-direct or copy-transport sibling), so a ``STAGE`` pin can
+    only choose the depth. ``d1`` and the asynchronous-peer
     prefetch ring ``d2`` are fork siblings — the ring is measured per shape (see
     :func:`_legality.resolve_sync_stage`) — and a ``d2`` that clamps back to ``d1`` under the smem
     budget spells identically, so it dedupes to one row."""
@@ -1015,7 +1023,7 @@ def _stage_values(term: _Term, node, plan: TilePlan) -> list[Stage | None]:
     if not plan.is_tiled:
         return [None]  # per-cell / unbindable — no operand slab to stage
     tile = plan.placed_on(term.place)
-    if plan.is_warp and _has_computed_operand(node):
+    if plan.is_warp and _requires_sync_stage(node):
         return _sync_values(term, node, tile)
 
     def resolve(st: Stage) -> Stage | None:
@@ -1030,7 +1038,7 @@ def _stage_values(term: _Term, node, plan: TilePlan) -> list[Stage | None]:
         wanted = Stage.parse(pinned)
         # SM70 pins are strict: do not silently turn a newer copy instruction or an unsupported
         # Volta fragment drain into the gmem-direct sibling.
-        if term.ctx.compute_capability < (8, 0):
+        if not term.ctx.has_cp_async:
             legal.enforce(legal.stage_target(wanted, term.ctx), pinned=True)
             if plan.is_warp:
                 legal.enforce(legal.warp_atom_stage(plan.atom, wanted), pinned=True)
@@ -1091,9 +1099,12 @@ def _contraction_reduces(term: _Term, node, plan: TilePlan) -> list[ReducePlan]:
 
 
 def _contraction_values(term: _Term, node, work: Workers | None) -> list[dict]:
-    """The contraction's values at ``work``: the tile × stage × reduce legal product, over EITHER
-    inhabitant of the ``a`` edge — a materialized ``Load`` (both tiers, every transport) or a
-    COMPUTED cone (the warp tier alone, over the mandatory compute fill)."""
+    """The contraction's legal tile × stage × reduce product at ``work``.
+
+    A single-channel materialized form reaches direct and copy transports. A computed operand or
+    multi-channel product is warp-only under mandatory ``sync`` staging; its demoted reading keeps
+    the general reduce path available independently.
+    """
     pin = term.pin("TILE", node)
     if pin is not None:
         try:
@@ -1115,7 +1126,8 @@ def _contraction_values(term: _Term, node, work: Workers | None) -> list[dict]:
                 legal.enforce(legal.warp_a_columns(node, plan, term.tile.inputs), pinned=True)
                 legal.enforce(legal.warp_k_step(node, plan), pinned=True)
                 legal.enforce(legal.fragment_epilogue(term.proj), pinned=True)
-                if _has_computed_operand(node):
+                if _requires_sync_stage(node):
+                    legal.enforce(legal.sync_stage_target(node, term.ctx), pinned=True)
                     legal.enforce(legal.computed_operand_cover(node, plan.placed_on(term.place)), pinned=True)
                     legal.enforce(legal.computed_operand_copy_dtype(node, plan.placed_on(term.place), term.tile.inputs), pinned=True)
                 # Fully materialized contractions use the ordinary operand-dtype rule. Inline-edge
@@ -1123,7 +1135,7 @@ def _contraction_values(term: _Term, node, work: Workers | None) -> list[dict]:
                 # scheduler-only fixtures that carry no Tensor metadata.
                 elif not legal.enforce(legal.warp_operand_dtype(node, plan, _a_dtype(node, term.tile.inputs)), pinned=False):
                     return []
-            elif _has_computed_operand(node):
+            elif _requires_sync_stage(node):
                 return []  # a scalar pin belongs to the demoted reading, not the compute-filled edge
             else:
                 # The CTA thread budget, raised HERE rather than left to materialization: a pinned

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -489,7 +489,8 @@ class _Stream:
     statistics, so it has no precision to trade. Only the PV gains the f16-accumulate sibling
     (``pv_atoms``), whose partials promote per streaming block in the realizer."""
 
-    qk: Fold  # the hoisted score edge — the head of the derived step
+    score: Fold | Load  # the hoisted score edge — computed or a PLACE materialization terminal
+    qk: Fold | None  # the computed score contraction, absent when ``score`` is materialized
     pv: Fold  # the synthesized P@V contraction — combine material, below the seam
     atom: object  # the score's mma atom
     pv_atoms: tuple  # the P@V atom, plus its f16-accumulate sibling when the gate offers it
@@ -497,6 +498,10 @@ class _Stream:
     tma: bool  # whether a TMA box can encode this trace's K/V operands
     stageable: bool  # the K/V slabs byte-copy at the atom's operand width
     q_stageable: bool  # ... and so does Q, which the ``split`` groups additionally stage
+
+    @property
+    def materialized_score(self) -> bool:
+        return isinstance(self.score, Load)
 
 
 def _kv_penultimate(load: Load, kv_name: str) -> bool:
@@ -520,55 +525,74 @@ def _stream_of(term: _Term, node) -> _Stream | None:
     stride, derived from the index + shape) and a fragment-unrealizable projection. Each is a
     property of the TERM, so it belongs in the choice layer — what a CANDIDATE must satisfy is
     :mod:`._legality`."""
-    qk, pv = stream_pair(node)
+    score, pv = stream_pair(node)
     inputs = term.tile.inputs
-    if qk is None or pv is None or not inputs or legal.fragment_epilogue(term.proj) is not None:
+    if score is None or pv is None or not inputs or legal.fragment_epilogue(term.proj) is not None:
         return None
-    if not (isinstance(qk.a, Load) and isinstance(qk.b, Load) and isinstance(pv.b, Load)):
-        return None
-    if not qk.axis.extent.is_static:
-        return None  # the score's fragment K-steps are unrolled — a symbolic head dim has no tier
-    atoms = tuple(name for name in atoms_for(_a_dtype(qk, inputs), ctx=term.ctx) if ATOM_REGISTRY[name].c_to_a_repack)
-    if not atoms:
-        return None
-    atom = ATOM_REGISTRY[atoms[0]]
-    # The two sites' PLACED readings — the ``(m, n)`` pair is a function of the SITE, so it is
-    # taken off the one rule (``Sched._mn_for``, through a bare probe plan) rather than restated.
-    qk_mn, pv_mn = term.sched.placed(qk, TilePlan()).axes, term.sched.placed(pv, TilePlan()).axes
-    if qk_mn is None or pv_mn is None or not pv_mn[1].extent.is_static:
-        return None
-    d_v, kv_name, m_name = pv_mn[1].extent.as_static(), node.axis.name, qk_mn[0].name
-    for s in node.lift.body:
-        if isinstance(s, Load) and s.index and not {v for e in s.index for v in e.free_vars()} <= {m_name, kv_name}:
-            return None  # a score bias indexed beyond (m, kv) — the fragment realizer cannot load it
-    strides = (
-        gmem_row_stride(qk.a, m_name, inputs),
-        gmem_row_stride(qk.b, (qk_mn[1] if qk.b_trans else qk.axis).name, inputs),
-        gmem_row_stride(pv.b, (pv_mn[1] if pv.b_trans else node.axis).name, inputs),
-    )
-    if any(s is None for s in strides):
+    qk = score if isinstance(score, Fold) and is_contraction(score) else None
+    if not isinstance(pv.b, Load):
         return None
 
     def dtype_of(load: Load):
         t = inputs.get(load.input)
         return getattr(t, "dtype", None)
 
+    if qk is not None:
+        if not (isinstance(qk.a, Load) and isinstance(qk.b, Load)) or not qk.axis.extent.is_static:
+            return None  # the score's fragment K-steps are unrolled — a symbolic head dim has no tier
+        channel_dtype = _a_dtype(qk, inputs)
+    else:
+        if not isinstance(score, Load) or getattr(dtype_of(score), "name", None) not in ("f16", "bf16", "f32"):
+            return None
+        channel_dtype = dtype_of(pv.b)  # P is repacked to the atom width consumed beside V
+    atoms = tuple(name for name in atoms_for(channel_dtype, ctx=term.ctx) if ATOM_REGISTRY[name].c_to_a_repack)
+    if not atoms:
+        return None
+    atom = ATOM_REGISTRY[atoms[0]]
+    # The two sites' PLACED readings — the ``(m, n)`` pair is a function of the SITE, so it is
+    # taken off the one rule (``Sched._mn_for``, through a bare probe plan) rather than restated.
+    qk_mn, pv_mn = term.sched.placed(qk if qk is not None else node, TilePlan()).axes, term.sched.placed(pv, TilePlan()).axes
+    if qk_mn is None or pv_mn is None or not pv_mn[1].extent.is_static:
+        return None
+    d_v, kv_name, m_name = pv_mn[1].extent.as_static(), node.axis.name, qk_mn[0].name
+    for s in node.lift.body:
+        if isinstance(s, Load) and s.index and not {v for e in s.index for v in e.free_vars()} <= {m_name, kv_name}:
+            return None  # a score bias indexed beyond (m, kv) — the fragment realizer cannot load it
+    if qk is None:
+        allowed = {a.name for a in term.place.free if a.name != pv_mn[1].name} | {kv_name}
+        if not {v for e in score.index for v in e.free_vars()} <= allowed:
+            return None  # a score varying over the output value axis cannot be one score fragment
+    strides = (
+        *(
+            (
+                gmem_row_stride(qk.a, m_name, inputs),
+                gmem_row_stride(qk.b, (qk_mn[1] if qk.b_trans else qk.axis).name, inputs),
+            )
+            if qk is not None
+            else ()
+        ),
+        gmem_row_stride(pv.b, (pv_mn[1] if pv.b_trans else node.axis).name, inputs),
+    )
+    if any(s is None for s in strides):
+        return None
+
     b_dt, a_dt = atom.operand_dtype("b"), atom.operand_dtype("a")
     # Which atoms EXIST for this operand dtype is a term fact; whether the precision-trading sibling
     # is OFFERED is the choice layer's gate (:func:`_twisted_values`), which a pin bypasses.
-    sibling = atoms_for(_a_dtype(qk, inputs), acc=_a_dtype(qk, inputs), ctx=term.ctx)
+    sibling = atoms_for(channel_dtype, acc=channel_dtype, ctx=term.ctx)
     return _Stream(
+        score=score,
         qk=qk,
         pv=pv,
         atom=atom,
         pv_atoms=(atom, *(ATOM_REGISTRY[n] for n in sibling)),
         d_v=d_v,
-        tma=term.ctx.has_tma and _kv_penultimate(qk.b, kv_name) and _kv_penultimate(pv.b, kv_name),
+        tma=qk is not None and term.ctx.has_tma and _kv_penultimate(qk.b, kv_name) and _kv_penultimate(pv.b, kv_name),
         # Staging byte-COPIES the operands into slabs typed at the atom's operand width, so an
         # operand traced at another dtype would deposit wrong-sized elements; gmem-direct fragment
         # loads convert per element, which is why a mismatch keeps the tier and drops its stage rows.
-        stageable=dtype_of(qk.b) == b_dt and dtype_of(pv.b) == b_dt and qk.axis.extent.as_static() % atom.atom_k == 0,
-        q_stageable=dtype_of(qk.a) == a_dt,
+        stageable=qk is not None and dtype_of(qk.b) == b_dt and dtype_of(pv.b) == b_dt and qk.axis.extent.as_static() % atom.atom_k == 0,
+        q_stageable=qk is not None and dtype_of(qk.a) == a_dt,
     )
 
 
@@ -1149,6 +1173,8 @@ def _contraction_values(term: _Term, node, work: Workers | None) -> list[dict]:
         plans = grouped.get(base.spell() if base is not None else "", []) + (grouped.get("", []) if base is not None else [])
     out = []
     for plan in plans:
+        if plan.is_tiled and plan.placed_on(term.place).axes is None:
+            continue  # output tiling needs an (m, n) grid pair; the unmapped scalar path remains
         for red in _contraction_reduces(term, node, plan):
             for stage in _stage_values(term, node, plan):
                 if work is not None and work.producer and not legal.enforce(legal.producer_transport(stage, red), pinned=False):
@@ -1218,7 +1244,6 @@ def _twisted_values(term: _Term, site: Site, work: Workers | None, parent: _Node
         atom = ctx.atom
         if legal.enforce(legal.twisted_atom(atom, ctx.d_v), pinned=False):
             um = work.units[0]
-            bk = -(-ctx.qk.axis.extent.as_static() // atom.atom_k)  # ceil: an overhanging final atom gmem-zero-fills
             # The grid's ``warps_m`` is the INVENTORY, already fixed above, so what a site
             # enumerates is the free half — the key-atom / query-tile pair, once each.
             for nt, fm in dict.fromkeys((nt, fm) for _, nt, fm in twisted_warp_moves()):
@@ -1232,6 +1257,8 @@ def _twisted_values(term: _Term, site: Site, work: Workers | None, parent: _Node
                         for pv in ctx.pv_atoms
                     )
                 else:
+                    assert ctx.qk is not None
+                    bk = -(-ctx.qk.axis.extent.as_static() // atom.atom_k)  # overhanging final atom gmem-zero-fills
                     out.append(TilePlan(atom=atom, units=(um, 1), regs=(fm, nt), bk=bk))
     plans, selected = _narrowed(term, node, out)
     if not selected and not _f16acc_allowed(term.ctx):
@@ -1265,6 +1292,8 @@ def _stream_stages(term: _Term, node, ctx: _Stream, qk: TilePlan, pv: TilePlan) 
     fallback — only this tier stages, so a staging pin that fell through to the chain / reduce
     siblings would let the prior bury the (necessarily lower-occupancy) staged row under a
     higher-occupancy scalar one."""
+    if ctx.materialized_score:
+        return [None]  # first tier: score + V read gmem-direct; no K/Q slabs exist to stage
     budget = term.ctx.max_dynamic_smem
 
     def resolve(st: Stage) -> Stage | None:
@@ -1295,12 +1324,27 @@ def _stream_values(term: _Term, node, work: Workers | None, kids: tuple) -> list
 
     The QK / PV SIBLING EQUALITY is enforced here, because this is where the pair is visible: a
     mismatched pair yields NO values, so the combination is never built."""
+    ctx = term.stream(node)
+    materialized = isinstance(stream_pair(node)[0], Load)
     qk, pv = _stream_tiles(kids)
+    if materialized and pv is not None and pv.is_warp:
+        if ctx is None or pv.atom.atom_k % ctx.atom.atom_n:
+            return []
+        nt = pv.bk * pv.atom.atom_k // ctx.atom.atom_n
+        qk = TilePlan(atom=ctx.atom, units=pv.units, regs=(pv.reg_m, nt), bk=1)
+        kept, _ = _narrowed(term, node, [qk])
+        if not kept:
+            return []
+        (qk,) = kept
     if qk is None and pv is None:
-        return _reduce_values(term, node)
+        rows = _reduce_values(term, node)
+        if materialized and not _narrowed(term, node, [TilePlan()])[0]:
+            return []
+        return [{"TILE": TilePlan(), **row} for row in rows] if materialized else rows
     if not legal.enforce(legal.twisted_sites_agree(qk or TilePlan(), pv or TilePlan()), pinned=False):
         return []
-    ctx = term.stream(node)
+    if materialized and qk is not None and not legal.enforce(legal.twisted_block(node, term.sched.placed(node, qk)), pinned=False):
+        return []
     # A pin the SCHEDULED form cannot honor drops these rows rather than ignoring the pin: the
     # reduce tiers do realize a partition, so the term still maps — through them.
     red_pin = term.pin("REDUCE", node)
@@ -1309,10 +1353,14 @@ def _stream_values(term: _Term, node, work: Workers | None, kids: tuple) -> list
             return []
         if ctx is not None and term.pin("STAGE", node):
             return []  # only the fragment tier stages; a staging pin must not fall through to the chain
-        return [{"REDUCE": ReducePlan(), "STAGE": None}]  # the chain: one thread per query row, kv serial
+        row = {"REDUCE": ReducePlan(), "STAGE": None}
+        if materialized and not _narrowed(term, node, [TilePlan()])[0]:
+            return []
+        return [{"TILE": TilePlan(), **row}] if materialized else [row]  # chain: one thread per row, kv serial
     if ctx is None:
         return []
-    placed_qk, placed_pv = term.sched.placed(ctx.qk, qk), term.sched.placed(ctx.pv, pv)
+    placed_qk = term.sched.placed(node if materialized else ctx.qk, qk)
+    placed_pv = term.sched.placed(ctx.pv, pv)
     if red_pin is not None:
         want = ReducePlan.parse(red_pin, work)
         # The pin names the PARTITION; which streaming geometry can carry it is the GEOMETRY's
@@ -1331,7 +1379,7 @@ def _stream_values(term: _Term, node, work: Workers | None, kids: tuple) -> list
             reduces += [p for p in splitk_moves() if legal.enforce(legal.splitkv_slice(node, placed_qk, p), pinned=False)]
     stages = _stream_stages(term, node, ctx, placed_qk, placed_pv)
     return [
-        {"REDUCE": red, "STAGE": stage}
+        {**({"TILE": qk} if materialized else {}), "REDUCE": red, "STAGE": stage}
         for red in reduces
         for stage in stages
         if not (work is not None and work.producer and not legal.enforce(legal.producer_transport(stage, red), pinned=False))
@@ -1833,19 +1881,28 @@ def _stream_option(
     and its ``STAGE`` is the K/V transport re-resolved against the same geometry."""
     qk, pv = _row_stream_tiles(root, row, work)
     ctx = term.stream(node)
+    materialized = ctx is not None and ctx.materialized_score
+    if materialized:
+        tile_spec = row.get(root.keys.get("TILE"), "") or ""
+        qk = resolve_site_tile(tile_spec, work) if tile_spec else None
+        qk = qk if qk is not None and qk.is_tiled else None
     spec = row.get(root.keys.get("STAGE"), "") or ""
     stage = None
     if qk is not None and qk.is_warp and ctx is not None:
-        placed_qk, placed_pv = term.sched.placed(ctx.qk, qk), term.sched.placed(ctx.pv, pv)
+        placed_qk = term.sched.placed(node if materialized else ctx.qk, qk)
+        placed_pv = term.sched.placed(ctx.pv, pv)
         place = _warp_stream_place(term, placed_qk, placed_pv)
-        if spec:
+        if spec and not materialized:
             stage = legal.resolve_twisted_stage(node, ctx.qk, placed_qk, placed_pv, Stage.parse(spec), term.ctx.max_dynamic_smem)
     else:
         # The chain: one thread per query row, the value axis off the grid and into the register
         # vector the P@V slice names.
         place = Placement(free=term.place.free, grid=tuple(term.place.grid[:-1]))
     workers = WarpSpec(work.producer) if work is not None and work.producer else None
-    own = [("REDUCE", node, rplan if rplan.stages else None), ("STAGE", node, stage)]
+    own = ([("TILE", node, qk)] if materialized else []) + [
+        ("REDUCE", node, rplan if rplan.stages else None),
+        ("STAGE", node, stage),
+    ]
     return _stamp(term, term.tile.op, name, knobs, [*own, *nested], workers=workers, place=place)
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1973,7 +1973,10 @@ def _materialize(term: _Term, resolved: _Row, row: dict, name: str, knobs: dict)
     rplan = decided("REDUCE") or ReducePlan.parse(value("REDUCE"), work)
     plan = decided("TILE")
     if plan is None:
-        plan = resolve_site_tile(value("TILE"), work, rplan.coop)
+        # An empty spelling is a unit register tile only when THIS root owns a TILE site. A
+        # nested-only term (flash's dd/pj tiles under a reduce root) has no root TILE key at all;
+        # borrowing its shared thread inventory there invents a slice the codec cannot address.
+        plan = resolve_site_tile(value("TILE"), work, rplan.coop) if "TILE" in keys else TilePlan()
     if is_contraction(node) and rplan.needs_split:
         # The stage is re-resolved INSIDE against the sliced node, so it stays a spelling here.
         return _splitk_option(term, plan, node, rplan, name, op_knobs, value("STAGE"), nested)

--- a/emmy/compiler/pipeline/pipeline.py
+++ b/emmy/compiler/pipeline/pipeline.py
@@ -926,8 +926,8 @@ class Run:
 def _is_structural_option(option: object) -> bool:
     """Classify one raw rewrite option by its effect: a ``Graph`` splice
     changes which ops exist — **structural**; an ``Op`` rebind is in-place —
-    **op-variant**. The Op/Graph return type IS the classification; rules wrap
-    a Graph option in a leaf :class:`OptionFork` (no production rule emits one today),
+    **op-variant**. The Op/Graph return type IS the classification; rules may wrap
+    a Graph option in a leaf :class:`OptionFork` (placement does this to carry its decision row),
     whose ``option`` is readable without firing any thunk. A *branch* ``Fork``
     reads op-variant: the sole branch-Fork emitter today is the partition
     planner (all ``TileOp`` leaves), and typing it would require ``expand()`` —
@@ -946,7 +946,7 @@ def _concrete_option(option: object) -> object | None:
     return option
 
 
-def _option_decision(option: object, root_knobs: dict) -> dict | None:
+def _option_decision(option: object, root_metadata: dict) -> dict | None:
     """The decision-knob delta one raw structural-fork option would stamp vs
     the offer op: non-``S_*`` knob keys the option's op / fork knobs **add or
     change** vs the offer (a ``Graph`` option reads the union over its nodes'
@@ -959,9 +959,10 @@ def _option_decision(option: object, root_knobs: dict) -> dict | None:
         knobs: dict = {}
         for node in option.nodes.values():
             knobs.update(getattr(node.op, "knobs", None) or {})
+            knobs.update(getattr(node.op, "decision_knobs", None) or {})
     else:
-        knobs = getattr(option, "knobs", None) or {}
-    delta = {k: v for k, v in knobs.items() if root_knobs.get(k) != v and not k.startswith("S_")}
+        knobs = {**(getattr(option, "knobs", None) or {}), **(getattr(option, "decision_knobs", None) or {})}
+    delta = {k: v for k, v in knobs.items() if root_metadata.get(k) != v and not k.startswith("S_")}
     return delta or None
 
 
@@ -974,7 +975,8 @@ def _choice_knobs(choice: object, option: object, root_op) -> dict:
     if isinstance(choice, Fork) and choice.knobs:
         return dict(choice.knobs)
     if isinstance(option, Graph):
-        return _option_decision(option, root_op.knobs) or {}
+        root_metadata = {**root_op.knobs, **root_op.decision_knobs}
+        return _option_decision(option, root_metadata) or {}
     return dict(getattr(option, "knobs", None) or {})
 
 
@@ -989,7 +991,8 @@ def _replay_structural_decision(graph: Graph, root_op, options: list) -> object 
     (the ``CUT`` considered-vs-declined idiom), and those ops chain to
     the pre-decision offer op via the engine-owned ``Op.source`` (stamped
     unconditionally on rebinds, stamped across loop-dialect splices,
-    preserved by ``_rename_buf_in_op``). So: find any op carrying every
+    preserved by ``_rename_buf_in_op``). Structural rows live in ``Op.decision_knobs`` so they
+    do not become per-kernel schedule evidence. So: find any op carrying every
     decision knob whose source chain contains an op structurally identical
     to this offer (same ``Op.cache_key``), and replay the option whose delta
     matches its stamped values. Matching by decision-knob agreement (not a
@@ -997,12 +1000,13 @@ def _replay_structural_decision(graph: Graph, root_op, options: list) -> object 
     key = root_op.cache_key()
     if key is None:
         return None
-    deltas = [(opt, _option_decision(opt, root_op.knobs)) for opt in options]
+    root_metadata = {**root_op.knobs, **root_op.decision_knobs}
+    deltas = [(opt, _option_decision(opt, root_metadata)) for opt in options]
     decision_keys = {k for _, d in deltas if d for k in d}
     if not decision_keys:
         return None
     for node in graph.nodes.values():
-        knobs = getattr(node.op, "knobs", None)
+        knobs = {**(getattr(node.op, "knobs", None) or {}), **(getattr(node.op, "decision_knobs", None) or {})}
         if not knobs or not decision_keys <= set(knobs):
             continue  # undecided or unrelated op — the cheap pre-filter
         chain = node.op.source_chain()

--- a/emmy/compiler/pipeline/pipeline.py
+++ b/emmy/compiler/pipeline/pipeline.py
@@ -1245,11 +1245,11 @@ class _TerminalBench:
             c_dialect = child_op.dialect
             if p_dialect is None or c_dialect is None:
                 continue
-            if p_dialect == c_dialect == "loop":
-                # loop→loop source hops are structural/decision hops, not
-                # lowering rewrites: the splice attribution stamped by
-                # ``Candidate.apply`` (a decomposition's kernels → the
-                # pre-split op), 005's keep-vs-split rebind, name stamps.
+            if child_op.source_is_graph_splice or p_dialect == c_dialect == "loop":
+                # Graph-splice attribution and loop→loop source hops are structural/decision
+                # provenance, not lowering rewrites. The former covers both PLACE fragments and
+                # schedule-realized split reductions; the latter covers 005's keep-vs-split
+                # rebind and name stamps.
                 # A ``lowering`` row holds ONE best child per parent, so
                 # recording a multi-kernel decomposition's hops would let
                 # ``best_per_op_time``'s chain walk resolve the pre-split

--- a/emmy/compiler/pipeline/rule_diff.py
+++ b/emmy/compiler/pipeline/rule_diff.py
@@ -37,6 +37,7 @@ PASS_SHORTHAND = {
     "loop/fusion": "f",
     "loop/stamp": "s",
     "lowering/tile": "t",
+    "lowering/schedule": "t",
     "lowering/kernel": "k",
     "lowering/cuda": "c",
 }

--- a/emmy/compiler/pipeline/search/candidate.py
+++ b/emmy/compiler/pipeline/search/candidate.py
@@ -169,7 +169,7 @@ class Candidate:
         ``Op`` rebinds ``root.op`` (id / inputs / hints kept);
         ``Graph`` is a fragment spliced via ``Graph.splice``. On the
         ``Op`` path the chain ``Op.source`` is stamped with the op
-        being replaced and the predecessor's ``knobs`` are merged
+        being replaced and the predecessor's ``knobs`` and ``decision_knobs`` are merged
         forward — so the rewrite chain threads through every in-place
         rebind for free. The stamp is UNCONDITIONAL (engine-owned):
         "the op this op replaced at this node" is a fact about the
@@ -192,12 +192,22 @@ class Candidate:
             if option is not old_op:
                 option.source = old_op
                 option.knobs = {**old_op.knobs, **option.knobs}
+                option.decision_knobs = {**old_op.decision_knobs, **option.decision_knobs}
             self.graph.nodes[match.root_node_id].op = option
         else:
             assert isinstance(option, Graph), f"expected Graph or Op; got {type(option).__name__}"
             # Decomposition expands one op into many distinct pieces (mint);
             # every other fragment splice aggregates the consumed pieces.
             pass_ = match.rule.pass_
+            decisions: dict = {}
+            for nid in match.consumed:
+                consumed = self.graph.nodes.get(nid)
+                if consumed is not None:
+                    decisions.update(consumed.op.decision_knobs)
+            if decisions:
+                for frag_node in option.nodes.values():
+                    if frag_node.op.dialect is not None:
+                        frag_node.op.decision_knobs = {**decisions, **frag_node.op.decision_knobs}
             mint_pieces = pass_ is not None and pass_.name.startswith("frontend/decomposition")
             if pass_ is not None and pass_.name.startswith("lowering/"):
                 root_op = self.graph.nodes[match.root_node_id].op
@@ -281,8 +291,8 @@ class LazyCandidate:
         ``try_rewrite``'s filter) is lifted into an :class:`OptionFork`
         leaf — an ``Op``'s knob delta rides along as the fork's ``knobs``."""
         if not isinstance(option, Fork):
-            # A ``Graph`` option is a structural decomposition (a multi-kernel rewrite): the
-            # graph itself carries no knobs, so it scores as a knob-less generic row.
+            # A bare ``Graph`` option is a structural decomposition without an explicit decision
+            # row. Placement uses ``OptionFork`` directly so its PLACE row remains rankable.
             knobs = dict(getattr(option, "knobs", None) or {}) if isinstance(option, Op) else {}
             option = OptionFork(option=option, knobs=knobs)
         return cls(inner=inner, cursor=cursor, pending=(match, option))

--- a/emmy/compiler/pipeline/search/candidate.py
+++ b/emmy/compiler/pipeline/search/candidate.py
@@ -178,19 +178,17 @@ class Candidate:
         own ancestor into ``source``, and honoring that copy would
         skip the replaced op in the chain (and silently disable the
         knob merge, which is idempotent for rules that already merged
-        manually). A
-        lowering-tier ``Graph`` splice of a loop-dialect kernel (a
-        structural decomposition — the placement realizer's cut)
-        stamps the consumed root op as each fragment kernel's
-        ``source``, so the chain also records *which op a decomposition
-        came from*. Knobs are NOT merged
-        forward on this path — fragment kernels carry their own
-        restamped structural features."""
+        manually). A lowering-tier ``Graph`` splice stamps the consumed root op as every same-dialect fragment
+        kernel's ``source``, so the chain also records *which op the fragment came from*. It marks that source edge as
+        a graph splice: structural-decision replay can follow the predecessor, while DB persistence does not mistake
+        one fragment's launch time for the parent op's aggregate cost. Knobs are NOT merged forward on this path —
+        fragment kernels carry their own restamped structural features."""
         self._log_apply(match, option)
         if isinstance(option, Op):
             old_op = self.graph.nodes[match.root_node_id].op
             if option is not old_op:
                 option.source = old_op
+                option.source_is_graph_splice = False
                 option.knobs = {**old_op.knobs, **option.knobs}
                 option.decision_knobs = {**old_op.decision_knobs, **option.decision_knobs}
             self.graph.nodes[match.root_node_id].op = option
@@ -211,10 +209,11 @@ class Candidate:
             mint_pieces = pass_ is not None and pass_.name.startswith("frontend/decomposition")
             if pass_ is not None and pass_.name.startswith("lowering/"):
                 root_op = self.graph.nodes[match.root_node_id].op
-                if root_op.dialect == "loop":
+                if root_op.dialect is not None:
                     for frag_node in option.nodes.values():
-                        if frag_node.op.source is None and frag_node.op.dialect == "loop":
+                        if frag_node.op.source is None and frag_node.op.dialect == root_op.dialect:
                             frag_node.op.source = root_op
+                            frag_node.op.source_is_graph_splice = True
             self.graph.splice(
                 option,
                 consumed=match.consumed,

--- a/emmy/compiler/pipeline/search/data/sample.py
+++ b/emmy/compiler/pipeline/search/data/sample.py
@@ -70,6 +70,9 @@ class Sample:
     source: str = "db"
     s_full: dict | None = None  # full compiled/derived S_* histogram when known
     error: str | None = None  # bench_fail failure text (db rows only; None on ok rows)
+    # Exact working-only placement + per-op schedule replay. Canonical and DB/prior
+    # samples stay on the scalar ``knobs`` representation.
+    kernel_set: dict | None = None
     # Optional exact work count. The intensity-floor gate reads THIS, not a ShapeKey reconstruction: the join key
     # excludes symbolic axes on the matmul side but includes them on the reduce-tier side, so no
     # one hint-multiplier formula over it can be right for both.
@@ -106,9 +109,16 @@ class Sample:
         from emmy.compiler.context import Context  # noqa: PLC0415
 
         tunable, _ctx, _s = _split_by_prefix(cfg.knobs)
+        kernel_set = None
+        latency_us = cfg.emmy_us
+        if cfg.ranking is not None and "kernel_set" in cfg.ranking:
+            from emmy.compiler.pipeline.search.working_golden import parse_kernel_set_ranking  # noqa: PLC0415
+
+            kernel_set = parse_kernel_set_ranking(cfg.ranking)
+            latency_us = float(cfg.ranking["latency_us"])
         return cls(
             knobs=tunable,
-            latency_us=cfg.emmy_us,
+            latency_us=latency_us,
             shape=cfg.shape_key,
             name=cfg.name,
             dtype=cfg.dtype,
@@ -120,6 +130,7 @@ class Sample:
             context=Context.from_target(cfg.compute_cap, gpu_name=cfg.gpu_name).features(),
             source="golden",
             s_full=dict(cfg.structural_features),
+            kernel_set=kernel_set,
         )
 
     @classmethod

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -334,7 +334,7 @@ def knob_features(knobs: dict) -> dict[str, float]:
         if knob is not None and knob.unfeatured:
             continue  # unfeatured knob (cosmetic re-spell / umbrella gate): never a ranking feature
         if knob is not None and knob.features is not None:
-            for feature, contribution in knob.features(val).items():
+            for feature, contribution in knob.features(name, val).items():
                 feats[feature] = feats.get(feature, 0.0) + contribution
             continue
         if knob is None:

--- a/emmy/compiler/pipeline/search/features.py
+++ b/emmy/compiler/pipeline/search/features.py
@@ -327,11 +327,15 @@ def knob_features(knobs: dict) -> dict[str, float]:
         if name.startswith(STRUCT_PREFIX) or name.startswith(CTX_PREFIX):
             feats[name] = float(val)
             continue
-        knob = get(name)
+        # Scoped families (``TILE@k``, ``PLACE@a``) share their bare family's
+        # descriptor. Schedule codecs get their geometry below; placement uses
+        # its custom pooled features here.
+        knob = get(family_of(name))
         if knob is not None and knob.unfeatured:
             continue  # unfeatured knob (cosmetic re-spell / umbrella gate): never a ranking feature
         if knob is not None and knob.features is not None:
-            feats.update(knob.features(val))
+            for feature, contribution in knob.features(val).items():
+                feats[feature] = feats.get(feature, 0.0) + contribution
             continue
         if knob is None:
             num = _coerce_float(val)

--- a/emmy/compiler/pipeline/search/pins.py
+++ b/emmy/compiler/pipeline/search/pins.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 import contextlib
 import os
+from collections import Counter
 
 from emmy import config
 from emmy.compiler.pipeline.knob import axis_of, family_of, get, is_off_value, pin_key_matches, values_equal
+
+
+class KernelSetReplayError(ValueError):
+    """An exact working kernel set no longer matches the compiler's offers."""
 
 
 def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | None:
@@ -77,3 +82,159 @@ def pinned_knobs(knobs: dict):
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = previous
+
+
+def _placed_kernel_nodes(graph) -> list[tuple[str, object]]:
+    """The same recognized-kernel inventory the two-level inner search tunes."""
+    from emmy.compiler.pipeline.passes.lowering.tile._flash import fused_producer_ids  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.two_level import _kernel_nodes  # noqa: PLC0415
+
+    eligible = dict(_kernel_nodes(graph))
+    absorbed = {producer for nid in eligible for producer in fused_producer_ids(graph, graph.nodes[nid])}
+    return [(nid, eligible[nid]) for nid in graph.topological_order() if nid in eligible and nid not in absorbed]
+
+
+def _placement_knobs(graph) -> dict[str, str]:
+    """Conflict-free realized placement rows on one placed kernel set."""
+    out: dict[str, str] = {}
+    for node in graph.nodes.values():
+        for key, value in node.op.decision_knobs.items():
+            if family_of(key) != "PLACE":
+                continue
+            value = str(value)
+            if key in out and out[key] != value:
+                raise KernelSetReplayError(f"placement {key} realized conflicting values {out[key]!r} and {value!r}")
+            out[key] = value
+    return out
+
+
+def _leaf_knobs(leaf: object) -> dict:
+    """The direct knob row carried by one flattened schedule leaf."""
+    from emmy.compiler.graph import Graph  # noqa: PLC0415
+    from emmy.compiler.pipeline.fork import Fork  # noqa: PLC0415
+
+    if isinstance(leaf, Fork):
+        return dict(leaf.knobs)
+    if isinstance(leaf, Graph):
+        return {}
+    return dict(getattr(leaf, "knobs", None) or {})
+
+
+def _exact_schedule_decide(kernel_set: dict):
+    """Build a deterministic schedule resolver keyed by pre-schedule ``op_key``."""
+    from emmy.compiler.pipeline.fork import flatten_leaves  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import stamp_schedule_families  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.policy.greedy import PARTITION_RULE  # noqa: PLC0415
+
+    by_key = {row["op_key"]: row for row in kernel_set["kernels"]}
+
+    def decide(fp):
+        if fp.structural or fp.match.rule.name != PARTITION_RULE:
+            raise KernelSetReplayError(f"unexpected exact-replay fork {fp.match.rule.name!r} at {fp.node_id}")
+        op_key = fp.root_op.cache_key()
+        component = by_key.get(op_key)
+        if component is None:
+            raise KernelSetReplayError(f"schedule offered unknown op_key {op_key!r} at {fp.node_id}")
+        want = {key: str(value) for key, value in component["pins"].items()}
+        matches = []
+        for leaf in flatten_leaves(fp.options):
+            got = stamp_schedule_families({**dict(fp.root_op.knobs or {}), **_leaf_knobs(leaf)})
+            if got == want:
+                matches.append(leaf)
+        if len(matches) != 1:
+            raise KernelSetReplayError(f"op_key {op_key!r} expected one schedule matching {want}, got {len(matches)}")
+        return matches[0]
+
+    return decide
+
+
+def _cuda_record_knobs(graph) -> list[dict[str, str]]:
+    """Ordered canonical Cuda rows for one lowered graph."""
+    from emmy.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
+    from emmy.compiler.pipeline.knob import stamp_schedule_families  # noqa: PLC0415
+
+    return [
+        stamp_schedule_families(graph.nodes[nid].op.knobs or {})
+        for nid in graph.topological_order()
+        if isinstance(graph.nodes[nid].op, CudaOp)
+    ]
+
+
+def _validate_component_cuda_rows(op_key: str, actual: list[dict[str, str]], expected: list[dict[str, str]]) -> None:
+    """Require one component's direct Cuda launch order to remain exact."""
+    if actual != expected:
+        raise KernelSetReplayError(f"op_key {op_key!r} CUDA record-knob mismatch: expected {expected}, realized {actual}")
+
+
+def _validate_cuda_inventory(actual: list[dict[str, str]], kernel_set: dict) -> None:
+    """Require every target Cuda row without imposing cross-component order."""
+    expected = Counter(
+        tuple(sorted((key, str(value)) for key, value in row.items()))
+        for component in kernel_set["kernels"]
+        for _ in range(component["multiplicity"])
+        for row in component["cuda_record_knobs"]
+    )
+    realized = Counter(tuple(sorted(row.items())) for row in actual)
+    if realized != expected:
+        raise KernelSetReplayError(f"CUDA record-knob inventory mismatch: expected {dict(expected)}, realized {dict(realized)}")
+
+
+def _lower_exact_schedule(graph, kernel_set: dict, tail_passes: list[str], ctx):
+    """Resolve the schedule fork exactly and reject any residual compiler IR."""
+    from emmy.compiler.ir.kernel import KernelOp  # noqa: PLC0415
+    from emmy.compiler.ir.loop import LoopOp  # noqa: PLC0415
+    from emmy.compiler.ir.tile import TileOp  # noqa: PLC0415
+    from emmy.compiler.pipeline import Pipeline  # noqa: PLC0415
+    from emmy.compiler.pipeline.pipeline import Run  # noqa: PLC0415
+
+    run = Run(pipeline=Pipeline.build(tail_passes), ctx=ctx, rejections=[])
+    compiled, _trace = run.resolve(graph, _exact_schedule_decide(kernel_set))
+    unlowered = [nid for nid, node in compiled.nodes.items() if isinstance(node.op, (LoopOp, TileOp, KernelOp))]
+    if unlowered:
+        raise KernelSetReplayError(f"exact replay left unlowered kernel node(s): {unlowered}")
+    return compiled
+
+
+def lower_exact_kernel_set(graph, kernel_set: dict, *, ctx=None):
+    """Replay exact placement, schedule leaves, and realized Cuda rows."""
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline import CUDA_PASSES, Pipeline  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.lowering.tile._flash import fused_producer_ids  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.slice import single_node_graph  # noqa: PLC0415
+
+    ctx = ctx or Context.probe()
+    schedule_index = CUDA_PASSES.index("lowering/schedule")
+    placement_passes = CUDA_PASSES[:schedule_index]
+    tail_passes = CUDA_PASSES[schedule_index:]
+    expected_placement = {key: str(value) for key, value in kernel_set["placement"].items()}
+    with pinned_knobs(expected_placement):
+        placed = Pipeline.build(placement_passes).run(graph, ctx=ctx)
+
+    actual_placement = _placement_knobs(placed)
+    if actual_placement != expected_placement:
+        raise KernelSetReplayError(f"placement mismatch: expected {expected_placement}, realized {actual_placement}")
+
+    components = {row["op_key"]: row for row in kernel_set["kernels"]}
+    placed_nodes = _placed_kernel_nodes(placed)
+    actual_counts = Counter(op.cache_key() for _, op in placed_nodes)
+    expected_counts = Counter({row["op_key"]: row["multiplicity"] for row in kernel_set["kernels"]})
+    if actual_counts != expected_counts:
+        raise KernelSetReplayError(f"kernel inventory mismatch: expected {dict(expected_counts)}, realized {dict(actual_counts)}")
+
+    absorbed = {producer: consumer for consumer, _op in placed_nodes for producer in fused_producer_ids(placed, placed.nodes[consumer])}
+    checked = set()
+    for nid, op in placed_nodes:
+        op_key = op.cache_key()
+        if op_key in checked:
+            continue
+        checked.add(op_key)
+        absorb = frozenset(producer for producer, consumer in absorbed.items() if consumer == nid)
+        sub = single_node_graph(placed, nid, absorb=absorb)
+        lowered_sub = _lower_exact_schedule(sub, kernel_set, tail_passes, ctx)
+        actual_component = _cuda_record_knobs(lowered_sub)
+        expected_component = [{key: str(value) for key, value in row.items()} for row in components[op_key]["cuda_record_knobs"]]
+        _validate_component_cuda_rows(op_key, actual_component, expected_component)
+
+    compiled = _lower_exact_schedule(placed.copy(), kernel_set, tail_passes, ctx)
+    _validate_cuda_inventory(_cuda_record_knobs(compiled), kernel_set)
+    return compiled

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -11,7 +11,7 @@ is :meth:`Run.resolve`'s returned trace, never accumulated policy attributes.
 It can only *use* a prior trained earlier by ``tune``, never train one.
 Exploration stays in :class:`~.mcts.TuningSearch` (``Pipeline.tune``).
 
-**Flatten, don't descend.** The lazy fork tree (``lowering/tile`` planner) is an
+**Flatten, don't descend.** The lazy fork tree (``lowering/schedule`` planner) is an
 MCTS data structure — it stages knob choices across levels (``BR`` → ``BM/BN`` →
 ``FM/FN``) so MCTS pays one node per pop. Greedy must NOT walk it level-by-level:
 a branch carries only a *partial* tile, and ``features.knob_features`` can't compute
@@ -49,11 +49,11 @@ if TYPE_CHECKING:
 
 @lru_cache(maxsize=1)
 def _tile_pipeline():
-    """The ``lowering/tile``-only pipeline the structural price probes drive —
+    """The ``lowering/schedule``-only pipeline the structural price probes drive —
     frozen and shareable, so one load serves every nested descent."""
     from emmy.compiler.pipeline import Pipeline  # noqa: PLC0415
 
-    return Pipeline.build(["lowering/tile"])
+    return Pipeline.build(["lowering/schedule"])
 
 
 # The rule whose fork prices a kernel: the prior's predicted µs for the chosen
@@ -229,7 +229,7 @@ def _leaf_graph(leaf: object) -> Graph:
 
 def _price_kernel(graph: Graph, nid: str, ctx: Context, prior, memo: dict[str, float | None], db: object | None = None) -> float | None:
     """One kernel's price: a nested deterministic resolution of its
-    single-node slice through ``lowering/tile`` only (the partition fork is
+    single-node slice through ``lowering/schedule`` only (the partition fork is
     where the prior prices a complete tile row; the kernel/cuda passes add
     nothing and cost real CPU), reading the chosen leaf's µs off the
     slice-resolve's trace entry at the partition fork. ``db`` rides into the
@@ -290,7 +290,7 @@ def _pick_structural(
 
     Both sides are priced the same way: the best µs at each kernel's partition
     fork, obtained by a nested deterministic resolution of the kernel's
-    single-node slice (``lowering/tile`` only, no backend, CPU-only —
+    single-node slice (``lowering/schedule`` only, no backend, CPU-only —
     :func:`_price_kernel`); a structural option's price is the Σ over its
     fragment's kernels. The nested pick follows the deploy evidence hierarchy
     (``db`` threads the tune DB down), so each side's price is a *measurement*

--- a/emmy/compiler/pipeline/search/policy/greedy.py
+++ b/emmy/compiler/pipeline/search/policy/greedy.py
@@ -760,7 +760,7 @@ def greedy_decide(
     Structural (``Graph``-splicing) options are priced with the trained prior
     grounded in measured DB evidence — :func:`_pick_structural` — so an
     unpinned ``compile`` / ``run`` can deploy the kernel sets ``tune`` measured
-    best (the demoted-matmul split); cold, the structural leaf is filtered and
+    best (for example, a placement cut); cold, the structural leaf is filtered and
     kernel sets stay unchanged.
     ``price_structural=False`` keeps the filter behavior — used by
     ``Pipeline.run``'s retry after a structural pick failed to lower, and by

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -61,6 +61,16 @@ O3_REBENCH_TOL = 2.0
 O3_NVCC_FLAGS = "-Xcicc -O3"
 
 
+@dataclass(frozen=True)
+class DirectTerminal:
+    """One directly observed successful terminal, kept exact across CudaOps."""
+
+    realized_knobs: dict[str, object]
+    pins: dict[str, str]
+    latency_us: float
+    cuda_record_knobs: tuple[dict[str, str], ...]
+
+
 @dataclass
 class SearchNode:
     candidate: LazyCandidate | None  # None for the root sentinel
@@ -85,6 +95,9 @@ class SearchNode:
     # CUDA kernels (for example a split reduction + combine). A candidate-file
     # annotation is only unambiguous in the one-CudaOp case.
     realized_cuda_ops: int | None = field(default=None, repr=False)
+    # Ordered canonical knob rows for every CudaOp in the directly-benched
+    # terminal. Unlike ``realized_knobs`` this never merges conflicting rows.
+    realized_cuda_record_knobs: tuple[dict[str, str], ...] | None = field(default=None, repr=False)
     # The leaf's deployable -O3 re-bench median (``observe_o3``), ``None`` when the
     # config wasn't in the re-bench tolerance band (or the sweep already ran at -O3).
     # Read back by ``_collect_node_records`` to emit the leaf's -O3-regime node row.
@@ -223,6 +236,7 @@ class TuningSearch(Search):
             {**self._node_knobs(token), **self._realized_knobs(candidate)} if candidate is not None else self._node_knobs(token)
         )
         token.realized_cuda_ops = self._realized_cuda_op_count(candidate)
+        token.realized_cuda_record_knobs = self._realized_cuda_rows(candidate)
         token.bench_stats = stats
         token.bench_status = status
         reward = (1.0 / stats.median) if status == "ok" and stats.median > 0 else 0.0
@@ -309,6 +323,44 @@ class TuningSearch(Search):
 
         return sum(isinstance(node.op, CudaOp) for node in graph.nodes.values())
 
+    @staticmethod
+    def _realized_cuda_rows(candidate: object | None) -> tuple[dict[str, str], ...] | None:
+        """Ordered, conflict-preserving CudaOp rows from one observed terminal."""
+        graph = getattr(candidate, "graph", None)
+        if graph is None:
+            return None
+        from emmy.compiler.ir.cuda.ir import CudaOp  # noqa: PLC0415
+        from emmy.compiler.pipeline.knob import stamp_schedule_families  # noqa: PLC0415
+
+        return tuple(
+            stamp_schedule_families(graph.nodes[nid].op.knobs or {})
+            for nid in graph.topological_order()
+            if isinstance(graph.nodes[nid].op, CudaOp)
+        )
+
+    def _best_realized_node(self) -> SearchNode | None:
+        """The fastest directly observed successful leaf, with stable tie-breaking."""
+        from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+
+        best: SearchNode | None = None
+        stack = list(self.tree.root.children)
+        while stack:
+            node = stack.pop()
+            stack.extend(node.children)
+            stats = node.bench_stats
+            if node.bench_status != "ok" or node.realized_knobs is None or stats is None or stats.median <= 0:
+                continue
+            if best is None:
+                best = node
+                continue
+            assert best.bench_stats is not None and best.realized_knobs is not None
+            if (stats.median, canonical_row_key(node.realized_knobs)) < (
+                best.bench_stats.median,
+                canonical_row_key(best.realized_knobs),
+            ):
+                best = node
+        return best
+
     def best_realized(self) -> tuple[dict, float, int | None] | None:
         """Return the fastest directly observed successful terminal.
 
@@ -318,20 +370,26 @@ class TuningSearch(Search):
         different configuration. Equal medians break deterministically by the
         canonical knob row.
         """
-        from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+        node = self._best_realized_node()
+        if node is None:
+            return None
+        assert node.realized_knobs is not None and node.bench_stats is not None
+        return dict(node.realized_knobs), float(node.bench_stats.median), node.realized_cuda_ops
 
-        best: tuple[dict, float, int | None] | None = None
-        stack = list(self.tree.root.children)
-        while stack:
-            node = stack.pop()
-            stack.extend(node.children)
-            stats = node.bench_stats
-            if node.bench_status != "ok" or node.realized_knobs is None or stats is None or stats.median <= 0:
-                continue
-            candidate = (dict(node.realized_knobs), float(stats.median), node.realized_cuda_ops)
-            if best is None or (candidate[1], canonical_row_key(candidate[0])) < (best[1], canonical_row_key(best[0])):
-                best = candidate
-        return best
+    def best_direct_terminal(self) -> DirectTerminal | None:
+        """Return the winning direct leaf without merging its CudaOp rows."""
+        node = self._best_realized_node()
+        if node is None or not node.realized_cuda_record_knobs:
+            return None
+        from emmy.compiler.pipeline.knob import stamp_schedule_families  # noqa: PLC0415
+
+        assert node.realized_knobs is not None and node.bench_stats is not None
+        return DirectTerminal(
+            realized_knobs=dict(node.realized_knobs),
+            pins=stamp_schedule_families(self._node_knobs(node)),
+            latency_us=float(node.bench_stats.median),
+            cuda_record_knobs=tuple(dict(row) for row in node.realized_cuda_record_knobs),
+        )
 
     def push(self, *cands: LazyCandidate, parent: object | None = None, structural: bool = False) -> None:
         # ``parent`` is the token the spawning candidate was popped with;

--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -219,7 +219,9 @@ class TuningSearch(Search):
         # not just its fork-prefix — so knobs stamped at deterministic lowering
         # steps (FK / BK / STAGE / …) reach the prior. Falls back to the
         # fork-prefix when no candidate is supplied.
-        token.realized_knobs = self._realized_knobs(candidate) if candidate is not None else self._node_knobs(token)
+        token.realized_knobs = (
+            {**self._node_knobs(token), **self._realized_knobs(candidate)} if candidate is not None else self._node_knobs(token)
+        )
         token.realized_cuda_ops = self._realized_cuda_op_count(candidate)
         token.bench_stats = stats
         token.bench_status = status

--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -22,7 +22,12 @@ scheduler spells each row ONCE, site-local, where it becomes stored state. ``STA
 :class:`~emmy.compiler.ir.schedule.Stage` slices in the same currency; ``RASTER`` stays a codec string
 (it has no slice type of its own).
 
-Two groups:
+Three groups:
+
+- **Structural placement knob** (``PLACE``) — the per-seam ``fuse`` / ``cut`` decision offered
+  after algebra recognition. It changes which kernels exist, so it is measured and priced by the
+  structural fork; the offer kernel's ``S_*`` features plus pooled ``PLACE_sites`` / ``PLACE_cut``
+  features train only on whole-kernel-set rewards and never enter an individual resulting kernel's schedule row.
 
 - **Schedule codec knobs** (``WORK`` / ``REDUCE`` / ``TILE`` / ``STAGE`` / ``RASTER``) — the tile-lowering schedule
   fork points that spell the ir schedule codecs (:mod:`emmy.compiler.ir.schedule`). Decided by the
@@ -44,6 +49,23 @@ from emmy.compiler.pipeline.knob import Knob, KnobType
 from emmy.compiler.pipeline.search.domain import Bound, Dimension, Space
 
 logger = logging.getLogger(__name__)
+
+
+def _place_features(value) -> dict[str, float]:
+    """One scoped seam's contribution to a pooled placement row."""
+    return {"PLACE_sites": 1.0, "PLACE_cut": 1.0 if str(value) == "cut" else 0.0}
+
+
+# Kernel placement is a structural decision, separate from every resulting kernel's schedule.
+# It has no OFF fill because a tree may have several scoped ``PLACE@path`` keys and the owning
+# placement fork stamps every legal seam explicitly.
+PLACE = Knob(
+    "PLACE",
+    KnobType.STR,
+    hints=("fuse", "cut"),
+    help="Per-seam kernel placement (PLACE@<path>=fuse|cut), decided by the structural placement fork.",
+    features=_place_features,
+)
 
 # --- Schedule codec knobs ---------------------------------------------------
 

--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -26,8 +26,9 @@ Three groups:
 
 - **Structural placement knob** (``PLACE``) — the per-seam ``fuse`` / ``cut`` decision offered
   after algebra recognition. It changes which kernels exist, so it is measured and priced by the
-  structural fork; the offer kernel's ``S_*`` features plus pooled ``PLACE_sites`` / ``PLACE_cut``
-  features train only on whole-kernel-set rewards and never enter an individual resulting kernel's schedule row.
+  structural fork; the offer kernel's ``S_*`` features plus pooled ``PLACE_sites`` / ``PLACE_cut`` and selected
+  ``PLACE_cut_site_<path>`` features train only on whole-kernel-set rewards and never enter an individual resulting
+  kernel's schedule row.
 
 - **Schedule codec knobs** (``WORK`` / ``REDUCE`` / ``TILE`` / ``STAGE`` / ``RASTER``) — the tile-lowering schedule
   fork points that spell the ir schedule codecs (:mod:`emmy.compiler.ir.schedule`). Decided by the
@@ -51,9 +52,19 @@ from emmy.compiler.pipeline.search.domain import Bound, Dimension, Space
 logger = logging.getLogger(__name__)
 
 
-def _place_features(value) -> dict[str, float]:
-    """One scoped seam's contribution to a pooled placement row."""
-    return {"PLACE_sites": 1.0, "PLACE_cut": 1.0 if str(value) == "cut" else 0.0}
+def _place_features(name: str, value) -> dict[str, float]:
+    """One scoped seam's contribution to a pooled placement row.
+
+    A selected cut also preserves its canonical tree-path identity. Counts alone alias every
+    single-cut sibling, preventing the outer prior from learning which seam produced the faster
+    kernel set.
+    """
+    cut = str(value) == "cut"
+    features = {"PLACE_sites": 1.0, "PLACE_cut": 1.0 if cut else 0.0}
+    if cut:
+        _, scoped, suffix = name.partition("@")
+        features[f"PLACE_cut_site_{suffix if scoped else 'primary'}"] = 1.0
+    return features
 
 
 # Kernel placement is a structural decision, separate from every resulting kernel's schedule.
@@ -114,7 +125,7 @@ STAGE = Knob(
 # = the per-cell / pure-reduce forms' derived launch geometry.
 
 
-def _work_features(val) -> dict[str, float]:
+def _work_features(_name: str, val) -> dict[str, float]:
     """The ``WORK`` sub-features for the online prior — ONLY the ``+p`` producer band, as the
     same ``D_wspec_warps`` the retired per-row ``WSPEC`` key spelled (name/semantics preserved;
     a legacy row's ``WSPEC`` key writes the identical value). The inventory's tile geometry is
@@ -141,7 +152,7 @@ WORK = Knob(
 )
 
 
-def _raster_features(val) -> dict[str, float]:
+def _raster_features(_name: str, val) -> dict[str, float]:
     """The ``RASTER`` sub-features for the priors — the stripe group size (``0.0`` = the flat
     N-fastest order) and the orientation flag (``1.0`` = ``gn``, the transposed grouping)."""
     if not val:

--- a/emmy/compiler/pipeline/search/two_level.py
+++ b/emmy/compiler/pipeline/search/two_level.py
@@ -19,8 +19,8 @@ spawn site), not on a fixed
 pass index:
 
 - **Outer** (:func:`run_two_level_tune`) drives ``frontend`` + ``loop`` and the
-  recognition half of ``lowering/tile`` (:func:`outer_pipeline`). Fusion stays
-  deterministic and maximal; recognition offers ``PLACE`` choices that either
+  recognition and placement steps of ``lowering/tile`` (:func:`outer_pipeline`). Fusion stays
+  deterministic and maximal; placement offers ``PLACE`` choices that either
   keep that region or materialize one closed seam. A terminal has every
   placement decision resolved and every kernel represented by an unmapped
   ``TileOp``. Each terminal is a candidate kernel set;
@@ -71,13 +71,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The structural / op-variant boundary lies between tile recognition and tile
-# scheduling. Recognition owns the PLACE fork because it changes the kernel set;
-# scheduling and every later lowering fork remain separable per kernel.
+# The structural / op-variant boundary lies between tile placement and tile
+# scheduling. Recognition certifies maximal algebra, placement owns the PLACE fork
+# because it changes the kernel set, and every later fork is separable per kernel.
 
 # Lowering-only passes after loop fusion: ``recognize → schedule → kernel → cuda``.
 # The inner per-op search receives an already-recognized ``TileOp`` slice, so
-# ``010_recognize`` cannot re-open its outer-owned placement decision. The
+# ``010_recognize`` / ``015_place`` cannot re-open the outer-owned placement decision. The
 # recognized algebra — and thus its ``Op.cache_key`` — is never re-touched by
 # ``loop/fusion``; inner ``perf`` / ``lowering`` rows therefore transfer to the
 # assembled graph. Slicing this as the tail of ``CUDA_PASSES`` keeps it aligned
@@ -89,13 +89,13 @@ def outer_pipeline() -> Pipeline:
     """Drive maximal fusion, algebra recognition, and structural placement only.
 
     ``010_recognize`` lifts each fused ``LoopOp`` to an unmapped ``TileOp`` and
-    offers the fused-vs-materialized ``PLACE`` fork. A cut's new ``LoopOp`` pieces
-    re-enter that same rule until the complete kernel set is recognized. The outer
+    ``015_place`` offers the fused-vs-materialized ``PLACE`` fork. A cut's recognized
+    pieces re-enter placement until the complete kernel set is resolved. The outer
     pipeline stops before ``020_schedule``: tile/reduce/stage choices are inner,
     per-kernel decisions, including graph splices caused by a selected reduce plan.
     """
     passes = [Pass.load(name, i) for i, name in enumerate(LOOP_PASSES)]
-    passes.append(Pass.load("lowering/tile", len(passes), {"010_recognize"}))
+    passes.append(Pass.load("lowering/tile", len(passes)))
     return Pipeline(passes=passes)
 
 
@@ -126,6 +126,28 @@ class OpResult:
     searched_knobs: dict[str, str] | None = None
     searched_us: float | None = None
     searched_cuda_ops: int | None = None
+    searched_pins: dict[str, str] | None = None
+    searched_cuda_record_knobs: tuple[dict[str, str], ...] | None = None
+
+
+@dataclass(frozen=True)
+class KernelSetOpWinner:
+    """Exact direct result for one deduplicated recognized kernel."""
+
+    op_key: str
+    multiplicity: int
+    pins: dict[str, str]
+    latency_us: float
+    cuda_record_knobs: tuple[dict[str, str], ...]
+
+
+@dataclass(frozen=True)
+class KernelSetWinner:
+    """One exact searched placement plus its independently tuned kernels."""
+
+    placement: dict[str, str]
+    kernels: tuple[KernelSetOpWinner, ...]
+    latency_us: float
 
 
 @dataclass
@@ -164,6 +186,47 @@ class TwoLevelResult:
     n_terminals: int  # kernel-set alternatives evaluated by the outer search
     assembled: Graph | None  # greedy DB-best Graph[CudaOp] assembled from the bests
     prior_summaries: list[str] = field(default_factory=list)  # online-prior stats
+
+    def searched_winner(self) -> tuple[dict[str, str], float] | KernelSetWinner | None:
+        """Return the scalar wire when possible, otherwise the exact kernel set."""
+        if self.best_reward is None:
+            return None
+        scalar = self.best_reward.searched_winner()
+        if scalar is not None:
+            return scalar
+        if self.best_fused is None or not self.best_reward.per_op:
+            return None
+
+        placement: dict[str, str] = {}
+        for node in self.best_fused.nodes.values():
+            for key, value in node.op.decision_knobs.items():
+                if key.split("@", 1)[0] != "PLACE":
+                    continue
+                if key in placement and str(placement[key]) != str(value):
+                    return None
+                placement[key] = str(value)
+
+        kernels: list[KernelSetOpWinner] = []
+        for op in self.best_reward.per_op:
+            if (
+                op.multiplicity < 1
+                or op.searched_pins is None
+                or op.searched_us is None
+                or op.searched_us <= 0
+                or not op.searched_cuda_record_knobs
+            ):
+                return None
+            kernels.append(
+                KernelSetOpWinner(
+                    op_key=op.op_key,
+                    multiplicity=op.multiplicity,
+                    pins=dict(op.searched_pins),
+                    latency_us=float(op.searched_us),
+                    cuda_record_knobs=tuple(dict(row) for row in op.searched_cuda_record_knobs),
+                )
+            )
+        latency_us = sum(kernel.latency_us * kernel.multiplicity for kernel in kernels)
+        return KernelSetWinner(placement=placement, kernels=tuple(kernels), latency_us=latency_us)
 
 
 def _point_stats(us: float) -> PerfStats:
@@ -332,7 +395,7 @@ async def _inner_reward_async(
             # main + combine both count). Record that total under the LoopOp
             # key so ``best_per_op_time`` reads the true per-op cost.
             best_total = 1.0 / inner.tree.best_reward if inner.tree.best_reward > 0 else None
-            searched = inner.best_realized()
+            searched = inner.best_direct_terminal()
             if best_total is not None:
                 # captured=True: the sweep benches under graph capture by default, so
                 # this Σ-best bookkeeping row derives from captured measurements (a
@@ -363,13 +426,15 @@ async def _inner_reward_async(
                 inner._collect_node_records(context_key=ctx_key, op_sig=op_sig, gpu=gpu, run_id=run_id, o3_context_key=o3_ctx_key)
             )
             best = db.best_per_op_time(ctx_key, key, backend=backend_name)
-            searched_knobs = searched_us = searched_cuda_ops = None
+            searched_knobs = searched_us = searched_cuda_ops = searched_pins = searched_cuda_record_knobs = None
             if searched is not None:
                 from emmy.compiler.pipeline.knob import stamp_schedule_families  # noqa: PLC0415
 
-                searched_knobs = stamp_schedule_families(searched[0])
-                searched_us = searched[1]
-                searched_cuda_ops = searched[2]
+                searched_knobs = stamp_schedule_families(searched.realized_knobs)
+                searched_us = searched.latency_us
+                searched_cuda_ops = len(searched.cuda_record_knobs)
+                searched_pins = dict(searched.pins)
+                searched_cuda_record_knobs = tuple(dict(row) for row in searched.cuda_record_knobs)
             results[op_idx] = OpResult(
                 name=name,
                 op_key=key,
@@ -378,6 +443,8 @@ async def _inner_reward_async(
                 searched_knobs=searched_knobs,
                 searched_us=searched_us,
                 searched_cuda_ops=searched_cuda_ops,
+                searched_pins=searched_pins,
+                searched_cuda_record_knobs=searched_cuda_record_knobs,
             )
             if progress is not None:
                 progress.op_done(name, slot=op_idx)
@@ -446,7 +513,7 @@ async def run_two_level_tune(
     The outer drives a :class:`Run` directly (manual ``observe``)
     because its terminal reward comes from the inner tuning, not
     ``_bench_terminal_async``. The outer pipeline (:func:`outer_pipeline`) runs
-    through algebra recognition and stops before scheduling, so each ``PLACE``
+    through algebra recognition and placement and stops before scheduling, so each ``PLACE``
     fork branches the outer tree — one terminal per kernel set, compared by
     Σ-per-op cost. A graph with no
     structural offers yields a single terminal and this reduces to "tune each

--- a/emmy/compiler/pipeline/search/two_level.py
+++ b/emmy/compiler/pipeline/search/two_level.py
@@ -1,29 +1,29 @@
-"""Two-level autotuning: an outer fusion MCTS whose terminal reward comes from
+"""Two-level autotuning: an outer kernel-placement MCTS whose terminal reward comes from
 an inner, separable, per-op search.
 
 ``emmy tune`` used to run one SP-MCTS tree over the whole graph. Because
 the pipeline applies rules sequentially, op-variant forks (tile / pad / stage
-choices for one kernel) and fusion forks (how ops group into kernels) **nest**
-and cross-product under one global patience — so the bottleneck op starves the
-deep ops (see ``project_mcts_exploration_limit``). The two kinds of decision
-have opposite structure:
+choices for one kernel) and placement forks (which closed seams become kernel
+boundaries) **nest** and cross-product under one global patience — so the
+bottleneck op starves the deep ops (see ``project_mcts_exploration_limit``).
+The two kinds of decision have opposite structure:
 
 - **op-variant forks are separable** — every multi-option fork today is an
   in-place ``Op`` rebind that leaves the graph unchanged, so the whole-graph
   time is ``Σ_k t_k`` with each ``t_k`` depending only on op ``k``'s variant;
-- **fusion forks are NOT separable** — they change *which ops exist*.
+- **placement forks are NOT separable** — they change *which kernels exist*.
 
 So we split the search in two, drawing the boundary on the fork's *effect*
 (the ``Op``-rebind / ``Graph``-splice classification stamped at the engine's
 spawn site), not on a fixed
 pass index:
 
-- **Outer** (:func:`run_two_level_tune`) drives the graph-changing passes —
-  ``frontend`` + ``loop`` plus the pre-partition head of ``lowering/tile``
-  (:func:`outer_pipeline`), where any structural fork emitters live. A terminal is the state where
-  the cursor reaches ``partition_loops`` with every structural fork resolved —
-  every op post-fusion and structurally final, split producers/consumers
-  included as real ``LoopOp`` nodes. Each terminal is a candidate fused graph;
+- **Outer** (:func:`run_two_level_tune`) drives ``frontend`` + ``loop`` and the
+  recognition half of ``lowering/tile`` (:func:`outer_pipeline`). Fusion stays
+  deterministic and maximal; recognition offers ``PLACE`` choices that either
+  keep that region or materialize one closed seam. A terminal has every
+  placement decision resolved and every kernel represented by an unmapped
+  ``TileOp``. Each terminal is a candidate kernel set;
   its reward is ``1 / Σ best-per-op time`` from the inner search,
   backpropagated by the reused :class:`TuningSearch` — so keep-vs-split is an
   outer-terminal comparison, the natural cost model for a kernel-set decision.
@@ -31,9 +31,8 @@ pass index:
   replays the decision read off the trajectory's own graph via the
   ``Op.source`` decomposition links and the stamped decision knobs
   (``pipeline._replay_structural_decision``) — keeping the tree linear in
-  *unique* kernels. Fusion itself is still
-  deterministic (no multi-option fusion forks); this remains the clean
-  insertion point for fusion search when those forks exist.
+  *unique* kernels. Fusion itself remains deterministic and maximal: it does
+  not consult placement, schedule, hardware, or search evidence.
 - **Inner** (:func:`_inner_reward_async`) tunes each finalized kernel *independently*
   in its own single-node slice (:func:`single_node_graph`) with a plain
   :class:`TuningSearch` over :data:`LOWERING_PASSES` only. Results key
@@ -72,42 +71,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The structural / op-variant boundary is the ``split`` phase: the keep-vs-cut
-# ``CUT`` offer is the only kernel-set-changing decision, so the outer search owns
-# ``frontend`` + ``loop`` + ``split`` and the inner tunes everything from
-# ``enumeration`` (tiling) on — see :func:`outer_pipeline`.
+# The structural / op-variant boundary lies between tile recognition and tile
+# scheduling. Recognition owns the PLACE fork because it changes the kernel set;
+# scheduling and every later lowering fork remain separable per kernel.
 
-# Lowering-only passes (post-fusion): ``tile → kernel → cuda``. The inner
-# per-op search runs these on a single-node slice so the finalized LoopOp body
-# — and thus its ``Op.cache_key`` — is never re-touched by ``loop/fusion``,
-# which is what keeps inner-tuned ``perf`` / ``lowering`` rows transferable to
-# the assembled graph. Sliced as the tail of ``CUDA_PASSES`` so it tracks
-# pass-list edits automatically. The pre-partition tile rules (005's split
-# offer) run here too, but every outer-terminal op already carries their
-# decision knob, so the rules' idempotence guards skip — the inner never
-# re-opens an outer-owned structural decision.
+# Lowering-only passes after loop fusion: ``recognize → schedule → kernel → cuda``.
+# The inner per-op search receives an already-recognized ``TileOp`` slice, so
+# ``010_recognize`` cannot re-open its outer-owned placement decision. The
+# recognized algebra — and thus its ``Op.cache_key`` — is never re-touched by
+# ``loop/fusion``; inner ``perf`` / ``lowering`` rows therefore transfer to the
+# assembled graph. Slicing this as the tail of ``CUDA_PASSES`` keeps it aligned
+# with pass-list edits and retains the LoopOp guardrail for unrecognized algebra.
 LOWERING_PASSES = CUDA_PASSES[len(LOOP_PASSES) :]
 
 
 def outer_pipeline() -> Pipeline:
-    """The graph-changing passes the outer search drives: ``frontend`` + ``loop``
-    (any fusion forks) **plus the ``split`` phase** — where a structural fork, the
-    only move that changes *which kernels exist*, would be offered.
-    An outer terminal is a graph whose kernel set is final:
-    the keep(SMEM) side is one fused ``TileGraphOp`` (``seed_fused``), the cut side
-    its producer + consumer; :func:`_inner_reward_async` picks each up as its own
-    slice (own patience, own progress leaf, deduped by ``Op.cache_key``) and tunes
-    its tiling via :data:`LOWERING_PASSES`.
+    """Drive maximal fusion, algebra recognition, and structural placement only.
 
-    Tiling (``enumeration``/partition) is **inner**, deliberately NOT driven here:
-    a tile-knob fork (``MMA`` / ``BN`` / …) does not change the kernel set, so
-    branching the OUTER tree on it would explode the tree (every tile combination ×
-    every structural choice) with no kernel-set distinction. The split boundary is
-    exactly where the kernel set is fixed but tiling is not — the right outer/inner
-    seam. Sub-partition splices
-    (``150_cross_cta_finalize``'s combine) likewise stay inner — their trigger knob
-    (``SPLITK``) doesn't exist until partition runs."""
+    ``010_recognize`` lifts each fused ``LoopOp`` to an unmapped ``TileOp`` and
+    offers the fused-vs-materialized ``PLACE`` fork. A cut's new ``LoopOp`` pieces
+    re-enter that same rule until the complete kernel set is recognized. The outer
+    pipeline stops before ``020_schedule``: tile/reduce/stage choices are inner,
+    per-kernel decisions, including graph splices caused by a selected reduce plan.
+    """
     passes = [Pass.load(name, i) for i, name in enumerate(LOOP_PASSES)]
+    passes.append(Pass.load("lowering/tile", len(passes), {"010_recognize"}))
     return Pipeline(passes=passes)
 
 
@@ -121,8 +109,8 @@ _FAIL_US = 1e12
 class OpResult:
     """One unique kernel's inner-search outcome, for the per-op summary.
 
-    ``multiplicity`` is the number of structurally-identical ``LoopOp`` nodes
-    in the fused graph that share this ``op_key`` — 24 for a 24-layer
+    ``multiplicity`` is the number of structurally-identical recognized kernels
+    in the outer terminal that share this ``op_key`` — 24 for a 24-layer
     RMSNorm, 1 for a singleton. The outer reward's ``total_us`` weights
     ``best_us`` by ``multiplicity`` so the Σ across ``per_op`` equals the
     whole-graph latency (every node position counts, even though dedup
@@ -154,8 +142,8 @@ class InnerReward:
     def searched_winner(self) -> tuple[dict[str, str], float] | None:
         """The actual searched winner when it maps to exactly one CUDA kernel.
 
-        A target can contain repeated/heterogeneous post-fusion kernels, and one
-        post-fusion kernel can lower to several CudaOps. In either case there is
+        A target can contain repeated or heterogeneous recognized kernels, and
+        one recognized kernel can lower to several CudaOps. In either case there is
         no single golden-format knob row whose latency represents the target, so
         callers must omit a winner annotation instead of inventing one.
         """
@@ -171,9 +159,9 @@ class InnerReward:
 class TwoLevelResult:
     """Outcome of :func:`run_two_level_tune`."""
 
-    best_fused: Graph | None  # winning fused graph (finalized LoopOps)
+    best_fused: Graph | None  # winning kernel set (unmapped TileOps)
     best_reward: InnerReward | None  # its Σ-per-op breakdown
-    n_terminals: int  # outer terminals evaluated (1 today)
+    n_terminals: int  # kernel-set alternatives evaluated by the outer search
     assembled: Graph | None  # greedy DB-best Graph[CudaOp] assembled from the bests
     prior_summaries: list[str] = field(default_factory=list)  # online-prior stats
 
@@ -194,16 +182,14 @@ def _mint_run_id() -> str:
 
 
 def _kernel_nodes(graph: Graph) -> list[tuple[str, object]]:
-    """Post-fusion kernel nodes — ``(node_id, op)`` for every kernel-bearing op.
-
-    An outer terminal sits at the ``split`` boundary (:func:`outer_pipeline`): the
-    keep(SMEM) side is a fused ``TileGraphOp`` (``seed_fused``), the cut side its
-    producer + consumer ``LoopOp``s (un-built — the inner tiles them). Count both
-    ``LoopOp`` and ``TileGraphOp`` so every kernel of either side gets its own inner
-    slice."""
+    """Outer-terminal kernels — one ``(node_id, TileOp)`` per recognized kernel."""
     from emmy.compiler.ir.loop import LoopOp  # noqa: PLC0415
+    from emmy.compiler.ir.tile import TileOp  # noqa: PLC0415
 
-    return [(nid, n.op) for nid, n in graph.nodes.items() if isinstance(n.op, LoopOp)]
+    # ``LoopOp`` is retained as a guardrail for algebra that recognition cannot
+    # lift (for example a symbolic loop). Its inner slice retries the complete
+    # tile pass and follows the same lowering failure contract as before.
+    return [(nid, n.op) for nid, n in graph.nodes.items() if isinstance(n.op, (LoopOp, TileOp))]
 
 
 async def _inner_reward_async(
@@ -223,7 +209,7 @@ async def _inner_reward_async(
     backend_slots=None,
     close_backends: bool = True,
 ) -> InnerReward:
-    """Tune every post-fusion kernel of ``fused_graph`` in its own single-node slice
+    """Tune every kernel in the outer terminal in its own single-node slice
     and return ``Σ best-per-op time`` — the outer terminal reward.
 
     One coroutine per unique kernel over a slot queue of ``len(pool)`` device-pinned
@@ -269,17 +255,15 @@ async def _inner_reward_async(
     # the two keys would coincide).
     o3_ctx_key = replace(ctx, compile_flags=O3_NVCC_FLAGS).structural_key() if "-O3" not in ctx.compile_flags else None
     backend_name = getattr(pool[0], "name", "cuda")
-    # Fold-aware slicing: a flash fold offer site's slice must CARRY the score producer its
-    # fusion consumes (``absorbed[producer] = consumer``) — a single-node slice turns the
-    # producer into a synthetic input, ``try_flash`` can never re-fuse, and every tune
-    # trajectory silently degrades to the cut (benching fragment kernels that greedy deploy
-    # never picks). The absorbed producer loses its own slice — the offer site's slice benches
-    # the whole attention (fused: one kernel; a cut trajectory: both), so the Σ stays honest.
+    # Fold-aware LoopOp guardrail: if recognition could not lift a flash offer in the outer
+    # pipeline, its inner slice must carry the score producer that recognition may consume.
+    # Normal outer terminals already contain the recognized TileOp and take this path with no
+    # absorbed producer.
     absorbed: dict[str, str] = {}
     for nid, _op in _kernel_nodes(fused_graph):
         for pid in fused_producer_ids(fused_graph, fused_graph.nodes[nid]):
             absorbed[pid] = nid
-    # Group structurally-identical LoopOps under one ``Op.cache_key`` —
+    # Group structurally-identical recognized kernels under one ``Op.cache_key`` —
     # insertion order = first occurrence (drives the progress tail name).
     # Ops with no cache key are unreachable through the bench path so they
     # don't enter the dedup map at all (matches the previous filter).
@@ -313,7 +297,7 @@ async def _inner_reward_async(
             if progress is not None:
                 progress.op_start(name, slot=op_idx)
             sub = single_node_graph(fused_graph, nid, absorb=frozenset(p for p, c in absorbed.items() if c == nid))
-            # Base knobs the prior sees on every row: the LoopOp's ``S_*``
+            # Base knobs the prior sees on every row: the kernel's ``S_*``
             # structural identity (op-aware rows) + the ``H_*`` host/hardware
             # regime (GPU + nvcc opt level), so one global prior spans ops and
             # regimes from the feature vector alone.
@@ -450,9 +434,8 @@ async def run_two_level_tune(
     backend_slots=None,
     close_backends: bool = True,
 ) -> TwoLevelResult:
-    """Drive the outer structural search, scoring each terminal by
-    :func:`_inner_reward_async`, then greedy-assemble the DB-best kernels and bench
-    the whole graph once for the separability check.
+    """Drive outer placement search, score each kernel set with
+    :func:`_inner_reward_async`, then lower the winning set with its DB-best schedules.
 
     ``backends`` (a list of device-pinned :class:`CudaBackend`s) fans the inner
     per-kernel search out across GPUs; the default single ``backend`` is the
@@ -463,9 +446,9 @@ async def run_two_level_tune(
     The outer drives a :class:`Run` directly (manual ``observe``)
     because its terminal reward comes from the inner tuning, not
     ``_bench_terminal_async``. The outer pipeline (:func:`outer_pipeline`) runs
-    through the pre-partition tile rules, so each structural fork
-    branches the outer tree —
-    one terminal per kernel-set, compared by Σ-per-op cost. A graph with no
+    through algebra recognition and stops before scheduling, so each ``PLACE``
+    fork branches the outer tree — one terminal per kernel set, compared by
+    Σ-per-op cost. A graph with no
     structural offers yields a single terminal and this reduces to "tune each
     op once, sum, assemble". Identical offer sites within one trajectory
     replay the first decision (read off the graph —
@@ -488,8 +471,8 @@ async def run_two_level_tune(
 
         prior = load_prior(seed=prior_seed)
     outer = TuningSearch(patience=patience, ucb_c=ucb_c, prior_model=prior, base_knobs=ctx.features())
-    # The outer drives only the graph-changing passes (through the
-    # pre-partition tile head) — no dump on this Run; the winning config's
+    # The outer drives fusion, recognition, and placement, stopping before the
+    # per-kernel schedule — no dump on this Run; the winning config's
     # full stage artifacts and in-memory frontend provenance slices come
     # from the final assembled CUDA_PASSES run below.
     outer_run = Run(pipeline=outer_pipeline(), ctx=ctx, search=outer, db=db)
@@ -521,7 +504,7 @@ async def run_two_level_tune(
         outer.observe(token, stats, "ok" if reward.ok else "bench_fail")
         positions = sum(r.multiplicity for r in reward.per_op)
         logger.info(
-            "[tune] fused terminal #%d: Σ per-op = %.2f us (%d unique kernels, %d positions)",
+            "[tune] placement terminal #%d: Σ per-op = %.2f us (%d unique kernels, %d positions)",
             n_terminals,
             reward.total_us,
             len(reward.per_op),
@@ -529,6 +512,13 @@ async def run_two_level_tune(
         )
         if best_reward is None or (reward.ok and reward.total_us < best_reward.total_us):
             best_fused, best_reward = fused.graph, reward
+
+    # Placement rows are whole-kernel-set observations: each outer fork prefix is
+    # labeled by the best Σ of its descendants. Feed them to the same online prior
+    # after the outer walk; inner per-kernel rows deliberately contain no PLACE
+    # metadata, so schedule evidence stays transferable between kernel sets.
+    if prior is not None:
+        prior.add_rows(outer._collect_rows())
 
     # One global end-of-run sanity block (the prior spans every kernel now).
     if manage_prior and (prior.fitted or prior.trajectory):
@@ -541,17 +531,18 @@ async def run_two_level_tune(
 
     assembled: Graph | None = None
     if best_fused is not None:
-        # Greedy replay over the *original* graph re-derives the same fused
-        # LoopOps and lowers each via the DB-best forks the inner search
-        # recorded. No backend → ``_bench_terminal`` persists nothing (so the
-        # 1.0us stub never clobbers a tuned row). The dump (if any) rides here
+        # Lower the winning outer terminal directly. This preserves the measured
+        # placement choice independent of a not-yet-refitted prior while each
+        # kernel's schedule replays from its DB evidence. No backend means the
+        # stub bench persists nothing, so the 1.0us stub never clobbers a tuned
+        # row. The dump (if any) rides here
         # so it captures the winning config's full stage artifacts. The
         # whole-graph separability bench used to run here too; dropped — its
         # only output was a small advisory gap line that nobody read, and at
         # the tight tune compile budget it could (and did) abort whole-model
         # tunes when a slow-compiling kernel raised. ``--bench`` re-benches
         # the assembled graph at -O3 anyway, which is the deployable number.
-        assembled = Pipeline.build(CUDA_PASSES).run(graph, ctx=ctx, db=db, dump=dump)
+        assembled = Pipeline.build(LOWERING_PASSES).run(best_fused.copy(), ctx=ctx, db=db, dump=dump)
     return TwoLevelResult(
         best_fused=best_fused, best_reward=best_reward, n_terminals=n_terminals, assembled=assembled, prior_summaries=prior_summaries
     )

--- a/emmy/compiler/pipeline/search/working_golden.py
+++ b/emmy/compiler/pipeline/search/working_golden.py
@@ -8,7 +8,9 @@ persistence. CLI commands only validate argument combinations and report errors.
 from __future__ import annotations
 
 import copy
+import math
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -422,19 +424,177 @@ def persist_proposal_rankings(path: str | Path, document: dict, target: WorkingG
     dump_golden_file(document, path, overwrite=True)
 
 
+def _kernel_set_knobs(value: object, *, where: str, placement: bool) -> dict:
+    """Validate and copy one canonical string-valued knob map from a working tune result."""
+    from emmy.compiler.pipeline.knob import KnobType, family_of, get  # noqa: PLC0415
+
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{where} must be a mapping")
+    out = {}
+    for name, item in value.items():
+        family = family_of(name) if isinstance(name, str) and name else ""
+        descriptor = get(family)
+        if descriptor is None:
+            raise ValueError(f"{where} names unknown knob {name!r}")
+        if (family == "PLACE") != placement:
+            expected = "PLACE" if placement else "schedule"
+            raise ValueError(f"{where} must contain only {expected} knobs")
+        if not isinstance(item, str):
+            raise ValueError(f"{where}.{name} must be a canonical string value, got {item!r}")
+        if descriptor.type in {KnobType.BOOL, KnobType.INT}:
+            try:
+                descriptor.parse(item)
+            except ValueError as exc:
+                raise ValueError(f"{where}.{name} has invalid {descriptor.type.value} spelling {item!r}") from exc
+        out[name] = item
+    return out
+
+
+def parse_kernel_set_ranking(ranking: object) -> dict:
+    """Validate and normalize one exact working-only ``ranking.kernel_set``."""
+    if not isinstance(ranking, Mapping):
+        raise ValueError("ranking must be a mapping")
+    if ranking.get("source") != "tune" or ranking.get("status") != "ok" or ranking.get("tune_winner") is not True:
+        raise ValueError("kernel-set winner requires source=tune, status=ok, and tune_winner=true")
+    if not isinstance(ranking.get("compile_flags"), str):
+        raise ValueError("kernel-set winner compile_flags must be a string")
+    if "measured_knobs" in ranking:
+        raise ValueError("kernel-set winner cannot carry scalar measured_knobs")
+    latency = ranking.get("latency_us")
+    if isinstance(latency, bool) or not isinstance(latency, int | float) or not math.isfinite(latency) or latency <= 0:
+        raise ValueError("kernel-set winner latency_us must be finite and positive")
+    raw = ranking.get("kernel_set")
+    if not isinstance(raw, Mapping):
+        raise ValueError("ranking.kernel_set must be a mapping")
+    unknown = set(raw) - {"placement", "kernels"}
+    if unknown:
+        raise ValueError(f"ranking.kernel_set has unknown field(s): {', '.join(sorted(unknown))}")
+    placement = _kernel_set_knobs(raw.get("placement"), where="ranking.kernel_set.placement", placement=True)
+    rows = raw.get("kernels")
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("ranking.kernel_set.kernels must be a non-empty list")
+
+    kernels = []
+    seen = set()
+    weighted = 0.0
+    allowed = {"op_key", "multiplicity", "pins", "latency_us", "cuda_record_knobs"}
+    for index, row in enumerate(rows):
+        where = f"ranking.kernel_set.kernels[{index}]"
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{where} must be a mapping")
+        unknown = set(row) - allowed
+        if unknown:
+            raise ValueError(f"{where} has unknown field(s): {', '.join(sorted(unknown))}")
+        op_key = row.get("op_key")
+        if not isinstance(op_key, str) or not op_key:
+            raise ValueError(f"{where}.op_key must be a non-empty string")
+        if op_key in seen:
+            raise ValueError(f"{where}.op_key duplicates {op_key!r}")
+        seen.add(op_key)
+        multiplicity = row.get("multiplicity")
+        if type(multiplicity) is not int or multiplicity <= 0:
+            raise ValueError(f"{where}.multiplicity must be a positive integer")
+        component_us = row.get("latency_us")
+        if (
+            isinstance(component_us, bool)
+            or not isinstance(component_us, int | float)
+            or not math.isfinite(component_us)
+            or component_us <= 0
+        ):
+            raise ValueError(f"{where}.latency_us must be finite and positive")
+        pins = _kernel_set_knobs(row.get("pins"), where=f"{where}.pins", placement=False)
+        cuda_rows = row.get("cuda_record_knobs")
+        if not isinstance(cuda_rows, list) or not cuda_rows:
+            raise ValueError(f"{where}.cuda_record_knobs must be a non-empty list")
+        normalized_cuda = [
+            _kernel_set_knobs(item, where=f"{where}.cuda_record_knobs[{cuda_index}]", placement=False)
+            for cuda_index, item in enumerate(cuda_rows)
+        ]
+        weighted += float(component_us) * multiplicity
+        kernels.append(
+            {
+                "op_key": op_key,
+                "multiplicity": multiplicity,
+                "pins": pins,
+                "latency_us": float(component_us),
+                "cuda_record_knobs": normalized_cuda,
+            }
+        )
+    if not math.isclose(float(latency), weighted, rel_tol=1e-12, abs_tol=1e-9):
+        raise ValueError(f"kernel-set winner latency_us {latency} does not equal weighted direct latency {weighted}")
+    return {"placement": placement, "kernels": kernels}
+
+
 def persist_tune_winner(
     path: str | Path,
     document: dict,
     target: WorkingGoldenTarget,
-    winner: tuple[dict[str, str], float] | None,
+    winner: object | None,
     *,
     compile_flags: str,
 ) -> None:
-    """Atomically persist one unambiguous directly searched winner."""
+    """Atomically persist one unambiguous directly searched winner, or fail closed.
+
+    Scalar winners retain their legacy flat wire. A multi-kernel winner records exact placement and
+    per-operation schedules. Only a tune with neither representation receives a target-scoped marker,
+    so a strict publication run cannot mistake an older winner or unchanged inventory for success.
+    """
     from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.two_level import KernelSetWinner  # noqa: PLC0415
 
     configs = document["configs"]
-    if winner is not None:
+    marker_path = kernel_set_path = None
+    for entry_path in target.entry_indexes:
+        realization = configs[entry_path[0]]["realizations"][entry_path[1]]
+        if golden_entry_state(realization) == GoldenEntryState.VERIFIED:
+            continue
+        ranking = realization.get("ranking")
+        if not isinstance(ranking, dict) or ranking.get("source") != "tune":
+            continue
+        if winner is None and ranking.get("status") == "no_exact_pin" and marker_path is None:
+            marker_path = entry_path
+            continue
+        if isinstance(winner, KernelSetWinner) and "kernel_set" in ranking and kernel_set_path is None:
+            kernel_set_path = entry_path
+            continue
+        if ranking.get("tune_winner") is True or ranking.get("status") == "no_exact_pin":
+            realization["ranking"] = {**ranking, "status": "superseded"}
+            realization["ranking"].pop("tune_winner", None)
+
+    if isinstance(winner, KernelSetWinner):
+        winner_ranking = {
+            "source": "tune",
+            "status": "ok",
+            "tune_winner": True,
+            "compile_flags": compile_flags,
+            "latency_us": winner.latency_us,
+            "kernel_set": {
+                "placement": dict(winner.placement),
+                "kernels": [
+                    {
+                        "op_key": kernel.op_key,
+                        "multiplicity": kernel.multiplicity,
+                        "pins": dict(kernel.pins),
+                        "latency_us": kernel.latency_us,
+                        "cuda_record_knobs": [dict(row) for row in kernel.cuda_record_knobs],
+                    }
+                    for kernel in winner.kernels
+                ],
+            },
+        }
+        parse_kernel_set_ranking(winner_ranking)
+        if kernel_set_path is None:
+            config_index, realization_index = target.entry_indexes[0]
+            seed = copy.deepcopy(configs[config_index]["realizations"][realization_index])
+            for key in ("knobs", "measurements", "ranking"):
+                seed.pop(key, None)
+            seed["ranking"] = winner_ranking
+            configs[config_index]["realizations"].append(seed)
+            kernel_set_path = (config_index, len(configs[config_index]["realizations"]) - 1)
+            target.entry_indexes.append(kernel_set_path)
+        else:
+            configs[kernel_set_path[0]]["realizations"][kernel_set_path[1]]["ranking"] = winner_ranking
+    elif winner is not None:
         winner_knobs, winner_us = winner
         winner_ranking = {
             "status": "ok",
@@ -456,10 +616,8 @@ def persist_tune_winner(
         )
         if writable is not None:
             realization = configs[writable[0]]["realizations"][writable[1]]
-            previous = dict(realization.get("ranking") or {})
             realization["ranking"] = {
                 **winner_ranking,
-                "source": previous.get("source", "tune"),
                 "tune_winner": True,
             }
         elif not matching:
@@ -471,4 +629,24 @@ def persist_tune_winner(
             seed["ranking"] = {**winner_ranking, "tune_winner": True}
             configs[config_index]["realizations"].append(seed)
             target.entry_indexes.append((config_index, len(configs[config_index]["realizations"]) - 1))
+    else:
+        marker = {
+            "source": "tune",
+            "status": "no_exact_pin",
+            "compile_flags": compile_flags,
+            "latency_us": None,
+            "measured_knobs": None,
+            "error": "tune produced no exact replayable winner",
+        }
+        if marker_path is None:
+            config_index, realization_index = target.entry_indexes[0]
+            seed = copy.deepcopy(configs[config_index]["realizations"][realization_index])
+            for key in ("knobs", "measurements", "ranking"):
+                seed.pop(key, None)
+            seed["ranking"] = marker
+            configs[config_index]["realizations"].append(seed)
+            marker_path = (config_index, len(configs[config_index]["realizations"]) - 1)
+            target.entry_indexes.append(marker_path)
+        else:
+            configs[marker_path[0]]["realizations"][marker_path[1]]["ranking"] = marker
     dump_golden_file(document, path, overwrite=True)

--- a/experiments/golden-bench-2026/kernels/recipe.yaml
+++ b/experiments/golden-bench-2026/kernels/recipe.yaml
@@ -3,9 +3,10 @@
 command:
   stage:
     - emmy
+    - LICENSE
+    - README.md
     - pyproject.toml
     - requirements.txt
-    - Makefile
     - experiments/golden-bench-2026/kernels/recipe.yaml
   strict: true
   run: |
@@ -23,14 +24,17 @@ command:
         final_status=1
       fi
       printf 'study=%s\nstatus=%s\n' "$study" "$$final_status" > $task_dir/status.txt
-      archive_tmp=$${task_dir}.artifacts.tar.gz
+      archive_tmp=$task_dir.artifacts.tar.gz
       tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
       mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
       exit "$$final_status"
     }
     trap finalize EXIT
 
-    [ -d venv ] || make setup
+    if [ ! -x ./venv/bin/emmy ]; then
+      python3.12 -m venv venv --prompt emmy
+      ./venv/bin/pip install -e ".[dev]"
+    fi
     export EMMY_TUNE_DB=$task_dir/autotune.db
     export EMMY_ONLINE_FILE=$task_dir/online.json
     export EMMY_CUBIN_CACHE=$task_dir/cubins

--- a/tests/architecture/test_layering.py
+++ b/tests/architecture/test_layering.py
@@ -47,7 +47,7 @@ def test_checkpoint_format_names_stop_at_frontend_decomposition() -> None:
 
 
 def test_lowering_tile_does_not_import_kernel_ir() -> None:
-    """``lowering/tile/*.py`` may not import from ``ir.kernel.ir``.
+    """Tile structure and schedule passes may not import from ``ir.kernel.ir``.
 
     The Tile-IR / Kernel-IR boundary is: Tile passes encode scheduling
     *decisions* (``StagePolicy``, ``AsyncWait``, ``WarpSpecialize``);
@@ -64,20 +64,20 @@ def test_lowering_tile_does_not_import_kernel_ir() -> None:
     2. you're in the wrong directory — Kernel-IR-emitting passes live
        under ``lowering/kernel/``.
     """
-    tile_dir = _REPO_ROOT / "emmy" / "compiler" / "pipeline" / "passes" / "lowering" / "tile"
-    assert tile_dir.is_dir(), f"lowering/tile/ not found at {tile_dir}"
     forbidden = "from emmy.compiler.ir.kernel"
     offenders: list[str] = []
-    for py in sorted(tile_dir.glob("*.py")):
-        text = py.read_text()
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            if forbidden in line:
-                offenders.append(f"{py.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()}")
-    assert not offenders, "lowering/tile/*.py must not import from ir.kernel — layering violation.\n" + "\n".join(offenders)
+    for leaf in ("tile", "schedule"):
+        pass_dir = _REPO_ROOT / "emmy" / "compiler" / "pipeline" / "passes" / "lowering" / leaf
+        assert pass_dir.is_dir(), f"lowering/{leaf}/ not found at {pass_dir}"
+        for py in sorted(pass_dir.glob("*.py")):
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                if forbidden in line:
+                    offenders.append(f"{py.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()}")
+    assert not offenders, "tile/schedule passes must not import from ir.kernel — layering violation.\n" + "\n".join(offenders)
 
 
 def test_lowering_tile_does_not_import_kernel_passes() -> None:
-    """``lowering/tile/**/*.py`` may not import from the ``lowering/kernel`` pass layer.
+    """Tile structure and schedule passes may not import from the ``lowering/kernel`` pass layer.
 
     The tile layer (``enumeration`` + ``assembly`` + ``split``) runs ABOVE the
     kernel pass layer; a tile pass importing ``lowering.kernel`` is a back-edge in
@@ -90,16 +90,17 @@ def test_lowering_tile_does_not_import_kernel_passes() -> None:
     If this fires: move the shared helper into a ``lowering/`` root module and import
     it there from both layers, rather than reaching down into ``lowering/kernel``.
     """
-    tile_dir = _REPO_ROOT / "emmy" / "compiler" / "pipeline" / "passes" / "lowering" / "tile"
-    assert tile_dir.is_dir(), f"lowering/tile/ not found at {tile_dir}"
     forbidden = "emmy.compiler.pipeline.passes.lowering.kernel"
     offenders: list[str] = []
-    for py in sorted(tile_dir.rglob("*.py")):
-        for lineno, line in enumerate(py.read_text().splitlines(), start=1):
-            if forbidden in line and "import" in line:
-                offenders.append(f"{py.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()}")
+    for leaf in ("tile", "schedule"):
+        pass_dir = _REPO_ROOT / "emmy" / "compiler" / "pipeline" / "passes" / "lowering" / leaf
+        assert pass_dir.is_dir(), f"lowering/{leaf}/ not found at {pass_dir}"
+        for py in sorted(pass_dir.rglob("*.py")):
+            for lineno, line in enumerate(py.read_text().splitlines(), start=1):
+                if forbidden in line and "import" in line:
+                    offenders.append(f"{py.relative_to(_REPO_ROOT)}:{lineno}: {line.strip()}")
     assert not offenders, (
-        "lowering/tile/**/*.py must not import from lowering/kernel — back-edge in the pass DAG.\n"
+        "tile/schedule passes must not import from lowering/kernel — back-edge in the pass DAG.\n"
         "Shared structural predicates live in lowering/_predicates.\n" + "\n".join(offenders)
     )
 

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -44,20 +44,29 @@ def test_common_kernel_corpus_is_small_and_identical(project_root) -> None:
     assert "./venv/bin/emmy trace" in run
     assert "./venv/bin/emmy tune" in run
     assert "./venv/bin/emmy run" in run
+    assert "python3.12 -m venv" in run
+    assert "make setup" not in run
     assert "for repeat in 0 1 2 3 4" in run
     assert "--golden $task_dir/working.yaml --bench --strict" in run
     assert "scripts/" not in run
     assert recipe.command.stage == [
         "emmy",
+        "LICENSE",
+        "README.md",
         "pyproject.toml",
         "requirements.txt",
-        "Makefile",
         "experiments/golden-bench-2026/kernels/recipe.yaml",
     ]
     assert recipe.command.strict is True
     assert recipe.command.result_files == ["artifacts.tar.gz"]
     assert "pip freeze --all" in run
     assert "tar -C $task_dir" in run
+    command = render_command(
+        run,
+        build_substitution_map(tasks[0].variant, [0], "/repo", "/task"),
+    )
+    assert "archive_tmp=/task.artifacts.tar.gz" in command
+    assert "${task_dir}" not in command
 
 
 def test_native_fp8_kernel_corpus_is_separate_and_identical(project_root) -> None:

--- a/tests/compiler/backend/test_torch_ref.py
+++ b/tests/compiler/backend/test_torch_ref.py
@@ -56,6 +56,22 @@ def test_linear_and_elementwise():
     _assert_matches_numpy(g, {"x": r.standard_normal((4, 8)), "w": r.standard_normal((16, 8))})
 
 
+def test_multi_output_callable_preserves_graph_output_order():
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (4,)), node_id="x")
+    g.add_node(ElementwiseOp(op="relu"), ["x"], Tensor("positive", (4,)), node_id="positive")
+    g.add_node(ElementwiseOp(op="negative"), ["x"], Tensor("negative", (4,)), node_id="negative")
+    g.inputs, g.outputs = ["x"], ["negative", "positive"]
+    x = torch.tensor([-2.0, -1.0, 1.0, 2.0])
+
+    fn, inputs = torch_ref.build_callable(g, {"x": x})
+    outputs = fn(*inputs)
+
+    assert list(outputs) == ["negative", "positive"]
+    torch.testing.assert_close(outputs["negative"], -x)
+    torch.testing.assert_close(outputs["positive"], torch.relu(x))
+
+
 def test_declared_dtype_cast_is_enforced():
     """The trace folds HF's explicit casts (e.g. the fp32 RMSNorm body casting
     back to fp16) into each node's declared output dtype; ``build_callable``

--- a/tests/compiler/cli/test_compile.py
+++ b/tests/compiler/cli/test_compile.py
@@ -64,12 +64,19 @@ def test_compile_code_functional_softmax_bakes_kwargs(run_cli):
 
 
 def test_compile_passes_shorthand(run_cli, tmp_path):
-    """'dolft' should expand to decomposition/optimization/lifting/fusion/lowering/tile."""
+    """'dolft' should expand through both structural and schedule halves of Tile lowering."""
     out = tmp_path / "out.txt"
     rc, stdout, stderr = run_cli("compile", "-c", "F.relu(torch.randn(8))", "--passes", "dolft", "-o", str(out), "-vv")
     assert rc == 0, f"stderr: {stderr}"
     log = stdout + stderr
-    for name in ("frontend/decomposition", "frontend/optimization", "loop/lifting", "loop/fusion", "lowering/tile"):
+    for name in (
+        "frontend/decomposition",
+        "frontend/optimization",
+        "loop/lifting",
+        "loop/fusion",
+        "lowering/tile",
+        "lowering/schedule",
+    ):
         assert name in log, f"missing pass {name!r} in log"
     assert "lowering/cuda" not in log
 

--- a/tests/compiler/cli/test_golden_file_replay.py
+++ b/tests/compiler/cli/test_golden_file_replay.py
@@ -191,6 +191,97 @@ def test_working_direct_tune_winner_is_automatically_pinned(tmp_path):
 
     assert len(args.golden_configs) == 1
     assert args.golden_configs[0].knobs == {"WORK": "w1x1"}
+    assert args.expected_golden_pins == 1
+
+
+def test_working_kernel_set_winner_is_automatically_pinned(tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    document = _working_loop(path)
+    realization = document["configs"][0]["realizations"][0]
+    realization["ranking"] = {
+        "source": "tune",
+        "status": "ok",
+        "tune_winner": True,
+        "compile_flags": "-O1",
+        "latency_us": 7.0,
+        "kernel_set": {
+            "placement": {},
+            "kernels": [
+                {
+                    "op_key": "working-op",
+                    "multiplicity": 1,
+                    "pins": {"WORK": "w1x1"},
+                    "latency_us": 7.0,
+                    "cuda_record_knobs": [{"WORK": "w1x1"}],
+                }
+            ],
+        },
+    }
+    dump_golden_file(document, path, overwrite=True)
+    args = _args(path)
+
+    resolve_golden_arg(args)
+
+    assert len(args.golden_configs) == 1
+    sample = args.golden_configs[0]
+    assert sample.knobs == {}
+    assert sample.latency_us == 7.0
+    assert sample.kernel_set == realization["ranking"]["kernel_set"]
+    assert args.expected_golden_pins == 1
+
+
+def test_working_kernel_set_winner_rejects_extra_component_field(tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    document = _working_loop(path)
+    document["configs"][0]["realizations"][0]["ranking"] = {
+        "source": "tune",
+        "status": "ok",
+        "tune_winner": True,
+        "latency_us": 7.0,
+        "kernel_set": {
+            "placement": {},
+            "kernels": [
+                {
+                    "op_key": "working-op",
+                    "multiplicity": 1,
+                    "pins": {"WORK": "w1x1"},
+                    "latency_us": 7.0,
+                    "cuda_record_knobs": [{"WORK": "w1x1"}],
+                    "node_id": "y",
+                }
+            ],
+        },
+    }
+    dump_golden_file(document, path, overwrite=True)
+
+    with pytest.raises(SystemExit, match="2"):
+        resolve_golden_arg(_args(path))
+
+
+def test_working_unreplayable_tune_result_requires_an_exact_row(tmp_path):
+    from emmy.commands.compile import resolve_golden_arg
+
+    path = tmp_path / "working.yaml"
+    document = _working_loop(path)
+    document["configs"][0]["realizations"][0]["ranking"] = {
+        "source": "tune",
+        "status": "no_exact_pin",
+        "compile_flags": "-O1",
+        "latency_us": None,
+        "measured_knobs": None,
+        "error": "tune produced no exact replayable winner",
+    }
+    dump_golden_file(document, path, overwrite=True)
+    args = _args(path)
+
+    resolve_golden_arg(args)
+
+    assert args.golden_configs == []
+    assert args.expected_golden_pins == 1
 
 
 def test_working_invalid_direct_tune_winner_is_rejected(tmp_path):

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -99,6 +99,77 @@ def test_pinned_knobs_merges_scoped_keys_into_aggregate_and_restores(monkeypatch
     assert os.environ["EMMY_KNOBS"] == "FAST_MATH=true,PLACE@a=fuse"
 
 
+def test_exact_kernel_set_schedule_decider_requires_one_matching_component() -> None:
+    from types import SimpleNamespace
+
+    from emmy.compiler.ir.base import InputOp
+    from emmy.compiler.pipeline.fork import OptionFork
+    from emmy.compiler.pipeline.knob import stamp_schedule_families
+    from emmy.compiler.pipeline.search.pins import KernelSetReplayError, _exact_schedule_decide
+    from emmy.compiler.pipeline.search.policy.greedy import PARTITION_RULE
+
+    matching = OptionFork(InputOp(), knobs={"TILE": "f2x2"})
+    other = OptionFork(InputOp(), knobs={"TILE": "f4x1"})
+    pins = stamp_schedule_families(matching.knobs)
+    root_op = SimpleNamespace(cache_key=lambda: "op-a", knobs={})
+    fp = SimpleNamespace(
+        structural=False,
+        match=SimpleNamespace(rule=SimpleNamespace(name=PARTITION_RULE)),
+        node_id="root",
+        root_op=root_op,
+        options=[matching, other],
+    )
+    decide = _exact_schedule_decide(
+        {
+            "kernels": [
+                {
+                    "op_key": "op-a",
+                    "multiplicity": 1,
+                    "pins": pins,
+                    "latency_us": 1.0,
+                    "cuda_record_knobs": [pins],
+                }
+            ]
+        }
+    )
+
+    assert decide(fp) is matching
+    root_op.cache_key = lambda: "unexpected"
+    with pytest.raises(KernelSetReplayError, match="unknown op_key"):
+        decide(fp)
+    root_op.cache_key = lambda: "op-a"
+    fp.options = [other]
+    with pytest.raises(KernelSetReplayError, match="got 0"):
+        decide(fp)
+
+
+def test_exact_kernel_set_cuda_integrity_preserves_component_order_only() -> None:
+    from emmy.compiler.pipeline.search.pins import (
+        KernelSetReplayError,
+        _validate_component_cuda_rows,
+        _validate_cuda_inventory,
+    )
+
+    first = [{"TILE": "f2x2", "REDUCE": "g2k"}, {"TILE": "f8x1", "REDUCE": ""}]
+    second = [{"TILE": "f4x1", "REDUCE": ""}]
+    kernel_set = {
+        "kernels": [
+            {"op_key": "op-a", "multiplicity": 1, "cuda_record_knobs": first},
+            {"op_key": "op-b", "multiplicity": 2, "cuda_record_knobs": second},
+        ]
+    }
+
+    _validate_component_cuda_rows("op-a", list(first), first)
+    with pytest.raises(KernelSetReplayError, match="op-a.*mismatch"):
+        _validate_component_cuda_rows("op-a", list(reversed(first)), first)
+
+    # Whole-graph topological order may put another component before op-a. The
+    # inventory gate checks exact multiplicity/content without imposing that order.
+    _validate_cuda_inventory([*second, *first, *second], kernel_set)
+    with pytest.raises(KernelSetReplayError, match="inventory mismatch"):
+        _validate_cuda_inventory([*second, *first], kernel_set)
+
+
 def _symbolic_input_graph():
     """Frontend-ish graph with one symbolic input (``x``, seq axis 1) and one
     static input (``w``) — enough for ``_hint_sized_inputs``' input pairing."""
@@ -385,16 +456,16 @@ def test_unreproducible_pin_flag(monkeypatch):
     A synthetic registry (mirroring space.py's TILE/STAGE/FAST_EXP declarations)
     keeps the test independent of module-load order."""
     from emmy.compiler.pipeline import knob as knob_mod
-    from emmy.compiler.pipeline.knob import Knob, KnobType
+    from emmy.compiler.pipeline.search import space
     from emmy.compiler.pipeline.search.pins import unreproducible_pin_flag
 
     monkeypatch.setattr(
         knob_mod,
         "_REGISTRY",
         {
-            "TILE": Knob("TILE", KnobType.STR, off=""),
-            "STAGE": Knob("STAGE", KnobType.STR, off=""),
-            "FAST_EXP": Knob("FAST_EXP", KnobType.BOOL, off=False),
+            "TILE": space.TILE,
+            "STAGE": space.STAGE,
+            "FAST_EXP": space.FAST_EXP,
         },
     )
 
@@ -469,6 +540,38 @@ def test_bench_golden_variants_unmatched_pin_fails_row_without_benching(monkeypa
     assert any("unreproducible pin" in f and "NOT benched" in f for f in benches[0].flags)
     assert len(benched) == 1  # only the honored row spent GPU time
     assert benches[1].status == "ok" and benches[1].flags == [] and benches[1].bench is not None
+
+
+def test_bench_kernel_set_mismatch_fails_row_without_benching(monkeypatch):
+    from types import SimpleNamespace
+
+    from emmy.commands import trace as tmod
+    from emmy.commands.run import _bench_golden_variants
+    from emmy.compiler.pipeline.search import pins as pins_mod
+
+    monkeypatch.setattr(tmod, "graph_from_code", lambda code, dynamic_shapes=None: (object(), "slug", (None, (), {})))
+
+    def reject(_graph, _kernel_set):
+        raise pins_mod.KernelSetReplayError("kernel inventory mismatch: missing op-a")
+
+    monkeypatch.setattr(pins_mod, "lower_exact_kernel_set", reject)
+    backend = SimpleNamespace(
+        compile=lambda _graph: (_ for _ in ()).throw(AssertionError("exact kernel sets bypass scalar compile")),
+        bench_pinned_async=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("mismatched rows are not benched")),
+    )
+    sample = SimpleNamespace(
+        name="working.multi",
+        knobs={},
+        pins={"FAST_MATH": False},
+        shape=object(),
+        dynamic=None,
+        kernel_set={"placement": {}, "kernels": []},
+    )
+
+    (row,) = asyncio.run(_bench_golden_variants(backend, "torch.matmul(a, b)", [sample], warmup=1, iters=1))
+
+    assert row.status == "pin_unmatched" and row.bench is None
+    assert any("kernel inventory mismatch" in flag and "NOT benched" in flag for flag in row.flags)
 
 
 @pytest.mark.parametrize(
@@ -667,6 +770,46 @@ def test_ab_json_labels_each_row_with_its_lane(tmp_path, monkeypatch):
     # The filter a sweep applies: only same-lane rows are comparable to the greedy.
     same_lane = [p for p in rec["pinned"] if p["lane"] == rec["greedy"]["lane"]]
     assert len(same_lane) == 1 and same_lane[0]["lane"] == "std"
+
+
+def test_ab_json_keeps_exact_kernel_set_manifest(tmp_path, monkeypatch):
+    import json
+    from types import SimpleNamespace
+
+    from emmy.commands import run as run_mod
+    from emmy.compiler.pipeline.search.data import Sample
+
+    monkeypatch.setattr(run_mod, "_launch_order_cuda_nodes", lambda _graph: [])
+    kernel_set = {
+        "placement": {"PLACE@root": "cut"},
+        "kernels": [
+            {
+                "op_key": "op-a",
+                "multiplicity": 2,
+                "pins": {"TILE": "f2x2", "FAST_EXP": True},
+                "latency_us": 3.0,
+                "cuda_record_knobs": [{"TILE": "f2x2", "FAST_EXP": True}],
+            }
+        ],
+    }
+    sample = Sample(
+        knobs={},
+        pins={"FAST_MATH": True},
+        latency_us=6.0,
+        name="working.multi",
+        shape=object(),
+        kernel_set=kernel_set,
+    )
+    row = run_mod._GoldenBench(sample, object(), None, (), "ok")
+    out = tmp_path / "ab.json"
+    args = SimpleNamespace(code=None, input=None, ir=None, golden="working.multi", dynamic=None, warmup=1, iters=1, json=str(out))
+
+    run_mod._write_ab_json(args, {}, object(), None, [row])
+
+    pinned = json.loads(out.read_text())["pinned"][0]
+    assert pinned["winner_kind"] == "kernel_set"
+    assert pinned["lane"] == "fm"
+    assert pinned["pinned_kernel_set"] == kernel_set
 
 
 @requires_cuda
@@ -1242,6 +1385,43 @@ def test_accuracy_check_fails_scrambled_output_passes_outliers():
     assert not verdicts(noisy.astype(np.float16)), "outliers with a near-zero mean must pass (escape hatch)"
     # Correct low-noise: must PASS.
     assert not verdicts((base + rng.standard_normal(base.shape) * 0.001).astype(np.float16))
+
+
+def test_accuracy_check_rejects_missing_or_misordered_output_shape():
+    import numpy as np
+    import torch
+
+    from emmy.commands.run import _check_accuracy
+
+    outputs = {
+        "small": np.zeros(4, dtype=np.float32),
+        "large": np.zeros(8, dtype=np.float32),
+    }
+    eager = (torch.zeros(8), torch.zeros(4))
+
+    error = _check_accuracy(outputs, eager)
+
+    assert error is not None
+    assert "size 4 does not match eager 8" in error
+
+
+def test_accuracy_check_pairs_named_outputs_independent_of_mapping_order():
+    import numpy as np
+    import torch
+
+    from emmy.commands.run import _check_accuracy, _strict_correctness_proof
+
+    outputs = {
+        "small": np.zeros(4, dtype=np.float32),
+        "large": np.ones(8, dtype=np.float32),
+    }
+    eager = {
+        "large": torch.ones(8),
+        "small": torch.zeros(4),
+    }
+
+    assert _check_accuracy(outputs, eager) is None
+    assert _strict_correctness_proof(outputs, eager)["status"] == "pass"
 
 
 def test_accuracy_check_gaussian_fp16_budget_not_free():

--- a/tests/compiler/cli/test_run_golden.py
+++ b/tests/compiler/cli/test_run_golden.py
@@ -120,3 +120,21 @@ def test_strict_result_requires_every_requested_exact_row():
     errors = run_mod._strict_benchmark_errors(args, {"Emmy": 10.0}, bench, True, proof, [])
 
     assert "expected 1 exact --ab row(s), got 0" in errors
+
+
+def test_strict_result_requires_expected_working_golden_row():
+    args = SimpleNamespace(bench_backends="emmy", ab=None, expected_golden_pins=1)
+    proof = {
+        "status": "pass",
+        "reference": "eager",
+        "rtol": 1e-3,
+        "atol": 1e-3,
+        "max_abs_error": 0.0,
+        "mean_abs_error": 0.0,
+        "max_rel_error": 0.0,
+    }
+    bench = SimpleNamespace(captured=True)
+
+    errors = run_mod._strict_benchmark_errors(args, {"Emmy": 10.0}, bench, True, proof, [])
+
+    assert "expected 1 exact working-golden row(s), got 0" in errors

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -16,6 +16,7 @@ from emmy.compiler.pipeline.search.golden import dump_golden_file, load_golden_f
 from emmy.compiler.pipeline.search.working_golden import (
     WorkingGoldenTarget,
     load_working_targets,
+    parse_kernel_set_ranking,
     persist_proposal_rankings,
     persist_tune_winner,
     realized_tuning_knobs,
@@ -181,7 +182,7 @@ def test_ranking_write_preserves_verified_and_records_actual_searched_winner(tmp
     assert "measurements" not in winner
 
 
-def test_ambiguous_multi_cuda_winner_is_not_annotated(tmp_path):
+def test_ambiguous_multi_cuda_winner_is_recorded_as_unreplayable(tmp_path):
     path = tmp_path / "working.yaml"
     dump_golden_file(_document(_matmul("mm")), path)
     document, targets = load_working_targets(path)
@@ -191,8 +192,138 @@ def test_ambiguous_multi_cuda_winner_is_not_annotated(tmp_path):
 
     got = load_golden_file(path)
     assert len(got["configs"]) == 1
-    assert got["configs"][0]["realizations"][0]["name"] == "mm"
+    realizations = got["configs"][0]["realizations"]
+    assert realizations[0]["name"] == "mm"
+    markers = [realization for realization in realizations if (realization.get("ranking") or {}).get("status") == "no_exact_pin"]
+    assert len(markers) == 1
+    assert "knobs" not in markers[0]
+    assert markers[0]["ranking"]["source"] == "tune"
+    assert "tune_winner" not in markers[0]["ranking"]
     assert got["configs"][0]["target"] == {"origins": ["matmul"]}
+
+    persist_tune_winner(path, document, targets[0], None, compile_flags="-O1")
+    again = load_golden_file(path)["configs"][0]["realizations"]
+    assert sum((realization.get("ranking") or {}).get("status") == "no_exact_pin" for realization in again) == 1
+
+
+def test_exact_multi_kernel_winner_persists_without_flattening(tmp_path):
+    from emmy.compiler.pipeline.search.two_level import KernelSetOpWinner, KernelSetWinner
+
+    path = tmp_path / "working.yaml"
+    dump_golden_file(_document(_matmul("mm")), path)
+    document, targets = load_working_targets(path)
+    winner = KernelSetWinner(
+        placement={"PLACE@root": "cut"},
+        kernels=(
+            KernelSetOpWinner(
+                op_key="op-a",
+                multiplicity=2,
+                pins={"TILE": "f2x2", "REDUCE": "", "LOOPIFY": "0"},
+                latency_us=4.0,
+                cuda_record_knobs=({"TILE": "f2x2", "REDUCE": "", "LOOPIFY": "0"},),
+            ),
+            KernelSetOpWinner(
+                op_key="op-b",
+                multiplicity=1,
+                pins={"TILE": "f4x1", "REDUCE": "g2k"},
+                latency_us=6.0,
+                cuda_record_knobs=(
+                    {"TILE": "f4x1", "REDUCE": "g2k"},
+                    {"TILE": "f8x1", "REDUCE": ""},
+                ),
+            ),
+        ),
+        latency_us=14.0,
+    )
+
+    persist_tune_winner(path, document, targets[0], winner, compile_flags="-Xcicc -O1")
+    persist_tune_winner(path, document, targets[0], winner, compile_flags="-Xcicc -O1")
+
+    realizations = load_golden_file(path)["configs"][0]["realizations"]
+    exact = [row for row in realizations if (row.get("ranking") or {}).get("tune_winner") is True]
+    assert len(exact) == 1
+    row = exact[0]
+    assert "knobs" not in row and "measurements" not in row
+    assert "measured_knobs" not in row["ranking"]
+    assert parse_kernel_set_ranking(row["ranking"]) == {
+        "placement": {"PLACE@root": "cut"},
+        "kernels": [
+            {
+                "op_key": "op-a",
+                "multiplicity": 2,
+                "pins": {"TILE": "f2x2", "REDUCE": "", "LOOPIFY": "0"},
+                "latency_us": 4.0,
+                "cuda_record_knobs": [{"TILE": "f2x2", "REDUCE": "", "LOOPIFY": "0"}],
+            },
+            {
+                "op_key": "op-b",
+                "multiplicity": 1,
+                "pins": {"TILE": "f4x1", "REDUCE": "g2k"},
+                "latency_us": 6.0,
+                "cuda_record_knobs": [
+                    {"TILE": "f4x1", "REDUCE": "g2k"},
+                    {"TILE": "f8x1", "REDUCE": ""},
+                ],
+            },
+        ],
+    }
+
+
+def test_kernel_set_ranking_rejects_inexact_latency_and_multiplicity() -> None:
+    ranking = {
+        "source": "tune",
+        "status": "ok",
+        "tune_winner": True,
+        "compile_flags": "-O1",
+        "latency_us": 8.0,
+        "kernel_set": {
+            "placement": {},
+            "kernels": [
+                {
+                    "op_key": "op-a",
+                    "multiplicity": 2,
+                    "pins": {"TILE": "f2x2"},
+                    "latency_us": 3.0,
+                    "cuda_record_knobs": [{"TILE": "f2x2"}],
+                }
+            ],
+        },
+    }
+
+    with pytest.raises(ValueError, match="weighted direct latency"):
+        parse_kernel_set_ranking(ranking)
+    ranking["kernel_set"]["kernels"][0]["multiplicity"] = 0
+    with pytest.raises(ValueError, match="positive integer"):
+        parse_kernel_set_ranking(ranking)
+    ranking["kernel_set"]["kernels"][0]["multiplicity"] = 2
+    ranking["measured_knobs"] = {"TILE": "f2x2"}
+    with pytest.raises(ValueError, match="scalar measured_knobs"):
+        parse_kernel_set_ranking(ranking)
+
+
+def test_current_tune_result_retires_stale_winner_and_owns_matching_proposal(tmp_path):
+    path = tmp_path / "working.yaml"
+    stale = _matmul("mm", knobs={"TILE": "f2x2"})
+    stale["ranking"] = {
+        "source": "tune",
+        "status": "ok",
+        "tune_winner": True,
+        "latency_us": 9.0,
+        "compile_flags": "-O1",
+        "measured_knobs": {"TILE": "f2x2"},
+    }
+    proposal = _matmul("mm", knobs={"TILE": "f4x2"})
+    proposal["ranking"] = {"source": "proposal", "status": "ok", "latency_us": 8.0}
+    dump_golden_file(_document(stale, proposal), path)
+    document, targets = load_working_targets(path)
+
+    persist_tune_winner(path, document, targets[0], ({"TILE": "f4x2"}, 7.5), compile_flags="-O1")
+
+    realizations = load_golden_file(path)["configs"][0]["realizations"]
+    assert realizations[0]["ranking"]["status"] == "superseded"
+    assert "tune_winner" not in realizations[0]["ranking"]
+    assert realizations[1]["ranking"]["source"] == "tune"
+    assert realizations[1]["ranking"]["tune_winner"] is True
 
 
 def test_working_file_rejects_canonical_path_and_symlink(tmp_path):
@@ -331,7 +462,7 @@ def test_multi_gpu_working_sweep_shares_slots_and_prior_across_targets(monkeypat
         await asyncio.sleep(0.01)
         active -= 1
         kwargs["backend_slots"].put_nowait(backend)
-        return SimpleNamespace(prior_summaries=[], best_reward=None, assembled=None)
+        return SimpleNamespace(prior_summaries=[], best_reward=None, assembled=None, searched_winner=lambda: None)
 
     target_dirs = []
 

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -418,6 +418,94 @@ def test_flash_form_fork_offers_geometry_grid():
         assert len(chain) == 1 and len(serial) >= 1, f"{dtype}: chain/serial siblings missing ({len(chain)}/{len(serial)})"
 
 
+def test_materialized_score_flash_offers_warp_row_on_capable_targets(monkeypatch):
+    """Cutting the QK score edge leaves the same algebraic TWISTED carrier, whose schedule owns
+    the tensor-core P@V choice. Every target that advertises the fp16 mma primitive must offer the
+    same materialized-score warp row; staging stays disabled because the score is already in gmem."""
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline.search.golden_eval import enumerate_graph  # noqa: PLC0415
+    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
+
+    monkeypatch.setenv("EMMY_KNOBS", "PLACE@dd=cut")
+    args = tuple(torch.randn(1, 1, 16, 16, dtype=torch.float16) for _ in range(3))
+    rows_by_target = []
+    for target in ((8, 0), (9, 0), (12, 0)):
+        graph = trace_module(_Sdpa(), args)
+        rows = [
+            row
+            for row in enumerate_graph(graph, Context.from_target(target))
+            if row.get("TILE") and "TILE@pj" in row and str(row.get("WORK", "")).startswith("w")
+        ]
+        rows_by_target.append(rows)
+
+    assert all(rows for rows in rows_by_target)
+    assert all(not row["STAGE"] for rows in rows_by_target for row in rows)
+    assert rows_by_target[0][0] == rows_by_target[1][0] == rows_by_target[2][0]
+
+
+def test_materialized_score_flash_lowers_workspace_to_pv_mma(monkeypatch):
+    """A pinned PLACE cut plus the generic warp schedule loads the materialized scores straight
+    into C fragments, runs online softmax, repacks P to A, and tensor-core schedules P@V."""
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline import CUDA_PASSES, Pipeline  # noqa: PLC0415
+    from emmy.compiler.pipeline.fork import flatten_leaves  # noqa: PLC0415
+    from emmy.compiler.pipeline.pipeline import Run  # noqa: PLC0415
+    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
+
+    monkeypatch.setenv("EMMY_KNOBS", "PLACE@dd=cut")
+    monkeypatch.setenv("EMMY_TILE", "mma_m16n8k16_f16_f32/f1x2")
+    monkeypatch.setenv("EMMY_TILE@PJ", "mma_m16n8k16_f16_f32/f1x2")
+    monkeypatch.setenv("EMMY_STAGE", "")
+    monkeypatch.setenv("EMMY_REDUCE", "")
+    monkeypatch.setenv("EMMY_WORK", "w1x1")
+    args = tuple(torch.randn(1, 1, 16, 16, dtype=torch.float16) for _ in range(3))
+    graph = trace_module(_Sdpa(), args)
+    output = graph.outputs[0]
+    compiled, _ = Run(pipeline=Pipeline.build(CUDA_PASSES), ctx=Context.from_target((9, 0))).resolve(
+        graph, lambda fp: flatten_leaves(fp.options)[0]
+    )
+    kernels = [node for node in compiled.nodes.values() if getattr(node.op, "kernel_source", None)]
+    assert len(kernels) == 2, "the PLACE cut must launch one score producer and one residue"
+    residue = compiled.nodes[output]
+    src = residue.op.kernel_source
+    assert any("__cut_sacc" in name for name in residue.inputs)
+    assert "sacc_f0[0] =" in src and "__cut_sacc[" in src, "the score workspace must load into C fragments"
+    assert "emmy_c_to_a_f16" in src, "online-softmax probabilities must repack from C to A fragments"
+    assert "emmy_mma_m16n8k16_f16_f32" in src, "P@V must run on the target's advertised mma primitive"
+
+
+def test_materialized_score_splitkv_keeps_fragment_partial(monkeypatch):
+    """A schedule-selected cross-CTA KV partition preserves the materialized-score warp form in
+    the partial kernel instead of silently falling back to scalar P@V."""
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline import CUDA_PASSES, Pipeline  # noqa: PLC0415
+    from emmy.compiler.pipeline.fork import flatten_leaves  # noqa: PLC0415
+    from emmy.compiler.pipeline.pipeline import Run  # noqa: PLC0415
+    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
+
+    monkeypatch.setenv("EMMY_KNOBS", "PLACE@dd=cut")
+    args = tuple(torch.randn(1, 1, 32, 16, dtype=torch.float16) for _ in range(3))
+    graph = trace_module(_Sdpa(), args)
+    picked = False
+
+    def choose_split(fp):
+        nonlocal picked
+        leaves = flatten_leaves(fp.options)
+        for leaf in leaves:
+            row = getattr(leaf, "knobs", {}) or {}
+            if row.get("TILE") and "TILE@pj" in row and row.get("REDUCE") == "g2k" and str(row.get("WORK", "")).startswith("w"):
+                picked = True
+                return leaf
+        return leaves[0]
+
+    compiled, _ = Run(pipeline=Pipeline.build(CUDA_PASSES), ctx=Context.from_target((9, 0))).resolve(graph, choose_split)
+    partial = next(node.op for nid, node in compiled.nodes.items() if nid.endswith("__partial"))
+    assert picked
+    assert "__cut_sacc[" in partial.kernel_source
+    assert "emmy_c_to_a_f16" in partial.kernel_source
+    assert "emmy_mma_m16n8k16_f16_f32" in partial.kernel_source
+
+
 @requires_cuda
 @pytest.mark.parametrize(("um", "nt"), [(2, 4), (4, 8)])
 def test_warp_flash_geometry_pin_matches_torch(monkeypatch, um, nt):

--- a/tests/compiler/e2e/test_knob_pinning.py
+++ b/tests/compiler/e2e/test_knob_pinning.py
@@ -11,7 +11,7 @@ env-var mechanism (see ``emmy/compiler/pipeline/knob.py`` —
 ``apply_knobs_env`` splats the aggregate into per-knob
 ``EMMY_<K>=V`` vars at import time, and ``Knob.narrow`` overrides
 the schedule's candidate codecs with the pinned value in
-``lowering/tile/020_schedule`` so only the matching variant is built).
+``lowering/schedule/020_schedule`` so only the matching variant is built).
 
 The shared failure mode is the "single-CTA + F-replicated" codegen
 class: ``BN·FN = full_N AND BM·FM = full_M`` with ``FM·FN > 1`` (so

--- a/tests/compiler/ir/test_body_cone.py
+++ b/tests/compiler/ir/test_body_cone.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.expr import Var
-from emmy.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Write
+from emmy.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Write, lexical_free_values
 from emmy.compiler.ir.stmt.body import Body
 from emmy.compiler.ir.stmt.leaves import SelectBranch
 
@@ -34,6 +34,37 @@ def _cell() -> Body:
             Accum(name="acc", value="p"),
         ]
     )
+
+
+# --- lexical free values ---------------------------------------------
+
+
+def test_lexical_free_values_respect_definition_order() -> None:
+    body = Body((_asn("use", "negative", "later"), _asn("later", "copy", "external")))
+    assert lexical_free_values(body, bound={"external"}) == frozenset({"later"})
+
+
+def test_lexical_free_values_do_not_export_nested_assignments() -> None:
+    body = Body(
+        (
+            Loop(axis=Axis("k", 4), body=Body((_ld("nested", "x", "k"),))),
+            _asn("use", "negative", "nested"),
+        )
+    )
+    assert lexical_free_values(body, bound={"k"}) == frozenset({"nested"})
+
+
+def test_lexical_free_values_export_and_preseed_accumulators() -> None:
+    body = Body(
+        (
+            Loop(
+                axis=Axis("k", 4),
+                body=Body((_ld("xv", "x", "k"), _asn("scaled", "multiply", "acc", "xv"), Accum("acc", "scaled"))),
+            ),
+            _asn("out", "negative", "acc"),
+        )
+    )
+    assert lexical_free_values(body) == frozenset()
 
 
 # --- backward_cone ----------------------------------------------------

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -45,6 +45,8 @@ tests/compiler/passes/
 ├── test_launch_geometry_rules.py   # launch-geometry pass
 ├── test_masked_tile.py             # masked-tile pass (dynamic-shape boundary guard)
 ├── test_stage_inputs_classify.py   # Stage-input classifier
+├── test_schedule_site_ownership.py # nested-only schedule rows do not invent root slices
+├── test_sync_transport.py          # computed-operand slab fills keep nested SSA hygienic
 ├── test_lowering_accuracy.py       # 040 / 060 / 070 + TMA end-to-end CUDA accuracy
 ├── test_knob_pinning.py            # EMMY_KNOBS-pinned regression configs (article-reproduction tile/transport sweep)
 ├── test_warp_specialize_deadlock.py # WS=1 stranded-TMA deadlock (Qwen3 k_linear_mean_reduce) regressions

--- a/tests/compiler/passes/ARCHITECTURE.md
+++ b/tests/compiler/passes/ARCHITECTURE.md
@@ -15,6 +15,19 @@ This catches semantic bugs that structural tests (checking which ops are
 present) cannot: wrong axis in a reduction, swapped operands, missing
 scale constant, incorrect coordinate mapping, etc.
 
+## Pass-contract guardrails
+
+Some pass properties span every rule and are enforced statically in
+`test_hardware_capability_contract.py`. Passes receive target facts through `Context`, never a process-global target
+probe; primitive legality uses a named capability rather than a repeated compute-capability threshold; and physical
+product identity is restricted to measured placement routing. Algebra recognition cannot consult capabilities.
+
+The same guard keeps fusion independent of placement and scheduling. `loop/fusion` cannot import target, context,
+knob, search, or lowering policy; accept `ctx`; inspect hardware or knob attributes, including through `getattr`; or
+spell schedule-family keys. Fusion tests continue to prove semantics, while this static contract prevents a later
+performance workaround from weakening the maximal algebraic region instead of adding a generic `PLACE` or schedule
+choice.
+
 ## File Layout
 
 ```

--- a/tests/compiler/passes/test_decompose_rules.py
+++ b/tests/compiler/passes/test_decompose_rules.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import numpy as np
 
 from emmy.compiler.backend.numpy import NumpyBackend
+from emmy.compiler.context import Context
 from emmy.compiler.dim import Dim
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import ConstantOp, InputOp
@@ -826,25 +827,14 @@ def test_transpose_fold_sub_sm90_matvec_exception():
     matvec weight (the decode gemv tier needs the k-major layout for the
     ``b<n>t`` REDUCE band — the recorded ``.m1.t`` golden winners on sm_89);
     a matrix-matmul weight keeps the historic no-fold behavior."""
-    from emmy.compiler import target as target_mod
-
-    target_mod.set_target((8, 9))
-    try:
-        folded_m1 = _folded_weights(Pipeline.build([_DECOMP_PASS]).run(_linear_graph(1)))
-        folded_m64 = _folded_weights(Pipeline.build([_DECOMP_PASS]).run(_linear_graph(64)))
-    finally:
-        target_mod.set_target(None)
+    ctx = Context(compute_capability=(8, 9))
+    folded_m1 = _folded_weights(Pipeline.build([_DECOMP_PASS]).run(_linear_graph(1), ctx=ctx))
+    folded_m64 = _folded_weights(Pipeline.build([_DECOMP_PASS]).run(_linear_graph(64), ctx=ctx))
     assert folded_m1, "M=1 matvec weight must fold k-major below sm_90 (the .m1.t golden layout)"
     assert not folded_m64, "M>1 weights must keep the historic sub-sm_90 no-fold behavior"
 
 
 def test_transpose_fold_sm90_unchanged():
     """At sm_90+ the fold fires for every parameter transpose, matvec or not."""
-    from emmy.compiler import target as target_mod
-
-    target_mod.set_target((12, 0))
-    try:
-        folded_m64 = _folded_weights(Pipeline.build([_DECOMP_PASS]).run(_linear_graph(64)))
-    finally:
-        target_mod.set_target(None)
+    folded_m64 = _folded_weights(Pipeline.build([_DECOMP_PASS]).run(_linear_graph(64), ctx=Context(compute_capability=(12, 0))))
     assert folded_m64

--- a/tests/compiler/passes/test_hardware_capability_contract.py
+++ b/tests/compiler/passes/test_hardware_capability_contract.py
@@ -1,0 +1,114 @@
+"""Guard the compiler-pass boundary between target facts and transformations."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PASS_ROOT = Path(__file__).parents[3] / "emmy" / "compiler" / "pipeline" / "passes"
+PASS_FILES = tuple(sorted(PASS_ROOT.rglob("*.py")))
+MEASURED_ROUTING = PASS_ROOT / "lowering" / "tile" / "_cut.py"
+ALGEBRA_RECOGNITION = {PASS_ROOT / "lowering" / "tile" / name for name in ("010_recognize.py", "_atomize.py", "_flash.py", "_softmax.py")}
+FUSION_FILES = tuple(sorted((PASS_ROOT / "loop" / "fusion").glob("*.py")))
+
+
+@pytest.mark.parametrize("path", PASS_FILES, ids=lambda path: str(path.relative_to(PASS_ROOT)))
+def test_passes_do_not_probe_process_global_target(path: Path):
+    """A pass receives target facts through ``Context``; it never probes global device state."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    forbidden: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "emmy.compiler.target":
+            if any(alias.name in {"compute_capability", "live_compute_capability"} for alias in node.names):
+                forbidden.append(node.lineno)
+        elif isinstance(node, ast.Import):
+            if any(alias.name == "emmy.compiler.target" for alias in node.names):
+                forbidden.append(node.lineno)
+    assert not forbidden, f"target probes at lines {forbidden}; add a Context capability predicate"
+
+
+def _reads_compute_capability(node: ast.AST) -> bool:
+    return any(isinstance(child, ast.Attribute) and child.attr == "compute_capability" for child in ast.walk(node))
+
+
+def _getattr_name(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name) or node.func.id != "getattr" or len(node.args) < 2:
+        return None
+    name = node.args[1]
+    return name.value if isinstance(name, ast.Constant) and isinstance(name.value, str) else None
+
+
+@pytest.mark.parametrize("path", PASS_FILES, ids=lambda path: str(path.relative_to(PASS_ROOT)))
+def test_passes_do_not_compare_compute_capability_thresholds(path: Path):
+    """Primitive legality is named once on ``Context``, not restated as SM-number branches."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    forbidden = [node.lineno for node in ast.walk(tree) if isinstance(node, ast.Compare) and _reads_compute_capability(node)]
+    assert not forbidden, f"direct capability comparisons at lines {forbidden}; use a Context capability predicate"
+
+
+@pytest.mark.parametrize("path", PASS_FILES, ids=lambda path: str(path.relative_to(PASS_ROOT)))
+def test_product_identity_is_only_used_for_measured_routing(path: Path):
+    """A product name may select measured placement evidence, never an implementation path."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    allowed_lines: set[int] = set()
+    if path == MEASURED_ROUTING:
+        routing = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "_routing_entry")
+        allowed_lines.update(range(routing.lineno, routing.end_lineno + 1))
+    forbidden = []
+    for node in ast.walk(tree):
+        reads_identity = (isinstance(node, ast.Attribute) and node.attr in {"gpu_name", "hardware_id"}) or _getattr_name(node) in {
+            "gpu_name",
+            "hardware_id",
+        }
+        if reads_identity and node.lineno not in allowed_lines:
+            forbidden.append(node.lineno)
+    assert not forbidden, f"product-identity reads at lines {forbidden}; only measured routing may use them"
+
+
+@pytest.mark.parametrize("path", sorted(ALGEBRA_RECOGNITION), ids=lambda path: path.name)
+def test_algebra_recognition_does_not_read_hardware_capabilities(path: Path):
+    """Hardware filters the atom/schedule domain after recognition; it cannot change the algebra."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    forbidden = [node.lineno for node in ast.walk(tree) if isinstance(node, ast.Attribute) and node.attr.startswith("has_")]
+    assert not forbidden, f"hardware-capability reads at lines {forbidden}; recognition must stay algebra-only"
+
+
+@pytest.mark.parametrize("path", FUSION_FILES, ids=lambda path: path.name)
+def test_fusion_does_not_consult_placement_schedule_or_hardware(path: Path):
+    """Fusion forms the maximal reasonable algebraic region; later layers decide kernel cuts."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imports.append((node.lineno, node.module))
+        elif isinstance(node, ast.Import):
+            imports.extend((node.lineno, alias.name) for alias in node.names)
+    forbidden_imports = [
+        (line, module)
+        for line, module in imports
+        if module.startswith(
+            (
+                "emmy.compiler.context",
+                "emmy.compiler.target",
+                "emmy.config",
+                "emmy.compiler.pipeline.knob",
+                "emmy.compiler.pipeline.search",
+                "emmy.compiler.pipeline.passes.lowering",
+            )
+        )
+    ]
+    forbidden_names = [
+        node.lineno
+        for node in ast.walk(tree)
+        if (isinstance(node, ast.Constant) and node.value in {"PLACE", "TILE", "REDUCE", "STAGE", "WORK", "RASTER"})
+        or (
+            isinstance(node, ast.Attribute)
+            and (node.attr.startswith("has_") or node.attr in {"knobs", "gpu_name", "hardware_id", "compute_capability"})
+        )
+        or _getattr_name(node) in {"knobs", "gpu_name", "hardware_id", "compute_capability"}
+        or (isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(arg.arg == "ctx" for arg in node.args.args))
+    ]
+    assert not forbidden_imports, f"fusion imports later-layer policy: {forbidden_imports}"
+    assert not forbidden_names, f"fusion reads placement/schedule/hardware facts at lines {forbidden_names}"

--- a/tests/compiler/passes/test_hardware_capability_contract.py
+++ b/tests/compiler/passes/test_hardware_capability_contract.py
@@ -14,6 +14,17 @@ ALGEBRA_RECOGNITION = {PASS_ROOT / "lowering" / "tile" / name for name in ("010_
 FUSION_FILES = tuple(sorted((PASS_ROOT / "loop" / "fusion").glob("*.py")))
 
 
+def test_structural_placement_reaches_a_pass_fixpoint_before_scheduling() -> None:
+    """The canonical pipeline cannot enumerate a schedule while a new cut piece is still placeable."""
+    from emmy.compiler.pipeline import TILE_PASSES
+
+    assert TILE_PASSES.index("lowering/tile") < TILE_PASSES.index("lowering/schedule")
+    structural_rules = {path.name for path in (PASS_ROOT / "lowering" / "tile").glob("[0-9]*.py")}
+    schedule_rules = {path.name for path in (PASS_ROOT / "lowering" / "schedule").glob("[0-9]*.py")}
+    assert structural_rules == {"010_recognize.py", "015_place.py"}
+    assert schedule_rules == {"020_schedule.py", "030_split_reduce.py"}
+
+
 @pytest.mark.parametrize("path", PASS_FILES, ids=lambda path: str(path.relative_to(PASS_ROOT)))
 def test_passes_do_not_probe_process_global_target(path: Path):
     """A pass receives target facts through ``Context``; it never probes global device state."""

--- a/tests/compiler/passes/test_move_catalog.py
+++ b/tests/compiler/passes/test_move_catalog.py
@@ -189,6 +189,54 @@ def _fp16_matmul_graph() -> Graph:
     return g
 
 
+def _product_contraction_term():
+    """A fully materialized two-channel contraction over one shared A edge."""
+    from emmy.compiler.ir.axis import Axis
+    from emmy.compiler.ir.expr import Var
+    from emmy.compiler.ir.stmt import Load
+    from emmy.compiler.ir.tile import Channel, Fold, TileOp
+    from emmy.compiler.ir.tile.ir import Placement
+
+    node = Fold.contraction(
+        k_axis=Axis("k", 64),
+        a=Load(name="a_e", input="a", index=(Var("m"), Var("k"))),
+        channels=(
+            Channel(b=Load(name="b0_e", input="b0", index=(Var("k"), Var("n"))), acc="acc0"),
+            Channel(b=Load(name="b1_e", input="b1", index=(Var("k"), Var("n"))), acc="acc1"),
+        ),
+    )
+    inputs = {
+        "a": Tensor("a", (64, 64), "f16"),
+        "b0": Tensor("b0", (64, 64), "f16"),
+        "b1": Tensor("b1", (64, 64), "f16"),
+    }
+    return TileOp(op=node, place=Placement(free=(Axis("m", 64), Axis("n", 64))), inputs=inputs), node
+
+
+def test_product_contraction_offers_only_complete_sync_transport():
+    """A product row must carry every channel; direct and two-slab copy transports are ineligible."""
+    from emmy.compiler.pipeline.passes.lowering.tile import _schedule as sch
+
+    tile, node = _product_contraction_term()
+    term = sch._Term(tile, tile.place.on_grid(), Context.from_target((9, 0)))
+    plans = [plan for group in term.tiles(node).values() for plan in group if plan.is_warp]
+    stages = [stage for plan in plans for stage in sch._stage_values(term, node, plan)]
+    assert plans and stages
+    assert all(stage is not None and stage.transport == "sync" for stage in stages)
+    assert any(stage.depth == 1 for stage in stages)
+
+
+def test_product_contraction_demotes_when_sync_copy_primitive_is_absent():
+    """The algebra remains schedulable on an older target through the general PLANAR reading."""
+    from emmy.compiler.pipeline.passes.lowering.tile import _schedule as sch
+
+    tile, _ = _product_contraction_term()
+    terms = sch._readings(tile, Context.from_target((7, 0)))
+    rows, _keys, _idents, origin = sch._enumerate(terms)
+    assert rows
+    assert {reading for reading, _ in origin} == {1}, "the sync product declines; its demoted reading remains"
+
+
 def test_warp_staged_rows_fit_the_smem_budget():
     """Every enumerated warp row with a non-empty ``STAGE`` fits its depth-1 operand slot in the
     ctx smem budget, and an over-budget tile still rides gmem-direct. The 256×256 ``w4x4/f4x8``
@@ -251,6 +299,8 @@ def test_bare_reduce_forks_the_coop_catalog():
 
     def decide(fp):
         leaves = flatten_leaves(fp.options)
+        if any(any(family_of(key) == "PLACE" for key in (getattr(leaf, "knobs", {}) or {})) for leaf in leaves):
+            return leaves[0]
         for leaf in leaves:
             rows.append(dict(getattr(leaf, "knobs", {}) or {}))
         return leaves[0]

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -2,9 +2,9 @@
 
 Placement offers the maximal fused region plus every realizable single-seam cut before schedule
 enumeration. ROUTING entries (PLACE-only golden knobs) and authoritative ``PLACE`` pins collapse
-that fork; otherwise option-0 is fused and search may measure the fragments. Cut pieces re-recognize
-and schedule as fresh roots, recursively. These tests run off-GPU through the full CUDA pass list,
-asserting fork identity, kernel sets, and buffer wiring.
+that fork; otherwise option-0 is fused and search may measure the fragments. Cut pieces retain
+recognized algebra and place/schedule as fresh roots, recursively. These tests run off-GPU through
+the full CUDA pass list, asserting fork identity, kernel sets, and buffer wiring.
 """
 
 from __future__ import annotations
@@ -214,8 +214,60 @@ def test_placement_space_is_capability_independent(monkeypatch) -> None:
     assert rows and all(row == rows[0] for row in rows[1:])
 
 
+def test_recognized_flash_fragment_offers_and_replays_score_cut(monkeypatch) -> None:
+    """Graph-producing recognition still reaches the shared placement and schedule paths."""
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+    from test_recognize_boundary_rules import _packed_rope_sdpa_graph
+
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.delenv("EMMY_PLACE", raising=False)
+    rows = [_placement_rows(_packed_rope_sdpa_graph(), Context.from_target(target)) for target in ((8, 0), (9, 0), (12, 0))]
+    assert rows and all(row == rows[0] for row in rows[1:])
+    assert any(row.get("PLACE@dd") == "cut" for row in rows[0])
+
+    from emmy.compiler.ir.tile import TileOp
+    from emmy.compiler.ir.tile.ir import is_contraction
+    from emmy.compiler.ir.tile.ops import head
+    from emmy.compiler.pipeline.search.two_level import outer_pipeline
+
+    monkeypatch.setenv("EMMY_KNOBS", "PLACE@dd=cut")
+    placed, _ = Run(pipeline=outer_pipeline(), ctx=Context.from_target((9, 0))).resolve(
+        _packed_rope_sdpa_graph(), lambda fp: flatten_leaves(fp.options)[0]
+    )
+    score = next(node.op for node in placed.nodes.values() if "__cut_" in node.id and isinstance(node.op, TileOp))
+    assert is_contraction(head(score.op)), "placement must preserve the recognized score contraction"
+
+    out = _compile(_packed_rope_sdpa_graph(), "PLACE@dd=cut", monkeypatch, Context.from_target((9, 0)))
+    kernels = [node.op for node in out.nodes.values() if getattr(node.op, "kernel_source", None)]
+    assert len(kernels) == 2
+    assert all(kernel.decision_knobs == {"PLACE@dd": "cut"} for kernel in kernels)
+    assert all(any(key in kernel.knobs for key in ("TILE", "TILE@dd", "REDUCE", "REDUCE@dd")) for kernel in kernels)
+
+
+def test_drifted_routing_cut_does_not_stamp_a_cut_that_did_not_happen(monkeypatch) -> None:
+    """A stale routing entry falls back to the recognized form with truthful lineage."""
+    from emmy.compiler.pipeline.knob import SCHEDULE_FAMILIES
+    from emmy.compiler.pipeline.passes.lowering.tile import _cut
+    from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_prologue_contraction
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+    from test_recognize_boundary_rules import _prologue_shape
+
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.delenv("EMMY_PLACE", raising=False)
+    for family in SCHEDULE_FAMILIES:
+        monkeypatch.delenv(f"EMMY_{family}", raising=False)
+    entry = SimpleNamespace(name="drifted.routing", knobs={"PLACE@missing": "cut"})
+    monkeypatch.setattr(_cut, "_routing_entry", lambda *_args, **_kwargs: entry)
+    node, free = _prologue_shape(b_layouts=(False, False))
+    tree, n_axis, stores = bind_prologue_contraction(node, free)
+    decision = _cut._placement_decision(Context.from_target((9, 0)), {}, tree, stores, (*free, n_axis))
+    assert decision.decided and decision.seam is None
+    assert decision.knobs == {}
+
+
 def test_selecting_place_cut_schedules_each_resulting_kernel(monkeypatch) -> None:
-    """A cut is followed by independent recognition and schedule enumeration for both pieces."""
+    """A cut is followed by independent placement and schedule enumeration for both pieces."""
     from emmy.compiler.pipeline.knob import SCHEDULE_FAMILIES, family_of
 
     monkeypatch.delenv("EMMY_KNOBS", raising=False)
@@ -248,7 +300,7 @@ def test_selecting_place_cut_schedules_each_resulting_kernel(monkeypatch) -> Non
 
 
 def test_shared_a_product_cut_retains_every_contraction_channel(monkeypatch) -> None:
-    """A cut materializes the shared A edge; recursive recognition must preserve the whole product."""
+    """A cut materializes the shared A edge while preserving the whole recognized product."""
     from emmy.compiler.ir.tile import Fold, TileOp
     from emmy.compiler.ir.tile.ir import is_contraction
     from emmy.compiler.ir.tile.ops import axis_names
@@ -302,8 +354,8 @@ def test_rms_norm_place_cut_splits_stat_and_scale(monkeypatch) -> None:
 
 def test_norm_linear_cone_cut_recurses_to_the_full_cascade(monkeypatch) -> None:
     """Bare ``PLACE=cut`` cuts the cone edge (the fold seam is the pure-copy degenerate and is
-    not cuttable), the cone piece re-recognizes as the rms_norm shape and cuts again — the
-    plan's worked cascade: statistic + scale + plain matmul, all from EXISTING kinds."""
+    not cuttable), then recursively cuts the cone's recognized statistic edge: statistic + scale
+    + plain matmul, all from existing algebraic readings."""
     out = _compile(_norm_linear_graph(), "PLACE=cut", monkeypatch)
     kernels = _kernel_ids(out)
     cuts = [k for k in kernels if "__cut_" in k]

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -1,12 +1,10 @@
 """Phase 4 — placement routing + the cut realizer.
 
-ROUTING entries (PLACE-only golden knobs) and authoritative ``PLACE`` pins resolve a cut BEFORE
-any schedule fork exists; the realizer splits the recognized tree at the seam into un-mapped
-``LoopOp`` pieces that re-recognize as fresh roots (recursive — a piece's entry may itself cut).
-Fuse is the default by ABSENCE: with no pin and no entry, recognition is byte-untouched (the
-digest harness holds separately). These tests run off-GPU: the pieces compile through the full
-CUDA pass list with deterministic option-0 resolution, so kernel SETS and buffer wiring are
-asserted without a device (GPU accuracy is covered by the e2e smoke on the 5090 host).
+Placement offers the maximal fused region plus every realizable single-seam cut before schedule
+enumeration. ROUTING entries (PLACE-only golden knobs) and authoritative ``PLACE`` pins collapse
+that fork; otherwise option-0 is fused and search may measure the fragments. Cut pieces re-recognize
+and schedule as fresh roots, recursively. These tests run off-GPU through the full CUDA pass list,
+asserting fork identity, kernel sets, and buffer wiring.
 """
 
 from __future__ import annotations
@@ -23,7 +21,7 @@ from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import MatmulOp, RmsNormOp
 from emmy.compiler.ir.tensor.ir import ElementwiseOp
-from emmy.compiler.pipeline import CUDA_PASSES, Pipeline
+from emmy.compiler.pipeline import CUDA_PASSES, TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
 from emmy.compiler.pipeline.pipeline import Run
 from emmy.compiler.pipeline.search.data.shape import ShapeKey
@@ -76,6 +74,21 @@ def _activation_linear_graph(S: int = 2, H: int = 16, inter: int = 32) -> Graph:
     g.add_node(ElementwiseOp("silu"), ["x"], Tensor("xa", (Dim(S), Dim(H)), dtype=F16), node_id="xa")
     g.add_node(MatmulOp(), ["xa", "w"], Tensor("y", (Dim(S), Dim(inter)), dtype=F16), node_id="y")
     g.inputs, g.outputs = ["x", "w"], ["y"]
+    return g
+
+
+def _norm_gate_up_graph(S: int = 2, H: int = 16, inter: int = 32) -> Graph:
+    g = Graph()
+    _inp(g, "x", (1, S, H))
+    _inp(g, "wn", (H,))
+    _inp(g, "wg", (H, inter))
+    _inp(g, "wu", (H, inter))
+    g.add_node(RmsNormOp(), ["x", "wn"], Tensor("xn", (1, Dim(S), Dim(H)), dtype=F16), node_id="xn")
+    g.add_node(MatmulOp(), ["xn", "wg"], Tensor("gate", (1, Dim(S), Dim(inter)), dtype=F16), node_id="gate")
+    g.add_node(MatmulOp(), ["xn", "wu"], Tensor("up", (1, Dim(S), Dim(inter)), dtype=F16), node_id="up")
+    g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("sg", (1, Dim(S), Dim(inter)), dtype=F16), node_id="sg")
+    g.add_node(ElementwiseOp("multiply"), ["sg", "up"], Tensor("o", (1, Dim(S), Dim(inter)), dtype=F16), node_id="o")
+    g.inputs, g.outputs = ["x", "wn", "wg", "wu"], ["o"]
     return g
 
 
@@ -157,7 +170,123 @@ def test_place_sites_are_the_non_root_nodes() -> None:
 
 def test_rms_norm_deploys_unchanged_under_default_fuse(monkeypatch) -> None:
     out = _compile(_rms_graph(), None, monkeypatch)
-    assert len(_kernel_ids(out)) == 1, "no routing entry and no pin = fuse = the recognized form"
+    assert len(_kernel_ids(out)) == 1, "cold option-0 keeps the recognized form fused"
+
+
+def _placement_rows(graph: Graph, ctx: Context) -> list[dict]:
+    """Capture the first placement fork and keep its fused option."""
+    from emmy.compiler.pipeline.knob import family_of
+
+    rows: list[dict] = []
+
+    def decide(fp):
+        leaves = flatten_leaves(fp.options)
+        offered = [
+            {key: value for key, value in (getattr(leaf, "knobs", {}) or {}).items() if family_of(key) == "PLACE"} for leaf in leaves
+        ]
+        if not rows and offered and all(offered):
+            rows.extend(offered)
+        return leaves[0]
+
+    Run(pipeline=Pipeline.build(TILE_PASSES), ctx=ctx).resolve(graph, decide)
+    return rows
+
+
+def test_unpinned_placement_offers_fused_and_every_legal_cut(monkeypatch) -> None:
+    """Placement is a structural fork, not an edit to the maximal fused region."""
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.delenv("EMMY_PLACE", raising=False)
+    rows = _placement_rows(_norm_linear_graph(S=2, H=16, inter=32), Context.from_target((9, 0)))
+    assert len(rows) >= 2
+    assert all(value == "fuse" for value in rows[0].values())
+    assert all(set(row) == set(rows[0]) for row in rows), "every option must spell the same seam keys"
+    assert all(sum(value == "cut" for value in row.values()) == 1 for row in rows[1:])
+
+
+def test_placement_space_is_capability_independent(monkeypatch) -> None:
+    """Recognition and placement enumerate the same algebraic seams on every target."""
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.delenv("EMMY_PLACE", raising=False)
+    rows = [
+        _placement_rows(_norm_linear_graph(S=2, H=16, inter=32), Context.from_target(target))
+        for target in ((8, 0), (9, 0), (10, 0), (12, 0))
+    ]
+    assert rows and all(row == rows[0] for row in rows[1:])
+
+
+def test_selecting_place_cut_schedules_each_resulting_kernel(monkeypatch) -> None:
+    """A cut is followed by independent recognition and schedule enumeration for both pieces."""
+    from emmy.compiler.pipeline.knob import SCHEDULE_FAMILIES, family_of
+
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.delenv("EMMY_PLACE", raising=False)
+    selected = False
+
+    def decide(fp):
+        nonlocal selected
+        leaves = flatten_leaves(fp.options)
+        if not selected:
+            cut = next(
+                (leaf for leaf in leaves if any(family_of(key) == "PLACE" and value == "cut" for key, value in leaf.knobs.items())),
+                None,
+            )
+            if cut is not None:
+                selected = True
+                return cut
+        return leaves[0]
+
+    out, trace = Run(pipeline=Pipeline.build(CUDA_PASSES), ctx=Context.from_target((9, 0))).resolve(
+        _norm_linear_graph(S=2, H=16, inter=32), decide
+    )
+    kernels = [node.op for node in out.nodes.values() if getattr(node.op, "kernel_source", None)]
+    assert selected and len(kernels) >= 2
+    assert any(decision.chosen_kind == "graph" for decision in trace)
+    assert all(any(family_of(key) in SCHEDULE_FAMILIES for key in kernel.knobs) for kernel in kernels)
+    assert all(not any(family_of(key) == "PLACE" for key in kernel.knobs) for kernel in kernels)
+    assert all(any(family_of(key) == "PLACE" for key in kernel.decision_knobs) for kernel in kernels)
+    assert all(all(family_of(key) == "PLACE" for key in kernel.decision_knobs) for kernel in kernels)
+
+
+def test_shared_a_product_cut_retains_every_contraction_channel(monkeypatch) -> None:
+    """A cut materializes the shared A edge; recursive recognition must preserve the whole product."""
+    from emmy.compiler.ir.tile import Fold, TileOp
+    from emmy.compiler.ir.tile.ir import is_contraction
+    from emmy.compiler.ir.tile.ops import axis_names
+    from emmy.compiler.pipeline.search.two_level import outer_pipeline
+
+    monkeypatch.setenv("EMMY_KNOBS", "PLACE@a=cut")
+    graph, _ = Run(pipeline=outer_pipeline(), ctx=Context.from_target((9, 0))).resolve(
+        _norm_gate_up_graph(), lambda fp: flatten_leaves(fp.options)[0]
+    )
+    products = []
+    for node in graph.nodes.values():
+        if not isinstance(node.op, TileOp):
+            continue
+        root = node.op.op
+        contraction = root.operands[0] if isinstance(root, Fold) and root.axis is None and root.operands else root
+        if is_contraction(contraction) and len(contraction.channels) > 1:
+            products.append((node.op, root, contraction))
+    assert len(products) == 1
+    tile, root, product = products[0]
+    assert len(product.channels) == 2
+    assert not (root.lift.free_names() - axis_names(root) - {axis.name for axis in tile.place.free})
+
+    lowered = _compile(_norm_gate_up_graph(), "PLACE@a=cut", monkeypatch)
+    assert all(not isinstance(node.op, TileOp) for node in lowered.nodes.values())
+
+
+def test_nested_placement_delta_excludes_the_inherited_parent_choice() -> None:
+    """Recursive placement replay compares both metadata channels on the recognized root."""
+    from emmy.compiler.pipeline.pipeline import _option_decision
+
+    fragment = Graph()
+    fragment.add_node(
+        InputOp(decision_knobs={"PLACE@a": "cut", "PLACE@b": "cut"}),
+        [],
+        Tensor("out", (), dtype=F16),
+        node_id="out",
+    )
+    assert _option_decision(fragment, {"PLACE@a": "cut"}) == {"PLACE@b": "cut"}
 
 
 def test_rms_norm_place_cut_splits_stat_and_scale(monkeypatch) -> None:

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -393,6 +393,26 @@ def _normed_sdpa_graph():
     return graph
 
 
+def _packed_rope_sdpa_graph():
+    """A closed packed Q/K map cone with RMS statistics and half-rotation selects."""
+    from emmy.commands.trace import graph_from_code
+
+    code = """(lambda p,v,c,s: torch.nn.functional.scaled_dot_product_attention(
+        (lambda x: (x*c)+(torch.cat((-x[...,4:],x[...,:4]),dim=-1)*s))(
+            (lambda x: x*torch.rsqrt((x.float()*x.float()).mean(-1,keepdim=True)+1e-6).to(x.dtype))(
+                p[...,:32].view(1,8,4,8).transpose(1,2))),
+        (lambda x: (x*c)+(torch.cat((-x[...,4:],x[...,:4]),dim=-1)*s))(
+            (lambda x: x*torch.rsqrt((x.float()*x.float()).mean(-1,keepdim=True)+1e-6).to(x.dtype))(
+                p[...,32:48].view(1,8,2,8).transpose(1,2))),
+        v, is_causal=True, enable_gqa=True))(
+            torch.randn(1,8,48,dtype=torch.float16),
+            torch.randn(1,2,8,8,dtype=torch.float16),
+            torch.randn(1,1,8,8,dtype=torch.float16),
+            torch.randn(1,1,8,8,dtype=torch.float16))"""
+    graph, _, _ = graph_from_code(code)
+    return graph
+
+
 def test_normed_gqa_sdpa_certifies_flash():
     """The fused flash form must certify when gate-free loop fusion moves RMSNorm'd Q/K
     cones into the repeated score contractions. The existing flash recognizer recovers those
@@ -417,6 +437,37 @@ def test_normed_gqa_sdpa_certifies_flash():
     first = src.step_stmts()[0]
     assert getattr(first, "role", None) is AxisRole.CONTRACTION, "flash did not absorb the score contraction (fold stayed cut)"
     assert not isinstance(first.a, Load) and not isinstance(first.b, Load), "normalized Q/K cones were reduced to raw loads"
+
+
+def test_packed_rope_qk_cones_certify_flash_without_dropping_loads():
+    """Closed Q/K operand edges may have several sequence-bearing loads.
+
+    Packed affine views, RMS statistics, and a half-rotation ``Select`` are still one pure map per
+    Q/K cell. Recognition must preserve the packed data and both rotary inputs on each computed
+    edge instead of requiring one physical load to stand in for the logical attention operand.
+    """
+    pytest.importorskip("torch")
+    from emmy.compiler.ir.tile.ir import operand_body
+
+    def decide(fp):
+        return flatten_leaves(fp.options)[0]
+
+    terminal, _ = Run(pipeline=Pipeline.build(TILE_PASSES), ctx=Context.from_target((9, 0))).resolve(_packed_rope_sdpa_graph(), decide)
+    flashes = [
+        n.op
+        for n in terminal.nodes.values()
+        if isinstance(n.op, TileOp)
+        and isinstance(n.op.op, Fold)
+        and n.op.op.axis is None
+        and n.op.op.operands
+        and n.op.op.operands[0].role is AxisRole.TWISTED
+    ]
+    assert len(flashes) == 1
+    qk = flashes[0].op.operands[0].step_stmts()[0]
+    assert qk.role is AxisRole.CONTRACTION and not isinstance(qk.a, Load) and not isinstance(qk.b, Load)
+    for edge in (qk.a, qk.b):
+        reads = {stmt.input for stmt in operand_body(edge) if isinstance(stmt, Load)}
+        assert {"x0", "x2", "x3"} <= reads, "the computed edge must retain packed data plus both rotary inputs"
 
 
 def test_bind_contraction_declined_cone_raises_not_positional():

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -211,8 +211,11 @@ def _resolve(g: Graph, pick=None, ctx: Context | None = None) -> tuple[list[dict
     rows: list[dict] = []
 
     def decide(fp):
+        from emmy.compiler.pipeline.knob import SCHEDULE_FAMILIES, family_of
+
         leaves = flatten_leaves(fp.options)
-        rows.extend(dict(getattr(leaf, "knobs", {}) or {}) for leaf in leaves)
+        offered = [dict(getattr(leaf, "knobs", {}) or {}) for leaf in leaves]
+        rows.extend(row for row in offered if any(family_of(key) in SCHEDULE_FAMILIES for key in row))
         if pick is not None:
             for leaf in leaves:
                 if pick(dict(getattr(leaf, "knobs", {}) or {})):
@@ -443,6 +446,28 @@ def test_bind_contraction_declined_cone_raises_not_positional():
     )
     loop = Loop(axis=Axis(name="k", extent=Dim(64)), body=body, role=AxisRole.CONTRACTION)
     with pytest.raises(LoweringError, match="computed cone"):
+        bind_contraction(loop, "m", "n", Body(()))
+
+
+def test_bind_contraction_rejects_operand_that_varies_across_both_output_axes():
+    """An mma B fragment is stationary across M; crossed (m, n, k) algebra stays PLANAR."""
+    from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_contraction
+    from emmy.compiler.pipeline.pipeline import LoweringError
+
+    loop = Loop(
+        axis=Axis("k", Dim(32)),
+        role=AxisRole.CONTRACTION,
+        body=Body(
+            (
+                Load(name="a", input="a_buf", index=(Var("k"),)),
+                Load(name="b", input="b_buf", index=(Var("m"), Var("k"), Var("n"))),
+                Assign(name="prod", op="multiply", args=("a", "b")),
+                Accum(name="acc", value="prod", op="add", axes=("k",)),
+            )
+        ),
+    )
+
+    with pytest.raises(LoweringError, match="could not bind A/B operands"):
         bind_contraction(loop, "m", "n", Body(()))
 
 

--- a/tests/compiler/passes/test_schedule_site_ownership.py
+++ b/tests/compiler/passes/test_schedule_site_ownership.py
@@ -1,0 +1,52 @@
+"""Schedule-site ownership regressions."""
+
+from __future__ import annotations
+
+import torch
+
+
+class _NormalizedGqa(torch.nn.Module):
+    def forward(self, q, k, v):
+        q = (q.float() * torch.rsqrt(torch.mean(q.float() ** 2, dim=-1, keepdim=True) + 1e-6)).half()
+        k = (k.float() * torch.rsqrt(torch.mean(k.float() ** 2, dim=-1, keepdim=True) + 1e-6)).half()
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, enable_gqa=True)
+
+
+def test_nested_only_thread_work_does_not_invent_root_tile():
+    """A nested cooperative reduce owns WORK without creating a TILE slice at its root."""
+    from emmy.compiler import target as target_mod  # noqa: PLC0415
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pass, Pipeline  # noqa: PLC0415
+    from emmy.compiler.pipeline.fork import flatten_leaves  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.lowering.tile._schedule import schedule  # noqa: PLC0415
+    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
+
+    target_mod.set_target((9, 0))
+    try:
+        ctx = Context.from_target((9, 0), gpu_name="NVIDIA H200")
+        q = torch.randn(1, 16, 128, 128, dtype=torch.float16)
+        k, v = (torch.randn(1, 8, 128, 128, dtype=torch.float16) for _ in range(2))
+        graph = trace_module(_NormalizedGqa(), (q, k, v))
+        if "lowering/schedule" in CUDA_PASSES:
+            placed = Pipeline.build(CUDA_PASSES[: CUDA_PASSES.index("lowering/schedule")]).run(graph, ctx=ctx)
+        else:
+            prefix = Pipeline.build(LOOP_PASSES)
+            recognize = Pass.load("lowering/tile", len(prefix.passes), {"010_recognize"})
+            placed = Pipeline([*prefix.passes, recognize]).run(graph, ctx=ctx)
+        tile = placed.nodes["scaled_dot_product_attention"].op
+        leaves = flatten_leaves([schedule(tile, "scaled_dot_product_attention", {}, ctx)])
+        matching = [
+            leaf
+            for leaf in leaves
+            if leaf.knobs.get("WORK") == "t128"
+            and leaf.knobs.get("REDUCE") == ""
+            and leaf.knobs.get("REDUCE@flash_k_stat") == "coop"
+            and "TILE" not in leaf.knobs
+        ]
+
+        assert matching, "the fused GQA schedule must offer the nested-only cooperative row"
+        materialized = matching[0].expand()[0]
+        assert "TILE" not in materialized.schedule
+        assert materialized.schedule["REDUCE@flash_k_stat"].coop == 128
+    finally:
+        target_mod.set_target(None)

--- a/tests/compiler/passes/test_sync_transport.py
+++ b/tests/compiler/passes/test_sync_transport.py
@@ -1,0 +1,34 @@
+"""Generic sync compute-fill lowering invariants."""
+
+from emmy.compiler.ir.axis import Axis, AxisRole
+from emmy.compiler.ir.elementwise import ElementwiseImpl
+from emmy.compiler.ir.expr import Literal, Var
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
+from emmy.compiler.pipeline.passes.lowering.kernel._stage import CtaTile, SyncOperand, SyncTransport
+
+
+def test_compute_fill_suffixes_nested_ssa_for_every_vector_cell() -> None:
+    """Replicated computed operands must rename definitions inside nested statistic folds."""
+
+    def value(_k0, _row, col):
+        reduce_axis = Axis("r", 4)
+        loop = Loop(
+            axis=reduce_axis,
+            role=AxisRole.PLANAR,
+            body=Body(
+                (
+                    Load(name="value", input="x", index=(col, Var(reduce_axis.name))),
+                    Accum(name="acc", value="value", op=ElementwiseImpl("add"), axes=(reduce_axis.name,)),
+                )
+            ),
+        )
+        close = Assign(name="out", op=ElementwiseImpl("add"), args=("acc", "acc"))
+        return [loop, close], "out"
+
+    operand = SyncOperand(tag="b", shape=(1, 8), value=value)
+    transport = SyncTransport(operands=(operand,), slab_dtype="half", cta=CtaTile(Literal(0, "int"), 1), elem_bytes=2)
+    fill = Body(tuple(transport.fill(k0=Literal(0, "int"), slot=Literal(0, "int"), k0_cur=Literal(0, "int"))))
+
+    assert {acc.name for acc in fill.accums} == {f"acc__c{i}" for i in range(8)}
+    assert {load.names[0] for load in fill.loads if load.input == "x"} == {f"value__c{i}" for i in range(8)}
+    assert {assign.name for assign in fill.iter_of_type(Assign)} == {f"out__c{i}" for i in range(8)}

--- a/tests/compiler/pipeline/search/test_features.py
+++ b/tests/compiler/pipeline/search/test_features.py
@@ -22,6 +22,14 @@ def test_scoped_place_rows_encode_kernel_set_choice() -> None:
     assert cut["PLACE_cut"] == 1.0
 
 
+def test_scoped_place_rows_preserve_the_selected_seam() -> None:
+    cut_a = knob_features({"PLACE@a": "cut", "PLACE@map": "fuse"})
+    cut_map = knob_features({"PLACE@a": "fuse", "PLACE@map": "cut"})
+    assert cut_a != cut_map
+    assert cut_a["PLACE_cut_site_a"] == 1.0
+    assert cut_map["PLACE_cut_site_map"] == 1.0
+
+
 def _feats(reduce_codec: str, work: str = "", **extra):
     """A tileless reduce row: the site-local ``REDUCE`` value plus the ``WORK`` inventory its
     cooperative width lives in."""

--- a/tests/compiler/pipeline/search/test_features.py
+++ b/tests/compiler/pipeline/search/test_features.py
@@ -14,6 +14,14 @@ from emmy.compiler.pipeline.search.features import knob_features
 _CTX = {"S_ext_free_prod": 512.0, "S_ext_reduce_prod": 2048.0, "S_reduce_add": 1.0, "H_sm_count": 128.0}
 
 
+def test_scoped_place_rows_encode_kernel_set_choice() -> None:
+    fused = knob_features({"PLACE@a": "fuse", "PLACE@b": "fuse"})
+    cut = knob_features({"PLACE@a": "cut", "PLACE@b": "fuse"})
+    assert fused["PLACE_sites"] == cut["PLACE_sites"] == 2.0
+    assert fused["PLACE_cut"] == 0.0
+    assert cut["PLACE_cut"] == 1.0
+
+
 def _feats(reduce_codec: str, work: str = "", **extra):
     """A tileless reduce row: the site-local ``REDUCE`` value plus the ``WORK`` inventory its
     cooperative width lives in."""

--- a/tests/compiler/pipeline/search/test_golden_spelling_canonical.py
+++ b/tests/compiler/pipeline/search/test_golden_spelling_canonical.py
@@ -155,13 +155,15 @@ def _tree(build, pick=None, *, target=(12, 0)):
 def _routing_tree(record):
     """Rebuild the pre-schedule tree that placement routing resolves against."""
     recognize = importlib.import_module("emmy.compiler.pipeline.passes.lowering.tile.010_recognize")
+    from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_prologue_contraction
+
     graph = record.target_program.copy()
     roots = [n for n in graph.nodes.values() if isinstance(n.op, LoopOp)]
     assert len(roots) == 1, f"{record.name}: expected one persisted LoopOp, got {len(roots)}"
     root = roots[0]
     fused, _ = recognize._fuse(root.op.body)
     node, free, stores = recognize._lift(list(fused), root.output.name)
-    prologue = recognize.bind_prologue_contraction(node, free)
+    prologue = bind_prologue_contraction(node, free)
     return prologue[0] if prologue is not None else node
 
 

--- a/tests/compiler/pipeline/search/test_two_level.py
+++ b/tests/compiler/pipeline/search/test_two_level.py
@@ -22,7 +22,7 @@ from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.cuda.ir import CudaOp
-from emmy.compiler.ir.frontend.ir import MatmulOp
+from emmy.compiler.ir.frontend.ir import MatmulOp, RmsNormOp
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.pipeline import LOOP_PASSES, Pipeline, TuningSearch
 from emmy.compiler.pipeline.search.db import SearchDB
@@ -139,6 +139,42 @@ def _two_identical_matmuls() -> Graph:
     g.inputs = ["xa", "xb", "ya", "yb"]
     g.outputs = [c1, c2]
     return g
+
+
+def _norm_linear() -> Graph:
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (2, 16)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("nw", (16,)), node_id="nw")
+    g.add_node(InputOp(), [], Tensor("w", (16, 32)), node_id="w")
+    g.add_node(RmsNormOp(), ["x", "nw"], Tensor("xn", (2, 16)), node_id="xn")
+    g.add_node(MatmulOp(), ["xn", "w"], Tensor("y", (2, 32)), node_id="y")
+    g.inputs, g.outputs = ["x", "nw", "w"], ["y"]
+    return g
+
+
+class _RecordingPrior:
+    """Uniform search prior that retains every streamed training row."""
+
+    fitted = False
+    trajectory = ()
+
+    def __init__(self) -> None:
+        self.rows: list[tuple[dict, float]] = []
+
+    def score(self, knobs) -> float:  # noqa: ARG002
+        return 0.0
+
+    def record_bench(self, knobs, median, status) -> None:  # noqa: ARG002
+        return None
+
+    def add_rows(self, rows) -> None:
+        self.rows.extend(rows)
+
+    def maybe_refit(self, *, force=False) -> bool:  # noqa: ARG002
+        return False
+
+    def checkpoint(self) -> None:
+        return None
 
 
 def _fuse(graph: Graph) -> Graph:
@@ -391,8 +427,7 @@ def test_inner_reward_parallel_matches_serial(monkeypatch) -> None:
 
 
 def test_run_two_level_tune_single_terminal_assembles_bests() -> None:
-    """With no fusion forks today the outer yields one terminal; the assembled
-    graph greedy-replays the per-op bests."""
+    """A graph with no placement seams yields one terminal and assembles its best schedules."""
     result = run_two_level(
         _two_distinct_matmuls(),
         ctx=Context.from_target((8, 0)),
@@ -400,13 +435,45 @@ def test_run_two_level_tune_single_terminal_assembles_bests() -> None:
         backend=_CountingBackend(),
         patience=_PATIENCE,
     )
-    assert result.n_terminals == 1, "no multi-option fusion forks today → exactly one outer terminal"
+    assert result.n_terminals == 1, "no realizable placement seam → exactly one outer terminal"
     assert result.best_reward is not None and result.best_reward.ok
     assert len(result.best_reward.per_op) == 2
 
-    # The winning fusion was greedy-assembled into a Graph[CudaOp] from the DB.
+    # The winning kernel set was lowered into a Graph[CudaOp] from the DB.
     assert result.assembled is not None
     assert any(isinstance(n.op, CudaOp) for n in result.assembled.nodes.values())
+
+
+def test_two_level_places_kernel_sets_outside_per_kernel_schedule() -> None:
+    """PLACE is an outer Σ comparison; its decision survives assembly but not inner node rows."""
+    prior = _RecordingPrior()
+    db = SearchDB()
+    result = run_two_level(
+        _norm_linear(),
+        ctx=Context.from_target((8, 0)),
+        db=db,
+        backend=_CountingBackend(),
+        patience=_PATIENCE,
+        prior=prior,
+        manage_prior=False,
+    )
+
+    assert result.n_terminals > 1, "the outer search must compare fused and materialized kernel sets"
+    placement_rows = [row for row, _ in prior.rows if any(key.startswith("PLACE") for key in row)]
+    assert placement_rows
+    assert all(any(key.startswith("S_") for key in row) for row in placement_rows)
+    values = {value for row in placement_rows for key, value in row.items() if key.startswith("PLACE")}
+    assert values >= {"fuse", "cut"}
+
+    assert result.best_fused is not None and result.assembled is not None
+    chosen = {
+        key: value for node in result.best_fused.nodes.values() for key, value in node.op.decision_knobs.items() if key.startswith("PLACE")
+    }
+    assembled = {
+        key: value for node in result.assembled.nodes.values() for key, value in node.op.decision_knobs.items() if key.startswith("PLACE")
+    }
+    assert chosen and assembled == chosen, "assembly must lower the measured outer terminal itself"
+    assert all(not any(key.startswith("PLACE") for key in row.features) for row in db.iter_nodes())
 
 
 def test_o3_band_is_per_regime_under_a_precision_gate(monkeypatch):

--- a/tests/compiler/pipeline/search/test_two_level.py
+++ b/tests/compiler/pipeline/search/test_two_level.py
@@ -30,7 +30,9 @@ from emmy.compiler.pipeline.search.slice import single_node_graph
 from emmy.compiler.pipeline.search.two_level import (
     LOWERING_PASSES,
     InnerReward,
+    KernelSetWinner,
     OpResult,
+    TwoLevelResult,
 )
 from tests.compiler.helpers import drain_tune, run_inner_reward, run_two_level
 
@@ -55,6 +57,55 @@ def test_searched_winner_requires_one_post_fusion_and_one_cuda_kernel() -> None:
     multi_cuda = OpResult(**{**one.__dict__, "searched_cuda_ops": 2})
     assert InnerReward(total_us=4.0, ok=True, per_op=[multi_cuda]).searched_winner() is None
     assert InnerReward(total_us=8.0, ok=True, per_op=[one, one]).searched_winner() is None
+
+
+def test_two_level_result_keeps_exact_multi_kernel_winner() -> None:
+    fused = Graph()
+    fused.add_node(
+        InputOp(decision_knobs={"PLACE@root": "cut"}),
+        [],
+        Tensor("x", (1,)),
+        node_id="x",
+    )
+    fused.inputs = fused.outputs = ["x"]
+    first = OpResult(
+        name="first",
+        op_key="op-a",
+        best_us=3.0,
+        multiplicity=2,
+        searched_knobs={"TILE": "f2x2"},
+        searched_us=4.0,
+        searched_cuda_ops=1,
+        searched_pins={"TILE": "f2x2", "REDUCE": ""},
+        searched_cuda_record_knobs=({"TILE": "f2x2", "REDUCE": ""},),
+    )
+    second = OpResult(
+        name="second",
+        op_key="op-b",
+        best_us=5.0,
+        searched_knobs={"REDUCE": "g2k"},
+        searched_us=6.0,
+        searched_cuda_ops=2,
+        searched_pins={"REDUCE": "g2k", "TILE": "f4x1"},
+        searched_cuda_record_knobs=(
+            {"REDUCE": "g2k", "TILE": "f4x1"},
+            {"REDUCE": "", "TILE": "f8x1"},
+        ),
+    )
+    result = TwoLevelResult(
+        best_fused=fused,
+        best_reward=InnerReward(total_us=11.0, ok=True, per_op=[first, second]),
+        n_terminals=1,
+        assembled=None,
+    )
+
+    winner = result.searched_winner()
+
+    assert isinstance(winner, KernelSetWinner)
+    assert winner.placement == {"PLACE@root": "cut"}
+    assert winner.latency_us == 14.0
+    assert [(kernel.op_key, kernel.multiplicity) for kernel in winner.kernels] == [("op-a", 2), ("op-b", 1)]
+    assert winner.kernels[1].cuda_record_knobs[1] == {"REDUCE": "", "TILE": "f8x1"}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/compiler/pipeline/test_persistence.py
+++ b/tests/compiler/pipeline/test_persistence.py
@@ -1,0 +1,112 @@
+"""Rewrite-chain persistence at the Graph-splice boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from emmy.compiler.context import Context
+from emmy.compiler.graph import Graph, Tensor
+from emmy.compiler.ir.base import Op
+from emmy.compiler.ir.cuda.ir import CudaOp
+from emmy.compiler.pipeline import Pass, Pattern, Pipeline, Rule
+from emmy.compiler.pipeline.pipeline import Cursor, Match, Run, _TerminalBench
+from emmy.compiler.pipeline.search.candidate import Candidate
+from emmy.compiler.pipeline.search.db import SearchDB
+
+
+@dataclass
+class _KeyedTileOp(Op):
+    key: str = ""
+
+    @property
+    def dialect(self) -> str:
+        return "tile"
+
+    def cache_key(self) -> str:
+        return self.key
+
+
+def _candidate_with_root(op: _KeyedTileOp, *, pass_name: str, rule_name: str) -> tuple[Candidate, Match]:
+    graph = Graph()
+    graph.add_node(op=op, inputs=[], output=Tensor("root", (1,)), node_id="root")
+    graph.outputs = ["root"]
+    rule = Rule(name=rule_name, pattern=[Pattern("root", _KeyedTileOp)], rewrite=lambda root: root)
+    pass_ = Pass(name=pass_name, rules=[rule])
+    run = Run(pipeline=Pipeline([pass_]), ctx=Context.from_target((9, 0)))
+    candidate = Candidate(run=run, graph=graph, cursor=Cursor(run=run))
+    match = Match(
+        graph=graph,
+        root_node_id="root",
+        rule=rule,
+        nodes={"root": "root"},
+        consumed={"root"},
+        _identities={"root": graph.nodes["root"]},
+    )
+    return candidate, match
+
+
+def _two_kernel_fragment(prefix: str) -> Graph:
+    fragment = Graph()
+    fragment.add_node(op=_KeyedTileOp(f"{prefix}-partial"), inputs=[], output=Tensor("partial", (1,)), node_id="partial")
+    fragment.add_node(op=_KeyedTileOp(f"{prefix}-residue"), inputs=["partial"], output=Tensor("root", (1,)), node_id="root")
+    fragment.outputs = ["root"]
+    return fragment
+
+
+def _persist_chain(cuda: CudaOp, ctx: Context) -> SearchDB:
+    graph = Graph()
+    graph.add_node(op=cuda, inputs=[], output=Tensor("out", (1,)), node_id="out")
+    graph.outputs = ["out"]
+    db = SearchDB()
+    bench = _TerminalBench(SimpleNamespace(graph=graph, ctx=ctx), backend=None, db=db)
+    bench._persist(cuda, stats=bench._point_stats(5.0), status="ok")
+    return db
+
+
+def _lowering_child(db: SearchDB, parent_key: str) -> str | None:
+    row = db._conn.execute("SELECT child_key FROM lowering WHERE parent_key = ?", (parent_key,)).fetchone()
+    return row[0] if row is not None else None
+
+
+def test_place_fragment_timing_does_not_price_the_offer_but_schedule_rebind_does() -> None:
+    offer = _KeyedTileOp("place-offer")
+    candidate, match = _candidate_with_root(offer, pass_name="lowering/tile", rule_name="015_place")
+    candidate.apply(match, _two_kernel_fragment("place"))
+
+    fragment = candidate.graph.nodes["root"].op
+    assert fragment.source is offer and fragment.source_is_graph_splice
+
+    scheduled = _KeyedTileOp("place-scheduled", knobs={"TILE": "f1x1"})
+    schedule_rule = Rule(name="020_schedule", pattern=[Pattern("root", _KeyedTileOp)], rewrite=lambda root: root)
+    Pass(name="lowering/schedule", rules=[schedule_rule])
+    schedule_match = Match(
+        graph=candidate.graph,
+        root_node_id="root",
+        rule=schedule_rule,
+        nodes={"root": "root"},
+        consumed={"root"},
+        _identities={"root": candidate.graph.nodes["root"]},
+    )
+    candidate.apply(schedule_match, scheduled)
+    assert scheduled.source is fragment and not scheduled.source_is_graph_splice
+
+    cuda = CudaOp(kernel_source='extern "C" __global__ void k() {}', kernel_name="k", source=scheduled)
+    db = _persist_chain(cuda, candidate.ctx)
+
+    assert _lowering_child(db, offer.cache_key()) is None
+    assert _lowering_child(db, fragment.cache_key()) == scheduled.cache_key()
+
+
+def test_split_reduce_fragment_timing_does_not_price_the_pre_split_kernel() -> None:
+    scheduled = _KeyedTileOp("split-offer", knobs={"REDUCE": "g2k"})
+    candidate, match = _candidate_with_root(scheduled, pass_name="lowering/schedule", rule_name="030_split_reduce")
+    candidate.apply(match, _two_kernel_fragment("split"))
+
+    partial = candidate.graph.nodes["partial"].op
+    assert partial.source is scheduled and partial.source_is_graph_splice
+
+    cuda = CudaOp(kernel_source='extern "C" __global__ void k_partial() {}', kernel_name="k_partial", source=partial)
+    db = _persist_chain(cuda, candidate.ctx)
+
+    assert _lowering_child(db, scheduled.cache_key()) is None

--- a/tests/compiler/pipeline/test_rule_diff.py
+++ b/tests/compiler/pipeline/test_rule_diff.py
@@ -66,11 +66,14 @@ def test_display_name_prefixes_known_pass():
 
 
 def test_pass_shorthand_matches_cli_shortcut_inverse():
-    # Single source of truth: commands/compile.py builds its --passes
-    # shortcut expander by inverting PASS_SHORTHAND.
+    # Single source of truth: commands/compile.py groups every pass carrying
+    # one shorthand so a multi-pass stage (tile structure + schedule) stays atomic.
     from emmy.commands.compile import _PASS_SHORTCUTS
 
-    assert _PASS_SHORTCUTS == {short: full for full, short in PASS_SHORTHAND.items()}
+    expected = {}
+    for full, short in PASS_SHORTHAND.items():
+        expected.setdefault(short, []).append(full)
+    assert _PASS_SHORTCUTS == expected
 
 
 def test_should_use_color_modes(monkeypatch):

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -136,6 +136,7 @@
  "tests/compiler/passes/test_schedule_pool_cache.py::test_pool_rows_are_read_only": 0.59,
  "tests/compiler/passes/test_schedule_pool_cache.py::test_second_resolve_hits_the_pool_and_serves_identical_rows": 0.58,
  "tests/compiler/passes/test_schedule_pool_cache.py::test_two_same_shape_kernels_share_one_enumeration": 0.75,
+ "tests/compiler/passes/test_schedule_site_ownership.py::test_nested_only_thread_work_does_not_invent_root_tile": 10.2,
  "tests/compiler/passes/test_warp_eligible_stamp.py::test_materialized_op_carries_warp_eligibility_stamp": 6.1,
  "tests/compiler/pipeline/search/data/test_dataset.py::test_golden_features_use_own_cards_sm_count": 0.06,
  "tests/compiler/pipeline/search/data/test_freeze.py::test_anchor_walk_treats_freeze_rows_as_treeless": 0.07,


### PR DESCRIPTION
## Summary

- Keep loop fusion deterministic and maximal, independent of placement, schedule, hardware, and search evidence.
- Add a post-recognition `PLACE@path=fuse|cut` structural fork owned by the outer two-level tuner; schedule every resulting recognized kernel independently in the inner tuner.
- Preserve recognized Tile IR across cuts, separate placement lineage from per-kernel schedule evidence, and exclude graph-splice fragments from ordinary predecessor timing evidence.
- Add exact multi-kernel tune-winner persistence and replay: placement, component cache keys and multiplicities, directly searched schedule pins, and ordered CUDA-row integrity data.
- Add a generic materialized-score flash schedule: workspace score → C-fragment load → online softmax/C-to-A repack → tensor-core P@V, including split-KV realization.
- Repair generic packed Q/K recognition, lexical closure, multi-channel sync staging, multi-output eager reference checks, and nested-only schedule-site materialization.
- Enforce the ownership invariant with static and dynamic tests: fusion cannot depend on target, placement, schedule, or search; recognition is algebra-only; schedule and lowering use named capabilities and atom metadata.
- Strengthen compiler, IR, pipeline, pass, kernel-lowering, command, and test architecture documentation around fusion → placement → schedule ownership.

Fusion rules and fusion tests are intentionally unchanged.

## H200 result

Targeted Qwen3-0.6B layer-0, seq=512 target `k_sdpa_mean_linear_reduce_28c822.` on one NVIDIA H200 141GB. The winner was searched at deploy optimization (`--nvcc-flags ""`), persisted as one exact kernel set with `PLACE@dd=cut`, and replayed in five independent strict processes with 10 warmups and 100 measured iterations.

| Metric | Median | Five-run range |
| --- | ---: | ---: |
| Eager PyTorch whole forward | 653.01 us | 652.82–653.12 us |
| Exact Emmy winner, captured whole program | 270.76 us | 270.40–271.05 us |
| Speedup | **2.4116x** | **2.4085–2.4154x** |

Every run has `strict.status=pass`, one `pinned[]` winner with `status=ok`, no flags, direct eager correctness at `rtol=atol=1e-3`, five captured launches, and `timing_semantics=whole_program_e2e`. The kernel-set manifest and ordered source-hash inventory are identical across all five processes. The new P@V residue is about 18.3 us plus a 6.0 us finalize; the tuned QK producer is about 210.5 us.

This is a targeted compiler result, not the complete seq=1+512 publication corpus. The target contains attention, normalization/rotary work, and linear operations, so the defensible baseline label is the PyTorch eager framework/vendor path. It is not a standalone cuBLAS primitive benchmark; a literal cuBLAS/cuBLASLt claim still requires the plain-contraction subset plus profiler or direct-library evidence.

## Verification

- Rebased on `origin/main` at `ab824a83`.
- `make test`: 3,405 passed, 652 skipped, 1 xfailed, 1 xpassed.
- Repository-owned Python: Ruff and format checks pass.
- `git diff --check`: pass.
- GitHub Actions: lint and test pass; Vercel checks pass.
- `make lint` reaches only five unrelated untracked scratch scripts with import-order findings; those files are not staged or included in this PR.

## Review notes

- There are no workload-name, model-name, GPU-name, H200, or isolated SM-number dispatches in the new recognition, schedule, or lowering paths.
- Measured GPU-specific routing remains choice evidence only; it cannot create an implementation path.
- The retained H200 VM remains running for follow-up kernel work, including a future capability-driven WGMMA implementation.
