### PR TITLE
Fix order-sensitive online-softmax exemption splitting the biased banded flash

### DIFF
--- a/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
@@ -115,10 +115,11 @@ def _duplicated_contraction(graph: Graph, region: set[str]) -> str | None:
         return frozenset().union(*(contraction_sources(input_id, next_seen) for input_id in producer.inputs))
 
     region_stmts = tuple(stmt for node_id in region for stmt in graph.nodes[node_id].op.body.iter())
-    online_softmax_region = (
-        any(isinstance(stmt, Accum) and stmt.op.name == "maximum" for stmt in region_stmts)
-        and any(isinstance(stmt, Assign) and stmt.op.name == "exp" for stmt in region_stmts)
-        and any(isinstance(stmt, Accum) and stmt.op.name == "add" for stmt in region_stmts)
+    # Regions grow incrementally, so the softmax sum may not have joined the region yet when this
+    # guard runs. The running-maximum statistic beside an exp value path already identifies online
+    # softmax; the duplication this guard targets carries an additive statistic instead.
+    online_softmax_region = any(isinstance(stmt, Accum) and stmt.op.name == "maximum" for stmt in region_stmts) and any(
+        isinstance(stmt, Assign) and stmt.op.name == "exp" for stmt in region_stmts
     )
 
     def branch_reaches_reduce(start: str) -> bool:


### PR DESCRIPTION
## Summary

Since #498, `test_warp_flash_banded_with_additive_bias_matches_torch` fails on RTX 4080: the stamped biased banded
flash lowers to 2 kernels instead of 1. Bisected to #498's new duplicated-contraction guard in
`loop/fusion/010_merge_loop_ops.py` — not the shipped goldens or prior (only sm120/sm70 artifacts shipped) and not
the deterministic topo order.

## Root cause

The guard's online-softmax exemption required all of {`Accum maximum`, `Assign exp`, `Accum add`} inside the
*current* merge region, but regions grow incrementally. On the biased banded flash the guard runs while the region
holds only the scores contraction, the running maximum, and the exp — the softmax sum has not joined yet — so the
exemption fails and the merge is refused for good, splitting the fused flash. Whether that intermediate state is
ever consulted depends on merge enumeration order, which is why the unbiased and causal-bias siblings kept passing.

## Fix

Drop the `Accum add` requirement (5-line change). A running-maximum statistic beside an exp value path already
identifies online softmax; the duplication the guard targets — a projection feeding a normalization's statistic and
value reads — carries an additive statistic and stays refused, as pinned by
`test_projection_feeding_rms_value_and_statistic_stays_materialized`. This matches the pass ARCHITECTURE's stated
intent ("retaining either buffer would prevent flash recognition"), so no doc change is needed.

## Validation (RTX 4080, `-Xcicc -O1`)

- `test_warp_flash_banded_with_additive_bias_matches_torch` passes: one fused kernel, numerics within tolerance
- full suite: failure set byte-identical to unmodified HEAD (196 pre-existing 4080 failures/errors re-run in both
  tree states under identical settings — none added, target test fixed)
- `tests/compiler/e2e/test_attention_coverage.py` + `tests/compiler/passes/test_fusion_rules.py`: 170 passed
- guard-motivating suites (`test_moe_split.py`, `test_exl3.py`, `test_exl3_head.py`): green apart from the
  pre-existing set
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)