### PR TITLE
Bind the sibling output axis in staged-fill gmem addresses

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -158,7 +158,10 @@ structurally different primitives — sit behind one `fill`/`commit`/`wait` seam
 **one atom-agnostic driver** (`_atom._staged`) builds the operand pair + the transport for either atom; the atom
 supplies only the slab drain leaf via `_AtomOps.staged_drain` (the shared inner fragment drain
 `_staged_inner_atom_loop` — `ldmatrix` on modern atoms, a cooperative shared gather on Volta — or the scalar
-`_scalar_drain`). The staging **decision** does not live here at all: the
+`_scalar_drain`). A fill's gmem-address σ binds **every** tiled output axis, not just the operand's own: the tile
+axis at `tile_base + cell` (masked axes clamp in-bounds) and the SIBLING axis at its block base — a slab is
+CTA-shared across the sibling, so a sibling var can only survive as a value-dead flat-index reshape residue (a
+merged / reshaped weight row), and left unbound it would emit the unsplit axis name the kernel no longer defines. The staging **decision** does not live here at all: the
 `Stage` on the `TileOp` arrives **already resolved** by the scheduler (transport eligibility, the slab K-chunk
 `bk_elems`, the depth clamps — or `None`, gmem-direct), and `state` (which slots the operand fragments) and the
 shared `reduce` (which emits the loop) apply it verbatim. The `Stage` spells two buffering levels:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -365,12 +365,31 @@ def _clamp_last(idx: Expr, ext: Expr) -> Expr:
     return TernaryExpr(cond=BinaryExpr("<", idx, ext), if_true=idx, if_false=BinaryExpr("-", ext, Literal(1, "int")))
 
 
-def _slab_index(operand_index, *, tile: Side, tile_base, k_axis, tile_is_row: bool):
+def _side_base(side: Side) -> Expr:
+    """The CTA's tile-base coordinate on ``side`` — ``block·tile`` (always in-bounds: the block
+    count is ``ceil(extent / tile)``, so ``block·tile < extent``)."""
+    return BinaryExpr("*", Var(side.block), Literal(side.tile, "int"))
+
+
+def _sibling_sigma(sibling: Side | None) -> dict[str, Expr]:
+    """The σ entry for the operand's OTHER tiled output axis. A staged slab is CTA-shared across
+    the sibling axis, so the drain contract already requires the operand's gmem address be
+    sibling-invariant in VALUE — but the sibling var can still appear SYNTACTICALLY, through a
+    flat-index reshape residue (a merged / reshaped weight row like ``(m·N + n) % N``, whose ``m``
+    contribution is a multiple of the modulus and folds away). After the tile split the kernel
+    decodes only the ``_b`` / ``_u`` split vars, never the bare axis name, so leaving the sibling
+    unsubstituted emits an undefined identifier. Bind it to the CTA's block base — an in-bounds
+    representative under which a value-dead residue evaluates unchanged."""
+    return {} if sibling is None else {sibling.axis.name: _side_base(sibling)}
+
+
+def _slab_index(operand_index, *, tile: Side, tile_base, k_axis, tile_is_row: bool, sibling: Side | None = None):
     """The **one** cp.async slab gmem-index factory, for either operand and either tier. The slab's
     inner (contiguous) dim maps to the contraction ``k_axis``, its outer dim to the stationary ``tile``
     axis (``m`` for A, ``n`` for B). For A the tile axis is the slab ROW (K the col); for B they swap
     (``slot[row][col] = A[row_base + row][k0 + col]`` / ``B[k0 + row][col_base + col]``). A masked tile
     coordinate is clamped in-bounds — the overhanging cell reads a duplicate and its store is guarded.
+    A residual reference to the ``sibling`` output axis binds to its block base (:func:`_sibling_sigma`).
     Returns a ``k0 -> ((row, col) -> gmem index)`` map — one K-chunk offset per :func:`staged_kloop`
     fill."""
 
@@ -378,7 +397,13 @@ def _slab_index(operand_index, *, tile: Side, tile_base, k_axis, tile_is_row: bo
         def gmem(row, col):
             tc, kc = (row, col) if tile_is_row else (col, row)
             t = BinaryExpr("+", tile_base, tc)
-            sig = Sigma({tile.axis.name: _clamp_last(t, tile.ext) if tile.mask else t, k_axis.name: BinaryExpr("+", k0, kc)})
+            sig = Sigma(
+                {
+                    tile.axis.name: _clamp_last(t, tile.ext) if tile.mask else t,
+                    k_axis.name: BinaryExpr("+", k0, kc),
+                    **_sibling_sigma(sibling),
+                }
+            )
             return tuple(sig.apply(e) for e in operand_index)
 
         return gmem
@@ -388,17 +413,18 @@ def _slab_index(operand_index, *, tile: Side, tile_base, k_axis, tile_is_row: bo
 
 def _tile_base(mn: tuple[Side, Side]) -> tuple[Expr, Expr]:
     """The CTA tile's ``(row_base, col_base)`` top-left origin — ``(m_b·tile_m, n_b·tile_n)``."""
-    return tuple(BinaryExpr("*", Var(s.block), Literal(s.tile, "int")) for s in mn)
+    return tuple(_side_base(s) for s in mn)
 
 
-def _box_origin(operand_index, *, tile: Side, tile_base: Expr, k_axis):
+def _box_origin(operand_index, *, tile: Side, tile_base: Expr, k_axis, sibling: Side | None = None):
     """The TMA box origin at K-chunk ``k0`` — the operand's OWN gmem index evaluated (σ) at the
     tile base and ``k0``, so an offset operand (a split-K partial's ``ksplit·(K/w) + k``) lands
     the box at its absolute coordinates. For a canonical operand this is exactly ``(tile_base,
-    k0)`` (A, tile axis the slab row) / ``(k0, tile_base)`` (B)."""
+    k0)`` (A, tile axis the slab row) / ``(k0, tile_base)`` (B). A residual reference to the
+    ``sibling`` output axis binds to its block base (:func:`_sibling_sigma`)."""
 
     def at(k0):
-        sig = Sigma({tile.axis.name: tile_base, k_axis.name: k0})
+        sig = Sigma({tile.axis.name: tile_base, k_axis.name: k0, **_sibling_sigma(sibling)})
         return tuple(sig.apply(e) for e in operand_index)
 
     return at
@@ -433,7 +459,7 @@ def _slab_operands(
     cp.async-staged byte slab; 0 everywhere else)."""
     ops: list[Operand] = []
     for i, (tag, is_row) in enumerate((("a", True), ("b", b_trans))):
-        tile, tile_base = mn[i], base[i]
+        tile, tile_base, sibling = mn[i], base[i], mn[1 - i]
         shape = (tile.tile, bk_elems) if is_row else (bk_elems, tile.tile)
         elem = elems[i]
         # A >2-D operand (batched / unit-batch view) boxes as rank-N with leading extent-1 dims;
@@ -447,8 +473,8 @@ def _slab_operands(
                 buf=bufs[i],
                 shape=shape,
                 box=box,
-                coords=_box_origin(index_srcs[i], tile=tile, tile_base=tile_base, k_axis=k_axis),
-                index=_slab_index(index_srcs[i], tile=tile, tile_base=tile_base, k_axis=k_axis, tile_is_row=is_row),
+                coords=_box_origin(index_srcs[i], tile=tile, tile_base=tile_base, k_axis=k_axis, sibling=sibling),
+                index=_slab_index(index_srcs[i], tile=tile, tile_base=tile_base, k_axis=k_axis, tile_is_row=is_row, sibling=sibling),
                 swizzle=swizzles[i],
                 dtype=cuda_name(elem) if elem is not None else None,
                 elem_bytes=elem.nbytes if elem is not None else None,
@@ -547,8 +573,8 @@ def _sync_operands(
             tag="a",
             buf=c.a.input,
             shape=(mn[0].tile, bk_elems),
-            coords=_box_origin(c.a.index, tile=mn[0], tile_base=row_base, k_axis=c.axis),
-            index=_slab_index(c.a.index, tile=mn[0], tile_base=row_base, k_axis=c.axis, tile_is_row=True),
+            coords=_box_origin(c.a.index, tile=mn[0], tile_base=row_base, k_axis=c.axis, sibling=mn[1]),
+            index=_slab_index(c.a.index, tile=mn[0], tile_base=row_base, k_axis=c.axis, tile_is_row=True, sibling=mn[1]),
             swizzle=swizzles[0],
         )
         async_ops.append(a_op)
@@ -578,8 +604,8 @@ def _sync_operands(
             tag=tag,
             buf=bl.input,
             shape=shape,
-            coords=_box_origin(bl.index, tile=mn[1], tile_base=col_base, k_axis=c.axis),
-            index=_slab_index(bl.index, tile=mn[1], tile_base=col_base, k_axis=c.axis, tile_is_row=c.b_trans),
+            coords=_box_origin(bl.index, tile=mn[1], tile_base=col_base, k_axis=c.axis, sibling=mn[0]),
+            index=_slab_index(bl.index, tile=mn[1], tile_base=col_base, k_axis=c.axis, tile_is_row=c.b_trans, sibling=mn[0]),
             swizzle=swizzles[1],
             trans=c.b_trans,
         )

--- a/tests/compiler/passes/test_staged_fill_sibling_axis.py
+++ b/tests/compiler/passes/test_staged_fill_sibling_axis.py
@@ -1,0 +1,86 @@
+"""The staged fill's gmem σ binds a residual reference to the operand's SIBLING output axis.
+
+A staged operand slab is CTA-shared across the other output axis (B across the m rows, A across the n
+columns), so its gmem address must be sibling-invariant in VALUE — but the sibling var can still appear
+SYNTACTICALLY, through a flat-index reshape residue: a merged / reshaped projection weight's row index
+arrives as ``((m·1024 + n) / 128 % 8) · 128 + (m·1024 + n) % 128``, where the ``m`` contribution is a
+multiple of every modulus and folds away. After the tile split the kernel decodes only the ``m_b`` /
+``m_u`` split vars, never the bare axis name, so a fill σ that substitutes only its OWN tile axis + K
+emitted the unsplit name — nvcc: ``identifier "a0" is undefined`` (the qwen3-8b v_proj ``d1/sync``
+greedy pick on sm_80). The fill and TMA box-origin σ now bind the sibling to its block base
+(``m_b · tile_m`` — always in-bounds), under which a value-dead residue evaluates unchanged."""
+
+from __future__ import annotations
+
+from emmy.compiler.dim import Dim
+from emmy.compiler.dtype import F16
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Expr, Literal, Var
+from emmy.compiler.ir.schedule import TilePlan, Workers
+from emmy.compiler.ir.stmt import Load
+from emmy.compiler.ir.tile import Channel, Fold
+from emmy.compiler.pipeline.passes.lowering.kernel._atom import _slab_operands, _sync_operands, _tile_base
+from emmy.compiler.pipeline.passes.lowering.kernel._stage import CtaTile
+
+K16 = "mma_m16n8k16_f16_f32"
+
+
+def _lit(n: int) -> Literal:
+    return Literal(n, "int")
+
+
+def _row_residue(sibling: Expr, own: Expr) -> Expr:
+    """The flat-index reshape residue: ``((s·1024 + o) / 128 % 8) · 128 + (s·1024 + o) % 128`` —
+    value-equal to ``o`` for ``o < 1024`` (the ``s`` term is a multiple of both moduli)."""
+    flat = sibling * _lit(1024) + own
+    return (flat / _lit(128)) % _lit(8) * _lit(128) + flat % _lit(128)
+
+
+def _mn(m: int = 32, n: int = 1024):
+    tile = TilePlan.parse(f"{K16}/f1x4/k8", Workers.parse("w1x1"))
+    return tile.at(Axis("m", Dim(m)), Axis("n", Dim(n))).mn
+
+
+def _free(exprs) -> set[str]:
+    return set().union(*(set(e.free_vars()) for e in exprs))
+
+
+def _assert_sibling_bound(op, sibling_name: str, block_name: str) -> None:
+    idx = op.index(_lit(0))(Var("_row"), Var("_col"))
+    assert sibling_name not in _free(idx), f"{op.tag} fill leaks the unsplit sibling var {sibling_name!r}"
+    assert block_name in _free(idx), f"{op.tag} fill does not bind the sibling block var {block_name!r}"
+    coords = op.coords(_lit(0))
+    assert sibling_name not in _free(coords), f"{op.tag} TMA box origin leaks the unsplit sibling var {sibling_name!r}"
+
+
+def test_slab_operands_bind_the_sibling_axis_to_its_block_base():
+    """Both copy-transport operands: a dead sibling residue in the gmem index substitutes to the
+    sibling's ``_b`` block base instead of leaking the unsplit axis name."""
+    mn = _mn()
+    ka = Axis("k", Dim(2048))
+    a_index = (Var("m"), _row_residue(Var("n"), Var("k")) * _lit(0) + Var("k"))  # dead n residue on A
+    b_index = (_row_residue(Var("m"), Var("n")), Var("k"))  # the merged-weight row residue on B
+    a_op, b_op = _slab_operands(
+        index_srcs=(a_index, b_index),
+        bufs=("x", "w"),
+        mn=mn,
+        k_axis=ka,
+        bk_elems=128,
+        base=_tile_base(mn),
+    )
+    _assert_sibling_bound(b_op, "m", "m_b")
+    _assert_sibling_bound(a_op, "n", "n_b")
+
+
+def test_sync_transport_async_b_binds_the_sibling_axis():
+    """The reproducer's exact path — the ``d1/sync`` transport's async (cp.async) B fill over a
+    weight whose row index carries the m residue."""
+    mn = _mn()
+    ka = Axis("k", Dim(2048))
+    a = Load(name="in1", input="x", index=(Var("m"), Var("k")), dtype=F16)
+    b = Load(name="in0", input="w", index=(_row_residue(Var("m"), Var("n")), Var("k")), dtype=F16)
+    c = Fold.contraction(k_axis=ka, a=a, channels=(Channel(b=b, acc="acc"),))
+    cta = CtaTile(linear_tid=Var("_t"), n_threads=32)
+    _, _, async_ops, _ = _sync_operands(c, 128, mn, cta)
+    b_op = next(op for op in async_ops if op.tag == "b")
+    _assert_sibling_bound(b_op, "m", "m_b")


### PR DESCRIPTION
## Summary

On sm_80, `STAGE=d1/sync` (and any staged transport) could emit a cp.async B-fill whose global address references
the *sibling* output axis by its unsplit name (`error: identifier "a0" is undefined`), failing nvcc at deploy time
on the greedy pick. Found by the A100 Qwen3-8B serving-twins tune for the megakernel comparison lane (#502): 11
candidate compiles failed and the cold greedy pick was broken for the merged k/v projection kernel.

Root cause: `_slab_index` / `_box_origin` (`lowering/kernel/_atom.py`) substitute only the operand's own tile axis
and the k axis. A value-dead compose-indexmaps reshape residue (`a0*1024` with both moduli dividing 1024) keeps a
syntactic reference to the sibling axis in the B index; after the tile split decodes only `a0_b`/`a0_u`, the bare
name is undefined.

Fix: bind the sibling axis to its block base (`block · tile`) in the fill/box σ — a staged slab is CTA-shared
across the sibling axis, so the drain contract already requires the address be sibling-invariant in value; the
value-dead residue evaluates unchanged and no unsplit name is emitted. Threaded through sync-copy, cp.async, and
TMA construction sites; one invariant sentence added to the kernel-lowering ARCHITECTURE.md.

## Testing

- New `tests/compiler/passes/test_staged_fill_sibling_axis.py` (IR-level, GPU-free): fails 2 before the fix,
  passes after.
- `tests/compiler/passes/` 319 passed, 1 xfailed; `tests/compiler/ir` + `tests/compiler/pipeline` 1086 passed
  (5 pre-existing `test_dynamic_shapes.py@cuda` failures reproduce on pristine main — broken dual-cupy install).
- Reproducer kernel now compiles clean under `nvcc --cubin -arch=sm_80`; emission byte-identical for
  residue-free staged matmuls (d2/cp and d1/sync, canonical and transposed B).

Known adjacent gap, deliberately not taken here: the gmem-direct mma leaves have the same one-axis σ, and a
simplifier fold for exact-multiple addends would kill the residue at its source (tile-IR goldens churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)