### PR TITLE
Stabilize the versioned recipe catalog CLI

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -47,7 +47,8 @@ lifecycle decision. It keeps at most three total onboarding shells for open-weig
 contains one to three proposed deployment entries made only from `deploy.gpu` and `deploy.gpu_count`; existing shells
 consume the three-shell limit and must retain a valid deployment matrix. Discovery remains read-only: the workflow
 ignores otherwise valid new candidates beyond the remaining shell slots. `emmy recipe list --json` supplies the
-compact agent inventory, and tag-filtered list queries enforce the maintained and onboarding counts after application.
+versioned compact agent inventory under its `recipes` field, and tag-filtered list queries enforce the maintained and
+onboarding counts after application.
 The workflow checks that the agent did not modify the checkout, then `.github/scripts/discovery_lifecycle.py`
 validates and applies its lifecycle manifest. The helper
 tolerates a model reasoning wrapper around the JSON object, but requires exactly the four expected top-level fields

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
         run: |
-          ./venv/bin/emmy recipe list recipes --json > "$AGENT_INVENTORY"
+          ./venv/bin/emmy recipe list --json > "$AGENT_INVENTORY"
           python3 - <<'PY'
           import os
           from pathlib import Path
@@ -251,12 +251,12 @@ jobs:
           ./venv/bin/python .github/scripts/discovery_lifecycle.py \
             --input "$AGENT_MANIFEST" \
             --summary "$DISCOVERY_SUMMARY"
-          maintained_count="$(./venv/bin/emmy recipe list recipes --tag maintained --json | jq '.recipes | length')"
+          maintained_count="$(./venv/bin/emmy recipe list --tag maintained --json | jq '.recipes | length')"
           if [ "$maintained_count" -ne "$MAINTAINED_MODEL_COUNT" ]; then
             echo "Expected $MAINTAINED_MODEL_COUNT maintained recipes, found $maintained_count" >&2
             exit 1
           fi
-          onboarding_count="$(./venv/bin/emmy recipe list recipes --tag onboarding --json | jq '.recipes | length')"
+          onboarding_count="$(./venv/bin/emmy recipe list --tag onboarding --json | jq '.recipes | length')"
           if [ "$onboarding_count" -gt 3 ]; then
             echo "Expected at most 3 onboarding recipes, found $onboarding_count" >&2
             exit 1

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -216,7 +216,7 @@ jobs:
             ]
           }}
           maintained_models must contain exactly {os.environ['MAINTAINED_MODEL_COUNT']} entries. Use task "embed" only
-          for an embedding model. Copy deploy.gpu values exactly from deployment setups in repository-inventory.
+          for an embedding model. Copy each deployment's gpu value exactly from repository-inventory.
           Return an empty onboarding_models list when nothing new is suitable. The manifest file is required; do not edit any
           repository file. When OpenCode requires your final response, return the best manifest supported by the
           evidence already gathered without making another tool call. Before returning, check every key letter for
@@ -251,12 +251,12 @@ jobs:
           ./venv/bin/python .github/scripts/discovery_lifecycle.py \
             --input "$AGENT_MANIFEST" \
             --summary "$DISCOVERY_SUMMARY"
-          maintained_count="$(./venv/bin/emmy recipe list recipes --tag maintained --json | jq 'length')"
+          maintained_count="$(./venv/bin/emmy recipe list recipes --tag maintained --json | jq '.recipes | length')"
           if [ "$maintained_count" -ne "$MAINTAINED_MODEL_COUNT" ]; then
             echo "Expected $MAINTAINED_MODEL_COUNT maintained recipes, found $maintained_count" >&2
             exit 1
           fi
-          onboarding_count="$(./venv/bin/emmy recipe list recipes --tag onboarding --json | jq 'length')"
+          onboarding_count="$(./venv/bin/emmy recipe list recipes --tag onboarding --json | jq '.recipes | length')"
           if [ "$onboarding_count" -gt 3 ]; then
             echo "Expected at most 3 onboarding recipes, found $onboarding_count" >&2
             exit 1

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -172,7 +172,7 @@ jobs:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          ./venv/bin/emmy recipe list recipes --json > "$RECIPE_INVENTORY"
+          ./venv/bin/emmy recipe list --json > "$RECIPE_INVENTORY"
           ./venv/bin/python - <<'PY'
           import asyncio
           import json

--- a/README.md
+++ b/README.md
@@ -221,10 +221,19 @@ emmy serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock
 # Inspect recipe metadata or count one lifecycle group in automation.
 emmy recipe list recipes --tag maintained --json
 
+# Inspect only the runnable recipes shipped by an installed Emmy wheel.
+emmy recipe list --bundled --json
+
 # Create an untested onboarding shell with one to three proposed deployments.
 emmy recipe create org/model-name --rationale "Why this model should be onboarded." \
   --deployment "NVIDIA H200 141GB" 1 --deployment "NVIDIA B200" 1
 ```
+
+`recipe list --json` is a versioned machine interface. It returns an object with `schema_version` and `recipes`;
+each recipe carries its directory `name`, model ID, task, lifecycle-aware `runnable` state, and matrix-expanded
+deployments with effective context lengths. Consumers must reject unknown schema versions. Fields may be added to a
+schema version, but existing fields are not removed or redefined. `--bundled` reads the recipes inside the installed
+wheel instead of a source-tree root.
 
 ```yaml
 tags:

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ emmy deploy local --recipe recipes/gemma-4-12B-it
 emmy deploy cloud --recipe recipes/gemma-4-12B-it --gpu "NVIDIA H200 141GB" --gpu-count 8
 ```
 
-`--recipe` also takes the bare name of a recipe bundled with the installed package (`--recipe gemma-4-12B-it`),
-which copies it into the current directory first — `deploy` writes its compose file next to the recipe, and `bench`
-its timestamped run directory. A path that exists always wins, so an edited working copy is never overwritten.
+`--recipe` also takes a bare recipe name (`--recipe gemma-4-12B-it`). An editable install resolves it from the live
+checkout; a wheel install resolves it from the packaged catalog. Emmy copies the recipe into the current directory
+first because `deploy` writes its compose file next to it and `bench` its timestamped run directory. A path that
+exists always wins, so an edited working copy is never overwritten.
 
 ## Publish a serving image
 
@@ -222,11 +223,8 @@ emmy serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock
 # runnable recipes bundled in an installed wheel.
 emmy recipe list --json
 
-# Inspect an explicit recipe root or count one lifecycle group in automation.
-emmy recipe list recipes --tag maintained --json
-
-# Inspect only the runnable recipes shipped by an installed Emmy wheel.
-emmy recipe list --bundled --json
+# Count one lifecycle group in automation.
+emmy recipe list --tag maintained --json
 
 # Create an untested onboarding shell with one to three proposed deployments.
 emmy recipe create org/model-name --rationale "Why this model should be onboarded." \
@@ -236,8 +234,7 @@ emmy recipe create org/model-name --rationale "Why this model should be onboarde
 `recipe list --json` is a versioned machine interface. It returns an object with `schema_version` and `recipes`;
 each recipe carries its directory `name`, model ID, task, lifecycle-aware `runnable` state, and matrix-expanded
 deployments with effective context lengths. Consumers must reject unknown schema versions. Fields may be added to a
-schema version, but existing fields are not removed or redefined. `--bundled` reads the recipes inside the installed
-wheel even for an editable install. With neither `ROOT` nor `--bundled`, Emmy detects its installation: an editable
+schema version, but existing fields are not removed or redefined. Emmy always detects its installation: an editable
 checkout uses its live top-level `recipes/`, while a regular wheel uses its packaged runnable recipe bundle.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -218,7 +218,11 @@ emmy serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock
 ## Recipe
 
 ```bash
-# Inspect recipe metadata or count one lifecycle group in automation.
+# Automatically inspect live source recipes for an editable install, or the
+# runnable recipes bundled in an installed wheel.
+emmy recipe list --json
+
+# Inspect an explicit recipe root or count one lifecycle group in automation.
 emmy recipe list recipes --tag maintained --json
 
 # Inspect only the runnable recipes shipped by an installed Emmy wheel.
@@ -233,7 +237,8 @@ emmy recipe create org/model-name --rationale "Why this model should be onboarde
 each recipe carries its directory `name`, model ID, task, lifecycle-aware `runnable` state, and matrix-expanded
 deployments with effective context lengths. Consumers must reject unknown schema versions. Fields may be added to a
 schema version, but existing fields are not removed or redefined. `--bundled` reads the recipes inside the installed
-wheel instead of a source-tree root.
+wheel even for an editable install. With neither `ROOT` nor `--bundled`, Emmy detects its installation: an editable
+checkout uses its live top-level `recipes/`, while a regular wheel uses its packaged runnable recipe bundle.
 
 ```yaml
 tags:

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -337,14 +337,15 @@ emmy
 with nothing installed).
 
 Everywhere a recipe directory is accepted — `deploy local` / `ssh` / `cloud` via `--recipe`, and `bench`'s
-positional arguments — a bare name with no path component instead selects one of the recipes bundled in the
-installed package, copying it into the current directory first. An existing path always wins over a bundled name.
+positional arguments — a bare name with no path component instead selects one of the recipes from the automatically
+detected editable checkout or installed bundle, copying it into the current directory first. An existing path wins.
 See [`emmy/recipe/ARCHITECTURE.md`](../recipe/ARCHITECTURE.md) for why the copy is mandatory.
 
 ### `emmy recipe`
 
 `recipe list` renders compact metadata without loading complete serving configurations into an automation prompt.
-Repeat `--tag` to require several tags. `--bundled` reads the runnable recipe set shipped in the installed wheel.
+Without a root it detects the installation: editable checkouts use their live top-level `recipes/`, while wheels use
+their packaged runnable set. Repeat `--tag` to require several tags. `--bundled` forces the packaged set.
 `--json` emits the versioned catalog object documented in the recipe architecture; each record includes matrix-
 expanded GPU/count/context metadata and whether the recipe is runnable. Machine consumers reject unknown versions.
 `recipe create` writes a minimal disabled `onboarding`/`untested` shell, validates every GPU against the hardware
@@ -352,7 +353,7 @@ table, accepts one to three native `deploy.gpu`/`deploy.gpu_count` setups, and n
 directory.
 
 ```bash
-emmy recipe list [ROOT | --bundled] [--tag TAG]... [--json]
+emmy recipe list [ROOT] [--bundled] [--tag TAG]... [--json]
 emmy recipe create <org/model> [--root ROOT] [--task generate|embed] --rationale TEXT \
   --deployment GPU COUNT [--deployment GPU COUNT]...
 ```

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -344,13 +344,15 @@ See [`emmy/recipe/ARCHITECTURE.md`](../recipe/ARCHITECTURE.md) for why the copy 
 ### `emmy recipe`
 
 `recipe list` renders compact metadata without loading complete serving configurations into an automation prompt.
-Repeat `--tag` to require several tags; `--json` makes the result suitable for lifecycle counts and agent input.
+Repeat `--tag` to require several tags. `--bundled` reads the runnable recipe set shipped in the installed wheel.
+`--json` emits the versioned catalog object documented in the recipe architecture; each record includes matrix-
+expanded GPU/count/context metadata and whether the recipe is runnable. Machine consumers reject unknown versions.
 `recipe create` writes a minimal disabled `onboarding`/`untested` shell, validates every GPU against the hardware
 table, accepts one to three native `deploy.gpu`/`deploy.gpu_count` setups, and never overwrites an existing model or
 directory.
 
 ```bash
-emmy recipe list [ROOT] [--tag TAG]... [--json]
+emmy recipe list [ROOT | --bundled] [--tag TAG]... [--json]
 emmy recipe create <org/model> [--root ROOT] [--task generate|embed] --rationale TEXT \
   --deployment GPU COUNT [--deployment GPU COUNT]...
 ```

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -344,8 +344,8 @@ See [`emmy/recipe/ARCHITECTURE.md`](../recipe/ARCHITECTURE.md) for why the copy 
 ### `emmy recipe`
 
 `recipe list` renders compact metadata without loading complete serving configurations into an automation prompt.
-Without a root it detects the installation: editable checkouts use their live top-level `recipes/`, while wheels use
-their packaged runnable set. Repeat `--tag` to require several tags. `--bundled` forces the packaged set.
+It detects the installation: editable checkouts use their live top-level `recipes/`, while wheels use their packaged
+runnable set. Repeat `--tag` to require several tags.
 `--json` emits the versioned catalog object documented in the recipe architecture; each record includes matrix-
 expanded GPU/count/context metadata and whether the recipe is runnable. Machine consumers reject unknown versions.
 `recipe create` writes a minimal disabled `onboarding`/`untested` shell, validates every GPU against the hardware
@@ -353,7 +353,7 @@ table, accepts one to three native `deploy.gpu`/`deploy.gpu_count` setups, and n
 directory.
 
 ```bash
-emmy recipe list [ROOT] [--bundled] [--tag TAG]... [--json]
+emmy recipe list [--tag TAG]... [--json]
 emmy recipe create <org/model> [--root ROOT] [--task generate|embed] --rationale TEXT \
   --deployment GPU COUNT [--deployment GPU COUNT]...
 ```

--- a/emmy/commands/bench/__init__.py
+++ b/emmy/commands/bench/__init__.py
@@ -105,7 +105,7 @@ def handle_bench(args):
             key, pattern = f.split("=", 1)
             parsed_filters.append((key, pattern))
 
-    # Enumerate tasks from recipe dirs (a bare name resolves to a bundled recipe)
+    # Enumerate tasks from recipe dirs (a bare name resolves through the installation's catalog)
     args.recipes = [resolve_recipe_dir(r) for r in args.recipes]
     tasks = enumerate_tasks(args.recipes, filters=parsed_filters)
     if not tasks:

--- a/emmy/commands/recipe.py
+++ b/emmy/commands/recipe.py
@@ -4,21 +4,30 @@ import json
 import logging
 from pathlib import Path
 
-from emmy.recipe.catalog import create_recipe_stub, recipe_inventory
+from emmy.recipe.bundled import bundled_root
+from emmy.recipe.catalog import create_recipe_stub, recipe_inventory_document
 
 logger = logging.getLogger(__name__)
 
 
 def _handle_list(args) -> None:
     try:
-        inventory = recipe_inventory(args.root, tuple(args.tag))
+        if args.bundled and args.root is not None:
+            raise ValueError("recipe list accepts either ROOT or --bundled, not both")
+        if args.bundled:
+            with bundled_root() as root:
+                if root is None:
+                    raise ValueError("this Emmy installation does not contain bundled recipes")
+                document = recipe_inventory_document(root, tuple(args.tag))
+        else:
+            document = recipe_inventory_document(args.root or Path("recipes"), tuple(args.tag))
     except (OSError, ValueError) as exc:
         logger.error(str(exc))
         raise SystemExit(2) from exc
     if args.json:
-        logger.info(json.dumps(inventory, sort_keys=True))
+        logger.info(json.dumps(document, sort_keys=True))
         return
-    for recipe in inventory:
+    for recipe in document["recipes"]:
         logger.info("%s\t%s\t%s", recipe["model_id"], ",".join(recipe["tags"]) or "-", recipe["path"])
 
 
@@ -37,9 +46,10 @@ def register_recipe_command(subparsers) -> None:
     actions = parser.add_subparsers(dest="recipe_action", required=True)
 
     list_parser = actions.add_parser("list", help="List recipe metadata")
-    list_parser.add_argument("root", nargs="?", type=Path, default=Path("recipes"), help="Recipe root (default: recipes)")
+    list_parser.add_argument("root", nargs="?", type=Path, help="Recipe root (default: recipes)")
+    list_parser.add_argument("--bundled", action="store_true", help="List recipes shipped with this Emmy installation")
     list_parser.add_argument("--tag", action="append", default=[], help="Require a tag; repeat to require multiple tags")
-    list_parser.add_argument("--json", action="store_true", help="Print a JSON array of recipe metadata")
+    list_parser.add_argument("--json", action="store_true", help="Print the versioned JSON recipe catalog")
     list_parser.set_defaults(func=_handle_list)
 
     create_parser = actions.add_parser("create", help="Create an onboarding/untested recipe stub")

--- a/emmy/commands/recipe.py
+++ b/emmy/commands/recipe.py
@@ -4,7 +4,7 @@ import json
 import logging
 from pathlib import Path
 
-from emmy.recipe.bundled import bundled_root
+from emmy.recipe.bundled import bundled_root, default_recipe_root
 from emmy.recipe.catalog import create_recipe_stub, recipe_inventory_document
 
 logger = logging.getLogger(__name__)
@@ -14,13 +14,14 @@ def _handle_list(args) -> None:
     try:
         if args.bundled and args.root is not None:
             raise ValueError("recipe list accepts either ROOT or --bundled, not both")
-        if args.bundled:
-            with bundled_root() as root:
-                if root is None:
-                    raise ValueError("this Emmy installation does not contain bundled recipes")
-                document = recipe_inventory_document(root, tuple(args.tag))
+        if args.root is not None:
+            document = recipe_inventory_document(args.root, tuple(args.tag))
         else:
-            document = recipe_inventory_document(args.root or Path("recipes"), tuple(args.tag))
+            root_context = bundled_root() if args.bundled else default_recipe_root()
+            with root_context as root:
+                if root is None:
+                    raise ValueError("this Emmy installation does not contain recipes")
+                document = recipe_inventory_document(root, tuple(args.tag))
     except (OSError, ValueError) as exc:
         logger.error(str(exc))
         raise SystemExit(2) from exc
@@ -46,8 +47,13 @@ def register_recipe_command(subparsers) -> None:
     actions = parser.add_subparsers(dest="recipe_action", required=True)
 
     list_parser = actions.add_parser("list", help="List recipe metadata")
-    list_parser.add_argument("root", nargs="?", type=Path, help="Recipe root (default: recipes)")
-    list_parser.add_argument("--bundled", action="store_true", help="List recipes shipped with this Emmy installation")
+    list_parser.add_argument(
+        "root",
+        nargs="?",
+        type=Path,
+        help="Recipe root (default: editable checkout recipes or installed wheel bundle)",
+    )
+    list_parser.add_argument("--bundled", action="store_true", help="Force recipes shipped with this installation")
     list_parser.add_argument("--tag", action="append", default=[], help="Require a tag; repeat to require multiple tags")
     list_parser.add_argument("--json", action="store_true", help="Print the versioned JSON recipe catalog")
     list_parser.set_defaults(func=_handle_list)

--- a/emmy/commands/recipe.py
+++ b/emmy/commands/recipe.py
@@ -4,7 +4,7 @@ import json
 import logging
 from pathlib import Path
 
-from emmy.recipe.bundled import bundled_root, default_recipe_root
+from emmy.recipe.bundled import default_recipe_root
 from emmy.recipe.catalog import create_recipe_stub, recipe_inventory_document
 
 logger = logging.getLogger(__name__)
@@ -12,16 +12,10 @@ logger = logging.getLogger(__name__)
 
 def _handle_list(args) -> None:
     try:
-        if args.bundled and args.root is not None:
-            raise ValueError("recipe list accepts either ROOT or --bundled, not both")
-        if args.root is not None:
-            document = recipe_inventory_document(args.root, tuple(args.tag))
-        else:
-            root_context = bundled_root() if args.bundled else default_recipe_root()
-            with root_context as root:
-                if root is None:
-                    raise ValueError("this Emmy installation does not contain recipes")
-                document = recipe_inventory_document(root, tuple(args.tag))
+        with default_recipe_root() as root:
+            if root is None:
+                raise ValueError("this Emmy installation does not contain recipes")
+            document = recipe_inventory_document(root, tuple(args.tag))
     except (OSError, ValueError) as exc:
         logger.error(str(exc))
         raise SystemExit(2) from exc
@@ -47,13 +41,6 @@ def register_recipe_command(subparsers) -> None:
     actions = parser.add_subparsers(dest="recipe_action", required=True)
 
     list_parser = actions.add_parser("list", help="List recipe metadata")
-    list_parser.add_argument(
-        "root",
-        nargs="?",
-        type=Path,
-        help="Recipe root (default: editable checkout recipes or installed wheel bundle)",
-    )
-    list_parser.add_argument("--bundled", action="store_true", help="Force recipes shipped with this installation")
     list_parser.add_argument("--tag", action="append", default=[], help="Require a tag; repeat to require multiple tags")
     list_parser.add_argument("--json", action="store_true", help="Print the versioned JSON recipe catalog")
     list_parser.set_defaults(func=_handle_list)

--- a/emmy/recipe/ARCHITECTURE.md
+++ b/emmy/recipe/ARCHITECTURE.md
@@ -15,8 +15,7 @@ validation.
 - `recipe.py` — `deep_merge()`, `load_recipe()`, `resolve_for_hardware()`, `validate_extra_args()`, `_load_raw_config()`, `_validate_and_build()`
 - `matrix.py` — `expand_matrix()`, `_expand_cross()`, `_expand_zip()`, `filter_combinations()`, `dot_to_nested()`, `build_override()`
 - `engines.py` — `VLLM_FLAG_MAP`, `SGLANG_FLAG_MAP`, `banned_extra_arg_flags()`, `build_engine_args()`
-- `bundled.py` — `bundled_root()`, `bundled_names()`, `resolve_recipe_dir()` — the recipes shipped inside an
-  installed wheel
+- `bundled.py` — automatic editable-checkout/wheel catalog selection and bare-name materialization
 
 ## Key Design Decisions
 
@@ -26,9 +25,8 @@ A wheel carries every runnable `recipes/<model>/recipe.yaml` under `emmy/recipes
 `recipes/` sits outside the package (see `scripts/prepare_dist.py`). Those copies are read-only — they live in
 site-packages, whereas `deploy` writes its compose file into the recipe directory and `bench` creates a timestamped
 run directory there. So `resolve_recipe_dir()` treats a bare name as a request for a **working copy**: it copies the
-bundled recipe into the current directory and returns that path. An existing directory always takes precedence, so a
-name that matches both a local directory and a bundled recipe resolves to the local one and an edited copy is never
-clobbered.
+recipe selected from the live editable checkout or installed bundle into the current directory and returns that path.
+An existing directory always takes precedence, so a matching edited copy is never clobbered.
 
 ### Recipe Lifecycle Tags
 
@@ -59,9 +57,9 @@ does not affect engine arguments, deployment, or benchmark behavior.
 versioned JSON document produced by `recipe_inventory_document()` adds the directory name, lifecycle-aware runnable
 state, and each matrix-expanded deployment's effective context length to the identity, tags, task, and rationale.
 This is the machine interface used by other services: consumers reject unknown `schema_version` values, while Emmy
-may add fields without removing or redefining fields in the current version. With no explicit root, editable installs
-read the checkout's live top-level `recipes/` and wheel installs read their packaged runnable recipes.
-`emmy recipe list --bundled --json` forces the packaged set for release-artifact inspection.
+may add fields without removing or redefining fields in the current version. Editable installs read the checkout's
+live top-level `recipes/` and wheel installs read their packaged runnable recipes. The CLI deliberately exposes no
+catalog-selection arguments, so every consumer observes the same installation-aware behavior.
 `create_recipe_stub()` is likewise shared by `emmy recipe create` and discovery: it validates one to three canonical
 GPU/count setups and writes the minimal disabled shell without duplicating YAML rendering in workflow scripts.
 

--- a/emmy/recipe/ARCHITECTURE.md
+++ b/emmy/recipe/ARCHITECTURE.md
@@ -15,7 +15,8 @@ validation.
 - `recipe.py` — `deep_merge()`, `load_recipe()`, `resolve_for_hardware()`, `validate_extra_args()`, `_load_raw_config()`, `_validate_and_build()`
 - `matrix.py` — `expand_matrix()`, `_expand_cross()`, `_expand_zip()`, `filter_combinations()`, `dot_to_nested()`, `build_override()`
 - `engines.py` — `VLLM_FLAG_MAP`, `SGLANG_FLAG_MAP`, `banned_extra_arg_flags()`, `build_engine_args()`
-- `bundled.py` — `bundled_names()`, `resolve_recipe_dir()` — the recipes shipped inside an installed wheel
+- `bundled.py` — `bundled_root()`, `bundled_names()`, `resolve_recipe_dir()` — the recipes shipped inside an
+  installed wheel
 
 ## Key Design Decisions
 
@@ -54,8 +55,12 @@ rejects direct use of disabled recipes, while bulk benchmark enumeration and pac
 `model.rationale` is descriptive lifecycle metadata. It records why the model currently belongs in the inventory and
 does not affect engine arguments, deployment, or benchmark behavior.
 
-`recipe_catalog()` is the shared repository scan behind `emmy recipe list` and model-discovery validation. Its compact
-records contain only the identity, tags, task, rationale, and expanded deployment setups needed for lifecycle work.
+`recipe_catalog()` is the shared repository scan behind `emmy recipe list` and model-discovery validation. The
+versioned JSON document produced by `recipe_inventory_document()` adds the directory name, lifecycle-aware runnable
+state, and each matrix-expanded deployment's effective context length to the identity, tags, task, and rationale.
+This is the machine interface used by other services: consumers reject unknown `schema_version` values, while Emmy
+may add fields without removing or redefining fields in the current version. `emmy recipe list --bundled --json`
+applies the same catalog contract to the runnable recipes shipped in the installed wheel.
 `create_recipe_stub()` is likewise shared by `emmy recipe create` and discovery: it validates one to three canonical
 GPU/count setups and writes the minimal disabled shell without duplicating YAML rendering in workflow scripts.
 

--- a/emmy/recipe/ARCHITECTURE.md
+++ b/emmy/recipe/ARCHITECTURE.md
@@ -59,8 +59,9 @@ does not affect engine arguments, deployment, or benchmark behavior.
 versioned JSON document produced by `recipe_inventory_document()` adds the directory name, lifecycle-aware runnable
 state, and each matrix-expanded deployment's effective context length to the identity, tags, task, and rationale.
 This is the machine interface used by other services: consumers reject unknown `schema_version` values, while Emmy
-may add fields without removing or redefining fields in the current version. `emmy recipe list --bundled --json`
-applies the same catalog contract to the runnable recipes shipped in the installed wheel.
+may add fields without removing or redefining fields in the current version. With no explicit root, editable installs
+read the checkout's live top-level `recipes/` and wheel installs read their packaged runnable recipes.
+`emmy recipe list --bundled --json` forces the packaged set for release-artifact inspection.
 `create_recipe_stub()` is likewise shared by `emmy recipe create` and discovery: it validates one to three canonical
 GPU/count setups and writes the minimal disabled shell without duplicating YAML rendering in workflow scripts.
 

--- a/emmy/recipe/__init__.py
+++ b/emmy/recipe/__init__.py
@@ -1,6 +1,6 @@
 """Recipe loading and configuration."""
 
-from emmy.recipe.bundled import bundled_names, resolve_recipe_dir
+from emmy.recipe.bundled import bundled_names, bundled_root, resolve_recipe_dir
 from emmy.recipe.engines import banned_extra_arg_flags, build_engine_args
 from emmy.recipe.matrix import (
     build_override,
@@ -45,6 +45,7 @@ __all__ = [
     "build_engine_args",
     "build_override",
     "bundled_names",
+    "bundled_root",
     "deep_merge",
     "dot_to_nested",
     "expand_matrix",

--- a/emmy/recipe/__init__.py
+++ b/emmy/recipe/__init__.py
@@ -1,6 +1,6 @@
 """Recipe loading and configuration."""
 
-from emmy.recipe.bundled import bundled_names, bundled_root, resolve_recipe_dir
+from emmy.recipe.bundled import bundled_names, bundled_root, default_recipe_root, editable_recipe_root, resolve_recipe_dir
 from emmy.recipe.engines import banned_extra_arg_flags, build_engine_args
 from emmy.recipe.matrix import (
     build_override,
@@ -46,9 +46,11 @@ __all__ = [
     "build_override",
     "bundled_names",
     "bundled_root",
+    "default_recipe_root",
     "deep_merge",
     "dot_to_nested",
     "expand_matrix",
+    "editable_recipe_root",
     "filter_combinations",
     "load_recipe",
     "resolve_for_hardware",

--- a/emmy/recipe/bundled.py
+++ b/emmy/recipe/bundled.py
@@ -1,4 +1,4 @@
-"""Recipes shipped inside the installed package.
+"""Resolve recipes from an editable checkout or installed package.
 
 `pip install emmy-ml` has no repo checkout, so the wheel bundles every
 `recipes/<model>/recipe.yaml` under `emmy/recipes/` (staged at build time by
@@ -14,6 +14,15 @@ from importlib.resources import as_file, files
 from pathlib import Path
 
 
+def editable_recipe_root() -> Path | None:
+    """Return the source recipe root when Emmy is imported from a checkout."""
+    checkout = Path(__file__).resolve().parents[2]
+    recipes = checkout / "recipes"
+    if (checkout / "pyproject.toml").is_file() and recipes.is_dir():
+        return recipes
+    return None
+
+
 @contextmanager
 def bundled_root():
     """Yield a filesystem root for the recipes shipped with the package."""
@@ -26,32 +35,48 @@ def bundled_root():
         yield root
 
 
+@contextmanager
+def default_recipe_root():
+    """Yield live checkout recipes for editable installs, otherwise the wheel bundle."""
+    editable = editable_recipe_root()
+    if editable is not None:
+        yield editable
+        return
+    with bundled_root() as root:
+        yield root
+
+
 def bundled_names() -> list[str]:
     """Names of the recipes shipped with the installed package."""
     with bundled_root() as root:
         if root is None:
             return []
-        return sorted(entry.name for entry in root.iterdir() if (entry / "recipe.yaml").is_file())
+        return _recipe_names(root)
+
+
+def _recipe_names(root: Path) -> list[str]:
+    return sorted(entry.name for entry in root.iterdir() if (entry / "recipe.yaml").is_file())
 
 
 def resolve_recipe_dir(name_or_path: str) -> str:
     """Return a usable recipe directory for a CLI `--recipe` value.
 
     An existing directory is used as given. Otherwise the value is looked up
-    among the bundled recipes and copied into the current directory, because
-    both `deploy` and `bench` write alongside the recipe they run.
+    in the installation's default recipe catalog and copied into the current
+    directory, because both `deploy` and `bench` write alongside the recipe
+    they run.
     """
     if Path(name_or_path).is_dir():
         return name_or_path
 
-    if name_or_path in bundled_names():
-        target = Path(name_or_path)
-        target.mkdir(parents=True)
-        with bundled_root() as source:
+    with default_recipe_root() as source:
+        available = _recipe_names(source) if source is not None else []
+        if name_or_path in available:
             assert source is not None
+            target = Path(name_or_path)
+            target.mkdir(parents=True)
             shutil.copyfile(source / name_or_path / "recipe.yaml", target / "recipe.yaml")
-        return str(target)
+            return str(target)
 
-    available = bundled_names()
-    hint = f" Bundled recipes: {', '.join(available)}." if available else ""
+    hint = f" Available recipes: {', '.join(available)}." if available else ""
     raise FileNotFoundError(f"No recipe directory {name_or_path!r}.{hint}")

--- a/emmy/recipe/bundled.py
+++ b/emmy/recipe/bundled.py
@@ -9,17 +9,29 @@ materializes a working copy in the current directory first.
 """
 
 import shutil
-from importlib.resources import files
+from contextlib import contextmanager
+from importlib.resources import as_file, files
 from pathlib import Path
+
+
+@contextmanager
+def bundled_root():
+    """Yield a filesystem root for the recipes shipped with the package."""
+    try:
+        resource = files("emmy.recipes")
+    except ModuleNotFoundError:
+        yield None
+        return
+    with as_file(resource) as root:
+        yield root
 
 
 def bundled_names() -> list[str]:
     """Names of the recipes shipped with the installed package."""
-    try:
-        root = files("emmy.recipes")
-    except ModuleNotFoundError:
-        return []
-    return sorted(entry.name for entry in root.iterdir() if (entry / "recipe.yaml").is_file())
+    with bundled_root() as root:
+        if root is None:
+            return []
+        return sorted(entry.name for entry in root.iterdir() if (entry / "recipe.yaml").is_file())
 
 
 def resolve_recipe_dir(name_or_path: str) -> str:
@@ -35,8 +47,9 @@ def resolve_recipe_dir(name_or_path: str) -> str:
     if name_or_path in bundled_names():
         target = Path(name_or_path)
         target.mkdir(parents=True)
-        source = files("emmy.recipes") / name_or_path / "recipe.yaml"
-        shutil.copyfile(str(source), target / "recipe.yaml")
+        with bundled_root() as source:
+            assert source is not None
+            shutil.copyfile(source / name_or_path / "recipe.yaml", target / "recipe.yaml")
         return str(target)
 
     available = bundled_names()

--- a/emmy/recipe/catalog.py
+++ b/emmy/recipe/catalog.py
@@ -8,13 +8,14 @@ from pathlib import Path
 import yaml
 
 from emmy import gpu as gpu_registry
-from emmy.recipe.lifecycle import ONBOARDING_TAG, UNTESTED_TAG, validate_recipe_tags
+from emmy.recipe.lifecycle import ONBOARDING_TAG, UNTESTED_TAG, recipe_is_runnable, validate_recipe_tags
 from emmy.recipe.matrix import build_override, expand_matrix
 from emmy.recipe.recipe import deep_merge
 
 HF_ID = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 DEPLOYMENT_FIELDS = frozenset({"deploy.gpu", "deploy.gpu_count"})
 MAX_STUB_DEPLOYMENTS = 3
+CATALOG_SCHEMA_VERSION = 1
 
 
 def recipe_catalog(root: str | Path) -> dict[str, dict]:
@@ -37,13 +38,18 @@ def recipe_catalog(root: str | Path) -> dict[str, dict]:
     return records
 
 
-def deployment_setups(config: dict) -> list[dict[str, object]]:
-    """Return the unique GPU/count combinations produced by one recipe matrix."""
+def _resolved_variants(config: dict) -> list[dict]:
+    """Apply every matrix combination to the recipe base configuration."""
     base = {key: value for key, value in config.items() if key != "matrices"}
     matrices = config.get("matrices")
-    variants = [base]
-    if matrices:
-        variants = [deep_merge(base, build_override(combination)) for combination in expand_matrix(matrices)]
+    if not matrices:
+        return [base]
+    return [deep_merge(base, build_override(combination)) for combination in expand_matrix(matrices)]
+
+
+def deployment_setups(config: dict) -> list[dict[str, object]]:
+    """Return the unique GPU/count combinations produced by one recipe matrix."""
+    variants = _resolved_variants(config)
 
     setups = []
     seen = set()
@@ -60,6 +66,33 @@ def deployment_setups(config: dict) -> list[dict[str, object]]:
     return setups
 
 
+def _inventory_deployments(config: dict) -> list[dict[str, object]]:
+    """Return machine-readable hardware metadata after applying matrix overrides."""
+    variants = _resolved_variants(config)
+
+    deployments = []
+    seen = set()
+    for variant in variants:
+        deploy = variant.get("deploy") or {}
+        gpu = deploy.get("gpu")
+        gpu_count = deploy.get("gpu_count", 1)
+        valid_count = isinstance(gpu_count, int) and not isinstance(gpu_count, bool) and gpu_count >= 1
+        if not isinstance(gpu, str) or not valid_count or (gpu, gpu_count) in seen:
+            continue
+        seen.add((gpu, gpu_count))
+
+        context_length = ((variant.get("engine") or {}).get("llm") or {}).get("context_length")
+        valid_context = isinstance(context_length, int) and not isinstance(context_length, bool) and context_length >= 1
+        deployments.append(
+            {
+                "gpu": gpu,
+                "gpu_count": gpu_count,
+                "context_length": context_length if valid_context else None,
+            }
+        )
+    return deployments
+
+
 def recipe_inventory(root: str | Path, tags: tuple[str, ...] = ()) -> list[dict]:
     """Return compact, JSON-ready metadata for recipes carrying every requested tag."""
     records = recipe_catalog(root)
@@ -69,21 +102,33 @@ def recipe_inventory(root: str | Path, tags: tuple[str, ...] = ()) -> list[dict]
             continue
         config = record["config"]
         model = config.get("model") or {}
+        task = model.get("task", "generate")
+        has_inference_engine = bool((config.get("engine") or {}).get("llm"))
         try:
             display_path = record["path"].relative_to(Path.cwd())
         except ValueError:
             display_path = record["path"]
         inventory.append(
             {
+                "name": record["path"].parent.name,
                 "path": str(display_path),
                 "model_id": model_id,
                 "tags": list(record["tags"]),
-                "task": model.get("task", "generate"),
-                "deployments": deployment_setups(config),
+                "task": task,
+                "runnable": recipe_is_runnable(config) and has_inference_engine and task in ("generate", "embed"),
+                "deployments": _inventory_deployments(config),
                 "rationale": model.get("rationale"),
             }
         )
     return inventory
+
+
+def recipe_inventory_document(root: str | Path, tags: tuple[str, ...] = ()) -> dict:
+    """Return the versioned machine-readable recipe catalog document."""
+    return {
+        "schema_version": CATALOG_SCHEMA_VERSION,
+        "recipes": recipe_inventory(root, tags),
+    }
 
 
 def validate_stub_deployments(value: object, model_id: str) -> list[dict[str, object]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emmy-ml"
-version = "0.3.2"
+version = "0.3.3"
 description = "Optimized LLM compiler, benchmarking, and deployment stack."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/recipes/ARCHITECTURE.md
+++ b/recipes/ARCHITECTURE.md
@@ -15,10 +15,10 @@ here for lifecycle continuity, but their tags disable deployment. The recipe for
 `cross`/`zip`, deep merge, `extra_args` validation, `docker_options`, command recipes — is documented in
 [`emmy/recipe/ARCHITECTURE.md`](../emmy/recipe/ARCHITECTURE.md); this file is about **what belongs here** and why.
 
-Every runnable `recipe.yaml` here also ships inside the published wheel, so `pip install emmy-ml` can deploy without
-a checkout: `--recipe <model>` (a bare name, no path) copies the bundled recipe into the current directory and uses
-that. Obsolete recipes and onboarding shells remain repository-only. Only the recipe files travel — `RESULTS.md` and
-local benchmark output do not.
+Every runnable `recipe.yaml` here also ships inside the published wheel. `--recipe <model>` (a bare name, no path)
+copies from this live tree in an editable install or from the packaged catalog in a wheel install, then uses that
+working copy. Obsolete recipes and onboarding shells remain repository-only. Only the recipe files travel —
+`RESULTS.md` and local benchmark output do not.
 
 ## Lifecycle
 

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -104,8 +104,8 @@ directly; they never import from another test module or from `conftest.py`.
 - **Recipe lifecycle** — named-model deployment assertions skip when their recipe is disabled; maintained and
   best-effort recipes keep the full serving contract coverage, while obsolete recipes remain covered by lifecycle
   validation. Catalog and command tests cover the versioned JSON inventory, effective deployment metadata,
-  tag-filtered inventory, editable-versus-wheel catalog selection, recipe-name materialization, and validated shell
-  creation. Repository-
+  tag-filtered inventory, the minimal installation-selected CLI, editable-versus-wheel catalog selection, recipe-name
+  materialization, and validated shell creation. Repository-
   automation tests validate required lifecycle rationales and the one-to-three-entry onboarding deployment matrix
   through that shared library. Qualification-manifest tests also pin the requested operation mode, exact model ID,
   target, and preserved lifecycle tag before artifacts may be staged.

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -103,7 +103,8 @@ directly; they never import from another test module or from `conftest.py`.
 - **Real recipes** — CLI dry-run tests use recipes from the `recipes/` directory to catch config drift.
 - **Recipe lifecycle** — named-model deployment assertions skip when their recipe is disabled; maintained and
   best-effort recipes keep the full serving contract coverage, while obsolete recipes remain covered by lifecycle
-  validation. Catalog and command tests cover tag-filtered inventory and validated shell creation. Repository-
+  validation. Catalog and command tests cover the versioned JSON inventory, effective deployment metadata,
+  tag-filtered inventory, bundled-recipe lookup, and validated shell creation. Repository-
   automation tests validate required lifecycle rationales and the one-to-three-entry onboarding deployment matrix
   through that shared library. Qualification-manifest tests also pin the requested operation mode, exact model ID,
   target, and preserved lifecycle tag before artifacts may be staged.

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -104,7 +104,8 @@ directly; they never import from another test module or from `conftest.py`.
 - **Recipe lifecycle** — named-model deployment assertions skip when their recipe is disabled; maintained and
   best-effort recipes keep the full serving contract coverage, while obsolete recipes remain covered by lifecycle
   validation. Catalog and command tests cover the versioned JSON inventory, effective deployment metadata,
-  tag-filtered inventory, bundled-recipe lookup, and validated shell creation. Repository-
+  tag-filtered inventory, editable-versus-wheel catalog selection, recipe-name materialization, and validated shell
+  creation. Repository-
   automation tests validate required lifecycle rationales and the one-to-three-entry onboarding deployment matrix
   through that shared library. Qualification-manifest tests also pin the requested operation mode, exact model ID,
   target, and preserved lifecycle tag before artifacts may be staged.

--- a/tests/commands/test_recipe.py
+++ b/tests/commands/test_recipe.py
@@ -30,8 +30,10 @@ def test_recipe_create_and_list_by_tag(run_cli, tmp_path):
     returncode, stdout, stderr = run_cli("recipe", "list", str(root), "--tag", "onboarding", "--json")
 
     assert returncode == 0, stderr
-    inventory = json.loads(stdout)
-    assert [recipe["model_id"] for recipe in inventory] == ["org/new-model"]
+    document = json.loads(stdout)
+    assert document["schema_version"] == 1
+    assert [recipe["model_id"] for recipe in document["recipes"]] == ["org/new-model"]
+    assert document["recipes"][0]["runnable"] is False
 
 
 def test_recipe_list_excludes_recipes_without_requested_tag(run_cli, tmp_path):
@@ -43,4 +45,4 @@ def test_recipe_list_excludes_recipes_without_requested_tag(run_cli, tmp_path):
     returncode, stdout, stderr = run_cli("recipe", "list", str(root), "--tag", "maintained", "--json")
 
     assert returncode == 0, stderr
-    assert json.loads(stdout) == []
+    assert json.loads(stdout) == {"schema_version": 1, "recipes": []}

--- a/tests/commands/test_recipe.py
+++ b/tests/commands/test_recipe.py
@@ -7,7 +7,7 @@ import yaml
 GPU = "NVIDIA H200 141GB"
 
 
-def test_recipe_create_and_list_by_tag(run_cli, tmp_path):
+def test_recipe_create(run_cli, tmp_path):
     root = tmp_path / "recipes"
     returncode, stdout, stderr = run_cli(
         "recipe",
@@ -27,22 +27,27 @@ def test_recipe_create_and_list_by_tag(run_cli, tmp_path):
     assert stdout.strip() == str(recipe_path)
     assert yaml.safe_load(recipe_path.read_text())["matrices"] == [{"deploy.gpu": GPU, "deploy.gpu_count": 1}]
 
-    returncode, stdout, stderr = run_cli("recipe", "list", str(root), "--tag", "onboarding", "--json")
+
+def test_recipe_list_by_tag(run_cli):
+    returncode, stdout, stderr = run_cli("recipe", "list", "--tag", "best-effort", "--json")
 
     assert returncode == 0, stderr
     document = json.loads(stdout)
     assert document["schema_version"] == 1
-    assert [recipe["model_id"] for recipe in document["recipes"]] == ["org/new-model"]
-    assert document["recipes"][0]["runnable"] is False
+    assert document["recipes"]
+    assert all("best-effort" in recipe["tags"] for recipe in document["recipes"])
 
 
-def test_recipe_list_excludes_recipes_without_requested_tag(run_cli, tmp_path):
-    root = tmp_path / "recipes"
-    recipe = root / "ready" / "recipe.yaml"
-    recipe.parent.mkdir(parents=True)
-    recipe.write_text("tags: [best-effort]\nmodel:\n  huggingface: org/ready\n")
-
-    returncode, stdout, stderr = run_cli("recipe", "list", str(root), "--tag", "maintained", "--json")
+def test_recipe_list_excludes_recipes_without_requested_tag(run_cli):
+    returncode, stdout, stderr = run_cli("recipe", "list", "--tag", "does-not-exist", "--json")
 
     assert returncode == 0, stderr
     assert json.loads(stdout) == {"schema_version": 1, "recipes": []}
+
+
+def test_recipe_list_rejects_catalog_selection_arguments(run_cli):
+    for arguments in (("recipes",), ("--bundled",)):
+        returncode, _stdout, stderr = run_cli("recipe", "list", *arguments, "--json")
+
+        assert returncode == 2
+        assert "unrecognized arguments" in stderr

--- a/tests/recipe/test_bundled.py
+++ b/tests/recipe/test_bundled.py
@@ -8,7 +8,7 @@ reading the real one, so the suite behaves the same either way.
 import pytest
 
 from emmy.recipe import bundled
-from emmy.recipe.bundled import bundled_root, resolve_recipe_dir
+from emmy.recipe.bundled import bundled_root, default_recipe_root, editable_recipe_root, resolve_recipe_dir
 
 
 @pytest.fixture
@@ -18,6 +18,7 @@ def fake_package(tmp_path, monkeypatch):
     (packaged / "Qwen3-Embedding-0.6B").mkdir(parents=True)
     (packaged / "Qwen3-Embedding-0.6B" / "recipe.yaml").write_text("model:\n  name: Qwen/Qwen3-Embedding-0.6B\n")
     monkeypatch.setattr(bundled, "files", lambda _package: packaged)
+    monkeypatch.setattr(bundled, "__file__", str(tmp_path / "site-packages" / "emmy" / "recipe" / "bundled.py"))
     return packaged
 
 
@@ -35,6 +36,29 @@ def test_bundled_root_returns_packaged_recipe_directory(fake_package):
         assert root == fake_package
 
 
+def test_default_root_prefers_live_recipes_in_an_editable_checkout(tmp_path, monkeypatch, fake_package):
+    checkout = tmp_path / "checkout"
+    source_file = checkout / "emmy" / "recipe" / "bundled.py"
+    source_file.parent.mkdir(parents=True)
+    (checkout / "pyproject.toml").write_text("[project]\nname = 'emmy-ml'\n")
+    recipes = checkout / "recipes"
+    recipes.mkdir()
+    monkeypatch.setattr(bundled, "__file__", str(source_file))
+
+    assert editable_recipe_root() == recipes
+    with default_recipe_root() as root:
+        assert root == recipes
+
+
+def test_default_root_uses_package_bundle_outside_a_checkout(tmp_path, monkeypatch, fake_package):
+    installed_file = tmp_path / "site-packages" / "emmy" / "recipe" / "bundled.py"
+    monkeypatch.setattr(bundled, "__file__", str(installed_file))
+
+    assert editable_recipe_root() is None
+    with default_recipe_root() as root:
+        assert root == fake_package
+
+
 def test_bundled_name_materializes_a_local_copy(tmp_path, monkeypatch, fake_package):
     """deploy writes its compose file into the recipe dir, so site-packages will not do."""
     monkeypatch.chdir(tmp_path)
@@ -45,6 +69,21 @@ def test_bundled_name_materializes_a_local_copy(tmp_path, monkeypatch, fake_pack
     copied = tmp_path / "Qwen3-Embedding-0.6B" / "recipe.yaml"
     assert copied.is_file()
     assert "Qwen3-Embedding-0.6B" in copied.read_text()
+
+
+def test_editable_recipe_name_materializes_from_live_checkout(tmp_path, monkeypatch):
+    checkout = tmp_path / "checkout"
+    source_file = checkout / "emmy" / "recipe" / "bundled.py"
+    source_file.parent.mkdir(parents=True)
+    (checkout / "pyproject.toml").write_text("[project]\nname = 'emmy-ml'\n")
+    recipe = checkout / "recipes" / "live-model" / "recipe.yaml"
+    recipe.parent.mkdir(parents=True)
+    recipe.write_text("model:\n  name: org/live-model\n")
+    monkeypatch.setattr(bundled, "__file__", str(source_file))
+    monkeypatch.chdir(tmp_path)
+
+    assert resolve_recipe_dir("live-model") == "live-model"
+    assert (tmp_path / "live-model" / "recipe.yaml").read_text() == recipe.read_text()
 
 
 def test_local_directory_shadows_a_bundled_name(tmp_path, monkeypatch, fake_package):

--- a/tests/recipe/test_bundled.py
+++ b/tests/recipe/test_bundled.py
@@ -8,7 +8,7 @@ reading the real one, so the suite behaves the same either way.
 import pytest
 
 from emmy.recipe import bundled
-from emmy.recipe.bundled import resolve_recipe_dir
+from emmy.recipe.bundled import bundled_root, resolve_recipe_dir
 
 
 @pytest.fixture
@@ -28,6 +28,11 @@ def test_existing_directory_is_used_as_given(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     assert resolve_recipe_dir(str(local)) == str(local)
+
+
+def test_bundled_root_returns_packaged_recipe_directory(fake_package):
+    with bundled_root() as root:
+        assert root == fake_package
 
 
 def test_bundled_name_materializes_a_local_copy(tmp_path, monkeypatch, fake_package):

--- a/tests/recipe/test_catalog.py
+++ b/tests/recipe/test_catalog.py
@@ -2,7 +2,7 @@
 
 import yaml
 
-from emmy.recipe.catalog import create_recipe_stub, recipe_inventory
+from emmy.recipe.catalog import CATALOG_SCHEMA_VERSION, create_recipe_stub, recipe_inventory, recipe_inventory_document
 
 GPU = "NVIDIA H200 141GB"
 
@@ -15,7 +15,11 @@ def _write_recipe(root, name, model_id, tags, *, rationale="Useful model."):
             {
                 "tags": tags,
                 "model": {"huggingface": model_id, "rationale": rationale, "task": "generate"},
-                "matrices": {"deploy.gpu": GPU, "deploy.gpu_count": 1},
+                "engine": {"llm": {"context_length": 8192, "vllm": {"image": "example/vllm"}}},
+                "matrices": [
+                    {"deploy.gpu": GPU, "deploy.gpu_count": 1},
+                    {"deploy.gpu": "NVIDIA B200", "deploy.gpu_count": 2, "engine.llm.context_length": 16384},
+                ],
             },
             sort_keys=False,
         )
@@ -33,13 +37,39 @@ def test_recipe_inventory_filters_tags_and_reports_deployments(tmp_path):
     assert inventory == [
         {
             "path": str(root / "ready" / "recipe.yaml"),
+            "name": "ready",
             "model_id": "org/ready",
             "tags": ["maintained"],
             "task": "generate",
-            "deployments": [{"deploy.gpu": GPU, "deploy.gpu_count": 1}],
+            "runnable": True,
+            "deployments": [
+                {"gpu": GPU, "gpu_count": 1, "context_length": 8192},
+                {"gpu": "NVIDIA B200", "gpu_count": 2, "context_length": 16384},
+            ],
             "rationale": "Useful model.",
         }
     ]
+
+
+def test_recipe_inventory_document_is_versioned(tmp_path):
+    root = tmp_path / "recipes"
+    _write_recipe(root, "ready", "org/ready", ["maintained"])
+
+    document = recipe_inventory_document(root)
+
+    assert document["schema_version"] == CATALOG_SCHEMA_VERSION == 1
+    assert [recipe["name"] for recipe in document["recipes"]] == ["ready"]
+
+
+def test_disabled_recipe_is_not_runnable_but_keeps_proposed_deployments(tmp_path):
+    root = tmp_path / "recipes"
+    recipe = _write_recipe(root, "old", "org/old", ["obsolete"])
+
+    record = recipe_inventory(root)[0]
+
+    assert record["runnable"] is False
+    assert record["deployments"][0]["context_length"] == 8192
+    assert recipe.is_file()
 
 
 def test_create_recipe_stub_writes_native_deployment_matrix(tmp_path):


### PR DESCRIPTION
## Summary

- add a schema-v1 machine contract for `emmy recipe list --json`
- report lifecycle-aware runnable state plus matrix-expanded GPU, GPU-count, and effective context metadata
- automatically use live top-level recipes for editable installs and packaged runnable recipes for wheel installs
- keep catalog selection out of the CLI: `recipe list` accepts only `--tag` and `--json`
- resolve bare recipe names from that same effective catalog for deploy and bench
- migrate Emmy's discovery/onboarding workflows to the minimal automatic form
- keep the discovery workflow on the versioned document shape
- bump the package version to 0.3.3 for the coordinated Relay release

The contract was also checked against the 29 recipes in #487: 26 are runnable and the three onboarding/obsolete recipes are correctly disabled. No runnable deployment is missing a context length.

## Compatibility

Consumers must reject unknown `schema_version` values. Schema v1 fields may be extended, but existing fields are not removed or redefined. Obsolete and onboarding recipes remain available in an editable source catalog while the wheel continues to bundle only runnable recipes.

Emmy detects the installation from its imported module path and checkout markers: editable installs use the checkout's live `recipes/`; regular wheel installs use the packaged bundle. There is deliberately no arbitrary catalog-root argument or bundled-catalog override.

## Testing

- `make lint`
- `make test` — 3,142 passed, 652 skipped, 1 xfailed, 1 xpassed
- `make wheel`
- focused recipe command/catalog tests — 18 passed
- loaded `dist/emmy_ml-0.3.3-py3-none-any.whl` from an isolated import target outside the repository — schema v1, 26 runnable bundled recipes
- verified wheel help exposes only `--tag` and `--json`, and removed `--bundled` exits with status 2
- ran the editable CLI outside the repository — schema v1, 26 recipes from the checkout's live `recipes/`
- ran the catalog against the exact #487 recipe tree — 29 total, 26 runnable, 3 disabled
