### PR TITLE
Defer product merges into contraction-bearing activation cones

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -238,7 +238,11 @@ coverage until that entire cone has been measured.
 
 Fusion also lets a decomposed contraction's pointwise product reunite with its sole sum-reduction consumer before an
 upstream activation-bearing cone is spliced into the product. Otherwise pass order can materialize the full M×K×N
-product, whose work-growth then prevents the reduction merge; ordinary softmax/attention reduction order is unchanged.
+product, whose work-growth then prevents the reduction merge and strands the product buffer (at serving capacity a
+device-memory overflow: the Qwen3-8B down projection's unreduced product is capacity × 12288 × 4096). The deferral
+holds even when the cone already carries its own contractions — a gated-MLP activation fused with its gate/up
+projection is the shape that reached the product first there — with only the max-shift online-softmax region exempt,
+so ordinary softmax/attention reduction order is unchanged.
 
 ## Resolve the hardware-atom binding once, structurally, at the tile level
 

--- a/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/010_merge_loop_ops.py
@@ -183,11 +183,18 @@ def _merge_region(match: Match, region: set[str], sink: Node) -> Graph:
     # first, after which the upstream cone can fuse into the complete contraction normally.
     # This is an ordering rule, not a shape specialization: it applies to an activation-bearing
     # producer cone feeding a multiplicative product whose sole Loop consumer add-reduces it.
-    # The activation condition keeps ordinary softmax/attention reduction order unchanged.
+    # The cone may already carry its own contractions (a gated-MLP activation fused with its
+    # gate/up projection reaches a down-projection product this way — splicing it first
+    # stranded the full ``M x K x N`` product on the Qwen3-8B serving trace, a device-memory
+    # overflow at capacity M). Only the max-shift online-softmax region is exempt, keeping
+    # ordinary softmax/attention reduction order unchanged.
     sink_users = list(graph.users(sink.id))
     sink_stmts = tuple(sink.op.body.iter())
     region_stmts = tuple(stmt for node_id in region - {sink.id} for stmt in graph.nodes[node_id].op.body.iter())
-    has_activation = not any(isinstance(stmt, Accum) for stmt in region_stmts) and any(
+    region_is_online_softmax = any(isinstance(stmt, Accum) and stmt.op.name == "maximum" for stmt in region_stmts) and any(
+        isinstance(stmt, Assign) and stmt.op.name == "exp" for stmt in region_stmts
+    )
+    has_activation = not region_is_online_softmax and any(
         isinstance(stmt, Assign) and stmt.op.name in {"exp", "silu", "tanh"} for stmt in region_stmts
     )
     is_product = any(isinstance(stmt, Assign) and stmt.op.name == "multiply" for stmt in sink_stmts)

--- a/tests/compiler/passes/test_fusion_rules.py
+++ b/tests/compiler/passes/test_fusion_rules.py
@@ -16,7 +16,7 @@ from emmy.compiler.backend.numpy import NumpyBackend
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import ConstantOp, InputOp
 from emmy.compiler.ir.expr import Literal, placeholder
-from emmy.compiler.ir.frontend.ir import LinearOp, RmsNormOp
+from emmy.compiler.ir.frontend.ir import LinearOp, RmsNormOp, SliceOp
 from emmy.compiler.ir.loop import Accum, Assign, Load, LoopOp, Write
 from emmy.compiler.ir.tensor.ir import ElementwiseOp, GatherOp, IndexMapOp, IndexSource, ReduceOp
 from emmy.compiler.pipeline import Pipeline
@@ -1127,3 +1127,49 @@ def test_product_reduction_fuses_before_upstream_activation():
         "r": rng.standard_normal((4, 6)).astype(np.float32),
     }
     _assert_close(_run(before, inputs), _run(fused, inputs))
+
+
+def _make_gated_mlp(m=4, k=16, n=12, k2=16):
+    """RMSNorm → merged gate/up linear → SiLU gate multiply → down projection.
+
+    The Qwen3-8B serving-trace shape: the activation cone reaching the down
+    projection's decomposed product already carries the gate/up contraction, so
+    an Accum-blind ordering guard lets the cone splice into the bare product
+    first; the reduction merge then exceeds the work-growth cap and strands the
+    full ``M x N x K2`` product (a 384 GiB arena at serving capacity).
+    """
+    g = Graph()
+    g.add_node(InputOp(), [], Tensor("x", (m, k)), node_id="x")
+    g.add_node(InputOp(), [], Tensor("rmsw", (k,)), node_id="rmsw")
+    g.add_node(RmsNormOp(), ["x", "rmsw"], Tensor("rms", (m, k)), node_id="rms")
+    g.add_node(InputOp(), [], Tensor("wgu", (2 * n, k)), node_id="wgu")
+    g.add_node(LinearOp(), ["rms", "wgu"], Tensor("gu", (m, 2 * n)), node_id="gu")
+    g.add_node(SliceOp(shape=(m, n), dim=-1, start=0), ["gu"], Tensor("gate", (m, n)), node_id="gate")
+    g.add_node(SliceOp(shape=(m, n), dim=-1, start=n), ["gu"], Tensor("up", (m, n)), node_id="up")
+    g.add_node(ElementwiseOp("silu"), ["gate"], Tensor("act", (m, n)), node_id="act")
+    g.add_node(ElementwiseOp("multiply"), ["act", "up"], Tensor("h", (m, n)), node_id="h")
+    g.add_node(InputOp(), [], Tensor("wd", (k2, n)), node_id="wd")
+    g.add_node(LinearOp(), ["h", "wd"], Tensor("y", (m, k2)), node_id="y")
+    g.inputs, g.outputs = ["x", "rmsw", "wgu", "wd"], ["y"]
+    return g
+
+
+def test_product_reduction_fuses_before_contraction_bearing_activation_cone():
+    """A gated-MLP cone (activation fused with its gate/up contraction) must not strand
+    the down projection's M×N×K product — every kernel output stays at operand rank."""
+    fused = _decompose_and_fuse(_make_gated_mlp())
+    bare = [node.id for node in _kernel_nodes(fused) if len(node.output.shape) > 2]
+    assert bare == [], f"gated-MLP fusion stranded a product workspace: {bare}"
+
+
+def test_gated_mlp_fusion_correctness():
+    m, k, n, k2 = 4, 16, 12, 16
+    inputs = {
+        "x": rng.standard_normal((m, k)).astype(np.float32),
+        "rmsw": rng.standard_normal((k,)).astype(np.float32),
+        "wgu": rng.standard_normal((2 * n, k)).astype(np.float32),
+        "wd": rng.standard_normal((k2, n)).astype(np.float32),
+    }
+    before = _run(_make_gated_mlp(), inputs)
+    after = _run(_decompose_and_fuse(_make_gated_mlp()), inputs)
+    _assert_close(before, after, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## Summary

Follow-up to #507, found by the same A100 Qwen3-8B serving-twins tune (#502 campaign): the fused-MLP twin
stranded the down-projection's *unreduced* rank-3 product `(num_tokens, 12288, 4096)` as a kernel output — a
3.5 GB intermediate per layer at decode bucket 32, 264 ms floors at m4096, and a fatal 412.9 GB boot arena at
the symbolic capacity realization (`emmy serve` OOM in EngineCore init).

Root cause is fusion order, not the tile scheduler: `_merge_region`'s "consumer absorbs the product before its
producer cone" deferral only fired for Accum-free producer regions. When the SiLU cone had already merged with
the gate/up contraction, the activation cone spliced into the bare down-proj product first; the later
product↔reduction merge exceeded the blowup factor and the rank-3 product was stranded (a hazard the passes
ARCHITECTURE.md already documented).

Fix: defer on any activation-bearing producer region, exempting only the online-softmax max-shift shape (same
discriminator `_duplicated_contraction` uses), so flash/softmax reduction order is untouched. After the fix the
MLP forms `k_rms_norm_linear_reduce` (computed-A gate⊗up, M×N output) + a plain down-proj mma — no materialized
rank-3 anywhere; M=1 and symbolic realizations clean.

## Testing

- New `test_product_reduction_fuses_before_contraction_bearing_activation_cone` + numeric-parity
  `test_gated_mlp_fusion_correctness` in `tests/compiler/passes/test_fusion_rules.py` — fail at base, pass with
  the fix.
- `tests/compiler/passes/` + `tests/compiler/pipeline/` 828 passed; full `tests/compiler/` 2520 passed with the
  failing remainder byte-identical to base (165 = 165, zero new) and reproducing on clean main on that box
  (dual-cupy install + concurrent GPU test contention).
- Ruff check/format clean.

Follow-ups noted: the A100 tune DB rows for the retired kernel shape are stale (re-trace/re-tune runs next in
the campaign); whether the two-kernel form should re-fuse via a PLACE routing entry is an evidence question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)