### PR TITLE
Automate nightly model verification and onboarding

### DIFF
--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: onboard-model
 description: >-
-  Onboard and benchmark a Hugging Face model on an exact target GPU platform. Use when asked to add a model recipe,
-  validate a new model on a supplied GPU server, benchmark serving, create reproducible experiments and a durable
-  results report, fully qualify and tune the model's Emmy compiler inventory even when serving is blocked, or publish
-  a prebuilt CloudRiftAI serving image.
+  Onboard or periodically reverify and benchmark a Hugging Face model on an exact target GPU platform. Use when asked
+  to add a model recipe, refresh a maintained recipe on a supplied GPU server, benchmark serving, create reproducible
+  experiments and a durable results report, fully qualify and tune the model's Emmy compiler inventory even when
+  serving is blocked, or publish a prebuilt CloudRiftAI serving image.
 ---
 
-# Onboard a model
+# Onboard or reverify a model
 
-Turn a Hugging Face model ID and an exact `(GPU name, GPU count)` into reviewed repository artifacts:
+Turn a Hugging Face model ID, an operation mode, and an exact `(GPU name, GPU count)` into reviewed repository
+artifacts:
 
 - one recommended serving recipe under `recipes/<model>/recipe.yaml`;
 - reproducible qualification or comparison configurations under `experiments/<model>/`, without committed run output;
@@ -32,14 +33,15 @@ to rescue a failed run.
 
 Require:
 
-1. the exact Hugging Face model ID;
-2. the exact hardware name used by `emmy/hardware.py` and GPU count;
-3. an SSH target accepted by `emmy deploy ssh` / `emmy bench --ssh`;
-4. a wall-clock deadline;
-5. whether publication is authorized and, when needed, Docker Hub credentials supplied without logging them;
-6. whether a multimodal model should be qualified as multimodal, text-only, or `auto` (infer the advertised modality
+1. an operation mode, exactly `onboarding` or `verification`;
+2. the exact Hugging Face model ID;
+3. the exact hardware name used by `emmy/hardware.py` and GPU count;
+4. an SSH target accepted by `emmy deploy ssh` / `emmy bench --ssh`;
+5. a wall-clock deadline;
+6. whether publication is authorized and, when needed, Docker Hub credentials supplied without logging them;
+7. whether a multimodal model should be qualified as multimodal, text-only, or `auto` (infer the advertised modality
    from the checkpoint and qualify that path);
-7. for a non-interactive run, an absolute output path for the machine-readable summary.
+8. for a non-interactive run, an absolute output path for the machine-readable summary.
 
 In an interactive run, ask only for missing inputs. In a non-interactive run, fail immediately on a missing or
 ambiguous input. The workflow-dispatch request is the publication authorization in CI: do not add a conversational
@@ -51,8 +53,15 @@ no overlay was supplied; never guess an overlay file. Check whether required var
 their values, and never echo a token.
 
 Before changing files, verify that the model exists on Hugging Face, the target host reports exactly the requested
-GPU name and count, and the checkout is on a feature branch. If `recipes/<model>/` already exists, use it as a
-starting point only when the caller explicitly allowed updates; otherwise fail instead of overwriting it.
+GPU name and count, and the checkout is on a feature branch. Model and GPU selection, VM rental, VM cleanup, git, and
+pull-request operations belong to the caller, not this skill.
+
+In `onboarding` mode, use the existing `onboarding`/`untested` recipe shell when present; a direct caller may instead
+authorize a new recipe. Replace those pending tags with `best-effort` only after qualification and artifact completion.
+In `verification` mode, begin with the existing active recipe, refresh its measurements and durable artifacts, and
+preserve its supplied lifecycle tag. The mode explicitly authorizes updates to that recipe; never use verification to
+silently change its model checkpoint, target GPU/count, or lifecycle. For any other existing recipe update, require
+explicit caller authorization or fail instead of overwriting it.
 
 ## 1. Research the serving path
 
@@ -287,13 +296,15 @@ In the summary, `cleanup.docker_logout: true` means no Docker credential remains
 login, or no Docker login was performed because the stock-only path did not require one.
 
 Write this JSON object atomically to the caller-supplied summary path outside the repository and print that path as the
-final line. List every repository file created, modified, or deleted by the onboarding run in `artifacts`. List only a
-complete repository golden in `compiler_artifacts`, and only retained experiment recipe YAML in
+final line. Include the requested mode on success and failure. List every repository file created, modified, or deleted
+by the qualification run in `artifacts`. List only a complete repository golden in `compiler_artifacts`, and only
+retained experiment recipe YAML in
 `experiment_artifacts`. Do not list or commit raw measurement output.
 
 ```json
 {
   "status": "success",
+  "mode": "onboarding",
   "model_id": "org/model",
   "target": {"gpu": "exact hardware.py name", "gpu_count": 1, "ssh": "user@host"},
   "recipe": "recipes/<model>/recipe.yaml",

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -82,8 +82,8 @@ rental. The workflow never falls back to GCP or changes the selected GPU type/co
 The workflow passes the resulting SSH target and an explicit `onboarding` or `verification` mode to the tracked
 `onboard-model` skill. Onboarding replaces the discovery shell and changes `onboarding`/`untested` to `best-effort`.
 Verification begins from the active recipe, refreshes measurements and durable artifacts, and preserves its existing
-lifecycle tag. The job has a six-hour limit and gives the agent an earlier deadline so artifact validation and cleanup
-retain time. Raw benchmark output, experiment reports, dated run snapshots, and qualification summaries are not
+lifecycle tag. The job has a 24-hour limit and gives the agent a 23.5-hour deadline so artifact validation and cleanup
+retain 30 minutes. Raw benchmark output, experiment reports, dated run snapshots, and qualification summaries are not
 repository artifacts. An Emmy-tuned prebuilt image is produced only when every release gate passes. Nightly image
 publication is disabled unless `NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual dispatch retains an explicit input.
 

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -11,7 +11,7 @@ tracked skills and CloudRift inference endpoint.
 | --- | --- | --- | --- |
 | **Tests** | Pull request to `main` | GitHub-hosted | Runs Ruff and the complete test suite. |
 | **Publish to PyPI** | Manual dispatch or published GitHub release | GitHub-hosted | Tests, builds, publishes to PyPI, and optionally creates the release. |
-| **Onboard model** | Manual dispatch | Self-hosted `agents` | Produces measured model artifacts on an exact GPU target and updates a PR. |
+| **Verify or onboard model** | Nightly schedule or manual dispatch | Self-hosted `agents` | Qualifies one available exact model/GPU deployment and updates the rolling lifecycle PR. |
 | **Discover model** | Nightly schedule or manual dispatch | Self-hosted `agents` | Refreshes recipe lifecycle tags and onboarding shells in one rolling PR without renting a VM. |
 
 There is no generic experiment workflow or GitHub dispatch input for `emmy bench`. Requested experiment runs start
@@ -64,31 +64,40 @@ provider alias, while `.opencode/agents/` owns the separate discovery and onboar
 tracked `.agents/skills/` remain the canonical task definitions. Compatibility symlinks under `.claude/skills/`
 expose the same packages through OpenCode's native skill tool.
 
-### Direct onboarding
+### Nightly verification and direct onboarding
 
-**Onboard model** accepts an exact Hugging Face model ID, exact GPU name/count, multimodal qualification mode, optional
-existing onboarding PR, and explicit image-publication authorization. The job has a six-hour limit and gives the
-agent an earlier deadline so artifact validation and cleanup retain time. When the PR contains a discovery shell, the
-qualified recipe replaces it and changes `onboarding`/`untested` to `best-effort`; later discovery runs can promote it
-to the maintained set.
+**Verify or onboard model** runs nightly and retains a manual exact model/GPU dispatch. Its mechanical selector reads
+the recipe inventory and CloudRift VM variant availability, without filtering on public-IP supply. It considers only
+declared deployments with an available exact CloudRift GPU count. Pending `onboarding`/`untested` recipes are the first
+priority. If none can run, it chooses a `maintained` recipe whose committed `RESULTS.md` has the oldest last-change
+timestamp; a missing report is oldest. Declaration order chooses among one recipe's available deployments, and model
+ID breaks remaining ties. No eligible deployment is a successful no-op.
 
-The workflow uses `gh` to resolve an existing labeled onboarding PR or prepares a new artifact branch, provisions
-exactly the requested platform through CloudRift or optional GCP, and passes the resulting SSH target to the tracked
-`onboard-model` skill. If neither provider can supply the exact target, the workflow fails; it does not silently change
-GPU type or count. The skill produces the recommended recipe, its compact serving report, and reproducible experiment
-YAML. Raw benchmark output, experiment reports, dated run snapshots, and onboarding summaries are not repository
-artifacts. An Emmy-tuned prebuilt image is produced only when the architecture, quantization, trace, serving, and
-release gates pass.
+The workflow resolves the exact visible CloudRift team named `Robots` and includes its UUID in every rent request, so
+the VM is team-owned and visible to team members. It attaches `emmy`, workflow, and GitHub job tags, makes at most
+three workflow-level rental attempts for the same selection, and sweeps a failed attempt by the complete tag set
+before retrying. Only V100 rentals set CloudRift's admin-only billing exemption; every other GPU is a regular team
+rental. The workflow never falls back to GCP or changes the selected GPU type/count.
+
+The workflow passes the resulting SSH target and an explicit `onboarding` or `verification` mode to the tracked
+`onboard-model` skill. Onboarding replaces the discovery shell and changes `onboarding`/`untested` to `best-effort`.
+Verification begins from the active recipe, refreshes measurements and durable artifacts, and preserves its existing
+lifecycle tag. The job has a six-hour limit and gives the agent an earlier deadline so artifact validation and cleanup
+retain time. Raw benchmark output, experiment reports, dated run snapshots, and qualification summaries are not
+repository artifacts. An Emmy-tuned prebuilt image is produced only when every release gate passes. Nightly image
+publication is disabled unless `NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual dispatch retains an explicit input.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
 allowed recipe, experiment, serving-image, and canonical-golden paths. Unmanifested or exploratory output is rejected.
-The workflow then commits those artifacts, updates or opens the onboarding PR, and uses renewable GitHub App
-credentials for the long-running push path.
+The validator also checks the requested mode, exact recipe model, and expected lifecycle tag. The workflow then
+commits those artifacts, rebases on the latest default branch, and updates or opens the rolling model lifecycle PR
+using renewable GitHub App credentials for the long-running push path.
 
 ### Discovery lifecycle PR
 
-**Discover model** runs nightly or by manual dispatch. It updates one rolling draft PR rather than opening one PR per
-model, and the workflow fails closed if more than one rolling discovery PR exists. It also adopts one unpaired
+**Discover model** runs nightly or by manual dispatch. Discovery and qualification share a static concurrency group
+and one rolling draft PR rather than opening one PR per model. Each workflow fails closed if more than one rolling PR
+exists. It also adopts one unpaired
 discovery branch left by an interrupted PR-creation step, while
 failing closed if multiple such branches would make ownership ambiguous. Before rendering inventory or running the
 agent, it rebases an existing rolling branch onto the latest default branch. The rebase push uses the exact original
@@ -127,11 +136,11 @@ GitHub Actions, and GitHub CLI credentials from every agent shell subprocess. On
 required Hugging Face and Docker Hub credentials. The self-hosted runner must not carry unrelated ambient cloud
 credentials.
 
-`emmy vm create gpu --lease` writes a run-owned lease as soon as CloudRift returns an instance ID or GCP creates the
-named instance. The lease binds the provider handle, exact request, workflow owner, and SSH target. Cleanup through
-`emmy vm delete lease` accepts only that lease, retries deletion, and audits only the recorded handle; it never
-enumerates or deletes unrelated VMs. An `if: always()` workflow step performs cleanup after OpenCode exits, then
-`emmy vm audit lease` fails the job if its owned VM is still active.
+`emmy vm create gpu --lease` writes a run-owned lease as soon as CloudRift returns an instance ID. The lease binds the
+provider handle, exact request, workflow owner, and SSH target. Cleanup first deletes and audits that handle, then
+lists and terminates every still-active CloudRift VM carrying the complete run-unique tag set. The tag audit catches a
+VM created before the lease was durable without selecting another job's rentals. An `if: always()` step performs both
+paths after OpenCode exits and fails the job if either ownership audit leaves a VM active.
 
 GitHub App credentials are used for long-lived branch writes and PR operations. Private keys and temporary provider
 configuration live only under run-specific `/tmp/emmy-*` paths and are removed by unconditional cleanup steps.
@@ -140,11 +149,12 @@ configuration live only under run-specific `/tmp/emmy-*` paths and are removed b
 
 Agent workflows use these repository secrets as applicable:
 
-- `CLOUDRIFT_API_KEY` for model discovery and CloudRift provisioning;
+- `CLOUDRIFT_API_KEY` for model discovery, Robots-team resolution, availability, and CloudRift provisioning;
 - `HF_TOKEN` for gated checkpoints;
-- `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for an eligible verified prebuilt image;
-- optional `GCP_SERVICE_ACCOUNT_KEY` and `GCP_SERVICE_ACCOUNT` for GCP capacity.
+- `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for an eligible verified prebuilt image.
 
 `ONBOARD_AGENT_MODEL` selects the discovery/onboarding model and defaults to `Qwen/Qwen3.6-35B-A3B-FP8`.
 `CLOUDRIFT_INFERENCE_URL` selects its OpenAI-compatible endpoint and defaults to
 `https://inference.cloudrift.ai/v1`.
+`NIGHTLY_ONBOARD_PUBLISH_IMAGE=true` authorizes a nightly qualification to publish an otherwise eligible image; it is
+false when unset.

--- a/.github/scripts/onboarding_artifacts.py
+++ b/.github/scripts/onboarding_artifacts.py
@@ -9,6 +9,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
+
+from emmy.recipe.lifecycle import validate_recipe_tags
+
 ALLOWED_ARTIFACT_PREFIXES = (
     "docker/vllm-emmy-serve/models/",
     "emmy/compiler/pipeline/search/goldens/",
@@ -60,12 +64,16 @@ def validate_summary(
     gpu: str,
     gpu_count: int,
     ssh_target: str,
+    mode: str,
+    expected_tag: str,
 ) -> tuple[dict, list[Path]]:
     summary = json.loads(summary_path.read_text())
     if summary.get("status") != "success":
         raise ValueError(f"Onboarding did not succeed: {summary.get('failure')}")
     if summary.get("model_id") != model_id:
         raise ValueError(f"Summary model mismatch: {summary.get('model_id')} != {model_id}")
+    if summary.get("mode") != mode:
+        raise ValueError(f"Summary mode mismatch: {summary.get('mode')} != {mode}")
     target = summary.get("target") or {}
     expected_target = {"gpu": gpu, "gpu_count": gpu_count, "ssh": ssh_target}
     if target != expected_target:
@@ -75,6 +83,15 @@ def validate_summary(
         raise ValueError(f"Remote workload or Docker credential cleanup is incomplete: {cleanup}")
 
     recipe = _relative_file(workspace, summary.get("recipe") or "", ("recipes/",))
+    recipe_config = yaml.safe_load((workspace / recipe).read_text()) or {}
+    recipe_model_id = (recipe_config.get("model") or {}).get("huggingface")
+    if recipe_model_id != model_id:
+        raise ValueError(f"Recipe model mismatch: {recipe_model_id} != {model_id}")
+    recipe_tags = validate_recipe_tags(recipe_config.get("tags"))
+    if expected_tag not in recipe_tags:
+        raise ValueError(f"Recipe must retain lifecycle tag {expected_tag!r}: {recipe_tags}")
+    if mode == "onboarding" and ({"onboarding", "untested"} & set(recipe_tags)):
+        raise ValueError(f"Onboarding recipe still has pending lifecycle tags: {recipe_tags}")
     report = _relative_file(workspace, summary.get("report") or "", ("recipes/",))
     if report != recipe.with_name("RESULTS.md"):
         raise ValueError(f"Report must be RESULTS.md beside the final recipe: {report}")
@@ -143,6 +160,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--gpu", required=True)
     parser.add_argument("--gpu-count", type=int, required=True)
     parser.add_argument("--ssh-target", required=True)
+    parser.add_argument("--mode", choices=("onboarding", "verification"), required=True)
+    parser.add_argument("--expected-tag", choices=("maintained", "best-effort"), required=True)
     parser.add_argument("--stage", action="store_true")
     return parser
 
@@ -157,6 +176,8 @@ def main() -> int:
             args.gpu,
             args.gpu_count,
             args.ssh_target,
+            args.mode,
+            args.expected_tag,
         )
         if args.stage:
             stage_artifacts(args.workspace.resolve(), artifacts)

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: model-discovery
+  group: model-lifecycle
   cancel-in-progress: false
 
 jobs:
@@ -52,7 +52,7 @@ jobs:
           }
           matches=$(retry_gh gh pr list --state open --limit 100 \
             --json number,headRefName,isCrossRepository,labels \
-            --jq '[.[] | select((.isCrossRepository | not) and (([.labels[].name] | index("model-discovery")) or (.headRefName | startswith("agents/model-discovery-"))))]')
+            --jq '[.[] | select((.isCrossRepository | not) and (([.labels[].name] | index("model-discovery")) or ([.labels[].name] | index("model-onboarding")) or (.headRefName | startswith("agents/model-discovery-"))))]')
           count=$(jq length <<< "$matches")
           if [ "$count" -gt 1 ]; then
             echo "Expected at most one rolling model discovery PR, found $count" >&2

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   onboard:
     runs-on: [self-hosted, agents]
-    timeout-minutes: 360
+    timeout-minutes: 1440
     permissions:
       contents: read
       pull-requests: read
@@ -299,7 +299,7 @@ jobs:
 
       - name: Set onboarding deadline
         if: steps.selection.outputs.selected == 'true'
-        run: echo "ONBOARD_DEADLINE=$(date -u -d '+5 hours 30 minutes' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+        run: echo "ONBOARD_DEADLINE=$(date -u -d '+23 hours 30 minutes' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
       - name: Generate ephemeral SSH key and isolated provider config
         if: steps.selection.outputs.selected == 'true'

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -1,6 +1,8 @@
-name: Onboard model
+name: Verify or onboard model
 
 on:
+  schedule:
+    - cron: "47 9 * * *"
   workflow_dispatch:
     inputs:
       model_id:
@@ -27,12 +29,9 @@ on:
         required: true
         default: true
         type: boolean
-      pull_request:
-        description: Optional open onboarding PR number to update (otherwise the selected workflow branch is detected)
-        required: false
-        type: string
+
 concurrency:
-  group: onboard-${{ inputs.pull_request || inputs.model_id }}-${{ inputs.gpu }}-${{ inputs.gpu_count }}
+  group: model-lifecycle
   cancel-in-progress: false
 
 jobs:
@@ -44,21 +43,24 @@ jobs:
       pull-requests: read
     env:
       GH_REPO: ${{ github.repository }}
-      MODEL_ID: ${{ inputs.model_id }}
-      TARGET_GPU: ${{ inputs.gpu }}
-      TARGET_GPU_COUNT: ${{ inputs.gpu_count }}
-      MULTIMODAL_MODE: ${{ inputs.multimodal_mode }}
-      PUBLISH_IMAGE: ${{ inputs.publish_image }}
-      RUN_OWNER: ${{ github.run_id }}-${{ github.run_attempt }}
+      REQUESTED_MODEL_ID: ${{ inputs.model_id }}
+      REQUESTED_GPU: ${{ inputs.gpu }}
+      REQUESTED_GPU_COUNT: ${{ inputs.gpu_count }}
+      CLOUDRIFT_TEAM_NAME: Robots
+      MULTIMODAL_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.multimodal_mode || 'auto' }}
+      PUBLISH_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.publish_image) || (github.event_name == 'schedule' && vars.NIGHTLY_ONBOARD_PUBLISH_IMAGE == 'true') }}
+      RUN_OWNER: ${{ github.repository }}/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
+      EMMY_RENTAL_TAGS: emmy,workflow:model-verification-onboarding,gh-job:${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
       VM_LEASE: /tmp/emmy-onboard-${{ github.run_id }}-${{ github.run_attempt }}.json
       ONBOARD_SUMMARY: /tmp/emmy-onboard-summary-${{ github.run_id }}-${{ github.run_attempt }}.json
       AGENT_PROMPT: /tmp/emmy-onboard-prompt-${{ github.run_id }}-${{ github.run_attempt }}.md
       AGENT_EVENTS: /tmp/emmy-onboard-events-${{ github.run_id }}-${{ github.run_attempt }}.jsonl
       AGENT_OUTPUT: /tmp/emmy-onboard-agent-${{ github.run_id }}-${{ github.run_attempt }}.txt
+      RECIPE_INVENTORY: /tmp/emmy-onboard-inventory-${{ github.run_id }}-${{ github.run_attempt }}.json
+      PROVIDER_CONFIG: /tmp/emmy-onboard-provider-${{ github.run_id }}-${{ github.run_attempt }}.yaml
+      PR_SUMMARY: /tmp/emmy-onboard-pr-${{ github.run_id }}-${{ github.run_attempt }}.md
       SSH_KEY: /tmp/emmy-onboard-ssh-${{ github.run_id }}-${{ github.run_attempt }}
       APP_KEY_FILE: /tmp/emmy-onboard-app-key-${{ github.run_id }}-${{ github.run_attempt }}.pem
-      GCP_KEY_FILE: /tmp/emmy-onboard-gcp-key-${{ github.run_id }}-${{ github.run_attempt }}.json
-      GCP_CONFIG_DIR: /tmp/emmy-onboard-gcloud-${{ github.run_id }}-${{ github.run_attempt }}
       AGENT_MODEL: ${{ vars.ONBOARD_AGENT_MODEL || 'Qwen/Qwen3.6-35B-A3B-FP8' }}
       CLOUDRIFT_INFERENCE_URL: ${{ vars.CLOUDRIFT_INFERENCE_URL || 'https://inference.cloudrift.ai/v1' }}
       OPENCODE_DISABLE_AUTOUPDATE: "true"
@@ -71,91 +73,90 @@ jobs:
           private-key: ${{ secrets.EXPERIMENT_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 
-      - name: Resolve existing or new pull request branch
-        id: branch
+      - name: Find rolling model lifecycle pull request
+        id: rolling
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          MODEL_ID: ${{ env.MODEL_ID }}
-          REQUESTED_PR: ${{ inputs.pull_request }}
-          CURRENT_BRANCH: ${{ github.ref_name }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          pull=''
-          if [ -n "$REQUESTED_PR" ]; then
-            if ! [[ "$REQUESTED_PR" =~ ^[1-9][0-9]*$ ]]; then
-              echo "Invalid pull request number: $REQUESTED_PR" >&2
-              exit 1
-            fi
-            pull=$(gh pr view "$REQUESTED_PR" \
-              --json number,state,headRefName,isCrossRepository,labels,title,body)
-          elif [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
-            pull=$(gh pr list --state open --head "$CURRENT_BRANCH" --limit 100 \
-              --json number,state,headRefName,isCrossRepository,labels,title,body \
-              --jq '[.[] | select([.labels[].name] | index("model-onboarding"))][0] // empty')
+          retry_gh() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              if [ "$attempt" -eq 3 ]; then
+                return 1
+              fi
+              sleep "$attempt"
+            done
+          }
+          matches=$(retry_gh gh pr list --state open --limit 100 \
+            --json number,headRefName,isCrossRepository,labels \
+            --jq '[.[] | select((.isCrossRepository | not) and (([.labels[].name] | index("model-discovery")) or ([.labels[].name] | index("model-onboarding")) or (.headRefName | startswith("agents/model-discovery-"))))]')
+          count=$(jq length <<< "$matches")
+          if [ "$count" -gt 1 ]; then
+            echo "Expected at most one rolling model lifecycle PR, found $count" >&2
+            exit 1
           fi
 
-          if [ -n "$pull" ]; then
-            number=$(jq -r .number <<< "$pull")
-            if [ "$(jq -r .state <<< "$pull")" != "OPEN" ]; then
-              echo "Pull request #$number is not open" >&2
+          number=$(jq -r '.[0].number // empty' <<< "$matches")
+          branch=$(jq -r '.[0].headRefName // empty' <<< "$matches")
+          if [ -n "$number" ]; then
+            echo "Updating rolling model lifecycle PR #$number from $branch"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            orphan_output=$(retry_gh gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/agents/model-discovery-" \
+              --jq '.[].ref | sub("^refs/heads/"; "")')
+            mapfile -t orphan_branches < <(printf '%s' "$orphan_output" | sort)
+            if [ "${#orphan_branches[@]}" -gt 1 ]; then
+              echo "Expected at most one unpaired model lifecycle branch, found ${#orphan_branches[@]}" >&2
               exit 1
             fi
-            if [ "$(jq -r .isCrossRepository <<< "$pull")" != "false" ]; then
-              echo "Onboarding cannot push artifacts to a fork pull request" >&2
-              exit 1
+            branch="${orphan_branches[0]:-}"
+            if [ -n "$branch" ]; then
+              echo "Adopting unpaired model lifecycle branch $branch"
             fi
-            if ! jq -e '[.labels[].name] | index("model-onboarding")' <<< "$pull" >/dev/null; then
-              echo "Pull request #$number is missing the model-onboarding label" >&2
-              exit 1
-            fi
-            if ! jq -e --arg model "$MODEL_ID" --arg marker "\`$MODEL_ID\`" \
-              '(.title | contains($model)) or ((.body // "") | contains($marker))' <<< "$pull" >/dev/null; then
-              echo "Pull request #$number does not describe $MODEL_ID" >&2
-              exit 1
-            fi
-            branch=$(jq -r .headRefName <<< "$pull")
-            echo "branch=$branch" >> "$GITHUB_OUTPUT"
-            echo "checkout_ref=$branch" >> "$GITHUB_OUTPUT"
-            echo "pr_number=$number" >> "$GITHUB_OUTPUT"
-            echo "existing=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
-          slug=$(tr '[:upper:]' '[:lower:]' <<< "$MODEL_ID" | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//g')
-          echo "branch=agents/onboard-$slug-$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "checkout_ref=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
-          echo "pr_number=" >> "$GITHUB_OUTPUT"
-          echo "existing=false" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout onboarding base
+      - name: Checkout model lifecycle branch
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          ref: ${{ steps.branch.outputs.checkout_ref }}
+          ref: ${{ steps.rolling.outputs.branch || github.event.repository.default_branch }}
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Create artifact branch
-        if: steps.branch.outputs.existing != 'true'
+      - name: Rebase existing branch on latest main
+        id: rebase
+        if: steps.rolling.outputs.branch != ''
         env:
-          ARTIFACT_BRANCH: ${{ steps.branch.outputs.branch }}
-        run: git switch -c "$ARTIFACT_BRANCH"
-
-      - name: Set onboarding deadline
-        run: echo "ONBOARD_DEADLINE=$(date -u -d '+5 hours 30 minutes' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
-
-      - name: Validate request
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          EXISTING_BRANCH: ${{ steps.rolling.outputs.branch }}
         run: |
-          python3 - <<'PY'
-          import os
-          import re
-          import sys
+          git config user.name "emmy-onboarding-bot"
+          git config user.email "emmy-onboarding-bot[bot]@users.noreply.github.com"
+          gh auth setup-git
+          git fetch origin \
+            "+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" \
+            "+refs/heads/$EXISTING_BRANCH:refs/remotes/origin/$EXISTING_BRANCH"
 
-          if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", os.environ["MODEL_ID"]):
-              sys.exit("model_id must be an exact Hugging Face owner/repository ID")
-          if int(os.environ["TARGET_GPU_COUNT"]) < 1:
-              sys.exit("gpu_count must be positive")
-          PY
+          original_head="$(git rev-parse HEAD)"
+          remote_head="$(git rev-parse "origin/$EXISTING_BRANCH")"
+          if [ "$original_head" != "$remote_head" ]; then
+            echo "Model lifecycle branch changed after selection; refusing to overwrite $remote_head" >&2
+            exit 1
+          fi
+
+          git rebase "origin/$BASE_BRANCH"
+          rebased_head="$(git rev-parse HEAD)"
+          if [ "$rebased_head" != "$original_head" ]; then
+            git push \
+              --force-with-lease="refs/heads/$EXISTING_BRANCH:$original_head" \
+              origin "HEAD:refs/heads/$EXISTING_BRANCH"
+          fi
+          echo "expected_head=$rebased_head" >> "$GITHUB_OUTPUT"
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -165,51 +166,194 @@ jobs:
       - name: Install Emmy
         run: make setup-agent
 
-      - name: Generate ephemeral SSH key
-        run: ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -q
-
-      - name: Isolate optional GCP credentials
-        run: |
-          case "$GCP_CONFIG_DIR" in
-            /tmp/emmy-onboard-gcloud-*) ;;
-            *) echo "Refusing unsafe GCP config path: $GCP_CONFIG_DIR" >&2; exit 1 ;;
-          esac
-          rm -rf -- "$GCP_CONFIG_DIR"
-          install -d -m 700 "$GCP_CONFIG_DIR"
-          echo "CLOUDSDK_CONFIG=$GCP_CONFIG_DIR" >> "$GITHUB_ENV"
-
-      - name: Configure optional GCP credentials
+      - name: Select one available deployment
+        id: selection
         env:
-          GCP_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          GCP_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-        if: env.GCP_KEY != ''
+          CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          rm -f -- "$GCP_KEY_FILE"
-          printf '%s' "$GCP_KEY" > "$GCP_KEY_FILE"
-          chmod 600 "$GCP_KEY_FILE"
-          CLOUDSDK_CONFIG="$GCP_CONFIG_DIR" gcloud auth activate-service-account --key-file="$GCP_KEY_FILE"
-          CLOUDSDK_CONFIG="$GCP_CONFIG_DIR" gcloud config set project "$(jq -r .project_id "$GCP_KEY_FILE")"
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$GCP_KEY_FILE" >> "$GITHUB_ENV"
-          echo "GCP_SERVICE_ACCOUNT=$GCP_ACCOUNT" >> "$GITHUB_ENV"
+          ./venv/bin/emmy recipe list recipes --json > "$RECIPE_INVENTORY"
+          ./venv/bin/python - <<'PY'
+          import asyncio
+          import json
+          import os
+          import re
+          import subprocess
+          from pathlib import Path
 
-      - name: Provision exact target VM
+          from emmy.provisioning.candidates import iter_candidates
+          from emmy.provisioning.cloudrift import list_available_instance_types, resolve_team_id
+
+          inventory = json.loads(Path(os.environ["RECIPE_INVENTORY"]).read_text())
+          available = asyncio.run(list_available_instance_types(os.environ["CLOUDRIFT_API_KEY"]))
+          team_id = asyncio.run(
+              resolve_team_id(os.environ["CLOUDRIFT_API_KEY"], os.environ["CLOUDRIFT_TEAM_NAME"])
+          )
+          with Path(os.environ["GITHUB_ENV"]).open("a") as output:
+              output.write(f"CLOUDRIFT_TEAM_ID={team_id}\n")
+
+          def available_deployment(deployment):
+              gpu = deployment.get("deploy.gpu")
+              count = deployment.get("deploy.gpu_count")
+              try:
+                  candidates = iter_candidates(gpu, count, "cloudrift", exact_gpu_count=True)
+              except (TypeError, ValueError):
+                  return False
+              return any(candidate.instance_type in available for candidate in candidates)
+
+          def write_selection(record, deployment, mode, lifecycle):
+              values = {
+                  "selected": "true",
+                  "model_id": record["model_id"],
+                  "gpu": deployment["deploy.gpu"],
+                  "gpu_count": str(deployment["deploy.gpu_count"]),
+                  "mode": mode,
+                  "lifecycle": lifecycle,
+              }
+              with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+                  for key, value in values.items():
+                      output.write(f"{key}={value}\n")
+              with Path(os.environ["GITHUB_ENV"]).open("a") as output:
+                  for key, value in {
+                      "MODEL_ID": values["model_id"],
+                      "TARGET_GPU": values["gpu"],
+                      "TARGET_GPU_COUNT": values["gpu_count"],
+                      "ONBOARD_MODE": values["mode"],
+                      "EXPECTED_LIFECYCLE": values["lifecycle"],
+                  }.items():
+                      output.write(f"{key}={value}\n")
+
+          if os.environ["EVENT_NAME"] == "workflow_dispatch":
+              model_id = os.environ["REQUESTED_MODEL_ID"]
+              gpu = os.environ["REQUESTED_GPU"]
+              try:
+                  gpu_count = int(os.environ["REQUESTED_GPU_COUNT"])
+              except ValueError as exc:
+                  raise SystemExit("gpu_count must be positive") from exc
+              if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", model_id):
+                  raise SystemExit("model_id must be an exact Hugging Face owner/repository ID")
+              if gpu_count < 1:
+                  raise SystemExit("gpu_count must be positive")
+              deployment = {"deploy.gpu": gpu, "deploy.gpu_count": gpu_count}
+              if not available_deployment(deployment):
+                  raise SystemExit(f"CloudRift has no available exact {gpu} x{gpu_count} VM")
+              existing = next((record for record in inventory if record["model_id"] == model_id), None)
+              if existing and "obsolete" in existing["tags"]:
+                  raise SystemExit(f"Refusing to run an obsolete recipe: {model_id}")
+              if existing and "maintained" in existing["tags"]:
+                  mode, lifecycle = "verification", "maintained"
+              elif existing and "best-effort" in existing["tags"]:
+                  mode, lifecycle = "verification", "best-effort"
+              else:
+                  mode, lifecycle = "onboarding", "best-effort"
+              write_selection(existing or {"model_id": model_id}, deployment, mode, lifecycle)
+              raise SystemExit(0)
+
+          ranked = []
+          for record in inventory:
+              tags = set(record["tags"])
+              if {"onboarding", "untested"}.issubset(tags):
+                  tier, mode, lifecycle = 0, "onboarding", "best-effort"
+              elif "maintained" in tags:
+                  tier, mode, lifecycle = 1, "verification", "maintained"
+              else:
+                  continue
+              deployment = next((item for item in record["deployments"] if available_deployment(item)), None)
+              if deployment is None:
+                  continue
+              report = str(Path(record["path"]).with_name("RESULTS.md"))
+              result = subprocess.run(
+                  ["git", "log", "-1", "--format=%ct", "--", report],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+              last_run = int(result.stdout.strip() or 0)
+              ranked.append((tier, last_run, record["model_id"], record, deployment, mode, lifecycle))
+
+          if not ranked:
+              with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+                  output.write("selected=false\n")
+              summary = os.environ.get("GITHUB_STEP_SUMMARY")
+              if summary:
+                  with Path(summary).open("a") as output:
+                      output.write("No onboarding or maintained recipe has an available exact CloudRift VM.\n")
+              raise SystemExit(0)
+
+          _, _, _, record, deployment, mode, lifecycle = min(ranked, key=lambda item: item[:3])
+          write_selection(record, deployment, mode, lifecycle)
+          PY
+
+      - name: Prepare artifact branch
+        id: branch
+        if: steps.selection.outputs.selected == 'true'
+        env:
+          EXISTING_BRANCH: ${{ steps.rolling.outputs.branch }}
+        run: |
+          branch="$EXISTING_BRANCH"
+          if [ -z "$branch" ]; then
+            branch="agents/model-discovery-${GITHUB_RUN_ID}"
+            git switch -c "$branch"
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Set onboarding deadline
+        if: steps.selection.outputs.selected == 'true'
+        run: echo "ONBOARD_DEADLINE=$(date -u -d '+5 hours 30 minutes' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      - name: Generate ephemeral SSH key and isolated provider config
+        if: steps.selection.outputs.selected == 'true'
+        run: |
+          ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -q
+          printf 'providers:\n  cloudrift:\n    team_id: "%s"\n' "$CLOUDRIFT_TEAM_ID" > "$PROVIDER_CONFIG"
+          chmod 600 "$PROVIDER_CONFIG"
+
+      - name: Rent exact target VM
         id: vm
+        if: steps.selection.outputs.selected == 'true'
         env:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
         run: |
-          ./venv/bin/emmy vm create gpu \
-            --gpu "$TARGET_GPU" \
-            --gpu-count "$TARGET_GPU_COUNT" \
-            --exact-gpu-count \
-            --ssh-key "$SSH_KEY" \
-            --name "onboard-$RUN_OWNER" \
-            --lease "$VM_LEASE" \
-            --owner "$GITHUB_REPOSITORY/$RUN_OWNER" \
-            --json
+          cleanup_tags() {
+            ./venv/bin/python - <<'PY'
+          import asyncio
+          import os
+
+          from emmy.provisioning.cloudrift import terminate_instances_by_tags
+
+          tags = [tag for tag in os.environ["EMMY_RENTAL_TAGS"].split(",") if tag]
+          asyncio.run(terminate_instances_by_tags(os.environ["CLOUDRIFT_API_KEY"], tags))
+          PY
+          }
+
+          billing=()
+          if [[ "$TARGET_GPU" == *V100* ]]; then
+            billing+=(--billing-exempt)
+          fi
+          for attempt in 1 2 3; do
+            rm -f -- "$VM_LEASE"
+            if ./venv/bin/emmy vm create gpu \
+              --gpu "$TARGET_GPU" \
+              --gpu-count "$TARGET_GPU_COUNT" \
+              --exact-gpu-count \
+              --provider cloudrift \
+              --config "$PROVIDER_CONFIG" \
+              --ssh-key "$SSH_KEY" \
+              --name "model-lifecycle-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" \
+              --lease "$VM_LEASE" \
+              --owner "$RUN_OWNER" \
+              "${billing[@]}" \
+              --json; then
+              break
+            fi
+            cleanup_tags
+            if [ "$attempt" -eq 3 ]; then
+              echo "CloudRift rental failed after three attempts" >&2
+              exit 1
+            fi
+          done
           {
-            echo "provider=$(jq -r .vm.provider "$VM_LEASE")"
             echo "instance_id=$(jq -r .vm.instance_id "$VM_LEASE")"
-            echo "zone=$(jq -r '.vm.zone // ""' "$VM_LEASE")"
             echo "ssh_host=$(jq -r .vm.ssh_host "$VM_LEASE")"
             echo "ssh_port=$(jq -r .vm.ssh_port "$VM_LEASE")"
             echo "ssh_user=$(jq -r .vm.ssh_user "$VM_LEASE")"
@@ -217,51 +361,35 @@ jobs:
             echo "lease=$VM_LEASE"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Remove provider credentials before agent execution
-        if: steps.vm.outcome == 'success'
-        run: |
-          python3 - <<'PY'
-          import os
-          import shutil
-          from pathlib import Path
-
-          key = Path(os.environ["GCP_KEY_FILE"])
-          if key.is_dir() and not key.is_symlink():
-              shutil.rmtree(key, ignore_errors=True)
-          else:
-              key.unlink(missing_ok=True)
-          config = Path(os.environ["GCP_CONFIG_DIR"])
-          if config.is_symlink() or config.is_file():
-              config.unlink(missing_ok=True)
-          else:
-              shutil.rmtree(config, ignore_errors=True)
-          PY
-
       - name: Run onboard-model agent
+        if: steps.vm.outcome == 'success'
         env:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ inputs.publish_image && secrets.DOCKERHUB_TOKEN || '' }}
+          DOCKERHUB_TOKEN: ${{ env.PUBLISH_IMAGE == 'true' && secrets.DOCKERHUB_TOKEN || '' }}
           SSH_TARGET: ${{ steps.vm.outputs.ssh_target }}
           SSH_PORT: ${{ steps.vm.outputs.ssh_port }}
-          EXISTING_PR: ${{ steps.branch.outputs.pr_number }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
           import os
           from pathlib import Path
 
-          existing = os.environ.get("EXISTING_PR")
-          plan = (
-              f"This is the execution of existing model-onboarding PR #{existing}. Read the matching onboarding "
-              "recipe shell. Replace the shell with the qualified recipe and replace its onboarding and untested "
-              "tags with best-effort after all artifacts are complete."
-              if existing
-              else "This is a new onboarding; create all required artifacts from the tracked skill."
-          )
+          mode = os.environ["ONBOARD_MODE"]
+          if mode == "onboarding":
+              task = (
+                  "Use the existing onboarding/untested recipe shell when present, or create the recipe for a direct "
+                  "manual request. Replace onboarding and untested with best-effort after qualification."
+              )
+          else:
+              task = (
+                  "Reverify the existing recipe from its current configuration, refresh its measured artifacts, and "
+                  f"preserve its {os.environ['EXPECTED_LIFECYCLE']} lifecycle tag."
+              )
           prompt = f"""Use the onboard-model skill non-interactively.
 
+          Operation mode: {mode}
           Hugging Face model ID: {os.environ['MODEL_ID']}
           Exact target: {os.environ['TARGET_GPU']} x {os.environ['TARGET_GPU_COUNT']}
           SSH target: {os.environ['SSH_TARGET']}
@@ -269,82 +397,62 @@ jobs:
           SSH private key: {os.environ['SSH_KEY']} (pass --ssh-key {os.environ['SSH_KEY']} to every Emmy remote command)
           Absolute deadline: {os.environ['ONBOARD_DEADLINE']}
           Multimodal mode: {os.environ['MULTIMODAL_MODE']}
-          Publication authorized by workflow dispatch: {os.environ['PUBLISH_IMAGE']}
+          Publication authorized: {os.environ['PUBLISH_IMAGE']}
           Atomic summary output: {os.environ['ONBOARD_SUMMARY']}
 
-          {plan}
-          Do not provision or delete the VM, commit, push, or open/update a pull request. Always write the required
-          atomic summary, including experiment_artifacts with retained experiment recipe.yaml files only. Put the
-          selected benchmark numbers in the final recipe's RESULTS.md; do not retain raw results, experiment reports,
-          dated run snapshots, or onboarding summaries. Also include artifacts listing every intended created,
-          modified, or deleted repository file and no exploratory output. Allowed areas are recipes/, experiments/,
-          docker/vllm-emmy-serve/models/, and canonical golden YAML files.
+          {task}
+          Do not select a model or GPU, provision or delete the VM, commit, push, or open/update a pull request.
+          Always write the required atomic summary with mode set to {mode}, including experiment_artifacts with
+          retained experiment recipe.yaml files only. Put selected benchmark numbers in the final recipe's
+          RESULTS.md; do not retain raw results, experiment reports, dated run snapshots, or onboarding summaries.
+          Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
+          output. Allowed areas are recipes/, experiments/, docker/vllm-emmy-serve/models/, and canonical golden YAML.
           """
           Path(os.environ["AGENT_PROMPT"]).write_text(prompt)
           PY
 
           set +e
-          env \
-            -u CLOUDSDK_CONFIG \
-            -u GOOGLE_APPLICATION_CREDENTIALS \
-            -u GCP_SERVICE_ACCOUNT \
-            opencode run \
-              "Complete the attached onboarding task exactly." \
-              --agent onboard-model \
-              --model cloudrift/agent \
-              --format json \
-              --file "$AGENT_PROMPT" > "$AGENT_EVENTS"
+          opencode run \
+            "Complete the attached onboarding task exactly." \
+            --agent onboard-model \
+            --model cloudrift/agent \
+            --format json \
+            --file "$AGENT_PROMPT" > "$AGENT_EVENTS"
           agent_status=$?
           set -e
           jq -s -r '[.[] | select(.type == "text") | .part.text][-1] // empty' \
             "$AGENT_EVENTS" > "$AGENT_OUTPUT"
           exit "$agent_status"
 
-      - name: Delete workflow-owned VM
-        if: always()
+      - name: Delete workflow-owned CloudRift VMs
+        if: always() && steps.selection.outputs.selected == 'true'
         env:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
-          GCP_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          GCP_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
         run: |
-          cleanup_provider_credentials() {
-            python3 - <<'PY'
-          import os
-          import shutil
-          from pathlib import Path
-
-          key = Path(os.environ["GCP_KEY_FILE"])
-          if key.is_dir() and not key.is_symlink():
-              shutil.rmtree(key, ignore_errors=True)
-          else:
-              key.unlink(missing_ok=True)
-          config = Path(os.environ["GCP_CONFIG_DIR"])
-          if config.is_symlink() or config.is_file():
-              config.unlink(missing_ok=True)
-          else:
-              shutil.rmtree(config, ignore_errors=True)
-          PY
-          }
-          trap cleanup_provider_credentials EXIT
-          cleanup_provider_credentials
-          lease_provider=""
+          set +e
+          lease_status=0
           if [ -f "$VM_LEASE" ]; then
-            lease_provider=$(python3 -c 'import json, os; print(json.load(open(os.environ["VM_LEASE"]))["vm"]["provider"])')
+            ./venv/bin/emmy vm delete lease "$VM_LEASE" --owner "$RUN_OWNER" || lease_status=$?
+            ./venv/bin/emmy vm audit lease "$VM_LEASE" --owner "$RUN_OWNER" || lease_status=$?
           fi
-          if [ "$lease_provider" = "gcp" ] && [ -n "$GCP_KEY" ]; then
-            install -d -m 700 "$GCP_CONFIG_DIR"
-            printf '%s' "$GCP_KEY" > "$GCP_KEY_FILE"
-            chmod 600 "$GCP_KEY_FILE"
-            export CLOUDSDK_CONFIG="$GCP_CONFIG_DIR"
-            export GOOGLE_APPLICATION_CREDENTIALS="$GCP_KEY_FILE"
-            export GCP_SERVICE_ACCOUNT="$GCP_ACCOUNT"
-            gcloud auth activate-service-account --key-file="$GCP_KEY_FILE"
-            gcloud config set project "$(jq -r .project_id "$GCP_KEY_FILE")"
-          fi
-          ./venv/bin/emmy vm delete lease "$VM_LEASE" --owner "$GITHUB_REPOSITORY/$RUN_OWNER"
-          ./venv/bin/emmy vm audit lease "$VM_LEASE" --owner "$GITHUB_REPOSITORY/$RUN_OWNER"
+          ./venv/bin/python - <<'PY'
+          import asyncio
+          import os
 
-      - name: Validate and stage onboarding artifacts
+          from emmy.provisioning.cloudrift import terminate_instances_by_tags
+
+          tags = [tag for tag in os.environ["EMMY_RENTAL_TAGS"].split(",") if tag]
+          asyncio.run(terminate_instances_by_tags(os.environ["CLOUDRIFT_API_KEY"], tags))
+          PY
+          tag_status=$?
+          set -e
+          if [ "$lease_status" -ne 0 ] || [ "$tag_status" -ne 0 ]; then
+            echo "CloudRift cleanup or audit failed" >&2
+            exit 1
+          fi
+
+      - name: Validate and stage model artifacts
+        if: steps.vm.outcome == 'success'
         env:
           SSH_TARGET: ${{ steps.vm.outputs.ssh_target }}
         run: |
@@ -357,14 +465,17 @@ jobs:
             --gpu "$TARGET_GPU" \
             --gpu-count "$TARGET_GPU_COUNT" \
             --ssh-target "$SSH_TARGET" \
+            --mode "$ONBOARD_MODE" \
+            --expected-tag "$EXPECTED_LIFECYCLE" \
             --stage
           git diff --cached --check
           if git diff --cached --quiet; then
-            echo "::error::Onboarding produced no repository artifacts"
+            echo "::error::Model qualification produced no repository artifacts"
             exit 1
           fi
 
       - name: Configure renewable GitHub App credentials
+        if: steps.vm.outcome == 'success'
         env:
           APP_PRIVATE_KEY: ${{ secrets.EXPERIMENT_APP_PRIVATE_KEY }}
           APP_ID: ${{ secrets.EXPERIMENT_APP_ID }}
@@ -378,14 +489,34 @@ jobs:
           git config --add credential.helper \
             "!APP_ID=$APP_ID APP_KEY_FILE=$APP_KEY_FILE $GITHUB_WORKSPACE/.github/scripts/git-credential-github-app.sh"
 
-      - name: Commit and push artifacts
+      - name: Commit, rebase, and push model artifacts
+        if: steps.vm.outcome == 'success'
         env:
           ARTIFACT_BRANCH: ${{ steps.branch.outputs.branch }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_HEAD: ${{ steps.rebase.outputs.expected_head }}
         run: |
-          git commit -m "onboard: add $MODEL_ID on $TARGET_GPU x$TARGET_GPU_COUNT"
-          git push origin "HEAD:$ARTIFACT_BRANCH"
+          git commit -m "recipes: $ONBOARD_MODE $MODEL_ID on $TARGET_GPU x$TARGET_GPU_COUNT"
+          git fetch origin "+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH"
+          if [ -n "$EXPECTED_HEAD" ]; then
+            git fetch origin "+refs/heads/$ARTIFACT_BRANCH:refs/remotes/origin/$ARTIFACT_BRANCH"
+            remote_head="$(git rev-parse "origin/$ARTIFACT_BRANCH")"
+            if [ "$remote_head" != "$EXPECTED_HEAD" ]; then
+              echo "Model lifecycle branch changed during qualification; refusing to overwrite $remote_head" >&2
+              exit 1
+            fi
+          fi
+          git rebase "origin/$BASE_BRANCH"
+          if [ -n "$EXPECTED_HEAD" ]; then
+            git push \
+              --force-with-lease="refs/heads/$ARTIFACT_BRANCH:$EXPECTED_HEAD" \
+              origin "HEAD:refs/heads/$ARTIFACT_BRANCH"
+          else
+            git push origin "HEAD:refs/heads/$ARTIFACT_BRANCH"
+          fi
 
       - name: Refresh GitHub App token
+        if: steps.vm.outcome == 'success'
         id: app-token-refresh
         uses: actions/create-github-app-token@v1
         with:
@@ -393,29 +524,51 @@ jobs:
           private-key: ${{ secrets.EXPERIMENT_APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 
-      - name: Create or update onboarding pull request
+      - name: Create or update rolling model lifecycle pull request
+        if: steps.vm.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
           ARTIFACT_BRANCH: ${{ steps.branch.outputs.branch }}
-          EXISTING_PR: ${{ steps.branch.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.rolling.outputs.number }}
         run: |
-          if [ -n "$EXISTING_PR" ]; then
-            gh pr ready "$EXISTING_PR" || true
-            gh pr comment "$EXISTING_PR" --body \
-              "Onboarding completed for \`$MODEL_ID\` on \`$TARGET_GPU x$TARGET_GPU_COUNT\`. Artifacts were measured, validated, and pushed by run $GITHUB_RUN_ID."
-          else
-            gh label create model-onboarding \
-              --description "Automated model discovery and onboarding" \
-              --color 1D76DB --force
-            gh pr create \
-              --head "$ARTIFACT_BRANCH" \
-              --base "${{ github.event.repository.default_branch }}" \
-              --title "Onboard $MODEL_ID on $TARGET_GPU x$TARGET_GPU_COUNT" \
-              --label model-onboarding \
-              --body "Automated model onboarding with measured recipe, experiment artifacts, and durable results report.\n\nWorkflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          fi
+          retry_gh() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              if [ "$attempt" -eq 3 ]; then
+                return 1
+              fi
+              sleep "$attempt"
+            done
+          }
+          cat > "$PR_SUMMARY" <<EOF
+          Automated $ONBOARD_MODE completed for \`$MODEL_ID\` on \`$TARGET_GPU x$TARGET_GPU_COUNT\`.
 
-      - name: Cleanup local credentials
+          Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          EOF
+          retry_gh gh label create model-discovery \
+            --description "Automated model recipe lifecycle" \
+            --color 5319E7 --force
+          retry_gh gh label create model-onboarding \
+            --description "Automated model discovery and onboarding" \
+            --color 1D76DB --force
+          if [ -n "$PR_NUMBER" ]; then
+            retry_gh gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+              -f title="Refresh model lifecycle and onboarding" >/dev/null
+            retry_gh gh pr comment "$PR_NUMBER" --body-file "$PR_SUMMARY"
+          else
+            PR_NUMBER=$(retry_gh gh api --method POST "repos/$GITHUB_REPOSITORY/pulls" \
+              -f head="$ARTIFACT_BRANCH" \
+              -f base="${{ github.event.repository.default_branch }}" \
+              -f title="Refresh model lifecycle and onboarding" \
+              -F body=@"$PR_SUMMARY" \
+              -F draft=true \
+              --jq .number)
+          fi
+          retry_gh gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+            -f 'labels[]=model-discovery' \
+            -f 'labels[]=model-onboarding' >/dev/null
+
+      - name: Cleanup local credentials and output
         if: always()
         run: |
           rm -f \
@@ -423,20 +576,11 @@ jobs:
             "$AGENT_EVENTS" \
             "$AGENT_PROMPT" \
             "$AGENT_OUTPUT" \
-            "$GCP_KEY_FILE" \
             "$ONBOARD_SUMMARY" \
+            "$PR_SUMMARY" \
+            "$PROVIDER_CONFIG" \
+            "$RECIPE_INVENTORY" \
             "$VM_LEASE" \
             "$SSH_KEY" \
             "$SSH_KEY.pub"
           git config --unset-all credential.helper || true
-          python3 - <<'PY'
-          import os
-          import shutil
-          from pathlib import Path
-
-          config = Path(os.environ["GCP_CONFIG_DIR"])
-          if config.is_symlink() or config.is_file():
-              config.unlink(missing_ok=True)
-          else:
-              shutil.rmtree(config, ignore_errors=True)
-          PY

--- a/.opencode/agents/onboard-model.md
+++ b/.opencode/agents/onboard-model.md
@@ -19,7 +19,7 @@ permission:
     "gh pr*": deny
 ---
 
-You are Emmy's non-interactive model onboarding agent. Load the `onboard-model` skill before doing task work and
+You are Emmy's non-interactive model qualification agent. Load the `onboard-model` skill before doing task work and
 follow it exactly, including every linked skill and architecture document. Use only the supplied GPU server, finish
 before the supplied deadline, keep only the authorized repository artifacts, write the atomic summary even on
 failure, and never commit, push, or change pull requests.

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -17,7 +17,7 @@ provisioning/
   lease.py        # durable allocation ownership, deletion, and audit
   candidates.py   # iter_candidates: ordered list of allocation attempts
   errors.py       # CapacityExhausted, TerminalProvisionError
-  cloudrift.py    # CloudRift API wrapper (create/delete/wait)
+  cloudrift.py    # CloudRift API wrapper (availability/team resolution/create/delete/wait)
   gcp.py          # gcloud-compute wrapper
   ssh.py          # generic wait_for_ssh
   host.py         # RemoteHost abstraction over an existing SSH target
@@ -49,6 +49,10 @@ Every CloudRift rental carries free-form tags for later filtering on listings. `
 through `emmy.config.rental_tags()` — repeatable `--tag` flags win, else the comma-separated `EMMY_RENTAL_TAGS` env
 var (how an experiment run or CI job labels its whole rental lane), else the default `emmy` tag.
 
+`providers.cloudrift.team_id` assigns a rental to that exact team UUID. Automation may resolve the UUID from one exact
+visible team name through `resolve_team_id`; a missing or ambiguous match fails before rent. Team selection is passed
+to CloudRift's rent request and does not depend on descriptive tags.
+
 For each candidate, the orchestrator makes up to `SAME_CANDIDATE_RETRIES` (= 2) attempts on transient errors. On the contracted exceptions it short-circuits:
 
 | Provider raises | Orchestrator does |
@@ -75,6 +79,11 @@ after allocation.
 deletes only the recorded handle, retries and polls provider state, then marks the lease deleted. `emmy vm audit
 lease` independently fails while that handle remains active. A missing lease is an idempotent no-op; an owner mismatch
 is always a hard refusal.
+
+Run-unique automation may add a second ownership check with `terminate_instances_by_tags()`. It requires at least one
+non-empty tag, lists instances carrying every supplied tag across the caller's visible personal/team scope, terminates
+all nonterminal matches in one request, and polls until none remain. The complete run-specific tag set is the safety
+boundary; broad or empty tag cleanup is invalid.
 
 **Timing:** `bench` (`benchmark/execution.py`) wraps `provision_cloud_vm()` → `vm_provision` and `provision_remote()`
 → `remote_provision` in a timer. These run once per `ExecutionGroup` (shared VM) but are seeded into each task's timer,
@@ -133,7 +142,12 @@ to `2026-08-05`, the current public generation for the instance endpoints used h
 `~upcoming` (CloudRift's own client default) so a future server
 release can't change request/response shapes under us.
 
-Two v059-era behaviours the client relies on:
+CloudRift API behaviours the client relies on:
+
+* **Availability.** `instance-types/list` exposes per-variant `available_nodes`. Automated selection treats a variant
+  as available when that count is positive and does not use public-IP capacity as a selection constraint.
+* **Team ownership.** `instances/rent.team_id` makes the team account own the rental. A user API key must belong to the
+  selected team; CloudRift rejects a mismatched team rather than falling back to the user's personal account.
 
 * **`instances/list` mask.** v058 added a `mask` (`with_connection_info` / `with_hardware_info` / `with_usage_info`,
   all default-false) and honours it for v058+ callers — older callers were force-fed `ALL`. `_get_instance_info` sends

--- a/emmy/provisioning/cloud.py
+++ b/emmy/provisioning/cloud.py
@@ -290,6 +290,7 @@ async def _provision_cloudrift(
     image_url = cr_config.get("image_url")
     billing_exempt = cr_config.get("billing_exempt", False)
     network = cr_config.get("network")
+    team_id = cr_config.get("team_id")
 
     return await cr_provider.create_instance(
         api_key=api_key or "",
@@ -304,6 +305,7 @@ async def _provision_cloudrift(
         ssh_private_key_path=ssh_key,
         billing_exempt=billing_exempt,
         network=network,
+        team_id=team_id,
         extra_public_keys=extra_authorized_keys,
         allocation_observer=allocation_observer,
     )

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -87,6 +87,7 @@ async def _rent_instance(
     network=None,
     node_id=None,
     tags=None,
+    team_id=None,
 ):
     """Rent a new CloudRift VM instance.
 
@@ -97,6 +98,7 @@ async def _rent_instance(
         node_id: optional node UUID; when set, rents on exactly that node via the
             ``ByNodeId`` selector instead of letting the provider place the instance.
         tags: optional list of free-form labels attached to the rental.
+        team_id: optional team UUID that owns the rental.
     """
     vm_config = {
         "ssh_key": {"PublicKeys": ssh_public_keys},
@@ -120,6 +122,8 @@ async def _rent_instance(
         data["billing_exempt"] = True
     if network is not None:
         data["network"] = network
+    if team_id is not None:
+        data["team_id"] = team_id
     if tags:
         data["tags"] = list(tags)
     return await _api_request("POST", "/api/v1/instances/rent", data, api_key, api_url, dry_run)
@@ -164,6 +168,82 @@ async def _terminate_instance(api_key, instance_id, api_url=DEFAULT_API_URL, dry
     """
     data = {"selector": {"ById": [instance_id]}}
     return await _api_request("POST", "/api/v1/instances/terminate", data, api_key, api_url, dry_run)
+
+
+async def list_available_instance_types(api_key, api_url=DEFAULT_API_URL):
+    """Return VM instance-variant names that CloudRift currently reports available."""
+    data = {"selector": {"ByServiceAndLocation": {"services": ["vm"]}}}
+    result = await _api_request("POST", "/api/v1/instance-types/list", data, api_key, api_url)
+    available = set()
+    for instance_type in result.get("instance_types", []):
+        for variant in instance_type.get("variants", []):
+            name = variant.get("name")
+            if isinstance(name, str) and variant.get("available_nodes", 0) > 0:
+                available.add(name)
+    return available
+
+
+async def resolve_team_id(api_key, team_name, api_url=DEFAULT_API_URL):
+    """Resolve one exact team name visible to the API key into its UUID."""
+    data = {"selector": "Mine", "with_members": False, "with_account_info": False}
+    result = await _api_request("POST", "/api/v1/teams/list", data, api_key, api_url)
+    matches = [team.get("id") for team in result.get("teams", []) if team.get("name") == team_name and team.get("id")]
+    if not matches:
+        raise TerminalProvisionError(f"CloudRift API key cannot access team {team_name!r}")
+    if len(matches) > 1:
+        raise TerminalProvisionError(f"CloudRift team name {team_name!r} is ambiguous")
+    return matches[0]
+
+
+def _validate_instance_tags(tags):
+    if not tags or not all(isinstance(tag, str) and tag.strip() for tag in tags):
+        raise ValueError("CloudRift instance tag selection requires at least one non-empty tag")
+    return list(dict.fromkeys(tag.strip() for tag in tags))
+
+
+async def list_instances_by_tags(api_key, tags, api_url=DEFAULT_API_URL):
+    """List instances carrying every supplied tag."""
+    tags = _validate_instance_tags(tags)
+    data = {
+        "selector": {"ByTags": {"all": tags, "any": []}},
+        "mask": {
+            "with_connection_info": False,
+            "with_hardware_info": False,
+            "with_usage_info": False,
+        },
+    }
+    result = await _api_request("POST", "/api/v1/instances/list", data, api_key, api_url)
+    return result.get("instances", [])
+
+
+async def terminate_instances_by_tags(api_key, tags, api_url=DEFAULT_API_URL, audit_attempts=12, audit_delay=10):
+    """Terminate all active instances carrying every supplied tag and verify they stop."""
+    tags = _validate_instance_tags(tags)
+    instances = await list_instances_by_tags(api_key, tags, api_url)
+    instance_ids = [
+        instance["id"] for instance in instances if instance.get("id") and instance.get("status") not in TERMINAL_INSTANCE_STATUSES
+    ]
+    if instance_ids:
+        logger.info(f"Terminating CloudRift instances selected by tags {tags}: {instance_ids}")
+        await _api_request(
+            "POST",
+            "/api/v1/instances/terminate",
+            {"selector": {"ById": instance_ids}},
+            api_key,
+            api_url,
+        )
+
+    for _ in range(audit_attempts):
+        remaining = [
+            instance
+            for instance in await list_instances_by_tags(api_key, tags, api_url)
+            if instance.get("status") not in TERMINAL_INSTANCE_STATUSES
+        ]
+        if not remaining:
+            return instance_ids
+        await asyncio.sleep(audit_delay)
+    remaining_ids = [instance.get("id") for instance in remaining]
+    raise RuntimeError(f"CloudRift instances remain active for tags {tags}: {remaining_ids}")
 
 
 async def _get_instance_info(api_key, instance_id, api_url=DEFAULT_API_URL, dry_run=False):
@@ -412,6 +492,7 @@ async def create_instance(
     allocation_observer=None,
     node=None,
     tags=None,
+    team_id=None,
 ):
     """Create a CloudRift VM instance.
 
@@ -423,6 +504,7 @@ async def create_instance(
             :func:`resolve_node_id`); placement fallback does not apply to a pinned node.
         tags: rental labels; ``None`` resolves through :func:`emmy.config.rental_tags`
             (``EMMY_RENTAL_TAGS`` override, default ``["emmy"]``).
+        team_id: optional team UUID that owns the rental.
         extra_public_keys: optional list of additional SSH public key strings to
             install in the VM's authorized_keys alongside the key from
             ``ssh_key_path`` (e.g. ["ssh-ed25519 AAAA bob@host"]).
@@ -473,6 +555,7 @@ async def create_instance(
             network=network,
             node_id=node_id,
             tags=tags,
+            team_id=team_id,
         )
     except httpx.HTTPStatusError as exc:
         code = exc.response.status_code

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -105,7 +105,8 @@ directly; they never import from another test module or from `conftest.py`.
   best-effort recipes keep the full serving contract coverage, while obsolete recipes remain covered by lifecycle
   validation. Catalog and command tests cover tag-filtered inventory and validated shell creation. Repository-
   automation tests validate required lifecycle rationales and the one-to-three-entry onboarding deployment matrix
-  through that shared library.
+  through that shared library. Qualification-manifest tests also pin the requested operation mode, exact model ID,
+  target, and preserved lifecycle tag before artifacts may be staged.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.
 - **Plain functions** — no test classes; tests are grouped by file and separated with comment headers.
 - **Assertions on stdout** — dry-run tests verify that the correct commands and messages appear in the expected order.

--- a/tests/github/test_onboarding_artifacts.py
+++ b/tests/github/test_onboarding_artifacts.py
@@ -21,7 +21,10 @@ def _write_artifacts(workspace):
     for raw_path in paths:
         path = workspace / raw_path
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("result\n")
+        if raw_path == paths[0]:
+            path.write_text("tags: [best-effort]\nmodel:\n  huggingface: org/Model\n")
+        else:
+            path.write_text("result\n")
     return paths
 
 
@@ -32,6 +35,7 @@ def test_validate_summary_accepts_exact_manifest(tmp_path):
         json.dumps(
             {
                 "status": "success",
+                "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
                 "recipe": paths[0],
@@ -51,6 +55,8 @@ def test_validate_summary_accepts_exact_manifest(tmp_path):
         "NVIDIA H200 141GB",
         1,
         "user@host",
+        "onboarding",
+        "best-effort",
     )
 
     assert artifacts == [Path(path) for path in paths]
@@ -66,6 +72,7 @@ def test_validate_summary_rejects_experiment_result(tmp_path):
         json.dumps(
             {
                 "status": "success",
+                "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
                 "recipe": paths[0],
@@ -86,6 +93,8 @@ def test_validate_summary_rejects_experiment_result(tmp_path):
             "NVIDIA H200 141GB",
             1,
             "user@host",
+            "onboarding",
+            "best-effort",
         )
 
 
@@ -99,6 +108,7 @@ def test_validate_summary_rejects_recipe_run_result(tmp_path):
         json.dumps(
             {
                 "status": "success",
+                "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
                 "recipe": paths[0],
@@ -119,6 +129,8 @@ def test_validate_summary_rejects_recipe_run_result(tmp_path):
             "NVIDIA H200 141GB",
             1,
             "user@host",
+            "onboarding",
+            "best-effort",
         )
 
 
@@ -132,6 +144,7 @@ def test_validate_summary_rejects_report_outside_final_recipe_dir(tmp_path):
         json.dumps(
             {
                 "status": "success",
+                "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
                 "recipe": paths[0],
@@ -152,6 +165,74 @@ def test_validate_summary_rejects_report_outside_final_recipe_dir(tmp_path):
             "NVIDIA H200 141GB",
             1,
             "user@host",
+            "onboarding",
+            "best-effort",
+        )
+
+
+def test_validate_summary_rejects_mode_mismatch(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": [paths[2]],
+                "artifacts": paths,
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="Summary mode mismatch"):
+        onboarding_artifacts.validate_summary(
+            summary_path,
+            tmp_path,
+            "org/Model",
+            "NVIDIA H200 141GB",
+            1,
+            "user@host",
+            "verification",
+            "best-effort",
+        )
+
+
+def test_validate_summary_rejects_lifecycle_change(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "verification",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": [paths[2]],
+                "artifacts": paths,
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="retain lifecycle tag 'maintained'"):
+        onboarding_artifacts.validate_summary(
+            summary_path,
+            tmp_path,
+            "org/Model",
+            "NVIDIA H200 141GB",
+            1,
+            "user@host",
+            "verification",
+            "maintained",
         )
 
 

--- a/tests/provisioning/test_cloud.py
+++ b/tests/provisioning/test_cloud.py
@@ -250,6 +250,23 @@ async def test_provision_cloudrift_no_network(mock_create, tmp_path):
     assert mock_create.call_args.kwargs["network"] is None
 
 
+@patch.dict("os.environ", {"CLOUDRIFT_API_KEY": "test-key"})
+@patch("emmy.provisioning.cloud.cr_provider.create_instance", new_callable=AsyncMock)
+async def test_provision_cloudrift_team_id(mock_create, tmp_path):
+    """team_id in providers_config is forwarded to create_instance."""
+    key_file = tmp_path / "id_ed25519"
+    key_file.write_text("private-key")
+    pub_file = tmp_path / "id_ed25519.pub"
+    pub_file.write_text("ssh-ed25519 AAAA test@host\n")
+    mock_create.return_value = VMConnectionInfo(host="1.2.3.4", username="user", ssh_port=22222)
+
+    providers_config = {"cloudrift": {"team_id": "team-robots"}}
+    conn = await _provision_cloudrift(_cr_cand(), str(key_file), providers_config, False, logging.getLogger())
+
+    assert conn is not None
+    assert mock_create.call_args.kwargs["team_id"] == "team-robots"
+
+
 # ── read_public_key_files (extra authorized keys) ────────────────
 
 

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -25,8 +25,12 @@ from emmy.provisioning.cloudrift import (
     _rent_instance,
     _terminate_instance,
     create_instance,
+    list_available_instance_types,
+    list_instances_by_tags,
     resolve_node_id,
+    resolve_team_id,
     select_image_url,
+    terminate_instances_by_tags,
     wait_for_status,
 )
 from emmy.provisioning.errors import CapacityExhausted, TerminalProvisionError
@@ -139,6 +143,127 @@ async def test_api_request_dry_run(caplog):
     assert '"foo": "bar"' in caplog.text
 
 
+# ── availability and tag ownership ────────────────────────────────
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_list_available_instance_types_uses_vm_capacity(mock_api):
+    mock_api.return_value = {
+        "instance_types": [
+            {
+                "name": "rtx49",
+                "variants": [
+                    {"name": "rtx49.1", "available_nodes": 2},
+                    {"name": "rtx49.4", "available_nodes": 0},
+                ],
+            },
+            {"name": "h200", "variants": [{"name": "h200.8", "available_nodes": 1}]},
+        ]
+    }
+
+    result = await list_available_instance_types(API_KEY, API_URL)
+
+    assert result == {"rtx49.1", "h200.8"}
+    mock_api.assert_awaited_once_with(
+        "POST",
+        "/api/v1/instance-types/list",
+        {"selector": {"ByServiceAndLocation": {"services": ["vm"]}}},
+        API_KEY,
+        API_URL,
+    )
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_team_id_requires_one_exact_visible_team(mock_api):
+    mock_api.return_value = {
+        "teams": [
+            {"id": "team-robots", "name": "Robots"},
+            {"id": "team-research", "name": "Research"},
+        ]
+    }
+
+    result = await resolve_team_id(API_KEY, "Robots", API_URL)
+
+    assert result == "team-robots"
+    mock_api.assert_awaited_once_with(
+        "POST",
+        "/api/v1/teams/list",
+        {"selector": "Mine", "with_members": False, "with_account_info": False},
+        API_KEY,
+        API_URL,
+    )
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_team_id_rejects_missing_team(mock_api):
+    mock_api.return_value = {"teams": [{"id": "team-research", "name": "Research"}]}
+
+    with pytest.raises(TerminalProvisionError, match="cannot access team 'Robots'"):
+        await resolve_team_id(API_KEY, "Robots", API_URL)
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_list_instances_by_tags_requires_all_tags(mock_api):
+    mock_api.return_value = {"instances": [{"id": "inst-1", "status": "Active"}]}
+
+    result = await list_instances_by_tags(API_KEY, ["emmy", "gh-job:7", "emmy"], API_URL)
+
+    assert result == [{"id": "inst-1", "status": "Active"}]
+    data = mock_api.await_args.args[2]
+    assert data["selector"] == {"ByTags": {"all": ["emmy", "gh-job:7"], "any": []}}
+    assert data["mask"] == {
+        "with_connection_info": False,
+        "with_hardware_info": False,
+        "with_usage_info": False,
+    }
+
+
+@pytest.mark.parametrize("tags", [[], [""], ["emmy", "  "]])
+async def test_list_instances_by_tags_rejects_unsafe_selection(tags):
+    with pytest.raises(ValueError, match="at least one non-empty tag"):
+        await list_instances_by_tags(API_KEY, tags, API_URL)
+
+
+@patch("emmy.provisioning.cloudrift.asyncio.sleep", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.list_instances_by_tags", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_terminate_instances_by_tags_terminates_every_active_match(mock_api, mock_list, mock_sleep):
+    mock_list.side_effect = [
+        [
+            {"id": "inst-1", "status": "Active"},
+            {"id": "inst-2", "status": "Initializing"},
+            {"id": "inst-old", "status": "Terminated"},
+        ],
+        [{"id": "inst-1", "status": "Deactivating"}],
+        [{"id": "inst-1", "status": "Terminated"}, {"id": "inst-2", "status": "Inactive"}],
+    ]
+
+    result = await terminate_instances_by_tags(API_KEY, ["emmy", "gh-job:7"], API_URL, audit_delay=0)
+
+    assert result == ["inst-1", "inst-2"]
+    mock_api.assert_awaited_once_with(
+        "POST",
+        "/api/v1/instances/terminate",
+        {"selector": {"ById": ["inst-1", "inst-2"]}},
+        API_KEY,
+        API_URL,
+    )
+    mock_sleep.assert_awaited_once_with(0)
+
+
+@patch("emmy.provisioning.cloudrift.asyncio.sleep", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.list_instances_by_tags", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_terminate_instances_by_tags_fails_when_audit_stays_active(mock_api, mock_list, mock_sleep):
+    mock_list.return_value = [{"id": "inst-1", "status": "Active"}]
+
+    with pytest.raises(RuntimeError, match="inst-1"):
+        await terminate_instances_by_tags(API_KEY, ["gh-job:7"], API_URL, audit_attempts=2, audit_delay=0)
+
+    assert mock_sleep.await_count == 2
+    mock_api.assert_awaited_once()
+
+
 # ── _rent_instance ────────────────────────────────────────────────
 
 
@@ -167,6 +292,22 @@ async def test_rent_instance_payload(mock_api):
     }
     assert call_data["with_public_ip"] is True
     assert result["instance_ids"] == ["c4bf5e16-1063-11f1-9096-5f6ae8f8983f"]
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_payload_includes_team(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(
+        API_KEY,
+        "rtx49-7c-kn.1",
+        ["ssh-ed25519 AAAA user@host"],
+        DEFAULT_IMAGE_URL_NVIDIA,
+        api_url=API_URL,
+        team_id="team-robots",
+    )
+
+    assert mock_api.await_args.args[2]["team_id"] == "team-robots"
 
 
 @patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary

- select one available CloudRift model deployment nightly, prioritizing pending onboarding recipes and then the oldest maintained recipe
- resolve the Robots team, rent the exact GPU with workflow and GitHub job tags, retry safely, and audit cleanup by lease and tags
- extend the model qualification skill for onboarding and verification modes while preserving one rebased rolling lifecycle PR
- validate model artifacts, lifecycle transitions, and CloudRift team/tag behavior with focused tests and architecture documentation

## Verification

- make test: 3132 passed, 652 skipped, 1 xfailed, 1 xpassed
- make lint
- actionlint on onboard-model.yml and discover-model.yml
- skill-creator quick validation
- YAML parsing, embedded shell syntax, diff, and credential-pattern checks

No live CloudRift rental was performed during local validation.