### PR TITLE
Serving: clamp vLLM dummy-run seq lens, lift the wide-head rung cap

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -451,9 +451,9 @@ explicit `--revision` wins. So a served rung can be reproduced off the CLI. Gene
 defaults to **whole-step CUDA graphs for decode AND chunk/mixed steps** (a `--compilation-config` with
 `cudagraph_mode: FULL` + capture sizes laddered up to `--max-num-seqs` plus the chunk rungs, and
 `--attention-backend TRITON_ATTN` — mixed-batch full capture needs a backend declaring always-supported capture;
-`EMMY_GEN_CHUNK_CAPTURE=0` restores the decode-only `FULL_DECODE_ONLY` config, and a model with an attention
-head wider than 256 gets its rungs capped at `config.WIDE_HEAD_MIXED_RUNG_CAP` — vLLM 0.23's TRITON_ATTN
-faults capturing wider mixed batches on such models; see
+`EMMY_GEN_CHUNK_CAPTURE=0` restores the decode-only `FULL_DECODE_ONLY` config; capture sizes above
+`--max-model-len` — the rider-top rung — are made safe by the plugin's dummy-run seq-lens clamp
+(`serving/vllm_patches.py`); see
 `serving/ARCHITECTURE.md`); pass vLLM's own `--enforce-eager` to opt out (forced automatically when
 `EMMY_GEN_DECODE_BUCKET=0`, and for MoE models — the routed expert dispatch host-syncs, which a whole-step capture
 cannot record; `_is_moe_model` probes the LOCAL config cache as UX, a caller-supplied `--compilation-config` on an

--- a/emmy/commands/serve.py
+++ b/emmy/commands/serve.py
@@ -183,31 +183,6 @@ def _is_moe_model(model: str, vllm_args: list[str]) -> bool:
     return bool(getattr(cfg, "num_experts", None) or getattr(cfg, "num_local_experts", None))
 
 
-def _max_head_dim(model: str, vllm_args: list[str]) -> int | None:
-    """The widest attention head the checkpoint's LOCAL config declares, or ``None`` when the
-    probe cannot tell (uncached model, unreadable config — same best-effort contract as
-    :func:`_is_moe_model`; the authoritative guard lives in ``EmmyGenModel.__init__``).
-    Gemma-4 declares ``head_dim`` for its sliding layers and a wider ``global_head_dim`` for
-    its full-attention layers, so both attributes count."""
-    cfg = _local_config(model, vllm_args)
-    if cfg is None:
-        return None
-    cfg = getattr(cfg, "text_config", cfg)
-    dims = []
-    for attr in ("head_dim", "global_head_dim"):
-        try:
-            value = getattr(cfg, attr, None)
-        except Exception:  # noqa: BLE001 — transformers' heterogeneous-config API raises on ambiguous global access
-            value = None
-        if isinstance(value, int):
-            dims.append(value)
-    if not dims:
-        hidden, heads = getattr(cfg, "hidden_size", None), getattr(cfg, "num_attention_heads", None)
-        if isinstance(hidden, int) and isinstance(heads, int) and heads > 0:
-            dims.append(hidden // heads)
-    return max(dims) if dims else None
-
-
 def _chunk_capture_rungs(vllm_args: list[str], bucket: int) -> set[int]:
     """Token-count capture sizes for the chunk/prefill and mixed prefill+decode steps
     (``EMMY_GEN_CHUNK_CAPTURE``). vLLM pads a step UP to the first rung at or above its
@@ -329,26 +304,11 @@ def _gen_graph_args(vllm_args: list[str], *, model: str | None = None) -> list[s
         # their per-step staging D2D were the measured c64 TPOT loss, and the eager
         # symbolic-prefill burst the short-prompt TTFT loss. FULL also retires the
         # uniform-decode dispatch routine: every step dispatches by padded token count.
-        # A model with an attention head wider than 256 (the probe below) takes a CAPPED rung
-        # list instead of the full one: past that width the mixed-capture-capable vLLM 0.23
-        # backends are only partially usable — TRITON_ATTN's unified-attention kernel raises
-        # an illegal memory access capturing WIDE mixed batches (measured at 4128 tokens on
-        # gemma-4-12B / RTX 5090; clean through 2112, benched end to end with greedy chat
-        # parity), and FLEX_ATTENTION mis-shapes its sliding-window block mask outright.
-        # Steps wider than the capped top rung stay eager. The authoritative guard for a
-        # probe miss is in ``EmmyGenModel.__init__``.
+        # Capture sizes above --max-model-len (the rider-top rung) are legal only because the
+        # plugin patches vLLM 0.23's dummy-run seq lens (``serving/vllm_patches.py``) —
+        # unpatched, the warmup overruns the block table and dies with an illegal access.
         mode = "FULL"
         sizes = sorted(set(sizes) | _chunk_capture_rungs(vllm_args, bucket))
-        head_dim = _max_head_dim(model, vllm_args) if model is not None else None
-        if head_dim is not None and head_dim > 256:
-            cap = emmy_config.WIDE_HEAD_MIXED_RUNG_CAP
-            sizes = [s for s in sizes if s <= cap]
-            logger.info(
-                "chunk capture capped at %d-token rungs: this model's widest attention head (%d) exceeds 256, "
-                "where vLLM 0.23's TRITON_ATTN faults capturing wider mixed batches; wider steps stay eager",
-                cap,
-                head_dim,
-            )
         if not _has_flag(vllm_args, "--attention-backend"):
             backend_args = ["--attention-backend", "TRITON_ATTN"]
     # ``custom_ops: +rotary_embedding``: the plugin runs the model EAGERLY inside the cudagraph

--- a/emmy/config.py
+++ b/emmy/config.py
@@ -66,15 +66,6 @@ GEN_EMBED_HOST = "EMMY_GEN_EMBED_HOST"
 READABLE = "EMMY_READABLE"
 RENTAL_TAGS = "EMMY_RENTAL_TAGS"
 
-#: The widest mixed-batch capture rung validated on a WIDE-HEAD model (attention heads past
-#: 256 — gemma-4-12B's 512-wide global layers) on RTX 5090 / vLLM 0.23: TRITON_ATTN's
-#: unified-attention kernel raises an illegal memory access capturing a 4128-token mixed batch
-#: but captures and serves cleanly through 2112 (the 2048 chunk quantum + a 64-wide rider top,
-#: benched end to end with greedy chat parity); the fault threshold between 2112 and 4128 is
-#: unbisected. Narrow-head models take the full rung list. Read by the serve command's rung
-#: builder and ``EmmyGenModel``'s boot guard — not an env var.
-WIDE_HEAD_MIXED_RUNG_CAP = 2112
-
 _CACHE_ROOT = Path.home() / ".cache" / "emmy"
 
 
@@ -399,10 +390,9 @@ def gen_chunk_capture(default: int = 1) -> int:
     TTFT loss (the eager symbolic-prefill burst); with capture on, small_c1 TTFT closed from
     1.36x to 1.09x of stock and greedy chat outputs stayed content-identical (2026-08-15 5090
     validation). Set 0 to restore decode-only capture and vLLM's own attention-backend choice.
-    Off automatically under speculative decoding (the chunk rungs are not spec-adjusted); a
-    model with an attention head wider than 256 (gemma-4's global layers) gets its rungs
-    capped at :data:`WIDE_HEAD_MIXED_RUNG_CAP` instead — see that constant for the vLLM 0.23
-    backend faults behind the cap. See ``commands/serve.py`` and
+    Off automatically under speculative decoding (the chunk rungs are not spec-adjusted).
+    Rungs above ``--max-model-len`` rely on the plugin's dummy-run seq-lens clamp
+    (``serving/vllm_patches.py``). See ``commands/serve.py`` and
     `serving/ARCHITECTURE.md`."""
     return int_env(GEN_CHUNK_CAPTURE, default)
 

--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -410,14 +410,16 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   capture requires an attention backend declaring `AttentionCGSupport.ALWAYS`, so the emmy arm passes
   `--attention-backend TRITON_ATTN` (FA2 declares uniform-batch support only; on such a backend vLLM silently
   downgrades FULL back to FULL_DECODE_ONLY — the pre-chunk-capture behavior, also restorable explicitly with
-  `EMMY_GEN_CHUNK_CAPTURE=0`, which drops the rungs and the backend override too). A model with an attention
-  head WIDER than 256 takes a CAPPED size list (`config.WIDE_HEAD_MIXED_RUNG_CAP`, 2112 — the serve command's
-  head-dim probe, plus an authoritative boot guard in `EmmyGenModel.__init__` that rejects over-cap sizes
-  readably): past that width vLLM 0.23's TRITON_ATTN raises an illegal memory access capturing WIDE mixed
-  batches (measured at 4128 tokens on gemma-4-12B's 512-wide global layers / RTX 5090; clean through 2112),
-  and FLEX_ATTENTION mis-shapes its sliding-window block mask outright — so gemma-4 runs chunk capture on the
-  2048-chunk-quantum lane and leaves wider steps eager. 5090-measured (2026-08-15, fcbc880f+fix tree, medians
-  of 3): small_c1 256/256 TTFT 90.4 → 72.2 ms (capture off → on; stock 66.5 — the 1.36x gap closes to 1.09x)
+  `EMMY_GEN_CHUNK_CAPTURE=0`, which drops the rungs and the backend override too). A capture size above
+  `--max-model-len` (only the rider-top rung can be) is safe ONLY because the plugin patches vLLM 0.23's
+  dummy-run seq lens (`vllm_patches.py`): unpatched, `_dummy_run` fills every dummy request's seq_len with the
+  step's token count, so an over-model-len capture size overruns the block table's
+  `cdiv(max_model_len, block_size)`-page rows — TRITON_ATTN's unmasked block-table load then feeds garbage page
+  ids into its K/V loads (capture-warmup illegal memory access, reproduced standalone: clean at 4096, faulting
+  from 4097, at head_dim 256 AND 512 — head width is irrelevant), and FLEX_ATTENTION fails the same arithmetic
+  loudly in its sliding-window block-mask shapes. 5090-measured with the earlier 2112 rung cap (2026-08-15,
+  fcbc880f+fix tree, medians of 3): small_c1 256/256 TTFT 90.4 → 72.2 ms (capture off → on; stock 66.5 — the
+  1.36x gap closes to 1.09x)
   with TPOT unchanged, and c64 np256 on the capped lane TPOT 34.9 → 33.1 ms, 1243 → 1255 tok/s, greedy chat
   outputs content-identical. Capture sizes at or below
   the decode bucket run the static

--- a/emmy/serving/__init__.py
+++ b/emmy/serving/__init__.py
@@ -17,6 +17,12 @@ def register() -> None:
     # from docker logs, and the gemma4 verify gate greps them there.
     ensure_plugin_logging()
 
+    # vLLM 0.23 dummy-run seq lens exceed max_model_len for capture sizes above it,
+    # overrunning the block table (capture-warmup illegal access); see vllm_patches.
+    from emmy.serving.vllm_patches import clamp_dummy_run_seq_lens
+
+    clamp_dummy_run_seq_lens()
+
     if "EmmyEmbedModel" not in ModelRegistry.get_supported_archs():
         ModelRegistry.register_model("EmmyEmbedModel", "emmy.serving.vllm_model:EmmyEmbedModel")
     if "EmmyGenModel" not in ModelRegistry.get_supported_archs():

--- a/emmy/serving/vllm_model_gen.py
+++ b/emmy/serving/vllm_model_gen.py
@@ -395,30 +395,6 @@ class EmmyGenModel(nn.Module, SupportsPP):
         n_layers = self.runner.num_layers
         self.make_empty_intermediate_tensors = _hidden_intermediate_tensors_factory(config.hidden_size, self.runner.residual_dtype)
 
-        # AUTHORITATIVE mixed-capture guard (the serve command's head-dim probe is best-effort
-        # UX only): on a model with an attention head wider than 256, vLLM 0.23's mixed-capture
-        # backends are only partially usable — TRITON_ATTN's unified-attention kernel raises an
-        # illegal memory access capturing a mixed batch wider than the validated rung cap
-        # (measured at 4128 tokens on gemma-4-12B, whose global layers are 512-wide; clean
-        # through 2112), and FLEX_ATTENTION mis-shapes its sliding-window block mask outright.
-        # A scalar-FULL boot with a capture size past the cap would die in CUDA mid-capture;
-        # fail readably instead. FULL_AND_PIECEWISE is exempt (its mixed steps run piecewise,
-        # attention outside the graphs), as is decode-only capture.
-        if not mc.enforce_eager:
-            cg_mode = getattr(vllm_config.compilation_config, "cudagraph_mode", None)
-            sizes = getattr(vllm_config.compilation_config, "cudagraph_capture_sizes", None) or []
-            widest = max((self.runner.layer_meta(i)[0] for i in range(n_layers)), default=0)
-            cap = emmy_config.WIDE_HEAD_MIXED_RUNG_CAP
-            over = sorted(s for s in sizes if s > cap)
-            if cg_mode is not None and getattr(cg_mode, "name", str(cg_mode)) == "FULL" and widest > 256 and over:
-                raise ValueError(
-                    f"cudagraph_mode FULL captures mixed prefill+decode steps, and this model's widest "
-                    f"attention head ({widest}) exceeds 256 — where vLLM 0.23's TRITON_ATTN faults "
-                    f"capturing mixed batches wider than {cap} tokens (FLEX_ATTENTION breaks outright). "
-                    f"Capture sizes {over} exceed that cap; drop them, or serve with "
-                    f"EMMY_GEN_CHUNK_CAPTURE=0 (whole-step decode capture only)."
-                )
-
         # AUTHORITATIVE MoE capture guard (the serve command's config probe is best-effort UX
         # only): single-token decode is capture-legal through the runner's FIXED-SLOT tier
         # (``_moe_combine_slots`` — fixed launch set, no host sync), so an MoE boot may keep

--- a/emmy/serving/vllm_patches.py
+++ b/emmy/serving/vllm_patches.py
@@ -1,0 +1,53 @@
+"""Runtime workarounds for vLLM defects, applied from the plugin ``register`` hook.
+
+Each patch documents the upstream defect and the pinned vLLM version it targets; drop the
+patch when the pin moves to a release that ships the fix.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def clamp_dummy_run_seq_lens() -> None:
+    """vLLM 0.23: ``GPUModelRunner._dummy_run`` fills every dummy request's seq_len with the
+    step's total TOKEN count. When a capture size exceeds ``--max-model-len`` (emmy's
+    rider-top rung — chunk quantum + decode bucket — is the one rung that can), each dummy
+    request claims a longer KV prefix than the block table can address (its rows hold
+    ``cdiv(max_model_len, block_size)`` page ids). The unified-attention kernel loads block
+    tables without a bounds mask, so the last request's programs read page ids from past the
+    end of the tensor, and the garbage ids send the K/V loads far out of bounds — the
+    capture-warmup illegal memory access. FLEX_ATTENTION trips over the same arithmetic
+    loudly: its sliding-window block mask builds ``cdiv(seq_len, block_size)`` columns
+    against a block table sliced to the row width. Head width is irrelevant — any model
+    faults once a capture size passes max_model_len (verified by standalone kernel repro on
+    RTX 4080: clean at 4096, faults at 4097, both head_dim 256 and 512).
+
+    Clamping the seq-lens buffers to ``max_model_len`` before attention metadata is built
+    restores the invariant every real batch already holds; legal batches are untouched.
+
+    Only the DEFAULT model runner (``gpu_model_runner.py``) has this defect — and out-of-tree
+    architectures like ``EmmyGenModel`` always get it (vLLM 0.23's newer runner is opt-in for
+    stock Llama/Mistral/Qwen3 only, and its dummy batches use legal per-request seq lens).
+    Verified end to end on the default runner: a 4128-token capture with max-model-len 4096
+    warms up and captures cleanly with the clamp, greedy output correct.
+    """
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    if getattr(GPUModelRunner, "_emmy_seq_lens_clamped", False):
+        return
+    orig = GPUModelRunner._build_attention_metadata
+
+    def build_with_clamped_seq_lens(self, *args, **kwargs):
+        lens = self.optimistic_seq_lens_cpu
+        if int(lens.max()) > self.max_model_len:  # only dummy batches ever exceed
+            lens.clamp_(max=self.max_model_len)
+            # Same H2D refresh protocol as _dummy_run's own seq-lens fill.
+            self.seq_lens.copy_(lens, non_blocking=True)
+            if not getattr(self, "_emmy_seq_lens_clamp_logged", False):
+                self._emmy_seq_lens_clamp_logged = True
+                logger.info("emmy vllm patch: dummy-run seq lens clamped to max_model_len")
+        return orig(self, *args, **kwargs)
+
+    GPUModelRunner._build_attention_metadata = build_with_clamped_seq_lens
+    GPUModelRunner._emmy_seq_lens_clamped = True

--- a/plans/vllm-generic-integration-improvements.md
+++ b/plans/vllm-generic-integration-improvements.md
@@ -99,9 +99,33 @@ arithmetic failing loudly. Fixed by clamping dummy seq lens to max-model-len fro
 removed. Only vLLM 0.23's DEFAULT model runner has the defect (its newer opt-in runner — stock
 Llama/Mistral/Qwen3 only — builds dummy batches with legal per-request seq lens), and `EmmyGenModel` always
 rides the default runner. Engine-level validation on the 4080 (default runner forced): the 4128 capture's two
-over-model-len dummy runs were clamped 4128 → 4096, capture completed, greedy output correct. Remaining
-follow-ups: re-run the 4096-chunk-lane c64 cell on a 5090 with the clamp (the ~5 ms/step host-idle recovery),
-re-bench against a stock arm at a comparable admission shape, and upstream the report.
+over-model-len dummy runs were clamped 4128 → 4096, capture completed, greedy output correct.
+
+**2026-08-15/16 5090 validation of the clamp (rented vast.ai 5090):** the exact originally-faulting boot
+(gemma-4-12B-it @707f0a3b, fp16, TRITON_ATTN, mnbt 4128, decode bucket 32, mml 4096) now warms up and captures
+ALL 64 mixed-batch FULL rungs including 4128 (the clamp log line fires exactly at that warmup) and serves with
+greedy chat output byte-identical to stock vLLM. The 4096-chunk-lane c64 cell (decode bucket 64, mnbt 4160,
+rider-top rung 4160 > mml; bench client: 256 random prompts, 512 in / 128 out, concurrency 64, medians of 3):
+
+| arm | median TPOT ms | tok/s | median TTFT ms |
+| --- | --: | --: | --: |
+| capture ON (rungs to 4160) | 32.75 | 628 | 7125 |
+| capture OFF (decode-only) | 33.69 | 632 | 7040 |
+| stock vLLM (own defaults) | 24.93 | 589 | 9181 |
+
+Capture ON takes −0.94 ms/step TPOT over OFF on this lane (the projected ~5 ms/step applied to MIXED steps;
+this 512/128 workload is decode-dominated in steady state, so the mixed-step win dilutes — the full recovery
+needs the re-baseline's prefill-heavier mix). Emmy leads stock on throughput (+7%) and TTFT (−22%); stock
+leads TPOT — the same not-shape-comparable admission asymmetry as the 2048-lane row above. Greedy chat parity
+hashes are byte-identical across ON / OFF / stock.
+
+**Caveat — the clamp was 5090-validated on the fcbc-era tree (`bench/fcbc-clamp` = `bench/chunk-capture-fcbc880f`
++ the clamp commit), NOT on this branch:** trees containing main PRs #498–#503 (this branch's base) hang on the
+FIRST inference step on the 5090 (100% util / ~122 W spin-kernel signature, capture ON and OFF alike, eager
+prefill included) while stock vLLM and the fcbc-era tree serve fine — a pre-existing serving regression between
+fcbc880f and #503, unrelated to the clamp (which only touches dummy-run seq lens). Remaining follow-ups: bisect
+that regression on a 5090, re-bench against a stock arm at a comparable admission shape, and upstream the vLLM
+report.
 
 ## Target architecture
 

--- a/plans/vllm-generic-integration-improvements.md
+++ b/plans/vllm-generic-integration-improvements.md
@@ -86,9 +86,22 @@ Measured cells (capture ON / capture OFF / stock):
 
 The c64 "TPOT at or below stock" target is NOT met on this lane (33.1 vs 27.3, but the arms are not
 shape-comparable — see the asterisk) and the projected ~5 ms/step host-idle recovery applies to the 4096-chunk
-lane, which the TRITON width fault keeps eager. Remaining follow-ups: the vLLM-side triton wide-head fix (then
-lift the cap and re-run the 4096-lane c64 cell), and re-benching against a stock arm at a comparable admission
-shape.
+lane, which the TRITON width fault keeps eager.
+
+**2026-08-15 root cause (standalone kernel repro on the dev 4080, `compute-sanitizer`-attributed):** the fault
+is NOT a head-width or batch-width limit. vLLM 0.23's `_dummy_run` fills every dummy request's seq_len with the
+step's token count, so a capture size above `--max-model-len` (only the rider-top rung can be: 4128 > 4096)
+claims more block-table pages than a row holds (258 vs 256); the unified-attention kernel's unmasked
+block-table load then reads past the tensor and the garbage page ids send K/V loads out of bounds. Clean at
+4096, faults from 4097, at head_dim 256 AND 512; FLEX_ATTENTION's 258-vs-256 block-mask error is the same
+arithmetic failing loudly. Fixed by clamping dummy seq lens to max-model-len from the plugin
+(`serving/vllm_patches.py`); `WIDE_HEAD_MIXED_RUNG_CAP`, the head-dim probe, and the wide-head boot guard are
+removed. Only vLLM 0.23's DEFAULT model runner has the defect (its newer opt-in runner — stock
+Llama/Mistral/Qwen3 only — builds dummy batches with legal per-request seq lens), and `EmmyGenModel` always
+rides the default runner. Engine-level validation on the 4080 (default runner forced): the 4128 capture's two
+over-model-len dummy runs were clamped 4128 → 4096, capture completed, greedy output correct. Remaining
+follow-ups: re-run the 4096-chunk-lane c64 cell on a 5090 with the clamp (the ~5 ms/step host-idle recovery),
+re-bench against a stock arm at a comparable admission shape, and upstream the report.
 
 ## Target architecture
 

--- a/plans/vllm-generic-integration-improvements.md
+++ b/plans/vllm-generic-integration-improvements.md
@@ -73,7 +73,9 @@ raises an illegal memory access capturing a WIDE mixed batch on gemma-4-12B (512
 offset-overflow artifact), pinned by a `CUDA_LAUNCH_BLOCKING=1` boot — and FLEX_ATTENTION fails its
 sliding-window block-mask build outright (`used_pages.masked_fill_`: 256 vs 258 pages). So wide-head models get
 their rungs capped at `config.WIDE_HEAD_MIXED_RUNG_CAP` (2112) and run chunk capture on the 2048-chunk-quantum
-lane, wider steps eager; the 4096-chunk lane stays eager until a fixed vLLM lands.
+lane, wider steps eager; the 4096-chunk lane stays eager until a fixed vLLM lands. (SUPERSEDED by the
+2026-08-15 root cause below — the attribution to head width was wrong, the cap is gone, and the 4096 lane
+runs.)
 
 Measured cells (capture ON / capture OFF / stock):
 
@@ -120,12 +122,13 @@ leads TPOT — the same not-shape-comparable admission asymmetry as the 2048-lan
 hashes are byte-identical across ON / OFF / stock.
 
 **Caveat — the clamp was 5090-validated on the fcbc-era tree (`bench/fcbc-clamp` = `bench/chunk-capture-fcbc880f`
-+ the clamp commit), NOT on this branch:** trees containing main PRs #498–#503 (this branch's base) hang on the
-FIRST inference step on the 5090 (100% util / ~122 W spin-kernel signature, capture ON and OFF alike, eager
-prefill included) while stock vLLM and the fcbc-era tree serve fine — a pre-existing serving regression between
-fcbc880f and #503, unrelated to the clamp (which only touches dummy-run seq lens). Remaining follow-ups: bisect
-that regression on a 5090, re-bench against a stock arm at a comparable admission shape, and upstream the vLLM
-report.
++ the clamp commit), NOT on a current-main base:** trees on newer bases appeared to hang on their first serving
+step on the 5090 (100% util / ~123 W, capture ON and OFF alike, eager prefill included) while stock vLLM and
+the fcbc-era tree served fine. That was bisected separately to #482's mlp_down fork erasure — a bounded 4-5
+order-of-magnitude cold-pick slowdown (~40 s/token, so any client timeout reads as a hang), not a deadlock and
+unrelated to this clamp, which only touches dummy-run seq lens. It clears with the gemma-4-it golden re-record
+on current main. Remaining follow-ups: re-validate serving on a current-main base once that re-record lands,
+re-bench against a stock arm at a comparable admission shape, and upstream the vLLM report.
 
 ## Target architecture
 

--- a/tests/serving/test_serve_command.py
+++ b/tests/serving/test_serve_command.py
@@ -221,36 +221,18 @@ def test_serve_cmd_generate_chunk_capture_respects_user_attention_backend():
     assert _capture_cfg(cmd)["cudagraph_mode"] == "FULL"  # vLLM downgrades it if the backend can't
 
 
-def test_serve_cmd_generate_wide_head_model_caps_the_rungs(monkeypatch):
-    """On a model with an attention head wider than 256 (gemma-4's 512-wide global layers),
-    vLLM 0.23's TRITON_ATTN faults capturing mixed batches wider than the validated cap
-    (illegal access at 4128 tokens, clean through 2112 — 5090-measured), so the head-dim
-    probe caps the rung list there; wider steps stay eager."""
-
-    class _Cfg:
-        head_dim = 256
-        global_head_dim = 512
-
-    monkeypatch.setattr("emmy.commands.serve._local_config", lambda model, vllm_args: _Cfg())
+def test_serve_cmd_generate_rider_top_rung_above_model_len_survives(monkeypatch):
+    """The rider-top rung (chunk quantum + decode bucket) may exceed --max-model-len — the
+    plugin's dummy-run seq-lens clamp (``serving/vllm_patches.py``) makes such a capture
+    size safe on vLLM 0.23, so the rung list is NOT capped by head width or model len."""
+    monkeypatch.setenv("EMMY_GEN_DECODE_BUCKET", "32")
     cmd = build_serve_cmd(MODEL, stock=False, vllm_args=[], generate=True)
     cfg = _capture_cfg(cmd)
     assert cfg["cudagraph_mode"] == "FULL"
     sizes = cfg["cudagraph_capture_sizes"]
-    assert max(sizes) <= 2112
-    assert 2048 in sizes  # the c4/c8 chunk-quantum lane's exact chunk width stays covered
+    assert 4128 in sizes  # rider top = 4096 chunk quantum + 32 bucket, past model len 4096
+    assert 4096 in sizes  # the exact chunk width
     assert 272 in sizes  # the short-prompt rungs stay dense (a 257-token prefill pads to 272)
-    assert cmd[cmd.index("--attention-backend") + 1] == "TRITON_ATTN"
-
-
-def test_serve_cmd_generate_narrow_head_model_keeps_full_rungs(monkeypatch):
-    class _Cfg:
-        head_dim = 128
-
-    monkeypatch.setattr("emmy.commands.serve._local_config", lambda model, vllm_args: _Cfg())
-    cmd = build_serve_cmd(MODEL, stock=False, vllm_args=[], generate=True)
-    cfg = _capture_cfg(cmd)
-    assert cfg["cudagraph_mode"] == "FULL"
-    assert {4096, 4112} <= set(cfg["cudagraph_capture_sizes"])
     assert cmd[cmd.index("--attention-backend") + 1] == "TRITON_ATTN"
 
 

--- a/tests/serving/test_vllm_patches.py
+++ b/tests/serving/test_vllm_patches.py
@@ -1,0 +1,64 @@
+"""The dummy-run seq-lens clamp (``serving/vllm_patches.py``) against a stub runner.
+
+The real defect needs a CUDA capture warmup to fire; here we verify the patch mechanics —
+over-limit seq lens are clamped on both buffers before delegation, legal ones pass through
+untouched, and re-applying the patch never double-wraps.
+"""
+
+import sys
+import types
+
+import torch
+
+from emmy.serving.vllm_patches import clamp_dummy_run_seq_lens
+
+
+class _RunnerBase:
+    def __init__(self, lens: list[int], max_model_len: int):
+        self.optimistic_seq_lens_cpu = torch.tensor(lens, dtype=torch.int32)
+        self.seq_lens = torch.zeros(len(lens), dtype=torch.int32)
+        self.max_model_len = max_model_len
+        self.built = 0
+
+    def _build_attention_metadata(self, *args, **kwargs):
+        self.built += 1
+        return "metadata"
+
+
+def _install_stub(monkeypatch) -> type:
+    class Runner(_RunnerBase):  # fresh class per test: the patch mutates it
+        pass
+
+    for name in ("vllm", "vllm.v1", "vllm.v1.worker"):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    mod = types.ModuleType("vllm.v1.worker.gpu_model_runner")
+    mod.GPUModelRunner = Runner
+    monkeypatch.setitem(sys.modules, "vllm.v1.worker.gpu_model_runner", mod)
+    return Runner
+
+
+def test_over_model_len_dummy_seq_lens_are_clamped(monkeypatch):
+    _install_stub(monkeypatch)
+    clamp_dummy_run_seq_lens()
+    runner = sys.modules["vllm.v1.worker.gpu_model_runner"].GPUModelRunner([4128, 4128, 0], max_model_len=4096)
+    assert runner._build_attention_metadata(num_tokens=1) == "metadata"
+    assert runner.built == 1
+    assert runner.optimistic_seq_lens_cpu.tolist() == [4096, 4096, 0]
+    assert runner.seq_lens.tolist() == [4096, 4096, 0]
+
+
+def test_legal_seq_lens_pass_through_untouched(monkeypatch):
+    _install_stub(monkeypatch)
+    clamp_dummy_run_seq_lens()
+    runner = sys.modules["vllm.v1.worker.gpu_model_runner"].GPUModelRunner([4096, 17, 0], max_model_len=4096)
+    runner._build_attention_metadata()
+    assert runner.optimistic_seq_lens_cpu.tolist() == [4096, 17, 0]
+    assert runner.seq_lens.tolist() == [0, 0, 0]  # no refresh issued
+
+
+def test_patch_is_idempotent(monkeypatch):
+    runner_cls = _install_stub(monkeypatch)
+    clamp_dummy_run_seq_lens()
+    once = runner_cls._build_attention_metadata
+    clamp_dummy_run_seq_lens()
+    assert runner_cls._build_attention_metadata is once


### PR DESCRIPTION
Rebased onto `main` after #517 merged.

## Root cause of the TRITON_ATTN mixed-capture fault

vLLM 0.23's default model runner fills every dummy request's seq_len with the step's total token
count during FULL-capture warmups. A capture size above `--max-model-len` (only the rider-top rung
can be: 4128 > 4096) therefore claims more block-table pages than a row holds (258 vs 256). The
unified-attention kernel loads block tables without a bounds mask, so the last request's programs
read garbage page ids past the tensor, and those drive the K/V loads out of bounds — the
capture-warmup illegal memory access. Standalone kernel repro on a 4080 (compute-sanitizer
attributes the fault to the K load): clean at 4096, faulting from 4097, at head_dim 256 AND 512 —
head width was a red herring. FLEX_ATTENTION's 258-vs-256 sliding-mask shape error is the same
arithmetic failing loudly, so one fix covers both backends.

Whether the out-of-bounds read faults or silently returns garbage depends on what the caching
allocator placed after the block table, which is why this reproduced 100% on the 5090 and stayed
invisible elsewhere.

## Fix

The plugin's `register()` now applies `serving/vllm_patches.clamp_dummy_run_seq_lens`: clamp the
dummy-run seq-lens buffers to `max_model_len` before attention metadata is built. Every legal batch
already satisfies the clamp, so real steps are untouched. `WIDE_HEAD_MIXED_RUNG_CAP`, the serve
command's head-dim probe, and the `EmmyGenModel` wide-head boot guard are removed — the rung list is
no longer capped, re-opening the 4096-chunk c64 lane.

Only vLLM's default (V1) model runner has the defect; its newer opt-in runner (stock
Llama/Mistral/Qwen3 only) builds legal dummy seq lens, and `EmmyGenModel` always rides the default
runner. Upstream `main` still carries the unclamped fill as of 2026-08-15.

## Validation

- Standalone kernel repro plus threshold bisect on the dev 4080: the threshold is exactly
  `max_model_len`.
- Engine-level on the 4080 (default runner forced): both over-model-len dummy runs clamped
  4128 → 4096, capture completed, greedy output correct. Unit tests for the patch mechanics included.
- 5090 (rented, gemma-4-12B-it @707f0a3b): the exact originally-faulting boot (mnbt 4128) captures
  all 64 mixed rungs and serves with greedy chat output byte-identical to stock vLLM. The 4096-lane
  c64 cell (bucket 64, mnbt 4160; 256 prompts, 512 in / 128 out, concurrency 64, medians of 3) runs
  capture ON at TPOT 32.75 ms vs OFF 33.69, with parity byte-identical across ON / OFF / stock.
  Full numbers in `plans/vllm-generic-integration-improvements.md`.
- Full suite on the rebased branch (dev 4080): 2 failed, 3560 passed — both failures
  (`test_fused_causal_sdpa_split_partition_keeps_absolute_predicate_coordinates`,
  `test_exl3_checkpoint_e2e_cuda`) reproduce identically on a clean `main` worktree. Lint clean.

**Scope note:** the 5090 serving evidence above was collected on `bench/fcbc-clamp` (the re-baseline
tree plus this clamp). Serving on a current-`main` base is separately blocked by #482's mlp_down fork
erasure — a bounded cold-pick slowdown of roughly 40 s/token that reads as a hang under any client
timeout — which clears with the gemma-4-it golden re-record, and is unrelated to this change (it only
touches dummy-run seq lens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
