### PR TITLE
Support Robots team API key in model onboarding

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -73,8 +73,9 @@ priority. If none can run, it chooses a `maintained` recipe whose committed `RES
 timestamp; a missing report is oldest. Declaration order chooses among one recipe's available deployments, and model
 ID breaks remaining ties. No eligible deployment is a successful no-op.
 
-The workflow resolves the exact visible CloudRift team named `Robots` and includes its UUID in every rent request, so
-the VM is team-owned and visible to team members. It attaches `emmy`, workflow, and GitHub job tags, makes at most
+The workflow accepts a Robots-scoped CloudRift team API key, whose authenticated principal makes every rent and tag
+query team-owned without a request `team_id`. With a user API key it instead resolves the exact visible team named
+`Robots` and includes its UUID in every rent request. It attaches `emmy`, workflow, and GitHub job tags, makes at most
 three workflow-level rental attempts for the same selection, and sweeps a failed attempt by the complete tag set
 before retrying. Only V100 rentals set CloudRift's admin-only billing exemption; every other GPU is a regular team
 rental. The workflow never falls back to GCP or changes the selected GPU type/count.

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -187,10 +187,14 @@ jobs:
           inventory = json.loads(Path(os.environ["RECIPE_INVENTORY"]).read_text())
           available = asyncio.run(list_available_instance_types(os.environ["CLOUDRIFT_API_KEY"]))
           team_id = asyncio.run(
-              resolve_team_id(os.environ["CLOUDRIFT_API_KEY"], os.environ["CLOUDRIFT_TEAM_NAME"])
+              resolve_team_id(
+                  os.environ["CLOUDRIFT_API_KEY"],
+                  os.environ["CLOUDRIFT_TEAM_NAME"],
+                  allow_implicit_team_key=True,
+              )
           )
           with Path(os.environ["GITHUB_ENV"]).open("a") as output:
-              output.write(f"CLOUDRIFT_TEAM_ID={team_id}\n")
+              output.write(f"CLOUDRIFT_TEAM_ID={team_id or ''}\n")
 
           def available_deployment(deployment):
               gpu = deployment.get("deploy.gpu")
@@ -305,7 +309,11 @@ jobs:
         if: steps.selection.outputs.selected == 'true'
         run: |
           ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -q
-          printf 'providers:\n  cloudrift:\n    team_id: "%s"\n' "$CLOUDRIFT_TEAM_ID" > "$PROVIDER_CONFIG"
+          if [ -n "$CLOUDRIFT_TEAM_ID" ]; then
+            printf 'providers:\n  cloudrift:\n    team_id: "%s"\n' "$CLOUDRIFT_TEAM_ID" > "$PROVIDER_CONFIG"
+          else
+            printf 'providers:\n  cloudrift: {}\n' > "$PROVIDER_CONFIG"
+          fi
           chmod 600 "$PROVIDER_CONFIG"
 
       - name: Rent exact target VM

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -49,9 +49,11 @@ Every CloudRift rental carries free-form tags for later filtering on listings. `
 through `emmy.config.rental_tags()` — repeatable `--tag` flags win, else the comma-separated `EMMY_RENTAL_TAGS` env
 var (how an experiment run or CI job labels its whole rental lane), else the default `emmy` tag.
 
-`providers.cloudrift.team_id` assigns a rental to that exact team UUID. Automation may resolve the UUID from one exact
-visible team name through `resolve_team_id`; a missing or ambiguous match fails before rent. Team selection is passed
-to CloudRift's rent request and does not depend on descriptive tags.
+`providers.cloudrift.team_id` assigns a user-key rental to that exact team UUID. Automation may resolve the UUID from
+one exact visible team name through `resolve_team_id`; a missing or ambiguous match fails before rent. A caller that
+explicitly permits implicit team-key ownership may accept the user-only team-list endpoint's 401 only after the key
+authenticates against a team-aware account endpoint. In that case the omitted request UUID makes CloudRift use the
+team API key's principal. Team selection does not depend on descriptive tags.
 
 For each candidate, the orchestrator makes up to `SAME_CANDIDATE_RETRIES` (= 2) attempts on transient errors. On the contracted exceptions it short-circuits:
 

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -183,10 +183,26 @@ async def list_available_instance_types(api_key, api_url=DEFAULT_API_URL):
     return available
 
 
-async def resolve_team_id(api_key, team_name, api_url=DEFAULT_API_URL):
-    """Resolve one exact team name visible to the API key into its UUID."""
+async def resolve_team_id(api_key, team_name, api_url=DEFAULT_API_URL, allow_implicit_team_key=False):
+    """Resolve one exact team name, or accept ownership implicit in a team API key."""
     data = {"selector": "Mine", "with_members": False, "with_account_info": False}
-    result = await _api_request("POST", "/api/v1/teams/list", data, api_key, api_url)
+    try:
+        result = await _api_request("POST", "/api/v1/teams/list", data, api_key, api_url)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 401 or not allow_implicit_team_key:
+            raise
+        # Team API keys are intentionally rejected by the user-only teams/list
+        # endpoint. Verify the key against a team-aware endpoint before relying
+        # on CloudRift to infer the owning team from the authenticated principal.
+        await _api_request(
+            "POST",
+            "/api/v2/account/info",
+            {"selector": "ByToken", "with_auto_top_up": False},
+            api_key,
+            api_url,
+        )
+        logger.info(f"CloudRift team API key supplies implicit ownership for configured team {team_name!r}")
+        return None
     matches = [team.get("id") for team in result.get("teams", []) if team.get("name") == team_name and team.get("id")]
     if not matches:
         raise TerminalProvisionError(f"CloudRift API key cannot access team {team_name!r}")

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -3,7 +3,7 @@
 Response fixtures are captured from real CloudRift API calls.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
@@ -199,6 +199,50 @@ async def test_resolve_team_id_rejects_missing_team(mock_api):
     mock_api.return_value = {"teams": [{"id": "team-research", "name": "Research"}]}
 
     with pytest.raises(TerminalProvisionError, match="cannot access team 'Robots'"):
+        await resolve_team_id(API_KEY, "Robots", API_URL)
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_team_id_accepts_authenticated_implicit_team_key(mock_api):
+    request = httpx.Request("POST", f"{API_URL}/api/v1/teams/list")
+    unauthorized = httpx.HTTPStatusError(
+        "team keys cannot list teams",
+        request=request,
+        response=httpx.Response(401, request=request),
+    )
+    mock_api.side_effect = [unauthorized, {"balance": 100.0}]
+
+    result = await resolve_team_id(API_KEY, "Robots", API_URL, allow_implicit_team_key=True)
+
+    assert result is None
+    assert mock_api.await_args_list == [
+        call(
+            "POST",
+            "/api/v1/teams/list",
+            {"selector": "Mine", "with_members": False, "with_account_info": False},
+            API_KEY,
+            API_URL,
+        ),
+        call(
+            "POST",
+            "/api/v2/account/info",
+            {"selector": "ByToken", "with_auto_top_up": False},
+            API_KEY,
+            API_URL,
+        ),
+    ]
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_resolve_team_id_keeps_implicit_team_key_opt_in(mock_api):
+    request = httpx.Request("POST", f"{API_URL}/api/v1/teams/list")
+    mock_api.side_effect = httpx.HTTPStatusError(
+        "unauthorized",
+        request=request,
+        response=httpx.Response(401, request=request),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
         await resolve_team_id(API_KEY, "Robots", API_URL)
 
 


### PR DESCRIPTION
## Summary

- recognize CloudRift team API keys that are intentionally denied the user-only teams/list endpoint
- verify implicit team ownership through the team-aware account endpoint before proceeding
- omit team_id for team-key rentals so CloudRift assigns the VM to the authenticated Robots team principal
- preserve exact Robots team-name resolution and explicit team_id for user API keys

## End-to-end evidence

Post-merge workflow run 31925755627 reached CloudRift and failed before rental because the configured team key received 401 from teams/list. CloudRift server semantics confirm that team keys cannot enumerate teams and automatically own rentals made without an explicit team_id.

https://github.com/cloudrift-ai/emmy/actions/runs/31925755627

## Verification

- make test: 3134 passed, 652 skipped, 1 xfailed, 1 xpassed
- focused CloudRift provisioning tests: 96 passed
- make lint
- actionlint, YAML parsing, and embedded shell syntax checks

No VM was created by the failed workflow run.