### PR TITLE
Require explicit Robots ownership for model onboarding

### DIFF
--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -24,8 +24,9 @@ Repository storage retains reproducibility input and durable evidence for each q
 serving experiment root, commit `recipe.yaml`, one cumulative `RESULTS.md`, top-level system-only experiment records,
 and `results_<gpu-short>x<gpu-count>.tar.gz` for each measured exact GPU name/count. Derive `<gpu-short>` with
 `emmy.hardware.gpu_short_name`; for example, a single RTX 4090 uses `results_rtx4090x1.tar.gz`. Track these archives
-with Git LFS. Do not commit the ignored dated run directory, loose benchmark JSON/TXT/logs, plots, compiler run
-summaries, partial working goldens, or onboarding-summary files.
+with Git LFS. When the caller says LFS is configured locally, verify the archive attribute but do not modify or list
+`.gitattributes`; the caller owns that infrastructure file. Do not commit the ignored dated run directory, loose
+benchmark JSON/TXT/logs, plots, compiler run summaries, partial working goldens, or onboarding-summary files.
 
 Use one serving experiment root for all GPU platforms that share the protocol. On a platform-specific run, replace
 only that platform's archive and top-level records, update only its section of the shared experiment `RESULTS.md`, and

--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -13,17 +13,24 @@ Turn a Hugging Face model ID, an operation mode, and an exact `(GPU name, GPU co
 artifacts:
 
 - one recommended serving recipe under `recipes/<model>/recipe.yaml`;
-- reproducible qualification or comparison configurations under `experiments/<model>/`, without committed run output;
+- one reusable serving experiment under `experiments/<model>/` with a cumulative report, system-only row records,
+  and one Git LFS raw-results archive per exact GPU platform;
 - one compact, self-contained `recipes/<model>/RESULTS.md` only when a valid final deployment recipe exists;
 - a complete compiler golden under `emmy/compiler/pipeline/search/goldens/` when full coverage qualifies;
 - when Emmy is eligible, tuned kernels and a verified, prebuilt
   `cloudriftai/vllm-emmy-<model-slug>:<tag>` image.
 
-Repository storage is intentionally minimal. Do not commit experiment `RESULTS.md` files, benchmark JSON/TXT/logs,
-dated run snapshots, plots, compiler run summaries, partial working goldens, or onboarding-summary files unless the
-caller explicitly asks to retain a particular experiment result. Keep measurement output ignored or outside the
-checkout long enough to write the final recipe report, then remove task-owned copies from the checkout. Experiment
-YAML is reproducibility input and may remain committed.
+Repository storage retains reproducibility input and durable evidence for each qualified serving platform. In the
+serving experiment root, commit `recipe.yaml`, one cumulative `RESULTS.md`, top-level system-only experiment records,
+and `results_<gpu-short>x<gpu-count>.tar.gz` for each measured exact GPU name/count. Derive `<gpu-short>` with
+`emmy.hardware.gpu_short_name`; for example, a single RTX 4090 uses `results_rtx4090x1.tar.gz`. Track these archives
+with Git LFS. Do not commit the ignored dated run directory, loose benchmark JSON/TXT/logs, plots, compiler run
+summaries, partial working goldens, or onboarding-summary files.
+
+Use one serving experiment root for all GPU platforms that share the protocol. On a platform-specific run, replace
+only that platform's archive and top-level records, update only its section of the shared experiment `RESULTS.md`, and
+preserve every other platform archive, record, and report section. Reuse the existing serving experiment root when it
+already represents the protocol; otherwise create `experiments/<model>/serving/`.
 
 Use only the supplied SSH server. The caller owns VM creation and deletion; this skill owns deployed workloads and
 must tear them down before returning. Never switch GPU type, count, provider, model quantization, or model checkpoint
@@ -80,15 +87,14 @@ duplicated in `extra_args`.
 
 ## 2. Create and validate a conservative baseline
 
-Create a provisional experiment recipe under
-`experiments/<model>/serving_<hardware-slug>/recipe.yaml`. Start with the smallest tensor-parallel size that fits the
-weights on the requested GPU count, conservative memory utilization and concurrency, and a short benchmark. Keep
-the target matrix exact.
+Create or update the shared experiment recipe under the model's serving experiment root. Start with the smallest
+tensor-parallel size that fits the weights on the requested GPU count, conservative memory utilization and
+concurrency, and a short benchmark. Keep the current target matrix row exact and preserve the other platform rows.
 
 Deploy before benchmarking:
 
 ```bash
-emmy deploy ssh --recipe experiments/<model>/serving_<hardware-slug> --ssh <target>
+emmy deploy ssh --recipe experiments/<model>/serving --ssh <target>
 ```
 
 Require all of these before measuring performance:
@@ -216,10 +222,12 @@ Use comparison lanes to select and explain the recommended configuration. Benchm
 section 5. Include the comparisons that matter for this model's decision and clearly identify the engine and
 configuration selected by `recipes/<model>/recipe.yaml`; do not force unrelated models into one table layout.
 
-Commit a canonical experiment `recipe.yaml` when the comparison configuration remains useful. Follow the repository's
-`run-experiment` skill for the final measurement: retain its last raw `results/` directory, top-level system-only
-experiment records, and factual experiment `RESULTS.md`, including failed-row evidence. Fold the measured winner into
-a single-variant serving recipe under `recipes/<model>/recipe.yaml`; recipes have no `benchmark:` block.
+Commit the canonical experiment `recipe.yaml` when the comparison configuration remains useful. Follow the
+repository's `run-experiment` skill for the final measurement. Store the run as
+`results_<gpu-short>x<gpu-count>.tar.gz`, replace only the current platform's top-level system-only experiment records,
+and update its section in the shared factual experiment `RESULTS.md`, including failed-row evidence. Preserve every
+other platform snapshot. Fold the measured winner into a single-variant serving recipe under
+`recipes/<model>/recipe.yaml`; recipes have no `benchmark:` block.
 
 ## 7. Write the durable report
 
@@ -235,8 +243,9 @@ the recipe report directly; do not add a result-analysis script.
 Before writing performance numbers, find a successful experiment row and raw artifacts for the exact selected recipe
 configuration: model revision, engine image tag or digest, GPU name/count, precision policy, context, concurrency,
 workload, and engine knobs must all match. Re-run that lane with the existing `emmy bench` experiment when evidence
-is missing, stale, or does not identify the selected engine. Update the recipe report from the new measurement, but
-do not copy measurements into the experiment record or experiment artifact index.
+is missing, stale, or does not identify the selected engine. Update the current platform section of the recipe report
+from the new measurement while preserving still-valid sections for other platforms, but do not copy measurements
+into the experiment record or experiment artifact index.
 Never estimate a missing value, copy a competing engine's result, or combine metrics from different runs.
 
 Choose the report structure that makes this model's evidence easy to understand. A dense model, a quantized model, a
@@ -269,7 +278,7 @@ input, raw results, per-row system-only experiment records, and its factual last
 Before reporting success:
 
 ```bash
-emmy bench --dry-run experiments/<model>/serving_<hardware-slug>
+emmy bench --dry-run experiments/<model>/serving
 emmy deploy ssh --dry-run --recipe recipes/<model> --ssh <target>
 ```
 
@@ -287,8 +296,9 @@ Also verify:
   verified FAST_MATH pack for the exact serving shape;
 - `EMMY_FAST_MATH=1` appears in an Emmy recipe unless its accuracy gate regressed, and never appears in a
   mainstream-only recipe;
-- no experiment result, experiment `RESULTS.md`, dated run snapshot, or onboarding summary is staged unless the caller
-  explicitly requested that exact repository artifact;
+- the experiment snapshot contains the shared `recipe.yaml` and `RESULTS.md`, the exact platform's LFS archive and
+  top-level records, while other platform archives, records, and report sections remain unchanged;
+- no ignored dated run directory, loose benchmark output, or onboarding summary is staged;
 - tracked artifacts contain no credentials, absolute scratch paths, or VM identifiers;
 - deployed workloads are torn down and `docker logout` has run.
 
@@ -297,9 +307,10 @@ login, or no Docker login was performed because the stock-only path did not requ
 
 Write this JSON object atomically to the caller-supplied summary path outside the repository and print that path as the
 final line. Include the requested mode on success and failure. List every repository file created, modified, or deleted
-by the qualification run in `artifacts`. List only a complete repository golden in `compiler_artifacts`, and only
-retained experiment recipe YAML in
-`experiment_artifacts`. Do not list or commit raw measurement output.
+by the qualification run in `artifacts`. List only a complete repository golden in `compiler_artifacts`. In
+`experiment_artifacts`, list the shared experiment recipe and report, the current platform's compressed archive, and
+its retained top-level experiment records. List deleted prior records for the current platform in `artifacts`, but not
+in `experiment_artifacts`. Do not list unchanged artifacts from other platforms or the ignored dated run directory.
 
 ```json
 {
@@ -308,18 +319,24 @@ retained experiment recipe YAML in
   "model_id": "org/model",
   "target": {"gpu": "exact hardware.py name", "gpu_count": 1, "ssh": "user@host"},
   "recipe": "recipes/<model>/recipe.yaml",
-  "experiment": "experiments/<model>/serving_<hardware-slug>/recipe.yaml",
+  "experiment": "experiments/<model>/serving/recipe.yaml",
   "artifacts": [
     "recipes/<model>/recipe.yaml",
     "recipes/<model>/RESULTS.md",
     "emmy/compiler/pipeline/search/goldens/<gpu-slug>_<compute-cap>_<model-slug>.yaml",
-    "experiments/<model>/serving_<hardware-slug>/recipe.yaml"
+    "experiments/<model>/serving/recipe.yaml",
+    "experiments/<model>/serving/RESULTS.md",
+    "experiments/<model>/serving/results_<gpu-short>x<gpu-count>.tar.gz",
+    "experiments/<model>/serving/<gpu-short>x<gpu-count>_<row-id>.experiment.yaml"
   ],
   "compiler_artifacts": [
     "emmy/compiler/pipeline/search/goldens/<gpu-slug>_<compute-cap>_<model-slug>.yaml"
   ],
   "experiment_artifacts": [
-    "experiments/<model>/serving_<hardware-slug>/recipe.yaml"
+    "experiments/<model>/serving/recipe.yaml",
+    "experiments/<model>/serving/RESULTS.md",
+    "experiments/<model>/serving/results_<gpu-short>x<gpu-count>.tar.gz",
+    "experiments/<model>/serving/<gpu-short>x<gpu-count>_<row-id>.experiment.yaml"
   ],
   "report": "recipes/<model>/RESULTS.md",
   "compiler": {

--- a/.agents/skills/run-experiment/SKILL.md
+++ b/.agents/skills/run-experiment/SKILL.md
@@ -2,15 +2,17 @@
 name: run-experiment
 description: >-
   Run or rerun Emmy experiment recipes, including requests to adjust an experiment harness before running it, then
-  preserve the latest compressed raw results, system-only YAML experiment records, and a thoughtful RESULTS.md
-  interpretation. Use for requests such as "run this experiment", "benchmark this recipe", "rerun this on a GPU", or
-  "customize and execute this Emmy experiment". Interpret results through intelligent review, never repository code.
+  preserve per-platform compressed raw results, system-only YAML experiment records, and a thoughtful cumulative
+  RESULTS.md interpretation. Use for requests such as "run this experiment", "benchmark this recipe", "rerun this on
+  a GPU", or "customize and execute this Emmy experiment". Interpret results through intelligent review, never
+  repository code.
 ---
 
 # Run Experiment
 
-Produce one durable snapshot of the last requested run. Use Emmy for execution. Preserve measurements as raw evidence
-and review them yourself; do not add a result-conversion, plotting, manifest, analysis, or report-generation script.
+Produce one durable snapshot for each requested exact GPU platform. Use Emmy for execution. Preserve measurements as
+raw evidence and review them yourself; do not add a result-conversion, plotting, manifest, analysis, or
+report-generation script.
 
 ## Prepare
 
@@ -24,7 +26,8 @@ and review them yourself; do not add a result-conversion, plotting, manifest, an
 
 ## Run
 
-Run the selected directories in one Emmy invocation when practical:
+Run the selected directories in one Emmy invocation per exact GPU name/count when practical. Separate invocations
+keep each platform archive self-contained:
 
 ```bash
 ./venv/bin/emmy bench experiments/<model>/<experiment> [host and filter flags]
@@ -40,7 +43,7 @@ retain the machine. Verify the records were updated after cleanup.
 
 ## Assemble the durable snapshot
 
-For each selected experiment directory:
+For each selected experiment directory and exact GPU name/count:
 
 1. Load `recipe.yaml` and every `<timestamp>/*.experiment.yaml` from the run just completed. Verify that records cover
    the expected filtered rows, use one run ID, parse as YAML, contain generic system information, and have a terminal
@@ -49,16 +52,20 @@ For each selected experiment directory:
    compare the intended lanes, calculate only quantities needed for a clear interpretation, and inspect repeat
    stability, failures, correctness evidence, and protocol limitations. Do this as intelligent review, not with code
    added to the experiment recipe or repository.
-3. Remove only the prior top-level `*.experiment.yaml` files for that exact experiment. Copy the latest records beside
-   `recipe.yaml`, preserving the timestamped local directory exactly as Emmy produced it.
-4. Replace `<experiment>/results.tar.gz` with a gzip-compressed tar archive whose root member is the latest timestamped
-   directory. Do not delete that local directory. Track `experiments/**/results.tar.gz` with Git LFS.
-5. Overwrite `<experiment>/RESULTS.md` with a thoughtful, evidence-backed interpretation. Include the question,
-   protocol, result summary, repeat variation, comparisons, conclusion, limitations, timestamp, run ID, machine and
-   software information, row status, failures, archive path, and member names. Distinguish direct comparisons from
-   directional ones and avoid claims the harness does not support.
-6. Ensure the durable experiment contains `recipe.yaml`, `results.tar.gz`, top-level experiment records, and
-   `RESULTS.md`. Do not retain durable records, archives, or reports from an earlier run.
+3. Derive the platform key as `<gpu-short>x<gpu-count>` with `emmy.hardware.gpu_short_name`, for example `rtx4090x1`.
+   Remove only prior top-level `<platform-key>*.experiment.yaml` files and copy the latest records beside `recipe.yaml`.
+   Preserve every other platform's records and the timestamped local directory exactly as Emmy produced it.
+4. Replace `<experiment>/results_<platform-key>.tar.gz` with a gzip-compressed tar archive whose root member is the
+   latest timestamped directory. Do not delete that local directory or another platform's archive. Track
+   `experiments/**/results_*.tar.gz` with Git LFS.
+5. Update the current platform section in `<experiment>/RESULTS.md` with a thoughtful, evidence-backed interpretation.
+   Preserve other platform sections. Include the question, protocol, result summary, repeat variation, comparisons,
+   conclusion, limitations, timestamp, run ID, machine and software information, row status, failures, archive path,
+   and member names. Distinguish direct comparisons from directional ones and avoid claims the harness does not
+   support.
+6. Ensure the durable experiment contains `recipe.yaml`, one cumulative `RESULTS.md`, and for every retained platform
+   one named archive plus matching top-level records. The current platform's archive, records, and report section must
+   describe the same most recent run; do not modify another platform's snapshot.
 
 ## Verify and commit
 
@@ -69,10 +76,11 @@ reported value and conclusion back to the raw files and protocol.
 Force-stage only the requested experiments' durable snapshot because `experiments/` is ignored by default:
 
 ```bash
-git lfs track "experiments/**/results.tar.gz"
+git lfs track "experiments/**/results_*.tar.gz"
 git add .gitattributes
-git add -f experiments/<model>/<experiment>/results.tar.gz \
-  experiments/<model>/<experiment>/*.experiment.yaml \
+git add -f -A -- experiments/<model>/<experiment>/recipe.yaml \
+  experiments/<model>/<experiment>/results_<gpu-short>x<gpu-count>.tar.gz \
+  ':(glob)experiments/<model>/<experiment>/<gpu-short>x<gpu-count>*.experiment.yaml' \
   experiments/<model>/<experiment>/RESULTS.md
 ```
 

--- a/.agents/skills/run-experiment/SKILL.md
+++ b/.agents/skills/run-experiment/SKILL.md
@@ -56,8 +56,9 @@ For each selected experiment directory and exact GPU name/count:
    Remove only prior top-level `<platform-key>*.experiment.yaml` files and copy the latest records beside `recipe.yaml`.
    Preserve every other platform's records and the timestamped local directory exactly as Emmy produced it.
 4. Replace `<experiment>/results_<platform-key>.tar.gz` with a gzip-compressed tar archive whose root member is the
-   latest timestamped directory. Do not delete that local directory or another platform's archive. Track
-   `experiments/**/results_*.tar.gz` with Git LFS.
+   latest timestamped directory. Keep that local directory through archive extraction or byte verification and never
+   delete another platform's archive. If the caller requires an artifact-only checkout, delete the task-owned local
+   directory only after that archive verification. Track `experiments/**/results_*.tar.gz` with Git LFS.
 5. Update the current platform section in `<experiment>/RESULTS.md` with a thoughtful, evidence-backed interpretation.
    Preserve other platform sections. Include the question, protocol, result summary, repeat variation, comparisons,
    conclusion, limitations, timestamp, run ID, machine and software information, row status, failures, archive path,

--- a/.agents/skills/run-experiment/SKILL.md
+++ b/.agents/skills/run-experiment/SKILL.md
@@ -76,13 +76,16 @@ reported value and conclusion back to the raw files and protocol.
 Force-stage only the requested experiments' durable snapshot because `experiments/` is ignored by default:
 
 ```bash
-git lfs track "experiments/**/results_*.tar.gz"
-git add .gitattributes
+git check-attr filter -- experiments/<model>/<experiment>/results_<gpu-short>x<gpu-count>.tar.gz
 git add -f -A -- experiments/<model>/<experiment>/recipe.yaml \
   experiments/<model>/<experiment>/results_<gpu-short>x<gpu-count>.tar.gz \
   ':(glob)experiments/<model>/<experiment>/<gpu-short>x<gpu-count>*.experiment.yaml' \
   experiments/<model>/<experiment>/RESULTS.md
 ```
+
+The archive must report `filter: lfs`. If the repository pattern is missing and the caller permits infrastructure
+changes, add it with `git lfs track "experiments/**/results_*.tar.gz"` and stage `.gitattributes`. If the caller says
+LFS is configured locally, do not modify or list `.gitattributes`; the caller owns that file.
 
 Stage harness edits normally, review the staged diff, and commit once with a concise subject such as
 `Record <experiment> run`. Never stage the timestamped raw directory. Do not push or open a pull request unless the

--- a/.agents/skills/run-experiment/agents/openai.yaml
+++ b/.agents/skills/run-experiment/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Run Experiment"
   short_description: "Run Emmy experiments and retain evidence"
-  default_prompt: "Use $run-experiment to run an Emmy experiment, preserve its records and compressed raw results, and interpret it."
+  default_prompt: "Use $run-experiment to update one GPU platform's archive and records while preserving other platform evidence."

--- a/.agents/skills/tune-kernels/SKILL.md
+++ b/.agents/skills/tune-kernels/SKILL.md
@@ -30,7 +30,9 @@ decision to the author or agent after validation.
 
 When the caller supplies SSH, run tracing, tuning, O3 verification, and profiling on that host. The caller owns the
 VM; never provision, stop, or delete it here. Record the SSH target and verify its GPU names/count before spending a
-search budget. Fail on a mismatch rather than switching hardware.
+search budget. Fail on a mismatch rather than switching hardware. For raw `ssh` and `rsync`, keep the user/host and
+port separate: pass the port with `ssh -p` or the rsync remote shell. Do not pass Emmy's `user@host:port` connection
+string as the raw SSH hostname.
 
 Create a task-owned remote scratch directory and source tree on durable storage. Never put the remote checkout,
 virtual environment, package cache, or build temporary files under `/tmp`: Cloud GPU images commonly mount it as a
@@ -63,21 +65,25 @@ A typical setup is:
 ```bash
 REPO_URL=$(git remote get-url origin)
 REVISION=$(git rev-parse HEAD)
-REMOTE_BASE=$(ssh "$REMOTE" 'set -eu; base="$HOME/.cache/emmy"; mkdir -p "$base"; \
+REMOTE="$SSH_USER@$SSH_HOST"
+SSH=(ssh -i "$SSH_KEY" -p "$SSH_PORT" -o IdentitiesOnly=yes)
+REMOTE_BASE=$("${SSH[@]}" "$REMOTE" 'set -eu; base="$HOME/.cache/emmy"; mkdir -p "$base"; \
   case "$(df -PT "$base" | awk "NR == 2 {print \\$2}")" in tmpfs|ramfs) exit 1;; esac; \
   test "$(df -Pk "$base" | awk "NR == 2 {print \\$4}")" -ge 8388608; printf "%s\\n" "$base"')
-REMOTE_ROOT=$(ssh "$REMOTE" "mktemp -d '$REMOTE_BASE/tune.XXXXXX'")
+REMOTE_ROOT=$("${SSH[@]}" "$REMOTE" "mktemp -d '$REMOTE_BASE/tune.XXXXXX'")
 LOCAL_MANIFEST=$(mktemp /tmp/emmy-tune-files.XXXXXX)
-ssh "$REMOTE" "git clone --no-checkout '$REPO_URL' '$REMOTE_ROOT/repo' && \
+"${SSH[@]}" "$REMOTE" "git clone --no-checkout '$REPO_URL' '$REMOTE_ROOT/repo' && \
   git -C '$REMOTE_ROOT/repo' checkout --detach '$REVISION'"
 git ls-files -z | while IFS= read -r -d '' tracked_path; do
   if [ -e "$tracked_path" ] || [ -L "$tracked_path" ]; then
     printf '%s\0' "$tracked_path"
   fi
 done > "$LOCAL_MANIFEST"
-rsync -a --from0 --files-from="$LOCAL_MANIFEST" ./ "$REMOTE:$REMOTE_ROOT/repo/"
-rsync -a --relative _tune/<run>/working.yaml "$REMOTE:$REMOTE_ROOT/repo/"
-ssh "$REMOTE" "mkdir -p '$REMOTE_ROOT/tmp' && cd '$REMOTE_ROOT/repo' && \
+RSYNC_RSH="ssh -i $SSH_KEY -p $SSH_PORT -o IdentitiesOnly=yes" \
+  rsync -a --from0 --files-from="$LOCAL_MANIFEST" ./ "$REMOTE:$REMOTE_ROOT/repo/"
+RSYNC_RSH="ssh -i $SSH_KEY -p $SSH_PORT -o IdentitiesOnly=yes" \
+  rsync -a --relative _tune/<run>/working.yaml "$REMOTE:$REMOTE_ROOT/repo/"
+"${SSH[@]}" "$REMOTE" "mkdir -p '$REMOTE_ROOT/tmp' && cd '$REMOTE_ROOT/repo' && \
   TMPDIR='$REMOTE_ROOT/tmp' PIP_NO_CACHE_DIR=1 make setup"
 ```
 

--- a/.agents/skills/tune-kernels/SKILL.md
+++ b/.agents/skills/tune-kernels/SKILL.md
@@ -32,10 +32,18 @@ When the caller supplies SSH, run tracing, tuning, O3 verification, and profilin
 VM; never provision, stop, or delete it here. Record the SSH target and verify its GPU names/count before spending a
 search budget. Fail on a mismatch rather than switching hardware.
 
-Create a task-owned remote scratch directory and source tree:
+Create a task-owned remote scratch directory and source tree on durable storage. Never put the remote checkout,
+virtual environment, package cache, or build temporary files under `/tmp`: Cloud GPU images commonly mount it as a
+small tmpfs. Prefer `$HOME/.cache/emmy`, reject `tmpfs` and `ramfs`, and require at least 8 GiB free before setup.
+The caller may preinstall `python3.12-venv`, `git`, `make`, and `rsync`; otherwise install those prerequisites with
+the host's package manager before creating the source tree. Do not fall back to installing compiler dependencies or
+running compiler qualification on the local caller when remote setup fails.
+
+Then create the task-owned source tree:
 
 1. capture the local repository URL and revision;
-2. create an exact remote directory with `mktemp -d`, record it immediately, and clone the repository there;
+2. create an exact remote directory with `mktemp -d` under the validated durable base, record it immediately, and
+   clone the repository there;
 3. check out the captured revision, then rsync the local tracked-file list so reviewed uncommitted source changes are
    represented; remove the exact tracked paths deleted locally, and add only explicitly enumerated task-owned
    untracked source files to that list;
@@ -55,7 +63,10 @@ A typical setup is:
 ```bash
 REPO_URL=$(git remote get-url origin)
 REVISION=$(git rev-parse HEAD)
-REMOTE_ROOT=$(ssh "$REMOTE" 'mktemp -d /tmp/emmy-tune.XXXXXX')
+REMOTE_BASE=$(ssh "$REMOTE" 'set -eu; base="$HOME/.cache/emmy"; mkdir -p "$base"; \
+  case "$(df -PT "$base" | awk "NR == 2 {print \\$2}")" in tmpfs|ramfs) exit 1;; esac; \
+  test "$(df -Pk "$base" | awk "NR == 2 {print \\$4}")" -ge 8388608; printf "%s\\n" "$base"')
+REMOTE_ROOT=$(ssh "$REMOTE" "mktemp -d '$REMOTE_BASE/tune.XXXXXX'")
 LOCAL_MANIFEST=$(mktemp /tmp/emmy-tune-files.XXXXXX)
 ssh "$REMOTE" "git clone --no-checkout '$REPO_URL' '$REMOTE_ROOT/repo' && \
   git -C '$REMOTE_ROOT/repo' checkout --detach '$REVISION'"
@@ -66,7 +77,8 @@ git ls-files -z | while IFS= read -r -d '' tracked_path; do
 done > "$LOCAL_MANIFEST"
 rsync -a --from0 --files-from="$LOCAL_MANIFEST" ./ "$REMOTE:$REMOTE_ROOT/repo/"
 rsync -a --relative _tune/<run>/working.yaml "$REMOTE:$REMOTE_ROOT/repo/"
-ssh "$REMOTE" "cd '$REMOTE_ROOT/repo' && make setup"
+ssh "$REMOTE" "mkdir -p '$REMOTE_ROOT/tmp' && cd '$REMOTE_ROOT/repo' && \
+  TMPDIR='$REMOTE_ROOT/tmp' PIP_NO_CACHE_DIR=1 make setup"
 ```
 
 Apply the validated NUL-delimited output of `git diff --name-only --diff-filter=D "$REVISION" --` as exact removals

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 experiments/**/results.tar.gz filter=lfs diff=lfs merge=lfs -text
+experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -102,6 +102,8 @@ The artifact worktree stays on the rolling lifecycle branch, while Python contro
 manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
 The selector runs the exact-SHA catalog logic against the rolling worktree's `recipes/` directory so lifecycle mode
 and priority always reflect the branch that the agent will update.
+The workflow also attaches the exact-SHA `onboard-model` and `run-experiment` skills as authoritative agent inputs;
+older copies on the rolling branch cannot silently override a proposed artifact contract.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
 allowed recipe, experiment, serving-image, and canonical-golden paths. The validator requires the shared experiment

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -91,9 +91,11 @@ The workflow passes the resulting SSH target and an explicit `onboarding` or `ve
 `onboard-model` skill. Onboarding replaces the discovery shell and changes `onboarding`/`untested` to `best-effort`.
 Verification begins from the active recipe, refreshes measurements and durable artifacts, and preserves its existing
 lifecycle tag. The job has a 24-hour limit and gives the agent a 23.5-hour deadline so artifact validation and cleanup
-retain 30 minutes. Raw benchmark output, experiment reports, dated run snapshots, and qualification summaries are not
-repository artifacts. An Emmy-tuned prebuilt image is produced only when every release gate passes. Nightly image
-publication is disabled unless `NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual dispatch retains an explicit input.
+retain 30 minutes. The shared serving experiment retains one LFS archive and top-level row-record set per exact GPU
+platform plus one cumulative `RESULTS.md`; a run replaces only its platform snapshot. Ignored dated run directories,
+loose benchmark output, and qualification summaries are not repository artifacts. An Emmy-tuned prebuilt image is
+produced only when every release gate passes. Nightly image publication is disabled unless
+`NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual dispatch retains an explicit input.
 
 The artifact worktree stays on the rolling lifecycle branch, while Python control code is loaded from the exact
 `github.sha` whose workflow definition started the job. This keeps normal scheduled runs reproducible and lets a
@@ -102,9 +104,12 @@ The selector runs the exact-SHA catalog logic against the rolling worktree's `re
 and priority always reflect the branch that the agent will update.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
-allowed recipe, experiment, serving-image, and canonical-golden paths. The validator mechanically includes the
-separately declared recipe, report, and retained experiment recipes in the staging set, while optional outputs must
-remain in `artifacts`; unmanifested or exploratory output is rejected.
+allowed recipe, experiment, serving-image, and canonical-golden paths. The validator requires the shared experiment
+recipe and report, the exact `results_<gpu-short>x<gpu-count>.tar.gz` archive, and matching current-platform row
+records.
+It rejects changes to another platform snapshot and requires the current archive to be created or updated. Optional
+outputs must remain in `artifacts`; unmanifested or exploratory output is rejected. Git LFS is configured locally
+before staging so the normal push uploads the archive object with the rolling branch.
 The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
 the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
 model, and expected lifecycle tag. The workflow then commits those artifacts, rebases on the latest default branch,

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -78,7 +78,7 @@ ID breaks remaining ties. No eligible deployment is a successful no-op.
 
 The workflow requires the repository's `CLOUDRIFT_TEAM_ID` variable to contain the exact Robots team UUID. Before it
 checks capacity, it validates that `CLOUDRIFT_API_KEY` can act for that UUID through a team-scoped account request;
-every rent then includes the UUID and disables public-IP allocation. It attaches `emmy`, workflow, and GitHub job tags,
+every rent then includes the UUID and requests a public IP so the GitHub runner can reach the VM over SSH. It attaches `emmy`, workflow, and GitHub job tags,
 makes at most three workflow-level rental attempts for the same selection, and sweeps a failed attempt by the complete
 tag set before retrying. Only V100 rentals set CloudRift's admin-only billing exemption; every other GPU is a regular
 team rental. The workflow never falls back to GCP or changes the selected GPU type/count.

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -98,6 +98,8 @@ publication is disabled unless `NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual
 The artifact worktree stays on the rolling lifecycle branch, while Python control code is loaded from the exact
 `github.sha` whose workflow definition started the job. This keeps normal scheduled runs reproducible and lets a
 manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
+The selector runs the exact-SHA catalog logic against the rolling worktree's `recipes/` directory so lifecycle mode
+and priority always reflect the branch that the agent will update.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
 allowed recipe, experiment, serving-image, and canonical-golden paths. The validator mechanically includes the

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -108,8 +108,9 @@ allowed recipe, experiment, serving-image, and canonical-golden paths. The valid
 recipe and report, the exact `results_<gpu-short>x<gpu-count>.tar.gz` archive, and matching current-platform row
 records.
 It rejects changes to another platform snapshot and requires the current archive to be created or updated. Optional
-outputs must remain in `artifacts`; unmanifested or exploratory output is rejected. Git LFS is configured locally
-before staging so the normal push uploads the archive object with the rolling branch.
+outputs must remain in `artifacts`; unmanifested or exploratory output is rejected. The job installs a pinned,
+checksum-verified Git LFS binary in the runner's temporary directory when needed, then configures LFS locally before
+staging so the normal push uploads the archive object with the rolling branch.
 The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
 the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
 model, and expected lifecycle tag. The workflow then commits those artifacts, rebases on the latest default branch,

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -95,6 +95,10 @@ retain 30 minutes. Raw benchmark output, experiment reports, dated run snapshots
 repository artifacts. An Emmy-tuned prebuilt image is produced only when every release gate passes. Nightly image
 publication is disabled unless `NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual dispatch retains an explicit input.
 
+The artifact worktree stays on the rolling lifecycle branch, while Python control code is loaded from the exact
+`github.sha` whose workflow definition started the job. This keeps normal scheduled runs reproducible and lets a
+manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
+
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
 allowed recipe, experiment, serving-image, and canonical-golden paths. Unmanifested or exploratory output is rejected.
 The validator also checks the requested mode, exact recipe model, and expected lifecycle tag. The workflow then

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -112,7 +112,9 @@ records.
 It rejects changes to another platform snapshot and requires the current archive to be created or updated. Optional
 outputs must remain in `artifacts`; unmanifested or exploratory output is rejected. The job installs a pinned,
 checksum-verified Git LFS binary in the runner's temporary directory when needed, then configures LFS locally before
-staging so the normal push uploads the archive object with the rolling branch.
+staging so the normal push uploads the archive object with the rolling branch. After the agent returns, the workflow
+requires each task-local timestamp directory to be a root member of the declared platform archive before removing
+that ignored local directory; only the durable archive proceeds to staging.
 The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
 the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
 model, and expected lifecycle tag. The workflow then commits those artifacts, rebases on the latest default branch,

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -101,9 +101,11 @@ manual dispatch test a workflow PR without leaking that PR's implementation comm
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
 allowed recipe, experiment, serving-image, and canonical-golden paths. Unmanifested or exploratory output is rejected.
-The validator also checks the requested mode, exact recipe model, and expected lifecycle tag. The workflow then
-commits those artifacts, rebases on the latest default branch, and updates or opens the rolling model lifecycle PR
-using renewable GitHub App credentials for the long-running push path.
+The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
+the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
+model, and expected lifecycle tag. The workflow then commits those artifacts, rebases on the latest default branch,
+and updates or opens the rolling model lifecycle PR using renewable GitHub App credentials for the long-running push
+path.
 
 ### Discovery lifecycle PR
 

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -90,8 +90,10 @@ retaining the owned lease as an independent verification handle.
 The workflow passes the resulting SSH target and an explicit `onboarding` or `verification` mode to the tracked
 `onboard-model` skill. Onboarding replaces the discovery shell and changes `onboarding`/`untested` to `best-effort`.
 Verification begins from the active recipe, refreshes measurements and durable artifacts, and preserves its existing
-lifecycle tag. The job has a 24-hour limit and gives the agent a 23.5-hour deadline so artifact validation and cleanup
-retain 30 minutes. The shared serving experiment retains one LFS archive and top-level row-record set per exact GPU
+lifecycle tag. Before the agent starts, the workflow installs the small remote Python/rsync prerequisite set and
+requires `$HOME/.cache/emmy` to be durable storage with at least 8 GiB free. Compiler staging keeps its checkout,
+venv, cache, and build temporary files there rather than on a small `/tmp` tmpfs. The job has a 24-hour limit and gives
+the agent a 23.5-hour deadline so artifact validation and cleanup retain 30 minutes. The shared serving experiment retains one LFS archive and top-level row-record set per exact GPU
 platform plus one cumulative `RESULTS.md`; a run replaces only its platform snapshot. Ignored dated run directories,
 loose benchmark output, and qualification summaries are not repository artifacts. An Emmy-tuned prebuilt image is
 produced only when every release gate passes. Nightly image publication is disabled unless
@@ -102,7 +104,7 @@ The artifact worktree stays on the rolling lifecycle branch, while Python contro
 manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
 The selector runs the exact-SHA catalog logic against the rolling worktree's `recipes/` directory so lifecycle mode
 and priority always reflect the branch that the agent will update.
-The workflow also attaches the exact-SHA `onboard-model` and `run-experiment` skills as authoritative agent inputs;
+The workflow also attaches the exact-SHA `onboard-model`, `tune-kernels`, and `run-experiment` skills as authoritative agent inputs;
 older copies on the rolling branch cannot silently override a proposed artifact contract.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -100,7 +100,9 @@ The artifact worktree stays on the rolling lifecycle branch, while Python contro
 manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
-allowed recipe, experiment, serving-image, and canonical-golden paths. Unmanifested or exploratory output is rejected.
+allowed recipe, experiment, serving-image, and canonical-golden paths. The validator mechanically includes the
+separately declared recipe, report, and retained experiment recipes in the staging set, while optional outputs must
+remain in `artifacts`; unmanifested or exploratory output is rejected.
 The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
 the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
 model, and expected lifecycle tag. The workflow then commits those artifacts, rebases on the latest default branch,

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -76,12 +76,16 @@ priority. If none can run, it chooses a `maintained` recipe whose committed `RES
 timestamp; a missing report is oldest. Declaration order chooses among one recipe's available deployments, and model
 ID breaks remaining ties. No eligible deployment is a successful no-op.
 
-The workflow accepts a Robots-scoped CloudRift team API key, whose authenticated principal makes every rent and tag
-query team-owned without a request `team_id`. With a user API key it instead resolves the exact visible team named
-`Robots` and includes its UUID in every rent request. It attaches `emmy`, workflow, and GitHub job tags, makes at most
-three workflow-level rental attempts for the same selection, and sweeps a failed attempt by the complete tag set
-before retrying. Only V100 rentals set CloudRift's admin-only billing exemption; every other GPU is a regular team
-rental. The workflow never falls back to GCP or changes the selected GPU type/count.
+The workflow requires the repository's `CLOUDRIFT_TEAM_ID` variable to contain the exact Robots team UUID. Before it
+checks capacity, it validates that `CLOUDRIFT_API_KEY` can act for that UUID through a team-scoped account request;
+every rent then includes the UUID and disables public-IP allocation. It attaches `emmy`, workflow, and GitHub job tags,
+makes at most three workflow-level rental attempts for the same selection, and sweeps a failed attempt by the complete
+tag set before retrying. Only V100 rentals set CloudRift's admin-only billing exemption; every other GPU is a regular
+team rental. The workflow never falls back to GCP or changes the selected GPU type/count.
+
+Unconditional teardown sends the complete tag-scoped terminate request before its bounded status audit and lease
+audit. This ordering gives cancellation cleanup a short critical path inside GitHub's cancellation grace period while
+retaining the owned lease as an independent verification handle.
 
 The workflow passes the resulting SSH target and an explicit `onboarding` or `verification` mode to the tracked
 `onboard-model` skill. Onboarding replaces the discovery shell and changes `onboarding`/`untested` to `best-effort`.
@@ -158,6 +162,8 @@ Agent workflows use these repository secrets as applicable:
 - `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for an eligible verified prebuilt image.
 
 `ONBOARD_AGENT_MODEL` selects the discovery/onboarding model and defaults to `Qwen/Qwen3.6-35B-A3B-FP8`.
+`CLOUDRIFT_TEAM_ID` must be the exact Robots team UUID; the verification/onboarding workflow fails before capacity
+selection if the variable is absent, malformed, or inaccessible to `CLOUDRIFT_API_KEY`.
 `CLOUDRIFT_INFERENCE_URL` selects its OpenAI-compatible endpoint and defaults to
 `https://inference.cloudrift.ai/v1`.
 `NIGHTLY_ONBOARD_PUBLISH_IMAGE=true` authorizes a nightly qualification to publish an otherwise eligible image; it is

--- a/.github/scripts/onboarding_artifacts.py
+++ b/.github/scripts/onboarding_artifacts.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import yaml
 
+from emmy.hardware import gpu_short_name
 from emmy.recipe.lifecycle import validate_recipe_tags
 
 ALLOWED_ARTIFACT_PREFIXES = (
@@ -31,11 +32,39 @@ def _relative_file(workspace: Path, raw_path: str, prefixes: tuple[str, ...]) ->
     return path
 
 
-def _relative_experiment_recipe(workspace: Path, raw_path: str) -> Path:
+def _platform_name(gpu: str, gpu_count: int) -> str:
+    return f"{gpu_short_name(gpu)}x{gpu_count}"
+
+
+def _is_platform_record(path: Path, platform: str) -> bool:
+    exact_name = path.name == f"{platform}.experiment.yaml"
+    expanded_name = path.name.startswith(f"{platform}_") and path.name.endswith(".experiment.yaml")
+    return exact_name or expanded_name
+
+
+def _is_durable_experiment_artifact(path: Path) -> bool:
+    named_archive = path.name.startswith("results_") and path.name.endswith(".tar.gz")
+    return path.name in {"recipe.yaml", "RESULTS.md"} or path.name.endswith(".experiment.yaml") or named_archive
+
+
+def _relative_experiment_artifact(workspace: Path, raw_path: str, experiment_dir: Path, platform: str) -> Path:
     path = _relative_file(workspace, raw_path, ("experiments/",))
-    if path.name != "recipe.yaml":
-        raise ValueError(f"Only experiment recipe.yaml files may be retained: {raw_path}")
+    allowed_names = {"recipe.yaml", "RESULTS.md", f"results_{platform}.tar.gz"}
+    allowed_for_platform = path.name in allowed_names or _is_platform_record(path, platform)
+    if path.parent != experiment_dir or not allowed_for_platform:
+        raise ValueError(f"Artifact is outside the {platform} durable experiment snapshot: {raw_path}")
     return path
+
+
+def _is_tracked_deletion(workspace: Path, path: Path) -> bool:
+    result = subprocess.run(
+        ["git", "ls-files", "--deleted", "--", str(path)],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and path.as_posix() in result.stdout.splitlines()
 
 
 def _relative_artifact(workspace: Path, raw_path: str) -> Path:
@@ -43,7 +72,7 @@ def _relative_artifact(workspace: Path, raw_path: str) -> Path:
     normalized = path.as_posix()
     if path.is_absolute() or ".." in path.parts:
         raise ValueError(f"Artifact path is not repository-relative: {raw_path}")
-    if normalized.startswith(ALLOWED_ARTIFACT_PREFIXES) and (workspace / path).is_file():
+    if normalized.startswith(ALLOWED_ARTIFACT_PREFIXES) and ((workspace / path).is_file() or _is_tracked_deletion(workspace, path)):
         return path
     raise ValueError(f"Artifact path is outside the allowed onboarding areas or does not exist: {raw_path}")
 
@@ -52,7 +81,7 @@ def _invalid_result_artifacts(artifacts: list[Path]) -> list[Path]:
     return [
         path
         for path in artifacts
-        if (path.parts[0] == "experiments" and path.name != "recipe.yaml")
+        if (path.parts[0] == "experiments" and not _is_durable_experiment_artifact(path))
         or (path.parts[0] == "recipes" and path.name not in {"recipe.yaml", "RESULTS.md"})
     ]
 
@@ -95,13 +124,27 @@ def validate_summary(
     report = _relative_file(workspace, summary.get("report") or "", ("recipes/",))
     if report != recipe.with_name("RESULTS.md"):
         raise ValueError(f"Report must be RESULTS.md beside the final recipe: {report}")
+    experiment_recipe = _relative_file(workspace, summary.get("experiment") or "", ("experiments/",))
+    if experiment_recipe.name != "recipe.yaml":
+        raise ValueError(f"Experiment must identify its recipe.yaml: {experiment_recipe}")
+    experiment_dir = experiment_recipe.parent
+    platform = _platform_name(gpu, gpu_count)
     raw_experiment_artifacts = summary.get("experiment_artifacts")
     if not isinstance(raw_experiment_artifacts, list) or not raw_experiment_artifacts:
-        raise ValueError("Summary must list the retained experiment recipe in experiment_artifacts")
-    experiment_artifacts = [_relative_experiment_recipe(workspace, raw_path) for raw_path in raw_experiment_artifacts]
-    experiment_recipe = Path(summary.get("experiment") or "")
+        raise ValueError("Summary must list the retained durable experiment snapshot in experiment_artifacts")
+    experiment_artifacts = [
+        _relative_experiment_artifact(workspace, raw_path, experiment_dir, platform) for raw_path in raw_experiment_artifacts
+    ]
     if experiment_recipe not in experiment_artifacts:
         raise ValueError("The experiment recipe must be included in experiment_artifacts")
+    experiment_report = experiment_dir / "RESULTS.md"
+    if experiment_report not in experiment_artifacts:
+        raise ValueError("The shared experiment RESULTS.md must be included in experiment_artifacts")
+    experiment_archive = experiment_dir / f"results_{platform}.tar.gz"
+    if experiment_archive not in experiment_artifacts:
+        raise ValueError(f"The exact platform archive must be included in experiment_artifacts: {experiment_archive}")
+    if not any(_is_platform_record(path, platform) for path in experiment_artifacts):
+        raise ValueError(f"At least one {platform} experiment record must be included in experiment_artifacts")
     raw_artifacts = summary.get("artifacts")
     if not isinstance(raw_artifacts, list) or not raw_artifacts:
         raise ValueError("Summary must include a non-empty artifacts list")
@@ -117,14 +160,27 @@ def validate_summary(
     )
     invalid_result_artifacts = _invalid_result_artifacts(artifacts)
     if invalid_result_artifacts:
-        raise ValueError(f"Only recipe.yaml and final recipe RESULTS.md artifacts may be retained: {invalid_result_artifacts}")
+        raise ValueError(f"Only durable recipe and experiment artifacts may be retained: {invalid_result_artifacts}")
+    invalid_experiment_artifacts = [
+        path
+        for path in artifacts
+        if path.parts[0] == "experiments"
+        and not (
+            path.parent == experiment_dir
+            and (path.name in {"recipe.yaml", "RESULTS.md", experiment_archive.name} or _is_platform_record(path, platform))
+        )
+    ]
+    if invalid_experiment_artifacts:
+        raise ValueError(
+            f"Only the {platform} snapshot may change; other platform results must be preserved: {invalid_experiment_artifacts}"
+        )
     return summary, artifacts
 
 
-def stage_artifacts(workspace: Path, artifacts: list[Path]) -> None:
+def stage_artifacts(workspace: Path, artifacts: list[Path], required_archive: Path | None = None) -> None:
     invalid_result_artifacts = _invalid_result_artifacts(artifacts)
     if invalid_result_artifacts:
-        raise ValueError(f"Only recipe.yaml and final recipe RESULTS.md artifacts may be retained: {invalid_result_artifacts}")
+        raise ValueError(f"Only durable recipe and experiment artifacts may be retained: {invalid_result_artifacts}")
     tracked_changes = subprocess.run(
         ["git", "diff", "--name-only", "HEAD"],
         cwd=workspace,
@@ -150,6 +206,19 @@ def stage_artifacts(workspace: Path, artifacts: list[Path]) -> None:
     unexpected = (set(tracked_changes) | set(untracked) | set(ignored_experiments)) - allowed
     if unexpected:
         raise ValueError(f"Agent changed paths outside its artifact manifest: {sorted(unexpected)}")
+    changed = set(tracked_changes) | set(untracked) | set(ignored_experiments)
+    if required_archive is not None and required_archive.as_posix() not in changed:
+        raise ValueError(f"Exact platform results archive was not created or updated: {required_archive}")
+    if required_archive is not None:
+        attribute = subprocess.run(
+            ["git", "check-attr", "filter", "--", str(required_archive)],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        if attribute != f"{required_archive}: filter: lfs":
+            raise ValueError(f"Exact platform results archive is not tracked by Git LFS: {required_archive}")
 
     regular = [str(path) for path in artifacts if path.parts and path.parts[0] != "experiments"]
     if regular:
@@ -187,7 +256,9 @@ def main() -> int:
             args.expected_tag,
         )
         if args.stage:
-            stage_artifacts(args.workspace.resolve(), artifacts)
+            archive_name = f"results_{_platform_name(args.gpu, args.gpu_count)}.tar.gz"
+            archive = next(path for path in artifacts if path.parts[0] == "experiments" and path.name == archive_name)
+            stage_artifacts(args.workspace.resolve(), artifacts, archive)
         print(json.dumps(summary, sort_keys=True))
         return 0
     except Exception as exc:

--- a/.github/scripts/onboarding_artifacts.py
+++ b/.github/scripts/onboarding_artifacts.py
@@ -104,13 +104,20 @@ def validate_summary(
         raise ValueError("The experiment recipe must be included in experiment_artifacts")
     raw_artifacts = summary.get("artifacts")
     if not isinstance(raw_artifacts, list) or not raw_artifacts:
-        raise ValueError("Summary must list every intended repository file in artifacts")
-    artifacts = [_relative_artifact(workspace, raw_path) for raw_path in raw_artifacts]
+        raise ValueError("Summary must include a non-empty artifacts list")
+    artifacts = list(
+        dict.fromkeys(
+            [
+                *(_relative_artifact(workspace, raw_path) for raw_path in raw_artifacts),
+                recipe,
+                report,
+                *experiment_artifacts,
+            ]
+        )
+    )
     invalid_result_artifacts = _invalid_result_artifacts(artifacts)
     if invalid_result_artifacts:
         raise ValueError(f"Only recipe.yaml and final recipe RESULTS.md artifacts may be retained: {invalid_result_artifacts}")
-    if not {recipe, report, *experiment_artifacts}.issubset(set(artifacts)):
-        raise ValueError("artifacts must include the recipe, report, and every experiment_artifacts entry")
     return summary, artifacts
 
 

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -409,6 +409,52 @@ jobs:
             echo "lease=$VM_LEASE"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Prepare target GPU host
+        if: steps.vm.outcome == 'success'
+        timeout-minutes: 30
+        env:
+          SSH_TARGET: ${{ steps.vm.outputs.ssh_target }}
+          SSH_PORT: ${{ steps.vm.outputs.ssh_port }}
+        run: |
+          ssh_args=(
+            ssh -i "$SSH_KEY" -p "$SSH_PORT"
+            -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=no
+            -o UserKnownHostsFile=/dev/null
+          )
+          "${ssh_args[@]}" "$SSH_TARGET" 'bash -s' <<'REMOTE'
+          set -euo pipefail
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            git make python3.12-venv rsync
+
+          scratch_base="$HOME/.cache/emmy"
+          mkdir -p "$scratch_base"
+          filesystem_type=$(df -PT "$scratch_base" | awk 'NR == 2 {print $2}')
+          case "$filesystem_type" in
+            tmpfs|ramfs)
+              echo "Durable onboarding scratch resolved to $filesystem_type" >&2
+              exit 1
+              ;;
+          esac
+          free_kb=$(df -Pk "$scratch_base" | awk 'NR == 2 {print $4}')
+          if [ "$free_kb" -lt 8388608 ]; then
+            echo "Durable onboarding scratch requires at least 8 GiB free" >&2
+            exit 1
+          fi
+
+          bootstrap_venv=$(mktemp -d "$scratch_base/bootstrap.XXXXXX")
+          cleanup() {
+            case "$bootstrap_venv" in
+              "$scratch_base"/bootstrap.*) rm -rf -- "$bootstrap_venv" ;;
+              *) echo "Refusing to remove unexpected bootstrap path" >&2; exit 1 ;;
+            esac
+          }
+          trap cleanup EXIT
+          TMPDIR="$bootstrap_venv" python3.12 -m venv "$bootstrap_venv"
+          "$bootstrap_venv/bin/pip" --version >/dev/null
+          REMOTE
+
       - name: Run onboard-model agent
         if: steps.vm.outcome == 'success'
         env:
@@ -437,7 +483,7 @@ jobs:
               )
           prompt = f"""Use the onboard-model skill non-interactively.
 
-          The attached exact-workflow-SHA copies of the onboard-model and run-experiment skills are authoritative.
+          The attached exact-workflow-SHA copies of the onboard-model, tune-kernels, and run-experiment skills are authoritative.
           Follow them instead of any older skill copies in the artifact worktree.
 
           Operation mode: {mode}
@@ -474,6 +520,7 @@ jobs:
             --model cloudrift/agent \
             --format json \
             --file "$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md" \
+            --file "$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md" \
             --file "$AGENT_PROMPT" > "$AGENT_EVENTS"
           agent_status=$?

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -56,7 +56,6 @@ jobs:
       AGENT_PROMPT: /tmp/emmy-onboard-prompt-${{ github.run_id }}-${{ github.run_attempt }}.md
       AGENT_EVENTS: /tmp/emmy-onboard-events-${{ github.run_id }}-${{ github.run_attempt }}.jsonl
       AGENT_OUTPUT: /tmp/emmy-onboard-agent-${{ github.run_id }}-${{ github.run_attempt }}.txt
-      RECIPE_INVENTORY: /tmp/emmy-onboard-inventory-${{ github.run_id }}-${{ github.run_attempt }}.json
       PROVIDER_CONFIG: /tmp/emmy-onboard-provider-${{ github.run_id }}-${{ github.run_attempt }}.yaml
       PR_SUMMARY: /tmp/emmy-onboard-pr-${{ github.run_id }}-${{ github.run_attempt }}.md
       SSH_KEY: /tmp/emmy-onboard-ssh-${{ github.run_id }}-${{ github.run_attempt }}
@@ -185,10 +184,8 @@ jobs:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          ./venv/bin/emmy recipe list --json > "$RECIPE_INVENTORY"
           ./venv/bin/python - <<'PY'
           import asyncio
-          import json
           import os
           import re
           import subprocess
@@ -196,8 +193,9 @@ jobs:
 
           from emmy.provisioning.candidates import iter_candidates
           from emmy.provisioning.cloudrift import list_available_instance_types, validate_team_id_access
+          from emmy.recipe.catalog import recipe_inventory_document
 
-          inventory_document = json.loads(Path(os.environ["RECIPE_INVENTORY"]).read_text())
+          inventory_document = recipe_inventory_document(Path("recipes"))
           if inventory_document.get("schema_version") != 1 or not isinstance(inventory_document.get("recipes"), list):
               raise SystemExit("Unsupported `emmy recipe list --json` schema")
           inventory = inventory_document["recipes"]
@@ -617,7 +615,6 @@ jobs:
             "$ONBOARD_SUMMARY" \
             "$PR_SUMMARY" \
             "$PROVIDER_CONFIG" \
-            "$RECIPE_INVENTORY" \
             "$VM_LEASE" \
             "$SSH_KEY" \
             "$SSH_KEY.pub"

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -130,8 +130,23 @@ jobs:
       - name: Configure Git LFS
         run: |
           if ! git lfs version >/dev/null 2>&1; then
-            sudo apt-get update -qq
-            sudo apt-get install --no-install-recommends -y git-lfs
+            lfs_version=3.7.1
+            case "$(uname -m)" in
+              x86_64) lfs_arch=amd64; lfs_sha256=1c0b6ee5200ca708c5cebebb18fdeb0e1c98f1af5c1a9cba205a4c0ab5a5ec08 ;;
+              aarch64) lfs_arch=arm64; lfs_sha256=73a9c90eeb4312133a63c3eaee0c38c019ea7bfa0953d174809d25b18588dd8d ;;
+              *) echo "Unsupported Git LFS architecture: $(uname -m)" >&2; exit 1 ;;
+            esac
+            lfs_dir="$RUNNER_TEMP/git-lfs-$lfs_version"
+            lfs_archive="$RUNNER_TEMP/git-lfs-$lfs_version-$lfs_arch.tar.gz"
+            curl --fail --location --retry 3 --retry-all-errors --silent --show-error \
+              --output "$lfs_archive" \
+              "https://github.com/git-lfs/git-lfs/releases/download/v$lfs_version/git-lfs-linux-$lfs_arch-v$lfs_version.tar.gz"
+            printf '%s  %s\n' "$lfs_sha256" "$lfs_archive" | sha256sum --check
+            mkdir -p "$lfs_dir"
+            tar -xzf "$lfs_archive" -C "$lfs_dir" --strip-components=1 "git-lfs-$lfs_version/git-lfs"
+            chmod +x "$lfs_dir/git-lfs"
+            echo "$lfs_dir" >> "$GITHUB_PATH"
+            export PATH="$lfs_dir:$PATH"
           fi
           git lfs install --local
           mkdir -p .git/info

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -550,9 +550,14 @@ jobs:
           import tarfile
           from pathlib import Path, PurePosixPath
 
+          from emmy.hardware import gpu_short_name
+
           workspace = Path.cwd().resolve()
           experiments_root = (workspace / "experiments").resolve()
-          summary = json.loads(Path(os.environ["ONBOARD_SUMMARY"]).read_text())
+          summary_path = Path(os.environ["ONBOARD_SUMMARY"])
+          summary = json.loads(summary_path.read_text())
+          if summary.get("status") != "success":
+              raise SystemExit(f"Onboarding did not succeed: {summary.get('failure')}")
           experiment_recipe = Path(summary.get("experiment") or "")
           if experiment_recipe.is_absolute() or ".." in experiment_recipe.parts or experiment_recipe.name != "recipe.yaml":
               raise SystemExit(f"Unsafe experiment recipe path: {experiment_recipe}")
@@ -560,29 +565,89 @@ jobs:
           if experiments_root not in experiment_dir.parents:
               raise SystemExit(f"Experiment directory is outside experiments/: {experiment_dir}")
 
-          archive_paths = [
-              Path(raw_path)
-              for raw_path in summary.get("experiment_artifacts") or []
-              if Path(raw_path).parent == experiment_recipe.parent
-              and Path(raw_path).name.startswith("results_")
-              and Path(raw_path).name.endswith(".tar.gz")
-          ]
-          if len(archive_paths) != 1:
-              raise SystemExit(f"Expected one current-platform results archive, found: {archive_paths}")
-          archive = workspace / archive_paths[0]
-          with tarfile.open(archive, "r:gz") as source:
-              member_paths = [
-                  PurePosixPath(member.name.removeprefix("./"))
-                  for member in source.getmembers()
-              ]
-              member_roots = {path.parts[0] for path in member_paths if path.parts}
-
           timestamp = re.compile(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}")
-          raw_directories = [path for path in experiment_dir.iterdir() if path.is_dir() and timestamp.fullmatch(path.name)]
+          raw_directories = sorted(
+              path for path in experiment_dir.iterdir() if path.is_dir() and timestamp.fullmatch(path.name)
+          )
+          platform = f"{gpu_short_name(os.environ['TARGET_GPU'])}x{int(os.environ['TARGET_GPU_COUNT'])}"
+          archive_path = experiment_recipe.parent / f"results_{platform}.tar.gz"
+          archive = workspace / archive_path
+          legacy_archive = experiment_dir / "results.tar.gz"
+
+          def verify_archive(path):
+              member_paths = []
+              with tarfile.open(path, "r:gz") as source:
+                  for member in source.getmembers():
+                      member_paths.append(PurePosixPath(member.name.removeprefix("./")))
+                      if member.isfile():
+                          contents = source.extractfile(member)
+                          if contents is None:
+                              raise SystemExit(f"Could not read archived file: {member.name}")
+                          while contents.read(1024 * 1024):
+                              pass
+              return {path.parts[0] for path in member_paths if path.parts}
+
+          if raw_directories:
+              temporary_archive = archive.with_name(f".{archive.name}.{os.getpid()}.tmp")
+              try:
+                  with tarfile.open(temporary_archive, "w:gz") as output:
+                      for raw_directory in raw_directories:
+                          output.add(raw_directory, arcname=raw_directory.name)
+                  temporary_roots = verify_archive(temporary_archive)
+                  missing_roots = [path.name for path in raw_directories if path.name not in temporary_roots]
+                  if missing_roots:
+                      raise SystemExit(f"New results archive is missing raw directories: {missing_roots}")
+                  os.replace(temporary_archive, archive)
+              finally:
+                  temporary_archive.unlink(missing_ok=True)
+          elif not archive.is_file() and legacy_archive.is_file():
+              verify_archive(legacy_archive)
+              os.replace(legacy_archive, archive)
+
+          if not archive.is_file():
+              raise SystemExit(f"Current-platform results archive was not produced: {archive_path}")
+
+          member_roots = verify_archive(archive)
+
           for raw_directory in raw_directories:
               if raw_directory.name not in member_roots:
-                  raise SystemExit(f"Raw directory is not preserved by {archive_paths[0]}: {raw_directory.name}")
+                  raise SystemExit(f"Raw directory is not preserved by {archive_path}: {raw_directory.name}")
               shutil.rmtree(raw_directory)
+
+          if legacy_archive != archive:
+              legacy_archive.unlink(missing_ok=True)
+
+          experiment_report = experiment_recipe.with_name("RESULTS.md")
+          platform_records = sorted(
+              path.relative_to(workspace)
+              for path in experiment_dir.glob("*.experiment.yaml")
+              if path.is_file()
+              and (path.name == f"{platform}.experiment.yaml" or path.name.startswith(f"{platform}_"))
+          )
+          durable_snapshot = [
+              experiment_recipe,
+              experiment_report,
+              archive_path,
+              *platform_records,
+          ]
+          missing = [path for path in durable_snapshot if not (workspace / path).is_file()]
+          if missing:
+              raise SystemExit(f"Current-platform durable snapshot is incomplete: {missing}")
+
+          legacy_path = experiment_recipe.parent / "results.tar.gz"
+          for key in ("experiment_artifacts", "artifacts"):
+              existing = summary.get(key) or []
+              if not isinstance(existing, list):
+                  raise SystemExit(f"Summary {key} must be a list")
+              retained = [path for path in existing if Path(path) != legacy_path]
+              summary[key] = list(dict.fromkeys([*retained, *(path.as_posix() for path in durable_snapshot)]))
+
+          temporary_summary = summary_path.with_name(f".{summary_path.name}.{os.getpid()}.tmp")
+          try:
+              temporary_summary.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+              os.replace(temporary_summary, summary_path)
+          finally:
+              temporary_summary.unlink(missing_ok=True)
           PY
 
       - name: Delete workflow-owned CloudRift VMs

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -326,7 +326,7 @@ jobs:
         if: steps.selection.outputs.selected == 'true'
         run: |
           ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -q
-          printf 'providers:\n  cloudrift:\n    team_id: "%s"\n    with_public_ip: false\n' \
+          printf 'providers:\n  cloudrift:\n    team_id: "%s"\n    with_public_ip: true\n' \
             "$CLOUDRIFT_TEAM_ID" > "$PROVIDER_CONFIG"
           chmod 600 "$PROVIDER_CONFIG"
 

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -519,11 +519,11 @@ jobs:
               raise SystemExit(f"Expected one current-platform results archive, found: {archive_paths}")
           archive = workspace / archive_paths[0]
           with tarfile.open(archive, "r:gz") as source:
-              member_roots = {
-                  PurePosixPath(member.name.removeprefix("./")).parts[0]
+              member_paths = [
+                  PurePosixPath(member.name.removeprefix("./"))
                   for member in source.getmembers()
-                  if member.name.removeprefix("./")
-              }
+              ]
+              member_roots = {path.parts[0] for path in member_paths if path.parts}
 
           timestamp = re.compile(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}")
           raw_directories = [path for path in experiment_dir.iterdir() if path.is_dir() and timestamp.fullmatch(path.name)]

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -177,6 +177,7 @@ jobs:
           mkdir -p "$WORKFLOW_SOURCE"
           git archive "$WORKFLOW_SHA" | tar -x -C "$WORKFLOW_SOURCE"
           echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"
+          echo "PYTHONSAFEPATH=1" >> "$GITHUB_ENV"
 
       - name: Select one available deployment
         id: selection

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -487,6 +487,52 @@ jobs:
           fi
           exit "$agent_status"
 
+      - name: Remove archived task-local raw results
+        if: steps.vm.outcome == 'success'
+        run: |
+          ./venv/bin/python - <<'PY'
+          import json
+          import os
+          import re
+          import shutil
+          import tarfile
+          from pathlib import Path, PurePosixPath
+
+          workspace = Path.cwd().resolve()
+          experiments_root = (workspace / "experiments").resolve()
+          summary = json.loads(Path(os.environ["ONBOARD_SUMMARY"]).read_text())
+          experiment_recipe = Path(summary.get("experiment") or "")
+          if experiment_recipe.is_absolute() or ".." in experiment_recipe.parts or experiment_recipe.name != "recipe.yaml":
+              raise SystemExit(f"Unsafe experiment recipe path: {experiment_recipe}")
+          experiment_dir = (workspace / experiment_recipe).parent.resolve()
+          if experiments_root not in experiment_dir.parents:
+              raise SystemExit(f"Experiment directory is outside experiments/: {experiment_dir}")
+
+          archive_paths = [
+              Path(raw_path)
+              for raw_path in summary.get("experiment_artifacts") or []
+              if Path(raw_path).parent == experiment_recipe.parent
+              and Path(raw_path).name.startswith("results_")
+              and Path(raw_path).name.endswith(".tar.gz")
+          ]
+          if len(archive_paths) != 1:
+              raise SystemExit(f"Expected one current-platform results archive, found: {archive_paths}")
+          archive = workspace / archive_paths[0]
+          with tarfile.open(archive, "r:gz") as source:
+              member_roots = {
+                  PurePosixPath(member.name.removeprefix("./")).parts[0]
+                  for member in source.getmembers()
+                  if member.name.removeprefix("./")
+              }
+
+          timestamp = re.compile(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}")
+          raw_directories = [path for path in experiment_dir.iterdir() if path.is_dir() and timestamp.fullmatch(path.name)]
+          for raw_directory in raw_directories:
+              if raw_directory.name not in member_roots:
+                  raise SystemExit(f"Raw directory is not preserved by {archive_paths[0]}: {raw_directory.name}")
+              shutil.rmtree(raw_directory)
+          PY
+
       - name: Delete workflow-owned CloudRift VMs
         if: always() && steps.selection.outputs.selected == 'true'
         env:

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -127,6 +127,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Configure Git LFS
+        run: |
+          git lfs install --local
+          lfs_attribute='experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text'
+          grep -qxF "$lfs_attribute" .git/info/attributes 2>/dev/null || \
+            printf '%s\n' "$lfs_attribute" >> .git/info/attributes
+
       - name: Rebase existing branch on latest main
         id: rebase
         if: steps.rolling.outputs.branch != ''
@@ -423,8 +430,11 @@ jobs:
           {task}
           Do not select a model or GPU, provision or delete the VM, commit, push, or open/update a pull request.
           Always write the required atomic summary with mode set to {mode}, including experiment_artifacts with
-          retained experiment recipe.yaml files only. Put selected benchmark numbers in the final recipe's
-          RESULTS.md; do not retain raw results, experiment reports, dated run snapshots, or onboarding summaries.
+          the shared experiment recipe and RESULTS.md, the exact results_<gpu-short>x<gpu-count>.tar.gz archive, and
+          the retained top-level experiment records for this platform. Replace only this platform's archive and
+          records; preserve every other platform archive, record, and RESULTS.md section. Do not retain the ignored
+          dated run directory or onboarding summaries. Update the final recipe's RESULTS.md for this platform while
+          preserving still-valid measurements for its other platforms.
           Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
           output. Allowed areas are recipes/, experiments/, docker/vllm-emmy-serve/models/, and canonical golden YAML.
           """
@@ -495,7 +505,7 @@ jobs:
           git diff --exit-code -- .github .agents/skills/onboard-model .claude/skills/onboard-model
           test -z "$(git ls-files --others --exclude-standard -- \
             .github .agents/skills/onboard-model .claude/skills/onboard-model)"
-          ./venv/bin/python .github/scripts/onboarding_artifacts.py \
+          ./venv/bin/python "$WORKFLOW_SOURCE/.github/scripts/onboarding_artifacts.py" \
             --summary "$ONBOARD_SUMMARY" \
             --model-id "$MODEL_ID" \
             --gpu "$TARGET_GPU" \
@@ -504,6 +514,7 @@ jobs:
             --mode "$ONBOARD_MODE" \
             --expected-tag "$EXPECTED_LIFECYCLE" \
             --stage
+          git lfs status
           git diff --cached --check
           if git diff --cached --quiet; then
             echo "::error::Model qualification produced no repository artifacts"

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -129,7 +129,12 @@ jobs:
 
       - name: Configure Git LFS
         run: |
+          if ! git lfs version >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install --no-install-recommends -y git-lfs
+          fi
           git lfs install --local
+          mkdir -p .git/info
           lfs_attribute='experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text'
           grep -qxF "$lfs_attribute" .git/info/attributes 2>/dev/null || \
             printf '%s\n' "$lfs_attribute" >> .git/info/attributes

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -46,7 +46,7 @@ jobs:
       REQUESTED_MODEL_ID: ${{ inputs.model_id }}
       REQUESTED_GPU: ${{ inputs.gpu }}
       REQUESTED_GPU_COUNT: ${{ inputs.gpu_count }}
-      CLOUDRIFT_TEAM_NAME: Robots
+      CLOUDRIFT_TEAM_ID: ${{ vars.CLOUDRIFT_TEAM_ID }}
       MULTIMODAL_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.multimodal_mode || 'auto' }}
       PUBLISH_IMAGE: ${{ (github.event_name == 'workflow_dispatch' && inputs.publish_image) || (github.event_name == 'schedule' && vars.NIGHTLY_ONBOARD_PUBLISH_IMAGE == 'true') }}
       RUN_OWNER: ${{ github.repository }}/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
@@ -182,19 +182,18 @@ jobs:
           from pathlib import Path
 
           from emmy.provisioning.candidates import iter_candidates
-          from emmy.provisioning.cloudrift import list_available_instance_types, resolve_team_id
+          from emmy.provisioning.cloudrift import list_available_instance_types, validate_team_id_access
 
           inventory = json.loads(Path(os.environ["RECIPE_INVENTORY"]).read_text())
-          available = asyncio.run(list_available_instance_types(os.environ["CLOUDRIFT_API_KEY"]))
           team_id = asyncio.run(
-              resolve_team_id(
+              validate_team_id_access(
                   os.environ["CLOUDRIFT_API_KEY"],
-                  os.environ["CLOUDRIFT_TEAM_NAME"],
-                  allow_implicit_team_key=True,
+                  os.environ.get("CLOUDRIFT_TEAM_ID"),
               )
           )
+          available = asyncio.run(list_available_instance_types(os.environ["CLOUDRIFT_API_KEY"]))
           with Path(os.environ["GITHUB_ENV"]).open("a") as output:
-              output.write(f"CLOUDRIFT_TEAM_ID={team_id or ''}\n")
+              output.write(f"CLOUDRIFT_TEAM_ID={team_id}\n")
 
           def available_deployment(deployment):
               gpu = deployment.get("deploy.gpu")
@@ -309,11 +308,8 @@ jobs:
         if: steps.selection.outputs.selected == 'true'
         run: |
           ssh-keygen -t ed25519 -f "$SSH_KEY" -N "" -q
-          if [ -n "$CLOUDRIFT_TEAM_ID" ]; then
-            printf 'providers:\n  cloudrift:\n    team_id: "%s"\n' "$CLOUDRIFT_TEAM_ID" > "$PROVIDER_CONFIG"
-          else
-            printf 'providers:\n  cloudrift: {}\n' > "$PROVIDER_CONFIG"
-          fi
+          printf 'providers:\n  cloudrift:\n    team_id: "%s"\n    with_public_ip: false\n' \
+            "$CLOUDRIFT_TEAM_ID" > "$PROVIDER_CONFIG"
           chmod 600 "$PROVIDER_CONFIG"
 
       - name: Rent exact target VM
@@ -438,11 +434,6 @@ jobs:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
         run: |
           set +e
-          lease_status=0
-          if [ -f "$VM_LEASE" ]; then
-            ./venv/bin/emmy vm delete lease "$VM_LEASE" --owner "$RUN_OWNER" || lease_status=$?
-            ./venv/bin/emmy vm audit lease "$VM_LEASE" --owner "$RUN_OWNER" || lease_status=$?
-          fi
           ./venv/bin/python - <<'PY'
           import asyncio
           import os
@@ -450,9 +441,25 @@ jobs:
           from emmy.provisioning.cloudrift import terminate_instances_by_tags
 
           tags = [tag for tag in os.environ["EMMY_RENTAL_TAGS"].split(",") if tag]
-          asyncio.run(terminate_instances_by_tags(os.environ["CLOUDRIFT_API_KEY"], tags))
+          asyncio.run(
+              terminate_instances_by_tags(
+                  os.environ["CLOUDRIFT_API_KEY"],
+                  tags,
+                  audit_attempts=18,
+                  audit_delay=5,
+              )
+          )
           PY
           tag_status=$?
+          lease_status=0
+          if [ -f "$VM_LEASE" ]; then
+            ./venv/bin/emmy vm delete lease "$VM_LEASE" \
+              --owner "$RUN_OWNER" \
+              --retries 1 \
+              --audit-attempts 3 \
+              --audit-delay 5 || lease_status=$?
+            ./venv/bin/emmy vm audit lease "$VM_LEASE" --owner "$RUN_OWNER" || lease_status=$?
+          fi
           set -e
           if [ "$lease_status" -ne 0 ] || [ "$tag_status" -ne 0 ]; then
             echo "CloudRift cleanup or audit failed" >&2

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -413,8 +413,9 @@ jobs:
         if: steps.vm.outcome == 'success'
         timeout-minutes: 30
         env:
-          SSH_TARGET: ${{ steps.vm.outputs.ssh_target }}
+          SSH_HOST: ${{ steps.vm.outputs.ssh_host }}
           SSH_PORT: ${{ steps.vm.outputs.ssh_port }}
+          SSH_USER: ${{ steps.vm.outputs.ssh_user }}
         run: |
           ssh_args=(
             ssh -i "$SSH_KEY" -p "$SSH_PORT"
@@ -422,7 +423,7 @@ jobs:
             -o StrictHostKeyChecking=no
             -o UserKnownHostsFile=/dev/null
           )
-          "${ssh_args[@]}" "$SSH_TARGET" 'bash -s' <<'REMOTE'
+          "${ssh_args[@]}" "$SSH_USER@$SSH_HOST" 'bash -s' <<'REMOTE'
           set -euo pipefail
           sudo env DEBIAN_FRONTEND=noninteractive apt-get update -qq
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
@@ -462,8 +463,10 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ env.PUBLISH_IMAGE == 'true' && secrets.DOCKERHUB_TOKEN || '' }}
+          SSH_HOST: ${{ steps.vm.outputs.ssh_host }}
           SSH_TARGET: ${{ steps.vm.outputs.ssh_target }}
           SSH_PORT: ${{ steps.vm.outputs.ssh_port }}
+          SSH_USER: ${{ steps.vm.outputs.ssh_user }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -490,6 +493,8 @@ jobs:
           Hugging Face model ID: {os.environ['MODEL_ID']}
           Exact target: {os.environ['TARGET_GPU']} x {os.environ['TARGET_GPU_COUNT']}
           SSH target: {os.environ['SSH_TARGET']}
+          Raw SSH host: {os.environ['SSH_HOST']}
+          Raw SSH user: {os.environ['SSH_USER']}
           SSH port: {os.environ['SSH_PORT']}
           SSH private key: {os.environ['SSH_KEY']} (pass --ssh-key {os.environ['SSH_KEY']} to every Emmy remote command)
           Absolute deadline: {os.environ['ONBOARD_DEADLINE']}

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -197,7 +197,10 @@ jobs:
           from emmy.provisioning.candidates import iter_candidates
           from emmy.provisioning.cloudrift import list_available_instance_types, validate_team_id_access
 
-          inventory = json.loads(Path(os.environ["RECIPE_INVENTORY"]).read_text())
+          inventory_document = json.loads(Path(os.environ["RECIPE_INVENTORY"]).read_text())
+          if inventory_document.get("schema_version") != 1 or not isinstance(inventory_document.get("recipes"), list):
+              raise SystemExit("Unsupported `emmy recipe list --json` schema")
+          inventory = inventory_document["recipes"]
           team_id = asyncio.run(
               validate_team_id_access(
                   os.environ["CLOUDRIFT_API_KEY"],
@@ -209,8 +212,8 @@ jobs:
               output.write(f"CLOUDRIFT_TEAM_ID={team_id}\n")
 
           def available_deployment(deployment):
-              gpu = deployment.get("deploy.gpu")
-              count = deployment.get("deploy.gpu_count")
+              gpu = deployment.get("gpu", deployment.get("deploy.gpu"))
+              count = deployment.get("gpu_count", deployment.get("deploy.gpu_count"))
               try:
                   candidates = iter_candidates(gpu, count, "cloudrift", exact_gpu_count=True)
               except (TypeError, ValueError):
@@ -218,11 +221,13 @@ jobs:
               return any(candidate.instance_type in available for candidate in candidates)
 
           def write_selection(record, deployment, mode, lifecycle):
+              gpu = deployment.get("gpu", deployment.get("deploy.gpu"))
+              gpu_count = deployment.get("gpu_count", deployment.get("deploy.gpu_count"))
               values = {
                   "selected": "true",
                   "model_id": record["model_id"],
-                  "gpu": deployment["deploy.gpu"],
-                  "gpu_count": str(deployment["deploy.gpu_count"]),
+                  "gpu": gpu,
+                  "gpu_count": str(gpu_count),
                   "mode": mode,
                   "lifecycle": lifecycle,
               }
@@ -250,7 +255,7 @@ jobs:
                   raise SystemExit("model_id must be an exact Hugging Face owner/repository ID")
               if gpu_count < 1:
                   raise SystemExit("gpu_count must be positive")
-              deployment = {"deploy.gpu": gpu, "deploy.gpu_count": gpu_count}
+              deployment = {"gpu": gpu, "gpu_count": gpu_count}
               if not available_deployment(deployment):
                   raise SystemExit(f"CloudRift has no available exact {gpu} x{gpu_count} VM")
               existing = next((record for record in inventory if record["model_id"] == model_id), None)

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -127,33 +127,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Configure Git LFS
-        run: |
-          if ! git lfs version >/dev/null 2>&1; then
-            lfs_version=3.7.1
-            case "$(uname -m)" in
-              x86_64) lfs_arch=amd64; lfs_sha256=1c0b6ee5200ca708c5cebebb18fdeb0e1c98f1af5c1a9cba205a4c0ab5a5ec08 ;;
-              aarch64) lfs_arch=arm64; lfs_sha256=73a9c90eeb4312133a63c3eaee0c38c019ea7bfa0953d174809d25b18588dd8d ;;
-              *) echo "Unsupported Git LFS architecture: $(uname -m)" >&2; exit 1 ;;
-            esac
-            lfs_dir="$RUNNER_TEMP/git-lfs-$lfs_version"
-            lfs_archive="$RUNNER_TEMP/git-lfs-$lfs_version-$lfs_arch.tar.gz"
-            curl --fail --location --retry 3 --retry-all-errors --silent --show-error \
-              --output "$lfs_archive" \
-              "https://github.com/git-lfs/git-lfs/releases/download/v$lfs_version/git-lfs-linux-$lfs_arch-v$lfs_version.tar.gz"
-            printf '%s  %s\n' "$lfs_sha256" "$lfs_archive" | sha256sum --check
-            mkdir -p "$lfs_dir"
-            tar -xzf "$lfs_archive" -C "$lfs_dir" --strip-components=1 "git-lfs-$lfs_version/git-lfs"
-            chmod +x "$lfs_dir/git-lfs"
-            echo "$lfs_dir" >> "$GITHUB_PATH"
-            export PATH="$lfs_dir:$PATH"
-          fi
-          git lfs install --local
-          mkdir -p .git/info
-          lfs_attribute='experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text'
-          grep -qxF "$lfs_attribute" .git/info/attributes 2>/dev/null || \
-            printf '%s\n' "$lfs_attribute" >> .git/info/attributes
-
       - name: Rebase existing branch on latest main
         id: rebase
         if: steps.rolling.outputs.branch != ''
@@ -196,6 +169,7 @@ jobs:
       - name: Load exact workflow source
         env:
           WORKFLOW_SHA: ${{ github.sha }}
+          GIT_LFS_SKIP_SMUDGE: "1"
         run: |
           if ! git cat-file -e "$WORKFLOW_SHA^{commit}"; then
             git fetch --depth=1 origin "$WORKFLOW_SHA"
@@ -204,6 +178,33 @@ jobs:
           git archive "$WORKFLOW_SHA" | tar -x -C "$WORKFLOW_SOURCE"
           echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"
           echo "PYTHONSAFEPATH=1" >> "$GITHUB_ENV"
+
+      - name: Configure Git LFS
+        run: |
+          if ! git lfs version >/dev/null 2>&1; then
+            lfs_version=3.7.1
+            case "$(uname -m)" in
+              x86_64) lfs_arch=amd64; lfs_sha256=1c0b6ee5200ca708c5cebebb18fdeb0e1c98f1af5c1a9cba205a4c0ab5a5ec08 ;;
+              aarch64) lfs_arch=arm64; lfs_sha256=73a9c90eeb4312133a63c3eaee0c38c019ea7bfa0953d174809d25b18588dd8d ;;
+              *) echo "Unsupported Git LFS architecture: $(uname -m)" >&2; exit 1 ;;
+            esac
+            lfs_dir="$RUNNER_TEMP/git-lfs-$lfs_version"
+            lfs_archive="$RUNNER_TEMP/git-lfs-$lfs_version-$lfs_arch.tar.gz"
+            curl --fail --location --retry 3 --retry-all-errors --silent --show-error \
+              --output "$lfs_archive" \
+              "https://github.com/git-lfs/git-lfs/releases/download/v$lfs_version/git-lfs-linux-$lfs_arch-v$lfs_version.tar.gz"
+            printf '%s  %s\n' "$lfs_sha256" "$lfs_archive" | sha256sum --check
+            mkdir -p "$lfs_dir"
+            tar -xzf "$lfs_archive" -C "$lfs_dir" --strip-components=1 "git-lfs-$lfs_version/git-lfs"
+            chmod +x "$lfs_dir/git-lfs"
+            echo "$lfs_dir" >> "$GITHUB_PATH"
+            export PATH="$lfs_dir:$PATH"
+          fi
+          git lfs install --local
+          mkdir -p .git/info
+          lfs_attribute='experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text'
+          grep -qxF "$lfs_attribute" .git/info/attributes 2>/dev/null || \
+            printf '%s\n' "$lfs_attribute" >> .git/info/attributes
 
       - name: Select one available deployment
         id: selection
@@ -436,6 +437,9 @@ jobs:
               )
           prompt = f"""Use the onboard-model skill non-interactively.
 
+          The attached exact-workflow-SHA copies of the onboard-model and run-experiment skills are authoritative.
+          Follow them instead of any older skill copies in the artifact worktree.
+
           Operation mode: {mode}
           Hugging Face model ID: {os.environ['MODEL_ID']}
           Exact target: {os.environ['TARGET_GPU']} x {os.environ['TARGET_GPU_COUNT']}
@@ -467,6 +471,8 @@ jobs:
             --agent onboard-model \
             --model cloudrift/agent \
             --format json \
+            --file "$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md" \
+            --file "$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md" \
             --file "$AGENT_PROMPT" > "$AGENT_EVENTS"
           agent_status=$?
           set -e

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -61,6 +61,7 @@ jobs:
       PR_SUMMARY: /tmp/emmy-onboard-pr-${{ github.run_id }}-${{ github.run_attempt }}.md
       SSH_KEY: /tmp/emmy-onboard-ssh-${{ github.run_id }}-${{ github.run_attempt }}
       APP_KEY_FILE: /tmp/emmy-onboard-app-key-${{ github.run_id }}-${{ github.run_attempt }}.pem
+      WORKFLOW_SOURCE: /tmp/emmy-onboard-source-${{ github.run_id }}-${{ github.run_attempt }}
       AGENT_MODEL: ${{ vars.ONBOARD_AGENT_MODEL || 'Qwen/Qwen3.6-35B-A3B-FP8' }}
       CLOUDRIFT_INFERENCE_URL: ${{ vars.CLOUDRIFT_INFERENCE_URL || 'https://inference.cloudrift.ai/v1' }}
       OPENCODE_DISABLE_AUTOUPDATE: "true"
@@ -165,6 +166,17 @@ jobs:
 
       - name: Install Emmy
         run: make setup-agent
+
+      - name: Load exact workflow source
+        env:
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          if ! git cat-file -e "$WORKFLOW_SHA^{commit}"; then
+            git fetch --depth=1 origin "$WORKFLOW_SHA"
+          fi
+          mkdir -p "$WORKFLOW_SOURCE"
+          git archive "$WORKFLOW_SHA" | tar -x -C "$WORKFLOW_SOURCE"
+          echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"
 
       - name: Select one available deployment
         id: selection
@@ -598,4 +610,8 @@ jobs:
             "$VM_LEASE" \
             "$SSH_KEY" \
             "$SSH_KEY.pub"
+          case "$WORKFLOW_SOURCE" in
+            /tmp/emmy-onboard-source-*) rm -rf -- "$WORKFLOW_SOURCE" ;;
+            *) echo "Refusing to remove unexpected workflow source path: $WORKFLOW_SOURCE" >&2; exit 1 ;;
+          esac
           git config --unset-all credential.helper || true

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -444,6 +444,11 @@ jobs:
           set -e
           jq -s -r '[.[] | select(.type == "text") | .part.text][-1] // empty' \
             "$AGENT_EVENTS" > "$AGENT_OUTPUT"
+          if [ -s "$AGENT_OUTPUT" ]; then
+            sed 's/^/onboard-model: /' "$AGENT_OUTPUT"
+          else
+            echo "::error::Onboarding agent produced no final text output"
+          fi
           exit "$agent_status"
 
       - name: Delete workflow-owned CloudRift VMs

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -459,6 +459,8 @@ jobs:
           records; preserve every other platform archive, record, and RESULTS.md section. Do not retain the ignored
           dated run directory or onboarding summaries. Update the final recipe's RESULTS.md for this platform while
           preserving still-valid measurements for its other platforms.
+          Git LFS is already configured through the workflow's local attributes. Verify the named archive reports
+          filter: lfs, but do not run git lfs track and do not modify or list .gitattributes in the summary.
           Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
           output. Allowed areas are recipes/, experiments/, docker/vllm-emmy-serve/models/, and canonical golden YAML.
           """

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -151,7 +151,8 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
   row identity and matrix parameters, Git revision and dirty flag, execution lifecycle, and generic system
   information. It never contains interpreted or parsed experiment measurements.
 - **Raw experiment results** — Logs and declared measurement files preserved in an ignored timestamped local run
-  directory. The last run is committed as an LFS-backed `results.tar.gz`, not as a second structured result format.
+  directory. Each exact GPU platform's last run is committed as an LFS-backed
+  `results_<gpu-short>x<gpu-count>.tar.gz`, not as a second structured result format.
 - **Benchmark** — A controlled measurement of speed, latency, throughput, or resource use.
 - **Latency** — The time needed to complete one operation or request. Lower latency is faster.
 - **Throughput** — The amount of work completed per unit of time, such as requests per second. Higher throughput is

--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ emmy bench experiments/gemma-4-12B/* --ssh user@host1 --ssh user@host2  # Pre-al
 ```
 
 Each real run creates a timestamped raw-results directory and writes one system-only YAML experiment record per
-matrix row. Use `$run-experiment` to run or customize an experiment, replace its LFS-backed `results.tar.gz`, assemble
-the records and a thoughtful `RESULTS.md` interpretation, and commit the durable last-run snapshot. The runner and
-experiment code never interpret measurements; the skill reviews the raw evidence. The timestamped directory is
-ignored and may be deleted after its archive has been extracted or byte-checked against the raw files.
+matrix row. Use `$run-experiment` to run or customize an experiment, replace the platform's LFS-backed
+`results_<gpu-short>x<gpu-count>.tar.gz`, assemble its records, update the shared `RESULTS.md` interpretation, and
+commit the durable platform snapshot. Other platform snapshots remain unchanged. The runner and experiment code never
+interpret measurements; the skill reviews the raw evidence. The timestamped directory is ignored and may be deleted
+after its archive has been extracted or byte-checked against the raw files.
 
 ## Deploy
 

--- a/emmy/benchmark/ARCHITECTURE.md
+++ b/emmy/benchmark/ARCHITECTURE.md
@@ -54,9 +54,10 @@ worktree, every declared result file, GPU identity, NVCC, and cuBLAS. A failed c
 declared results.
 
 The repository `run-experiment` skill validates row coverage, copies the latest records beside the recipe, writes a
-thoughtful interpretation grounded in the raw evidence, replaces the Git LFS-backed raw-results archive, and commits
-the archive, records, and `RESULTS.md` as one durable last-run snapshot. The timestamped raw directory stays local and
-ignored. Interpretation belongs to the skill's intelligent review, never the runner or a repository script.
+thoughtful interpretation grounded in the raw evidence, replaces the exact GPU platform's named Git LFS raw-results
+archive, and commits its archive and records with the shared `RESULTS.md`. Other platform snapshots remain unchanged.
+The timestamped raw directory stays local and ignored. Interpretation belongs to the skill's intelligent review,
+never the runner or a repository script.
 
 `commands.bench` owns orchestration, `execution` runs execution groups, `experiment_record` owns the typed record
 schema and YAML serialization, top-level `system_info` owns the typed host schema plus the one shared generic/PCI

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -636,15 +636,15 @@ emmy fit --folds 0 --out _tune/fits/ab    # full-train only, fixed run dir for a
 ## Experiments
 
 Experiments are self-contained parameter sweeps in `experiments/{model}/{name}/`. Each directory keeps the recipe and
-one durable snapshot of its last run:
+one durable snapshot per exact GPU platform:
 
 ```
 experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090/
   recipe.yaml
   <YYYY-MM-DD_HH-MM-SS>/  # ignored local raw output
-  results.tar.gz          # Git LFS archive of the last run
-  <row>.experiment.yaml
-  RESULTS.md
+  results_rtx5090x1.tar.gz  # Git LFS archive of the platform's last run
+  rtx5090x1_<row>.experiment.yaml
+  RESULTS.md                # one interpretation across retained platforms
 ```
 
 ```bash
@@ -652,9 +652,9 @@ emmy bench experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090
 ```
 
 Use the repository `run-experiment` skill to select/customize the harness, execute Emmy, validate every row, replace
-the raw-results archive, assemble the system-only records and a thoughtful `RESULTS.md` interpretation, and commit the
-complete last-run snapshot. The CLI and experiment code do not interpret measurements; the skill performs the
-intelligent review and the CLI itself performs no Git operation.
+the platform's named raw-results archive and system-only records, update its section in the shared `RESULTS.md`, and
+commit the complete platform snapshot without changing other platform results. The CLI and experiment code do not
+interpret measurements; the skill performs the intelligent review and the CLI itself performs no Git operation.
 
 ## Adding a New VM Provider
 

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -80,7 +80,8 @@ after allocation.
 `emmy vm create gpu --lease PATH --owner ID` enables the observer. `emmy vm delete lease` validates the exact owner,
 deletes only the recorded handle, retries and polls provider state, then marks the lease deleted. `emmy vm audit
 lease` independently fails while that handle remains active. A missing lease is an idempotent no-op; an owner mismatch
-is always a hard refusal.
+is always a hard refusal. CloudRift's `Deactivating` state acknowledges that termination is scheduled, so cleanup and
+lease audit accept it without waiting for the provider's asynchronous transition to a terminal state.
 
 Run-unique automation may add a second ownership check with `terminate_instances_by_tags()`. It requires at least one
 non-empty tag, lists instances carrying every supplied tag across the caller's visible personal/team scope, terminates

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -49,11 +49,11 @@ Every CloudRift rental carries free-form tags for later filtering on listings. `
 through `emmy.config.rental_tags()` — repeatable `--tag` flags win, else the comma-separated `EMMY_RENTAL_TAGS` env
 var (how an experiment run or CI job labels its whole rental lane), else the default `emmy` tag.
 
-`providers.cloudrift.team_id` assigns a user-key rental to that exact team UUID. Automation may resolve the UUID from
-one exact visible team name through `resolve_team_id`; a missing or ambiguous match fails before rent. A caller that
-explicitly permits implicit team-key ownership may accept the user-only team-list endpoint's 401 only after the key
-authenticates against a team-aware account endpoint. In that case the omitted request UUID makes CloudRift use the
-team API key's principal. Team selection does not depend on descriptive tags.
+`providers.cloudrift.team_id` assigns a rental to that exact team UUID, and `validate_team_id_access` proves the API
+key can act for the UUID through a team-scoped account request. Automation must pass an explicit UUID rather than
+inferring that a key rejected by the user-only team-list endpoint is necessarily team-scoped. `resolve_team_id` remains
+available for interactive user keys that can list one exact visible team name. `providers.cloudrift.with_public_ip`
+defaults to true for compatibility; callers on a reachable private network can disable public-IP allocation.
 
 For each candidate, the orchestrator makes up to `SAME_CANDIDATE_RETRIES` (= 2) attempts on transient errors. On the contracted exceptions it short-circuits:
 

--- a/emmy/provisioning/cloud.py
+++ b/emmy/provisioning/cloud.py
@@ -291,6 +291,7 @@ async def _provision_cloudrift(
     billing_exempt = cr_config.get("billing_exempt", False)
     network = cr_config.get("network")
     team_id = cr_config.get("team_id")
+    with_public_ip = cr_config.get("with_public_ip", True)
 
     return await cr_provider.create_instance(
         api_key=api_key or "",
@@ -306,6 +307,7 @@ async def _provision_cloudrift(
         billing_exempt=billing_exempt,
         network=network,
         team_id=team_id,
+        with_public_ip=with_public_ip,
         extra_public_keys=extra_authorized_keys,
         allocation_observer=allocation_observer,
     )

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -644,9 +644,9 @@ async def create_instance(
 
 
 async def instance_is_active(api_key, instance_id, api_url=DEFAULT_API_URL):
-    """Return whether CloudRift still reports an active instance handle."""
+    """Return whether CloudRift still reports an instance requiring cleanup."""
     info = await _get_instance_info(api_key, instance_id, api_url)
-    return info is not None and info.get("status") not in TERMINAL_INSTANCE_STATUSES
+    return info is not None and info.get("status") not in CLEANUP_ACCEPTED_INSTANCE_STATUSES
 
 
 async def delete_instance(api_key, instance_id, api_url=DEFAULT_API_URL, dry_run=False):

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -88,6 +88,7 @@ async def _rent_instance(
     node_id=None,
     tags=None,
     team_id=None,
+    with_public_ip=True,
 ):
     """Rent a new CloudRift VM instance.
 
@@ -99,6 +100,7 @@ async def _rent_instance(
             ``ByNodeId`` selector instead of letting the provider place the instance.
         tags: optional list of free-form labels attached to the rental.
         team_id: optional team UUID that owns the rental.
+        with_public_ip: whether CloudRift should assign a public IP to the VM.
     """
     vm_config = {
         "ssh_key": {"PublicKeys": ssh_public_keys},
@@ -116,7 +118,7 @@ async def _rent_instance(
         "config": {
             "VirtualMachine": vm_config,
         },
-        "with_public_ip": True,
+        "with_public_ip": with_public_ip,
     }
     if billing_exempt:
         data["billing_exempt"] = True
@@ -183,32 +185,32 @@ async def list_available_instance_types(api_key, api_url=DEFAULT_API_URL):
     return available
 
 
-async def resolve_team_id(api_key, team_name, api_url=DEFAULT_API_URL, allow_implicit_team_key=False):
-    """Resolve one exact team name, or accept ownership implicit in a team API key."""
+async def resolve_team_id(api_key, team_name, api_url=DEFAULT_API_URL):
+    """Resolve one exact team name visible to a user API key."""
     data = {"selector": "Mine", "with_members": False, "with_account_info": False}
-    try:
-        result = await _api_request("POST", "/api/v1/teams/list", data, api_key, api_url)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code != 401 or not allow_implicit_team_key:
-            raise
-        # Team API keys are intentionally rejected by the user-only teams/list
-        # endpoint. Verify the key against a team-aware endpoint before relying
-        # on CloudRift to infer the owning team from the authenticated principal.
-        await _api_request(
-            "POST",
-            "/api/v2/account/info",
-            {"selector": "ByToken", "with_auto_top_up": False},
-            api_key,
-            api_url,
-        )
-        logger.info(f"CloudRift team API key supplies implicit ownership for configured team {team_name!r}")
-        return None
+    result = await _api_request("POST", "/api/v1/teams/list", data, api_key, api_url)
     matches = [team.get("id") for team in result.get("teams", []) if team.get("name") == team_name and team.get("id")]
     if not matches:
         raise TerminalProvisionError(f"CloudRift API key cannot access team {team_name!r}")
     if len(matches) > 1:
         raise TerminalProvisionError(f"CloudRift team name {team_name!r} is ambiguous")
     return matches[0]
+
+
+async def validate_team_id_access(api_key, team_id, api_url=DEFAULT_API_URL):
+    """Validate an exact team UUID and prove that the API key can act for it."""
+    try:
+        normalized_team_id = str(uuid.UUID(team_id))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise TerminalProvisionError("CloudRift team ID must be a UUID") from exc
+    await _api_request(
+        "POST",
+        "/api/v2/account/info",
+        {"selector": {"ByTeam": normalized_team_id}, "with_auto_top_up": False},
+        api_key,
+        api_url,
+    )
+    return normalized_team_id
 
 
 def _validate_instance_tags(tags):
@@ -509,6 +511,7 @@ async def create_instance(
     node=None,
     tags=None,
     team_id=None,
+    with_public_ip=True,
 ):
     """Create a CloudRift VM instance.
 
@@ -521,6 +524,7 @@ async def create_instance(
         tags: rental labels; ``None`` resolves through :func:`emmy.config.rental_tags`
             (``EMMY_RENTAL_TAGS`` override, default ``["emmy"]``).
         team_id: optional team UUID that owns the rental.
+        with_public_ip: whether CloudRift should assign a public IP to the VM.
         extra_public_keys: optional list of additional SSH public key strings to
             install in the VM's authorized_keys alongside the key from
             ``ssh_key_path`` (e.g. ["ssh-ed25519 AAAA bob@host"]).
@@ -572,6 +576,7 @@ async def create_instance(
             node_id=node_id,
             tags=tags,
             team_id=team_id,
+            with_public_ip=with_public_ip,
         )
     except httpx.HTTPStatusError as exc:
         code = exc.response.status_code

--- a/emmy/provisioning/cloudrift.py
+++ b/emmy/provisioning/cloudrift.py
@@ -29,6 +29,7 @@ DEFAULT_CLOUDINIT_URL = "https://storage.googleapis.com/cloudrift-vm-disks/cloud
 # change request/response shapes (e.g. add another default-off field mask) under us.
 API_VERSION = "2026-08-05"
 TERMINAL_INSTANCE_STATUSES = {"Deleted", "Failed", "Inactive", "Terminated"}
+CLEANUP_ACCEPTED_INSTANCE_STATUSES = TERMINAL_INSTANCE_STATUSES | {"Deactivating"}
 
 
 def select_image_url(instance_type):
@@ -235,11 +236,11 @@ async def list_instances_by_tags(api_key, tags, api_url=DEFAULT_API_URL):
 
 
 async def terminate_instances_by_tags(api_key, tags, api_url=DEFAULT_API_URL, audit_attempts=12, audit_delay=10):
-    """Terminate all active instances carrying every supplied tag and verify they stop."""
+    """Terminate all active tagged instances and verify CloudRift starts stopping them."""
     tags = _validate_instance_tags(tags)
     instances = await list_instances_by_tags(api_key, tags, api_url)
     instance_ids = [
-        instance["id"] for instance in instances if instance.get("id") and instance.get("status") not in TERMINAL_INSTANCE_STATUSES
+        instance["id"] for instance in instances if instance.get("id") and instance.get("status") not in CLEANUP_ACCEPTED_INSTANCE_STATUSES
     ]
     if instance_ids:
         logger.info(f"Terminating CloudRift instances selected by tags {tags}: {instance_ids}")
@@ -255,7 +256,7 @@ async def terminate_instances_by_tags(api_key, tags, api_url=DEFAULT_API_URL, au
         remaining = [
             instance
             for instance in await list_instances_by_tags(api_key, tags, api_url)
-            if instance.get("status") not in TERMINAL_INSTANCE_STATUSES
+            if instance.get("status") not in CLEANUP_ACCEPTED_INSTANCE_STATUSES
         ]
         if not remaining:
             return instance_ids

--- a/experiments/ARCHITECTURE.md
+++ b/experiments/ARCHITECTURE.md
@@ -6,17 +6,18 @@ An experiment answers a comparison or qualification question. It uses the recipe
 ## Directory convention
 
 ```text
-experiments/<model>/<workload_or_question>_<hardware>/
+experiments/<model>/<workload_or_question>/
   recipe.yaml
-  <YYYY-MM-DD_HH-MM-SS>/      # temporary ignored raw output
-  results.tar.gz              # Git LFS archive of the last run directory
-  <row>.experiment.yaml      # assembled record for each last-run row
-  RESULTS.md                  # thoughtful interpretation of the last run
+  <YYYY-MM-DD_HH-MM-SS>/                    # temporary ignored raw output
+  results_<gpu-short>x<gpu-count>.tar.gz    # one Git LFS archive per exact platform
+  <gpu-short>x<gpu-count>_<row>.experiment.yaml
+  RESULTS.md                                # one interpretation across all platforms
 ```
 
-Use the model's established repository slug and a short `snake_case` experiment name. Keep one protocol in one recipe
-when platforms differ only by hardware allocation or a small control; use a zipped matrix rather than copied command
-bodies. Split directories only when the workload or raw evidence set differs.
+Use the model's established repository slug and a short `snake_case` experiment name. Derive `<gpu-short>` with
+`emmy.hardware.gpu_short_name`; `results_rtx4090x1.tar.gz` is the archive for one RTX 4090. Keep one protocol in one
+recipe when platforms differ only by hardware allocation or a small control; use a zipped matrix rather than copied
+command bodies. Split directories only when the workload or raw evidence set differs.
 
 ## Last-run artifacts
 
@@ -25,15 +26,16 @@ expanded row there. It keeps raw client/server logs and every declared command r
 writes legacy JSON/TXT wrappers, a task/instance manifest, or a report. Dry runs do not create a directory.
 
 Use the repository `run-experiment` skill to finish a requested run. The skill checks matrix-row coverage, system
-information, declared command-result presence, and terminal status; copies the records beside `recipe.yaml`; replaces
-the Git LFS-backed `results.tar.gz`; overwrites `RESULTS.md`; and commits the complete durable snapshot. Once the
-archive has been extracted or byte-checked against the raw files, the ignored timestamped directory may be deleted;
-the archive is the durable raw copy. Existing records, archive, and report always describe the same most recent run.
+information, declared command-result presence, and terminal status; copies the platform's records beside
+`recipe.yaml`; replaces its Git LFS-backed named archive; updates its section in `RESULTS.md`; and commits the complete
+durable snapshot. Once the archive has been extracted or byte-checked against the raw files, the ignored timestamped
+directory may be deleted; the archive is the durable raw copy. Each platform's records, archive, and report section
+always describe that platform's most recent run. Updating one platform preserves every other platform snapshot.
 
-`RESULTS.md` is an intelligent review of the last run. It reports the protocol, measurements, repeat variation,
-comparisons, conclusion, limitations, system, status, and archive location, with every claim grounded in the raw
-files. Recipes and repository scripts cannot contain result interpretation, post-processing, or report generation;
-command blocks are only the measured workload.
+`RESULTS.md` is an intelligent review across the retained platform runs. Each platform section reports the protocol,
+measurements, repeat variation, comparisons, conclusion, limitations, system, status, and archive location, with every
+claim grounded in its raw files. Recipes and repository scripts cannot contain result interpretation, post-processing,
+or report generation; command blocks are only the measured workload.
 
 ## Lifetime
 

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -105,10 +105,10 @@ directly; they never import from another test module or from `conftest.py`.
   best-effort recipes keep the full serving contract coverage, while obsolete recipes remain covered by lifecycle
   validation. Catalog and command tests cover the versioned JSON inventory, effective deployment metadata,
   tag-filtered inventory, the minimal installation-selected CLI, editable-versus-wheel catalog selection, recipe-name
-  materialization, and validated shell creation. Repository-
-  automation tests validate required lifecycle rationales and the one-to-three-entry onboarding deployment matrix
-  through that shared library. Qualification-manifest tests also pin the requested operation mode, exact model ID,
-  target, and preserved lifecycle tag before artifacts may be staged.
+  materialization, and validated shell creation. Repository-automation tests validate required lifecycle rationales
+  and the one-to-three-entry onboarding deployment matrix through that shared library. Qualification-manifest tests
+  also pin the requested operation mode, exact model ID, target, preserved lifecycle tag, current-platform archive and
+  row records, and isolation from other platform results before artifacts may be staged.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.
 - **Plain functions** — no test classes; tests are grouped by file and separated with comment headers.
 - **Assertions on stdout** — dry-run tests verify that the correct commands and messages appear in the expected order.

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -35,13 +35,15 @@ def test_onboarding_loads_control_code_from_exact_workflow_commit():
     document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
     steps = document["jobs"]["onboard"]["steps"]
     load_index = next(index for index, step in enumerate(steps) if step.get("name") == "Load exact workflow source")
+    lfs_index = next(index for index, step in enumerate(steps) if step.get("name") == "Configure Git LFS")
     selection_index = next(index for index, step in enumerate(steps) if step.get("name") == "Select one available deployment")
     load_script = steps[load_index]["run"]
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
     cleanup_script = next(step["run"] for step in steps if step.get("name") == "Cleanup local credentials and output")
 
-    assert load_index < selection_index
+    assert load_index < lfs_index < selection_index
     assert 'git archive "$WORKFLOW_SHA"' in load_script
+    assert "GIT_LFS_SKIP_SMUDGE" in steps[load_index]["env"]
     assert 'echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"' in load_script
     assert 'echo "PYTHONSAFEPATH=1" >> "$GITHUB_ENV"' in load_script
     assert '"$WORKFLOW_SOURCE/.github/scripts/onboarding_artifacts.py"' in validation_script
@@ -63,6 +65,8 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert "experiments/**/results_*.tar.gz filter=lfs" in lfs_script
     assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script
     assert "preserve every other platform archive" in agent_script
+    assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
+    assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
     assert "git lfs status" in validation_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in (workspace / ".gitattributes").read_text()
 

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -91,6 +91,9 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
     (raw_directory / "benchmark.log").write_text("measured\n")
     archive = experiment_dir / "results_rtx4090x1.tar.gz"
     with tarfile.open(archive, "w:gz") as output:
+        root_info = tarfile.TarInfo(".")
+        root_info.type = tarfile.DIRTYPE
+        output.addfile(root_info)
         output.add(raw_directory, arcname=raw_directory.name)
     summary = tmp_path / "summary.json"
     summary.write_text(

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -82,7 +82,11 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert '"$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
     assert "do not modify or list .gitattributes" in agent_script
-    assert 'tarfile.open(archive, "r:gz")' in cleanup_script
+    assert 'tarfile.open(temporary_archive, "w:gz")' in cleanup_script
+    assert "temporary_roots = verify_archive(temporary_archive)" in cleanup_script
+    assert "os.replace(temporary_archive, archive)" in cleanup_script
+    assert 'tarfile.open(path, "r:gz")' in cleanup_script
+    assert "contents.read(1024 * 1024)" in cleanup_script
     assert "raw_directory.name not in member_roots" in cleanup_script
     assert "shutil.rmtree(raw_directory)" in cleanup_script
     assert "git lfs status" in validation_script
@@ -98,6 +102,9 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
     raw_directory = experiment_dir / "2026-08-16_14-41-08"
     raw_directory.mkdir(parents=True)
     (raw_directory / "benchmark.log").write_text("measured\n")
+    (experiment_dir / "recipe.yaml").write_text("name: serving\n")
+    (experiment_dir / "RESULTS.md").write_text("# Results\n")
+    (experiment_dir / "rtx4090x1_serving.experiment.yaml").write_text("status: succeeded\n")
     archive = experiment_dir / "results_rtx4090x1.tar.gz"
     with tarfile.open(archive, "w:gz") as output:
         root_info = tarfile.TarInfo(".")
@@ -108,8 +115,10 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
     summary.write_text(
         json.dumps(
             {
+                "status": "success",
                 "experiment": "experiments/Model/serving/recipe.yaml",
                 "experiment_artifacts": ["experiments/Model/serving/results_rtx4090x1.tar.gz"],
+                "artifacts": [],
             }
         )
     )
@@ -117,7 +126,12 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
     subprocess.run(
         [sys.executable, "-"],
         cwd=tmp_path,
-        env={**os.environ, "ONBOARD_SUMMARY": str(summary)},
+        env={
+            **os.environ,
+            "ONBOARD_SUMMARY": str(summary),
+            "TARGET_GPU": "NVIDIA GeForce RTX 4090",
+            "TARGET_GPU_COUNT": "1",
+        },
         input=cleanup_source,
         text=True,
         check=True,
@@ -125,6 +139,76 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
 
     assert not raw_directory.exists()
     assert archive.is_file()
+    updated_summary = json.loads(summary.read_text())
+    archive_path = "experiments/Model/serving/results_rtx4090x1.tar.gz"
+    assert archive_path in updated_summary["experiment_artifacts"]
+    assert archive_path in updated_summary["artifacts"]
+
+
+def test_onboarding_creates_platform_archive_and_preserves_other_platform(tmp_path):
+    document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
+    step = next(step for step in document["jobs"]["onboard"]["steps"] if step.get("name") == "Remove archived task-local raw results")
+    cleanup_source = step["run"].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+
+    experiment_dir = tmp_path / "experiments" / "Model" / "serving"
+    raw_directory = experiment_dir / "2026-08-16_14-41-08"
+    raw_directory.mkdir(parents=True)
+    (raw_directory / "benchmark.log").write_text("measured\n")
+    (experiment_dir / "recipe.yaml").write_text("name: serving\n")
+    (experiment_dir / "RESULTS.md").write_text("# Results\n")
+    (experiment_dir / "rtx4090x1_serving.experiment.yaml").write_text("status: succeeded\n")
+    archive = experiment_dir / "results_rtx4090x1.tar.gz"
+    old_results = tmp_path / "old-results"
+    old_results.mkdir()
+    (old_results / "obsolete.log").write_text("old measurement\n")
+    with tarfile.open(archive, "w:gz") as output:
+        output.add(old_results, arcname="2026-08-01_00-00-00")
+    other_archive = experiment_dir / "results_h200x1.tar.gz"
+    other_archive.write_bytes(b"preserved platform")
+    summary = tmp_path / "summary.json"
+    summary.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "experiment": "experiments/Model/serving/recipe.yaml",
+                "experiment_artifacts": [
+                    "experiments/Model/serving/recipe.yaml",
+                    "experiments/Model/serving/RESULTS.md",
+                ],
+                "artifacts": [],
+            }
+        )
+    )
+
+    subprocess.run(
+        [sys.executable, "-"],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "ONBOARD_SUMMARY": str(summary),
+            "TARGET_GPU": "NVIDIA GeForce RTX 4090",
+            "TARGET_GPU_COUNT": "1",
+        },
+        input=cleanup_source,
+        text=True,
+        check=True,
+    )
+
+    assert archive.is_file()
+    with tarfile.open(archive, "r:gz") as source:
+        assert "2026-08-16_14-41-08/benchmark.log" in source.getnames()
+        assert "2026-08-01_00-00-00/obsolete.log" not in source.getnames()
+    assert not raw_directory.exists()
+    assert other_archive.read_bytes() == b"preserved platform"
+    updated_summary = json.loads(summary.read_text())
+    expected_snapshot = {
+        "experiments/Model/serving/recipe.yaml",
+        "experiments/Model/serving/RESULTS.md",
+        "experiments/Model/serving/results_rtx4090x1.tar.gz",
+        "experiments/Model/serving/rtx4090x1_serving.experiment.yaml",
+    }
+    assert expected_snapshot <= set(updated_summary["experiment_artifacts"])
+    assert expected_snapshot <= set(updated_summary["artifacts"])
 
 
 def test_onboarding_consumes_versioned_recipe_inventory():

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -67,6 +67,7 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert "preserve every other platform archive" in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
+    assert "do not modify or list .gitattributes" in agent_script
     assert "git lfs status" in validation_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in (workspace / ".gitattributes").read_text()
 

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -42,6 +42,7 @@ def test_onboarding_loads_control_code_from_exact_workflow_commit():
     assert load_index < selection_index
     assert 'git archive "$WORKFLOW_SHA"' in load_script
     assert 'echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"' in load_script
+    assert 'echo "PYTHONSAFEPATH=1" >> "$GITHUB_ENV"' in load_script
     assert 'rm -rf -- "$WORKFLOW_SOURCE"' in cleanup_script
 
 

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -37,13 +37,31 @@ def test_onboarding_loads_control_code_from_exact_workflow_commit():
     load_index = next(index for index, step in enumerate(steps) if step.get("name") == "Load exact workflow source")
     selection_index = next(index for index, step in enumerate(steps) if step.get("name") == "Select one available deployment")
     load_script = steps[load_index]["run"]
+    validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
     cleanup_script = next(step["run"] for step in steps if step.get("name") == "Cleanup local credentials and output")
 
     assert load_index < selection_index
     assert 'git archive "$WORKFLOW_SHA"' in load_script
     assert 'echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"' in load_script
     assert 'echo "PYTHONSAFEPATH=1" >> "$GITHUB_ENV"' in load_script
+    assert '"$WORKFLOW_SOURCE/.github/scripts/onboarding_artifacts.py"' in validation_script
     assert 'rm -rf -- "$WORKFLOW_SOURCE"' in cleanup_script
+
+
+def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
+    workspace = Path(__file__).parents[2]
+    document = yaml.safe_load((workspace / ".github" / "workflows" / "onboard-model.yml").read_text())
+    steps = document["jobs"]["onboard"]["steps"]
+    lfs_script = next(step["run"] for step in steps if step.get("name") == "Configure Git LFS")
+    agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
+    validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
+
+    assert "git lfs install --local" in lfs_script
+    assert "experiments/**/results_*.tar.gz filter=lfs" in lfs_script
+    assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script
+    assert "preserve every other platform archive" in agent_script
+    assert "git lfs status" in validation_script
+    assert "experiments/**/results_*.tar.gz filter=lfs" in (workspace / ".gitattributes").read_text()
 
 
 def test_onboarding_consumes_versioned_recipe_inventory():

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -56,6 +56,7 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
 
+    assert "sudo apt-get install --no-install-recommends -y git-lfs" in lfs_script
     assert "git lfs install --local" in lfs_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in lfs_script
     assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -46,6 +46,16 @@ def test_onboarding_loads_control_code_from_exact_workflow_commit():
     assert 'rm -rf -- "$WORKFLOW_SOURCE"' in cleanup_script
 
 
+def test_onboarding_consumes_versioned_recipe_inventory():
+    document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
+    script = next(step["run"] for step in document["jobs"]["onboard"]["steps"] if step.get("name") == "Select one available deployment")
+
+    assert 'inventory_document.get("schema_version") != 1' in script
+    assert 'inventory = inventory_document["recipes"]' in script
+    assert 'deployment.get("gpu", deployment.get("deploy.gpu"))' in script
+    assert 'deployment.get("gpu_count", deployment.get("deploy.gpu_count"))' in script
+
+
 def test_discovery_prompt_keeps_obsolete_classification_conservative():
     document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "discover-model.yml").read_text())
     script = next(step["run"] for step in document["jobs"]["discover"]["steps"] if step.get("name") == "Run discover-models agent")

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -56,7 +56,9 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
 
-    assert "sudo apt-get install --no-install-recommends -y git-lfs" in lfs_script
+    assert "lfs_version=3.7.1" in lfs_script
+    assert "sha256sum --check" in lfs_script
+    assert 'echo "$lfs_dir" >> "$GITHUB_PATH"' in lfs_script
     assert "git lfs install --local" in lfs_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in lfs_script
     assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -31,6 +31,20 @@ def test_opencode_message_precedes_variadic_file_option(workflow, message):
     assert script.index(message) < script.index('--file "$AGENT_PROMPT"')
 
 
+def test_onboarding_loads_control_code_from_exact_workflow_commit():
+    document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
+    steps = document["jobs"]["onboard"]["steps"]
+    load_index = next(index for index, step in enumerate(steps) if step.get("name") == "Load exact workflow source")
+    selection_index = next(index for index, step in enumerate(steps) if step.get("name") == "Select one available deployment")
+    load_script = steps[load_index]["run"]
+    cleanup_script = next(step["run"] for step in steps if step.get("name") == "Cleanup local credentials and output")
+
+    assert load_index < selection_index
+    assert 'git archive "$WORKFLOW_SHA"' in load_script
+    assert 'echo "PYTHONPATH=$WORKFLOW_SOURCE" >> "$GITHUB_ENV"' in load_script
+    assert 'rm -rf -- "$WORKFLOW_SOURCE"' in cleanup_script
+
+
 def test_discovery_prompt_keeps_obsolete_classification_conservative():
     document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "discover-model.yml").read_text())
     script = next(step["run"] for step in document["jobs"]["discover"]["steps"] if step.get("name") == "Run discover-models agent")

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -59,6 +59,7 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     document = yaml.safe_load((workspace / ".github" / "workflows" / "onboard-model.yml").read_text())
     steps = document["jobs"]["onboard"]["steps"]
     lfs_script = next(step["run"] for step in steps if step.get("name") == "Configure Git LFS")
+    host_setup_script = next(step["run"] for step in steps if step.get("name") == "Prepare target GPU host")
     agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
     cleanup_script = next(step["run"] for step in steps if step.get("name") == "Remove archived task-local raw results")
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
@@ -68,9 +69,15 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert 'echo "$lfs_dir" >> "$GITHUB_PATH"' in lfs_script
     assert "git lfs install --local" in lfs_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in lfs_script
+    assert "python3.12-venv" in host_setup_script
+    assert 'scratch_base="$HOME/.cache/emmy"' in host_setup_script
+    assert "tmpfs|ramfs" in host_setup_script
+    assert "8388608" in host_setup_script
+    subprocess.run(["bash", "-n"], input=host_setup_script, text=True, check=True)
     assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script
     assert "preserve every other platform archive" in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
+    assert '"$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
     assert "do not modify or list .gitattributes" in agent_script
     assert 'tarfile.open(archive, "r:gz")' in cleanup_script

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -50,6 +50,7 @@ def test_onboarding_consumes_versioned_recipe_inventory():
     document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
     script = next(step["run"] for step in document["jobs"]["onboard"]["steps"] if step.get("name") == "Select one available deployment")
 
+    assert 'recipe_inventory_document(Path("recipes"))' in script
     assert 'inventory_document.get("schema_version") != 1' in script
     assert 'inventory = inventory_document["recipes"]' in script
     assert 'deployment.get("gpu", deployment.get("deploy.gpu"))' in script

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -1,5 +1,9 @@
 import importlib.util
 import json
+import os
+import subprocess
+import sys
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -56,6 +60,7 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     steps = document["jobs"]["onboard"]["steps"]
     lfs_script = next(step["run"] for step in steps if step.get("name") == "Configure Git LFS")
     agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
+    cleanup_script = next(step["run"] for step in steps if step.get("name") == "Remove archived task-local raw results")
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
 
     assert "lfs_version=3.7.1" in lfs_script
@@ -68,8 +73,46 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
     assert "do not modify or list .gitattributes" in agent_script
+    assert 'tarfile.open(archive, "r:gz")' in cleanup_script
+    assert "raw_directory.name not in member_roots" in cleanup_script
+    assert "shutil.rmtree(raw_directory)" in cleanup_script
     assert "git lfs status" in validation_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in (workspace / ".gitattributes").read_text()
+
+
+def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_path):
+    document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
+    step = next(step for step in document["jobs"]["onboard"]["steps"] if step.get("name") == "Remove archived task-local raw results")
+    cleanup_source = step["run"].split("<<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+
+    experiment_dir = tmp_path / "experiments" / "Model" / "serving"
+    raw_directory = experiment_dir / "2026-08-16_14-41-08"
+    raw_directory.mkdir(parents=True)
+    (raw_directory / "benchmark.log").write_text("measured\n")
+    archive = experiment_dir / "results_rtx4090x1.tar.gz"
+    with tarfile.open(archive, "w:gz") as output:
+        output.add(raw_directory, arcname=raw_directory.name)
+    summary = tmp_path / "summary.json"
+    summary.write_text(
+        json.dumps(
+            {
+                "experiment": "experiments/Model/serving/recipe.yaml",
+                "experiment_artifacts": ["experiments/Model/serving/results_rtx4090x1.tar.gz"],
+            }
+        )
+    )
+
+    subprocess.run(
+        [sys.executable, "-"],
+        cwd=tmp_path,
+        env={**os.environ, "ONBOARD_SUMMARY": str(summary)},
+        input=cleanup_source,
+        text=True,
+        check=True,
+    )
+
+    assert not raw_directory.exists()
+    assert archive.is_file()
 
 
 def test_onboarding_consumes_versioned_recipe_inventory():

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -71,6 +71,8 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert "experiments/**/results_*.tar.gz filter=lfs" in lfs_script
     assert "python3.12-venv" in host_setup_script
     assert 'scratch_base="$HOME/.cache/emmy"' in host_setup_script
+    assert '"$SSH_USER@$SSH_HOST"' in host_setup_script
+    assert '"$SSH_TARGET"' not in host_setup_script
     assert "tmpfs|ramfs" in host_setup_script
     assert "8388608" in host_setup_script
     subprocess.run(["bash", "-n"], input=host_setup_script, text=True, check=True)

--- a/tests/github/test_onboarding_artifacts.py
+++ b/tests/github/test_onboarding_artifacts.py
@@ -16,16 +16,27 @@ def _write_artifacts(workspace):
     paths = [
         "recipes/Model/recipe.yaml",
         "recipes/Model/RESULTS.md",
-        "experiments/Model/serving_h200/recipe.yaml",
+        "experiments/Model/serving/recipe.yaml",
+        "experiments/Model/serving/RESULTS.md",
+        "experiments/Model/serving/results_h200x1.tar.gz",
+        "experiments/Model/serving/h200x1_np8_deadbeef.experiment.yaml",
     ]
     for raw_path in paths:
         path = workspace / raw_path
         path.parent.mkdir(parents=True, exist_ok=True)
         if raw_path == paths[0]:
             path.write_text("tags: [best-effort]\nmodel:\n  huggingface: org/Model\n")
+        elif path.suffixes == [".tar", ".gz"]:
+            path.write_bytes(b"compressed results")
         else:
             path.write_text("result\n")
     return paths
+
+
+def _init_repo(workspace):
+    subprocess.run(["git", "init", "-q"], cwd=workspace, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=workspace, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=workspace, check=True)
 
 
 def test_validate_summary_accepts_exact_manifest(tmp_path):
@@ -41,7 +52,7 @@ def test_validate_summary_accepts_exact_manifest(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2]],
+                "experiment_artifacts": paths[2:],
                 "artifacts": paths,
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
@@ -75,7 +86,7 @@ def test_validate_summary_includes_separately_declared_artifacts(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2]],
+                "experiment_artifacts": paths[2:],
                 "artifacts": [paths[0]],
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
@@ -96,9 +107,78 @@ def test_validate_summary_includes_separately_declared_artifacts(tmp_path):
     assert artifacts == [Path(path) for path in paths]
 
 
+def test_validate_summary_requires_exact_platform_archive(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": [paths[2], paths[3], paths[5]],
+                "artifacts": paths,
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="exact platform archive"):
+        onboarding_artifacts.validate_summary(
+            summary_path,
+            tmp_path,
+            "org/Model",
+            "NVIDIA H200 141GB",
+            1,
+            "user@host",
+            "onboarding",
+            "best-effort",
+        )
+
+
+def test_validate_summary_rejects_other_platform_archive(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    other_archive = tmp_path / "experiments" / "Model" / "serving" / "results_rtx4090x1.tar.gz"
+    other_archive.write_bytes(b"other platform")
+    other_path = str(other_archive.relative_to(tmp_path))
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": paths[2:],
+                "artifacts": [*paths, other_path],
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="other platform results must be preserved"):
+        onboarding_artifacts.validate_summary(
+            summary_path,
+            tmp_path,
+            "org/Model",
+            "NVIDIA H200 141GB",
+            1,
+            "user@host",
+            "onboarding",
+            "best-effort",
+        )
+
+
 def test_validate_summary_rejects_experiment_result(tmp_path):
     paths = _write_artifacts(tmp_path)
-    raw_result = tmp_path / "experiments" / "Model" / "serving_h200" / "2026-08-08" / "result.json"
+    raw_result = tmp_path / "experiments" / "Model" / "serving" / "2026-08-08" / "result.json"
     raw_result.parent.mkdir(parents=True)
     raw_result.write_text("result\n")
     summary_path = tmp_path / "summary.json"
@@ -112,14 +192,14 @@ def test_validate_summary_rejects_experiment_result(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2], str(raw_result.relative_to(tmp_path))],
+                "experiment_artifacts": [*paths[2:], str(raw_result.relative_to(tmp_path))],
                 "artifacts": [*paths, str(raw_result.relative_to(tmp_path))],
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
         )
     )
 
-    with pytest.raises(ValueError, match="Only experiment recipe.yaml"):
+    with pytest.raises(ValueError, match="durable experiment snapshot"):
         onboarding_artifacts.validate_summary(
             summary_path,
             tmp_path,
@@ -148,14 +228,14 @@ def test_validate_summary_rejects_recipe_run_result(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2]],
+                "experiment_artifacts": paths[2:],
                 "artifacts": [*paths, str(raw_result.relative_to(tmp_path))],
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
         )
     )
 
-    with pytest.raises(ValueError, match="Only recipe.yaml and final recipe RESULTS.md"):
+    with pytest.raises(ValueError, match="Only durable recipe and experiment artifacts"):
         onboarding_artifacts.validate_summary(
             summary_path,
             tmp_path,
@@ -184,7 +264,7 @@ def test_validate_summary_rejects_report_outside_final_recipe_dir(tmp_path):
                 "recipe": paths[0],
                 "report": str(nested_report.relative_to(tmp_path)),
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2]],
+                "experiment_artifacts": paths[2:],
                 "artifacts": [*paths, str(nested_report.relative_to(tmp_path))],
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
@@ -217,7 +297,7 @@ def test_validate_summary_rejects_mode_mismatch(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2]],
+                "experiment_artifacts": paths[2:],
                 "artifacts": paths,
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
@@ -250,7 +330,7 @@ def test_validate_summary_rejects_lifecycle_change(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2]],
+                "experiment_artifacts": paths[2:],
                 "artifacts": paths,
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
@@ -271,9 +351,7 @@ def test_validate_summary_rejects_lifecycle_change(tmp_path):
 
 
 def test_stage_artifacts_rejects_unmanifested_agent_changes(tmp_path):
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    _init_repo(tmp_path)
     baseline = tmp_path / "README.md"
     baseline.write_text("baseline\n")
     subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
@@ -288,9 +366,7 @@ def test_stage_artifacts_rejects_unmanifested_agent_changes(tmp_path):
 
 
 def test_stage_artifacts_rejects_unmanifested_ignored_experiment(tmp_path):
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    _init_repo(tmp_path)
     (tmp_path / ".gitignore").write_text("experiments/\n")
     subprocess.run(["git", "add", ".gitignore"], cwd=tmp_path, check=True)
     subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
@@ -302,3 +378,104 @@ def test_stage_artifacts_rejects_unmanifested_ignored_experiment(tmp_path):
 
     with pytest.raises(ValueError, match="outside its artifact manifest"):
         onboarding_artifacts.stage_artifacts(tmp_path, [Path("experiments/Model/recipe.yaml")])
+
+
+def test_stage_artifacts_requires_updated_platform_archive(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".gitattributes").write_text("experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text\n")
+    paths = _write_artifacts(tmp_path)
+    subprocess.run(["git", "add", "--force", "--", ".gitattributes", *paths], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+    (tmp_path / paths[3]).write_text("updated report\n")
+
+    with pytest.raises(ValueError, match="was not created or updated"):
+        onboarding_artifacts.stage_artifacts(
+            tmp_path,
+            [Path(path) for path in paths],
+            Path(paths[4]),
+        )
+
+
+def test_stage_artifacts_requires_git_lfs_for_platform_archive(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / "README.md").write_text("baseline\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+    paths = _write_artifacts(tmp_path)
+
+    with pytest.raises(ValueError, match="not tracked by Git LFS"):
+        onboarding_artifacts.stage_artifacts(
+            tmp_path,
+            [Path(path) for path in paths],
+            Path(paths[4]),
+        )
+
+
+def test_platform_update_preserves_other_platform_snapshot(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".gitattributes").write_text("experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text\n")
+    paths = _write_artifacts(tmp_path)
+    experiment_dir = tmp_path / "experiments" / "Model" / "serving"
+    other_archive = experiment_dir / "results_rtx4090x1.tar.gz"
+    other_record = experiment_dir / "rtx4090x1_np8_feedface.experiment.yaml"
+    other_archive.write_bytes(b"preserve archive")
+    other_record.write_text("preserve record\n")
+    old_record = experiment_dir / "h200x1_np4_cafebabe.experiment.yaml"
+    old_record.write_text("old current-platform record\n")
+    baseline = [
+        ".gitattributes",
+        *paths,
+        str(other_archive.relative_to(tmp_path)),
+        str(other_record.relative_to(tmp_path)),
+        str(old_record.relative_to(tmp_path)),
+    ]
+    subprocess.run(["git", "add", "--force", "--", *baseline], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+
+    (tmp_path / paths[3]).write_text("H200 updated; RTX 4090 preserved\n")
+    (tmp_path / paths[4]).write_bytes(b"new H200 archive")
+    (tmp_path / paths[5]).write_text("new H200 record\n")
+    old_record.unlink()
+    old_record_path = str(old_record.relative_to(tmp_path))
+    summary_path = tmp_path.parent / f"{tmp_path.name}-summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": paths[2:],
+                "artifacts": [*paths, old_record_path],
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    _, artifacts = onboarding_artifacts.validate_summary(
+        summary_path,
+        tmp_path,
+        "org/Model",
+        "NVIDIA H200 141GB",
+        1,
+        "user@host",
+        "onboarding",
+        "best-effort",
+    )
+    onboarding_artifacts.stage_artifacts(tmp_path, artifacts, Path(paths[4]))
+
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert str(other_archive.relative_to(tmp_path)) not in staged
+    assert str(other_record.relative_to(tmp_path)) not in staged
+    assert other_archive.read_bytes() == b"preserve archive"
+    assert other_record.read_text() == "preserve record\n"
+    assert old_record_path in staged

--- a/tests/github/test_onboarding_artifacts.py
+++ b/tests/github/test_onboarding_artifacts.py
@@ -62,6 +62,40 @@ def test_validate_summary_accepts_exact_manifest(tmp_path):
     assert artifacts == [Path(path) for path in paths]
 
 
+def test_validate_summary_includes_separately_declared_artifacts(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": [paths[2]],
+                "artifacts": [paths[0]],
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    _, artifacts = onboarding_artifacts.validate_summary(
+        summary_path,
+        tmp_path,
+        "org/Model",
+        "NVIDIA H200 141GB",
+        1,
+        "user@host",
+        "onboarding",
+        "best-effort",
+    )
+
+    assert artifacts == [Path(path) for path in paths]
+
+
 def test_validate_summary_rejects_experiment_result(tmp_path):
     paths = _write_artifacts(tmp_path)
     raw_result = tmp_path / "experiments" / "Model" / "serving_h200" / "2026-08-08" / "result.json"

--- a/tests/provisioning/test_cloud.py
+++ b/tests/provisioning/test_cloud.py
@@ -267,6 +267,23 @@ async def test_provision_cloudrift_team_id(mock_create, tmp_path):
     assert mock_create.call_args.kwargs["team_id"] == "team-robots"
 
 
+@patch.dict("os.environ", {"CLOUDRIFT_API_KEY": "test-key"})
+@patch("emmy.provisioning.cloud.cr_provider.create_instance", new_callable=AsyncMock)
+async def test_provision_cloudrift_public_ip_setting(mock_create, tmp_path):
+    """with_public_ip in providers_config is forwarded to create_instance."""
+    key_file = tmp_path / "id_ed25519"
+    key_file.write_text("private-key")
+    pub_file = tmp_path / "id_ed25519.pub"
+    pub_file.write_text("ssh-ed25519 AAAA test@host\n")
+    mock_create.return_value = VMConnectionInfo(host="1.2.3.4", username="user", ssh_port=22222)
+
+    providers_config = {"cloudrift": {"with_public_ip": False}}
+    conn = await _provision_cloudrift(_cr_cand(), str(key_file), providers_config, False, logging.getLogger())
+
+    assert conn is not None
+    assert mock_create.call_args.kwargs["with_public_ip"] is False
+
+
 # ── read_public_key_files (extra authorized keys) ────────────────
 
 

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -3,7 +3,7 @@
 Response fixtures are captured from real CloudRift API calls.
 """
 
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -31,6 +31,7 @@ from emmy.provisioning.cloudrift import (
     resolve_team_id,
     select_image_url,
     terminate_instances_by_tags,
+    validate_team_id_access,
     wait_for_status,
 )
 from emmy.provisioning.errors import CapacityExhausted, TerminalProvisionError
@@ -203,47 +204,26 @@ async def test_resolve_team_id_rejects_missing_team(mock_api):
 
 
 @patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
-async def test_resolve_team_id_accepts_authenticated_implicit_team_key(mock_api):
-    request = httpx.Request("POST", f"{API_URL}/api/v1/teams/list")
-    unauthorized = httpx.HTTPStatusError(
-        "team keys cannot list teams",
-        request=request,
-        response=httpx.Response(401, request=request),
-    )
-    mock_api.side_effect = [unauthorized, {"balance": 100.0}]
+async def test_validate_team_id_access_uses_team_scoped_account_request(mock_api):
+    team_id = "f7b1d7c4-4b3b-4b3b-8b3b-4b3b4b3b4b3b"
+    mock_api.return_value = {"balance": 100.0}
 
-    result = await resolve_team_id(API_KEY, "Robots", API_URL, allow_implicit_team_key=True)
+    result = await validate_team_id_access(API_KEY, team_id, API_URL)
 
-    assert result is None
-    assert mock_api.await_args_list == [
-        call(
-            "POST",
-            "/api/v1/teams/list",
-            {"selector": "Mine", "with_members": False, "with_account_info": False},
-            API_KEY,
-            API_URL,
-        ),
-        call(
-            "POST",
-            "/api/v2/account/info",
-            {"selector": "ByToken", "with_auto_top_up": False},
-            API_KEY,
-            API_URL,
-        ),
-    ]
-
-
-@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
-async def test_resolve_team_id_keeps_implicit_team_key_opt_in(mock_api):
-    request = httpx.Request("POST", f"{API_URL}/api/v1/teams/list")
-    mock_api.side_effect = httpx.HTTPStatusError(
-        "unauthorized",
-        request=request,
-        response=httpx.Response(401, request=request),
+    assert result == team_id
+    mock_api.assert_awaited_once_with(
+        "POST",
+        "/api/v2/account/info",
+        {"selector": {"ByTeam": team_id}, "with_auto_top_up": False},
+        API_KEY,
+        API_URL,
     )
 
-    with pytest.raises(httpx.HTTPStatusError):
-        await resolve_team_id(API_KEY, "Robots", API_URL)
+
+@pytest.mark.parametrize("team_id", [None, "", "Robots", "not-a-uuid"])
+async def test_validate_team_id_access_rejects_missing_or_invalid_uuid(team_id):
+    with pytest.raises(TerminalProvisionError, match="team ID must be a UUID"):
+        await validate_team_id_access(API_KEY, team_id, API_URL)
 
 
 @patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
@@ -352,6 +332,22 @@ async def test_rent_instance_payload_includes_team(mock_api):
     )
 
     assert mock_api.await_args.args[2]["team_id"] == "team-robots"
+
+
+@patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
+async def test_rent_instance_can_disable_public_ip(mock_api):
+    mock_api.return_value = RENT_RESPONSE
+
+    await _rent_instance(
+        API_KEY,
+        "rtx49-7c-kn.1",
+        ["ssh-ed25519 AAAA user@host"],
+        DEFAULT_IMAGE_URL_NVIDIA,
+        api_url=API_URL,
+        with_public_ip=False,
+    )
+
+    assert mock_api.await_args.args[2]["with_public_ip"] is False
 
 
 @patch("emmy.provisioning.cloudrift._api_request", new_callable=AsyncMock)
@@ -524,6 +520,14 @@ async def test_create_instance_tags_default_to_emmy(mock_wait, mock_rent, tmp_pa
     await _tagged_create(tmp_path, mock_rent, mock_wait)
 
     assert mock_rent.call_args.kwargs["tags"] == ["emmy"]
+
+
+@patch("emmy.provisioning.cloudrift._rent_instance", new_callable=AsyncMock)
+@patch("emmy.provisioning.cloudrift.wait_for_status", new_callable=AsyncMock)
+async def test_create_instance_forwards_public_ip_choice(mock_wait, mock_rent, tmp_path):
+    await _tagged_create(tmp_path, mock_rent, mock_wait, with_public_ip=False)
+
+    assert mock_rent.call_args.kwargs["with_public_ip"] is False
 
 
 @patch("emmy.provisioning.cloudrift._rent_instance", new_callable=AsyncMock)

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -25,6 +25,7 @@ from emmy.provisioning.cloudrift import (
     _rent_instance,
     _terminate_instance,
     create_instance,
+    instance_is_active,
     list_available_instance_types,
     list_instances_by_tags,
     resolve_node_id,
@@ -285,6 +286,30 @@ async def test_terminate_instances_by_tags_fails_when_audit_stays_active(mock_ap
 
     assert mock_sleep.await_count == 2
     mock_api.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("Active", True),
+        ("Initializing", True),
+        ("Deactivating", False),
+        ("Inactive", False),
+        ("Terminated", False),
+    ],
+)
+@patch("emmy.provisioning.cloudrift._get_instance_info", new_callable=AsyncMock)
+async def test_instance_is_active_accepts_scheduled_cleanup(mock_get, status, expected):
+    mock_get.return_value = {"id": "inst-1", "status": status}
+
+    assert await instance_is_active(API_KEY, "inst-1", API_URL) is expected
+
+
+@patch("emmy.provisioning.cloudrift._get_instance_info", new_callable=AsyncMock)
+async def test_instance_is_active_returns_false_when_instance_is_absent(mock_get):
+    mock_get.return_value = None
+
+    assert not await instance_is_active(API_KEY, "inst-1", API_URL)
 
 
 # ── _rent_instance ────────────────────────────────────────────────

--- a/tests/provisioning/test_cloudrift.py
+++ b/tests/provisioning/test_cloudrift.py
@@ -259,7 +259,6 @@ async def test_terminate_instances_by_tags_terminates_every_active_match(mock_ap
             {"id": "inst-old", "status": "Terminated"},
         ],
         [{"id": "inst-1", "status": "Deactivating"}],
-        [{"id": "inst-1", "status": "Terminated"}, {"id": "inst-2", "status": "Inactive"}],
     ]
 
     result = await terminate_instances_by_tags(API_KEY, ["emmy", "gh-job:7"], API_URL, audit_delay=0)
@@ -272,7 +271,7 @@ async def test_terminate_instances_by_tags_terminates_every_active_match(mock_ap
         API_KEY,
         API_URL,
     )
-    mock_sleep.assert_awaited_once_with(0)
+    mock_sleep.assert_not_awaited()
 
 
 @patch("emmy.provisioning.cloudrift.asyncio.sleep", new_callable=AsyncMock)


### PR DESCRIPTION
## Summary
- require an exact `CLOUDRIFT_TEAM_ID` repository variable and validate the API key against that team before checking capacity
- include the validated team UUID on every rental and request a public IP so the GitHub `agents` runner can reach the VM over SSH
- send tag-scoped termination first during unconditional cleanup and accept CloudRift `Deactivating` as an acknowledged teardown state
- remove the unsafe inference that a `/teams/list` 401 implies a team-scoped key

## E2E findings
- run `31926757970` rented `super-bone-8897` under the user account because the configured key was user-scoped; that VM was cleaned up manually
- run `31929692972` proved explicit Robots ownership and the three-attempt path; its private-only retry could not become SSH-ready from the GitHub runner, so the workflow now requests a public IP
- cancellation issued tag-based termination successfully; CloudRift remained `Deactivating` beyond the audit window, so cleanup now treats that provider-acknowledged state as scheduled teardown

## Validation
- `make lint`
- actionlint 1.7.7 (custom `agents` runner label ignored) on the preceding workflow revision; the latest workflow change is a scalar `false` to `true`
- `pytest -q tests/provisioning/test_cloudrift.py tests/provisioning/test_cloud.py` (102 passed)
- `pytest -q tests/github/test_discovery_lifecycle.py` (35 passed)
- full `pytest -q` on the preceding revision (3140 passed, 652 skipped, 1 xfailed, 1 xpassed)

## Required configuration
`CLOUDRIFT_TEAM_ID` must be the exact Robots team UUID. The workflow fails before rental if it is absent, malformed, or inaccessible to `CLOUDRIFT_API_KEY`.