### PR TITLE
Fix sync-fill SSA suffixing, nested TILE ownership, and strict-run accounting

### DIFF
--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -1990,12 +1990,16 @@ def _strict_benchmark_errors(args, results, bench, captured, correctness, pinned
     if not valid_proof(correctness):
         errors.append("deployed Emmy row lacks direct strict eager correctness")
 
-    ab_rows = [row for row in pinned_rows or [] if getattr(row.sample, "shape", None) is None]
+    pinned_rows = list(pinned_rows or [])
+    ab_rows = [row for row in pinned_rows if getattr(row.sample, "shape", None) is None]
+    automatic_rows = [row for row in pinned_rows if getattr(row.sample, "shape", None) is not None]
+    expected_automatic_rows = len(getattr(args, "golden_configs", []) or [])
+    if len(automatic_rows) != expected_automatic_rows:
+        errors.append(f"expected {expected_automatic_rows} exact working-golden row(s), got {len(automatic_rows)}")
     expected_ab_rows = len(args.ab or [])
     if len(ab_rows) != expected_ab_rows:
         errors.append(f"expected {expected_ab_rows} exact --ab row(s), got {len(ab_rows)}")
-    exact_rows = ab_rows if expected_ab_rows else list(pinned_rows or [])
-    for row in exact_rows:
+    for row in pinned_rows:
         label = row.sample.name
         if row.status != "ok" or row.flags:
             errors.append(f"{label} failed exact-pin integrity: status={row.status}, flags={list(row.flags)}")
@@ -2521,7 +2525,12 @@ def _check_accuracy(outputs, eager_out) -> str | None:
     # output against its positional eager counterpart (graph-output order).
     # Historic single-output behavior (every output vs THE eager tensor) is the
     # degenerate case of the fallback-to-first pairing below.
-    eager_refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
+    if isinstance(eager_out, dict):
+        if set(eager_out) != set(outputs):
+            return f"CORRECTNESS FAIL: output names differ: Emmy={list(outputs)}, eager={list(eager_out)}"
+        eager_refs = [eager_out[name] for name in outputs]
+    else:
+        eager_refs = list(eager_out) if isinstance(eager_out, (tuple, list)) else [eager_out]
     eager_flats = [t.detach().cpu().flatten().tolist() for t in eager_refs]
     if any(e != e for flat in eager_flats for e in flat):
         return "eager reference contains NaN (reproducer inputs out of domain)"
@@ -2661,7 +2670,7 @@ def _check_accuracy(outputs, eager_out) -> str | None:
                     budget,
                 )
         else:
-            logger.warning("Output size %d does not match eager %d; skipping accuracy", len(values), len(eager_flat))
+            failures.append(f"output {buf_name}: size {len(values)} does not match eager {len(eager_flat)}")
     return f"accuracy check failed vs eager: {'; '.join(failures)}" if failures else None
 
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -60,6 +60,7 @@ from emmy.compiler.ir.kernel.ir import (
     TmaLoad,
 )
 from emmy.compiler.ir.stmt import Body, Cond, Load, Loop, Stmt, StridedLoop, Write
+from emmy.compiler.ir.tile.ir import deep_defines
 
 
 def _mul(a: Expr, b: Expr) -> Expr:
@@ -553,7 +554,7 @@ class SyncTransport:
                 plans.append("vector")
             else:
                 plans.append("cell")
-            cell_defs |= set(a.defines())
+            cell_defs |= deep_defines(a)
         return plans
 
     def fill(self, *, k0: Expr, slot: Expr, k0_cur: Expr | None = None) -> list[Stmt]:
@@ -596,7 +597,7 @@ class SyncTransport:
                 stmts, val = op.value(k0_cur, row, cell_col)
                 cell_stmts.append(stmts)
                 vals.append(val)
-            hoisted_defs = {nm for p, stmt in enumerate(cell_stmts[0]) if plans[p] == "hoist" for nm in stmt.defines()}
+            hoisted_defs = {nm for p, stmt in enumerate(cell_stmts[0]) if plans[p] == "hoist" for nm in deep_defines(stmt)}
             vals = [val if val in hoisted_defs else f"{val}__c{j}" for j, val in enumerate(vals)]
             # Per-cell SSA defs — the names each replica suffixes. HOISTED positions (run-invariant
             # stmts: the stat-row loads, whose value is identical across the run's cells) emit once,
@@ -606,7 +607,7 @@ class SyncTransport:
             # binding every cell's suffixed name (one 16 B ld like the cp.async fill, instead of V
             # scalar loads — the compute fill issued 3.6x cuBLAS's LSU instructions). Everything
             # else replicates per cell as before.
-            local = {nm for p, st in enumerate(cell_stmts[0]) if plans[p] != "hoist" for nm in st.defines()}
+            local = {nm for p, st in enumerate(cell_stmts[0]) if plans[p] != "hoist" for nm in deep_defines(st)}
             for p in range(len(cell_stmts[0])):
                 if plans[p] == "hoist":
                     body.append(cell_stmts[0][p])

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -1961,7 +1961,10 @@ def _materialize(term: _Term, resolved: _Row, row: dict, name: str, knobs: dict)
     rplan = decided("REDUCE") or ReducePlan.parse(value("REDUCE"), work)
     plan = decided("TILE")
     if plan is None:
-        plan = resolve_site_tile(value("TILE"), work, rplan.coop)
+        # An empty spelling is a unit register tile only when THIS root owns a TILE site. A
+        # nested-only term (flash's dd/pj tiles under a reduce root) has no root TILE key at all;
+        # borrowing its shared thread inventory there invents a slice the codec cannot address.
+        plan = resolve_site_tile(value("TILE"), work, rplan.coop) if "TILE" in keys else TilePlan()
     if is_contraction(node) and rplan.needs_split:
         # The stage is re-resolved INSIDE against the sliced node, so it stays a spelling here.
         return _splitk_option(term, plan, node, rplan, name, op_knobs, value("STAGE"), nested)

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -1244,6 +1244,43 @@ def test_accuracy_check_fails_scrambled_output_passes_outliers():
     assert not verdicts((base + rng.standard_normal(base.shape) * 0.001).astype(np.float16))
 
 
+def test_accuracy_check_rejects_missing_or_misordered_output_shape():
+    import numpy as np
+    import torch
+
+    from emmy.commands.run import _check_accuracy
+
+    outputs = {
+        "small": np.zeros(4, dtype=np.float32),
+        "large": np.zeros(8, dtype=np.float32),
+    }
+    eager = (torch.zeros(8), torch.zeros(4))
+
+    error = _check_accuracy(outputs, eager)
+
+    assert error is not None
+    assert "size 4 does not match eager 8" in error
+
+
+def test_accuracy_check_pairs_named_outputs_independent_of_mapping_order():
+    import numpy as np
+    import torch
+
+    from emmy.commands.run import _check_accuracy, _strict_correctness_proof
+
+    outputs = {
+        "small": np.zeros(4, dtype=np.float32),
+        "large": np.ones(8, dtype=np.float32),
+    }
+    eager = {
+        "large": torch.ones(8),
+        "small": torch.zeros(4),
+    }
+
+    assert _check_accuracy(outputs, eager) is None
+    assert _strict_correctness_proof(outputs, eager)["status"] == "pass"
+
+
 def test_accuracy_check_gaussian_fp16_budget_not_free():
     """A GAUSSIAN fp16 output earns no outlier budget (``peak ≈ 5·RMS`` — the heavy-tail
     signature ``peak > 8·RMS`` doesn't fire), and the escape hatch consults the budget:

--- a/tests/compiler/passes/test_schedule_site_ownership.py
+++ b/tests/compiler/passes/test_schedule_site_ownership.py
@@ -1,0 +1,52 @@
+"""Schedule-site ownership regressions."""
+
+from __future__ import annotations
+
+import torch
+
+
+class _NormalizedGqa(torch.nn.Module):
+    def forward(self, q, k, v):
+        q = (q.float() * torch.rsqrt(torch.mean(q.float() ** 2, dim=-1, keepdim=True) + 1e-6)).half()
+        k = (k.float() * torch.rsqrt(torch.mean(k.float() ** 2, dim=-1, keepdim=True) + 1e-6)).half()
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, enable_gqa=True)
+
+
+def test_nested_only_thread_work_does_not_invent_root_tile():
+    """A nested cooperative reduce owns WORK without creating a TILE slice at its root."""
+    from emmy.compiler import target as target_mod  # noqa: PLC0415
+    from emmy.compiler.context import Context  # noqa: PLC0415
+    from emmy.compiler.pipeline import CUDA_PASSES, LOOP_PASSES, Pass, Pipeline  # noqa: PLC0415
+    from emmy.compiler.pipeline.fork import flatten_leaves  # noqa: PLC0415
+    from emmy.compiler.pipeline.passes.lowering.tile._schedule import schedule  # noqa: PLC0415
+    from emmy.compiler.trace.torch import trace_module  # noqa: PLC0415
+
+    target_mod.set_target((9, 0))
+    try:
+        ctx = Context.from_target((9, 0), gpu_name="NVIDIA H200")
+        q = torch.randn(1, 16, 128, 128, dtype=torch.float16)
+        k, v = (torch.randn(1, 8, 128, 128, dtype=torch.float16) for _ in range(2))
+        graph = trace_module(_NormalizedGqa(), (q, k, v))
+        if "lowering/schedule" in CUDA_PASSES:
+            placed = Pipeline.build(CUDA_PASSES[: CUDA_PASSES.index("lowering/schedule")]).run(graph, ctx=ctx)
+        else:
+            prefix = Pipeline.build(LOOP_PASSES)
+            recognize = Pass.load("lowering/tile", len(prefix.passes), {"010_recognize"})
+            placed = Pipeline([*prefix.passes, recognize]).run(graph, ctx=ctx)
+        tile = placed.nodes["scaled_dot_product_attention"].op
+        leaves = flatten_leaves([schedule(tile, "scaled_dot_product_attention", {}, ctx)])
+        matching = [
+            leaf
+            for leaf in leaves
+            if leaf.knobs.get("WORK") == "t128"
+            and leaf.knobs.get("REDUCE") == ""
+            and leaf.knobs.get("REDUCE@flash_k_stat") == "coop"
+            and "TILE" not in leaf.knobs
+        ]
+
+        assert matching, "the fused GQA schedule must offer the nested-only cooperative row"
+        materialized = matching[0].expand()[0]
+        assert "TILE" not in materialized.schedule
+        assert materialized.schedule["REDUCE@flash_k_stat"].coop == 128
+    finally:
+        target_mod.set_target(None)

--- a/tests/compiler/passes/test_sync_transport.py
+++ b/tests/compiler/passes/test_sync_transport.py
@@ -1,0 +1,34 @@
+"""Generic sync compute-fill lowering invariants."""
+
+from emmy.compiler.ir.axis import Axis, AxisRole
+from emmy.compiler.ir.elementwise import ElementwiseImpl
+from emmy.compiler.ir.expr import Literal, Var
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
+from emmy.compiler.pipeline.passes.lowering.kernel._stage import CtaTile, SyncOperand, SyncTransport
+
+
+def test_compute_fill_suffixes_nested_ssa_for_every_vector_cell() -> None:
+    """Replicated computed operands must rename definitions inside nested statistic folds."""
+
+    def value(_k0, _row, col):
+        reduce_axis = Axis("r", 4)
+        loop = Loop(
+            axis=reduce_axis,
+            role=AxisRole.PLANAR,
+            body=Body(
+                (
+                    Load(name="value", input="x", index=(col, Var(reduce_axis.name))),
+                    Accum(name="acc", value="value", op=ElementwiseImpl("add"), axes=(reduce_axis.name,)),
+                )
+            ),
+        )
+        close = Assign(name="out", op=ElementwiseImpl("add"), args=("acc", "acc"))
+        return [loop, close], "out"
+
+    operand = SyncOperand(tag="b", shape=(1, 8), value=value)
+    transport = SyncTransport(operands=(operand,), slab_dtype="half", cta=CtaTile(Literal(0, "int"), 1), elem_bytes=2)
+    fill = Body(tuple(transport.fill(k0=Literal(0, "int"), slot=Literal(0, "int"), k0_cur=Literal(0, "int"))))
+
+    assert {acc.name for acc in fill.accums} == {f"acc__c{i}" for i in range(8)}
+    assert {load.names[0] for load in fill.loads if load.input == "x"} == {f"value__c{i}" for i in range(8)}
+    assert {assign.name for assign in fill.iter_of_type(Assign)} == {f"out__c{i}" for i in range(8)}


### PR DESCRIPTION
## Summary

Three standalone correctness fixes extracted from #508 so they can land independently of the placement-fork review. Each repairs a bug that exists on `main` today.

- **Nested SSA suffixing in the sync compute fill.** The transport's run-plan classification read shallow `defines()`, which misses names defined inside nested block statements. A computed operand whose value is a nested statistic fold collided all vector cells on one SSA name and silently hoisted the per-cell close, dropping every cell's contribution but one — a silent wrong-answer generator. All three classification sets now use `deep_defines`.
- **Nested-only terms invented a root TILE slice.** An empty TILE spelling beside a thread inventory resolves to a unit register tile only when the root owns a TILE site; a nested-only term (flash's dd/pj tiles under a reduce root) borrowed the shared thread inventory and invented a slice the tree-path codec cannot address.
- **Strict-run accounting holes.** Automatic working-golden rows were entirely unchecked whenever any `--ab` row was present; an output size mismatch in the accuracy check logged a warning and skipped the buffer instead of failing; and a name-keyed eager reference was not paired by name. Strict runs now count automatic rows against the resolved golden pins, check every pinned row, fail on size mismatches, and pair named outputs order-independently.

Each fix ships with a regression test verified to fail before and pass after.

## Verification

- `tests/compiler/passes/test_sync_transport.py`, `tests/compiler/passes/test_schedule_site_ownership.py`, and the strict/accuracy subset of `tests/compiler/cli/test_run.py` pass on this branch.
- The same changes are part of #508, where both full suites ran (RTX 5090 local; 8×V100 fully green).
- Ruff check and format clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)