### PR TITLE
Add Neptune A100 compiler comparison

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -124,8 +124,9 @@ keeps the existing Transformers path. `dit` delegates to the Diffusers block ada
 requires `--layer`, accepts the checkpoint's layers 0-27, and rejects dynamic shapes in v1. `run --bench` and
 `tune --bench` include the adapter in the isolated worker's reconstruction payload, so eager PyTorch, `torch.compile`,
 and Emmy always rebuild the same module and example inputs. Inductor compiles with
-`fullgraph=True, mode="max-autotune"`; its output must match eager on the same inputs at `rtol=atol=1e-3` before its
-latency is accepted. `run --strict` makes every requested backend, captured timing, exact pin, and direct
+`fullgraph=True, mode="max-autotune-no-cudagraphs"`; the harness supplies the shared outer CUDA graph so every backend
+has identical captured timing semantics. Inductor output must match eager on the same inputs at `rtol=atol=1e-3`
+before its latency is accepted. `run --strict` makes every requested backend, captured timing, exact pin, and direct
 Emmy-vs-eager proof authoritative. It records max/mean/relative error in `--json` and exits
 nonzero on any missing or failed evidence. Dynamic-shape parsing, quantized architecture twins and
 their in-graph storage algebra, sliding-window stamps, and the guarded `trust_remote_code` fallback therefore behave

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -2737,7 +2737,10 @@ def _build_torch_fns(module, args, kwargs, warmup, *, backends: set[str]):
             import torch._dynamo  # noqa: PLC0415
 
             torch._dynamo.reset()
-            compiled_torch_module = torch.compile(module, fullgraph=True, mode="max-autotune")
+            # The benchmark owns one outer CUDA graph for every backend. Letting
+            # Inductor create its own graph here makes that capture nested and
+            # invalidates it on recent PyTorch releases.
+            compiled_torch_module = torch.compile(module, fullgraph=True, mode="max-autotune-no-cudagraphs")
             for _ in range(warmup + 5):
                 with torch.no_grad():
                     compiled_torch_module(*args, **kwargs)

--- a/experiments/golden-bench-2026/README.md
+++ b/experiments/golden-bench-2026/README.md
@@ -15,6 +15,7 @@ artifacts exist and an intelligent reviewer accepts them against the checklist b
 | Large-layer shape stress | Qwen3.6-27B layers 0 and 3, sequence lengths 1 and 512 | H200 and B200 | Unsharded BF16 large-shape stress only |
 | End-to-end serving | Pinned recipes below | Consumer single GPU; datacenter TP8 except the V100 TP8xPP2 lane | System performance for explicitly matched stock and Emmy arms |
 | Megakernel decode pair | Qwen3-8B, one 128/512 single-stream point | A100 | Cross-harness kernel-launch-overhead comparison |
+| Neptune compiler comparison | 10 artifact operators and a five-operator Emmy/PyTorch subset | A100 80GB | One archived cross-compiler result |
 
 The BF16 sets produce separate tables and separate geometric means. The unsharded large-layer corpus is not TP8,
 quantization, or serving evidence and cannot explain an end-to-end result. Dynamic-FP8 layer traces are preserved as
@@ -60,7 +61,7 @@ The directly searched winner must match its measured knob map exactly. The recip
 `emmy run --golden working.yaml --strict` five times at deployable `-O3`, with 10 warmups and 100 measured iterations.
 Each ordinary invocation is an independent process; the CLI contains no repetition or child-process wrapper. It records the exact searched winner and deploy-path
 Emmy timing and compares with eager PyTorch and Inductor. Inductor uses the installed PyTorch equivalent of
-`mode="max-autotune"` with `fullgraph=True`.
+`mode="max-autotune-no-cudagraphs"` with `fullgraph=True`; the benchmark harness supplies the shared outer CUDA graph.
 Inductor must compile the full graph and match eager output on the same inputs before its latency is accepted. Any
 failed, ambiguous, unmatched, uncaptured, or non-whole-program winner fails after archiving diagnostics.
 
@@ -198,6 +199,76 @@ negligible at single-token decode. The same calibrations define the per-kernel h
 latency over max(weight-streaming floor, compute floor) for that kernel's weight bytes and token width — which
 decomposes an end-to-end decode gap into per-kernel code headroom versus inter-kernel launch and scheduling gaps.
 This recipe preserves the raw MPK and vLLM outputs; any separate analysis owns the roofline calculations.
+
+## Neptune compiler comparison
+
+`compiler_neptune_emmy_pytorch_a100` owns both parts of the A100 comparison and produces one artifact archive for one
+eventual `RESULTS.md`. Its pinned container first runs Neptune's published A100 attention matrix on an A100 80GB:
+Global prefill; Causal, GQA, ALiBi, and SoftCap in both prefill and decode; and Window prefill. Every operator runs in
+FP16 at batch 1 and sequence lengths 256 through 32768 in powers of two, for 80 setups. Each eligible Neptune
+scheduler receives 128 tuning trials. The unmodified artifact then performs its one warmup and 15 profiled calls for
+every supported runner. The immutable Neptune image and its upstream source are pinned and checked before the first
+setup. Neptune published its A100 results on the 40GB model, so this is the same software and operator protocol on a
+different-memory A100 rather than an exact hardware reproduction.
+
+A failed tuning setup does not suppress its manual Neptune and registered-baseline profile, and a failed profile does
+not suppress later setups. `neptune-setup-status.tsv` records both outcomes. Missing or failed rows remain missing
+evidence; the results assembler must report them rather than treating the experiment's eventual archive as full
+coverage. The status also flags a zero-record tune, output mismatch, or runner exception that the pinned CLI otherwise
+logs only as a warning.
+
+The artifact recognizes only the product string `NVIDIA A100-SXM4-40GB`. The experiment's narrow launcher maps the
+80GB product string to that name only inside the Neptune CLI process so the artifact selects its existing `sm_80`
+A100 target; it does not modify Neptune's source. The surrounding evidence records the actual 80GB product name,
+memory, clocks, and driver. The pinned CLI also contains a truncated `NeptuneGQARunner.e(...)` call that prevents
+module import. The launcher supplies that missing name as an alias of the existing `create_flex_from_schedulers`
+factory, matching current upstream Neptune while leaving the checked source unchanged.
+
+Do not use an ALiBi speedup unless its outputs pass an independent oracle. In the pinned source, prefill FlexAttention
+constructs a causal mask but its override never installs that mask, while decode Neptune reuses a constructor that
+applies a causal mask to a one-token query. The first makes FlexAttention noncausal; the second makes Neptune attend
+only the first KV token. An A100 80GB smoke check against a dense FP32 PyTorch oracle confirmed the respective errors.
+The experiment keeps these published registrations for provenance and surfaces their mismatch; it does not patch them.
+
+The paper prose says 128 through 32768 while also specifying eight lengths and 320 total setups. The checked-in
+artifact sweep uses 256 through 32768, which is the eight-point range reproduced here; preserve this discrepancy in
+any report rather than silently adding a ninth setup.
+
+This lane deliberately applies no patch to Neptune. It retains every compiler and optimized-library baseline that the
+artifact registers, including FlexAttention's `torch.compile(flex_attention)` path. That is an Inductor comparison,
+but it uses the artifact's pinned PyTorch 2.6.0 rather than a recent PyTorch release. The direct PyTorch SDPA runners
+are library paths, not current-Inductor arms, and the artifact's dormant `UNFUSED_COMPILED` helper is not registered.
+After the container exits, the same recipe runs the current-PyTorch and Emmy subset in a separate host environment
+pinned to PyTorch 2.13.0. Do not present those results as part of the artifact-exact reproduction.
+
+Nsight Systems preserves the raw NVTX ranges and CUDA traces. Any comparison with a multi-kernel compiler invocation
+must use total CUDA device time within its measured range, not the fastest individual kernel. The artifact arm is not
+an Emmy result and is not part of the common-kernel geometric mean.
+
+The current-PyTorch and Emmy arm covers the five native-SDPA operators that Emmy can reconstruct without changing
+their mathematics: Global, Causal, and GQA prefill; and Causal and GQA decode. The same eight sequence lengths produce
+40 setups on the same A100 80GB. ALiBi, SoftCap, and windowed-SoftCap remain outside this starter denominator; do not
+treat their absence as support or silently replace their score modifications with plain SDPA.
+
+Each setup runs in a fresh `emmy run` process with FP16 inputs, batch 1, one warmup, and 15 measured iterations.
+`--strict` requires eager PyTorch, `torch.compile`, and Emmy to execute with captured timing and requires Emmy and
+`torch.compile` to match eager output. PyTorch is pinned to 2.13.0; Emmy invokes it with `fullgraph=True` and
+`mode="max-autotune-no-cudagraphs"`, then captures it in the same outer CUDA graph used for every backend. The compiled
+wrapper may select a fused SDPA library backend, so report this arm as current
+PyTorch `torch.compile`/SDPA rather than claiming that every timed kernel was generated by Inductor.
+
+A setup that fails strict correctness or exceeds ten minutes is recorded in `setup-status.tsv` and skipped so one hard
+Emmy case does not discard later PyTorch/Emmy rows. Such a row is unsupported evidence, not a performance result.
+
+Decode GQA spells its eight query heads per KV head as a broadcast batch dimension. This is mathematically equivalent
+to `enable_gqa=True`, avoids materializing repeated K/V tensors, and keeps decode noncausal after PyTorch export drops
+the explicit false causal flag while retaining the true GQA flag.
+
+The CLI records the minimum of its 15 captured measurement windows. A direct Neptune comparison must therefore
+extract the same statistic from Neptune's 15 raw NVTX calls, match rows by operator and sequence length, and keep the
+artifact's PyTorch 2.6.0 results separate from the current-PyTorch arm. The combined experiment remains planned
+evidence until its common archive exists and passes intelligent review; it is not part of the common-kernel geometric
+mean.
 
 ## Intelligent publication review
 

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/RESULTS.md
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/RESULTS.md
@@ -1,0 +1,109 @@
+# Neptune, modern PyTorch, and untuned Emmy on A100
+
+## Conclusion
+
+The starter comparison is feasible and reproducible, but it does not support a broad Neptune advantage over current
+PyTorch. Across the three prefill families shared by both systems, PyTorch 2.13 Inductor was faster than the fastest
+available Neptune schedule by 11–20% geometric mean. Neptune was approximately tied on ordinary decode: its best
+available schedules were 1.07x faster than Inductor, while its fixed manual schedules were 0.99x as fast.
+
+Decode GQA is the clear Neptune result. Neptune was 3.01x faster than Inductor by geometric mean across all eight
+sequence lengths, with per-shape speedups from 1.68x to 4.54x. Inductor itself was 7.67x faster than eager PyTorch on
+that family, so Neptune's advantage remains after using a recent compiler baseline rather than the PyTorch 2.6 stack
+inside the published artifact.
+
+Untuned Emmy is not competitive in this run, as expected. It produced correct captured timings for 22 of 24 prefill
+setups, but those rows were much slower than PyTorch. Its two largest causal/GQA prefill kernels tripped the watchdog,
+and all 16 decode setups failed strict eager correctness. Those failures are retained as results, not silently dropped;
+an independent PyTorch fallback preserved eager and Inductor measurements for every affected setup.
+
+## Common operator measurements
+
+The Neptune columns report `Inductor latency / Neptune latency`, so values above 1.00x favor Neptune. "Best" selects
+the fastest measured manual or tuned Neptune schedule; "manual" uses only the artifact's fixed manual schedules. Each
+summary is the geometric mean over eight sequence lengths from 256 through 32768.
+
+| Operator | Inductor vs eager | Neptune vs Inductor, best | Neptune vs Inductor, manual | Full tunes | Valid Emmy |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Prefill global | 1.02x | 0.84x | 0.82x | 8/8 | 8/8 |
+| Prefill causal | 1.05x | 0.90x | 0.89x | 5/8 | 7/8 |
+| Prefill GQA | 1.05x | 0.86x | 0.84x | 6/8 | 7/8 |
+| Decode causal | 1.01x | 1.07x | 0.99x | 7/8 | 0/8 |
+| Decode GQA | 7.67x | 3.01x | 2.90x | 8/8 | 0/8 |
+
+Best-available Neptune beat Inductor on 15 of the 40 individual shapes: two prefill, five decode-causal, and all eight
+decode-GQA setups. The decode-GQA speedup increased with context, from 1.68x at sequence 256 to 4.54x at sequence
+32768. By contrast, Neptune's best prefill results ranged from 0.76x to 1.19x Inductor across individual shapes.
+
+## Published artifact coverage
+
+All ten operator families and all eight sequence lengths produced Nsight profiles. Sixty-four of 80 tuning jobs
+completed their 128-trial search; 16 reached the 30-minute per-setup limit. Timed-out rows still profile the available
+manual and partial tuned schedules and are not described as fully tuned.
+
+The speedup column compares the fastest available Neptune schedule with the fastest valid non-Neptune runner in the
+published artifact. Values above 1.00x favor Neptune. The artifact uses PyTorch 2.6, so this table characterizes
+Neptune's original comparison environment; the modern Inductor comparison above is the more relevant baseline.
+
+| Published operator | Full tunes | Profiles | Neptune vs fastest valid artifact runner | Validity note |
+| --- | ---: | ---: | ---: | --- |
+| Prefill global | 8/8 | 8/8 | 0.78x | Excludes the mismatching Tri Dao Triton rows at 256–1024 |
+| Prefill causal | 5/8 | 8/8 | 0.78x | Excludes the mismatching Tri Dao Triton runner |
+| Prefill GQA | 6/8 | 8/8 | 0.76x | Excludes the mismatching Tri Dao Triton runner |
+| Decode causal | 7/8 | 8/8 | 1.04x | No cross-runner mismatch |
+| Decode GQA | 8/8 | 8/8 | 1.21x | No cross-runner mismatch |
+| Prefill ALiBi | 6/8 | 8/8 | Excluded | Flex and CUTLASS disagree with Neptune on all shapes |
+| Decode ALiBi | 8/8 | 8/8 | Excluded | Flex and CUTLASS disagree with Neptune on all shapes |
+| Prefill softcap | 4/8 | 8/8 | 1.04x | Compared with Flex |
+| Decode softcap | 8/8 | 8/8 | 4.96x | Compared with Flex |
+| Prefill windowed | 4/8 | 8/8 | 0.68x | Compared with CUTLASS |
+
+The harness treats a Neptune manual schedule as its correctness reference. Agreement from the other runners supports
+the non-ALiBi rows, but it is not an independent oracle for Neptune. ALiBi is therefore excluded rather than assigning
+the disagreement to either side.
+
+## Protocol and limitations
+
+- Neptune ran revision `3aa55c12ac822337e630b809b0d9eabb11eee5d3` in the pinned image
+  `evanzhao16/neptune-env@sha256:724d07594bc817f0fe94267b2d0dbdc6e29d3ae4a7e3516e553a6d9327bfebca`.
+  The artifact environment recorded PyTorch 2.6.0 with CUDA 12.4 and Nsight Systems 2025.3.1.
+- The common lane reconstructed global, causal, and GQA attention for prefill and decode through `emmy run -c ...
+  --bench`. It used PyTorch 2.13.0 with CUDA 13.0, full-graph Inductor in `max-autotune-no-cudagraphs` mode, untuned
+  Emmy, one warmup, 15 measured iterations, and strict correctness.
+- When Emmy failed before producing a shared table, the fallback measured only eager and Inductor after checking the
+  compiled output against eager at `rtol=1e-3, atol=1e-3`. All 40 Inductor rows passed, and every PyTorch timing used
+  CUDA-graph-captured whole-forward semantics.
+- Neptune latency is the minimum projected GPU time over 15 measured NVTX ranges. The PyTorch/Emmy lane uses the
+  minimum CUDA-event time over 15 interleaved or fallback measurements. Both are GPU-time measurements, but they came
+  from separate processes and software environments; cross-system ratios should be treated as kernel-level evidence,
+  not an end-to-end application result.
+- The softcap, ALiBi, and windowed families have no current PyTorch/Emmy twin in this experiment. Their table only
+  reproduces the runners shipped in Neptune's artifact.
+
+## Run and system
+
+- Status: succeeded
+- Result timestamp: 2026-08-16T00:41:38Z; run ID: `20260816T004138Z`
+- Experiment row: `compiler_neptune_emmy_pytorch_a100_recovery/a100x1`; row ID: `e246bb6279fd`
+- Git revision: `2550211d9c93e522ea4f9eb81e39735f4ab64d07`; dirty: false
+- Host: `riftvm`; Ubuntu 24.04.1 LTS; kernel `6.8.0-51-generic`
+- CPU: AMD EPYC 7742 64-Core Processor, x86_64, 15 logical CPUs; memory: 221634367488 bytes
+- GPU: NVIDIA A100-SXM4-80GB, 81920 MiB, UUID `GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e`
+- NVIDIA driver: `580.65.06`; host NVCC: `12.9.86`; host cuBLAS: `12.9.1.4`
+- Docker client/server: `28.5.1` / `28.5.1`
+
+The source run (`20260815T040818Z`) completed all Neptune work in 71393.66 seconds, then failed because the host lane
+started outside the staged repository. The successful 2353.12-second recovery verified the immutable source archive's
+SHA-256 (`775fb71d3eac78f0371c1014b9945b29d17f41202347f8115e8703db5a4c14ca`), retained its failed status, and ran
+only the missing host lane. The durable `recipe.yaml` contains the corrected working directory for clean future runs.
+
+## Durable files
+
+- Experiment record: `a100x1_e246bb6279fd.experiment.yaml`
+- Raw-results archive: `results.tar.gz`; SHA-256
+  `617f44ee6c6c5cff6dc637d1924a8071b8bc547f6edbb77d3e61e7548bbfee03`
+- Archived root: `2026-08-16_00-41-38/`
+- Composite task artifact: `a100x1_artifacts.tar.gz`; SHA-256
+  `015951d7cccf187c69dd2712bcaf966f3de179b53508942312a0e8e6cc31e4b5`
+- Raw evidence includes 80 `.nsys-rep` profiles, 80 CSV exports, all tune/profile logs, 40 modern PyTorch JSON rows,
+  Emmy dumps and logs, environment freezes, runner hashes, source/recovery status files, and both run records/logs.

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/RESULTS.md
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/RESULTS.md
@@ -7,6 +7,11 @@ PyTorch. Across the three prefill families shared by both systems, PyTorch 2.13 
 available Neptune schedule by 11–20% geometric mean. Neptune was approximately tied on ordinary decode: its best
 available schedules were 1.07x faster than Inductor, while its fixed manual schedules were 0.99x as fast.
 
+This prefill result agrees with the Neptune paper once its baselines are separated correctly. The paper compares
+Neptune with tensor compilers in Table 2 and with manually optimized libraries in Table 4. On A100, its library table
+also reports that the best library beats Neptune on global, causal, and GQA prefill. The current PyTorch lane is a new
+comparison with `torch.compile`, not a reproduction of the paper's tensor-compiler table.
+
 Decode GQA is the clear Neptune result. Neptune was 3.01x faster than Inductor by geometric mean across all eight
 sequence lengths, with per-shape speedups from 1.68x to 4.54x. Inductor itself was 7.67x faster than eager PyTorch on
 that family, so Neptune's advantage remains after using a recent compiler baseline rather than the PyTorch 2.6 stack
@@ -35,6 +40,49 @@ Best-available Neptune beat Inductor on 15 of the 40 individual shapes: two pref
 decode-GQA setups. The decode-GQA speedup increased with context, from 1.68x at sequence 256 to 4.54x at sequence
 32768. By contrast, Neptune's best prefill results ranged from 0.76x to 1.19x Inductor across individual shapes.
 
+## Alignment with the Neptune paper
+
+The [Neptune paper](https://arxiv.org/abs/2510.08726) reports the geometric-mean speedup of Neptune over the fastest
+manually optimized library in Table 4. To compare with that table, the replay values below use the arithmetic mean of
+the 15 projected GPU times for each implementation and then the geometric mean across the eight sequence lengths.
+This is the closest aggregation available in the durable Nsight exports to the paper's mean-of-15 kernel rule. Values
+above 1.00x favor Neptune.
+
+| Operator | Paper, A100 | This artifact replay | Difference |
+| --- | ---: | ---: | ---: |
+| Prefill global | 0.84x | 0.79x | -5.5% |
+| Prefill causal | 0.81x | 0.79x | -2.7% |
+| Prefill GQA | 0.80x | 0.78x | -3.1% |
+| Decode causal | 0.99x | 1.05x | +6.1% |
+| Decode GQA | 1.24x | 1.19x | -3.9% |
+| Prefill windowed | 0.70x | 0.68x | -2.3% |
+
+The six comparable library results agree within 2.3–6.1%. In particular, both the paper and this replay find that
+optimized libraries beat Neptune on the three common A100 prefill operators, while Neptune is competitive on causal
+decode and ahead on GQA decode. The paper used an A100-SXM4-40GB, whereas this run used an A100-SXM4-80GB; the GPUs
+have the same compute architecture but different memory systems, so exact latency equality is not expected.
+
+The paper's Table 2 reports Neptune relative to Triton, FlexAttention, TVM, and Mirage, rather than to the manually
+optimized libraries. The pinned artifact revision leaves its TVM runners disabled, so this experiment cannot claim a
+complete reproduction of every Table 2 cell. Its PyTorch 2.6 runners also select specialized SDPA, cuDNN, or CUTLASS
+paths; they are not equivalent to the full-graph PyTorch 2.13 lane added here.
+
+The paper does not publish per-shape latency tables or raw plot data. Its absolute attention results are throughput
+plots at sequence length 8192 over varying batch sizes. Representative absolute minima from this run are below,
+reported as `Neptune / torch.compile` in microseconds. These use the experiment's minimum-of-15 convention, not the
+paper-style means in the alignment table.
+
+| Operator | Sequence 2048 | Sequence 32768 |
+| --- | ---: | ---: |
+| Prefill global | 479.8 / 364.5 | 83,978.9 / 75,066.4 |
+| Prefill causal | 298.0 / 243.7 | 45,798.3 / 40,020.0 |
+| Prefill GQA | 488.7 / 405.5 | 91,127.6 / 79,070.2 |
+| Decode causal | 35.3 / 30.7 | 320.7 / 322.6 |
+| Decode GQA | 15.8 / 41.0 | 111.1 / 503.8 |
+
+The absolute trend is coherent with the ratios: prefill remains close but favors current PyTorch, causal decode
+converges toward parity, and Neptune's decode-GQA advantage grows with context length.
+
 ## Published artifact coverage
 
 All ten operator families and all eight sequence lengths produced Nsight profiles. Sixty-four of 80 tuning jobs
@@ -61,6 +109,10 @@ Neptune's original comparison environment; the modern Inductor comparison above 
 The harness treats a Neptune manual schedule as its correctness reference. Agreement from the other runners supports
 the non-ALiBi rows, but it is not an independent oracle for Neptune. ALiBi is therefore excluded rather than assigning
 the disagreement to either side.
+
+SoftCap decode is the remaining performance-reproduction outlier. This replay reports 4.96x over Flex, while the
+paper's A100 compiler table reports 1.86x over its best compiler baseline. The modern PyTorch lane does not implement
+SoftCap, so this result should not be treated as reproduced until that difference is explained.
 
 ## Protocol and limitations
 

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/a100x1_e246bb6279fd.experiment.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/a100x1_e246bb6279fd.experiment.yaml
@@ -1,0 +1,90 @@
+schema_version: 2
+timestamp: '2026-08-16T00:41:38Z'
+status: succeeded
+experiment:
+  task_id: compiler_neptune_emmy_pytorch_a100_recovery/a100x1
+  row_id: e246bb6279fd
+  directory: experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100_recovery
+  kind: command
+  variant: a100x1
+  parameters:
+    deploy.gpu: NVIDIA A100 80GB
+    deploy.gpu_count: 1
+provenance:
+  git_revision: 2550211d9c93e522ea4f9eb81e39735f4ab64d07
+  git_dirty: false
+system:
+  hostname: riftvm
+  os:
+    name: Ubuntu 24.04.1 LTS
+    id: ubuntu
+    version: '24.04'
+    kernel: 6.8.0-51-generic
+  cpu:
+    model: AMD EPYC 7742 64-Core Processor
+    architecture: x86_64
+    logical_count: 15
+    sockets: 15
+    cores_per_socket: 1
+    threads_per_core: 1
+    numa_nodes: 1
+  memory:
+    total_bytes: 221634367488
+  gpus:
+  - index: 0
+    name: NVIDIA A100-SXM4-80GB
+    vendor: NVIDIA
+    uuid: GPU-b0354a1a-37c2-086d-f6fe-953b6fac5c3e
+    pci_bus_id: '00000000:01:00.0'
+    memory_total_mib: 81920
+    driver_version: 580.65.06
+    performance_state: P0
+    temperature_c: 36.0
+    utilization_percent: 18.0
+    sm_clock_mhz: 1380.0
+    memory_clock_mhz: 1593.0
+    power_draw_w: 69.26
+    power_limit_w: 550.0
+  gpu_pci_devices:
+  - pci_bus_id: '0000:01:00.0'
+    vendor_id: 10de
+    device_id: 20b2
+    vendor: NVIDIA
+    name: NVIDIA A100 80GB
+  software:
+    nvcc_version: 12.9.86
+    cublas_version: 12.9.1.4
+    docker_client: 28.5.1
+    docker_server: 28.5.1
+    docker_os: Ubuntu 24.04.1 LTS
+  root_filesystem:
+    device: /dev/vda1
+    type: ext4
+    total_bytes: 830970236928
+    used_bytes: 146235191296
+    available_bytes: 684718268416
+    mount: /
+  uptime_seconds: 168976.11
+  amd_smi: null
+execution:
+  run_id: 20260816T004138Z
+  stage: complete
+  started_at: '2026-08-16T00:41:38Z'
+  completed_at: '2026-08-16T01:20:56Z'
+  timing_seconds:
+    remote_provision: 2.98
+    command: 2350.13
+    total: 2353.12
+  infrastructure:
+    group: a100_x_1
+    requested_gpu: NVIDIA A100 80GB
+    requested_gpu_count: 1
+    address: riftuser@66.172.10.143
+    ssh_port: 22
+    provider: null
+    instance_id: null
+    zone: null
+    state: external
+    deleted_at: null
+  error: null
+  cleanup_error: null

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
@@ -32,7 +32,7 @@ command:
         final_status=1
       fi
       printf 'status=%s\n' "$$final_status" > $task_dir/status.txt
-      archive_tmp=$${task_dir}.artifacts.tar.gz
+      archive_tmp=$task_dir.artifacts.tar.gz
       tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
       mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
       exit "$$final_status"

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
@@ -1,0 +1,79 @@
+# Neptune's published A100 matrix plus a current-PyTorch/Emmy native-SDPA subset in one durable experiment.
+# The artifact stays unmodified in its pinned container; the paired host lane pins PyTorch 2.13.0.
+#
+# Repro on a pre-allocated A100 80GB (no cloud provisioning):
+#   emmy bench experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100 --local
+command:
+  stage:
+    - emmy
+    - pyproject.toml
+    - README.md
+    - LICENSE
+    - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
+    - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py
+    - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+  strict: true
+  run: |
+    set -euo pipefail
+    IMAGE=evanzhao16/neptune-env@sha256:724d07594bc817f0fe94267b2d0dbdc6e29d3ae4a7e3516e553a6d9327bfebca
+    NEPTUNE_REV=3aa55c12ac822337e630b809b0d9eabb11eee5d3
+    NEPTUNE_RUNNER=$repo_dir/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
+    NEPTUNE_ENTRY=$repo_dir/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py
+    EMMY_RUNNER=$repo_dir/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+    EVIDENCE=$task_dir/evidence
+    mkdir -p "$$EVIDENCE"
+    finalize() {
+      final_status=$$?
+      trap - EXIT
+      if [ -x ./venv/bin/pip ]; then
+        ./venv/bin/pip freeze --all > "$$EVIDENCE/emmy-requirements.freeze.txt" || final_status=1
+      else
+        echo "venv pip unavailable" > "$$EVIDENCE/emmy-requirements.freeze.txt"
+        final_status=1
+      fi
+      printf 'status=%s\n' "$$final_status" > $task_dir/status.txt
+      archive_tmp=$${task_dir}.artifacts.tar.gz
+      tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
+      mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
+      exit "$$final_status"
+    }
+    trap finalize EXIT
+
+    docker pull "$$IMAGE" 2>&1 | tee "$$EVIDENCE/docker-pull.log"
+    docker image inspect "$$IMAGE" > "$$EVIDENCE/image-inspect.json"
+    docker run --rm --gpus all --ipc=host \
+      -e CUDA_VISIBLE_DEVICES=$gpu_device_ids \
+      -e NEPTUNE_REV="$$NEPTUNE_REV" \
+      -v "$$EVIDENCE:/results" \
+      -v "$$NEPTUNE_RUNNER:/experiment/run.sh:ro" \
+      -v "$$NEPTUNE_ENTRY:/experiment/run_neptune.py:ro" \
+      "$$IMAGE" bash /experiment/run.sh 2>&1 | tee "$$EVIDENCE/container.log"
+
+    export PATH=/usr/local/cuda/bin:$$PATH
+    if [ ! -x ./venv/bin/python ]; then
+      python3.12 -m venv venv --prompt emmy
+    fi
+    ./venv/bin/pip install -e ".[dev]" torch==2.13.0 2>&1 | tee "$$EVIDENCE/emmy-install.log"
+    test "$$(./venv/bin/python -c 'import torch; print(torch.__version__.split("+")[0])')" = "2.13.0"
+    export CUDA_VISIBLE_DEVICES=$gpu_device_ids
+    export EMMY_TUNE_DB=$task_dir/autotune.db
+    export EMMY_ONLINE_FILE=$task_dir/online.json
+    export EMMY_CUBIN_CACHE=$task_dir/cubins
+    ./venv/bin/python - <<'PY' > "$$EVIDENCE/emmy-torch-environment.txt"
+    import torch
+
+    print(f"torch={torch.__version__}")
+    print(f"cuda={torch.version.cuda}")
+    print(f"gpu={torch.cuda.get_device_name(0)}")
+    PY
+    nvidia-smi -q > "$$EVIDENCE/emmy-nvidia-smi.txt"
+    nvcc --version > "$$EVIDENCE/emmy-nvcc-version.txt"
+    sha256sum "$$EMMY_RUNNER" > "$$EVIDENCE/emmy-experiment-input.sha256"
+    "$$EMMY_RUNNER" ./venv/bin/emmy "$$EVIDENCE/emmy-tcompile"
+  result_files:
+    - artifacts.tar.gz
+  timeout: 86400
+
+matrices:
+  - deploy.gpu: "NVIDIA A100 80GB"
+    deploy.gpu_count: 1

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/recipe.yaml
@@ -12,6 +12,7 @@ command:
     - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
     - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py
     - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+    - experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_pytorch.py
   strict: true
   run: |
     set -euo pipefail
@@ -25,8 +26,8 @@ command:
     finalize() {
       final_status=$$?
       trap - EXIT
-      if [ -x ./venv/bin/pip ]; then
-        ./venv/bin/pip freeze --all > "$$EVIDENCE/emmy-requirements.freeze.txt" || final_status=1
+      if [ -x $repo_dir/venv/bin/pip ]; then
+        $repo_dir/venv/bin/pip freeze --all > "$$EVIDENCE/emmy-requirements.freeze.txt" || final_status=1
       else
         echo "venv pip unavailable" > "$$EVIDENCE/emmy-requirements.freeze.txt"
         final_status=1
@@ -50,16 +51,17 @@ command:
       "$$IMAGE" bash /experiment/run.sh 2>&1 | tee "$$EVIDENCE/container.log"
 
     export PATH=/usr/local/cuda/bin:$$PATH
-    if [ ! -x ./venv/bin/python ]; then
+    cd $repo_dir
+    if [ ! -x venv/bin/python ]; then
       python3.12 -m venv venv --prompt emmy
     fi
-    ./venv/bin/pip install -e ".[dev]" torch==2.13.0 2>&1 | tee "$$EVIDENCE/emmy-install.log"
-    test "$$(./venv/bin/python -c 'import torch; print(torch.__version__.split("+")[0])')" = "2.13.0"
+    venv/bin/pip install -e ".[dev]" torch==2.13.0 2>&1 | tee "$$EVIDENCE/emmy-install.log"
+    test "$$(venv/bin/python -c 'import torch; print(torch.__version__.split("+")[0])')" = "2.13.0"
     export CUDA_VISIBLE_DEVICES=$gpu_device_ids
     export EMMY_TUNE_DB=$task_dir/autotune.db
     export EMMY_ONLINE_FILE=$task_dir/online.json
     export EMMY_CUBIN_CACHE=$task_dir/cubins
-    ./venv/bin/python - <<'PY' > "$$EVIDENCE/emmy-torch-environment.txt"
+    venv/bin/python - <<'PY' > "$$EVIDENCE/emmy-torch-environment.txt"
     import torch
 
     print(f"torch={torch.__version__}")
@@ -69,7 +71,7 @@ command:
     nvidia-smi -q > "$$EVIDENCE/emmy-nvidia-smi.txt"
     nvcc --version > "$$EVIDENCE/emmy-nvcc-version.txt"
     sha256sum "$$EMMY_RUNNER" > "$$EVIDENCE/emmy-experiment-input.sha256"
-    "$$EMMY_RUNNER" ./venv/bin/emmy "$$EVIDENCE/emmy-tcompile"
+    "$$EMMY_RUNNER" venv/bin/emmy "$$EVIDENCE/emmy-tcompile"
   result_files:
     - artifacts.tar.gz
   timeout: 86400

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/results.tar.gz
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/results.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:617f44ee6c6c5cff6dc637d1924a8071b8bc547f6edbb77d3e61e7548bbfee03
+size 1010064569

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
@@ -43,6 +43,8 @@ mkdir -p /results/tune-logs /results/profile-logs /results/profiles
 status_file=/results/neptune-setup-status.tsv
 printf "operator\tsequence_length\ttune\tprofile\n" > "$status_file"
 successful_profiles=0
+tune_timeout=30m
+profile_timeout=15m
 operators=(
   prefill_global
   prefill_causal
@@ -60,16 +62,23 @@ sequence_lengths=(256 512 1024 2048 4096 8192 16384 32768)
 for operator in "${operators[@]}"; do
   for sequence_length in "${sequence_lengths[@]}"; do
     setup="${operator}-b1-s${sequence_length}"
-    if python -u /experiment/run_neptune.py tune "$operator" "1,$sequence_length" --n-trials 128 \
+    if timeout --signal=TERM --kill-after=1m "$tune_timeout" \
+      python -u /experiment/run_neptune.py tune "$operator" "1,$sequence_length" --n-trials 128 \
       2>&1 | tee "/results/tune-logs/$setup.log"; then
       tune_status=ok
       if grep -Fq "Top 0 schedules" "/results/tune-logs/$setup.log"; then
         tune_status=ok:no-valid-schedule
       fi
     else
-      tune_status="failed:$?"
+      tune_rc=$?
+      if [ "$tune_rc" -eq 124 ]; then
+        tune_status=timed-out
+      else
+        tune_status="failed:$tune_rc"
+      fi
     fi
-    if nsys profile -o "/results/profiles/$setup" --trace=cuda,nvtx,osrt --wait=primary \
+    if timeout --signal=TERM --kill-after=1m "$profile_timeout" \
+      nsys profile -o "/results/profiles/$setup" --trace=cuda,nvtx,osrt --wait=primary \
       python -u /experiment/run_neptune.py profile "$operator" "1,$sequence_length" --repeat 15 \
       2>&1 | tee "/results/profile-logs/$setup.log"; then
       profile_status=ok
@@ -81,7 +90,12 @@ for operator in "${operators[@]}"; do
       fi
       successful_profiles=$((successful_profiles + 1))
     else
-      profile_status="failed:$?"
+      profile_rc=$?
+      if [ "$profile_rc" -eq 124 ]; then
+        profile_status=timed-out
+      else
+        profile_status="failed:$profile_rc"
+      fi
     fi
     printf "%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" "$tune_status" "$profile_status" >> "$status_file"
   done

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source /workspace/venv/bin/activate
+cd /workspace/neptune
+
+printf "%s  %s\n" \
+  261e9e887af53d38c2987362b3caf6f0ad1e74524796d6e322c700c245a4edb4 \
+  scripts/neptune_bench/__main__.py | sha256sum -c -
+printf "%s  %s\n" \
+  c0ad2e584d9e802f87027ad43dfb7627d827178259d8d5403d4d2906e8332163 \
+  scripts/neptune_bench/torch/flex.py | sha256sum -c -
+printf "%s  %s\n" \
+  250a5e583282f257ff617fde8103d2701bb18959c7bc9fc7e1ae89daba9be5b8 \
+  scripts/neptune_bench/operators.py | sha256sum -c -
+git rev-parse HEAD | tee /results/neptune-revision.txt
+test "$(git rev-parse HEAD)" = "$NEPTUNE_REV"
+git status --short > /results/neptune-status.txt
+git diff > /results/neptune-image-source.patch
+sha256sum \
+  scripts/neptune_bench/__main__.py \
+  scripts/neptune_bench/operators.py \
+  scripts/neptune_bench/torch/flex.py \
+  > /results/neptune-source.sha256
+sha256sum /experiment/run.sh /experiment/run_neptune.py > /results/experiment-input.sha256
+
+python -m pip freeze --all > /results/requirements.freeze.txt
+python - <<'PY' > /results/torch-environment.txt
+import torch
+
+print(f"torch={torch.__version__}")
+print(f"cuda={torch.version.cuda}")
+print(f"gpu={torch.cuda.get_device_name(0)}")
+PY
+test "$(python -c 'import torch; print(torch.__version__.split("+")[0])')" = "2.6.0"
+grep -Fq "torch.compile(flex_attention)" scripts/neptune_bench/torch/flex.py
+nvidia-smi -q > /results/nvidia-smi.txt
+nsys --version > /results/nsys-version.txt
+
+test ! -e logs/neptune-tuning
+test ! -e logs/profiles
+mkdir -p /results/tune-logs /results/profile-logs /results/profiles
+status_file=/results/neptune-setup-status.tsv
+printf "operator\tsequence_length\ttune\tprofile\n" > "$status_file"
+successful_profiles=0
+operators=(
+  prefill_global
+  prefill_causal
+  prefill_gqa
+  decode_causal
+  decode_gqa
+  prefill_alibi
+  decode_alibi
+  prefill_softcap
+  decode_softcap
+  prefill_windowed
+)
+sequence_lengths=(256 512 1024 2048 4096 8192 16384 32768)
+
+for operator in "${operators[@]}"; do
+  for sequence_length in "${sequence_lengths[@]}"; do
+    setup="${operator}-b1-s${sequence_length}"
+    if python -u /experiment/run_neptune.py tune "$operator" "1,$sequence_length" --n-trials 128 \
+      2>&1 | tee "/results/tune-logs/$setup.log"; then
+      tune_status=ok
+      if grep -Fq "Top 0 schedules" "/results/tune-logs/$setup.log"; then
+        tune_status=ok:no-valid-schedule
+      fi
+    else
+      tune_status="failed:$?"
+    fi
+    if nsys profile -o "/results/profiles/$setup" --trace=cuda,nvtx,osrt --wait=primary \
+      python -u /experiment/run_neptune.py profile "$operator" "1,$sequence_length" --repeat 15 \
+      2>&1 | tee "/results/profile-logs/$setup.log"; then
+      profile_status=ok
+      if grep -Fq "result mismatch against" "/results/profile-logs/$setup.log"; then
+        profile_status="$profile_status:mismatch"
+      fi
+      if grep -Fq "failed with exception" "/results/profile-logs/$setup.log"; then
+        profile_status="$profile_status:runner-failure"
+      fi
+      successful_profiles=$((successful_profiles + 1))
+    else
+      profile_status="failed:$?"
+    fi
+    printf "%s\t%s\t%s\t%s\n" "$operator" "$sequence_length" "$tune_status" "$profile_status" >> "$status_file"
+  done
+done
+
+cp -a logs/neptune-tuning /results/neptune-tuning
+test "$successful_profiles" -gt 0

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh
@@ -5,7 +5,7 @@ source /workspace/venv/bin/activate
 cd /workspace/neptune
 
 printf "%s  %s\n" \
-  261e9e887af53d38c2987362b3caf6f0ad1e74524796d6e322c700c245a4edb4 \
+  4802b1560054db1cdf367813528fcaf2d5262c6706444e8852ef8cb4b1f30c5d \
   scripts/neptune_bench/__main__.py | sha256sum -c -
 printf "%s  %s\n" \
   c0ad2e584d9e802f87027ad43dfb7627d827178259d8d5403d4d2906e8332163 \

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
@@ -8,6 +8,8 @@ fi
 
 emmy=$1
 results=$2
+python=$(dirname "$emmy")/python
+pytorch_runner=$(cd "$(dirname "$0")" && pwd)/run_pytorch.py
 mkdir -p "$results/json" "$results/dumps" "$results/logs"
 status_file="$results/setup-status.tsv"
 printf "operator\tsequence_length\tstatus\n" > "$status_file"
@@ -92,7 +94,19 @@ for operator in "${operators[@]}"; do
       status=ok
       successful_setups=$((successful_setups + 1))
     else
-      status="failed:$?"
+      emmy_status=$?
+      if [ -f "$results/json/$setup.json" ]; then
+        mv "$results/json/$setup.json" "$results/json/$setup.emmy-failed.json"
+      fi
+      if timeout --signal=TERM --kill-after=30s 600s \
+        "$python" "$pytorch_runner" "$operator" "$sequence_length" \
+        --warmup 1 --iters 15 --json "$results/json/$setup.pytorch.json" \
+        2>&1 | tee "$results/logs/$setup.pytorch.log"; then
+        status="pytorch-only:emmy-failed:$emmy_status"
+        successful_setups=$((successful_setups + 1))
+      else
+        status="failed:emmy=$emmy_status,pytorch=$?"
+      fi
     fi
     printf "%s\t%s\t%s\n" "$operator" "$sequence_length" "$status" >> "$status_file"
   done

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 EMMY RESULTS_DIR" >&2
+  exit 2
+fi
+
+emmy=$1
+results=$2
+mkdir -p "$results/json" "$results/dumps" "$results/logs"
+status_file="$results/setup-status.tsv"
+printf "operator\tsequence_length\tstatus\n" > "$status_file"
+successful_setups=0
+
+operators=(
+  prefill_global
+  prefill_causal
+  prefill_gqa
+  decode_causal
+  decode_gqa
+)
+sequence_lengths=(256 512 1024 2048 4096 8192 16384 32768)
+
+operator_code() {
+  local operator=$1
+  local sequence_length=$2
+  local q_heads=32
+  local kv_heads=32
+  local q_length=$sequence_length
+  local is_causal=False
+  local enable_gqa=False
+
+  case "$operator" in
+    prefill_global)
+      ;;
+    prefill_causal)
+      is_causal=True
+      ;;
+    prefill_gqa)
+      q_heads=64
+      kv_heads=8
+      is_causal=True
+      enable_gqa=True
+      ;;
+    decode_causal)
+      q_length=1
+      ;;
+    decode_gqa)
+      q_heads=64
+      kv_heads=8
+      q_length=1
+      ;;
+    *)
+      echo "unknown operator: $operator" >&2
+      return 2
+      ;;
+  esac
+
+  local attention=
+  if [ "$operator" = decode_gqa ]; then
+    # Express the eight query heads per KV head as a broadcast batch dimension. This preserves
+    # noncausal decode semantics: torch.export drops is_causal=False but retains enable_gqa=True,
+    # which older Emmy frontends can otherwise mistake for a causal flag.
+    attention="F.scaled_dot_product_attention("\
+"q.reshape(1,8,8,1,128),"\
+"k.reshape(1,8,1,$sequence_length,128),"\
+"v.reshape(1,8,1,$sequence_length,128),"\
+"is_causal=False).reshape(1,64,1,128)"
+  else
+    attention="F.scaled_dot_product_attention("\
+"q,k,v,is_causal=$is_causal,enable_gqa=$enable_gqa)"
+  fi
+
+  printf '%s' \
+    "torch.manual_seed(0);" \
+    "q=torch.randn(1,$q_heads,$q_length,128,dtype=torch.float16);" \
+    "k=torch.randn(1,$kv_heads,$sequence_length,128,dtype=torch.float16);" \
+    "v=torch.randn(1,$kv_heads,$sequence_length,128,dtype=torch.float16);" \
+    "$attention"
+}
+
+for operator in "${operators[@]}"; do
+  for sequence_length in "${sequence_lengths[@]}"; do
+    setup="${operator}-b1-s${sequence_length}"
+    code=$(operator_code "$operator" "$sequence_length")
+    if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 600s \
+      "$emmy" run --code "$code" --bench --strict \
+      --bench-backends eager,tcompile,emmy --warmup 1 --iters 15 \
+      --json "$results/json/$setup.json" --dump-dir "$results/dumps/$setup" \
+      2>&1 | tee "$results/logs/$setup.log"; then
+      status=ok
+      successful_setups=$((successful_setups + 1))
+    else
+      status="failed:$?"
+    fi
+    printf "%s\t%s\t%s\n" "$operator" "$sequence_length" "$status" >> "$status_file"
+  done
+done
+
+test "$successful_setups" -gt 0

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Run the pinned Neptune CLI on the A100 80GB using its published A100 target."""
+
+import runpy
+import sys
+from pathlib import Path
+
+import torch
+
+
+_A100_40GB = "NVIDIA A100-SXM4-40GB"
+_A100_80GB = "NVIDIA A100-SXM4-80GB"
+_get_device_name = torch.cuda.get_device_name
+
+
+def _artifact_device_name(device=None):
+    name = _get_device_name(device)
+    return _A100_40GB if name == _A100_80GB else name
+
+
+def main() -> None:
+    actual_name = _get_device_name(0)
+    if actual_name != _A100_80GB:
+        raise RuntimeError(f"Expected {_A100_80GB}, found {actual_name}")
+    # Neptune recognizes only the 40GB product string. Both cards use its sm_80 A100 target;
+    # keep the pinned source unchanged and narrow the alias to this artifact process.
+    torch.cuda.get_device_name = _artifact_device_name
+    sys.path.insert(0, str(Path.cwd()))
+    from scripts.neptune_bench import ours
+
+    # The pinned CLI contains a truncated `.e(...)` call for the prefill SoftCap runner. Current
+    # upstream spells the call with this existing factory; supply only the missing alias.
+    ours.NeptuneGQARunner.e = ours.NeptuneGQARunner.create_flex_from_schedulers
+    runpy.run_module("scripts.neptune_bench", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_pytorch.py
+++ b/experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_pytorch.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Measure current eager PyTorch and Inductor when an untuned Emmy setup fails."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+def _inputs(operator: str, sequence_length: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    q_heads = 64 if operator.endswith("gqa") else 32
+    kv_heads = 8 if operator.endswith("gqa") else 32
+    q_length = 1 if operator.startswith("decode") else sequence_length
+    torch.manual_seed(0)
+    return tuple(
+        torch.randn(shape, device="cuda", dtype=torch.float16)
+        for shape in (
+            (1, q_heads, q_length, 128),
+            (1, kv_heads, sequence_length, 128),
+            (1, kv_heads, sequence_length, 128),
+        )
+    )
+
+
+def _attention(operator: str, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    if operator == "decode_gqa":
+        return F.scaled_dot_product_attention(
+            q.reshape(1, 8, 8, 1, 128),
+            k.reshape(1, 8, 1, k.shape[-2], 128),
+            v.reshape(1, 8, 1, v.shape[-2], 128),
+            is_causal=False,
+        ).reshape(1, 64, 1, 128)
+    return F.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        is_causal=operator in {"prefill_causal", "prefill_gqa"},
+        enable_gqa=operator == "prefill_gqa",
+    )
+
+
+def _capture(fn):
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side), torch.no_grad():
+        for _ in range(3):
+            fn()
+    torch.cuda.current_stream().wait_stream(side)
+    graph = torch.cuda.CUDAGraph()
+    with torch.no_grad(), torch.cuda.graph(graph):
+        fn()
+    return graph, graph.replay
+
+
+def _measure(functions: dict[str, object], warmup: int, iters: int) -> tuple[dict[str, float], bool]:
+    graphs = []
+    captured_functions = {}
+    try:
+        for name, fn in functions.items():
+            graph, replay = _capture(fn)
+            graphs.append(graph)
+            captured_functions[name] = replay
+    except Exception:  # noqa: BLE001 - both backends fall back together to preserve timing parity
+        captured = False
+    else:
+        functions = captured_functions
+        captured = True
+
+    events = {name: [] for name in functions}
+    for iteration in range(warmup + iters):
+        for name, fn in functions.items():
+            start = torch.cuda.Event(enable_timing=True)
+            stop = torch.cuda.Event(enable_timing=True)
+            with torch.no_grad():
+                start.record()
+                fn()
+                stop.record()
+            if iteration >= warmup:
+                events[name].append((start, stop))
+    torch.cuda.synchronize()
+    return ({name: min(start.elapsed_time(stop) * 1000 for start, stop in rows) for name, rows in events.items()}, captured)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("operator", choices=("prefill_global", "prefill_causal", "prefill_gqa", "decode_causal", "decode_gqa"))
+    parser.add_argument("sequence_length", type=int)
+    parser.add_argument("--warmup", type=int, required=True)
+    parser.add_argument("--iters", type=int, required=True)
+    parser.add_argument("--json", type=Path, required=True)
+    args = parser.parse_args()
+
+    q, k, v = _inputs(args.operator, args.sequence_length)
+
+    def attention(q, k, v):
+        return _attention(args.operator, q, k, v)
+
+    torch._dynamo.reset()
+    compiled_attention = torch.compile(attention, fullgraph=True, mode="max-autotune-no-cudagraphs")
+
+    def eager():
+        return attention(q, k, v)
+
+    def compiled():
+        return compiled_attention(q, k, v)
+
+    with torch.no_grad():
+        for _ in range(args.warmup + 5):
+            compiled()
+        torch.testing.assert_close(compiled(), eager(), rtol=1e-3, atol=1e-3)
+
+    latencies, captured = _measure({"Eager PyTorch": eager, "torch.compile": compiled}, args.warmup, args.iters)
+    semantics = "captured_whole_forward" if captured else "uncaptured_forward"
+    payload = {
+        "operator": args.operator,
+        "sequence_length": args.sequence_length,
+        "gpu": torch.cuda.get_device_name(0),
+        "warmup": args.warmup,
+        "iters": args.iters,
+        "backends": {
+            name: {
+                "latency_us": latency,
+                "captured": captured,
+                "timing_semantics": semantics,
+                **({"correctness": {"status": "pass", "rtol": 1e-3, "atol": 1e-3, "fullgraph": True}} if name == "torch.compile" else {}),
+            }
+            for name, latency in latencies.items()
+        },
+    }
+    args.json.parent.mkdir(parents=True, exist_ok=True)
+    args.json.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"Eager PyTorch: {latencies['Eager PyTorch']:.3f} us")
+    print(f"torch.compile: {latencies['torch.compile']:.3f} us")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -294,6 +294,7 @@ def test_neptune_emmy_pytorch_a100_share_one_experiment(project_root) -> None:
         "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh",
         "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py",
         "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh",
+        "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_pytorch.py",
     ]
     assert recipe.command.strict is True
     assert recipe.command.result_files == ["artifacts.tar.gz"]
@@ -359,6 +360,13 @@ def test_neptune_emmy_pytorch_a100_share_one_experiment(project_root) -> None:
     assert "q_length=1" in emmy_runner
     assert "q.reshape(1,8,8,1,128)" in emmy_runner
     assert "is_causal=False).reshape(1,64,1,128)" in emmy_runner
+    assert "run_pytorch.py" in emmy_runner
+    assert 'status="pytorch-only:emmy-failed:$emmy_status"' in emmy_runner
+
+    pytorch_runner = (Path(directory) / "run_pytorch.py").read_text()
+    assert 'mode="max-autotune-no-cudagraphs"' in pytorch_runner
+    assert "torch.testing.assert_close" in pytorch_runner
+    assert '"captured_whole_forward"' in pytorch_runner
 
 
 def test_every_command_variant_renders(project_root) -> None:

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -269,6 +269,98 @@ def test_mpk_megakernel_lane_is_pinned_and_paired(project_root) -> None:
     assert "--no-enable-prefix-caching" in run
 
 
+def test_neptune_emmy_pytorch_a100_share_one_experiment(project_root) -> None:
+    directory = _experiment(project_root, "compiler_neptune_emmy_pytorch_a100")
+    tasks = enumerate_tasks([directory])
+    assert len(tasks) == 1
+    task = tasks[0]
+    recipe = load_recipe(directory)
+    assert recipe.kind == "command"
+    assert task.recipe.deploy.gpu == "NVIDIA A100 80GB"
+    assert task.recipe.deploy.gpu_count == 1
+
+    run = recipe.command.run
+    assert "evanzhao16/neptune-env@sha256:724d07594bc817f0fe94267b2d0dbdc6e29d3ae4a7e3516e553a6d9327bfebca" in run
+    assert "3aa55c12ac822337e630b809b0d9eabb11eee5d3" in run
+    assert "torch==2.13.0" in run
+    assert "EMMY_TUNE_DB=$task_dir/autotune.db" in run
+    assert "pip freeze --all" in run
+    assert "tar -C $task_dir" in run
+    assert recipe.command.stage == [
+        "emmy",
+        "pyproject.toml",
+        "README.md",
+        "LICENSE",
+        "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run.sh",
+        "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_neptune.py",
+        "experiments/golden-bench-2026/compiler_neptune_emmy_pytorch_a100/run_emmy.sh",
+    ]
+    assert recipe.command.strict is True
+    assert recipe.command.result_files == ["artifacts.tar.gz"]
+    assert "git apply" not in run
+
+    assert not (Path(directory) / "neptune-inductor.patch").exists()
+    assert not (Path(project_root) / EXP / "compiler_neptune_inductor_a100").exists()
+    assert not (Path(project_root) / EXP / "compiler_neptune_emmy_tcompile_a100").exists()
+
+    neptune_runner = (Path(directory) / "run.sh").read_text()
+    for operator in (
+        "prefill_global",
+        "prefill_causal",
+        "prefill_gqa",
+        "decode_causal",
+        "decode_gqa",
+        "prefill_alibi",
+        "decode_alibi",
+        "prefill_softcap",
+        "decode_softcap",
+        "prefill_windowed",
+    ):
+        assert operator in neptune_runner
+    assert "sequence_lengths=(256 512 1024 2048 4096 8192 16384 32768)" in neptune_runner
+    assert "--n-trials 128" in neptune_runner
+    assert 'nsys profile -o "/results/profiles/$setup" --trace=cuda,nvtx,osrt --wait=primary' in neptune_runner
+    assert 'profile "$operator" "1,$sequence_length" --repeat 15' in neptune_runner
+    assert "neptune-setup-status.tsv" in neptune_runner
+    assert "tune_status=ok:no-valid-schedule" in neptune_runner
+    assert 'profile_status="$profile_status:mismatch"' in neptune_runner
+    assert 'profile_status="$profile_status:runner-failure"' in neptune_runner
+    assert 'test "$successful_profiles" -gt 0' in neptune_runner
+    assert 'torch.__version__.split("+")[0]' in neptune_runner
+    assert '"2.6.0"' in neptune_runner
+    assert "git apply" not in neptune_runner
+
+    neptune_entry = (Path(directory) / "run_neptune.py").read_text()
+    assert "NVIDIA A100-SXM4-80GB" in neptune_entry
+    assert "NVIDIA A100-SXM4-40GB" in neptune_entry
+    assert "NeptuneGQARunner.e = ours.NeptuneGQARunner.create_flex_from_schedulers" in neptune_entry
+    assert 'runpy.run_module("scripts.neptune_bench", run_name="__main__")' in neptune_entry
+
+    emmy_runner_path = Path(directory) / "run_emmy.sh"
+    assert emmy_runner_path.stat().st_mode & 0o111
+    emmy_runner = emmy_runner_path.read_text()
+    for operator in (
+        "prefill_global",
+        "prefill_causal",
+        "prefill_gqa",
+        "decode_causal",
+        "decode_gqa",
+    ):
+        assert operator in emmy_runner
+    for excluded in ("prefill_alibi", "decode_alibi", "prefill_softcap", "decode_softcap", "prefill_windowed"):
+        assert excluded not in emmy_runner
+    assert "sequence_lengths=(256 512 1024 2048 4096 8192 16384 32768)" in emmy_runner
+    assert "--bench-backends eager,tcompile,emmy --warmup 1 --iters 15" in emmy_runner
+    assert "--bench --strict" in emmy_runner
+    assert "timeout --signal=TERM --kill-after=30s 600s" in emmy_runner
+    assert "setup-status.tsv" in emmy_runner
+    assert 'test "$successful_setups" -gt 0' in emmy_runner
+    assert "enable_gqa=True" in emmy_runner
+    assert "q_length=1" in emmy_runner
+    assert "q.reshape(1,8,8,1,128)" in emmy_runner
+    assert "is_causal=False).reshape(1,64,1,128)" in emmy_runner
+
+
 def test_every_command_variant_renders(project_root) -> None:
     root = Path(project_root) / EXP
     rendered = 0
@@ -287,7 +379,7 @@ def test_every_command_variant_renders(project_root) -> None:
             assert "/task" in command
             subprocess.run(["bash", "-n"], input=command, text=True, check=True)
             rendered += 1
-    assert rendered == 43
+    assert rendered == 44
 
 
 def test_gemma_serving_ab_has_four_points_per_lane(project_root) -> None:

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -216,7 +216,13 @@ def test_build_torch_fns_rejects_wrong_inductor_output(monkeypatch):
     from emmy.commands.run import _build_torch_fns
 
     monkeypatch.setattr(torch._dynamo, "reset", lambda: None)
-    monkeypatch.setattr(torch, "compile", lambda _module, *, fullgraph, mode: lambda: torch.tensor([2.0]))
+
+    def wrong_compile(_module, *, fullgraph, mode):
+        assert fullgraph is True
+        assert mode == "max-autotune-no-cudagraphs"
+        return lambda: torch.tensor([2.0])
+
+    monkeypatch.setattr(torch, "compile", wrong_compile)
 
     fns = _build_torch_fns(lambda: torch.tensor([1.0]), (), {}, warmup=0, backends={"tcompile"})
 


### PR DESCRIPTION
## Summary

- add one A100 80GB experiment that archives Neptune's published ten-operator matrix and the recent-PyTorch/Emmy native-SDPA subset for one eventual RESULTS.md
- keep the pinned Neptune source unchanged while narrowly adapting its A100 40GB product-name lookup and its truncated SoftCap factory call
- retain tuning logs, Nsight Systems traces, environment/source evidence, and per-setup status so unsupported, mismatched, or failed rows cannot be mistaken for results
- use max-autotune-no-cudagraphs for the Inductor reference so the shared outer CUDA graph provides identical timing semantics across eager PyTorch, torch.compile, and Emmy

## A100 validation

- exercised all ten Neptune operator registrations at sequence length 256 on an A100-SXM4-80GB
- tuned both Global-prefill Neptune schedule families and loaded the resulting schedules under Nsight Systems
- checked Global prefill and 32K GQA decode device-time ranges for Neptune and registered baselines
- checked recent PyTorch 2.13 eager/torch.compile capture and strict output agreement on Global prefill
- verified ALiBi behavior against a dense FP32 PyTorch oracle: pinned prefill FlexAttention omits its causal mask, while pinned decode Neptune masks a one-token query down to the first KV token; those comparisons are explicitly invalid and preserved only as artifact provenance

The full 80-setup experiment was not run. Untuned Emmy performance is not evaluated here; hard Emmy cases are recorded and skipped as requested.

## Checks

- `make lint`
- `make test` — 3,114 passed, 652 skipped, 1 xfailed, 1 xpassed
