### PR TITLE
Read a cell-varying contraction operand per register cell

### DIFF
--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -125,7 +125,12 @@ fill→drain skeleton — and the atom contributes only leaves, never a loop. Pe
   `LdmatrixLoad` / `MmaSyncPtx` / `RegStore` and decode the atom-lane offset at render.
 - **scalar** (`_ScalarOps`) — atom `(1, 1, 1)`, `lanes == 1`. The UNIT is a **single thread** (so there is no `_lane`
   axis); its leaves are plain `Load`s + an fma cell, the projection `tail` replicated per register cell with its
-  operand loads deduped (the arithmetic-intensity reuse).
+  operand loads deduped (the arithmetic-intensity reuse). One A read per register ROW and one B read per COLUMN is a
+  property of the OPERAND, not of the tier: a computed edge whose cone reads the OTHER output axis (an A broadcast
+  over n — the o_proj shape `out[m, n] = Σ_k B[n, k] · A[m, k, n]`) holds a different value in every cell of its row,
+  so it is read once per register CELL instead, σ-bound to both coordinates. Sharing it would both fold the wrong
+  value into every column past the first and leave the sibling coordinate free — the kernel binds only the split
+  `_b` / `_u` vars, so the per-copy rename would emit an identifier nothing defines.
 
 Each atom is a strategy class in **`_atom.py`** supplying `state` / `store` plus the descriptor reads the shared
 `reduce` consumes — `gmem_leaves` (the four gmem-direct leaf constructors), `staged_drain` (the slab-reading leaf),

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -739,6 +739,21 @@ def _unroll_inner(axis) -> bool:
     return unroll_ok(axis.extent, 64)
 
 
+def _cell_varying(body, side: Side | None) -> bool:
+    """Whether an operand's producing ``body`` varies along ``side`` — the OTHER output axis of the
+    register tile (n for A, m for B).
+
+    A gmem ``Load`` edge indexes its own axes only, so this is False and the tile's reuse holds: one
+    A read per register row, one B read per column. A COMPUTED edge is free to read the sibling
+    coordinate — the o_proj shape whose A cone is broadcast over n (``out[m, n] = Σ_k B[n, k] ·
+    A[m, k, n]``) — and then the row read is BOTH the wrong value for every column but the first and
+    a reference to a coordinate the kernel does not define: after the tile split only the ``_b`` /
+    ``_u`` split vars are bound, so the per-copy rename (:func:`copy_cell`) suffixes the surviving
+    axis name into an undefined identifier (nvcc: ``identifier "a1__ar9" is undefined``, the
+    whole-model qwen3-0.6b layer-0 o_proj on sm_89). Such an operand is read per CELL instead."""
+    return side is not None and Body(body).depends_on(body, side.name)
+
+
 def _dedup_loads(stmts: list[Stmt]) -> list[Stmt]:
     """Collapse syntactically-identical scalar ``Load``s (same buffer + index) to one binding,
     rewriting the dropped names to the survivor — the operand reuse a register tile exists for (a
@@ -1207,26 +1222,45 @@ class _ScalarOps(_AtomOps):
         gmem ``Load`` — or the computed register-resident body, e.g. flash PV's ``P``), each COL its
         B ``Load`` once, each ``(i, j)`` cell folds ``acc__c{i}_{j} += b·a``, and the K-loop is a unit
         ``Loop`` (``Loop.render`` seeds the accumulators; the store reads them). A masked axis wraps
-        its read in-bounds (``% extent``) and the overhanging store is guarded (:meth:`store`)."""
+        its read in-bounds (``% extent``) and the overhanging store is guarded (:meth:`store`).
+
+        An operand that VARIES ALONG THE OTHER output axis (:func:`_cell_varying`) is read once per
+        CELL instead — the row / column reuse is a property of the operand, not of the tier."""
         c = self.c
         assert len(self.channels) == 1, "the scalar tier is single-fold — a multi-B node rides the warp sync compute-fill"
         k_axis = c.axis
         m, n = mn
         prot = _scalar_protected(c, self.tile, self.lead)
         b_name, a_name = operand_name(c.b), operand_name(c.a)
+        a_body, b_body = operand_body(c.a), operand_body(c.b)
+        a_cell, b_cell = _cell_varying(a_body, n), _cell_varying(b_body, m)
+
+        def at_m(i):  # register row ``i``'s m coordinate (a 1-D output has no m side)
+            return {} if m is None else {m.name: _wrap(m, offset[0].base(i))}
+
+        def at_n(j):  # register column ``j``'s n coordinate
+            return {n.name: _wrap(n, offset[1].base(j))}
 
         def read_row(i):
-            if m is None:
-                return copy_cell(operand_body(c.a), Sigma({}), f"__ar{i}", prot)
-            return copy_cell(operand_body(c.a), Sigma({m.name: _wrap(m, offset[0].base(i))}), f"__ar{i}", prot)
+            return [] if a_cell else copy_cell(a_body, Sigma(at_m(i)), f"__ar{i}", prot)
 
         def read_col(j):
-            return copy_cell(operand_body(c.b), Sigma({n.name: _wrap(n, offset[1].base(j))}), f"__bc{j}", prot)
+            return [] if b_cell else copy_cell(b_body, Sigma(at_n(j)), f"__bc{j}", prot)
 
         def contract(i, j):
+            # A cell-varying operand's read lands here, σ-bound to BOTH coordinates and suffixed with
+            # the full cell, so every coordinate it mentions is substituted and each cell owns its copy.
+            cell = Sigma({**at_m(i), **at_n(j)})
+            a_sfx = f"__ar{i}_{j}" if a_cell else f"__ar{i}"
+            b_sfx = f"__bc{i}_{j}" if b_cell else f"__bc{j}"
+            reads = [
+                *(copy_cell(a_body, cell, a_sfx, prot) if a_cell else ()),
+                *(copy_cell(b_body, cell, b_sfx, prot) if b_cell else ()),
+            ]
             v = f"{c.acc}__v__c{i}_{j}"
             return [
-                Assign(name=v, op=_MUL, args=(f"{b_name}__bc{j}", f"{a_name}__ar{i}")),
+                *reads,
+                Assign(name=v, op=_MUL, args=(f"{b_name}{b_sfx}", f"{a_name}{a_sfx}")),
                 Accum(name=f"{c.acc}__c{i}_{j}", value=v, op=_ADD, axes=(k_axis.name,)),
             ]
 

--- a/tests/compiler/passes/test_scalar_cell_varying_operand.py
+++ b/tests/compiler/passes/test_scalar_cell_varying_operand.py
@@ -1,0 +1,110 @@
+"""The scalar register tile reads a CELL-varying operand once per cell, not once per row / column.
+
+The tile's reuse — one A read per register row, one B read per column — holds for a gmem ``Load``
+edge, which indexes its own axes only. A COMPUTED edge may read the OTHER output axis: the qwen3-0.6b
+layer-0 o_proj arrives as ``out[m, n] = Σ_k B[n, k] · A[m, k, n]``, its A cone broadcast over n. Read
+once per row, that A is both the wrong value for every column past the first and a reference to a
+coordinate nothing binds — the kernel decodes only the ``_b`` / ``_u`` split vars, so the per-copy
+rename suffixed the surviving axis name and nvcc rejected the kernel (``identifier "a1__ar9" is
+undefined``, 10 errors, one per register row, sm_89).
+
+The emission is exercised the way ``_factor._bind``'s output-tiled arm makes it — the atom's
+``reduce_codegen`` + ``store_sink`` sealed through ``grid_tile`` — so the assertions read the same
+``Tile`` the CUDA backend renders, without needing a GPU.
+"""
+
+from __future__ import annotations
+
+from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import Var
+from emmy.compiler.ir.schedule import TilePlan
+from emmy.compiler.ir.stmt import Assign, Body, Load, Stmt, Write
+from emmy.compiler.ir.tile import Channel, Fold
+from emmy.compiler.pipeline.passes.lowering.kernel._atom import reduce_codegen, store_sink
+from emmy.compiler.pipeline.passes.lowering.kernel._tiling import atomize, grid_tile, register_tile, unit_tile
+
+_M, _N, _K = Axis("m", 8), Axis("n", 8), Axis("k", 4)
+_PLAN = TilePlan(units=(2, 2), regs=(2, 2))  # a scalar 2×2 thread tile of 2×2 register cells
+
+
+def _a_load() -> Load:
+    """The ordinary A edge — indexed by its own ``(m, k)``, so it is shared down the register row."""
+    return Load(name="a", input="A", index=(Var("m"), Var("k")))
+
+
+def _b_load() -> Load:
+    return Load(name="b", input="B", index=(Var("n"), Var("k")))
+
+
+def _cone(name: str, buf: str, index: tuple) -> Fold:
+    """A computed operand edge (an inline producer cone) whose load carries ``index`` — the o_proj
+    shape's broadcast A when ``index`` mentions n."""
+    body = Body((Load(name=f"{name}_l", input=buf, index=index), Assign(name=name, op="multiply", args=(f"{name}_l", f"{name}_l"))))
+    return Fold.projection(body=body)
+
+
+def _tile(a, b):
+    """The scalar contraction ``a ⊗ b`` bound to the grid — the ``Tile`` and its ``(m, n)`` sides."""
+    c = Fold.contraction(k_axis=_K, a=a, channels=(Channel(b=b, acc="acc"),))
+    plan = _PLAN.at(_M, _N)
+    mn = plan.mn
+    state, reduce_region = reduce_codegen(c, plan)
+    epilogue = Body((Write(output="out", index=(Var("m"), Var("n")), value=c.acc),))
+    return grid_tile(
+        unit_tile(register_tile(atomize(plan.atom.shape[:2]), mn), mn),
+        mn=mn,
+        block_threads=plan.launch_threads,
+        lanes=plan.atom.lanes,
+        state_decls=state,
+        reduce_region=reduce_region,
+        store=store_sink(c, plan, epilogue),
+    ), mn
+
+
+def _unbound(tile) -> set[str]:
+    """The names the tile body reads without defining them or binding them as an axis. Anything left
+    is an identifier the rendered kernel would not define."""
+    body = Body(tile.body)
+    reads = {v for s in body.iter() for v in (*s.deps(), *(fv for e in s.exprs() for fv in e.free_vars()))}
+    defined = {n for s in body.iter() for n in s.defines()}
+    return reads - defined - set(body.axis_names) - {a.name for a in tile.axes}
+
+
+def _loads_of(tile, buf: str) -> tuple[Stmt, ...]:
+    return tuple(s for s in Body(tile.body).loads if s.input == buf)
+
+
+def _muls(tile) -> list[Stmt]:
+    return [s for s in Body(tile.body).iter() if isinstance(s, Assign) and s.name.startswith("acc__v")]
+
+
+def _cells(mn) -> list[tuple[int, int]]:
+    return [(i, j) for i in range(mn[0].reg) for j in range(mn[1].reg)]
+
+
+def test_a_operand_varying_along_n_is_read_per_cell() -> None:
+    """The reproducer. A's cone reads n, so each register cell gets its own copy, σ-bound to BOTH
+    coordinates — no axis name survives free, and each cell's multiply reads its own value."""
+    tile, mn = _tile(_cone("a", "A", (Var("m"), Var("k"), Var("n"))), _b_load())
+    assert _unbound(tile) == set()
+    assert len(_loads_of(tile, "A")) == len(_cells(mn))
+    assert {s.args[1] for s in _muls(tile)} == {f"a__ar{i}_{j}" for i, j in _cells(mn)}
+
+
+def test_b_operand_varying_along_m_is_read_per_cell() -> None:
+    """The mirror hazard on the B side — a computed B whose cone reads m cannot be shared across the
+    column either."""
+    tile, mn = _tile(_a_load(), _cone("b", "B", (Var("n"), Var("k"), Var("m"))))
+    assert _unbound(tile) == set()
+    assert len(_loads_of(tile, "B")) == len(_cells(mn))
+    assert {s.args[0] for s in _muls(tile)} == {f"b__bc{i}_{j}" for i, j in _cells(mn)}
+
+
+def test_materialized_operands_keep_the_row_and_column_reuse() -> None:
+    """The common matmul emission is untouched: one A read per register row, one B read per column —
+    the arithmetic-intensity reuse the register tile exists for."""
+    tile, mn = _tile(_a_load(), _b_load())
+    assert _unbound(tile) == set()
+    assert len(_loads_of(tile, "A")) == mn[0].reg
+    assert len(_loads_of(tile, "B")) == mn[1].reg
+    assert {s.args for s in _muls(tile)} == {(f"b__bc{j}", f"a__ar{i}") for i, j in _cells(mn)}


### PR DESCRIPTION
## Bug report (verified diagnosis; the repro is real)

**scalar leaf codegen emits an undefined variable for a computed A operand that varies along n
(whole-model Qwen3-0.6B, sm_89)**

Environment: RTX 4090 (sm_89), CUDA 13.3, torch 2.13.0+cu130, transformers 5.15.0, python 3.12.3, Ubuntu 24.04,
main @ 02a94511.

Reproduction: fresh main; `CUDA_HOME=/usr/local/cuda PATH=/usr/local/cuda/bin:$PATH ./venv/bin/emmy run
Qwen/Qwen3-0.6B`. Deterministic. Observed: nvcc compile failure in `k_linear_reduce_5ca923`: `identifier "a1__ar9"
is undefined` — 10 errors, one per register row (`a1__ar0`…`a1__ar9`). Axis names: `a0`=m, `a1`=n, `a2`=k; `_b`/`_u`
suffixes are a tiled axis's block/unit indices. The kernel never defines `a1__ar{i}` nor bare `a1` — n exists only as
`a1_b`/`a1_u`.

Diagnosis: The kernel realizes `out[m, n] = Σ_k B[n, k] · A[m, k, n]` — the o_proj matmul of layer 0's attention. Its
A operand is computed (in-kernel algebra, not a plain load). Frontend decomposition broadcasts A over n
(`broadcast_to`; the `_bc` buffer suffix is that pass's naming), so A's buffer `linear_3_a_unsq_bc` has layout
[m, k, n] = [512, 2048, 1024]. The scalar leaf codegen (`_ScalarOps` in
`emmy/compiler/pipeline/passes/lowering/kernel/_atom.py`) assumes that A, among the output axes, varies along m
alone. Its `gmem_leaves` `read_row` replicates A's inlined expression subtree (its "cone") once per register row,
substituting only the m coordinate, and all columns share the copy. The cone's n-axis reference survives as a free
name; `copy_cell`'s per-copy rename suffixes it (`a1` → `a1__ar{i}`) with no definition. Adding the name to
`_scalar_protected` does NOT fix it — bare `a1` is equally undefined (verified empirically). The repair looks
structural: either the leaf makes per-cell A copies (one per (row, column), substituting both coordinates), or the
leaf binder's eligibility check (`_factor._bind`) declines this operand shape so a different leaf codegen handles it.

## The fix

**Per-cell copies, in the scalar leaf** — the first of the two proposed repairs.

The register tile's read sharing (one A read per register ROW, one B read per COLUMN) is a property of the OPERAND,
not of the tier: a gmem `Load` edge indexes its own axes only, so it is genuinely uniform along the sibling axis. A
computed edge is free to read that axis, and then the row read is both the wrong value for every column past the
first and — because after the tile split only the `_b` / `_u` split vars are bound — a reference nothing defines.
`_ScalarOps.gmem_leaves` now asks that question per operand (`_cell_varying`, a `Body.depends_on` on the sibling
axis name) and, when the answer is yes, emits that operand's read inside `contract(i, j)` instead: one copy per
register cell, σ-bound to BOTH output coordinates, suffixed `__ar{i}_{j}` / `__bc{i}_{j}`. The mirror case (a
computed B whose cone reads m) takes the same path.

Why not the binder decline: declining would drop the shape out of the output-tiled arm into the degenerate
one-thread-per-output-cell fold — a large, permanent perf loss for a kernel the register tile can express exactly.
Declines belong where the tier structurally *cannot* represent the operand (the mma tier's CTA-shared smem slab is
such a place — a slab is shared across the sibling axis, so an operand varying along it has nowhere to live). A
per-thread register cell has no such constraint: it just has to read its own value.

Cost: the n-varying operand's reads cannot be shared, so its read count goes from `reg_m` to `reg_m · reg_n` per
K step. That is inherent to the shape — the values genuinely differ per column — and there is no regression against
the status quo, where the kernel did not compile at all. The common matmul emission (both operands materialized) is
untouched: same statements, same names, same order, verified by a test that pins the row/column form.

Scope note (not fixed here, no repro): the mma tier's `sync` compute-fill has the analogous exposure —
`_sync_operands.a_value` σ-binds only `(m, k)`, so a computed A cone that reads n would leak the same bare axis
name into the slab fill. Unlike the scalar cell, a CTA-shared slab cannot hold an n-varying A at all, so the repair
there is an eligibility decline in `computed_operand_cover` rather than more copies. Left alone deliberately: it
needs its own repro, and a purely syntactic decline would also refuse the value-dead sibling residues
`_sibling_sigma` exists to handle (PR #507), so it is a separate change with its own risk.

## Verification (RTX 4090, sm_89, CUDA 13.0, `EMMY_NVCC_FLAGS="-Xcicc -O1"`)

In-repo reproducer — `tests/compiler/e2e/test_block.py` (the same kernel, `linear_3_a_unsq_bc`, same
`identifier "a1__ar{i}" is undefined`), on this branch's tree with and without the patch:

| | before (origin/main) | after |
| --- | --- | --- |
| `tests/compiler/e2e/test_block.py` | 2 failed, 1 passed | 3 passed |
| `tests/compiler/passes/test_scalar_cell_varying_operand.py` (new) | 2 failed, 1 passed | 3 passed |

`test_block.py::test_qwen_block_accuracy` is the report's kernel: same buffer (`linear_3_a_unsq_bc`), same
`k_linear_reduce_*` name, same four/ten `a1__ar{i}` errors — a Qwen3 layer-0 block compiled end to end and compared
against torch eager, so the "after" column is a NUMERIC check, not just a successful nvcc run.

The report's own command, `emmy run Qwen/Qwen3-0.6B`, was also run on the patched tree, and did NOT reach an
end-to-end verdict — for a reason that sits outside this change. It compiles past the point where main stops (the
kernel that used to abort the run is emitted and accepted by nvcc; kernel compiles continued for another eight
minutes with no nvcc error), then spends 70+ minutes at 100% CPU inside the FRONTEND loop-fusion pass — a py-spy
dump shows hundreds of nested frames of the `source_buffers` generator in `passes/loop/fusion/010_merge_loop_ops.py`
— and finally dies there without writing anything further to its log (no traceback: consistent with a C-stack
overflow in that recursion; the kernel log records no OOM kill for it). That pass runs before kernel lowering and
cannot see this change. `emmy run --layer 0` cannot substitute either: it stops earlier on the pre-existing
`Input arity mismatch: graph has 4 inputs, code provided 3`, on both trees. So the whole-model command remains
blocked on a separate, pre-existing frontend problem; the kernel this PR fixes is covered by the block-level
evidence above.

Full paired run of the two directories around the change, same command on both trees
(`pytest tests/compiler/passes/ tests/compiler/e2e/ -p no:randomly -n 4 --dist=loadgroup`):

| | before (origin/main) | after |
| --- | --- | --- |
| result | **8 failed**, 682 passed, 122 skipped, 1 xfailed, 127 errors | **4 failed**, 686 passed, 122 skipped, 1 xfailed, 127 errors |

The four that flipped are exactly this bug (the two `test_block` CUDA cases + the two new unit tests). The four that
remain, and the 127 setup errors, are identical on both trees: three `test_matmul_coverage` cases die with
`CUDA error: misaligned address`, which poisons their xdist worker's CUDA context so every later test on that worker
errors in `torch.manual_seed` — the known pre-existing failure on this box.
`test_fused_edge.py::test_sdpa_consumer_projection_reaches_mma` also fails on both; run in isolation (uncontaminated
context) it is 1 failed / 20 passed / 4 skipped on **both** trees, so it is pre-existing and untouched by this
change.

Pre-existing failures on this box (present on pristine main, unrelated, not chased):
`CUDA_ERROR_MISALIGNED_ADDRESS` in `tests/compiler/e2e/test_matmul_coverage.py` and
`tests/compiler/backend/test_pack_gpu.py`, and the `emmy run --layer` arity mismatch. A GPU box also trips the
`tests/durations.json` staleness gate for the two `test_block` CUDA cases — the checked-in baseline is measured
without CUDA, so it holds no `[cuda]` entries; that gate fires for any GPU-only test ≥ 5 s and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vgf2BkkXJcBWZvDwEgDSgG
