### PR TITLE
ci: notify Discord about model lifecycle runs

### DIFF
--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -306,6 +306,13 @@ Also verify:
 In the summary, `cleanup.docker_logout: true` means no Docker credential remains: either logout completed after a
 login, or no Docker login was performed because the stock-only path did not require one.
 
+For a successful run, include one-line `deployment_summary` and `performance_summary` values of at most 1000
+characters each. The deployment summary names the selected engine/image and the important serving configuration.
+The performance summary reports the selected recipe lane's measured workload and key throughput/latency/failure
+numbers. Use only measurements from the same exact successful lane that supports the final recipe; never estimate or
+copy numbers from a competing lane. These values are used in the workflow notification and do not replace either
+durable `RESULTS.md` report.
+
 Write this JSON object atomically to the caller-supplied summary path outside the repository and print that path as the
 final line. Include the requested mode on success and failure. List every repository file created, modified, or deleted
 by the qualification run in `artifacts`. List only a complete repository golden in `compiler_artifacts`. In
@@ -319,6 +326,8 @@ in `experiment_artifacts`. Do not list unchanged artifacts from other platforms 
   "mode": "onboarding",
   "model_id": "org/model",
   "target": {"gpu": "exact hardware.py name", "gpu_count": 1, "ssh": "user@host"},
+  "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+  "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, p50 TPOT 7.1 ms, 0 failures",
   "recipe": "recipes/<model>/recipe.yaml",
   "experiment": "experiments/<model>/serving/recipe.yaml",
   "artifacts": [
@@ -353,11 +362,12 @@ in `experiment_artifacts`. Do not list unchanged artifacts from other platforms 
 }
 ```
 
-Use `status: "failed"`, nullable serving artifact fields, `report: null`, and a `failure` object with `gate` and
-`message` when no valid serving recipe is produced. Keep a complete golden populated if compiler qualification
-succeeded. Put partial inventories and useful diagnostics in the external output location, not the repository. Always
-write the summary, then return nonzero for a failed run. Do not delete the VM. The caller uses the SSH target and its
-separately captured provider/instance handle to perform and verify VM cleanup.
+Use `status: "failed"`, nullable serving artifact fields, `deployment_summary: null`, `performance_summary: null`,
+`report: null`, and a `failure` object with `gate` and `message` when no valid serving recipe is produced. Keep a
+complete golden populated if compiler qualification succeeded. Put partial inventories and useful diagnostics in the
+external output location, not the repository. Always write the summary, then return nonzero for a failed run. Do not
+delete the VM. The caller uses the SSH target and its separately captured provider/instance handle to perform and
+verify VM cleanup.
 
 On any failure, tear down workloads, report the first failed gate and external diagnostic paths, remove task-owned
 measurement output from the checkout, and return nonzero. Never claim partial onboarding as success.

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -122,15 +122,16 @@ requires each task-local timestamp directory to be a root member of the declared
 that ignored local directory; only the durable archive proceeds to staging.
 The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
 the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
-model, and expected lifecycle tag. The workflow then commits those artifacts, rebases on the latest default branch,
-and updates or opens the rolling model lifecycle PR using renewable GitHub App credentials for the long-running push
-path.
+model, expected lifecycle tag, and compact deployment and measured-performance summaries from the selected recipe
+lane. The workflow then commits those artifacts, rebases on the latest default branch, and updates or opens the
+rolling model lifecycle PR using renewable GitHub App credentials for the long-running push path.
 
-Both lifecycle workflows finish with a separate GitHub-hosted notification job. Discovery posts its result, run, and
-rolling PR; onboarding also includes the selected model, target, and operation mode. Because the notification job is
-independent of the self-hosted agent job, it still runs after a failure, cancellation, or timeout. Discord delivery
-retries three times, remains non-blocking, and disables all mentions; the workflow run and rolling PR retain the
-detailed evidence.
+Both lifecycle workflows finish with a separate GitHub-hosted notification job. Discovery groups only recipe entries
+actually modified by the run under their resulting lifecycle and links the run and rolling PR. Onboarding includes the
+selected model, target, operation mode, serving deployment, and measured performance from its validated atomic
+summary. Because the notification job is independent of the self-hosted agent job, it still runs after a failure,
+cancellation, or timeout. Discord delivery retries three times, remains non-blocking, and disables all mentions; the
+workflow run, durable reports, and rolling PR retain the complete evidence.
 
 ### Discovery lifecycle PR
 

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -126,6 +126,12 @@ model, and expected lifecycle tag. The workflow then commits those artifacts, re
 and updates or opens the rolling model lifecycle PR using renewable GitHub App credentials for the long-running push
 path.
 
+Both lifecycle workflows finish with a separate GitHub-hosted notification job. Discovery posts its result, run, and
+rolling PR; onboarding also includes the selected model, target, and operation mode. Because the notification job is
+independent of the self-hosted agent job, it still runs after a failure, cancellation, or timeout. Discord delivery
+retries three times, remains non-blocking, and disables all mentions; the workflow run and rolling PR retain the
+detailed evidence.
+
 ### Discovery lifecycle PR
 
 **Discover model** runs nightly or by manual dispatch. Discovery and qualification share a static concurrency group
@@ -183,6 +189,7 @@ configuration live only under run-specific `/tmp/emmy-*` paths and are removed b
 Agent workflows use these repository secrets as applicable:
 
 - `CLOUDRIFT_API_KEY` for model discovery, Robots-team resolution, availability, and CloudRift provisioning;
+- `DISCORD_EMMY_ROBOTS_WEBHOOK_URL` for non-pinging model discovery, verification, and onboarding summaries;
 - `HF_TOKEN` for gated checkpoints;
 - `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for an eligible verified prebuilt image.
 

--- a/.github/scripts/discord_notification.py
+++ b/.github/scripts/discord_notification.py
@@ -1,0 +1,173 @@
+"""Post a compact, non-pinging model lifecycle summary to Discord."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+LOGGER = logging.getLogger(__name__)
+
+SUCCESS_COLOR = 5_763_719
+FAILURE_COLOR = 15_548_997
+CANCELLED_COLOR = 16_705_372
+NEUTRAL_COLOR = 9_807_270
+
+
+def _run_url(environment: Mapping[str, str]) -> str:
+    return f"{environment['GITHUB_SERVER_URL']}/{environment['GITHUB_REPOSITORY']}/actions/runs/{environment['GITHUB_RUN_ID']}"
+
+
+def _pull_request_field(environment: Mapping[str, str]) -> dict[str, Any] | None:
+    number = environment.get("PR_NUMBER", "")
+    if not number.isdigit():
+        return None
+    url = f"{environment['GITHUB_SERVER_URL']}/{environment['GITHUB_REPOSITORY']}/pull/{number}"
+    return {"name": "Rolling PR", "value": f"[#{number}]({url})", "inline": True}
+
+
+def _onboard_summary(environment: Mapping[str, str]) -> tuple[str, str, int, list[dict[str, Any]]]:
+    result = environment.get("WORKFLOW_RESULT", "failure")
+    selected = environment.get("SELECTED", "")
+    mode = environment.get("ONBOARD_MODE", "")
+    model_id = environment.get("MODEL_ID") or "Automatic selection"
+    gpu = environment.get("TARGET_GPU") or "Automatic selection"
+    gpu_count = environment.get("TARGET_GPU_COUNT", "")
+    target = f"{gpu} x{gpu_count}" if gpu_count else gpu
+
+    if result == "success" and selected == "false":
+        title = "No eligible model deployment"
+        description = "The nightly selector found no onboarding or maintained recipe with available hardware."
+        color = NEUTRAL_COLOR
+    elif result == "success":
+        operation = "verification" if mode == "verification" else "onboarding"
+        title = f"Model {operation} completed"
+        description = "The model lifecycle artifacts were pushed and the rolling pull request was updated."
+        color = SUCCESS_COLOR
+    elif result == "cancelled":
+        title = "Model onboarding workflow cancelled"
+        description = "The model lifecycle workflow was cancelled before it completed."
+        color = CANCELLED_COLOR
+    else:
+        operation = f" {mode}" if mode else ""
+        title = f"Model{operation} failed"
+        description = "The model lifecycle workflow failed. Open the run for the failing step and logs."
+        color = FAILURE_COLOR
+
+    fields: list[dict[str, Any]] = [
+        {"name": "Model", "value": f"`{model_id[:1000]}`", "inline": False},
+        {"name": "Target", "value": f"`{target[:1000]}`", "inline": False},
+    ]
+    if mode:
+        fields.append({"name": "Mode", "value": f"`{mode[:1000]}`", "inline": True})
+    return title, description, color, fields
+
+
+def _discover_summary(environment: Mapping[str, str]) -> tuple[str, str, int, list[dict[str, Any]]]:
+    result = environment.get("WORKFLOW_RESULT", "failure")
+    if result == "success":
+        return (
+            "Model discovery completed",
+            "The maintained recipe set was reviewed and the rolling model lifecycle pull request was refreshed.",
+            SUCCESS_COLOR,
+            [],
+        )
+    if result == "cancelled":
+        return (
+            "Model discovery workflow cancelled",
+            "The model discovery workflow was cancelled before it completed.",
+            CANCELLED_COLOR,
+            [],
+        )
+    return (
+        "Model discovery failed",
+        "The model discovery workflow failed. Open the run for the failing step and logs.",
+        FAILURE_COLOR,
+        [],
+    )
+
+
+def build_payload(environment: Mapping[str, str], *, now: datetime | None = None) -> dict[str, Any]:
+    """Build the Discord webhook body from a GitHub Actions environment."""
+    workflow_kind = environment.get("WORKFLOW_KIND", "")
+    if workflow_kind == "onboard":
+        title, description, color, fields = _onboard_summary(environment)
+    elif workflow_kind == "discover":
+        title, description, color, fields = _discover_summary(environment)
+    else:
+        raise ValueError(f"Unsupported WORKFLOW_KIND: {workflow_kind!r}")
+
+    pull_request = _pull_request_field(environment)
+    if pull_request is not None:
+        fields.append(pull_request)
+    timestamp = now or datetime.now(UTC)
+    return {
+        "username": "Emmy Robots",
+        "allowed_mentions": {"parse": []},
+        "embeds": [
+            {
+                "title": title,
+                "url": _run_url(environment),
+                "description": description,
+                "color": color,
+                "fields": fields,
+                "footer": {"text": f"{environment['GITHUB_REPOSITORY']} · run {environment['GITHUB_RUN_ID']}"},
+                "timestamp": timestamp.astimezone(UTC).isoformat(),
+            }
+        ],
+    }
+
+
+def send_notification(
+    webhook_url: str,
+    payload: Mapping[str, Any],
+    *,
+    opener: Callable[..., Any] = urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> bool:
+    """Send a webhook payload, retrying transient delivery failures three times."""
+    separator = "&" if "?" in webhook_url else "?"
+    request = Request(
+        f"{webhook_url}{separator}wait=true",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "User-Agent": "emmy-github-actions"},
+        method="POST",
+    )
+    for attempt in range(1, 4):
+        try:
+            with opener(request, timeout=15) as response:
+                response.read()
+                if response.status != 200:
+                    raise RuntimeError(f"unexpected HTTP status {response.status}")
+            return True
+        except (HTTPError, URLError, TimeoutError, RuntimeError) as error:
+            if attempt == 3:
+                LOGGER.warning(
+                    "::warning::Discord notification failed after three attempts: %s",
+                    type(error).__name__,
+                )
+                return False
+            sleeper(attempt)
+    return False
+
+
+def main(environment: Mapping[str, str] | None = None) -> int:
+    """Send the configured notification without making its workflow fail."""
+    values = os.environ if environment is None else environment
+    webhook_url = values.get("DISCORD_WEBHOOK_URL", "").strip()
+    if not webhook_url:
+        LOGGER.warning("::warning::DISCORD_EMMY_ROBOTS_WEBHOOK_URL is not configured; skipping Discord notification")
+        return 0
+    send_notification(webhook_url, build_payload(values))
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())

--- a/.github/scripts/discord_notification.py
+++ b/.github/scripts/discord_notification.py
@@ -18,6 +18,14 @@ SUCCESS_COLOR = 5_763_719
 FAILURE_COLOR = 15_548_997
 CANCELLED_COLOR = 16_705_372
 NEUTRAL_COLOR = 9_807_270
+FIELD_VALUE_LIMIT = 1024
+
+LIFECYCLE_LABELS = {
+    "maintained": "Maintained",
+    "best-effort": "Best effort",
+    "obsolete": "Obsolete",
+    "onboarding": "Onboarding",
+}
 
 
 def _run_url(environment: Mapping[str, str]) -> str:
@@ -30,6 +38,51 @@ def _pull_request_field(environment: Mapping[str, str]) -> dict[str, Any] | None
         return None
     url = f"{environment['GITHUB_SERVER_URL']}/{environment['GITHUB_REPOSITORY']}/pull/{number}"
     return {"name": "Rolling PR", "value": f"[#{number}]({url})", "inline": True}
+
+
+def _line_fields(name: str, lines: list[str]) -> list[dict[str, Any]]:
+    fields = []
+    chunk = []
+    length = 0
+    for line in lines:
+        added = len(line) + (1 if chunk else 0)
+        if chunk and length + added > FIELD_VALUE_LIMIT:
+            fields.append({"name": name if not fields else f"{name} (continued)", "value": "\n".join(chunk), "inline": False})
+            chunk = []
+            length = 0
+        chunk.append(line[:FIELD_VALUE_LIMIT])
+        length += len(chunk[-1]) + (1 if len(chunk) > 1 else 0)
+    if chunk:
+        fields.append({"name": name if not fields else f"{name} (continued)", "value": "\n".join(chunk), "inline": False})
+    return fields
+
+
+def _modified_model_fields(raw_changes: str) -> list[dict[str, Any]]:
+    if not raw_changes:
+        return [{"name": "Modified models", "value": "None; the lifecycle review produced no recipe changes.", "inline": False}]
+    try:
+        changes = json.loads(raw_changes)
+    except json.JSONDecodeError:
+        changes = None
+    if not isinstance(changes, list):
+        return [{"name": "Modified models", "value": "Summary unavailable; open the rolling PR for the diff.", "inline": False}]
+    if not changes:
+        return [{"name": "Modified models", "value": "None; the lifecycle review produced no recipe changes.", "inline": False}]
+
+    grouped = {lifecycle: [] for lifecycle in LIFECYCLE_LABELS}
+    for change in changes:
+        if not isinstance(change, dict):
+            continue
+        model_id = change.get("model_id")
+        lifecycle = change.get("lifecycle")
+        if isinstance(model_id, str) and lifecycle in grouped:
+            grouped[lifecycle].append(f"• `{model_id}`")
+
+    fields = []
+    for lifecycle, label in LIFECYCLE_LABELS.items():
+        if grouped[lifecycle]:
+            fields.extend(_line_fields(label, grouped[lifecycle]))
+    return fields or [{"name": "Modified models", "value": "Summary unavailable; open the rolling PR for the diff.", "inline": False}]
 
 
 def _onboard_summary(environment: Mapping[str, str]) -> tuple[str, str, int, list[dict[str, Any]]]:
@@ -64,6 +117,13 @@ def _onboard_summary(environment: Mapping[str, str]) -> tuple[str, str, int, lis
         {"name": "Model", "value": f"`{model_id[:1000]}`", "inline": False},
         {"name": "Target", "value": f"`{target[:1000]}`", "inline": False},
     ]
+    deployment_summary = environment.get("DEPLOYMENT_SUMMARY", "").strip()
+    performance_summary = environment.get("PERFORMANCE_SUMMARY", "").strip()
+    if result == "success" and selected != "false":
+        if deployment_summary:
+            fields.append({"name": "Deployment", "value": deployment_summary[:FIELD_VALUE_LIMIT], "inline": False})
+        if performance_summary:
+            fields.append({"name": "Performance", "value": performance_summary[:FIELD_VALUE_LIMIT], "inline": False})
     if mode:
         fields.append({"name": "Mode", "value": f"`{mode[:1000]}`", "inline": True})
     return title, description, color, fields
@@ -76,7 +136,7 @@ def _discover_summary(environment: Mapping[str, str]) -> tuple[str, str, int, li
             "Model discovery completed",
             "The maintained recipe set was reviewed and the rolling model lifecycle pull request was refreshed.",
             SUCCESS_COLOR,
-            [],
+            _modified_model_fields(environment.get("MODIFIED_MODELS", "")),
         )
     if result == "cancelled":
         return (
@@ -164,7 +224,8 @@ def main(environment: Mapping[str, str] | None = None) -> int:
     if not webhook_url:
         LOGGER.warning("::warning::DISCORD_EMMY_ROBOTS_WEBHOOK_URL is not configured; skipping Discord notification")
         return 0
-    send_notification(webhook_url, build_payload(values))
+    if send_notification(webhook_url, build_payload(values)):
+        LOGGER.info("Discord notification delivered")
     return 0
 
 

--- a/.github/scripts/discovery_lifecycle.py
+++ b/.github/scripts/discovery_lifecycle.py
@@ -410,15 +410,19 @@ def _summary(manifest: dict) -> str:
 def apply_manifest(manifest: dict, workspace: Path, summary_path: Path) -> dict:
     """Apply a validated manifest and return change/count outputs."""
     records = recipe_catalog(workspace / "recipes")
-    changed = False
+    modified_models = []
     for decision in manifest["maintained_models"]:
-        changed = _set_lifecycle(records[decision["model_id"]], MAINTAINED_TAG, decision["rationale"]) or changed
+        if _set_lifecycle(records[decision["model_id"]], MAINTAINED_TAG, decision["rationale"]):
+            modified_models.append({"model_id": decision["model_id"], "lifecycle": MAINTAINED_TAG})
     for decision in manifest["best_effort_models"]:
-        changed = _set_lifecycle(records[decision["model_id"]], BEST_EFFORT_TAG, decision["rationale"]) or changed
+        if _set_lifecycle(records[decision["model_id"]], BEST_EFFORT_TAG, decision["rationale"]):
+            modified_models.append({"model_id": decision["model_id"], "lifecycle": BEST_EFFORT_TAG})
     for decision in manifest["obsolete_models"]:
-        changed = _set_lifecycle(records[decision["model_id"]], OBSOLETE_TAG, decision["rationale"]) or changed
+        if _set_lifecycle(records[decision["model_id"]], OBSOLETE_TAG, decision["rationale"]):
+            modified_models.append({"model_id": decision["model_id"], "lifecycle": OBSOLETE_TAG})
     for decision in manifest["existing_onboarding_models"]:
-        changed = _set_lifecycle(records[decision["model_id"]], ONBOARDING_TAG, decision["rationale"]) or changed
+        if _set_lifecycle(records[decision["model_id"]], ONBOARDING_TAG, decision["rationale"]):
+            modified_models.append({"model_id": decision["model_id"], "lifecycle": ONBOARDING_TAG})
     for candidate in manifest["onboarding_models"]:
         create_recipe_stub(
             workspace / "recipes",
@@ -427,9 +431,9 @@ def apply_manifest(manifest: dict, workspace: Path, summary_path: Path) -> dict:
             candidate["task"],
             candidate["deployments"],
         )
-        changed = True
+        modified_models.append({"model_id": candidate["model_id"], "lifecycle": ONBOARDING_TAG})
     summary_path.write_text(_summary(manifest))
-    return {"changed": changed}
+    return {"changed": bool(modified_models), "modified_models": modified_models}
 
 
 def _write_outputs(result: dict) -> None:
@@ -438,7 +442,12 @@ def _write_outputs(result: dict) -> None:
         return
     with open(output_path, "a") as output:
         for key, value in result.items():
-            rendered = str(value).lower() if isinstance(value, bool) else value
+            if isinstance(value, bool):
+                rendered = str(value).lower()
+            elif isinstance(value, (dict, list)):
+                rendered = json.dumps(value, separators=(",", ":"), sort_keys=True)
+            else:
+                rendered = value
             output.write(f"{key}={rendered}\n")
 
 

--- a/.github/scripts/discovery_lifecycle.py
+++ b/.github/scripts/discovery_lifecycle.py
@@ -410,19 +410,15 @@ def _summary(manifest: dict) -> str:
 def apply_manifest(manifest: dict, workspace: Path, summary_path: Path) -> dict:
     """Apply a validated manifest and return change/count outputs."""
     records = recipe_catalog(workspace / "recipes")
-    modified_models = []
+    changed = False
     for decision in manifest["maintained_models"]:
-        if _set_lifecycle(records[decision["model_id"]], MAINTAINED_TAG, decision["rationale"]):
-            modified_models.append({"model_id": decision["model_id"], "lifecycle": MAINTAINED_TAG})
+        changed = _set_lifecycle(records[decision["model_id"]], MAINTAINED_TAG, decision["rationale"]) or changed
     for decision in manifest["best_effort_models"]:
-        if _set_lifecycle(records[decision["model_id"]], BEST_EFFORT_TAG, decision["rationale"]):
-            modified_models.append({"model_id": decision["model_id"], "lifecycle": BEST_EFFORT_TAG})
+        changed = _set_lifecycle(records[decision["model_id"]], BEST_EFFORT_TAG, decision["rationale"]) or changed
     for decision in manifest["obsolete_models"]:
-        if _set_lifecycle(records[decision["model_id"]], OBSOLETE_TAG, decision["rationale"]):
-            modified_models.append({"model_id": decision["model_id"], "lifecycle": OBSOLETE_TAG})
+        changed = _set_lifecycle(records[decision["model_id"]], OBSOLETE_TAG, decision["rationale"]) or changed
     for decision in manifest["existing_onboarding_models"]:
-        if _set_lifecycle(records[decision["model_id"]], ONBOARDING_TAG, decision["rationale"]):
-            modified_models.append({"model_id": decision["model_id"], "lifecycle": ONBOARDING_TAG})
+        changed = _set_lifecycle(records[decision["model_id"]], ONBOARDING_TAG, decision["rationale"]) or changed
     for candidate in manifest["onboarding_models"]:
         create_recipe_stub(
             workspace / "recipes",
@@ -431,9 +427,9 @@ def apply_manifest(manifest: dict, workspace: Path, summary_path: Path) -> dict:
             candidate["task"],
             candidate["deployments"],
         )
-        modified_models.append({"model_id": candidate["model_id"], "lifecycle": ONBOARDING_TAG})
+        changed = True
     summary_path.write_text(_summary(manifest))
-    return {"changed": bool(modified_models), "modified_models": modified_models}
+    return {"changed": changed}
 
 
 def _write_outputs(result: dict) -> None:
@@ -442,12 +438,7 @@ def _write_outputs(result: dict) -> None:
         return
     with open(output_path, "a") as output:
         for key, value in result.items():
-            if isinstance(value, bool):
-                rendered = str(value).lower()
-            elif isinstance(value, (dict, list)):
-                rendered = json.dumps(value, separators=(",", ":"), sort_keys=True)
-            else:
-                rendered = value
+            rendered = str(value).lower() if isinstance(value, bool) else value
             output.write(f"{key}={rendered}\n")
 
 

--- a/.github/scripts/onboarding_artifacts.py
+++ b/.github/scripts/onboarding_artifacts.py
@@ -20,6 +20,16 @@ ALLOWED_ARTIFACT_PREFIXES = (
     "experiments/",
     "recipes/",
 )
+SUMMARY_TEXT_LIMIT = 1000
+
+
+def _summary_text(summary: dict, field: str) -> str:
+    value = summary.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Summary must include a non-empty {field}")
+    if "\n" in value or "\r" in value or len(value) > SUMMARY_TEXT_LIMIT:
+        raise ValueError(f"Summary {field} must be one line of at most {SUMMARY_TEXT_LIMIT} characters")
+    return value
 
 
 def _relative_file(workspace: Path, raw_path: str, prefixes: tuple[str, ...]) -> Path:
@@ -107,6 +117,8 @@ def validate_summary(
     expected_target = {"gpu": gpu, "gpu_count": gpu_count, "ssh": ssh_target}
     if target != expected_target:
         raise ValueError(f"Summary target mismatch: {target} != {expected_target}")
+    _summary_text(summary, "deployment_summary")
+    _summary_text(summary, "performance_summary")
     cleanup = summary.get("cleanup") or {}
     if cleanup.get("workloads") != "complete" or cleanup.get("docker_logout") is not True:
         raise ValueError(f"Remote workload or Docker credential cleanup is incomplete: {cleanup}")

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -20,6 +20,7 @@ jobs:
       pull-requests: read
     outputs:
       pr_number: ${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}
+      modified_models: ${{ steps.lifecycle.outputs.modified_models }}
     env:
       GH_REPO: ${{ github.repository }}
       MAINTAINED_MODEL_COUNT: 10
@@ -375,6 +376,7 @@ jobs:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_EMMY_ROBOTS_WEBHOOK_URL }}
       WORKFLOW_KIND: discover
       WORKFLOW_RESULT: ${{ needs.discover.result }}
+      MODIFIED_MODELS: ${{ needs.discover.outputs.modified_models }}
       PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
     steps:
       - name: Checkout exact workflow source

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -266,6 +266,46 @@ jobs:
             echo "Expected at most 3 onboarding recipes, found $onboarding_count" >&2
             exit 1
           fi
+          ./venv/bin/python - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          import yaml
+
+          paths = set()
+          for command in (
+              ["git", "diff", "--name-only", "-z", "HEAD", "--", "recipes"],
+              ["git", "ls-files", "--others", "--exclude-standard", "-z", "--", "recipes"],
+          ):
+              paths.update(
+                  subprocess.run(command, capture_output=True, text=True, check=True)
+                  .stdout.rstrip("\0")
+                  .split("\0")
+              )
+          modified_models = []
+          for raw_path in sorted(filter(None, paths)):
+              path = Path(raw_path)
+              if path.name != "recipe.yaml":
+                  continue
+              recipe = yaml.safe_load(path.read_text()) or {}
+              model_id = (recipe.get("model") or {}).get("huggingface")
+              lifecycle = next(
+                  (
+                      tag
+                      for tag in ("maintained", "best-effort", "obsolete", "onboarding")
+                      if tag in (recipe.get("tags") or [])
+                  ),
+                  None,
+              )
+              if not isinstance(model_id, str) or lifecycle is None:
+                  raise SystemExit(f"Modified recipe lacks a model ID or lifecycle: {path}")
+              modified_models.append({"model_id": model_id, "lifecycle": lifecycle})
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              payload = json.dumps(modified_models, separators=(",", ":"), sort_keys=True)
+              output.write(f"modified_models={payload}\n")
+          PY
           git diff --check
 
       - name: Refresh GitHub App token

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      pr_number: ${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}
     env:
       GH_REPO: ${{ github.repository }}
       MAINTAINED_MODEL_COUNT: 10
@@ -310,6 +312,7 @@ jobs:
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
       - name: Create or update rolling discovery pull request
+        id: lifecycle-pr
         if: steps.lifecycle.outputs.changed == 'true' || steps.rolling.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
@@ -347,6 +350,7 @@ jobs:
           retry_gh gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
             -f 'labels[]=model-discovery' \
             -f 'labels[]=model-onboarding' >/dev/null
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Cleanup discovery credentials and output
         if: always()
@@ -358,3 +362,27 @@ jobs:
             "$AGENT_INVENTORY" \
             "$DISCOVERY_SUMMARY"
           git config --unset-all credential.helper || true
+
+  notify:
+    name: Notify Discord
+    needs: discover
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_EMMY_ROBOTS_WEBHOOK_URL }}
+      WORKFLOW_KIND: discover
+      WORKFLOW_RESULT: ${{ needs.discover.result }}
+      PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
+    steps:
+      - name: Checkout exact workflow source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Send discovery summary
+        continue-on-error: true
+        run: python3 .github/scripts/discord_notification.py

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -43,6 +43,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      selected: ${{ steps.selection.outputs.selected }}
+      model_id: ${{ steps.selection.outputs.model_id }}
+      gpu: ${{ steps.selection.outputs.gpu }}
+      gpu_count: ${{ steps.selection.outputs.gpu_count }}
+      mode: ${{ steps.selection.outputs.mode }}
+      pr_number: ${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}
     env:
       GH_REPO: ${{ github.repository }}
       REQUESTED_MODEL_ID: ${{ inputs.model_id }}
@@ -765,6 +772,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Create or update rolling model lifecycle pull request
+        id: lifecycle-pr
         if: steps.vm.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.app-token-refresh.outputs.token }}
@@ -807,6 +815,7 @@ jobs:
           retry_gh gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
             -f 'labels[]=model-discovery' \
             -f 'labels[]=model-onboarding' >/dev/null
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Cleanup local credentials and output
         if: always()
@@ -827,3 +836,32 @@ jobs:
             *) echo "Refusing to remove unexpected workflow source path: $WORKFLOW_SOURCE" >&2; exit 1 ;;
           esac
           git config --unset-all credential.helper || true
+
+  notify:
+    name: Notify Discord
+    needs: onboard
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_EMMY_ROBOTS_WEBHOOK_URL }}
+      WORKFLOW_KIND: onboard
+      WORKFLOW_RESULT: ${{ needs.onboard.result }}
+      SELECTED: ${{ needs.onboard.outputs.selected }}
+      MODEL_ID: ${{ needs.onboard.outputs.model_id || inputs.model_id }}
+      TARGET_GPU: ${{ needs.onboard.outputs.gpu || inputs.gpu }}
+      TARGET_GPU_COUNT: ${{ needs.onboard.outputs.gpu_count || inputs.gpu_count }}
+      ONBOARD_MODE: ${{ needs.onboard.outputs.mode }}
+      PR_NUMBER: ${{ needs.onboard.outputs.pr_number }}
+    steps:
+      - name: Checkout exact workflow source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Send onboarding summary
+        continue-on-error: true
+        run: python3 .github/scripts/discord_notification.py

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -49,6 +49,8 @@ jobs:
       gpu: ${{ steps.selection.outputs.gpu }}
       gpu_count: ${{ steps.selection.outputs.gpu_count }}
       mode: ${{ steps.selection.outputs.mode }}
+      deployment_summary: ${{ steps.artifacts.outputs.deployment_summary }}
+      performance_summary: ${{ steps.artifacts.outputs.performance_summary }}
       pr_number: ${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}
     env:
       GH_REPO: ${{ github.repository }}
@@ -523,6 +525,7 @@ jobs:
           filter: lfs, but do not run git lfs track and do not modify or list .gitattributes in the summary.
           Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
           output. Allowed areas are recipes/, experiments/, docker/vllm-emmy-serve/models/, and canonical golden YAML.
+          Include one-line deployment_summary and performance_summary values drawn from the exact selected recipe lane.
           """
           Path(os.environ["AGENT_PROMPT"]).write_text(prompt)
           PY
@@ -698,6 +701,7 @@ jobs:
           fi
 
       - name: Validate and stage model artifacts
+        id: artifacts
         if: steps.vm.outcome == 'success'
         env:
           SSH_TARGET: ${{ steps.vm.outputs.ssh_target }}
@@ -714,6 +718,10 @@ jobs:
             --mode "$ONBOARD_MODE" \
             --expected-tag "$EXPECTED_LIFECYCLE" \
             --stage
+          {
+            echo "deployment_summary=$(jq -r .deployment_summary "$ONBOARD_SUMMARY")"
+            echo "performance_summary=$(jq -r .performance_summary "$ONBOARD_SUMMARY")"
+          } >> "$GITHUB_OUTPUT"
           git lfs status
           git diff --cached --check
           if git diff --cached --quiet; then
@@ -854,6 +862,8 @@ jobs:
       TARGET_GPU: ${{ needs.onboard.outputs.gpu || inputs.gpu }}
       TARGET_GPU_COUNT: ${{ needs.onboard.outputs.gpu_count || inputs.gpu_count }}
       ONBOARD_MODE: ${{ needs.onboard.outputs.mode }}
+      DEPLOYMENT_SUMMARY: ${{ needs.onboard.outputs.deployment_summary }}
+      PERFORMANCE_SUMMARY: ${{ needs.onboard.outputs.performance_summary }}
       PR_NUMBER: ${{ needs.onboard.outputs.pr_number }}
     steps:
       - name: Checkout exact workflow source

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -106,9 +106,10 @@ directly; they never import from another test module or from `conftest.py`.
   validation. Catalog and command tests cover the versioned JSON inventory, effective deployment metadata,
   tag-filtered inventory, the minimal installation-selected CLI, editable-versus-wheel catalog selection, recipe-name
   materialization, and validated shell creation. Repository-automation tests validate required lifecycle rationales
-  and the one-to-three-entry onboarding deployment matrix through that shared library. Qualification-manifest tests
-  also pin the requested operation mode, exact model ID, target, preserved lifecycle tag, current-platform archive and
-  row records, and isolation from other platform results before artifacts may be staged.
+  and the one-to-three-entry onboarding deployment matrix through that shared library. Notification tests cover the
+  modified-model lifecycle groups and validated deployment/performance summaries. Qualification-manifest tests also
+  pin the requested operation mode, exact model ID, target, preserved lifecycle tag, compact notification evidence,
+  current-platform archive and row records, and isolation from other platform results before artifacts may be staged.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.
 - **Plain functions** — no test classes; tests are grouped by file and separated with comment headers.
 - **Assertions on stdout** — dry-run tests verify that the correct commands and messages appear in the expected order.

--- a/tests/github/test_discord_notification.py
+++ b/tests/github/test_discord_notification.py
@@ -1,0 +1,128 @@
+import importlib.util
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.error import URLError
+
+MODULE_PATH = Path(__file__).parents[2] / ".github" / "scripts" / "discord_notification.py"
+SPEC = importlib.util.spec_from_file_location("discord_notification", MODULE_PATH)
+discord_notification = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(discord_notification)
+
+BASE_ENVIRONMENT = {
+    "GITHUB_REPOSITORY": "cloudrift-ai/emmy",
+    "GITHUB_RUN_ID": "12345",
+    "GITHUB_SERVER_URL": "https://github.com",
+}
+
+
+def test_onboarding_success_payload_has_target_pr_and_no_mentions():
+    environment = {
+        **BASE_ENVIRONMENT,
+        "WORKFLOW_KIND": "onboard",
+        "WORKFLOW_RESULT": "success",
+        "SELECTED": "true",
+        "MODEL_ID": "Qwen/Qwen3-Embedding-8B",
+        "TARGET_GPU": "NVIDIA GeForce RTX 4090",
+        "TARGET_GPU_COUNT": "1",
+        "ONBOARD_MODE": "onboarding",
+        "PR_NUMBER": "487",
+    }
+
+    payload = discord_notification.build_payload(environment, now=datetime(2026, 8, 16, tzinfo=UTC))
+    embed = payload["embeds"][0]
+
+    assert payload["allowed_mentions"] == {"parse": []}
+    assert embed["title"] == "Model onboarding completed"
+    assert embed["url"] == "https://github.com/cloudrift-ai/emmy/actions/runs/12345"
+    assert embed["timestamp"] == "2026-08-16T00:00:00+00:00"
+    assert embed["fields"] == [
+        {"name": "Model", "value": "`Qwen/Qwen3-Embedding-8B`", "inline": False},
+        {"name": "Target", "value": "`NVIDIA GeForce RTX 4090 x1`", "inline": False},
+        {"name": "Mode", "value": "`onboarding`", "inline": True},
+        {
+            "name": "Rolling PR",
+            "value": "[#487](https://github.com/cloudrift-ai/emmy/pull/487)",
+            "inline": True,
+        },
+    ]
+
+
+def test_discovery_failure_payload_is_noticeable_without_model_fields():
+    environment = {
+        **BASE_ENVIRONMENT,
+        "WORKFLOW_KIND": "discover",
+        "WORKFLOW_RESULT": "failure",
+    }
+
+    payload = discord_notification.build_payload(environment)
+    embed = payload["embeds"][0]
+
+    assert payload["allowed_mentions"] == {"parse": []}
+    assert embed["title"] == "Model discovery failed"
+    assert embed["color"] == discord_notification.FAILURE_COLOR
+    assert embed["fields"] == []
+
+
+def test_no_eligible_onboarding_is_a_neutral_summary():
+    environment = {
+        **BASE_ENVIRONMENT,
+        "WORKFLOW_KIND": "onboard",
+        "WORKFLOW_RESULT": "success",
+        "SELECTED": "false",
+    }
+
+    payload = discord_notification.build_payload(environment)
+    embed = payload["embeds"][0]
+
+    assert embed["title"] == "No eligible model deployment"
+    assert embed["color"] == discord_notification.NEUTRAL_COLOR
+
+
+def test_delivery_retries_and_requests_a_confirmed_discord_response():
+    calls = []
+    sleeps = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return b"{}"
+
+    def opener(request, *, timeout):
+        calls.append((request, timeout))
+        if len(calls) < 3:
+            raise URLError("temporary failure")
+        return Response()
+
+    payload = {"allowed_mentions": {"parse": []}}
+
+    delivered = discord_notification.send_notification(
+        "https://discord.com/api/webhooks/id/token?thread_id=7",
+        payload,
+        opener=opener,
+        sleeper=sleeps.append,
+    )
+
+    assert delivered is True
+    assert len(calls) == 3
+    assert calls[-1][0].full_url.endswith("?thread_id=7&wait=true")
+    assert calls[-1][1] == 15
+    assert json.loads(calls[-1][0].data) == payload
+    assert sleeps == [1, 2]
+
+
+def test_missing_webhook_is_non_fatal(caplog):
+    with caplog.at_level(logging.WARNING, logger="discord_notification"):
+        result = discord_notification.main({})
+
+    assert result == 0
+    assert "DISCORD_EMMY_ROBOTS_WEBHOOK_URL is not configured" in caplog.text

--- a/tests/github/test_discord_notification.py
+++ b/tests/github/test_discord_notification.py
@@ -28,6 +28,8 @@ def test_onboarding_success_payload_has_target_pr_and_no_mentions():
         "TARGET_GPU": "NVIDIA GeForce RTX 4090",
         "TARGET_GPU_COUNT": "1",
         "ONBOARD_MODE": "onboarding",
+        "DEPLOYMENT_SUMMARY": "vLLM 0.22.1, 32K context, concurrency 8",
+        "PERFORMANCE_SUMMARY": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
         "PR_NUMBER": "487",
     }
 
@@ -41,12 +43,52 @@ def test_onboarding_success_payload_has_target_pr_and_no_mentions():
     assert embed["fields"] == [
         {"name": "Model", "value": "`Qwen/Qwen3-Embedding-8B`", "inline": False},
         {"name": "Target", "value": "`NVIDIA GeForce RTX 4090 x1`", "inline": False},
+        {"name": "Deployment", "value": "vLLM 0.22.1, 32K context, concurrency 8", "inline": False},
+        {"name": "Performance", "value": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures", "inline": False},
         {"name": "Mode", "value": "`onboarding`", "inline": True},
         {
             "name": "Rolling PR",
             "value": "[#487](https://github.com/cloudrift-ai/emmy/pull/487)",
             "inline": True,
         },
+    ]
+
+
+def test_discovery_success_payload_groups_only_modified_models():
+    environment = {
+        **BASE_ENVIRONMENT,
+        "WORKFLOW_KIND": "discover",
+        "WORKFLOW_RESULT": "success",
+        "MODIFIED_MODELS": json.dumps(
+            [
+                {"model_id": "org/maintained", "lifecycle": "maintained"},
+                {"model_id": "org/best-effort", "lifecycle": "best-effort"},
+                {"model_id": "org/new", "lifecycle": "onboarding"},
+            ]
+        ),
+    }
+
+    payload = discord_notification.build_payload(environment)
+
+    assert payload["embeds"][0]["fields"] == [
+        {"name": "Maintained", "value": "• `org/maintained`", "inline": False},
+        {"name": "Best effort", "value": "• `org/best-effort`", "inline": False},
+        {"name": "Onboarding", "value": "• `org/new`", "inline": False},
+    ]
+
+
+def test_discovery_success_payload_reports_no_recipe_changes():
+    environment = {
+        **BASE_ENVIRONMENT,
+        "WORKFLOW_KIND": "discover",
+        "WORKFLOW_RESULT": "success",
+        "MODIFIED_MODELS": "[]",
+    }
+
+    payload = discord_notification.build_payload(environment)
+
+    assert payload["embeds"][0]["fields"] == [
+        {"name": "Modified models", "value": "None; the lifecycle review produced no recipe changes.", "inline": False}
     ]
 
 

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -83,6 +83,17 @@ def test_model_lifecycle_workflow_posts_discord_summary_from_separate_job(workfl
     assert notification["run"] == "python3 .github/scripts/discord_notification.py"
     assert 'echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"' in lifecycle_pr["run"]
     assert lifecycle["outputs"]["pr_number"] == "${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}"
+    if workflow_kind == "discover":
+        assert lifecycle["outputs"]["modified_models"] == "${{ steps.lifecycle.outputs.modified_models }}"
+        assert notify["env"]["MODIFIED_MODELS"] == "${{ needs.discover.outputs.modified_models }}"
+    else:
+        artifacts = next(step for step in lifecycle["steps"] if step.get("id") == "artifacts")
+        assert lifecycle["outputs"]["deployment_summary"] == "${{ steps.artifacts.outputs.deployment_summary }}"
+        assert lifecycle["outputs"]["performance_summary"] == "${{ steps.artifacts.outputs.performance_summary }}"
+        assert notify["env"]["DEPLOYMENT_SUMMARY"] == "${{ needs.onboard.outputs.deployment_summary }}"
+        assert notify["env"]["PERFORMANCE_SUMMARY"] == "${{ needs.onboard.outputs.performance_summary }}"
+        assert "deployment_summary=$(jq -r .deployment_summary" in artifacts["run"]
+        assert "performance_summary=$(jq -r .performance_summary" in artifacts["run"]
     assert "DISCORD_EMMY_ROBOTS_ALERT_ROLE_ID" not in (Path(__file__).parents[2] / ".github" / "workflows" / workflow).read_text()
 
 
@@ -335,7 +346,15 @@ def test_applies_lifecycle_and_creates_onboarding_shell(tmp_path):
     manifest = discovery_lifecycle.validate_manifest(selection, tmp_path)
     result = discovery_lifecycle.apply_manifest(manifest, tmp_path, tmp_path / "summary.md")
 
-    assert result == {"changed": True}
+    assert result == {
+        "changed": True,
+        "modified_models": [
+            {"model_id": "org/first", "lifecycle": "maintained"},
+            {"model_id": "org/second", "lifecycle": "best-effort"},
+            {"model_id": "org/third", "lifecycle": "obsolete"},
+            {"model_id": "org/new-model", "lifecycle": "onboarding"},
+        ],
+    }
     assert first.read_text().startswith("# Keep this qualification note.\ntags:\n  - maintained\n")
     assert yaml.safe_load(second.read_text())["tags"] == ["best-effort"]
     assert yaml.safe_load(third.read_text())["tags"] == ["obsolete"]
@@ -355,6 +374,23 @@ def test_applies_lifecycle_and_creates_onboarding_shell(tmp_path):
     summary = (tmp_path / "summary.md").read_text()
     assert "`org/new-model`" in summary
     assert "`org/third` → `org/first`" in summary
+
+
+def test_discovery_outputs_modified_models_as_compact_json(tmp_path, monkeypatch):
+    output_path = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    discovery_lifecycle._write_outputs(
+        {
+            "changed": True,
+            "modified_models": [{"model_id": "org/model", "lifecycle": "maintained"}],
+        }
+    )
+
+    assert output_path.read_text().splitlines() == [
+        "changed=true",
+        'modified_models=[{"lifecycle":"maintained","model_id":"org/model"}]',
+    ]
 
 
 def test_extracts_one_lifecycle_object_from_reasoning_text():

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -54,6 +54,38 @@ def test_onboarding_loads_control_code_from_exact_workflow_commit():
     assert 'rm -rf -- "$WORKFLOW_SOURCE"' in cleanup_script
 
 
+@pytest.mark.parametrize(
+    ("workflow", "primary_job", "workflow_kind", "notification_name"),
+    [
+        ("discover-model.yml", "discover", "discover", "Send discovery summary"),
+        ("onboard-model.yml", "onboard", "onboard", "Send onboarding summary"),
+    ],
+)
+def test_model_lifecycle_workflow_posts_discord_summary_from_separate_job(workflow, primary_job, workflow_kind, notification_name):
+    document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / workflow).read_text())
+    lifecycle = document["jobs"][primary_job]
+    notify = document["jobs"]["notify"]
+    lifecycle_pr = next(step for step in lifecycle["steps"] if step.get("id") == "lifecycle-pr")
+    checkout, notification = notify["steps"]
+
+    assert notify["needs"] == primary_job
+    assert notify["if"] == "${{ always() }}"
+    assert notify["runs-on"] == "ubuntu-latest"
+    assert notify["permissions"] == {"contents": "read"}
+    assert notify["env"]["DISCORD_WEBHOOK_URL"] == "${{ secrets.DISCORD_EMMY_ROBOTS_WEBHOOK_URL }}"
+    assert notify["env"]["WORKFLOW_KIND"] == workflow_kind
+    assert notify["env"]["WORKFLOW_RESULT"] == f"${{{{ needs.{primary_job}.result }}}}"
+    assert checkout["uses"] == "actions/checkout@v4"
+    assert checkout["with"]["ref"] == "${{ github.sha }}"
+    assert checkout["with"]["persist-credentials"] is False
+    assert notification["name"] == notification_name
+    assert notification["continue-on-error"] is True
+    assert notification["run"] == "python3 .github/scripts/discord_notification.py"
+    assert 'echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"' in lifecycle_pr["run"]
+    assert lifecycle["outputs"]["pr_number"] == "${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}"
+    assert "DISCORD_EMMY_ROBOTS_ALERT_ROLE_ID" not in (Path(__file__).parents[2] / ".github" / "workflows" / workflow).read_text()
+
+
 def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     workspace = Path(__file__).parents[2]
     document = yaml.safe_load((workspace / ".github" / "workflows" / "onboard-model.yml").read_text())

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -346,15 +346,7 @@ def test_applies_lifecycle_and_creates_onboarding_shell(tmp_path):
     manifest = discovery_lifecycle.validate_manifest(selection, tmp_path)
     result = discovery_lifecycle.apply_manifest(manifest, tmp_path, tmp_path / "summary.md")
 
-    assert result == {
-        "changed": True,
-        "modified_models": [
-            {"model_id": "org/first", "lifecycle": "maintained"},
-            {"model_id": "org/second", "lifecycle": "best-effort"},
-            {"model_id": "org/third", "lifecycle": "obsolete"},
-            {"model_id": "org/new-model", "lifecycle": "onboarding"},
-        ],
-    }
+    assert result == {"changed": True}
     assert first.read_text().startswith("# Keep this qualification note.\ntags:\n  - maintained\n")
     assert yaml.safe_load(second.read_text())["tags"] == ["best-effort"]
     assert yaml.safe_load(third.read_text())["tags"] == ["obsolete"]
@@ -376,20 +368,26 @@ def test_applies_lifecycle_and_creates_onboarding_shell(tmp_path):
     assert "`org/third` → `org/first`" in summary
 
 
-def test_discovery_outputs_modified_models_as_compact_json(tmp_path, monkeypatch):
-    output_path = tmp_path / "github-output"
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+def test_discovery_workflow_summarizes_tracked_and_new_recipe_changes(tmp_path):
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
+    existing = _recipe(tmp_path, "existing", "org/existing", tags=["best-effort"])
+    subprocess.run(["git", "add", "recipes"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "--quiet", "-m", "fixture"], cwd=tmp_path, check=True)
+    existing.write_text(existing.read_text().replace("best-effort", "maintained"))
+    _recipe(tmp_path, "new", "org/new", tags=["onboarding", "untested"])
 
-    discovery_lifecycle._write_outputs(
-        {
-            "changed": True,
-            "modified_models": [{"model_id": "org/model", "lifecycle": "maintained"}],
-        }
-    )
+    workflow = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "discover-model.yml").read_text())
+    script = next(step["run"] for step in workflow["jobs"]["discover"]["steps"] if step.get("name") == "Validate and apply model lifecycle")
+    source = script.split("./venv/bin/python - <<'PY'\n", 1)[1].split("\nPY", 1)[0]
+    output_path = tmp_path / "github-output"
+    env = {**os.environ, "GITHUB_OUTPUT": str(output_path)}
+
+    subprocess.run([sys.executable, "-"], cwd=tmp_path, env=env, input=source, text=True, check=True)
 
     assert output_path.read_text().splitlines() == [
-        "changed=true",
-        'modified_models=[{"lifecycle":"maintained","model_id":"org/model"}]',
+        'modified_models=[{"lifecycle":"maintained","model_id":"org/existing"},{"lifecycle":"onboarding","model_id":"org/new"}]'
     ]
 
 

--- a/tests/github/test_onboarding_artifacts.py
+++ b/tests/github/test_onboarding_artifacts.py
@@ -39,6 +39,20 @@ def _init_repo(workspace):
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=workspace, check=True)
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (None, "non-empty deployment_summary"),
+        ("", "non-empty deployment_summary"),
+        ("line one\nline two", "one line"),
+        ("x" * 1001, "at most 1000"),
+    ],
+)
+def test_summary_text_requires_compact_notification_evidence(value, message):
+    with pytest.raises(ValueError, match=message):
+        onboarding_artifacts._summary_text({"deployment_summary": value}, "deployment_summary")
+
+
 def test_validate_summary_accepts_exact_manifest(tmp_path):
     paths = _write_artifacts(tmp_path)
     summary_path = tmp_path / "summary.json"
@@ -49,6 +63,8 @@ def test_validate_summary_accepts_exact_manifest(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -83,6 +99,8 @@ def test_validate_summary_includes_separately_declared_artifacts(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -117,6 +135,8 @@ def test_validate_summary_requires_exact_platform_archive(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -153,6 +173,8 @@ def test_validate_summary_rejects_other_platform_archive(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -189,6 +211,8 @@ def test_validate_summary_rejects_experiment_result(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -225,6 +249,8 @@ def test_validate_summary_rejects_recipe_run_result(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -261,6 +287,8 @@ def test_validate_summary_rejects_report_outside_final_recipe_dir(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": str(nested_report.relative_to(tmp_path)),
                 "experiment": paths[2],
@@ -294,6 +322,8 @@ def test_validate_summary_rejects_mode_mismatch(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -327,6 +357,8 @@ def test_validate_summary_rejects_lifecycle_change(tmp_path):
                 "mode": "verification",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
@@ -445,6 +477,8 @@ def test_platform_update_preserves_other_platform_snapshot(tmp_path):
                 "mode": "onboarding",
                 "model_id": "org/Model",
                 "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],


### PR DESCRIPTION
## Summary

- post best-effort Discord summaries from separate hosted jobs for both model lifecycle workflows
- report only discovery recipe entries actually modified, grouped by their resulting lifecycle
- include the selected model, GPU target, operation, serving deployment, and measured performance for onboarding
- carry structured data from the authoritative lifecycle and artifact validators instead of re-reading the rolling PR
- preserve notifications after failure, cancellation, or timeout; disable mentions and retry delivery three times

## Validation

- make test (3179 passed, 652 skipped, 1 xfailed, 1 xpassed)
- make lint
- discovery workflow E2E from rebased PR branch: run 31973894931
  - exact head SHA cf55c8129bb9e338a4545755415cc554ac02e1eb
  - all discovery, lifecycle, rolling-PR, and notification steps passed
  - notification received 26 modified recipe entries and logged successful Discord delivery
  - rolling lifecycle PR #487 updated to 07ba64bb1dd5797eb89ae8ab7f5c7e4c7c34020a