### PR TITLE
Re-record RTX 5090 gemma-4-12b-it goldens as the serving-twin matrix

### DIFF
--- a/docs/docs/tutorials/07-golden-configurations.md
+++ b/docs/docs/tutorials/07-golden-configurations.md
@@ -108,8 +108,9 @@ own process, is reported as a failure, and the remaining rows continue.
 ## Recording rules worth knowing
 
 - **A recorded cut and a tile choice cannot go in the same entry.** A cut is decided before schedules are chosen, so
-  one entry records either the placement pin or a schedule row, never both. Here is a real cut entry, recorded for
-  the same shape as the fused one above:
+  one entry records either the placement pin or a schedule row, never both. Here is a cut entry recorded for the
+  same shape as the fused example above (the standalone inventory it comes from predates the current serving-twin
+  gemma-4 file, which carries no cut routings):
 
   ```yaml
   - name: gemma4_12b.norm_q_proj.m32.cut
@@ -163,7 +164,7 @@ Read a real file — they are plain YAML, and the comments in them are the recor
 
 ```bash
 find recipes -path '*/golden/*.yaml' -print
-grep -n -A9 "name: gemma4_12b.norm" recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml | head -30
+grep -n -A9 "name: post-sym.k_linear_mean_reduce" recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml | head -30
 ```
 
 Then run the file-scoped validation on the GPU named by the serving config. It needs model configuration and

--- a/recipes/gemma-4-12B-it/RESULTS.md
+++ b/recipes/gemma-4-12B-it/RESULTS.md
@@ -41,9 +41,11 @@ Hybrid accumulation held relative L2 error near `3.3e-4` across the measured K r
 `0.695 ± 0.033` exact match on the 200-question GSM8K check, with no measured quality regression. The deployed
 inventory had 226 of 276 measured realizations at or above eager performance and a 1.30× geometric-mean ratio.
 
-The current [RTX 5090 Gemma 4 golden](golden/rtx5090_sm120.yaml) contains
-281 self-contained programs. Representative selected FAST_MATH projection times at sequence length 512 were 61.5 µs
-for Q, 36.4 µs for KV, 64.1 µs for output, 362.4 µs for gate/up, and 214.2 µs for down projection.
+The [RTX 5090 Gemma 4 golden](golden/rtx5090_sm120.yaml) has since been re-recorded as the serving-twin
+realization matrix (2026-08-23; 22 self-contained twin programs, 352 verified realizations). The measurements below
+were taken against the 281-program standalone-target inventory current at publication: representative selected
+FAST_MATH projection times at sequence length 512 were 61.5 µs for Q, 36.4 µs for KV, 64.1 µs for output, 362.4 µs
+for gate/up, and 214.2 µs for down projection.
 
 ## Reproduce
 

--- a/recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml
+++ b/recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml
@@ -1,6999 +1,12034 @@
-gpu_name: NVIDIA GeForce RTX 5090
+# RTX 5090 gemma-4-12b-it serving goldens — full re-record of 2026-08-23 on a live 5090 (tuned,
+# O3-verified, and promoted at f7e236ca, the post-#554 recognition rebuild). Replaces the
+# pre-#482 standalone-target inventory whose mlp_down rows recorded atomic-finalize REDUCE
+# (g4a/g8a) realizable only on the retired #483 placement-cut pieces (the 4th orphaning; also
+# the 5090 first-request serving-hang class — cold-prior fallback picks 4-5 orders over the
+# roofline floor). Structure mirrors the #498 base-model rebuild: one config per serving-twin
+# program, every config carrying the full config-derived (bindings, pins) realization matrix
+# from docker/vllm-emmy-serve/models/gemma-4-12b-it.env. Every row's emmy_us is a deployable
+# -O3 whole-program measurement on the live card; reference_backend emmy-greedy is the greedy
+# deploy pick re-benched under the same inputs (twin IR has no runnable eager reference). Rows
+# whose tune winner did not beat that pick record the pick itself, so every row is realizable
+# without local tune evidence — the golden tier is cold-deploy truth.
 compute_cap:
 - 12
 - 0
-model: google/gemma-4-12B
 programs:
-- inputs: [x0, x1]
-  outputs: [matmul]
+- inputs:
+  - attn_out
+  - residual
+  outputs:
+  - mul_7
   nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 30720]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 30720]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
+  - id: add_2_c1
     op: constant
     attrs:
-      name: p_weight
-      value: null
+      name: add_2_c1
+      value: 1.0e-06
       context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [512, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [512, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [1, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [1, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [4096, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [4096, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [256, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [256, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [512, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [512, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [2048, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [2048, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [32, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [32, 512]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [256, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [256, 512]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [512, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [512, 512]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [4096, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [4096, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 30720]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [512, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [8192, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [8192, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 30720]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [16, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 30720]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [32, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [32, 15360]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 15360]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 262144]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [64, 262144]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 4096]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [2048, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 2048]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [512, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 512]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 15360]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [64, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [64, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [1024, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [1024, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [64, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [64, 512]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [1024, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [1024, 512]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 4096]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [64, 4096]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 8192]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [64, 8192]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 2048]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [64, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [256, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [256, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [256, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [256, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [256, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 4096]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 4096]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 2048]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 2048]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [2048, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 15360]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 512]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 512]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [512, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 512]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [4096, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [4096, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [4096, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [65536, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [65536, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [65536, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [65536, 512]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [16, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [16, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [16, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [16, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [w, x, nw]
-  outputs: [matmul]
-  nodes:
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 4096]]]
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[matmul, f16, [32, 4096]]]
-- inputs: [w, x, nw]
-  outputs: [matmul]
-  nodes:
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 2048]]]
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[matmul, f16, [32, 2048]]]
-- inputs: [w, x, nw]
-  outputs: [matmul]
-  nodes:
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 512]]]
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[matmul, f16, [32, 512]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [4096, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 4096]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [2048, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 2048]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [256, 15360]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 262144]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [32, 262144]]]
-- inputs: [sin, cos, q]
-  outputs: [add]
-  nodes:
-  - id: sin
-    op: input
-    outputs: [[sin, f16, [1, 1, 512, 256]]]
-  - id: cos
-    op: input
-    outputs: [[cos, f16, [1, 1, 512, 256]]]
-  - id: q
-    op: input
-    outputs: [[q, f16, [1, 16, 512, 256]]]
-  - id: slice_1_c1
-    op: constant
-    attrs:
-      name: slice_1_c1
-      value: 3.0
-      context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[slice_1_c1, f16, [1]]]
-  - id: slice_1_c2
-    op: constant
-    attrs:
-      name: slice_1_c2
-      value: 128.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[slice_1_c2, f16, [1]]]
-  - id: slice_1_c3
-    op: constant
-    attrs:
-      name: slice_1_c3
-      value: 9.223372036854776e+18
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[slice_1_c3, f16, [1]]]
-  - id: slice_2_c1
-    op: constant
-    attrs:
-      name: slice_2_c1
-      value: 3.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[slice_2_c1, f16, [1]]]
-  - id: slice_2_c2
-    op: constant
-    attrs:
-      name: slice_2_c2
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[slice_2_c2, f16, [1]]]
-  - id: slice_2_c3
-    op: constant
-    attrs:
-      name: slice_2_c3
-      value: 128.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[slice_2_c3, f16, [1]]]
-  - id: cat_c2
-    op: constant
-    attrs:
-      name: cat_c2
-      value: -1.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[cat_c2, f16, [1]]]
-  - id: sin_bc
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
     op: tensor.index_map
     attrs:
-      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 512}, {__dim__: 256}]}
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
       sources:
         __tuple__:
         - __index_source__:
             input_idx: 0
             coord_map:
-            - {var: out_coord_0}
-            - {literal: {value: 0, dtype: int}}
-            - {var: out_coord_2}
-            - {var: out_coord_3}
+            - var: out_coord_1
             select: null
-    inputs: [sin]
-    outputs: [[sin_bc, f16, [1, 16, 512, 256]]]
-  - id: cos_bc
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: add_3_c1_bc
     op: tensor.index_map
     attrs:
-      out_shape: {__tuple__: [{__dim__: 1}, {__dim__: 16}, {__dim__: 512}, {__dim__: 256}]}
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
       sources:
         __tuple__:
         - __index_source__:
             input_idx: 0
             coord_map:
-            - {var: out_coord_0}
-            - {literal: {value: 0, dtype: int}}
-            - {var: out_coord_2}
-            - {var: out_coord_3}
+            - var: out_coord_1
             select: null
-    inputs: [cos]
-    outputs: [[cos_bc, f16, [1, 16, 512, 256]]]
-  - id: slice_1
-    op: torch.slice
-    attrs: {shape: {__tuple__: [1, 16, 512, 128]}, dim: 3, start: 128}
-    inputs: [q, slice_1_c1, slice_1_c2, slice_1_c3]
-    outputs: [[slice_1, f16, [1, 16, 512, 128]]]
-  - id: slice_2
-    op: torch.slice
-    attrs: {shape: {__tuple__: [1, 16, 512, 128]}, dim: 3, start: 0}
-    inputs: [q, slice_2_c1, slice_2_c2, slice_2_c3]
-    outputs: [[slice_2, f16, [1, 16, 512, 128]]]
-  - id: mul
+    inputs:
+    - add_3_c1
+    outputs:
+    - - add_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: attn_out
+    op: input
+    outputs:
+    - - attn_out
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 4096
+  - id: b_layer_scalar
+    op: constant
+    attrs:
+      name: b_layer_scalar
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: layer_scalar
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - b_layer_scalar
+      - f16
+      - - 1
+  - id: b_layer_scalar_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - b_layer_scalar
+    outputs:
+    - - b_layer_scalar_bc
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 15360
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 3840
+        - 15360
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 15360
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 15360
+        - 3840
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 15360
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 15360
+        - 3840
+  - id: p_o_proj_weight
+    op: constant
+    attrs:
+      name: p_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 4096
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_o_proj_weight
+      - f16
+      - - 3840
+        - 4096
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - attn_out
+    - p_o_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 3840
+  - id: p_post_feedforward_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_feedforward_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_feedforward_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_feedforward_layernorm_weight
+      - f16
+      - - 3840
+  - id: p_pre_feedforward_layernorm_weight
+    op: constant
+    attrs:
+      name: p_pre_feedforward_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: pre_feedforward_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_pre_feedforward_layernorm_weight
+      - f16
+      - - 3840
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_5_c1
+    op: constant
+    attrs:
+      name: pow_5_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_5_c1
+      - f32
+      - - 1
+  - id: pow_5_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_5_c1
+    outputs:
+    - - pow_5_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_6_c1
+    op: constant
+    attrs:
+      name: pow_6_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_6_c1
+      - f32
+      - - 1
+  - id: pow_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_6_c1
+    outputs:
+    - - pow_6_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: residual
+    op: input
+    outputs:
+    - - residual
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - linear
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_1
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: multiply}}
-    inputs: [q, cos_bc]
-    outputs: [[mul, f16, [1, 16, 512, 256]]]
-  - id: neg
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: negative}}
-    inputs: [slice_1]
-    outputs: [[neg, f16, [1, 16, 512, 128]]]
-  - id: cat
-    op: torch.cat
-    inputs: [neg, slice_2, cat_c2]
-    outputs: [[cat, f16, [1, 16, 512, 256]]]
-  - id: mul_1
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: multiply}}
-    inputs: [cat, sin_bc]
-    outputs: [[mul_1, f16, [1, 16, 512, 256]]]
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
   - id: add
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: add}}
-    inputs: [mul, mul_1]
-    outputs: [[add, f16, [1, 16, 512, 256]]]
-- inputs: [w, ids]
-  outputs: [embedding]
-  nodes:
-  - id: w
-    op: input
-    outputs: [[w, f16, [262144, 3840]]]
-  - id: ids
-    op: input
-    outputs: [[ids, i64, [1, 512]]]
-  - id: embedding
-    op: tensor.gather
-    attrs: {axis: 0}
-    inputs: [w, ids]
-    outputs: [[embedding, f16, [1, 512, 3840]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [256, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [256, 1]]]
-  - id: sum_1
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2_bc
     op: tensor.index_map
     attrs:
-      out_shape: {__tuple__: [{__dim__: 256}]}
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
       sources:
         __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [256]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [256, 3840]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [32, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [32, 1]]]
-  - id: sum_1
-    op: tensor.index_map
-    attrs:
-      out_shape: {__tuple__: [{__dim__: 32}]}
-      sources:
-        __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [32]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [32, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [32, 3840]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [32, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [32, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [512, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [256, 512]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [256, 8192]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [32, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [32, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [256, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [256, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 16, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [{sym: seq_len, hint: 512}, 16, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [256]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [256]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 8, 256]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [{sym: seq_len, hint: 512}, 8, 256]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 16, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [{sym: seq_len, hint: 512}, 16, 512]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [{sym: seq_len, hint: 512}, 512]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 4096]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [32, 4096]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 4096]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [256, 4096]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 8192]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [32, 8192]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 8192]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [256, 8192]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 2048]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [32, 2048]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 2048]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [256, 2048]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [256, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [256, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 2048]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [{sym: seq_len, hint: 512}, 2048]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 4096]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [{sym: seq_len, hint: 512}, 4096]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 8192]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [{sym: seq_len, hint: 512}, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [{sym: seq_len, hint: 512}, 15360]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [{sym: seq_len, hint: 512}, 1]]]
-  - id: sum_1
-    op: tensor.index_map
-    attrs:
-      out_shape: {__tuple__: [{__dim__: {sym: seq_len, hint: 512}}]}
-      sources:
-        __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [{sym: seq_len, hint: 512}]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [{sym: seq_len, hint: 512}, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [256, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [256, 3840]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [{sym: seq_len, hint: 512}, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [256, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [256, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [256, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [256, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [256, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [256, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [256, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [256, 3840]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 8704]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [32, 8704]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 8704]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [256, 8704]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [{sym: seq_len, hint: 512}, 8704]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [{sym: seq_len, hint: 512}, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [32, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [32, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [32, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [32, 30720]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [32, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [256, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [256, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [64, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [64, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [4096, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [4096, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [{sym: seq_len, hint: 512}, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [{sym: seq_len, hint: 512}, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [256, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [256, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [256, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 30720]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [1, 30720]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [1, 8192]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8704]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [1, 8704]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [1, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [1, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [1, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [8, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [262144, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [8, 262144]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [8, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [8, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [512]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [512]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [8, 512]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [8, 512]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 2048]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [8, 2048]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 4096]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [8, 4096]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 8192]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [8, 8192]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 8704]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [8, 8704]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [8, 15360]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [8, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [8, 1]]]
-  - id: sum_1
-    op: tensor.index_map
-    attrs:
-      out_shape: {__tuple__: [{__dim__: 8}]}
-      sources:
-        __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [8]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [8, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [8, 3840]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [8, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f32, [8, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [15360, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [2048, 3840]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [2048, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8704]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 8704]]]
-- inputs: [x0, x1]
-  outputs: [matmul]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [2048, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[matmul, f16, [2048, 15360]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [2048, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [2048, 1]]]
-  - id: sum_1
-    op: tensor.index_map
-    attrs:
-      out_shape: {__tuple__: [{__dim__: 2048}]}
-      sources:
-        __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [2048]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [2048, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [2048, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [192, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [192, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [192, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [192, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [192, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [192, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [192, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [192, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [192, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [192, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [192, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [192, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [192, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [192, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [192, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [192, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [192, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [192, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [192, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [192, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [192, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [8, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [8, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [64, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [64, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [2048, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [2048, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [2048, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [4096, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [4096, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [4096, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [8, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [8, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [8, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [8, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [8, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [8, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [8, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [64, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [64, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [64, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [64, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [2048, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [2048, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [2048, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [2048, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [2048, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [2048, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [2048, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [2048, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [2048, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [4096, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [4096, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [4096, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [4096, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [4096, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [4096, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [4096, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [4096, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [4096, 30720]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [64, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [64, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [192, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [192, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [2048, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [2048, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [4096, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [4096, 15360]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [512, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [512, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [512, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [512, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [512, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [512, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [512, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [512, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [512, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [512, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [512, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [512, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [512, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [512, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [512, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [512, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [512, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [512, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [512, 3840]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [512, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [512, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [512, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [512, 3840]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [512, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [512, 1]]]
-  - id: sum_1
-    op: tensor.index_map
-    attrs:
-      out_shape: {__tuple__: [{__dim__: 512}]}
-      sources:
-        __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [512]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1024, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8192, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [1024, 8192]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1024, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [8704, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [1024, 8704]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1024, 3840]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [30720, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [1024, 30720]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1024, 15360]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [1024, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1024, 4096]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 4096]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [1024, 3840]]]
-- inputs: [x0, x1]
-  outputs: [linear]
-  nodes:
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1024, 8192]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [3840, 8192]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [x0, x1]
-    outputs: [[linear, f16, [1024, 3840]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1024, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1024, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1024, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1024, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8704, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1024, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1024, 8704]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1024, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1024, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1024, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1024, 15360]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [15360]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [1024, 15360]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [1024, 3840]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1024, 15360]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [1024, 15360]]]
-- inputs: [x]
-  outputs: [relu]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [1024, 3840]]]
-  - id: relu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: relu}}
-    inputs: [x]
-    outputs: [[relu, f16, [1024, 3840]]]
-- inputs: [x]
-  outputs: [sum_1]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f32, [1024, 3840]]]
-  - id: sum_1_keepdim
-    op: tensor.reduce
-    attrs: {op: {__elementwise__: sum}, axis: -1}
-    inputs: [x]
-    outputs: [[sum_1_keepdim, f32, [1024, 1]]]
-  - id: sum_1
-    op: tensor.index_map
-    attrs:
-      out_shape: {__tuple__: [{__dim__: 1024}]}
-      sources:
-        __tuple__:
-        - __index_source__: {input_idx: 0, coord_map: [{var: out_coord_0}, {literal: {value: 0, dtype: int}}], select: null}
-    inputs: [sum_1_keepdim]
-    outputs: [[sum_1, f32, [1024]]]
-- inputs: [x]
-  outputs: [rms_norm]
-  nodes:
-  - id: p_weight
-    op: constant
-    attrs:
-      name: p_weight
-      value: null
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: weight
-      source_parts: {__tuple__: []}
-      source_shape: {__tuple__: [3840]}
-      source_dtype: float32
-      source_graph: null
-    outputs: [[p_weight, f32, [3840]]]
-  - id: x
-    op: input
-    outputs: [[x, f32, [1024, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, p_weight]
-    outputs: [[rms_norm, f32, [1024, 3840]]]
-- inputs: [w, x, nw]
-  outputs: [matmul]
-  nodes:
-  - id: w
-    op: input
-    outputs: [[w, f16, [3840, 8192]]]
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[matmul, f16, [32, 8192]]]
-- inputs: [x, nw, wg, wu]
-  outputs: [mul]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: wg
-    op: input
-    outputs: [[wg, f16, [3840, 15360]]]
-  - id: wu
-    op: input
-    outputs: [[wu, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wg]
-    outputs: [[matmul, f16, [32, 15360]]]
-  - id: matmul_1
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wu]
-    outputs: [[matmul_1, f16, [32, 15360]]]
-  - id: gelu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: gelu_tanh}}
-    inputs: [matmul]
-    outputs: [[gelu, f16, [32, 15360]]]
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2
+    outputs:
+    - - pow_2_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
   - id: mul
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: multiply}}
-    inputs: [gelu, matmul_1]
-    outputs: [[mul, f16, [32, 15360]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [8192, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 8192]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [512, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 512]]]
-- inputs: [x, nw, wg, wu]
-  outputs: [mul]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: wg
-    op: input
-    outputs: [[wg, f16, [15360, 3840]]]
-  - id: wu
-    op: input
-    outputs: [[wu, f16, [15360, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
-  - id: linear
-    op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wg]
-    outputs: [[linear, f16, [32, 15360]]]
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - pow_2_bc
+    outputs:
+    - - mul
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - to_1
+      - f32
+      - - 3840
+  - id: to_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_1
+    outputs:
+    - - to_1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul
+    - to_1_bc
+    outputs:
+    - - mul_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_pre_feedforward_layernorm_weight
+    outputs:
+    - - to_3
+      - f32
+      - - 3840
+  - id: to_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_3
+    outputs:
+    - - to_3_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_post_feedforward_layernorm_weight
+    outputs:
+    - - to_5
+      - f32
+      - - 3840
+  - id: to_5_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_5
+    outputs:
+    - - to_5_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: type_as
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_1
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - residual
+    - type_as
+    outputs:
+    - - add_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_1
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_2
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_4_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4
+    outputs:
+    - - pow_4_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - pow_4_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_2
+    - to_3_bc
+    outputs:
+    - - mul_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: type_as_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_3
+    outputs:
+    - - type_as_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
   - id: linear_1
     op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wu]
-    outputs: [[linear_1, f16, [32, 15360]]]
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as_1
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
   - id: gelu
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: gelu_tanh}}
-    inputs: [linear]
-    outputs: [[gelu, f16, [32, 15360]]]
-  - id: mul
+    attrs:
+      op:
+        __elementwise__: gelu_tanh
+    inputs:
+    - linear_1
+    outputs:
+    - - gelu
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as_1
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: mul_4
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: multiply}}
-    inputs: [gelu, linear_1]
-    outputs: [[mul, f16, [32, 15360]]]
-- inputs: [x, nw, wg, wu]
-  outputs: [mul]
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - gelu
+    - linear_2
+    outputs:
+    - - mul_4
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_4
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - linear_3
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_5_c1_bc
+    outputs:
+    - - pow_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_5
+    outputs:
+    - - mean_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_3_c1_bc
+    outputs:
+    - - add_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_3
+    - pow_6_c1_bc
+    outputs:
+    - - pow_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_6_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_6
+    outputs:
+    - - pow_6_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - pow_6_bc
+    outputs:
+    - - mul_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_5
+    - to_5_bc
+    outputs:
+    - - mul_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: type_as_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_6
+    outputs:
+    - - type_as_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_1
+    - type_as_2
+    outputs:
+    - - add_4
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - add_4
+    - b_layer_scalar_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - attn_out
+  - residual
+  outputs:
+  - mul_7
   nodes:
-  - id: x
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: add_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_3_c1
+    outputs:
+    - - add_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: attn_out
     op: input
-    outputs: [[x, f16, [4096, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: wg
-    op: input
-    outputs: [[wg, f16, [3840, 15360]]]
-  - id: wu
-    op: input
-    outputs: [[wu, f16, [3840, 15360]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [4096, 3840]]]
-  - id: matmul
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wg]
-    outputs: [[matmul, f16, [4096, 15360]]]
-  - id: matmul_1
-    op: torch.matmul
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wu]
-    outputs: [[matmul_1, f16, [4096, 15360]]]
-  - id: gelu
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: gelu_tanh}}
-    inputs: [matmul]
-    outputs: [[gelu, f16, [4096, 15360]]]
-  - id: mul
-    op: tensor.elementwise
-    attrs: {op: {__elementwise__: multiply}}
-    inputs: [gelu, matmul_1]
-    outputs: [[mul, f16, [4096, 15360]]]
-- inputs: [x, nw, wg, wu]
-  outputs: [mul]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [4096, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: wg
-    op: input
-    outputs: [[wg, f16, [15360, 3840]]]
-  - id: wu
-    op: input
-    outputs: [[wu, f16, [15360, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [4096, 3840]]]
+    outputs:
+    - - attn_out
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8192
+  - id: b_layer_scalar
+    op: constant
+    attrs:
+      name: b_layer_scalar
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: layer_scalar
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - b_layer_scalar
+      - f16
+      - - 1
+  - id: b_layer_scalar_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - b_layer_scalar
+    outputs:
+    - - b_layer_scalar_bc
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 15360
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 3840
+        - 15360
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 15360
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 15360
+        - 3840
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 15360
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 15360
+        - 3840
+  - id: p_o_proj_weight
+    op: constant
+    attrs:
+      name: p_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 8192
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_o_proj_weight
+      - f16
+      - - 3840
+        - 8192
   - id: linear
     op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wg]
-    outputs: [[linear, f16, [4096, 15360]]]
+    attrs:
+      has_bias: false
+    inputs:
+    - attn_out
+    - p_o_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 3840
+  - id: p_post_feedforward_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_feedforward_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_feedforward_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_feedforward_layernorm_weight
+      - f16
+      - - 3840
+  - id: p_pre_feedforward_layernorm_weight
+    op: constant
+    attrs:
+      name: p_pre_feedforward_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: pre_feedforward_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_pre_feedforward_layernorm_weight
+      - f16
+      - - 3840
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_5_c1
+    op: constant
+    attrs:
+      name: pow_5_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_5_c1
+      - f32
+      - - 1
+  - id: pow_5_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_5_c1
+    outputs:
+    - - pow_5_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_6_c1
+    op: constant
+    attrs:
+      name: pow_6_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_6_c1
+      - f32
+      - - 1
+  - id: pow_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_6_c1
+    outputs:
+    - - pow_6_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: residual
+    op: input
+    outputs:
+    - - residual
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - linear
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2
+    outputs:
+    - - pow_2_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - pow_2_bc
+    outputs:
+    - - mul
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - to_1
+      - f32
+      - - 3840
+  - id: to_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_1
+    outputs:
+    - - to_1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul
+    - to_1_bc
+    outputs:
+    - - mul_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_pre_feedforward_layernorm_weight
+    outputs:
+    - - to_3
+      - f32
+      - - 3840
+  - id: to_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_3
+    outputs:
+    - - to_3_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_post_feedforward_layernorm_weight
+    outputs:
+    - - to_5
+      - f32
+      - - 3840
+  - id: to_5_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_5
+    outputs:
+    - - to_5_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: type_as
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_1
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - residual
+    - type_as
+    outputs:
+    - - add_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_1
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_2
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_4_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4
+    outputs:
+    - - pow_4_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - pow_4_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_2
+    - to_3_bc
+    outputs:
+    - - mul_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: type_as_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_3
+    outputs:
+    - - type_as_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
   - id: linear_1
     op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, wu]
-    outputs: [[linear_1, f16, [4096, 15360]]]
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as_1
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
   - id: gelu
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: gelu_tanh}}
-    inputs: [linear]
-    outputs: [[gelu, f16, [4096, 15360]]]
+    attrs:
+      op:
+        __elementwise__: gelu_tanh
+    inputs:
+    - linear_1
+    outputs:
+    - - gelu
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as_1
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - gelu
+    - linear_2
+    outputs:
+    - - mul_4
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_4
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - linear_3
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_5_c1_bc
+    outputs:
+    - - pow_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_5
+    outputs:
+    - - mean_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_3_c1_bc
+    outputs:
+    - - add_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_3
+    - pow_6_c1_bc
+    outputs:
+    - - pow_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_6_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_6
+    outputs:
+    - - pow_6_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - pow_6_bc
+    outputs:
+    - - mul_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_5
+    - to_5_bc
+    outputs:
+    - - mul_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: type_as_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_6
+    outputs:
+    - - type_as_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_1
+    - type_as_2
+    outputs:
+    - - add_4
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - add_4
+    - b_layer_scalar_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - hidden
+  outputs:
+  - reshape
+  - reshape_1
+  - reshape_2
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: add_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_3_c1
+    outputs:
+    - - add_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: hidden
+    op: input
+    outputs:
+    - - hidden
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 3840
+  - id: p_k_norm_weight
+    op: constant
+    attrs:
+      name: p_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 256
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_k_norm_weight
+      - f16
+      - - 256
+  - id: p_k_proj_weight
+    op: constant
+    attrs:
+      name: p_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_k_proj_weight
+      - f16
+      - - 2048
+        - 3840
+  - id: p_q_norm_weight
+    op: constant
+    attrs:
+      name: p_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 256
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_q_norm_weight
+      - f16
+      - - 256
+  - id: p_q_proj_weight
+    op: constant
+    attrs:
+      name: p_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 4096
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_q_proj_weight
+      - f16
+      - - 4096
+        - 3840
+  - id: p_v_proj_weight
+    op: constant
+    attrs:
+      name: p_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_v_proj_weight
+      - f16
+      - - 2048
+        - 3840
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: pow_5_c1
+    op: constant
+    attrs:
+      name: pow_5_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_5_c1
+      - f32
+      - - 1
+  - id: pow_5_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_5_c1
+    outputs:
+    - - pow_5_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: pow_6_c1
+    op: constant
+    attrs:
+      name: pow_6_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_6_c1
+      - f32
+      - - 1
+  - id: pow_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - pow_6_c1
+    outputs:
+    - - pow_6_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: pow_7_c1
+    op: constant
+    attrs:
+      name: pow_7_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_7_c1
+      - f32
+      - - 1
+  - id: pow_7_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_7_c1
+    outputs:
+    - - pow_7_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: pow_8_c1
+    op: constant
+    attrs:
+      name: pow_8_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_8_c1
+      - f32
+      - - 1
+  - id: pow_8_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - pow_8_c1
+    outputs:
+    - - pow_8_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - hidden
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2
+    outputs:
+    - - pow_2_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
   - id: mul
     op: tensor.elementwise
-    attrs: {op: {__elementwise__: multiply}}
-    inputs: [gelu, linear_1]
-    outputs: [[mul, f16, [4096, 15360]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
-  nodes:
-  - id: x
-    op: input
-    outputs: [[x, f16, [32, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [32, 3840]]]
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - pow_2_bc
+    outputs:
+    - - mul
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - to_1
+      - f32
+      - - 3840
+  - id: to_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_1
+    outputs:
+    - - to_1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul
+    - to_1_bc
+    outputs:
+    - - mul_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_q_norm_weight
+    outputs:
+    - - to_3
+      - f32
+      - - 256
+  - id: to_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - to_3
+    outputs:
+    - - to_3_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_k_norm_weight
+    outputs:
+    - - to_5
+      - f32
+      - - 256
+  - id: to_5_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - to_5
+    outputs:
+    - - to_5_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: type_as
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_1
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
   - id: linear
     op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [32, 30720]]]
-- inputs: [x, nw, w]
-  outputs: [linear]
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as
+    - p_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 4096
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as
+    - p_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 2048
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as
+    - p_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 2048
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 16
+        - 256
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_1
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: pow_4_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4
+    outputs:
+    - - pow_4_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - pow_4_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_2
+    - to_3_bc
+    outputs:
+    - - mul_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: type_as_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_3
+    outputs:
+    - - type_as_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 4096
+    inputs:
+    - type_as_1
+    outputs:
+    - - reshape
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 4096
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 8
+        - 256
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: pow_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_5_c1_bc
+    outputs:
+    - - pow_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_5
+    outputs:
+    - - mean_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: pow_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_2
+    - pow_6_c1_bc
+    outputs:
+    - - pow_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: pow_6_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_6
+    outputs:
+    - - pow_6_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - pow_6_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_4
+    - to_5_bc
+    outputs:
+    - - mul_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: type_as_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_5
+    outputs:
+    - - type_as_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: reshape_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 2048
+    inputs:
+    - type_as_2
+    outputs:
+    - - reshape_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 2048
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 8
+        - 256
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - view_2
+    outputs:
+    - - to_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: pow_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_7_c1_bc
+    outputs:
+    - - pow_7
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_7
+    outputs:
+    - - mean_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_3_c1_bc
+    outputs:
+    - - add_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: pow_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_3
+    - pow_8_c1_bc
+    outputs:
+    - - pow_8
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: pow_8_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_8
+    outputs:
+    - - pow_8_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - pow_8_bc
+    outputs:
+    - - mul_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: type_as_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 8
+        - __dim__: 256
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_6
+    outputs:
+    - - type_as_3
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: reshape_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 2048
+    inputs:
+    - type_as_3
+    outputs:
+    - - reshape_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 2048
+- inputs:
+  - hidden
+  outputs:
+  - reshape
+  - reshape_1
+  - reshape_2
   nodes:
-  - id: x
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: add_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_3_c1
+    outputs:
+    - - add_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: hidden
     op: input
-    outputs: [[x, f16, [64, 3840]]]
-  - id: nw
-    op: input
-    outputs: [[nw, f16, [3840]]]
-  - id: w
-    op: input
-    outputs: [[w, f16, [30720, 3840]]]
-  - id: rms_norm
-    op: torch.rms_norm
-    attrs: {eps: 1.0e-06}
-    inputs: [x, nw]
-    outputs: [[rms_norm, f16, [64, 3840]]]
+    outputs:
+    - - hidden
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 3840
+  - id: p_k_norm_weight
+    op: constant
+    attrs:
+      name: p_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 512
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_k_norm_weight
+      - f16
+      - - 512
+  - id: p_k_proj_weight
+    op: constant
+    attrs:
+      name: p_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 512
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_k_proj_weight
+      - f16
+      - - 512
+        - 3840
+  - id: p_q_norm_weight
+    op: constant
+    attrs:
+      name: p_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 512
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_q_norm_weight
+      - f16
+      - - 512
+  - id: p_q_proj_weight
+    op: constant
+    attrs:
+      name: p_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_q_proj_weight
+      - f16
+      - - 8192
+        - 3840
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: pow_5_c1
+    op: constant
+    attrs:
+      name: pow_5_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_5_c1
+      - f32
+      - - 1
+  - id: pow_5_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_5_c1
+    outputs:
+    - - pow_5_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: pow_6_c1
+    op: constant
+    attrs:
+      name: pow_6_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_6_c1
+      - f32
+      - - 1
+  - id: pow_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - pow_6_c1
+    outputs:
+    - - pow_6_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: pow_7_c1
+    op: constant
+    attrs:
+      name: pow_7_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_7_c1
+      - f32
+      - - 1
+  - id: pow_7_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_7_c1
+    outputs:
+    - - pow_7_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: pow_8_c1
+    op: constant
+    attrs:
+      name: pow_8_c1
+      value: -0.5
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_8_c1
+      - f32
+      - - 1
+  - id: pow_8_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - pow_8_c1
+    outputs:
+    - - pow_8_c1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - hidden
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+  - id: pow_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2
+    outputs:
+    - - pow_2_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - pow_2_bc
+    outputs:
+    - - mul
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - to_1
+      - f32
+      - - 3840
+  - id: to_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_1
+            select: null
+    inputs:
+    - to_1
+    outputs:
+    - - to_1_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul
+    - to_1_bc
+    outputs:
+    - - mul_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_q_norm_weight
+    outputs:
+    - - to_3
+      - f32
+      - - 512
+  - id: to_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - to_3
+    outputs:
+    - - to_3_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            select: null
+    inputs:
+    - p_k_norm_weight
+    outputs:
+    - - to_5
+      - f32
+      - - 512
+  - id: to_5_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - to_5
+    outputs:
+    - - to_5_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: type_as
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 3840
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            select: null
+    inputs:
+    - mul_1
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
   - id: linear
     op: torch.linear
-    attrs: {has_bias: false}
-    inputs: [rms_norm, w]
-    outputs: [[linear, f16, [64, 30720]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as
+    - p_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8192
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - type_as
+    - p_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 512
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 16
+        - 512
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_1
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: pow_4_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4
+    outputs:
+    - - pow_4_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - pow_4_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_2
+    - to_3_bc
+    outputs:
+    - - mul_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: type_as_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 16
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_3
+    outputs:
+    - - type_as_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 8192
+    inputs:
+    - type_as_1
+    outputs:
+    - - reshape
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8192
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 1
+        - 512
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: pow_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_5_c1_bc
+    outputs:
+    - - pow_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_5
+    outputs:
+    - - mean_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: pow_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_2
+    - pow_6_c1_bc
+    outputs:
+    - - pow_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: pow_6_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_6
+    outputs:
+    - - pow_6_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - pow_6_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_4
+    - to_5_bc
+    outputs:
+    - - mul_5
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: pow_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_7_c1_bc
+    outputs:
+    - - pow_7
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_7
+    outputs:
+    - - mean_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_3_c1_bc
+    outputs:
+    - - add_3
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: pow_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - add_3
+    - pow_8_c1_bc
+    outputs:
+    - - pow_8
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 1
+  - id: pow_8_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_8
+    outputs:
+    - - pow_8_bc
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - pow_8_bc
+    outputs:
+    - - mul_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: type_as_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_5
+    outputs:
+    - - type_as_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: reshape_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 512
+    inputs:
+    - type_as_2
+    outputs:
+    - - reshape_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 512
+  - id: type_as_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__:
+            sym: num_tokens
+            hint: 512
+        - __dim__: 1
+        - __dim__: 512
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_6
+    outputs:
+    - - type_as_3
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: reshape_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - num_tokens
+        - 512
+    inputs:
+    - type_as_3
+    outputs:
+    - - reshape_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 512
+loops:
+- inputs:
+  - attn_out
+  outputs:
+  - to
   nodes:
-  - id: scaled_dot_product_attention_c3
+  - id: attn_out
+    op: input
+    outputs:
+    - - attn_out
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 4096
+  - id: linear_wt
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: p_o_proj_weight
+      value: null
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 4096
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_wt
+      - f16
+      - - 4096
+        - 3840
+  - id: to
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 4096
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: attn_out
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_5d061b
+    inputs:
+    - linear_wt
+    - attn_out
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - residual
+  - to
+  outputs:
+  - add_1
+  nodes:
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 512, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 512, 256]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 512, 256]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 512, 256]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: mean_count
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: mean_count
+      value: 3840.0
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - mean_count
+      - f32
+      - - 1
+  - id: p_post_attention_layernorm_weight
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: p_post_attention_layernorm_weight
+      value: null
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 3840
+  - id: residual
+    op: input
+    outputs:
+    - - residual
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to
+    op: input
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_1
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: to
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in2
+                          - in2
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: v1
+                        op:
+                          elementwise: add
+                        dtype: null
+                        axes:
+                          tuple:
+                          - a1
+                        base: null
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+              - class: Assign
+                fields:
+                  name: v2
+                  op:
+                    elementwise: multiply
+                  args:
+                    tuple:
+                    - acc0
+                    - v0
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v3
+                  op:
+                    elementwise: add
+                  args:
+                    tuple:
+                    - in1
+                    - v2
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v4
+                  op:
+                    elementwise: rsqrt
+                  args:
+                    tuple:
+                    - v3
+                  dtype: null
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a2
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in3
+                        input: p_post_attention_layernorm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in4
+                        input: to
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v5
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in3
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v6
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in4
+                          - v4
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v7
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v5
+                          - v6
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v8
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v7
+                        dtype:
+                          dtype: f16
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in5
+                        input: residual
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v9
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in5
+                          - v8
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: add_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        values:
+                          tuple:
+                          - v9
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_70c7ab
+    inputs:
+    - mean_count
+    - add_c1
+    - to
+    - p_post_attention_layernorm_weight
+    - residual
+    outputs:
+    - - add_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - add_1
+  outputs:
+  - mul_4
+  nodes:
+  - id: add_1
+    op: input
+    outputs:
+    - - add_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 2048, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 2048, 256]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 2048, 256]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 2048, 256]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: gelu_c0
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: gelu_c0
+      value: 0.7978845608028654
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 4096, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 4096, 256]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 4096, 256]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 4096, 256]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - gelu_c0
+      - f16
+      - - 1
+  - id: gelu_c1
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: gelu_c1
+      value: 0.044715
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 512, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 512, 512]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 512, 512]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 512, 512]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - gelu_c1
+      - f16
+      - - 1
+  - id: gelu_half
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: gelu_half
+      value: 0.5
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - gelu_half
+      - f16
+      - - 1
+  - id: gelu_one
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: gelu_one
+      value: 1.0
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 2048, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 2048, 512]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 2048, 512]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 2048, 512]]]
-- inputs: [x0, x1, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_c3
+    outputs:
+    - - gelu_one
+      - f16
+      - - 1
+  - id: linear_1_wt
     op: constant
     attrs:
-      name: scaled_dot_product_attention_c3
-      value: 0.0
+      name: p_mlp_gate_proj_weight
+      value: null
       context_value: null
-      load_ops: {__tuple__: []}
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 15360
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_1_wt
+      - f16
+      - - 3840
+        - 15360
+  - id: linear_2_wt
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 15360
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_2_wt
+      - f16
+      - - 3840
+        - 15360
+  - id: mean_1_count
+    op: constant
+    attrs:
+      name: mean_1_count
+      value: 3840.0
+      context_value: null
+      load_ops:
+        __tuple__: []
       source_path: null
-      source_parts: {__tuple__: []}
+      source_parts:
+        __tuple__: []
       source_shape: null
       source_dtype: null
       source_graph: null
-    outputs: [[scaled_dot_product_attention_c3, f16, [1]]]
-  - id: x0
+    outputs:
+    - - mean_1_count
+      - f32
+      - - 1
+  - id: p_pre_feedforward_layernorm_weight
+    op: constant
+    attrs:
+      name: p_pre_feedforward_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: pre_feedforward_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_pre_feedforward_layernorm_weight
+      - f16
+      - - 3840
+  - id: mul_4
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_1_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_2_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in2
+            input: gelu_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in3
+            input: gelu_c0
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in4
+            input: gelu_one
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in5
+            input: gelu_half
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in6
+                        input: add_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in6
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v1
+                          - v1
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: v2
+                        op:
+                          elementwise: add
+                        dtype: null
+                        axes:
+                          tuple:
+                          - a1
+                        base: null
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+              - class: Assign
+                fields:
+                  name: v3
+                  op:
+                    elementwise: multiply
+                  args:
+                    tuple:
+                    - acc0
+                    - v0
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v4
+                  op:
+                    elementwise: add
+                  args:
+                    tuple:
+                    - in1
+                    - v3
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v5
+                  op:
+                    elementwise: rsqrt
+                  args:
+                    tuple:
+                    - v4
+                  dtype: null
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a2
+                      extent:
+                        dim: 15360
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a3
+                            extent:
+                              dim: 3840
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in7
+                              input: add_1
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a3
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v6
+                              op:
+                                elementwise: copy
+                              args:
+                                tuple:
+                                - in7
+                              dtype:
+                                dtype: f32
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in8
+                              input: p_pre_feedforward_layernorm_weight
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a3
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v7
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - v5
+                                - v6
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v8
+                              op:
+                                elementwise: copy
+                              args:
+                                tuple:
+                                - in8
+                              dtype:
+                                dtype: f32
+                          - class: Assign
+                            fields:
+                              name: v9
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - v7
+                                - v8
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v10
+                              op:
+                                elementwise: copy
+                              args:
+                                tuple:
+                                - v9
+                              dtype:
+                                dtype: f16
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in9
+                              input: linear_1_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a3
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v11
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in9
+                                - v10
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc1
+                              value: v11
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a3
+                              base: null
+                          - class: Assign
+                            fields:
+                              name: v12
+                              op:
+                                elementwise: copy
+                              args:
+                                tuple:
+                                - in7
+                              dtype:
+                                dtype: f32
+                          - class: Assign
+                            fields:
+                              name: v13
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - v12
+                                - v5
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v14
+                              op:
+                                elementwise: copy
+                              args:
+                                tuple:
+                                - in8
+                              dtype:
+                                dtype: f32
+                          - class: Assign
+                            fields:
+                              name: v15
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - v13
+                                - v14
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v16
+                              op:
+                                elementwise: copy
+                              args:
+                                tuple:
+                                - v15
+                              dtype:
+                                dtype: f16
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in10
+                              input: linear_2_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a3
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v17
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in10
+                                - v16
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc2
+                              value: v17
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a3
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v18
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc1
+                          - acc1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v19
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc1
+                          - v18
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v20
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in2
+                          - v19
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v21
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - acc1
+                          - v20
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v22
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in3
+                          - v21
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v23
+                        op:
+                          elementwise: tanh
+                        args:
+                          tuple:
+                          - v22
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v24
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in4
+                          - v23
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v25
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc1
+                          - in5
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v26
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v24
+                          - v25
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v27
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc2
+                          - v26
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: mul_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        values:
+                          tuple:
+                          - v27
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_mean_reduce_d1b0ab
+    inputs:
+    - mean_1_count
+    - add_2_c1
+    - gelu_c1
+    - gelu_c0
+    - gelu_one
+    - gelu_half
+    - add_1
+    - p_pre_feedforward_layernorm_weight
+    - linear_1_wt
+    - linear_2_wt
+    outputs:
+    - - mul_4
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+- inputs:
+  - mul_4
+  outputs:
+  - to_4
+  nodes:
+  - id: linear_3_wt
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 15360
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_3_wt
+      - f16
+      - - 15360
+        - 3840
+  - id: mul_4
     op: input
-    outputs: [[x0, f16, [1, 16, 4096, 512]]]
-  - id: x1
+    outputs:
+    - - mul_4
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 15360
+  - id: to_4
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 15360
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_3_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: mul_4
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_350cc3
+    inputs:
+    - linear_3_wt
+    - mul_4
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - add_1
+  - to_4
+  outputs:
+  - mul_7
+  nodes:
+  - id: add_1
     op: input
-    outputs: [[x1, f16, [1, 16, 4096, 512]]]
-  - id: x2
+    outputs:
+    - - add_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: b_layer_scalar
+    op: constant
+    attrs:
+      name: b_layer_scalar
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: layer_scalar
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - b_layer_scalar
+      - f16
+      - - 1
+  - id: mean_2_count
+    op: constant
+    attrs:
+      name: mean_2_count
+      value: 3840.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_2_count
+      - f32
+      - - 1
+  - id: p_post_feedforward_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_feedforward_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_feedforward_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_feedforward_layernorm_weight
+      - f16
+      - - 3840
+  - id: to_4
     op: input
-    outputs: [[x2, f16, [1, 16, 4096, 512]]]
-  - id: scaled_dot_product_attention
-    op: torch.sdpa
-    attrs: {is_causal: true, sliding_window: null, scale: null}
-    inputs: [x0, x1, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 4096, 512]]]
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mul_7
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_2_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_3_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in2
+            input: b_layer_scalar
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in3
+                        input: to_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in3
+                          - in3
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: v1
+                        op:
+                          elementwise: add
+                        dtype: null
+                        axes:
+                          tuple:
+                          - a1
+                        base: null
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+              - class: Assign
+                fields:
+                  name: v2
+                  op:
+                    elementwise: multiply
+                  args:
+                    tuple:
+                    - acc0
+                    - v0
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v3
+                  op:
+                    elementwise: add
+                  args:
+                    tuple:
+                    - in1
+                    - v2
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v4
+                  op:
+                    elementwise: rsqrt
+                  args:
+                    tuple:
+                    - v3
+                  dtype: null
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a2
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in4
+                        input: to_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in5
+                        input: p_post_feedforward_layernorm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v5
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in4
+                          - v4
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v6
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in5
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v7
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v5
+                          - v6
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v8
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v7
+                        dtype:
+                          dtype: f16
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in6
+                        input: add_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v9
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in6
+                          - v8
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v10
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in2
+                          - v9
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: mul_7
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        values:
+                          tuple:
+                          - v10
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_0d9bfc
+    inputs:
+    - mean_2_count
+    - add_3_c1
+    - b_layer_scalar
+    - to_4
+    - p_post_feedforward_layernorm_weight
+    - add_1
+    outputs:
+    - - mul_7
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - attn_out
+  outputs:
+  - to
+  nodes:
+  - id: attn_out
+    op: input
+    outputs:
+    - - attn_out
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8192
+  - id: linear_wt
+    op: constant
+    attrs:
+      name: p_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+        - 8192
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_wt
+      - f16
+      - - 8192
+        - 3840
+  - id: to
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 8192
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: attn_out
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_1d1123
+    inputs:
+    - linear_wt
+    - attn_out
+    outputs:
+    - - to
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - hidden
+  outputs:
+  - type_as
+  nodes:
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: hidden
+    op: input
+    outputs:
+    - - hidden
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: mean_count
+    op: constant
+    attrs:
+      name: mean_count
+      value: 3840.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_count
+      - f32
+      - - 1
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 3840
+  - id: type_as
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: hidden
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in2
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v1
+                          - v1
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: v2
+                        op:
+                          elementwise: add
+                        dtype: null
+                        axes:
+                          tuple:
+                          - a1
+                        base: null
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+              - class: Assign
+                fields:
+                  name: v3
+                  op:
+                    elementwise: multiply
+                  args:
+                    tuple:
+                    - acc0
+                    - v0
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v4
+                  op:
+                    elementwise: add
+                  args:
+                    tuple:
+                    - in1
+                    - v3
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v5
+                  op:
+                    elementwise: rsqrt
+                  args:
+                    tuple:
+                    - v4
+                  dtype: null
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a2
+                      extent:
+                        dim: 3840
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in3
+                        input: hidden
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in4
+                        input: p_input_layernorm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v6
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in3
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v7
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in4
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v8
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v5
+                          - v6
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v9
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v7
+                          - v8
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v10
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v9
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: type_as
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        values:
+                          tuple:
+                          - v10
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_07b679
+    inputs:
+    - mean_count
+    - add_c1
+    - hidden
+    - p_input_layernorm_weight
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+- inputs:
+  - type_as
+  outputs:
+  - to_2
+  nodes:
+  - id: linear_wt
+    op: constant
+    attrs:
+      name: p_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 4096
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_wt
+      - f16
+      - - 3840
+        - 4096
+  - id: type_as
+    op: input
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_2
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 4096
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 3840
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: type_as
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to_2
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: //
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_da9504
+    inputs:
+    - linear_wt
+    - type_as
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+- inputs:
+  - to_2
+  outputs:
+  - pow_4
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: mean_1_count
+    op: constant
+    attrs:
+      name: mean_1_count
+      value: 256.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_1_count
+      - f32
+      - - 1
+  - id: to_2
+    op: input
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: pow_4
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_1_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_1_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 16
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 256
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in2
+                              input: to_2
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a1
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v1
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in2
+                                - in2
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc0
+                          - v0
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in1
+                          - v2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v4
+                        op:
+                          elementwise: rsqrt
+                        args:
+                          tuple:
+                          - v3
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: pow_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        values:
+                          tuple:
+                          - v4
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_3aad25
+    inputs:
+    - mean_1_count
+    - add_1_c1
+    - to_2
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+- inputs:
+  - to_2
+  - pow_4
+  outputs:
+  - reshape
+  nodes:
+  - id: p_q_norm_weight
+    op: constant
+    attrs:
+      name: p_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 256
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_q_norm_weight
+      - f16
+      - - 256
+  - id: pow_4
+    op: input
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: to_2
+    op: input
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 256
+  - id: reshape
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 4096
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in0
+                        input: p_q_norm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 4096
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in1
+                        input: pow_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 4096
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 256
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 16
+                                    dtype: int
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: to_2
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 4096
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 256
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 16
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 4096
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v0
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in0
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in1
+                          - in2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v0
+                          - v1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v2
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: reshape
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v3
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_reshape_82ad93
+    inputs:
+    - p_q_norm_weight
+    - pow_4
+    - to_2
+    outputs:
+    - - reshape
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 4096
+- inputs:
+  - type_as
+  outputs:
+  - to_4
+  nodes:
+  - id: linear_1_wt
+    op: constant
+    attrs:
+      name: p_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_1_wt
+      - f16
+      - - 3840
+        - 2048
+  - id: type_as
+    op: input
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_4
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 2048
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 3840
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_1_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: type_as
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: //
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_dad69a
+    inputs:
+    - linear_1_wt
+    - type_as
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+- inputs:
+  - to_4
+  outputs:
+  - pow_6
+  nodes:
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: mean_2_count
+    op: constant
+    attrs:
+      name: mean_2_count
+      value: 256.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_2_count
+      - f32
+      - - 1
+  - id: to_4
+    op: input
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: pow_6
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_2_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_2_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 8
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 256
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in2
+                              input: to_4
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a1
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v1
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in2
+                                - in2
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc0
+                          - v0
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in1
+                          - v2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v4
+                        op:
+                          elementwise: rsqrt
+                        args:
+                          tuple:
+                          - v3
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: pow_6
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        values:
+                          tuple:
+                          - v4
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_e41b90
+    inputs:
+    - mean_2_count
+    - add_2_c1
+    - to_4
+    outputs:
+    - - pow_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+- inputs:
+  - to_4
+  - pow_6
+  outputs:
+  - reshape_1
+  nodes:
+  - id: p_k_norm_weight
+    op: constant
+    attrs:
+      name: p_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 256
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_k_norm_weight
+      - f16
+      - - 256
+  - id: pow_6
+    op: input
+    outputs:
+    - - pow_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: to_4
+    op: input
+    outputs:
+    - - to_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: reshape_1
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 2048
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in0
+                        input: p_k_norm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 2048
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in1
+                        input: pow_6
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 2048
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 256
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 8
+                                    dtype: int
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: to_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 2048
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 256
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 8
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 2048
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v0
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in0
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in1
+                          - in2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v0
+                          - v1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v2
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: reshape_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v3
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_reshape_d71c85
+    inputs:
+    - p_k_norm_weight
+    - pow_6
+    - to_4
+    outputs:
+    - - reshape_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 2048
+- inputs:
+  - type_as
+  outputs:
+  - to_6
+  nodes:
+  - id: linear_2_wt
+    op: constant
+    attrs:
+      name: p_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_2_wt
+      - f16
+      - - 3840
+        - 2048
+  - id: type_as
+    op: input
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_6
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 2048
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 3840
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_2_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: type_as
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to_6
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: //
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_dad69a
+    inputs:
+    - linear_2_wt
+    - type_as
+    outputs:
+    - - to_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+- inputs:
+  - to_6
+  outputs:
+  - pow_8
+  nodes:
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: mean_3_count
+    op: constant
+    attrs:
+      name: mean_3_count
+      value: 256.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_3_count
+      - f32
+      - - 1
+  - id: to_6
+    op: input
+    outputs:
+    - - to_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: pow_8
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_3_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_3_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 8
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 256
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in2
+                              input: to_6
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a1
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v1
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in2
+                                - in2
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc0
+                          - v0
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in1
+                          - v2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v4
+                        op:
+                          elementwise: rsqrt
+                        args:
+                          tuple:
+                          - v3
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: pow_8
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        values:
+                          tuple:
+                          - v4
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_e41b90
+    inputs:
+    - mean_3_count
+    - add_3_c1
+    - to_6
+    outputs:
+    - - pow_8
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+- inputs:
+  - to_6
+  - pow_8
+  outputs:
+  - reshape_2
+  nodes:
+  - id: pow_8
+    op: input
+    outputs:
+    - - pow_8
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 1
+  - id: to_6
+    op: input
+    outputs:
+    - - to_6
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 8
+        - 256
+  - id: reshape_2
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 2048
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in0
+                        input: to_6
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 2048
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 256
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 8
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 2048
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 256
+                                    dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in1
+                        input: pow_8
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 2048
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 256
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 8
+                                    dtype: int
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v0
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in0
+                          - in1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v0
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: reshape_2
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_reshape_99fe82
+    inputs:
+    - to_6
+    - pow_8
+    outputs:
+    - - reshape_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 2048
+- inputs:
+  - type_as
+  outputs:
+  - to_2
+  nodes:
+  - id: linear_wt
+    op: constant
+    attrs:
+      name: p_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_wt
+      - f16
+      - - 3840
+        - 8192
+  - id: type_as
+    op: input
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: to_2
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 8192
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 3840
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: type_as
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - acc0
+                        dtype:
+                          dtype: f32
+                    - class: Write
+                      fields:
+                        output: to_2
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: //
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 512
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  var: a1
+                                right:
+                                  literal:
+                                    value: 512
+                                    dtype: int
+                        values:
+                          tuple:
+                          - v1
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_abaf16
+    inputs:
+    - linear_wt
+    - type_as
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+- inputs:
+  - to_2
+  outputs:
+  - pow_4
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: mean_1_count
+    op: constant
+    attrs:
+      name: mean_1_count
+      value: 512.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_1_count
+      - f32
+      - - 1
+  - id: to_2
+    op: input
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: pow_4
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_1_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_1_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 16
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 512
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in2
+                              input: to_2
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a1
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v1
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in2
+                                - in2
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v1
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - acc0
+                          - v0
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: add
+                        args:
+                          tuple:
+                          - in1
+                          - v2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v4
+                        op:
+                          elementwise: rsqrt
+                        args:
+                          tuple:
+                          - v3
+                        dtype: null
+                    - class: Write
+                      fields:
+                        output: pow_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        values:
+                          tuple:
+                          - v4
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_233f07
+    inputs:
+    - mean_1_count
+    - add_1_c1
+    - to_2
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+- inputs:
+  - to_2
+  - pow_4
+  outputs:
+  - reshape
+  nodes:
+  - id: p_q_norm_weight
+    op: constant
+    attrs:
+      name: p_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 512
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_q_norm_weight
+      - f16
+      - - 512
+  - id: pow_4
+    op: input
+    outputs:
+    - - pow_4
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 1
+  - id: to_2
+    op: input
+    outputs:
+    - - to_2
+      - f32
+      - - sym: num_tokens
+          hint: 512
+        - 16
+        - 512
+  - id: reshape
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 8192
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in0
+                        input: p_q_norm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 8192
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 512
+                                    dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in1
+                        input: pow_4
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 8192
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 512
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 16
+                                    dtype: int
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: to_2
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: /
+                                    left:
+                                      binary:
+                                        op: +
+                                        left:
+                                          binary:
+                                            op: '*'
+                                            left:
+                                              var: a0
+                                            right:
+                                              literal:
+                                                value: 8192
+                                                dtype: int
+                                        right:
+                                          var: a1
+                                    right:
+                                      literal:
+                                        value: 512
+                                        dtype: int
+                                right:
+                                  literal:
+                                    value: 16
+                                    dtype: int
+                          - expr:
+                              binary:
+                                op: '%'
+                                left:
+                                  binary:
+                                    op: +
+                                    left:
+                                      binary:
+                                        op: '*'
+                                        left:
+                                          var: a0
+                                        right:
+                                          literal:
+                                            value: 8192
+                                            dtype: int
+                                    right:
+                                      var: a1
+                                right:
+                                  literal:
+                                    value: 512
+                                    dtype: int
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v0
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in0
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - in1
+                          - in2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v0
+                          - v1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v3
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v2
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: reshape
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - v3
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_reshape_719dfe
+    inputs:
+    - p_q_norm_weight
+    - pow_4
+    - to_2
+    outputs:
+    - - reshape
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 8192
+- inputs:
+  - type_as
+  outputs:
+  - view_1
+  nodes:
+  - id: linear_1_wt
+    op: constant
+    attrs:
+      name: p_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__:
+        - __op__:
+            op: torch.transpose
+            attrs:
+              axes:
+                __tuple__:
+                - -2
+                - -1
+      source_path: k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 512
+        - 3840
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - linear_1_wt
+      - f16
+      - - 3840
+        - 512
+  - id: type_as
+    op: input
+    outputs:
+    - - type_as
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 3840
+  - id: view_1
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 512
+                      window: null
+                  body:
+                    body:
+                    - class: Loop
+                      fields:
+                        axis:
+                          class: Axis
+                          fields:
+                            name: a2
+                            extent:
+                              dim: 3840
+                            window: null
+                        body:
+                          body:
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in0
+                              input: linear_1_wt
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a2
+                                - expr:
+                                    var: a1
+                              dtype: null
+                          - class: Load
+                            fields:
+                              names:
+                                tuple:
+                                - in1
+                              input: type_as
+                              index:
+                                tuple:
+                                - expr:
+                                    var: a0
+                                - expr:
+                                    var: a2
+                              dtype: null
+                          - class: Assign
+                            fields:
+                              name: v0
+                              op:
+                                elementwise: multiply
+                              args:
+                                tuple:
+                                - in0
+                                - in1
+                              dtype: null
+                          - class: Accum
+                            fields:
+                              name: acc0
+                              value: v0
+                              op:
+                                elementwise: add
+                              dtype: null
+                              axes:
+                                tuple:
+                                - a2
+                              base: null
+                        unroll: false
+                        role:
+                          axis_role: free
+                        seed: true
+                    - class: Write
+                      fields:
+                        output: view_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                          - expr:
+                              var: a1
+                        values:
+                          tuple:
+                          - acc0
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_linear_57cf55
+    inputs:
+    - linear_1_wt
+    - type_as
+    outputs:
+    - - view_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+- inputs:
+  - view_1
+  outputs:
+  - reshape_1
+  nodes:
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: mean_2_count
+    op: constant
+    attrs:
+      name: mean_2_count
+      value: 512.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_2_count
+      - f32
+      - - 1
+  - id: p_k_norm_weight
+    op: constant
+    attrs:
+      name: p_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 512
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_k_norm_weight
+      - f16
+      - - 512
+  - id: view_1
+    op: input
+    outputs:
+    - - view_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: reshape_1
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_2_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_2_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 512
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: view_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                          - expr:
+                              var: a1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in2
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v1
+                          - v1
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: v2
+                        op:
+                          elementwise: add
+                        dtype: null
+                        axes:
+                          tuple:
+                          - a1
+                        base: null
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+              - class: Assign
+                fields:
+                  name: v3
+                  op:
+                    elementwise: multiply
+                  args:
+                    tuple:
+                    - acc0
+                    - v0
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v4
+                  op:
+                    elementwise: add
+                  args:
+                    tuple:
+                    - in1
+                    - v3
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v5
+                  op:
+                    elementwise: rsqrt
+                  args:
+                    tuple:
+                    - v4
+                  dtype: null
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a2
+                      extent:
+                        dim: 512
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in3
+                        input: view_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in4
+                        input: p_k_norm_weight
+                        index:
+                          tuple:
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v6
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in3
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v7
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in4
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v8
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v5
+                          - v6
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v9
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v7
+                          - v8
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v10
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v9
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: reshape_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        values:
+                          tuple:
+                          - v10
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_bb7574
+    inputs:
+    - mean_2_count
+    - add_2_c1
+    - view_1
+    - p_k_norm_weight
+    outputs:
+    - - reshape_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 512
+- inputs:
+  - view_1
+  outputs:
+  - reshape_2
+  nodes:
+  - id: add_3_c1
+    op: constant
+    attrs:
+      name: add_3_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_3_c1
+      - f32
+      - - 1
+  - id: mean_3_count
+    op: constant
+    attrs:
+      name: mean_3_count
+      value: 512.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mean_3_count
+      - f32
+      - - 1
+  - id: view_1
+    op: input
+    outputs:
+    - - view_1
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 1
+        - 512
+  - id: reshape_2
+    op: loop
+    attrs:
+      body:
+        body:
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in0
+            input: mean_3_count
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Assign
+          fields:
+            name: v0
+            op:
+              elementwise: reciprocal
+            args:
+              tuple:
+              - in0
+            dtype: null
+        - class: Load
+          fields:
+            names:
+              tuple:
+              - in1
+            input: add_3_c1
+            index:
+              tuple:
+              - expr:
+                  literal:
+                    value: 0
+                    dtype: int
+            dtype: null
+        - class: Loop
+          fields:
+            axis:
+              class: Axis
+              fields:
+                name: a0
+                extent:
+                  dim:
+                    sym: num_tokens
+                    hint: 512
+                window: null
+            body:
+              body:
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a1
+                      extent:
+                        dim: 512
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in2
+                        input: view_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                          - expr:
+                              var: a1
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v1
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in2
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v2
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v1
+                          - v1
+                        dtype: null
+                    - class: Accum
+                      fields:
+                        name: acc0
+                        value: v2
+                        op:
+                          elementwise: add
+                        dtype: null
+                        axes:
+                          tuple:
+                          - a1
+                        base: null
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+              - class: Assign
+                fields:
+                  name: v3
+                  op:
+                    elementwise: multiply
+                  args:
+                    tuple:
+                    - acc0
+                    - v0
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v4
+                  op:
+                    elementwise: add
+                  args:
+                    tuple:
+                    - in1
+                    - v3
+                  dtype: null
+              - class: Assign
+                fields:
+                  name: v5
+                  op:
+                    elementwise: rsqrt
+                  args:
+                    tuple:
+                    - v4
+                  dtype: null
+              - class: Loop
+                fields:
+                  axis:
+                    class: Axis
+                    fields:
+                      name: a2
+                      extent:
+                        dim: 512
+                      window: null
+                  body:
+                    body:
+                    - class: Load
+                      fields:
+                        names:
+                          tuple:
+                          - in3
+                        input: view_1
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              literal:
+                                value: 0
+                                dtype: int
+                          - expr:
+                              var: a2
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v6
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - in3
+                        dtype:
+                          dtype: f32
+                    - class: Assign
+                      fields:
+                        name: v7
+                        op:
+                          elementwise: multiply
+                        args:
+                          tuple:
+                          - v5
+                          - v6
+                        dtype: null
+                    - class: Assign
+                      fields:
+                        name: v8
+                        op:
+                          elementwise: copy
+                        args:
+                          tuple:
+                          - v7
+                        dtype:
+                          dtype: f16
+                    - class: Write
+                      fields:
+                        output: reshape_2
+                        index:
+                          tuple:
+                          - expr:
+                              var: a0
+                          - expr:
+                              var: a2
+                        values:
+                          tuple:
+                          - v8
+                        value_dtype: null
+                        atomic: false
+                        swizzle: NONE
+                  unroll: false
+                  role:
+                    axis_role: free
+                  seed: true
+            unroll: false
+            role:
+              axis_role: free
+            seed: true
+      name: k_mean_d49a02
+    inputs:
+    - mean_3_count
+    - add_3_c1
+    - view_1
+    outputs:
+    - - reshape_2
+      - f16
+      - - sym: num_tokens
+          hint: 512
+        - 512
+gpu_name: NVIDIA GeForce RTX 5090
+model: google/gemma-4-12B-it
 configs:
 - program: 0
   target:
-    origins:
-    - matmul
+    loop: 0
   realizations:
-  - name: gemma4_12b.q_proj
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 84.2
-      reference_us: 97.6
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 61.5
-      reference_us: 97.6
-      reference_backend: cublas
-- program: 1
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 84.8
-      reference_us: 98.7
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 61.7
-      reference_us: 98.7
-      reference_backend: cublas
-- program: 2
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 45.3
-      reference_us: 48.8
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 36.4
-      reference_us: 48.8
-      reference_backend: cublas
-- program: 3
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 45.8
-      reference_us: 48.9
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 36.3
-      reference_us: 48.9
-      reference_backend: cublas
-- program: 4
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 82.0
-      reference_us: 103.3
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 64.1
-      reference_us: 103.3
-      reference_backend: cublas
-- program: 5
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 82.1
-      reference_us: 99.8
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 63.9
-      reference_us: 99.8
-      reference_backend: cublas
-- program: 6
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 561.7
-      reference_us: 573.3
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 362.4
-      reference_us: 573.3
-      reference_backend: cublas
-- program: 7
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 562.4
-      reference_us: 561.7
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 362.4
-      reference_us: 561.7
-      reference_backend: cublas
-- program: 8
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 286.2
-      reference_us: 286.3
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 214.2
-      reference_us: 286.3
-      reference_backend: cublas
-- program: 9
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 339.2
-      reference_us: 309.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 245.9
-      reference_us: 309.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      STAGE: d2/smem-tma
-      RASTER: ''
-      LOOPIFY: '0'
-    measurements:
-      emmy_us: 343.88
-      reference_us: 306.78
-      reference_backend: cublas
-- program: 10
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      REDUCE: coop
-    measurements:
-      emmy_us: 6.3
-      reference_us: 6.1
-      reference_backend: torch-eager
-  - name: gemma4_12b.rms_norm.k3840.m512
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m1
     bindings:
-      num_tokens: 512
+      num_tokens: 1
     pins:
       FAST_MATH: false
     knobs:
-      WORK: t128
+      WORK: t16
       TILE: ''
       REDUCE: coop
       STAGE: ''
+      LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 7.6
-      reference_us: 6.0
-      reference_backend: torch-eager
-- program: 11
+      emmy_us: 147.61599472590856
+      reference_us: 147.61599472590856
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t32x8
+      TILE: ''
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 38.317538224733795
+      reference_us: 38.317538224733795
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.28100061416626
+      reference_us: 12.28100061416626
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 30.811000615358353
+      reference_us: 30.811000615358353
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 47.990855716523676
+      reference_us: 47.990855716523676
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x8
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 403.24801206588745
+      reference_us: 403.24801206588745
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 563.5200142860413
+      reference_us: 563.5200142860413
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 89.80945565483788
+      reference_us: 92.22108667547052
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 147.50628811972481
+      reference_us: 147.50628811972481
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.278432698593926
+      reference_us: 12.278432698593926
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 28.1956570489066
+      reference_us: 30.82600049674511
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 87.65381574630737
+      reference_us: 87.65381574630737
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 170.21334171295166
+      reference_us: 213.53600025177002
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 359.55198605855304
+      reference_us: 402.27198600769043
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 563.7279748916626
+      reference_us: 563.7279748916626
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_5d061b.4f57a8700b55.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 90.05381844260475
+      reference_us: 92.12218631397593
+      reference_backend: emmy-greedy
+- program: 0
   target:
-    origins:
-    - rms_norm
+    loop: 1
   realizations:
-  - name: gemma4_12b.rms_norm.k3840.m1
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m1
     bindings:
       num_tokens: 1
     pins:
       FAST_MATH: false
     knobs:
       WORK: t512
+      TILE: ''
       REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
-      emmy_us: 3.0
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 12
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      REDUCE: coop
-    measurements:
-      emmy_us: 6.3
-      reference_us: 6.1
-      reference_backend: torch-eager
-- program: 13
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k256
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t64
-      REDUCE: coop
-    measurements:
-      emmy_us: 3.6
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 14
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k256.m256
+      emmy_us: 2.831636335362088
+      reference_us: 3.899875096976757
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m8
     bindings:
-      num_tokens: 256
+      num_tokens: 8
     pins:
       FAST_MATH: false
     knobs:
-      WORK: t256
+      WORK: t512
+      TILE: ''
       REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
-      emmy_us: 1.5
-      reference_us: 3.0
-      reference_backend: torch-eager
-- program: 15
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k256.m512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.6
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 16
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k256.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 2.4
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 17
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m32
+      emmy_us: 3.3270400762557983
+      reference_us: 3.3286378233139695
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m32
     bindings:
       num_tokens: 32
     pins:
       FAST_MATH: false
     knobs:
       WORK: t512
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.4
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 18
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.9
-      reference_us: 3.0
-      reference_backend: torch-eager
-- program: 19
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      REDUCE: coop
-    measurements:
-      emmy_us: 2.1
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 20
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 5.2
-      reference_us: 6.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.qknorm.k512.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
       TILE: ''
       REDUCE: coop
       STAGE: ''
+      LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 5.2
-      reference_us: 6.1
-      reference_backend: torch-eager
-- program: 21
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 313.0
-      reference_us: 318.4
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 223.7
-      reference_us: 318.4
-      reference_backend: cublas
-- program: 22
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 168.4
-      reference_us: 170.3
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 109.6
-      reference_us: 170.3
-      reference_backend: cublas
-- program: 23
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 294.0
-      reference_us: 285.4
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 205.0
-      reference_us: 285.4
-      reference_backend: cublas
-- program: 24
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2191.0
-      reference_us: 2099.8
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1413.0
-      reference_us: 2210.7
-      reference_backend: cublas
-- program: 25
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1112.0
-      reference_us: 1171.1
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 697.0
-      reference_us: 1171.1
-      reference_backend: cublas
-- program: 26
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 169.0
-      reference_us: 180.3
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj_global
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 108.6
-      reference_us: 180.3
-      reference_backend: cublas
-- program: 27
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.3
-      reference_us: 14.3
-      reference_backend: cublas
-  - name: gemma4_12b.k_proj_global
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 11.8
-      reference_us: 14.3
-      reference_backend: cublas
-- program: 28
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 154.3
-      reference_us: 158.1
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 118.2
-      reference_us: 158.1
-      reference_backend: cublas
-- program: 29
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 8.7
-      reference_us: 8.2
-      reference_backend: torch-eager
-- program: 30
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 168.7
-      reference_us: 180.3
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 109.6
-      reference_us: 180.3
-      reference_backend: cublas
-- program: 31
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.4
-      reference_us: 14.3
-      reference_backend: cublas
-  - name: gemma4_12b.k_proj_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 11.9
-      reference_us: 14.3
-      reference_backend: cublas
-- program: 32
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 154.4
-      reference_us: 158.1
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 117.1
-      reference_us: 158.1
-      reference_backend: cublas
-- program: 33
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 601.4
-      reference_us: 600.9
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj_global.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 439.8
-      reference_us: 600.9
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 679.2
-      reference_us: 667.9
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 513.5
-      reference_us: 667.9
-      reference_backend: cublas
-- program: 34
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 45.4
-      reference_us: 47.1
-      reference_backend: cublas
-  - name: gemma4_12b.k_proj_global.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 36.4
-      reference_us: 47.1
-      reference_backend: cublas
-- program: 35
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 595.1
-      reference_us: 570.2
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.s2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 389.5
-      reference_us: 570.2
-      reference_backend: cublas
-- program: 36
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 9.4
-      reference_us: 53.2
-      reference_backend: cublas
-- program: 37
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 5.7
-      reference_us: 12.3
-      reference_backend: cublas
-- program: 38
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 8.8
-      reference_us: 22.5
-      reference_backend: cublas
-- program: 39
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 16.7
-      reference_us: 47.1
-      reference_backend: cublas
-- program: 40
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f1x1/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 5.3
-      reference_us: 6.1
-      reference_backend: cublas
-- program: 41
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.4
-      reference_us: 38.6
-      reference_backend: cublas
-- program: 42
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f4x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d1/smem-tma
-    measurements:
-      emmy_us: 145.2
-      reference_us: 147.1
-      reference_backend: cublas
-- program: 43
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down.m16
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f4x1/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 72.9
-      reference_us: 79.7
-      reference_backend: cublas
-- program: 44
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 10.7
-      reference_us: 16.4
-      reference_backend: cublas
-- program: 45
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 6.6
-      reference_us: 10.2
-      reference_backend: cublas
-- program: 46
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 11.1
-      reference_us: 16.4
-      reference_backend: cublas
-- program: 47
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 17.6
-      reference_us: 26.6
-      reference_backend: cublas
-- program: 48
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f1x1/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 4.3
-      reference_us: 6.1
-      reference_backend: cublas
-- program: 49
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 18.7
-      reference_us: 26.6
-      reference_backend: cublas
-- program: 50
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d1/smem-tma
-    measurements:
-      emmy_us: 144.8
-      reference_us: 151.6
-      reference_backend: cublas
-- program: 51
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.7
-      reference_us: 77.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.5
-      reference_us: 76.9
-      reference_backend: cublas
-- program: 52
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 74.7
-      reference_us: 81.9
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 76.1
-      reference_us: 82.0
-      reference_backend: cublas
-- program: 53
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 18.9
-      reference_us: 16.4
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 16.9
-      reference_us: 16.4
-      reference_backend: cublas
-- program: 54
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 10.9
-      reference_us: 10.6
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 9.5
-      reference_us: 10.6
-      reference_backend: cublas
-- program: 55
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 16.1
-      reference_us: 18.4
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.9
-      reference_us: 18.4
-      reference_backend: cublas
-- program: 56
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 31.4
-      reference_us: 30.5
-      reference_backend: cublas
-- program: 57
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f1x1/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 5.2
-      reference_us: 6.2
-      reference_backend: cublas
-- program: 58
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 28.0
-      reference_us: 28.3
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 27.2
-      reference_us: 28.3
-      reference_backend: cublas
-- program: 59
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 76.9
-      reference_us: 78.2
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 75.8
-      reference_us: 78.2
-      reference_backend: cublas
-- program: 60
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.8
-      reference_us: 76.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.4
-      reference_us: 76.0
-      reference_backend: cublas
-- program: 61
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.9
-      reference_us: 78.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.5
-      reference_us: 78.0
-      reference_backend: cublas
-- program: 62
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 70.0
-      reference_us: 78.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 67.5
-      reference_us: 78.0
-      reference_backend: cublas
-- program: 63
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.lm_head.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x8+p1
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1216.5
-      reference_us: 1220.2
-      reference_backend: cublas
-- program: 64
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.q_proj.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 18.3
-      reference_us: 16.4
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 17.8
-      reference_us: 16.4
-      reference_backend: cublas
-- program: 65
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.kv_proj.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 10.7
-      reference_us: 12.3
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 9.6
-      reference_us: 12.3
-      reference_backend: cublas
-- program: 66
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 16.7
-      reference_us: 18.4
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 16.5
-      reference_us: 18.4
-      reference_backend: cublas
-- program: 67
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.q_proj_global.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x4/k4
-      REDUCE: g2a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 28.6
-      reference_us: 26.7
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x4/k4
-      REDUCE: g2a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 28.6
-      reference_us: 26.7
-      reference_backend: cublas
-- program: 68
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.k_proj_global.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f1x1/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 5.2
-      reference_us: 8.2
-      reference_backend: cublas
-- program: 69
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 28.9
-      reference_us: 28.4
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 28.1
-      reference_us: 28.4
-      reference_backend: cublas
-- program: 70
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 79.4
-      reference_us: 83.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 76.6
-      reference_us: 83.0
-      reference_backend: cublas
-- program: 71
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 71.4
-      reference_us: 79.4
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 69.1
-      reference_us: 79.4
-      reference_backend: cublas
-- program: 72
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m64
+      emmy_us: 3.38397288726548
+      reference_us: 499.455988407135
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m64
     bindings:
       num_tokens: 64
     pins:
@@ -7003,2808 +12038,465 @@ configs:
       TILE: ''
       REDUCE: coop
       STAGE: ''
+      LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 3.7
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 73
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k256.m1024
+      emmy_us: 3.4244383034640795
+      reference_us: 3.4254246378598148
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.9079999551177025
+      reference_us: 1718.1440591812134
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.626499429345131
+      reference_us: 15.626499429345131
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 72.96685661588397
+      reference_us: 73.02400044032505
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.024867655282997
+      reference_us: 6.024867655282997
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.83168277389267
+      reference_us: 3.8995000068098307
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.3869015968452065
+      reference_us: 500.3039836883545
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.4230069867495834
+      reference_us: 3.4230069867495834
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.051684870864405
+      reference_us: 6.051684870864405
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m1024.fm
     bindings:
       num_tokens: 1024
     pins:
-      FAST_MATH: false
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9.284148613611857
+      reference_us: 9.290766493182316
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.615999698638916
+      reference_us: 15.649499371647835
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
     knobs:
       WORK: t128
+      TILE: ''
       REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
-      emmy_us: 1.9
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 74
+      emmy_us: 72.88456814629691
+      reference_us: 73.05599961962018
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_70c7ab.433c606028b6.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.040289459458317
+      reference_us: 6.040289459458317
+      reference_backend: emmy-greedy
+- program: 0
   target:
-    origins:
-    - rms_norm
+    loop: 2
   realizations:
-  - name: gemma4_12b.qknorm.k512.m64
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@a0: coop
+      WORK: t512
+      TILE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16323.968887329102
+      reference_us: 16323.968887329102
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x8
+      TILE: mma_m16n8k16_f16_f32/f1x2
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 241.67199432849884
+      reference_us: 241.67199432849884
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x16
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 150.00685623713903
+      reference_us: 150.00685623713903
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m64
     bindings:
       num_tokens: 64
     pins:
       FAST_MATH: false
     knobs:
-      WORK: t512
-      REDUCE: coop
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f1x4
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
     measurements:
-      emmy_us: 1.5
-      reference_us: 2.1
-      reference_backend: torch-eager
-- program: 75
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m1024
+      emmy_us: 281.76000714302063
+      reference_us: 281.76000714302063
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x8
+      TILE: mma_m16n8k16_f16_f32/f1x4/k4
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 538.0480289459229
+      reference_us: 538.0480289459229
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f1x4/k2
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 3172.384023666382
+      reference_us: 3172.384023666382
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x16
+      TILE: mma_m16n8k16_f16_f32/f8x1/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7123.295783996582
+      reference_us: 9851.231575012207
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m16n8k16_f16_f32/f4x2/k2
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 856.9279909133911
+      reference_us: 856.9279909133911
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      REDUCE@a0: coop
+      WORK: t512
+      TILE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16270.591735839844
+      reference_us: 16270.591735839844
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x16
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 150.13485295431954
+      reference_us: 150.2079963684082
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x8
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 161.8826687335968
+      reference_us: 281.8160057067871
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x8
+      TILE: mma_m16n8k16_f16_f32/f1x2/k2
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 1222.5600481033325
+      reference_us: 1222.5600481033325
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m1024.fm
     bindings:
       num_tokens: 1024
     pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 2.6
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 76
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n4096.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.9
-      reference_us: 1.9
-      reference_backend: torch-eager
-- program: 77
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8192.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 1.1
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 78
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n2048.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 1.8
-      reference_backend: torch-eager
-- program: 79
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 48.4
-      reference_us: 50.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m256
-    bindings:
-      num_tokens: 256
-    pins:
       FAST_MATH: true
     knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 42.0
-      reference_us: 50.0
-      reference_backend: cublas
-- program: 80
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 89.8
-      reference_us: 99.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 76.7
-      reference_us: 99.0
-      reference_backend: cublas
-- program: 81
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 167.7
-      reference_us: 185.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 140.0
-      reference_us: 184.0
-      reference_backend: cublas
-- program: 82
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 51.5
-      reference_us: 47.0
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 40.1
-      reference_us: 47.0
-      reference_backend: cublas
-- program: 83
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 31.5
-      reference_us: 25.5
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 22.5
-      reference_us: 26.0
-      reference_backend: cublas
-- program: 84
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      WORK: w4x8
+      TILE: mma_m16n8k16_f16_f32/f1x2/k2
       REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 672.7
-      reference_us: 698.7
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 516.4
-      reference_us: 698.7
-      reference_backend: cublas
-- program: 85
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.q_proj.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 680.9
-      reference_us: 701.1
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 530.6
-      reference_us: 701.1
-      reference_backend: cublas
-- program: 86
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.kv_proj.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 369.0
-      reference_us: 360.5
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 257.7
-      reference_us: 360.5
-      reference_backend: cublas
-- program: 87
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.kv_proj.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 372.8
-      reference_us: 361.6
-      reference_backend: cublas
-  - name: gemma4_12b.kv_proj.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 261.3
-      reference_us: 361.6
-      reference_backend: cublas
-- program: 88
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 662.6
-      reference_us: 683.8
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 415.3
-      reference_us: 683.8
-      reference_backend: cublas
-- program: 89
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 675.3
-      reference_us: 673.5
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 421.3
-      reference_us: 673.5
-      reference_backend: cublas
-- program: 90
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2316.0
-      reference_us: 2317.8
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
       RASTER: gm8
-      STAGE: d2/smem-tma
     measurements:
-      emmy_us: 1500.8
-      reference_us: 2317.8
-      reference_backend: cublas
-- program: 91
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m4096.lin
+      emmy_us: 2392.927885055542
+      reference_us: 2392.927885055542
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m2048.fm
     bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2426.3
-      reference_us: 2318.4
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m4096.lin
-    bindings:
-      num_tokens: 4096
+      num_tokens: 2048
     pins:
       FAST_MATH: true
     knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f1x4/k2
       REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
       RASTER: gm8
-      STAGE: d2/smem-tma
     measurements:
-      emmy_us: 1557.4
-      reference_us: 2318.4
-      reference_backend: cublas
-- program: 92
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_down.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2375.9
-      reference_us: 2398.5
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2444.4
-      reference_us: 2398.5
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m4096
+      emmy_us: 3173.05588722229
+      reference_us: 3173.05588722229
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.m4096.fm
     bindings:
       num_tokens: 4096
     pins:
       FAST_MATH: true
     knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
+      WORK: w8x2
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
       REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1454.7
-      reference_us: 2398.5
-      reference_backend: cublas
-- program: 93
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2399.3
-      reference_us: 2321.9
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 2463.5
-      reference_us: 2321.9
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1527.5
-      reference_us: 2321.9
-      reference_backend: cublas
-- program: 94
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.q_proj_global.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1246.2
-      reference_us: 1298.5
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj_global.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 882.3
-      reference_us: 1298.5
-      reference_backend: cublas
-- program: 95
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.q_proj_global.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1257.3
-      reference_us: 1302.8
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj_global.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 913.9
-      reference_us: 1302.8
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1262.8
-      reference_us: 1295.6
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 913.9
-      reference_us: 1295.6
-      reference_backend: cublas
-- program: 96
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.k_proj_global.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 109.8
-      reference_us: 105.0
-      reference_backend: cublas
-  - name: gemma4_12b.k_proj_global.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x1
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 71.0
-      reference_us: 105.0
-      reference_backend: cublas
-- program: 97
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.k_proj_global.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 111.2
-      reference_us: 105.7
-      reference_backend: cublas
-  - name: gemma4_12b.k_proj_global.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x1
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 71.9
-      reference_us: 105.7
-      reference_backend: cublas
-- program: 98
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1288.2
-      reference_us: 1306.4
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 826.0
-      reference_us: 1306.4
-      reference_backend: cublas
-- program: 99
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1301.9
-      reference_us: 1297.7
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 855.3
-      reference_us: 1297.7
-      reference_backend: cublas
-- program: 100
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 20.0
-      reference_us: 16.7
-      reference_backend: torch-eager
-- program: 101
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k256.m65536
-    bindings:
-      num_tokens: 65536
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t64
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 31.3
-      reference_us: 39.2
-      reference_backend: torch-eager
-- program: 102
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m65536
-    bindings:
-      num_tokens: 65536
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 91.3
-      reference_us: 71.1
-      reference_backend: torch-eager
-- program: 103
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m16.lin
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 9.1
-      reference_us: 14.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m16.lin
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 8.9
-      reference_us: 14.0
-      reference_backend: cublas
-- program: 104
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m16.lin
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.7
-      reference_us: 29.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m16.lin
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.6
-      reference_us: 29.0
-      reference_backend: cublas
-- program: 105
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m16.lin
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f4x1/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.8
-      reference_us: 85.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m16.lin
-    bindings:
-      num_tokens: 16
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f4x1/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.7
-      reference_us: 85.0
-      reference_backend: cublas
-- program: 106
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 94.3
-      reference_us: 97.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.9
-      reference_us: 97.0
-      reference_backend: cublas
-- program: 107
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 179.3
-      reference_us: 159.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 136.8
-      reference_us: 159.0
-      reference_backend: cublas
-- program: 108
-  target:
-    origins:
-    - matmul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_q_proj.m32.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 16.0
-      reference_us: 19.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_q_proj.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 26.7
-      reference_us: 19.8
-      reference_backend: torch-eager
-- program: 109
-  target:
-    origins:
-    - matmul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_kv_proj.m32.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 10.0
-      reference_us: 14.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_kv_proj.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 23.1
-      reference_us: 14.3
-      reference_backend: torch-eager
-- program: 110
-  target:
-    origins:
-    - matmul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_kv_proj_global.m32.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 8.0
-      reference_us: 10.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_kv_proj_global.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 21.1
-      reference_us: 10.2
-      reference_backend: torch-eager
-- program: 111
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_q_proj.m32.lin.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 16.0
-      reference_us: 20.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_q_proj.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 26.5
-      reference_us: 20.5
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_q_proj.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 24.2
-      reference_us: 20.5
-      reference_backend: torch-eager
-- program: 112
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_kv_proj.m32.lin.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 10.0
-      reference_us: 14.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_kv_proj.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f1x1/k2
-      REDUCE: g8k
       STAGE: d1/smem
-      RASTER: ''
+      LOOPIFY: '0'
+      RASTER: gm8
     measurements:
-      emmy_us: 18.4
-      reference_us: 14.3
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_kv_proj.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f16/f1x1/k2
-      REDUCE: g8k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 18.2
-      reference_us: 14.3
-      reference_backend: torch-eager
-- program: 113
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f4x8/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 178.8
-      reference_us: 152.8
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 125.6
-      reference_us: 151.0
-      reference_backend: cublas
-- program: 114
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.lm_head.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8+p1
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1199.1
-      reference_us: 1208.2
-      reference_backend: cublas
-- program: 115
-  target:
-    origins:
-    - add
-    - cat
-    - cos_bc
-    - mul
-    - mul_1
-    - neg
-    - sin_bc
-    - slice_1
-    - slice_2
-  realizations:
-  - name: gemma4_12b.rope.s512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-    measurements:
-      emmy_us: 4.5
-      reference_us: 20.5
-      reference_backend: torch-eager
-- program: 116
-  target:
-    origins:
-    - embedding
-  realizations:
-  - name: gemma4_12b.embedding.s512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-    measurements:
-      emmy_us: 4.3
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 117
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.cut_cone_stat.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.9
-      reference_us: 10.0
-      reference_backend: torch-eager
-- program: 118
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_cone_scale.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-    measurements:
-      emmy_us: 1.24
-      reference_us: 2.05
-      reference_backend: torch-eager
-- program: 119
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.cut_cone_stat.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.7
-      reference_us: 8.0
-      reference_backend: torch-eager
-- program: 120
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_cone_scale.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 121
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_combine.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-    measurements:
-      emmy_us: 1.2
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 122
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.k_proj_global.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g8k
-      STAGE: d2/smem-tma
-      RASTER: ''
-    measurements:
-      emmy_us: 10.7
-      reference_us: 12.3
-      reference_backend: cublas
-- program: 123
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.q_proj_global.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      STAGE: d2/smem-tma
-      RASTER: ''
-    measurements:
-      emmy_us: 101.7
-      reference_us: 113.1
-      reference_backend: cublas
-  - name: gemma4_12b.q_proj_global.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      STAGE: d2/smem-tma
-      RASTER: ''
-    measurements:
-      emmy_us: 81.4
-      reference_us: 113.1
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 99.9
-      reference_us: 102.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 74.3
-      reference_us: 102.0
-      reference_backend: cublas
-- program: 124
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t512
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 3.6
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 125
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 5.9
-      reference_us: 6.1
-      reference_backend: torch-eager
-- program: 126
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.q_norm.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 6.0
-      reference_us: 8.2
-      reference_backend: torch-eager
-- program: 127
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.k_norm.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t64
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 3.7
-      reference_us: 6.1
-      reference_backend: torch-eager
-- program: 128
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.q_norm_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 9.3
-      reference_us: 10.2
-      reference_backend: torch-eager
-- program: 129
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.kv_norm_global.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 2.2
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 130
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n4096.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.7
-      reference_us: 1.9
-      reference_backend: torch-eager
-- program: 131
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n4096.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 1.5
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 132
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8192.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 1.9
-      reference_backend: torch-eager
-- program: 133
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8192.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 2.5
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 134
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n2048.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.7
-      reference_us: 1.6
-      reference_backend: torch-eager
-- program: 135
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n2048.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 1.1
-      reference_us: 1.9
-      reference_backend: torch-eager
-- program: 136
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m256.fp32
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 5.7
-      reference_us: 8.2
-      reference_backend: torch-eager
-- program: 137
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n2048.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 1.6
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 138
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n4096.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 2.0
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 139
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8192.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 4.4
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 140
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_ch.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x1
-      TILE: mma_m16n8k16_f16_f32/f4x8/k2
-      REDUCE: ''
-      STAGE: d2/smem-tma
-      RASTER: ''
-    measurements:
-      emmy_us: 333.5
-      reference_us: 315.6
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_ch.dynM
+      emmy_us: 6271.7437744140625
+      reference_us: 9811.58447265625
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_mean_reduce_d1b0ab.bd3b13605582.dynamic.fm
     bindings: {}
     pins:
       FAST_MATH: true
     knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      STAGE: d2/smem-async
-      RASTER: ''
-    measurements:
-      emmy_us: 255.9
-      reference_us: 289.5
-      reference_backend: cublas
-- program: 141
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.reduce.k3840.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t64
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 2.2
-      reference_us: 8.2
-      reference_backend: torch-eager
-- program: 142
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.dynM.fp32
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 10.7
-      reference_us: 12.4
-      reference_backend: torch-eager
-- program: 143
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n3840.m256.fp32
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 1.9
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 144
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n3840.dynM.fp32
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 3.2
-      reference_us: 4.1
-      reference_backend: torch-eager
-- program: 145
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m256.lin.cut
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 345.06
-      reference_us: 316.37
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_gate_up.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 559.4
-      reference_us: 362.0
-      reference_backend: torch-eager
-- program: 146
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.dynM.lin.cut
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 654.3
-      reference_us: 636.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_gate_up.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 1079.2
-      reference_us: 664.0
-      reference_backend: torch-eager
-- program: 147
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m256.lin.cut
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 99.0
-      reference_us: 94.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qkv.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 174.5
-      reference_us: 114.0
-      reference_backend: torch-eager
-- program: 148
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.dynM.lin.cut
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 190.0
-      reference_us: 184.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qkv.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
       WORK: w2x8
-      TILE: mma_m16n8k16_f16_f32/f4x4/k4
+      TILE: mma_m16n8k16_f16_f32/f4x2/k2
+      REDUCE: ''
       STAGE: d1/smem
+      LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 299.8
-      reference_us: 224.0
-      reference_backend: torch-eager
-- program: 149
+      emmy_us: 854.8480272293091
+      reference_us: 854.8480272293091
+      reference_backend: emmy-greedy
+- program: 0
   target:
-    origins:
-    - linear
-    - rms_norm
+    loop: 3
   realizations:
-  - name: gemma4_12b.norm_qk_global.m32.lin.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 21.3
-      reference_us: 33.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qk_global.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 40.1
-      reference_us: 37.0
-      reference_backend: torch-eager
-- program: 150
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m256.lin.cut
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 108.0
-      reference_us: 94.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qk_global.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 176.3
-      reference_us: 117.0
-      reference_backend: torch-eager
-- program: 151
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.dynM.lin.cut
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 212.5
-      reference_us: 217.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qk_global.dynM.lin
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w2x8
-      TILE: mma_m16n8k16_f16_f32/f4x4/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 297.9
-      reference_us: 222.0
-      reference_backend: torch-eager
-- program: 152
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m32.lin.cut
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 80.4
-      reference_us: 98.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 95.9
-      reference_us: 90.0
-      reference_backend: torch-eager
-- program: 153
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m256.lin.cut
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 178.0
-      reference_us: 195.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 293.0
-      reference_us: 231.0
-      reference_backend: torch-eager
-- program: 154
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8704.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f2
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 155
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8704.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 2.2
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 156
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8704.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 3.5
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 157
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 17.7
-      reference_us: 29.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 15.4
-      reference_us: 29.0
-      reference_backend: cublas
-- program: 158
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 18.9
-      reference_us: 47.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 16.2
-      reference_us: 47.0
-      reference_backend: cublas
-- program: 159
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 144.6
-      reference_us: 148.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 143.9
-      reference_us: 148.0
-      reference_backend: cublas
-- program: 160
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.9
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 161
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m256
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 3.2
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 162
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f4x1/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 146.7
-      reference_us: 154.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f1x4/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 145.6
-      reference_us: 154.0
-      reference_backend: cublas
-- program: 163
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 35.5
-      reference_us: 47.8
-      reference_backend: cublas
-- program: 164
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1316.3
-      reference_us: 1201.3
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 921.4
-      reference_us: 1201.3
-      reference_backend: cublas
-- program: 165
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 7352.0
-      reference_us: 4416.8
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 3292.3
-      reference_us: 4416.8
-      reference_backend: cublas
-- program: 166
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 204.3
-      reference_us: 180.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 124.3
-      reference_us: 180.0
-      reference_backend: cublas
-- program: 167
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 203.3
-      reference_us: 205.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.dynM
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 125.5
-      reference_us: 205.0
-      reference_backend: cublas
-- program: 168
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 108.0
-      reference_us: 101.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 75.9
-      reference_us: 101.0
-      reference_backend: cublas
-- program: 169
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k4
-      REDUCE: ''
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 291.8
-      reference_us: 273.7
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m256.lin
-    bindings:
-      num_tokens: 256
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 287.1
-      reference_us: 292.0
-      reference_backend: cublas
-- program: 170
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m1.t
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m1
     bindings:
       num_tokens: 1
     pins:
@@ -9813,5603 +12505,4892 @@ configs:
       WORK: t256
       TILE: ''
       REDUCE: coop-t
-      RASTER: ''
       STAGE: ''
-    measurements:
-      emmy_us: 142.6
-      reference_us: 145.4
-      reference_backend: cublas
-- program: 171
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.qkv_cat.m1.t
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: g8k/coop-t
-      RASTER: ''
-      STAGE: ''
-    measurements:
-      emmy_us: 14.1
-      reference_us: 48.4
-      reference_backend: cublas
-- program: 172
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m1.t
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: g8k/coop-t
-      RASTER: ''
-      STAGE: ''
-    measurements:
-      emmy_us: 15.9
-      reference_us: 51.0
-      reference_backend: cublas
-- program: 173
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.down_proj.m1.t
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      TILE: ''
-      REDUCE: g16k/coop-t
-      RASTER: ''
-      STAGE: ''
-    measurements:
-      emmy_us: 70.8
-      reference_us: 76.1
-      reference_backend: cublas
-- program: 174
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj.m1.t
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: g8k/coop-t
-      RASTER: ''
-      STAGE: ''
-    measurements:
-      emmy_us: 8.1
-      reference_us: 32.0
-      reference_backend: cublas
-- program: 175
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.o_proj_global.m1.t
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t256
-      TILE: ''
-      REDUCE: g16k/coop-t
-      RASTER: ''
-      STAGE: ''
-    measurements:
-      emmy_us: 14.2
-      reference_us: 45.0
-      reference_backend: cublas
-- program: 176
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 18.0
-      reference_us: 20.0
-      reference_backend: cublas
-- program: 177
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 19.1
-      reference_us: 21.0
-      reference_backend: cublas
-- program: 178
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 143.7
-      reference_us: 145.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 142.7
-      reference_us: 145.0
-      reference_backend: cublas
-- program: 179
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 10.2
-      reference_us: 14.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 10.1
-      reference_us: 14.0
-      reference_backend: cublas
-- program: 180
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 14.5
-      reference_us: 26.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k2
-      REDUCE: g8k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 14.3
-      reference_us: 26.0
-      reference_backend: cublas
-- program: 181
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.6
-      reference_us: 86.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4a
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 73.2
-      reference_us: 86.0
-      reference_backend: cublas
-- program: 182
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.lm_head.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8+p1
-      TILE: mma_m16n8k16_f16_f32/f2x2/k8
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1193.1
-      reference_us: 1190.0
-      reference_backend: cublas
-- program: 183
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t512
-      REDUCE: coop
-    measurements:
-      emmy_us: 3.7
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 184
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.qknorm.k512.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t512
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.4
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 185
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n2048.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 186
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n4096.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 187
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8192.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 188
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n8704.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 189
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 190
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.cut_cone_stat.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 1.5
-      reference_us: 8.0
-      reference_backend: torch-eager
-- program: 191
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_cone_scale.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-    measurements:
-      emmy_us: 0.8
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 192
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_combine.m8
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: ''
-    measurements:
-      emmy_us: 0.8
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 193
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 696.5
-      reference_us: 664.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 532.7
-      reference_us: 664.0
-      reference_backend: cublas
-- program: 194
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 702.1
-      reference_us: 712.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 541.2
-      reference_us: 712.0
-      reference_backend: cublas
-- program: 195
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 3644.6
-      reference_us: 2302.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1549.7
-      reference_us: 2302.0
-      reference_backend: cublas
-- program: 196
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1252.7
-      reference_us: 1201.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 830.3
-      reference_us: 1201.0
-      reference_backend: cublas
-- program: 197
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 336.2
-      reference_us: 305.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 222.1
-      reference_us: 305.0
-      reference_backend: cublas
-- program: 198
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 699.6
-      reference_us: 606.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 419.5
-      reference_us: 606.0
-      reference_backend: cublas
-- program: 199
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1275.5
-      reference_us: 1161.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 799.2
-      reference_us: 1161.0
-      reference_backend: cublas
-- program: 200
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 13.1
-      reference_us: 10.0
-      reference_backend: torch-eager
-- program: 201
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 685.1
-      reference_us: 687.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 517.6
-      reference_us: 687.0
-      reference_backend: cublas
-- program: 202
-  target:
-    origins:
-    - matmul
-  realizations:
-  - name: gemma4_12b.mlp_gate_up_split.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1182.7
-      reference_us: 1191.6
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_gate_up_split.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 790.9
-      reference_us: 1191.6
-      reference_backend: cublas
-- program: 203
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.cut_cone_stat.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 4.1
-      reference_us: 10.0
-      reference_backend: torch-eager
-- program: 204
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_cone_scale.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-    measurements:
-      emmy_us: 6.2
-      reference_us: 12.0
-      reference_backend: torch-eager
-- program: 205
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: ''
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 290.4
-      reference_us: 290.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: ''
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 263.3
-      reference_us: 290.0
-      reference_backend: cublas
-- program: 206
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g2a
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 76.8
-      reference_us: 79.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g2a
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 71.0
-      reference_us: 79.0
-      reference_backend: cublas
-- program: 207
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g2a
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 79.5
-      reference_us: 79.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g2a
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 75.8
-      reference_us: 79.0
-      reference_backend: cublas
-- program: 208
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g8a
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 160.6
-      reference_us: 147.0
-      reference_backend: cublas
-- program: 209
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g4k
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 41.6
-      reference_us: 47.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 37.6
-      reference_us: 47.0
-      reference_backend: cublas
-- program: 210
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g4k
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 77.8
-      reference_us: 74.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      RASTER: gm8
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 70.9
-      reference_us: 74.0
-      reference_backend: cublas
-- program: 211
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m192.lin.cut
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 294.2
-      reference_us: 307.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_gate_up.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 429.3
-      reference_us: 266.0
-      reference_backend: torch-eager
-- program: 212
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m192.lin.cut
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 81.1
-      reference_us: 86.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qkv.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 116.2
-      reference_us: 100.0
-      reference_backend: torch-eager
-- program: 213
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m192.lin.cut
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 83.1
-      reference_us: 85.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_qk_global.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 118.2
-      reference_us: 101.0
-      reference_backend: torch-eager
-- program: 214
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m192.lin.cut
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 169.2
-      reference_us: 170.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m192.lin
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 265.5
-      reference_us: 165.0
-      reference_backend: torch-eager
-- program: 215
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m8.lin.cut
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 76.7
-      reference_us: 101.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m8.lin
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
       LOOPIFY: '0'
-    measurements:
-      emmy_us: 105.4
-      reference_us: 100.0
-      reference_backend: torch-eager
-- program: 216
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m64.lin.cut
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 84.2
-      reference_us: 100.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
       RASTER: ''
-      LOOPIFY: '0'
     measurements:
-      emmy_us: 133.5
-      reference_us: 99.4
-      reference_backend: torch-eager
-- program: 217
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m2048.lin.cut
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 1373.2
-      reference_us: 1276.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m2048.lin
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f1x4/k4
-      STAGE: d1/smem
-      RASTER: ''
-      LOOPIFY: '0'
-    measurements:
-      emmy_us: 2066.0
-      reference_us: 1190.2
-      reference_backend: torch-eager
-- program: 218
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m4096.lin.cut
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 2708.4
-      reference_us: 2513.0
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_down_fused.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      STAGE: d2/smem
-      RASTER: ''
-      LOOPIFY: '0'
-    measurements:
-      emmy_us: 3238.6
-      reference_us: 2259.1
-      reference_backend: torch-eager
-- program: 219
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m1.lin.cut
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 15.2
-      reference_us: 47.0
-      reference_backend: torch-eager
-- program: 220
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m1.lin.cut
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 15.9
-      reference_us: 48.0
-      reference_backend: torch-eager
-- program: 221
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m1.lin.cut
-    bindings:
-      num_tokens: 1
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 142.9
-      reference_us: 147.0
-      reference_backend: torch-eager
-- program: 222
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m8.lin.cut
+      emmy_us: 73.83086000170026
+      reference_us: 73.83086000170026
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m8
     bindings:
       num_tokens: 8
     pins:
       FAST_MATH: false
     knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 20.3
-      reference_us: 21.0
-      reference_backend: torch-eager
-- program: 223
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m8.lin.cut
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 20.8
-      reference_us: 23.0
-      reference_backend: torch-eager
-- program: 224
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m8.lin.cut
-    bindings:
-      num_tokens: 8
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 145.9
-      reference_us: 151.0
-      reference_backend: torch-eager
-- program: 225
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m64.lin.cut
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 34.5
-      reference_us: 33.0
-      reference_backend: torch-eager
-- program: 226
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m64.lin.cut
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 38.6
-      reference_us: 33.0
-      reference_backend: torch-eager
-- program: 227
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m2048.lin.cut
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 676.6
-      reference_us: 638.0
-      reference_backend: torch-eager
-- program: 228
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m2048.lin.cut
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 701.8
-      reference_us: 658.0
-      reference_backend: torch-eager
-- program: 229
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m2048.lin.cut
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 2542.4
-      reference_us: 2220.0
-      reference_backend: torch-eager
-- program: 230
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m4096.lin.cut
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 1322.3
-      reference_us: 1301.0
-      reference_backend: torch-eager
-- program: 231
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m4096.lin.cut
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 1382.0
-      reference_us: 1329.0
-      reference_backend: torch-eager
-- program: 232
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m4096.lin.cut
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 7290.4
-      reference_us: 4398.0
-      reference_backend: torch-eager
-- program: 233
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m64
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 1.2
-      reference_us: 2.0
-      reference_backend: torch-eager
-- program: 234
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m192
-    bindings:
-      num_tokens: 192
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 2.6
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 235
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m2048
-    bindings:
-      num_tokens: 2048
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 59.3
-      reference_us: 59.0
-      reference_backend: torch-eager
-- program: 236
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 163.3
-      reference_us: 163.0
-      reference_backend: torch-eager
-- program: 237
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 193.8
-      reference_us: 180.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 125.6
-      reference_us: 180.0
-      reference_backend: cublas
-- program: 238
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 199.8
-      reference_us: 181.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 125.5
-      reference_us: 181.0
-      reference_backend: cublas
-- program: 239
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 903.6
-      reference_us: 624.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 449.5
-      reference_us: 624.0
-      reference_backend: cublas
-- program: 240
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 340.6
-      reference_us: 310.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 248.1
-      reference_us: 310.0
-      reference_backend: cublas
-- program: 241
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 92.1
-      reference_us: 95.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 74.2
-      reference_us: 95.0
-      reference_backend: cublas
-- program: 242
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 178.8
-      reference_us: 164.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m512.lin
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 135.7
-      reference_us: 164.0
-      reference_backend: cublas
-- program: 243
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m512.lin.cut
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 211.3
-      reference_us: 184.0
-      reference_backend: torch-eager
-- program: 244
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m512.lin.cut
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 213.5
-      reference_us: 184.0
-      reference_backend: torch-eager
-- program: 245
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m512.lin.cut
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 669.2
-      reference_us: 596.0
-      reference_backend: torch-eager
-- program: 246
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m512.lin.cut
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 355.8
-      reference_us: 330.0
-      reference_backend: torch-eager
-- program: 247
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 5.7
-      reference_us: 8.0
-      reference_backend: torch-eager
-- program: 248
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_cone_scale.m512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-    measurements:
-      emmy_us: 1.9
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 249
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.cut_cone_stat.m512
-    bindings:
-      num_tokens: 512
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 2.4
-      reference_us: 8.0
-      reference_backend: torch-eager
-- program: 250
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qkv_cat.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g2k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 366.3
-      reference_us: 322.0
-      reference_backend: cublas
-  - name: gemma4_12b.qkv_cat.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 263.2
-      reference_us: 322.0
-      reference_backend: cublas
-- program: 251
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.qk_global_cat.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 367.6
-      reference_us: 377.0
-      reference_backend: cublas
-  - name: gemma4_12b.qk_global_cat.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 262.4
-      reference_us: 377.0
-      reference_backend: cublas
-- program: 252
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.gate_up_cat.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 1670.0
-      reference_us: 1197.0
-      reference_backend: cublas
-  - name: gemma4_12b.gate_up_cat.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 904.0
-      reference_us: 1197.0
-      reference_backend: cublas
-- program: 253
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.mlp_down.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: g4k
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 652.1
-      reference_us: 576.0
-      reference_backend: cublas
-  - name: gemma4_12b.mlp_down.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 481.8
-      reference_us: 576.0
-      reference_backend: cublas
-- program: 254
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 171.8
-      reference_us: 148.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 132.4
-      reference_us: 148.0
-      reference_backend: cublas
-- program: 255
-  target:
-    origins:
-    - linear
-  realizations:
-  - name: gemma4_12b.o_proj_global.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 352.6
-      reference_us: 297.0
-      reference_backend: cublas
-  - name: gemma4_12b.o_proj_global.m1024.lin
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f4x8/k4
-      REDUCE: ''
-      RASTER: ''
-      STAGE: d2/smem-tma
-    measurements:
-      emmy_us: 256.6
-      reference_us: 297.0
-      reference_backend: cublas
-- program: 256
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qkv.m1024.lin.cut
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 377.6
-      reference_us: 364.0
-      reference_backend: torch-eager
-- program: 257
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_qk_global.m1024.lin.cut
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 430.2
-      reference_us: 339.0
-      reference_backend: torch-eager
-- program: 258
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m1024.lin.cut
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 1302.2
-      reference_us: 1154.0
-      reference_backend: torch-eager
-- program: 259
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_down_fused.m1024.lin.cut
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      PLACE: cut
-    measurements:
-      emmy_us: 678.2
-      reference_us: 615.0
-      reference_backend: torch-eager
-- program: 260
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.pw.n15360.m1024
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-      REDUCE: ''
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 10.5
-      reference_us: 12.0
-      reference_backend: torch-eager
-- program: 261
-  target:
-    origins:
-    - relu
-  realizations:
-  - name: gemma4_12b.cut_cone_scale.m1024
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: ''
-      TILE: f4
-    measurements:
-      emmy_us: 3.2
-      reference_us: 4.0
-      reference_backend: torch-eager
-- program: 262
-  target:
-    origins:
-    - sum_1
-    - sum_1_keepdim
-  realizations:
-  - name: gemma4_12b.cut_cone_stat.m1024
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
-      REDUCE: coop
-    measurements:
-      emmy_us: 3.4
-      reference_us: 8.0
-      reference_backend: torch-eager
-- program: 263
-  target:
-    origins:
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.rms_norm.k3840.m1024
-    bindings:
-      num_tokens: 1024
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: t128
+      WORK: t32x8
       TILE: ''
-      REDUCE: coop
-      STAGE: ''
-      RASTER: ''
-    measurements:
-      emmy_us: 9.9
-      reference_us: 10.0
-      reference_backend: torch-eager
-- program: 264
-  target:
-    origins:
-    - matmul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_q_proj_global.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 38.1
-      reference_us: 31.5
-      reference_backend: torch-eager
-- program: 265
-  target:
-    origins:
-    - gelu
-    - matmul
-    - matmul_1
-    - mul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_geglu.m32
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 179.3
-      reference_us: 159.7
-      reference_backend: torch-eager
-- program: 266
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_q_proj_global.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 36.5
-      reference_us: 30.9
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_q_proj_global.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 30.6
-      reference_us: 30.9
-      reference_backend: torch-eager
-- program: 267
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_kv_proj_global.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f1x1/k2
-      REDUCE: g8k
-      STAGE: d2/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 13.3
-      reference_us: 10.2
-      reference_backend: torch-eager
-  - name: gemma4_12b.norm_kv_proj_global.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f16/f1x1/k2
-      REDUCE: g8k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 12.7
-      reference_us: 10.2
-      reference_backend: torch-eager
-- program: 268
-  target:
-    origins:
-    - gelu
-    - linear
-    - linear_1
-    - mul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_geglu.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 178.6
-      reference_us: 166.6
-      reference_backend: torch-eager
-  - name: gemma4_12b.mlp_geglu.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: true
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f16/f2x2/k4
-      REDUCE: g4k
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 172.5
-      reference_us: 166.6
-      reference_backend: torch-eager
-- program: 269
-  target:
-    origins:
-    - gelu
-    - matmul
-    - matmul_1
-    - mul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_geglu.m4096
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f4x8
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 8994.9
-      reference_us: 4954.1
-      reference_backend: torch-eager
-- program: 270
-  target:
-    origins:
-    - gelu
-    - linear
-    - linear_1
-    - mul
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.mlp_geglu.m4096.lin
-    bindings:
-      num_tokens: 4096
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f4x8
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 10137.7
-      reference_us: 4869.7
-      reference_backend: torch-eager
-- program: 271
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m32.lin
-    bindings:
-      num_tokens: 32
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x16
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 161.6
-      reference_us: 154.1
-      reference_backend: torch-eager
-- program: 272
-  target:
-    origins:
-    - linear
-    - rms_norm
-  realizations:
-  - name: gemma4_12b.norm_gate_up.m64.lin
-    bindings:
-      num_tokens: 64
-    pins:
-      FAST_MATH: false
-    knobs:
-      REDUCE@a1: ''
-      STAGE@a1: ''
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f32/f2x2/k4
-      STAGE: d1/smem
-      RASTER: ''
-    measurements:
-      emmy_us: 169.4
-      reference_us: 163.5
-      reference_backend: torch-eager
-- program: 273
-  target:
-    loop: 0
-  realizations:
-  - name: gemma4_12b.attention.hd256.qk
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k8
       REDUCE: ''
       STAGE: d1/smem-tma
       LOOPIFY: '0'
-      RASTER: gm8
+      RASTER: ''
     measurements:
-      emmy_us: 14.14
-      reference_us: 26.76
+      emmy_us: 174.57600434621176
+      reference_us: 1299.3600368499756
       reference_backend: emmy-greedy
-  - name: gemma4_12b.attention.hd256.qk
-    bindings: {}
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m32
+    bindings:
+      num_tokens: 32
     pins:
       FAST_MATH: false
     knobs:
       WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 105.92355330785115
+      reference_us: 162.00000047683716
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
       TILE: mma_m16n8k16_f16_f32/f2x2/k8
       REDUCE: ''
       STAGE: d1/smem-tma
       LOOPIFY: '0'
-      RASTER: gm8
-    measurements:
-      emmy_us: 17.46
-      reference_us: 26.73
-      reference_backend: emmy-greedy
-- program: 273
-  target:
-    loop: 1
-  realizations:
-  - name: gemma4_12b.attention.hd256.softmax_v
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x4
-      TILE: mma_m16n8k16_f16_f16/f2x4/k8
-      REDUCE: ''
-      STAGE: d1/smem
-      LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 27.84
-      reference_us: 33.78
+      emmy_us: 128.65599989891052
+      reference_us: 128.65599989891052
       reference_backend: emmy-greedy
-  - name: gemma4_12b.attention.hd256.softmax_v
-    bindings: {}
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m192
+    bindings:
+      num_tokens: 192
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w4x4
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 186.57280206680298
+      reference_us: 186.57280206680298
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w8x1
       TILE: mma_m16n8k16_f16_f32/f1x8/k8
       REDUCE: ''
-      STAGE: d1/smem
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 32.95
-      reference_us: 33.75
+      emmy_us: 1348.0639457702637
+      reference_us: 1476.1919975280762
       reference_backend: emmy-greedy
-- program: 274
-  target:
-    loop: 2
-  realizations:
-  - name: gemma4_12b.attention.hd256.dynM.qk
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f4x8/k4
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2147.3278999328613
+      reference_us: 2147.3278999328613
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f4x8
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
       REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 307.3493242263794
+      reference_us: 307.3493242263794
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
       STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 41.63
-      reference_us: 51.18
+      emmy_us: 73.84685959134784
+      reference_us: 73.84685959134784
       reference_backend: emmy-greedy
-- program: 274
-  target:
-    loop: 3
-  realizations:
-  - name: gemma4_12b.attention.hd256.dynM.softmax_v
-    bindings: {}
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m32.fm
+    bindings:
+      num_tokens: 32
     pins:
-      FAST_MATH: false
+      FAST_MATH: true
     knobs:
-      WORK: w4x4
-      TILE: mma_m16n8k16_f16_f32/f1x4/k4
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
       REDUCE: ''
-      STAGE: d2/smem
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 30.74
-      reference_us: 432.88
+      emmy_us: 106.39288690355089
+      reference_us: 162.19733158747354
       reference_backend: emmy-greedy
-- program: 275
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 122.12400138378143
+      reference_us: 128.58399748802185
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 332.93867111206055
+      reference_us: 482.9440116882324
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x1
+      TILE: mma_m16n8k16_f16_f32/f2x8/k2
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 602.6560068130493
+      reference_us: 603.43998670578
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f4x4/k4
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1172.1279621124268
+      reference_us: 1475.2960205078125
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f4x8/k4
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2147.007942199707
+      reference_us: 2147.007942199707
+      reference_backend: emmy-greedy
+  - name: post-sym.k_linear_350cc3.9adc74c89722.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 308.54399998982746
+      reference_us: 308.54399998982746
+      reference_backend: emmy-greedy
+- program: 0
   target:
     loop: 4
   realizations:
-  - name: gemma4_12b.attention.hd256.s2048.qk
-    bindings: {}
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m1
+    bindings:
+      num_tokens: 1
     pins:
-      FAST_MATH: true
+      FAST_MATH: false
     knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f16/f4x2/k4
-      REDUCE: ''
-      STAGE: d1/smem-tma
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 190.29
-      reference_us: 505.68
+      emmy_us: 2.863724170059993
+      reference_us: 2.863724170059993
       reference_backend: emmy-greedy
-  - name: gemma4_12b.attention.hd256.s2048.qk
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.3717838090819283
+      reference_us: 3.372648680532301
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.40794540509429
+      reference_us: 3.40870989060646
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.409911341227769
+      reference_us: 3.409911341227769
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.8192797437938237
+      reference_us: 3.820213652749098
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.998451940474972
+      reference_us: 23.43590592229089
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 85.38933595021565
+      reference_us: 85.73333422342937
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f4x2/k8
-      REDUCE: ''
-      STAGE: d1/smem-tma
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 236.25
-      reference_us: 505.86
+      emmy_us: 6.075122007509557
+      reference_us: 2203.4881114959717
       reference_backend: emmy-greedy
-- program: 275
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.864919517232084
+      reference_us: 2.865696363257815
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.408600649329176
+      reference_us: 3.4118770739324265
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.406525675347234
+      reference_us: 3.4077269225397204
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.1394568578696544
+      reference_us: 6.1394568578696544
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9.709980881329878
+      reference_us: 9.709980881329878
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16.067096302586215
+      reference_us: 23.458231327145597
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 85.04533767700195
+      reference_us: 85.43999989827473
+      reference_backend: emmy-greedy
+  - name: post-sym.k_mean_0d9bfc.1a15a478194b.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.090146375865471
+      reference_us: 2203.295946121216
+      reference_backend: emmy-greedy
+- program: 1
   target:
     loop: 5
   realizations:
-  - name: gemma4_12b.attention.hd256.s2048.softmax_v
-    bindings: {}
-    pins:
-      FAST_MATH: true
-    knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f1x8/k4
-      REDUCE: ''
-      STAGE: d1/smem
-      LOOPIFY: '0'
-      RASTER: gm8
-    measurements:
-      emmy_us: 353.22
-      reference_us: 2923.49
-      reference_backend: emmy-greedy
-  - name: gemma4_12b.attention.hd256.s2048.softmax_v
-    bindings: {}
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m1
+    bindings:
+      num_tokens: 1
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w8x2
-      TILE: mma_m16n8k16_f16_f32/f1x8/k4
-      REDUCE: ''
-      STAGE: d1/smem
+      WORK: t32
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
       LOOPIFY: '0'
-      RASTER: gm8
+      RASTER: ''
     measurements:
-      emmy_us: 403.58
-      reference_us: 2926.27
+      emmy_us: 14.328399300575256
+      reference_us: 14.328399300575256
       reference_backend: emmy-greedy
-- program: 276
-  target:
-    loop: 6
-  realizations:
-  - name: gemma4_12b.attention.hd256.s4096.qk
-    bindings: {}
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m8
+    bindings:
+      num_tokens: 8
     pins:
-      FAST_MATH: true
+      FAST_MATH: false
     knobs:
-      WORK: w1x8
-      TILE: mma_m16n8k16_f16_f16/f4x2/k4
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1875.4240274429321
+      reference_us: 1887.935996055603
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
       REDUCE: ''
       STAGE: d1/smem-tma
       LOOPIFY: '0'
-      RASTER: gm8
+      RASTER: ''
     measurements:
-      emmy_us: 776.0
-      reference_us: 1960.58
+      emmy_us: 18.46119395473547
+      reference_us: 18.46119395473547
       reference_backend: emmy-greedy
-  - name: gemma4_12b.attention.hd256.s4096.qk
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 54.65066764089796
+      reference_us: 54.65066764089796
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 96.806401014328
+      reference_us: 161.95733348528543
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 715.7120108604431
+      reference_us: 719.6800112724304
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1117.5040006637573
+      reference_us: 1117.5040006637573
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w1x8
+      WORK: w1x4
       TILE: mma_m16n8k16_f16_f32/f4x2/k8
       REDUCE: ''
       STAGE: d1/smem-tma
       LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 175.12534062067667
+      reference_us: 175.12534062067667
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t32
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 14.327999949455261
+      reference_us: 14.327999949455261
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.455578569780318
+      reference_us: 18.455578569780318
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 54.77333399984571
+      reference_us: 54.77333399984571
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
       RASTER: gm8
     measurements:
-      emmy_us: 928.93
-      reference_us: 1960.16
+      emmy_us: 170.86933056513467
+      reference_us: 171.88799381256104
       reference_backend: emmy-greedy
-- program: 276
-  target:
-    loop: 7
-  realizations:
-  - name: gemma4_12b.attention.hd256.s4096.softmax_v
-    bindings: {}
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m1024.fm
+    bindings:
+      num_tokens: 1024
     pins:
       FAST_MATH: true
     knobs:
       WORK: w4x2
-      TILE: mma_m16n8k16_f16_f16/f1x8/k4
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
       REDUCE: ''
-      STAGE: d1/smem
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
-      RASTER: gm8
+      RASTER: ''
     measurements:
-      emmy_us: 1226.11
-      reference_us: 2744.96
+      emmy_us: 377.25865840911865
+      reference_us: 378.54933738708496
       reference_backend: emmy-greedy
-  - name: gemma4_12b.attention.hd256.s4096.softmax_v
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 715.6800031661987
+      reference_us: 719.6800112724304
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1116.6720390319824
+      reference_us: 1116.6720390319824
+      reference_backend: emmy-greedy
+  - name: post-sym-global.k_linear_1d1123.704cb1e5da0c.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 174.68265692392984
+      reference_us: 174.68265692392984
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 6
+  realizations:
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.7626077773162674
+      reference_us: 2.7630497078869225
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.3268266916275024
+      reference_us: 3.3289599418640137
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.340735882022309
+      reference_us: 3.3427692177303663
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.391023813667944
+      reference_us: 3.3913491135936673
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.7670641575219497
+      reference_us: 5.489406677392813
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.324345700534773
+      reference_us: 12.324345700534773
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.833509031331765
+      reference_us: 18.833509031331765
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.729287520222281
+      reference_us: 6.5236079926584285
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.7603323770031705
+      reference_us: 2.7630497078869225
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.3450166517276827
+      reference_us: 3.3450166517276827
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.391132112276756
+      reference_us: 3.391132112276756
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.769618329285197
+      reference_us: 5.769618329285197
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.355293806861429
+      reference_us: 7.355293806861429
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.401600182056427
+      reference_us: 12.40730874332381
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.574222370430274
+      reference_us: 18.574222370430274
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_07b679.c70699a6a133.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.733701004379097
+      reference_us: 6.530091653462328
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 7
+  realizations:
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.431877282949594
+      reference_us: 15.431877282949594
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1033.3119630813599
+      reference_us: 1035.1040363311768
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 21.485913058985837
+      reference_us: 21.532521299693897
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 27.50577860408359
+      reference_us: 31.71199944711501
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 71.20000038828168
+      reference_us: 71.20000038828168
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 329.5466701189677
+      reference_us: 472.4319875240326
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 840.287983417511
+      reference_us: 844.1280126571655
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
       WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f1x8/k4
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
       REDUCE: ''
-      STAGE: d1/smem
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 111.84355947706435
+      reference_us: 121.23599648475647
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.421045743502104
+      reference_us: 15.421045743502104
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 21.446260421172433
+      reference_us: 21.446260421172433
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 27.496889233589172
+      reference_us: 31.890580731053504
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 124.77599829435349
+      reference_us: 125.67199766635895
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 244.56000328063965
+      reference_us: 246.5440034866333
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: gm8
     measurements:
-      emmy_us: 1248.67
-      reference_us: 2744.0
+      emmy_us: 375.10399023691815
+      reference_us: 471.47199511528015
       reference_backend: emmy-greedy
-- program: 277
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 697.0239877700806
+      reference_us: 842.5279855728149
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_da9504.7370580ed4f8.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 112.19199498494466
+      reference_us: 121.20799720287323
+      reference_backend: emmy-greedy
+- program: 2
   target:
     loop: 8
   realizations:
-  - name: gemma4_12b.attention.hd512.qk
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9791184942822733
+      reference_us: 1.1103181075201152
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0448201056803619
+      reference_us: 1.0456008721793084
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1676070285819429
+      reference_us: 1.1676070285819429
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.319101732347254
+      reference_us: 4.465428314038685
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.378590475945246
+      reference_us: 2.7592486768796296
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.821206191229443
+      reference_us: 15.92584072597443
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 30.68800044782234
+      reference_us: 31.51499852538109
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.dynamic
     bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.701886818094074
+      reference_us: 4.701886818094074
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9815535831357644
+      reference_us: 1.1104605221774873
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1678315742671141
+      reference_us: 1.1678315742671141
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3231745472660772
+      reference_us: 4.482152483388448
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.680373958338087
+      reference_us: 4.680373958338087
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.40416776032007
+      reference_us: 8.7629473000242
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.84152380625407
+      reference_us: 15.951237981281583
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 30.688968571749598
+      reference_us: 31.516999006271362
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_3aad25.ca928a21f098.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.707622640537766
+      reference_us: 4.707622640537766
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 9
+  realizations:
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7112654926938095
+      reference_us: 0.7118176446001754
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8744426912523005
+      reference_us: 0.8744426912523005
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0202546016881107
+      reference_us: 1.0202546016881107
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0862221904829437
+      reference_us: 1.0862221904829437
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4618203285340883
+      reference_us: 1.4618203285340883
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.413570086161296
+      reference_us: 7.415229302865487
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.404148243091726
+      reference_us: 18.404148243091726
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.373333346276056
+      reference_us: 2.373333346276056
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.712171175680555
+      reference_us: 0.712171175680555
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0209866897598625
+      reference_us: 1.0209866897598625
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0866420313115996
+      reference_us: 1.0866420313115996
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.4431646602452535
+      reference_us: 2.4431646602452535
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.094551374882828
+      reference_us: 4.099409599773219
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.3223109598513005
+      reference_us: 7.4349850860994255
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.410666121376888
+      reference_us: 18.410666121376888
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_82ad93.e88626575306.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.374323776790074
+      reference_us: 2.374323776790074
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 10
+  realizations:
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 14.550260875536047
+      reference_us: 14.550260875536047
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 529.6800136566162
+      reference_us: 529.8560261726379
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 17.75142869779042
+      reference_us: 17.763428390026093
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 22.410181435671717
+      reference_us: 22.951442141865574
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m192
+    bindings:
+      num_tokens: 192
     pins:
       FAST_MATH: false
     knobs:
       WORK: w2x4
       TILE: mma_m16n8k16_f16_f32/f2x2/k8
       REDUCE: ''
-      STAGE: d1/smem-async
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 30.93
-      reference_us: 45.0
+      emmy_us: 42.25252244783485
+      reference_us: 42.25252244783485
       reference_backend: emmy-greedy
-- program: 277
-  target:
-    loop: 9
-  realizations:
-  - name: gemma4_12b.attention.hd512.softmax_v
-    bindings: {}
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m2048
+    bindings:
+      num_tokens: 2048
     pins:
       FAST_MATH: false
     knobs:
       WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f1x8/k2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
       REDUCE: ''
-      STAGE: d1/smem
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 46.77
-      reference_us: 58.98
+      emmy_us: 176.51732762654623
+      reference_us: 176.51732762654623
       reference_backend: emmy-greedy
-- program: 278
-  target:
-    loop: 10
-  realizations:
-  - name: gemma4_12b.attention.hd512.dynM.qk
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 324.8853286107381
+      reference_us: 471.5520143508911
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.dynamic
     bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1308.8959455490112
+      reference_us: 1320.512056350708
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 14.498783194500467
+      reference_us: 14.498783194500467
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 17.747428800378525
+      reference_us: 17.747428800378525
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 22.45309136130593
+      reference_us: 22.94399987819583
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 73.07885374341693
+      reference_us: 73.07885374341693
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 125.89199841022491
+      reference_us: 126.67599320411682
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 177.53599087397257
+      reference_us: 177.53599087397257
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f2x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 357.3760191599528
+      reference_us: 471.47199511528015
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1156.0319662094116
+      reference_us: 1318.0160522460938
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 11
+  realizations:
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9642316452784888
+      reference_us: 0.9642316452784888
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9736296145307157
+      reference_us: 0.974152652718083
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0953603673477423
+      reference_us: 1.095368412503025
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2006538275342722
+      reference_us: 1.2008461814660292
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.558464886431761
+      reference_us: 1.558464886431761
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.381311132126497
+      reference_us: 8.381311132126497
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.810539798131064
+      reference_us: 15.812571086580792
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.851008689641273
+      reference_us: 2.851008689641273
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9656069585683846
+      reference_us: 0.965823797150249
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0950877086112374
+      reference_us: 1.0950877086112374
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2006153567479205
+      reference_us: 1.2006153567479205
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.833677081143214
+      reference_us: 3.0239031170353745
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.67710791619171
+      reference_us: 4.67710791619171
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.376470633915492
+      reference_us: 8.376470633915492
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.811047856769864
+      reference_us: 15.811047856769864
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.8517486367906844
+      reference_us: 2.8517486367906844
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 12
+  realizations:
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.694266665312979
+      reference_us: 0.694266665312979
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7643764403911611
+      reference_us: 0.7643764403911611
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.977637788911504
+      reference_us: 0.977637788911504
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0201390413662652
+      reference_us: 1.0204371806915253
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f2
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1576864085269445
+      reference_us: 1.1577235835492958
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.0914287372511255
+      reference_us: 4.0914287372511255
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.405850869506153
+      reference_us: 7.405850869506153
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.558464886431761
+      reference_us: 1.558464886431761
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.6962859221246581
+      reference_us: 0.6968368213712088
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9791119745063406
+      reference_us: 0.9809546099141739
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0203316487455807
+      reference_us: 1.0205678969043268
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5754818351347866
+      reference_us: 1.5754818351347866
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.44815691429026
+      reference_us: 2.44815691429026
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.108773582756764
+      reference_us: 4.108773582756764
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.385362960674144
+      reference_us: 7.385362960674144
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_d71c85.a39693f97389.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5588143314474645
+      reference_us: 1.5591774774117633
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 13
+  realizations:
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 14.556290446848108
+      reference_us: 14.556290446848108
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 529.0079712867737
+      reference_us: 529.9839973449707
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 17.748000366347178
+      reference_us: 17.748000366347178
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 22.418182004581798
+      reference_us: 22.980465445407603
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 42.2427835671798
+      reference_us: 42.2427835671798
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 177.74399121602377
+      reference_us: 177.74399121602377
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f2x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 356.9066524505615
+      reference_us: 471.72799706459045
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1307.2960376739502
+      reference_us: 1319.3919658660889
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 14.495999916740086
+      reference_us: 14.495999916740086
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 17.79028560434069
+      reference_us: 17.79028560434069
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 22.40436320955103
+      reference_us: 22.95367385065833
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 73.08342627116612
+      reference_us: 73.08342627116612
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 125.76399743556976
+      reference_us: 126.59600377082825
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 177.63733863830566
+      reference_us: 177.63733863830566
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 374.58133697509766
+      reference_us: 471.43998742103577
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_linear_dad69a.607027e28f46.to_6.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1306.879997253418
+      reference_us: 1317.9839849472046
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 14
+  realizations:
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9655343161688911
+      reference_us: 0.9657618844843787
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9972427512977744
+      reference_us: 0.9977978032391828
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0947793820294276
+      reference_us: 1.0954035086589946
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2005198876923746
+      reference_us: 1.2005198876923746
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.562942081773785
+      reference_us: 1.562942081773785
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.38184857568821
+      reference_us: 8.38184857568821
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.81206302794199
+      reference_us: 15.81206302794199
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.852480070931571
+      reference_us: 2.8529371534075056
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9634937065235083
+      reference_us: 0.9647488131555507
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0953765407482696
+      reference_us: 1.0953765407482696
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2003461328836589
+      reference_us: 1.2003461328836589
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.8346363793719895
+      reference_us: 3.040097472144336
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.677981416755747
+      reference_us: 4.677981416755747
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.389378295225255
+      reference_us: 8.389378295225255
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.814603321135989
+      reference_us: 15.818158785502117
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_mean_e41b90.a27e788ea980.pow_8.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.85257135118757
+      reference_us: 2.85257135118757
+      reference_backend: emmy-greedy
+- program: 2
+  target:
+    loop: 15
+  realizations:
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.6826885166715403
+      reference_us: 0.6826885166715403
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.6899253296489373
+      reference_us: 0.690063805256075
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7285831099696479
+      reference_us: 0.7285831099696479
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.779570177489636
+      reference_us: 0.7796567892321559
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0390176857423334
+      reference_us: 1.0392681972400561
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.9104251411017468
+      reference_us: 3.9104251411017468
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.112623951959272
+      reference_us: 7.112623951959272
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3910562134860607
+      reference_us: 1.3927130812057877
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.6844273985248722
+      reference_us: 0.6844273985248722
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.728396519627585
+      reference_us: 0.728396519627585
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7797999773174524
+      reference_us: 0.7798092452877663
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.441481920813686
+      reference_us: 1.441481920813686
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.3207832605410847
+      reference_us: 2.3207832605410847
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.907653525119691
+      reference_us: 3.907653525119691
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.131885630743844
+      reference_us: 7.131885630743844
+      reference_backend: emmy-greedy
+  - name: pre-sym.k_reshape_99fe82.ce6e1d8482dd.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3913742823307742
+      reference_us: 1.3913742823307742
+      reference_backend: emmy-greedy
+- program: 3
+  target:
+    loop: 16
+  realizations:
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 28.825599806649343
+      reference_us: 28.825599806649343
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m8
+    bindings:
+      num_tokens: 8
     pins:
       FAST_MATH: false
     knobs:
       WORK: w1x1
-      TILE: mma_m16n8k16_f16_f32/f4x8/k2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
       REDUCE: ''
-      STAGE: ''
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 61.91
-      reference_us: 79.08
+      emmy_us: 31.86890386766003
+      reference_us: 31.86890386766003
       reference_backend: emmy-greedy
-- program: 278
-  target:
-    loop: 11
-  realizations:
-  - name: gemma4_12b.attention.hd512.dynM.softmax_v
-    bindings: {}
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m32
+    bindings:
+      num_tokens: 32
     pins:
       FAST_MATH: false
     knobs:
       WORK: w2x2
-      TILE: mma_m16n8k16_f16_f32/f1x8/k2
-      REDUCE: ''
-      STAGE: d1/smem
-      LOOPIFY: '0'
-      RASTER: ''
-    measurements:
-      emmy_us: 51.78
-      reference_us: 864.8
-      reference_backend: emmy-greedy
-- program: 279
-  target:
-    loop: 12
-  realizations:
-  - name: gemma4_12b.attention.hd512.s2048.qk
-    bindings: {}
-    pins:
-      FAST_MATH: false
-    knobs:
-      WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
       REDUCE: ''
       STAGE: d1/smem-tma
       LOOPIFY: '0'
-      RASTER: gm8
+      RASTER: ''
     measurements:
-      emmy_us: 433.28
-      reference_us: 714.89
+      emmy_us: 27.959999110963608
+      reference_us: 37.860923088513886
       reference_backend: emmy-greedy
-- program: 279
-  target:
-    loop: 13
-  realizations:
-  - name: gemma4_12b.attention.hd512.s2048.softmax_v
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 43.337739032247796
+      reference_us: 43.337739032247796
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 82.5413316488266
+      reference_us: 82.5413316488266
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x4
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 836.9280099868774
+      reference_us: 847.9999899864197
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f2x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1258.3359479904175
+      reference_us: 1258.3359479904175
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
       WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f1x8/k4
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
       REDUCE: ''
-      STAGE: d1/smem
+      STAGE: d1/smem-tma
       LOOPIFY: '0'
-      RASTER: gm8
+      RASTER: ''
     measurements:
-      emmy_us: 622.99
-      reference_us: 1177.92
+      emmy_us: 188.65920305252075
+      reference_us: 188.65920305252075
       reference_backend: emmy-greedy
-- program: 280
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 28.77623013087681
+      reference_us: 28.77623013087681
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 27.962668074501888
+      reference_us: 37.835077597544746
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 43.21530331736025
+      reference_us: 43.21530331736025
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w8x1
+      TILE: mma_m16n8k16_f16_f32/f1x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 212.85760402679443
+      reference_us: 213.2352113723755
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f2x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 357.93066024780273
+      reference_us: 357.93066024780273
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f2x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 851.2960076332092
+      reference_us: 851.2960076332092
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f2x8/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1258.080005645752
+      reference_us: 1258.080005645752
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_abaf16.3f7c356103aa.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f1x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 188.1600022315979
+      reference_us: 188.69119882583618
+      reference_backend: emmy-greedy
+- program: 3
   target:
-    loop: 14
+    loop: 17
   realizations:
-  - name: gemma4_12b.attention.hd512.s4096.qk
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.074133316675822
+      reference_us: 1.0743741707135273
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1723192644790865
+      reference_us: 1.1723192644790865
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2347886087867914
+      reference_us: 1.2347886087867914
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5650454074937228
+      reference_us: 1.5654420030528102
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.8909449991972553
+      reference_us: 3.345288686304284
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16.34518044893859
+      reference_us: 21.559651779091876
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 80.76533178488414
+      reference_us: 111.72621779971654
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.083591962347225
+      reference_us: 5.083591962347225
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.074896547301062
+      reference_us: 1.075255088067029
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2359058546754065
+      reference_us: 1.2359058546754065
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5648401643041532
+      reference_us: 1.5648401643041532
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.253894705521433
+      reference_us: 7.315153623149342
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.94500919290491
+      reference_us: 8.94500919290491
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16.366164215275496
+      reference_us: 21.57356557638749
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 80.76000213623047
+      reference_us: 110.95822519726222
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_233f07.37253e398e84.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t16
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.084571485616722
+      reference_us: 5.084571485616722
+      reference_backend: emmy-greedy
+- program: 3
+  target:
+    loop: 18
+  realizations:
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7289201348692507
+      reference_us: 0.7310373205814208
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.9619403160800145
+      reference_us: 0.9619403160800145
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0691422192170659
+      reference_us: 1.0691422192170659
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.525775719714421
+      reference_us: 1.5258560867075899
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.1129511217655903
+      reference_us: 2.1165616968844803
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.263853680003773
+      reference_us: 18.263853680003773
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 116.30400270223618
+      reference_us: 116.43377939860027
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.996903136853249
+      reference_us: 3.996903136853249
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7323711364364063
+      reference_us: 0.7323711364364063
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0703257501061039
+      reference_us: 1.0709538975968111
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5264931170535123
+      reference_us: 1.5264931170535123
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.180619158006612
+      reference_us: 4.180619158006612
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.511097685735028
+      reference_us: 7.511097685735028
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.32533324206317
+      reference_us: 18.32533324206317
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 116.41600396898058
+      reference_us: 116.67554908328587
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_reshape_719dfe.7f96f02b3fcc.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.0059115992013705
+      reference_us: 4.0059115992013705
+      reference_backend: emmy-greedy
+- program: 3
+  target:
+    loop: 19
+  realizations:
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 19.390745490205056
+      reference_us: 19.85919952392578
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f1x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.7767541633462
+      reference_us: 136.87771558761597
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
       WORK: w2x4
-      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.145163492722943
+      reference_us: 478.7999987602234
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
       REDUCE: ''
       STAGE: d1/smem-tma
       LOOPIFY: '0'
       RASTER: gm8
     measurements:
-      emmy_us: 1645.73
-      reference_us: 2746.18
+      emmy_us: 18.169018355282873
+      reference_us: 977.9840111732483
       reference_backend: emmy-greedy
-- program: 280
-  target:
-    loop: 15
-  realizations:
-  - name: gemma4_12b.attention.hd512.s4096.softmax_v
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 20.62733347217242
+      reference_us: 20.62733347217242
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x8
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 71.19542786053249
+      reference_us: 71.19542786053249
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 107.04711410734389
+      reference_us: 107.04711410734389
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.dynamic
     bindings: {}
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w8x2
-      TILE: mma_m16n8k16_f16_f32/f1x8/k4
-      REDUCE: ''
-      STAGE: d1/smem
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 2276.83
-      reference_us: 24740.74
+      emmy_us: 324.0533272425334
+      reference_us: 324.11734263102215
       reference_backend: emmy-greedy
-loops:
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.0625
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 512, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 512, 256]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_f894c4
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 512, 512]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 512, 512]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 512, 256]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: 512}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_192d5d
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 512, 256]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.0625
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_60084c
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, {sym: seq_len, hint: 512}, {sym: seq_len, hint: 512}]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, {sym: seq_len, hint: 512}, {sym: seq_len, hint: 512}]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_338a20
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, {sym: seq_len, hint: 512}, 256]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.0625
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 2048, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 2048, 256]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_b0a031
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 2048, 2048]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 2048, 2048]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 2048, 256]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: 2048}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_bae84f
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 2048, 256]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.0625
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 4096, 256]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 4096, 256]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_da9363
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 4096, 4096]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 4096, 4096]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 4096, 256]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 256}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: 4096}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_75cc65
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 4096, 256]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.044194173824159216
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 512, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 512, 512]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_f7f158
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 512, 512]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 512, 512]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 512, 512]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 512}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: 512}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_bff3e7
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 512, 512]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.044194173824159216
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_5a8cf8
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, {sym: seq_len, hint: 512}, {sym: seq_len, hint: 512}]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, {sym: seq_len, hint: 512}, {sym: seq_len, hint: 512}]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: {sym: seq_len, hint: 512}}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_3c0182
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, {sym: seq_len, hint: 512}, 512]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.044194173824159216
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 2048, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 2048, 512]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_a1d48f
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 2048, 2048]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 2048, 2048]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 2048, 512]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 2048}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 2048}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: 2048}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_f83398
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 2048, 512]]]
-- inputs: [x0, x1]
-  outputs: [scaled_dot_product_attention_scaled]
-  nodes:
-  - id: scaled_dot_product_attention_scale
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_scale
-      value: 0.044194173824159216
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_scale, f16, [1]]]
-  - id: x0
-    op: input
-    outputs: [[x0, f16, [1, 16, 4096, 512]]]
-  - id: x1
-    op: input
-    outputs: [[x1, f16, [1, 16, 4096, 512]]]
-  - id: scaled_dot_product_attention_scaled
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_scale
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                              body:
-                                body:
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in1]}
-                                    input: x1
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a2}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in2]}
-                                    input: x0
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v0, op: {elementwise: multiply}, args: {tuple: [in1, in2]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc0, value: v0, op: {elementwise: add}, dtype: null, axes: {tuple: [a3]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: multiply}, args: {tuple: [acc0, in0]}, dtype: null}
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              values: {tuple: [v1]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_46dc80
-    inputs: [scaled_dot_product_attention_scale, x1, x0]
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 4096, 4096]]]
-- inputs: [scaled_dot_product_attention_scaled, x2]
-  outputs: [scaled_dot_product_attention]
-  nodes:
-  - id: scaled_dot_product_attention_mask_fill_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_fill_c
-      value: -1000000000.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_fill_c, f16, [1]]]
-  - id: scaled_dot_product_attention_mask_zero_c
-    op: constant
-    attrs:
-      name: scaled_dot_product_attention_mask_zero_c
-      value: 0.0
-      context_value: null
-      load_ops: {__tuple__: []}
-      source_path: null
-      source_parts: {__tuple__: []}
-      source_shape: null
-      source_dtype: null
-      source_graph: null
-    outputs: [[scaled_dot_product_attention_mask_zero_c, f16, [1]]]
-  - id: scaled_dot_product_attention_scaled
-    op: input
-    outputs: [[scaled_dot_product_attention_scaled, f16, [1, 16, 4096, 4096]]]
-  - id: x2
-    op: input
-    outputs: [[x2, f16, [1, 16, 4096, 512]]]
-  - id: scaled_dot_product_attention
-    op: loop
-    attrs:
-      body:
-        body:
-        - class: Load
-          fields:
-            names: {tuple: [in0]}
-            input: scaled_dot_product_attention_mask_fill_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Load
-          fields:
-            names: {tuple: [in1]}
-            input: scaled_dot_product_attention_mask_zero_c
-            index: {tuple: [{expr: {literal: {value: 0, dtype: int}}}]}
-            dtype: null
-        - class: Loop
-          fields:
-            axis: {class: Axis, fields: {name: a0, extent: {dim: 16}, window: null}}
-            body:
-              body:
-              - class: Loop
-                fields:
-                  axis: {class: Axis, fields: {name: a1, extent: {dim: 4096}, window: null}}
-                  body:
-                    body:
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v0
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in2]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v1, op: {elementwise: add}, args: {tuple: [in2, v0]}, dtype: null}
-                          - class: Accum
-                            fields:
-                              name: acc0
-                              value: v1
-                              op: {elementwise: maximum}
-                              dtype: null
-                              axes: {tuple: [a2]}
-                              base: null
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a2, extent: {dim: 4096}, window: null}}
-                        body:
-                          body:
-                          - class: Select
-                            fields:
-                              name: v2
-                              branches:
-                                tuple:
-                                - class: SelectBranch
-                                  fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a2}, right: {var: a1}}}}}
-                                - class: SelectBranch
-                                  fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a2}, right: {var: a1}}}}}
-                          - class: Load
-                            fields:
-                              names: {tuple: [in3]}
-                              input: scaled_dot_product_attention_scaled
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a2}}
-                              dtype: null
-                          - class: Assign
-                            fields: {name: v3, op: {elementwise: add}, args: {tuple: [in3, v2]}, dtype: null}
-                          - class: Assign
-                            fields: {name: v4, op: {elementwise: subtract}, args: {tuple: [v3, acc0]}, dtype: null}
-                          - {class: Assign, fields: {name: v5, op: {elementwise: exp}, args: {tuple: [v4]}, dtype: null}}
-                          - class: Accum
-                            fields: {name: acc1, value: v5, op: {elementwise: add}, dtype: null, axes: {tuple: [a2]}, base: null}
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                    - class: Assign
-                      fields: {name: v6, op: {elementwise: reciprocal}, args: {tuple: [acc1]}, dtype: null}
-                    - class: Loop
-                      fields:
-                        axis: {class: Axis, fields: {name: a3, extent: {dim: 512}, window: null}}
-                        body:
-                          body:
-                          - class: Loop
-                            fields:
-                              axis: {class: Axis, fields: {name: a4, extent: {dim: 4096}, window: null}}
-                              body:
-                                body:
-                                - class: Select
-                                  fields:
-                                    name: v7
-                                    branches:
-                                      tuple:
-                                      - class: SelectBranch
-                                        fields: {value: in1, select: {expr: {binary: {op: <=, left: {var: a4}, right: {var: a1}}}}}
-                                      - class: SelectBranch
-                                        fields: {value: in0, select: {expr: {binary: {op: '>', left: {var: a4}, right: {var: a1}}}}}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in4]}
-                                    input: scaled_dot_product_attention_scaled
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a1}}
-                                      - {expr: {var: a4}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v8, op: {elementwise: add}, args: {tuple: [in4, v7]}, dtype: null}
-                                - class: Assign
-                                  fields: {name: v9, op: {elementwise: subtract}, args: {tuple: [v8, acc0]}, dtype: null}
-                                - {class: Assign, fields: {name: v10, op: {elementwise: exp}, args: {tuple: [v9]}, dtype: null}}
-                                - class: Assign
-                                  fields: {name: v11, op: {elementwise: multiply}, args: {tuple: [v10, v6]}, dtype: null}
-                                - class: Load
-                                  fields:
-                                    names: {tuple: [in5]}
-                                    input: x2
-                                    index:
-                                      tuple:
-                                      - {expr: {literal: {value: 0, dtype: int}}}
-                                      - {expr: {var: a0}}
-                                      - {expr: {var: a4}}
-                                      - {expr: {var: a3}}
-                                    dtype: null
-                                - class: Assign
-                                  fields: {name: v12, op: {elementwise: multiply}, args: {tuple: [in5, v11]}, dtype: null}
-                                - class: Accum
-                                  fields: {name: acc2, value: v12, op: {elementwise: add}, dtype: null, axes: {tuple: [a4]}, base: null}
-                              unroll: false
-                              role: {axis_role: free}
-                              seed: true
-                          - class: Write
-                            fields:
-                              output: scaled_dot_product_attention
-                              index:
-                                tuple:
-                                - {expr: {literal: {value: 0, dtype: int}}}
-                                - {expr: {var: a0}}
-                                - {expr: {var: a1}}
-                                - {expr: {var: a3}}
-                              values: {tuple: [acc2]}
-                              value_dtype: null
-                              atomic: false
-                              swizzle: NONE
-                        unroll: false
-                        role: {axis_role: free}
-                        seed: true
-                  unroll: false
-                  role: {axis_role: free}
-                  seed: true
-            unroll: false
-            role: {axis_role: free}
-            seed: true
-      name: k_sdpa_reduce_13839e
-    inputs: [scaled_dot_product_attention_mask_fill_c, scaled_dot_product_attention_mask_zero_c, scaled_dot_product_attention_scaled, x2]
-    outputs: [[scaled_dot_product_attention, f16, [1, 16, 4096, 512]]]
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 19.345568675620882
+      reference_us: 19.837440252304077
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.145163492722943
+      reference_us: 474.89601373672485
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x4
+      TILE: mma_m16n8k16_f16_f32/f1x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 18.166690522974186
+      reference_us: 976.7680168151855
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w1x8
+      TILE: mma_m16n8k16_f16_f32/f2x1/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 28.463542461395264
+      reference_us: 28.463542461395264
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 42.522435602934465
+      reference_us: 42.522435602934465
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x8
+      TILE: mma_m16n8k16_f16_f32/f2x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: gm8
+    measurements:
+      emmy_us: 71.06514487947736
+      reference_us: 71.06514487947736
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 106.82666964001125
+      reference_us: 106.82666964001125
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_linear_57cf55.5ad5294481f6.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 39.59295988082886
+      reference_us: 325.25867223739624
+      reference_backend: emmy-greedy
+- program: 3
+  target:
+    loop: 20
+  realizations:
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2917153893898867
+      reference_us: 1.2917153893898867
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2182634051253156
+      reference_us: 1.219672743362967
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2830436842607043
+      reference_us: 1.2833315946142592
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.370161894417594
+      reference_us: 57.423058678122125
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.74940801543655
+      reference_us: 1.74940801543655
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.5207916064312936
+      reference_us: 3.5207916064312936
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.661934196669171
+      reference_us: 7.329647155369029
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.8826868174211033
+      reference_us: 1.8826868174211033
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2915348513797886
+      reference_us: 1.2918333522975445
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2826289842921441
+      reference_us: 1.2826289842921441
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3715164674507392
+      reference_us: 57.38353028016932
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.8919318745402174
+      reference_us: 1.8919318745402174
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.3823999223254977
+      reference_us: 2.3823999223254977
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.5283675042142297
+      reference_us: 3.5283675042142297
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.657345675976477
+      reference_us: 7.339764605550205
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_bb7574.0bcd352c2381.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.8849207545226474
+      reference_us: 1.8849207545226474
+      reference_backend: emmy-greedy
+- program: 3
+  target:
+    loop: 21
+  realizations:
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m1
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1569629940721724
+      reference_us: 1.1571541445832678
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m8
+    bindings:
+      num_tokens: 8
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.085286943808846
+      reference_us: 1.0857043706852456
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m32
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1006659420480276
+      reference_us: 1.1014068271254231
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m64
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1137569761329404
+      reference_us: 1.4717164208653053
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m192
+    bindings:
+      num_tokens: 192
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2884232305711316
+      reference_us: 1.2884232305711316
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m2048
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.709420069769469
+      reference_us: 2.709420069769469
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m4096
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.7382472766919084
+      reference_us: 4.753676198777699
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.dynamic
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3943365120920916
+      reference_us: 3.3903673392574802
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m1.fm
+    bindings:
+      num_tokens: 1
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1575619840124667
+      reference_us: 1.1575619840124667
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m32.fm
+    bindings:
+      num_tokens: 32
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.101159865432958
+      reference_us: 1.101159865432958
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m64.fm
+    bindings:
+      num_tokens: 64
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t512
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1168859015641863
+      reference_us: 1.4761842200518716
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m512.fm
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.402741570151254
+      reference_us: 1.79148298191639
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m1024.fm
+    bindings:
+      num_tokens: 1024
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7337578390708845
+      reference_us: 1.7337578390708845
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m2048.fm
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.7110676778364313
+      reference_us: 2.7110676778364313
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.m4096.fm
+    bindings:
+      num_tokens: 4096
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.739685378271096
+      reference_us: 4.76631564957103
+      reference_backend: emmy-greedy
+  - name: pre-sym-global.k_mean_d49a02.bb7a571fe4ee.dynamic.fm
+    bindings: {}
+    pins:
+      FAST_MATH: true
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3945027769610867
+      reference_us: 3.4024488358270553
+      reference_backend: emmy-greedy


### PR DESCRIPTION
## Summary

Fixes the 4th RTX 5090 gemma-4 golden orphaning by re-recording the gemma-4-12b-it golden file as the serving-twin realization matrix on a live 5090 — **at current main (f7e236ca, post-#554 recognition rebuild)** — mirroring the #498 base-model rebuild. The file now lives at its #537 location, `recipes/gemma-4-12B-it/golden/rtx5090_sm120.yaml`.

**Root cause** (off-GPU repro + bisect over `fcbc880f..main`): the drifted `mlp_down` rows record atomic-finalize REDUCE (`g4a`/`g8a`), realizable only on the #483-era placement-cut piece. #482 erased that fork entirely (no golden consultation — the invisible flat-cell class); #498's `_duplicated_contraction` guard re-materialized the down matmul uncut with a cast tail, making the DRIFT visible while atomic finalize stays (correctly) unofferable. The resulting cold-prior fallback picks run 4–5 orders over the roofline floor and are the 5090 first-request serving-hang class. The #554 recognition rebuild then re-keyed and re-decomposed the serving kernels, leaving the old file essentially fully unkeyed (6 std / 4 fm matches over ~600 audited forks per lane).

**Fix**: full re-record under the current enumeration — on-card serving-twin trace from the pinned config, two-level tune over all 352 `(bindings, pins)` realizations (std + FAST_MATH), per-target deployable `-O3` verification, and promotion of the O3-fastest **cold-realizable** config per row (`reference_backend: emmy-greedy`; twin IR has no runnable eager reference). Every tune winner replayed clean at O3 (zero pin mismatches, zero demotions); every promoted row realizes with the golden tier as the only evidence.

## Audit results (off-GPU offer audit, serving matrix, RTX 5090 card, at f7e236ca)

| file | std MATCH/DRIFT/GAP | fm MATCH/DRIFT/GAP |
| --- | --- | --- |
| stale file on main | 6 / 0 / 668 | 4 / 0 / 626 |
| this PR | **190 / 0 / 161** | **190 / 0 / 163** |

The stale file also fails the serve-goldens realization-matrix contract for all 281 of its configs. Remaining gaps are forks outside the tuned serving matrix under the finer post-#554 kernel granularity.

## Dropped content

The pre-#482 standalone-target inventory (281 configs: `attention.hd*`, per-width projection rows, `PLACE: cut` routing entries) is removed: it never joins under the structural-identity golden keying, the cut routings no longer produce the recorded seams, and the serving audit never consults it. It stays in git history if the standalone bench flows want a re-record under their own file.

## Known follow-ups (recorded, not fixed)

- M=1 fused cones deploy scalar-tier (no warp option at M=1) — the #496-flagged structural gap; the golden makes the pick deterministic, not fast.
- Remaining GAPs are pre-existing coverage debt outside the serving matrix (the post-#554 fork granularity roughly doubled the audited fork count).

## Validation

- Repository golden schema validation + search/golden-replay/trace/tune-golden-file test subsets: pass (191 tests).
- `make test`: 3443 passed; the single failure (`test_exl3_checkpoint_e2e_cuda` on the dev 4080) is the documented pre-existing exl3 coded-head failure, unrelated (5090-scoped goldens are never consulted on a 4080).
- `make lint`: clean.
- Findings and working artifacts under `_tune/rerecord-5090-rr2-20260823/` (untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)