### PR TITLE
Fix PyPI build dependency bootstrap

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -9,7 +9,7 @@ tracked skills and CloudRift inference endpoint.
 
 | Workflow | Trigger | Runner | Result |
 | --- | --- | --- | --- |
-| **Tests** | Pull request to `main` | GitHub-hosted | Runs Ruff and the complete test suite. |
+| **Tests** | Pull request to `main` | GitHub-hosted | Runs Ruff, the complete test suite, and a PyPI package dry run. |
 | **Publish to PyPI** | Manual dispatch or published GitHub release | GitHub-hosted | Tests, builds, publishes to PyPI, and optionally creates the release. |
 | **Verify or onboard model** | Nightly schedule or manual dispatch | Self-hosted `agents` | Qualifies one available exact model/GPU deployment and updates the rolling lifecycle PR. |
 | **Discover model** | Nightly schedule or manual dispatch | Self-hosted `agents` | Refreshes recipe lifecycle tags and onboarding shells in one rolling PR without renting a VM. |
@@ -21,8 +21,9 @@ from a developer checkout through the tracked `.agents/skills/run-experiment` sk
 
 **Tests** installs the CI dependency set on Python 3.13. Its lint job runs Ruff check and format verification; its test
 job runs `make test`, including `tests/github/` coverage for helpers under `.github/scripts/`. Hugging Face downloads
-used by tests are cached because anonymous shared-runner traffic is rate-limited. This workflow has no write
-permission and does not use deployment credentials.
+used by tests are cached because anonymous shared-runner traffic is rate-limited. A separate bare-Python job runs
+`make pypi-dist`, the exact non-publishing build path used by the release workflow, and requires one wheel and one
+source distribution. This workflow has no write permission and does not use deployment credentials.
 
 ## Package publication
 
@@ -33,11 +34,12 @@ permission and does not use deployment credentials.
 - A manually published GitHub release must already have a tag matching `pyproject.toml`; the workflow validates and
   publishes that version without creating another release.
 
-Both paths run lint and tests before building. `scripts/prepare_dist.py` stages bundled recipes and rewrites
-repository-relative README links for PyPI. The build artifact moves between jobs through GitHub artifacts. PyPI uses
-trusted publishing through the `pypi` environment and an OIDC token, so the repository stores no PyPI password. The
-manual path creates its GitHub release only after a successful upload, preventing a failed publication from leaving a
-release behind.
+Both paths run lint and tests before building. `make pypi-dist` first installs its minimal build dependencies, then
+uses `scripts/prepare_dist.py` to stage bundled recipes and rewrite repository-relative README links for PyPI before
+building the wheel and source distribution. The build artifact moves between jobs through GitHub artifacts. PyPI
+uses trusted publishing through the `pypi` environment and an OIDC token, so the repository stores no PyPI password.
+The manual path creates its GitHub release only after a successful upload, preventing a failed publication from
+leaving a release behind.
 
 ## Model discovery and onboarding
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,14 +76,10 @@ jobs:
           fi
           echo "version=$PKG_VERSION" >> "$GITHUB_OUTPUT"
 
-      # Bundle the recipes into the package, and point the README's repo-relative
-      # links at GitHub — PyPI renders the README detached from the repo.
-      - name: Stage the source tree for distribution
-        run: python scripts/prepare_dist.py --recipes --readme
-
-      - run: pip install build
-
-      - run: python -m build
+      # Installs the minimal build dependencies before staging. Pull-request CI
+      # dry-runs this exact target so the publishing path cannot drift untested.
+      - name: Build the PyPI distribution
+        run: make pypi-dist
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,3 +49,21 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  package:
+    name: PyPI package dry run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Build with the release path without publishing
+        run: make pypi-dist
+
+      - name: Verify both distribution artifacts exist
+        run: |
+          test "$(find dist -maxdepth 1 -name '*.whl' | wc -l)" -eq 1
+          test "$(find dist -maxdepth 1 -name '*.tar.gz' | wc -l)" -eq 1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-agent clean bench bench-force bench-kernels bench-kernels-tune test-compose test-durations lint format git-sha-guard \
+.PHONY: help setup setup-agent clean bench bench-force bench-kernels bench-kernels-tune test-compose test-durations lint format git-sha-guard pypi-dist \
 	serve-models serve-config serve-config-guard serve-goldens serve-warm serve-image serve-verify serve-push
 
 help:
@@ -13,6 +13,7 @@ help:
 	@echo "  bench-force    - Run benchmarks in parallel (force re-run, skip cached results)"
 	@echo "  bench-kernels  - Run per-kernel perf comparison vs PyTorch (tests/perf/, requires CUDA)"
 	@echo "  wheel          - Build the emmy wheel into dist/"
+	@echo "  pypi-dist      - Dry-run the exact PyPI sdist + wheel build into dist/"
 	@echo "  vllm-emmy-image - Build the vLLM + emmy serving image (docker/vllm-emmy)"
 	@echo "  vllm-emmy-push  - Push the serving image to Docker Hub (cloudriftai/)"
 	@echo "  serve-goldens / serve-warm / serve-image / serve-verify  MODEL=<hf-id>"
@@ -105,6 +106,15 @@ wheel: setup
 	./venv/bin/pip install --quiet build
 	./venv/bin/python scripts/prepare_dist.py --recipes
 	rm -rf dist build && ./venv/bin/python -m build --wheel -o dist/ .
+
+# The release runner starts with a bare Python. Keep its complete build contract in one
+# target so pull-request CI can exercise the exact same dependency install and staging path.
+EMMY_PYPI_PYTHON ?= python3
+pypi-dist:
+	$(EMMY_PYPI_PYTHON) -m pip install --disable-pip-version-check build PyYAML
+	$(EMMY_PYPI_PYTHON) scripts/prepare_dist.py --recipes --readme
+	rm -rf dist build
+	$(EMMY_PYPI_PYTHON) -m build
 
 # Image tags embed the short sha; an empty rev-parse (e.g. root over a synced tree without
 # git safe.directory) would silently tag "...:0.23.0-" — fail loudly instead.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ make test      # run pytest
 make lint      # ruff check + format check
 make format    # auto-fix
 make wheel     # build the wheel into dist/
+make pypi-dist # dry-run the exact PyPI sdist + wheel build into dist/
 ```
 
 ### Release
@@ -326,6 +327,9 @@ Bump `version` in `pyproject.toml` on `main`, then run the **Publish to PyPI** w
 there, and refuses to run if that version is already tagged. It lints, tests, builds, uploads to PyPI via trusted
 publishing, and only then creates the tag and GitHub release, so a failed upload leaves nothing behind. Publishing
 a GitHub release by hand works too; the tag must agree with `pyproject.toml`.
+
+Pull requests run `make pypi-dist` in a bare Python 3.13 job. The same target installs the minimal release-build
+dependencies, stages the distribution tree, and builds both artifacts used by the publishing workflow.
 
 `scripts/prepare_dist.py` stages the tree for a distribution build: `--recipes` copies `recipes/*/recipe.yaml` into
 the package (`make wheel` runs this), and `--readme` rewrites this file's repo-relative links to absolute GitHub


### PR DESCRIPTION
## Summary

- install the release builder and PyYAML before distribution staging
- centralize the non-publishing release build in `make pypi-dist`
- use that exact target from the PyPI publisher
- add a bare-Python 3.13 package dry-run job to pull-request CI
- require the dry run to produce exactly one wheel and one source distribution

## Root cause

[Publish run 31927479935](https://github.com/cloudrift-ai/emmy/actions/runs/31927479935/job/95118086628) invoked `scripts/prepare_dist.py` in a fresh Python environment before installing PyYAML, so the build stopped at `import yaml`. The old workflow installed `build` only after the failing staging step.

## Testing

- `make lint`
- `make test` — 3,142 passed, 652 skipped, 1 xfailed, 1 xpassed
- `pytest tests/scripts/test_prepare_dist.py -q` — 7 passed
- fresh temporary Python environment with only `build` and `PyYAML`: staged 26 recipes and built `emmy_ml-0.3.3-py3-none-any.whl`
- parsed both modified workflow files as YAML
