### PR TITLE
Add generic recipe query for model lifecycle selection

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -72,16 +72,19 @@ expose the same packages through OpenCode's native skill tool.
 
 ### Nightly verification and direct onboarding
 
-**Verify or onboard model** runs nightly and retains a manual exact model/GPU dispatch. Its mechanical selector reads
-the recipe inventory and CloudRift VM variant availability, without filtering on public-IP supply. It considers only
-declared deployments with an available exact CloudRift GPU count. Pending `onboarding`/`untested` recipes are the first
-priority. If none can run, it chooses a `maintained` recipe whose committed `RESULTS.md` has the oldest last-change
-timestamp; a missing report is oldest. Declaration order chooses among one recipe's available deployments, and model
-ID breaks remaining ties. No eligible deployment is a successful no-op.
+**Verify or onboard model** runs nightly and retains a manual exact model/GPU dispatch. Its selector uses the
+`emmy recipe query` command against the rolling branch's recipe root, with the command implementation loaded from the
+exact workflow SHA.
+The query's filters and sorts read CloudRift VM variant availability without filtering on public-IP supply and consider
+only declared deployments with an available exact CloudRift GPU count. Pending `onboarding`/`untested` recipes are the
+first priority. If none can run, it chooses a `maintained` recipe whose committed `RESULTS.md` has the oldest
+last-change timestamp; a missing report is oldest. Declaration order chooses among one recipe's available deployments,
+and model ID breaks remaining ties. No eligible deployment is a successful no-op.
 
 The workflow requires the repository's `CLOUDRIFT_TEAM_ID` variable to contain the exact Robots team UUID. Before it
 checks capacity, it validates that `CLOUDRIFT_API_KEY` can act for that UUID through a team-scoped account request;
-every rent then includes the UUID and requests a public IP so the GitHub runner can reach the VM over SSH. It attaches `emmy`, workflow, and GitHub job tags,
+every rent then includes the UUID and requests a public IP so the GitHub runner can reach the VM over SSH. It attaches
+`emmy`, workflow, and GitHub job tags,
 makes at most three workflow-level rental attempts for the same selection, and sweeps a failed attempt by the complete
 tag set before retrying. Only V100 rentals set CloudRift's admin-only billing exemption; every other GPU is a regular
 team rental. The workflow never falls back to GCP or changes the selected GPU type/count.

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -52,8 +52,8 @@ lifecycle decision. It keeps at most three total onboarding shells for open-weig
 contains one to three proposed deployment entries made only from `deploy.gpu` and `deploy.gpu_count`; existing shells
 consume the three-shell limit and must retain a valid deployment matrix. Discovery remains read-only: the workflow
 ignores otherwise valid new candidates beyond the remaining shell slots. `emmy recipe list --json` supplies the
-versioned compact agent inventory under its `recipes` field, and tag-filtered list queries enforce the maintained and
-onboarding counts after application.
+versioned compact agent inventory under its `recipes` field, and recipe queries enforce the maintained and onboarding
+counts after application.
 The workflow checks that the agent did not modify the checkout, then `.github/scripts/discovery_lifecycle.py`
 validates and applies its lifecycle manifest. The helper
 tolerates a model reasoning wrapper around the JSON object, but requires exactly the four expected top-level fields
@@ -74,7 +74,8 @@ expose the same packages through OpenCode's native skill tool.
 
 **Verify or onboard model** runs nightly and retains a manual exact model/GPU dispatch. Its selector uses the
 `emmy recipe query` command against the rolling branch's recipe root, with the command implementation loaded from the
-exact workflow SHA.
+exact workflow SHA. Manual dispatch supplies one exact external candidate; scheduled dispatch queries declared
+deployments. A filtered-out manual candidate is an error, while no scheduled match is a successful no-op.
 The query's filters and sorts read CloudRift VM variant availability without filtering on public-IP supply and consider
 only declared deployments with an available exact CloudRift GPU count. Pending `onboarding`/`untested` recipes are the
 first priority. If none can run, it chooses a `maintained` recipe whose committed `RESULTS.md` has the oldest

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -256,12 +256,12 @@ jobs:
           ./venv/bin/python .github/scripts/discovery_lifecycle.py \
             --input "$AGENT_MANIFEST" \
             --summary "$DISCOVERY_SUMMARY"
-          maintained_count="$(./venv/bin/emmy recipe list --tag maintained --json | jq '.recipes | length')"
+          maintained_count="$(./venv/bin/emmy recipe query --filter 'tags contains "maintained"' --json | jq '.rows | length')"
           if [ "$maintained_count" -ne "$MAINTAINED_MODEL_COUNT" ]; then
             echo "Expected $MAINTAINED_MODEL_COUNT maintained recipes, found $maintained_count" >&2
             exit 1
           fi
-          onboarding_count="$(./venv/bin/emmy recipe list --tag onboarding --json | jq '.recipes | length')"
+          onboarding_count="$(./venv/bin/emmy recipe query --filter 'tags contains "onboarding"' --json | jq '.rows | length')"
           if [ "$onboarding_count" -gt 3 ]; then
             echo "Expected at most 3 onboarding recipes, found $onboarding_count" >&2
             exit 1

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -226,18 +226,15 @@ jobs:
           query=(
             recipe query
             --root recipes
-            --require 'provider.cloudrift.team_access == true'
+            --filter 'provider.cloudrift.team_access == true'
             --limit 1
             --json
           )
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             query+=(
-              --model "$REQUESTED_MODEL_ID"
-              --gpu "$REQUESTED_GPU"
-              --gpu-count "$REQUESTED_GPU_COUNT"
-              --allow-missing-model
-              --require 'lifecycle != "obsolete"'
-              --require 'deployment.availability.cloudrift == true'
+              --candidate "$REQUESTED_MODEL_ID" "$REQUESTED_GPU" "$REQUESTED_GPU_COUNT"
+              --filter 'lifecycle != "obsolete"'
+              --filter 'deployment.availability.cloudrift == true'
             )
           else
             query+=(
@@ -257,6 +254,10 @@ jobs:
           fi
           row=$(jq -c '.rows[0] // empty' <<< "$selection")
           if [ -z "$row" ]; then
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "Manual candidate is obsolete or has no available exact CloudRift VM." >&2
+              exit 1
+            fi
             echo "selected=false" >> "$GITHUB_OUTPUT"
             echo "No onboarding or maintained recipe has an available exact CloudRift VM." >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -223,124 +223,65 @@ jobs:
           CLOUDRIFT_API_KEY: ${{ secrets.CLOUDRIFT_API_KEY }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          ./venv/bin/python - <<'PY'
-          import asyncio
-          import os
-          import re
-          import subprocess
-          from pathlib import Path
-
-          from emmy.provisioning.candidates import iter_candidates
-          from emmy.provisioning.cloudrift import list_available_instance_types, validate_team_id_access
-          from emmy.recipe.catalog import recipe_inventory_document
-
-          inventory_document = recipe_inventory_document(Path("recipes"))
-          if inventory_document.get("schema_version") != 1 or not isinstance(inventory_document.get("recipes"), list):
-              raise SystemExit("Unsupported `emmy recipe list --json` schema")
-          inventory = inventory_document["recipes"]
-          team_id = asyncio.run(
-              validate_team_id_access(
-                  os.environ["CLOUDRIFT_API_KEY"],
-                  os.environ.get("CLOUDRIFT_TEAM_ID"),
-              )
+          query=(
+            recipe query
+            --root recipes
+            --require 'provider.cloudrift.team_access == true'
+            --limit 1
+            --json
           )
-          available = asyncio.run(list_available_instance_types(os.environ["CLOUDRIFT_API_KEY"]))
-          with Path(os.environ["GITHUB_ENV"]).open("a") as output:
-              output.write(f"CLOUDRIFT_TEAM_ID={team_id}\n")
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            query+=(
+              --model "$REQUESTED_MODEL_ID"
+              --gpu "$REQUESTED_GPU"
+              --gpu-count "$REQUESTED_GPU_COUNT"
+              --allow-missing-model
+              --require 'lifecycle != "obsolete"'
+              --require 'deployment.availability.cloudrift == true'
+            )
+          else
+            query+=(
+              --filter 'lifecycle in ["onboarding", "maintained"]'
+              --filter 'deployment.availability.cloudrift == true'
+              --sort 'lifecycle order ["onboarding", "maintained"]'
+              --sort 'results.last_run_at asc nulls-first'
+              --sort 'model_id asc'
+              --sort 'deployment.index asc'
+            )
+          fi
 
-          def available_deployment(deployment):
-              gpu = deployment.get("gpu", deployment.get("deploy.gpu"))
-              count = deployment.get("gpu_count", deployment.get("deploy.gpu_count"))
-              try:
-                  candidates = iter_candidates(gpu, count, "cloudrift", exact_gpu_count=True)
-              except (TypeError, ValueError):
-                  return False
-              return any(candidate.instance_type in available for candidate in candidates)
+          selection=$(./venv/bin/emmy "${query[@]}")
+          if [ "$(jq -r '.schema_version' <<< "$selection")" != "1" ]; then
+            echo "Unsupported emmy recipe query schema" >&2
+            exit 1
+          fi
+          row=$(jq -c '.rows[0] // empty' <<< "$selection")
+          if [ -z "$row" ]; then
+            echo "selected=false" >> "$GITHUB_OUTPUT"
+            echo "No onboarding or maintained recipe has an available exact CloudRift VM." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
-          def write_selection(record, deployment, mode, lifecycle):
-              gpu = deployment.get("gpu", deployment.get("deploy.gpu"))
-              gpu_count = deployment.get("gpu_count", deployment.get("deploy.gpu_count"))
-              values = {
-                  "selected": "true",
-                  "model_id": record["model_id"],
-                  "gpu": gpu,
-                  "gpu_count": str(gpu_count),
-                  "mode": mode,
-                  "lifecycle": lifecycle,
-              }
-              with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-                  for key, value in values.items():
-                      output.write(f"{key}={value}\n")
-              with Path(os.environ["GITHUB_ENV"]).open("a") as output:
-                  for key, value in {
-                      "MODEL_ID": values["model_id"],
-                      "TARGET_GPU": values["gpu"],
-                      "TARGET_GPU_COUNT": values["gpu_count"],
-                      "ONBOARD_MODE": values["mode"],
-                      "EXPECTED_LIFECYCLE": values["lifecycle"],
-                  }.items():
-                      output.write(f"{key}={value}\n")
-
-          if os.environ["EVENT_NAME"] == "workflow_dispatch":
-              model_id = os.environ["REQUESTED_MODEL_ID"]
-              gpu = os.environ["REQUESTED_GPU"]
-              try:
-                  gpu_count = int(os.environ["REQUESTED_GPU_COUNT"])
-              except ValueError as exc:
-                  raise SystemExit("gpu_count must be positive") from exc
-              if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", model_id):
-                  raise SystemExit("model_id must be an exact Hugging Face owner/repository ID")
-              if gpu_count < 1:
-                  raise SystemExit("gpu_count must be positive")
-              deployment = {"gpu": gpu, "gpu_count": gpu_count}
-              if not available_deployment(deployment):
-                  raise SystemExit(f"CloudRift has no available exact {gpu} x{gpu_count} VM")
-              existing = next((record for record in inventory if record["model_id"] == model_id), None)
-              if existing and "obsolete" in existing["tags"]:
-                  raise SystemExit(f"Refusing to run an obsolete recipe: {model_id}")
-              if existing and "maintained" in existing["tags"]:
-                  mode, lifecycle = "verification", "maintained"
-              elif existing and "best-effort" in existing["tags"]:
-                  mode, lifecycle = "verification", "best-effort"
-              else:
-                  mode, lifecycle = "onboarding", "best-effort"
-              write_selection(existing or {"model_id": model_id}, deployment, mode, lifecycle)
-              raise SystemExit(0)
-
-          ranked = []
-          for record in inventory:
-              tags = set(record["tags"])
-              if {"onboarding", "untested"}.issubset(tags):
-                  tier, mode, lifecycle = 0, "onboarding", "best-effort"
-              elif "maintained" in tags:
-                  tier, mode, lifecycle = 1, "verification", "maintained"
-              else:
-                  continue
-              deployment = next((item for item in record["deployments"] if available_deployment(item)), None)
-              if deployment is None:
-                  continue
-              report = str(Path(record["path"]).with_name("RESULTS.md"))
-              result = subprocess.run(
-                  ["git", "log", "-1", "--format=%ct", "--", report],
-                  check=True,
-                  capture_output=True,
-                  text=True,
-              )
-              last_run = int(result.stdout.strip() or 0)
-              ranked.append((tier, last_run, record["model_id"], record, deployment, mode, lifecycle))
-
-          if not ranked:
-              with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-                  output.write("selected=false\n")
-              summary = os.environ.get("GITHUB_STEP_SUMMARY")
-              if summary:
-                  with Path(summary).open("a") as output:
-                      output.write("No onboarding or maintained recipe has an available exact CloudRift VM.\n")
-              raise SystemExit(0)
-
-          _, _, _, record, deployment, mode, lifecycle = min(ranked, key=lambda item: item[:3])
-          write_selection(record, deployment, mode, lifecycle)
-          PY
+          model_id=$(jq -r '.model_id' <<< "$row")
+          gpu=$(jq -r '.deployment.gpu' <<< "$row")
+          gpu_count=$(jq -r '.deployment.gpu_count' <<< "$row")
+          mode=$(jq -r '.operation' <<< "$row")
+          lifecycle=$(jq -r '.expected_lifecycle' <<< "$row")
+          {
+            echo "selected=true"
+            echo "model_id=$model_id"
+            echo "gpu=$gpu"
+            echo "gpu_count=$gpu_count"
+            echo "mode=$mode"
+            echo "lifecycle=$lifecycle"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "MODEL_ID=$model_id"
+            echo "TARGET_GPU=$gpu"
+            echo "TARGET_GPU_COUNT=$gpu_count"
+            echo "ONBOARD_MODE=$mode"
+            echo "EXPECTED_LIFECYCLE=$lifecycle"
+          } >> "$GITHUB_ENV"
 
       - name: Prepare artifact branch
         id: branch

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ emmy serve Qwen/Qwen3-Embedding-0.6B --bench --random-input-len 32 --stock
 emmy recipe list --json
 
 # Count one lifecycle group in automation.
-emmy recipe list --tag maintained --json
+emmy recipe query --filter 'tags contains "maintained"' --json
 
 # Select the oldest runnable onboarding or maintained deployment. Referencing deployment.* expands each recipe into
 # deployment rows; the CloudRift availability and Git history fields are resolved only because this query uses them.
@@ -235,6 +235,10 @@ emmy recipe query \
   --sort 'lifecycle order ["onboarding", "maintained"]' \
   --sort 'results.last_run_at asc nulls-first' \
   --limit 1 --json
+
+# Check one exact external candidate, including a model without a recipe yet.
+emmy recipe query --candidate org/model-name "NVIDIA H200 141GB" 1 \
+  --filter 'deployment.availability.cloudrift == true' --json
 
 # Create an untested onboarding shell with one to three proposed deployments.
 emmy recipe create org/model-name --rationale "Why this model should be onboarded." \
@@ -246,8 +250,10 @@ each recipe carries its directory `name`, model ID, task, lifecycle-aware `runna
 deployments with effective context lengths. Consumers must reject unknown schema versions. Fields may be added to a
 schema version, but existing fields are not removed or redefined. Emmy always detects its installation: an editable
 checkout uses its live top-level `recipes/`, while a regular wheel uses its packaged runnable recipe bundle.
-`recipe query --json` returns a separate versioned `rows` interface for generic predicates and stable sort keys.
-CloudRift-derived fields require `CLOUDRIFT_API_KEY`; team-access checks also require `CLOUDRIFT_TEAM_ID`.
+`recipe query --json` returns a separate versioned `rows` interface for generic predicates and stable sort keys. Its
+optional `--candidate MODEL GPU COUNT` source hydrates lifecycle metadata from an existing recipe or represents a new
+model as onboarding work. CloudRift-derived fields require `CLOUDRIFT_API_KEY`; team-access checks also require
+`CLOUDRIFT_TEAM_ID`.
 
 ```yaml
 tags:

--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ emmy recipe list --json
 # Count one lifecycle group in automation.
 emmy recipe list --tag maintained --json
 
+# Select the oldest runnable onboarding or maintained deployment. Referencing deployment.* expands each recipe into
+# deployment rows; the CloudRift availability and Git history fields are resolved only because this query uses them.
+emmy recipe query \
+  --filter 'lifecycle in ["onboarding", "maintained"]' \
+  --filter 'deployment.availability.cloudrift == true' \
+  --sort 'lifecycle order ["onboarding", "maintained"]' \
+  --sort 'results.last_run_at asc nulls-first' \
+  --limit 1 --json
+
 # Create an untested onboarding shell with one to three proposed deployments.
 emmy recipe create org/model-name --rationale "Why this model should be onboarded." \
   --deployment "NVIDIA H200 141GB" 1 --deployment "NVIDIA B200" 1
@@ -237,6 +246,8 @@ each recipe carries its directory `name`, model ID, task, lifecycle-aware `runna
 deployments with effective context lengths. Consumers must reject unknown schema versions. Fields may be added to a
 schema version, but existing fields are not removed or redefined. Emmy always detects its installation: an editable
 checkout uses its live top-level `recipes/`, while a regular wheel uses its packaged runnable recipe bundle.
+`recipe query --json` returns a separate versioned `rows` interface for generic predicates and stable sort keys.
+CloudRift-derived fields require `CLOUDRIFT_API_KEY`; team-access checks also require `CLOUDRIFT_TEAM_ID`.
 
 ```yaml
 tags:

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -10,6 +10,7 @@ commands/deploy ─► deploy (DeployParams, deploy/teardown)
 commands/deploy ─► provisioning (remote setup, cloud VMs)
 commands/vm ────► provisioning (create/delete instances)
 commands/recipe ─► recipe (catalog queries and onboarding shell creation)
+recipe/query ───► provisioning (read-only CloudRift availability and team access)
 commands/publish ─► publish (image naming, metadata, collision and digest gates)
 ```
 
@@ -320,6 +321,7 @@ emmy
 +-- publish      -- validate, tag, and push the canonical image named by one recipe
 +-- recipe
 |   +-- list      -- inspect and filter compact recipe metadata
+|   +-- query     -- filter and order normalized recipe or deployment rows
 |   +-- create    -- create a validated onboarding shell
 +-- vm
     +-- create
@@ -348,12 +350,20 @@ It detects the installation: editable checkouts use their live top-level `recipe
 runnable set. Repeat `--tag` to require several tags.
 `--json` emits the versioned catalog object documented in the recipe architecture; each record includes matrix-
 expanded GPU/count/context metadata and whether the recipe is runnable. Machine consumers reject unknown versions.
+`recipe query` applies repeatable constrained predicates and stable sort keys to normalized catalog rows. A
+`deployment.*` field expands recipes into deployment rows. CloudRift availability, Robots-team access, and committed
+results history are lazy computed fields, so ordinary catalog-only queries perform no provider or Git work. `--require`
+uses the filter grammar but turns a false candidate condition into an error, which is useful for exact manual requests.
+`--root` exists on this automation-oriented interface so callers can run control code from one checkout against recipe
+data in another; without it, query and list use the same installation-aware catalog.
 `recipe create` writes a minimal disabled `onboarding`/`untested` shell, validates every GPU against the hardware
 table, accepts one to three native `deploy.gpu`/`deploy.gpu_count` setups, and never overwrites an existing model or
 directory.
 
 ```bash
 emmy recipe list [--tag TAG]... [--json]
+emmy recipe query [--filter EXPRESSION]... [--require EXPRESSION]... [--sort EXPRESSION]... [--limit N] [--json]
+emmy recipe query --model <org/model> --gpu GPU --gpu-count N [--allow-missing-model] [--root ROOT] [--json]
 emmy recipe create <org/model> [--root ROOT] [--task generate|embed] --rationale TEXT \
   --deployment GPU COUNT [--deployment GPU COUNT]...
 ```

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -347,23 +347,24 @@ See [`emmy/recipe/ARCHITECTURE.md`](../recipe/ARCHITECTURE.md) for why the copy 
 
 `recipe list` renders compact metadata without loading complete serving configurations into an automation prompt.
 It detects the installation: editable checkouts use their live top-level `recipes/`, while wheels use their packaged
-runnable set. Repeat `--tag` to require several tags.
+runnable set.
 `--json` emits the versioned catalog object documented in the recipe architecture; each record includes matrix-
 expanded GPU/count/context metadata and whether the recipe is runnable. Machine consumers reject unknown versions.
 `recipe query` applies repeatable constrained predicates and stable sort keys to normalized catalog rows. A
 `deployment.*` field expands recipes into deployment rows. CloudRift availability, Robots-team access, and committed
-results history are lazy computed fields, so ordinary catalog-only queries perform no provider or Git work. `--require`
-uses the filter grammar but turns a false candidate condition into an error, which is useful for exact manual requests.
-`--root` exists on this automation-oriented interface so callers can run control code from one checkout against recipe
-data in another; without it, query and list use the same installation-aware catalog.
+results history are lazy computed fields, so ordinary catalog-only queries perform no provider or Git work.
+`--candidate MODEL GPU COUNT` supplies one exact external deployment; a matching recipe contributes its lifecycle
+metadata, while an absent model becomes onboarding work. `--root` exists on this automation-oriented interface so
+callers can run control code from one checkout against recipe data in another; without it, query and list use the same
+installation-aware catalog.
 `recipe create` writes a minimal disabled `onboarding`/`untested` shell, validates every GPU against the hardware
 table, accepts one to three native `deploy.gpu`/`deploy.gpu_count` setups, and never overwrites an existing model or
 directory.
 
 ```bash
-emmy recipe list [--tag TAG]... [--json]
-emmy recipe query [--filter EXPRESSION]... [--require EXPRESSION]... [--sort EXPRESSION]... [--limit N] [--json]
-emmy recipe query --model <org/model> --gpu GPU --gpu-count N [--allow-missing-model] [--root ROOT] [--json]
+emmy recipe list [--json]
+emmy recipe query [--filter EXPRESSION]... [--sort EXPRESSION]... [--limit N] \
+  [--candidate MODEL GPU COUNT] [--root ROOT] [--json]
 emmy recipe create <org/model> [--root ROOT] [--task generate|embed] --rationale TEXT \
   --deployment GPU COUNT [--deployment GPU COUNT]...
 ```

--- a/emmy/commands/recipe.py
+++ b/emmy/commands/recipe.py
@@ -1,11 +1,27 @@
-"""List recipes and create onboarding stubs."""
+"""Query recipes and create onboarding stubs."""
 
+import asyncio
 import json
 import logging
+import os
+from contextlib import nullcontext
 from pathlib import Path
 
+import httpx
+
+from emmy.provisioning.errors import TerminalProvisionError
 from emmy.recipe.bundled import default_recipe_root
-from emmy.recipe.catalog import create_recipe_stub, recipe_inventory_document
+from emmy.recipe.catalog import create_recipe_stub, recipe_inventory, recipe_inventory_document
+from emmy.recipe.query import (
+    build_query_rows,
+    enrich_query_rows,
+    parse_predicate,
+    parse_sort,
+    query_document,
+    query_rows,
+    referenced_fields,
+)
+from emmy.redact import register_secret
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +52,70 @@ def _handle_create(args) -> None:
         raise SystemExit(2) from exc
 
 
+def _resolve_cloudrift_api_key() -> str:
+    api_key = os.environ.get("CLOUDRIFT_API_KEY")
+    if not api_key:
+        raise ValueError("CLOUDRIFT_API_KEY is required by the requested recipe query fields")
+    register_secret(api_key)
+    return api_key
+
+
+def _handle_query(args) -> None:
+    try:
+        if args.limit is not None and args.limit < 1:
+            raise ValueError("limit must be positive")
+        filters = [parse_predicate(source) for source in args.filters]
+        requirements = [parse_predicate(source) for source in args.requirements]
+        sorts = [parse_sort(source) for source in args.sorts]
+        fields = referenced_fields(filters, requirements, sorts)
+        root_context = nullcontext(args.root) if args.root is not None else default_recipe_root()
+        with root_context as root:
+            if root is None:
+                raise ValueError("this Emmy installation does not contain recipes")
+            if not root.is_dir():
+                raise ValueError(f"Recipe root is not a directory: {root}")
+            inventory = recipe_inventory(root)
+        expand_deployments = args.gpu is not None or any(field.startswith("deployment.") for field in fields)
+        rows = build_query_rows(
+            inventory,
+            model_id=args.model,
+            allow_missing_model=args.allow_missing_model,
+            gpu=args.gpu,
+            gpu_count=args.gpu_count,
+            expand_deployments=expand_deployments,
+        )
+        needs_cloudrift = any(field.startswith("provider.cloudrift.") or field.endswith(".availability.cloudrift") for field in fields)
+        api_key = _resolve_cloudrift_api_key() if needs_cloudrift else None
+        asyncio.run(
+            enrich_query_rows(
+                rows,
+                fields,
+                cloudrift_api_key=api_key,
+                cloudrift_team_id=os.environ.get("CLOUDRIFT_TEAM_ID"),
+            )
+        )
+        selected = query_rows(
+            rows,
+            filters=filters,
+            requirements=requirements,
+            sorts=sorts,
+            limit=args.limit,
+        )
+    except (OSError, ValueError, TerminalProvisionError, httpx.HTTPError) as exc:
+        logger.error(str(exc))
+        raise SystemExit(2) from exc
+
+    document = query_document(selected)
+    if args.json:
+        logger.info(json.dumps(document, sort_keys=True))
+        return
+    for row in document["rows"]:
+        deployment = row["deployment"] or {}
+        gpu = deployment.get("gpu", "-")
+        gpu_count = deployment.get("gpu_count", "-")
+        logger.info("%s\t%s\tx%s\t%s", row["model_id"], gpu, gpu_count, row["lifecycle"] or "-")
+
+
 def register_recipe_command(subparsers) -> None:
     parser = subparsers.add_parser("recipe", help="Inspect recipes and create onboarding stubs")
     actions = parser.add_subparsers(dest="recipe_action", required=True)
@@ -44,6 +124,48 @@ def register_recipe_command(subparsers) -> None:
     list_parser.add_argument("--tag", action="append", default=[], help="Require a tag; repeat to require multiple tags")
     list_parser.add_argument("--json", action="store_true", help="Print the versioned JSON recipe catalog")
     list_parser.set_defaults(func=_handle_list)
+
+    query_parser = actions.add_parser("query", help="Filter and order normalized recipe or deployment rows")
+    query_parser.add_argument(
+        "--filter",
+        action="append",
+        default=[],
+        dest="filters",
+        metavar="EXPRESSION",
+        help="Keep matching rows; repeat for logical AND",
+    )
+    query_parser.add_argument(
+        "--require",
+        action="append",
+        default=[],
+        dest="requirements",
+        metavar="EXPRESSION",
+        help="Fail if any candidate row does not match; repeat for logical AND",
+    )
+    query_parser.add_argument(
+        "--sort",
+        action="append",
+        default=[],
+        dest="sorts",
+        metavar="EXPRESSION",
+        help="Add a stable sort key in priority order",
+    )
+    query_parser.add_argument("--limit", type=int, default=None, help="Return at most this many rows")
+    query_parser.add_argument("--model", help="Restrict the candidate source to one exact Hugging Face model ID")
+    query_parser.add_argument("--gpu", help="Use this exact deployment GPU for --model")
+    query_parser.add_argument("--gpu-count", type=int, help="Use this exact deployment GPU count for --model")
+    query_parser.add_argument(
+        "--allow-missing-model",
+        action="store_true",
+        help="Create a synthetic onboarding candidate when --model is absent from the catalog",
+    )
+    query_parser.add_argument(
+        "--root",
+        type=Path,
+        help="Query this recipe root instead of the installation-aware catalog",
+    )
+    query_parser.add_argument("--json", action="store_true", help="Print the versioned JSON query result")
+    query_parser.set_defaults(func=_handle_query)
 
     create_parser = actions.add_parser("create", help="Create an onboarding/untested recipe stub")
     create_parser.add_argument("model_id", help="Hugging Face model ID in organization/model form")

--- a/emmy/commands/recipe.py
+++ b/emmy/commands/recipe.py
@@ -13,6 +13,7 @@ from emmy.provisioning.errors import TerminalProvisionError
 from emmy.recipe.bundled import default_recipe_root
 from emmy.recipe.catalog import create_recipe_stub, recipe_inventory, recipe_inventory_document
 from emmy.recipe.query import (
+    RecipeCandidate,
     build_query_rows,
     enrich_query_rows,
     parse_predicate,
@@ -31,7 +32,7 @@ def _handle_list(args) -> None:
         with default_recipe_root() as root:
             if root is None:
                 raise ValueError("this Emmy installation does not contain recipes")
-            document = recipe_inventory_document(root, tuple(args.tag))
+            document = recipe_inventory_document(root)
     except (OSError, ValueError) as exc:
         logger.error(str(exc))
         raise SystemExit(2) from exc
@@ -65,9 +66,16 @@ def _handle_query(args) -> None:
         if args.limit is not None and args.limit < 1:
             raise ValueError("limit must be positive")
         filters = [parse_predicate(source) for source in args.filters]
-        requirements = [parse_predicate(source) for source in args.requirements]
         sorts = [parse_sort(source) for source in args.sorts]
-        fields = referenced_fields(filters, requirements, sorts)
+        fields = referenced_fields(filters, sorts)
+        candidate = None
+        if args.candidate is not None:
+            model_id, gpu, raw_gpu_count = args.candidate
+            try:
+                gpu_count = int(raw_gpu_count)
+            except ValueError as exc:
+                raise ValueError("candidate GPU count must be positive") from exc
+            candidate = RecipeCandidate(model_id, gpu, gpu_count)
         root_context = nullcontext(args.root) if args.root is not None else default_recipe_root()
         with root_context as root:
             if root is None:
@@ -75,13 +83,10 @@ def _handle_query(args) -> None:
             if not root.is_dir():
                 raise ValueError(f"Recipe root is not a directory: {root}")
             inventory = recipe_inventory(root)
-        expand_deployments = args.gpu is not None or any(field.startswith("deployment.") for field in fields)
+        expand_deployments = any(field.startswith("deployment.") for field in fields)
         rows = build_query_rows(
             inventory,
-            model_id=args.model,
-            allow_missing_model=args.allow_missing_model,
-            gpu=args.gpu,
-            gpu_count=args.gpu_count,
+            candidate=candidate,
             expand_deployments=expand_deployments,
         )
         needs_cloudrift = any(field.startswith("provider.cloudrift.") or field.endswith(".availability.cloudrift") for field in fields)
@@ -97,7 +102,6 @@ def _handle_query(args) -> None:
         selected = query_rows(
             rows,
             filters=filters,
-            requirements=requirements,
             sorts=sorts,
             limit=args.limit,
         )
@@ -121,7 +125,6 @@ def register_recipe_command(subparsers) -> None:
     actions = parser.add_subparsers(dest="recipe_action", required=True)
 
     list_parser = actions.add_parser("list", help="List recipe metadata")
-    list_parser.add_argument("--tag", action="append", default=[], help="Require a tag; repeat to require multiple tags")
     list_parser.add_argument("--json", action="store_true", help="Print the versioned JSON recipe catalog")
     list_parser.set_defaults(func=_handle_list)
 
@@ -135,14 +138,6 @@ def register_recipe_command(subparsers) -> None:
         help="Keep matching rows; repeat for logical AND",
     )
     query_parser.add_argument(
-        "--require",
-        action="append",
-        default=[],
-        dest="requirements",
-        metavar="EXPRESSION",
-        help="Fail if any candidate row does not match; repeat for logical AND",
-    )
-    query_parser.add_argument(
         "--sort",
         action="append",
         default=[],
@@ -151,13 +146,11 @@ def register_recipe_command(subparsers) -> None:
         help="Add a stable sort key in priority order",
     )
     query_parser.add_argument("--limit", type=int, default=None, help="Return at most this many rows")
-    query_parser.add_argument("--model", help="Restrict the candidate source to one exact Hugging Face model ID")
-    query_parser.add_argument("--gpu", help="Use this exact deployment GPU for --model")
-    query_parser.add_argument("--gpu-count", type=int, help="Use this exact deployment GPU count for --model")
     query_parser.add_argument(
-        "--allow-missing-model",
-        action="store_true",
-        help="Create a synthetic onboarding candidate when --model is absent from the catalog",
+        "--candidate",
+        nargs=3,
+        metavar=("MODEL", "GPU", "COUNT"),
+        help="Query one exact external model/deployment",
     )
     query_parser.add_argument(
         "--root",

--- a/emmy/recipe/ARCHITECTURE.md
+++ b/emmy/recipe/ARCHITECTURE.md
@@ -12,6 +12,7 @@ validation.
   `SglangConfig`, `BenchmarkConfig`, `CommandConfig`
 - `lifecycle.py` — lifecycle tag validation and the runnable/disabled predicate
 - `catalog.py` — compact repository inventory, deployment extraction, and validated onboarding shell creation
+- `query.py` — constrained predicates, deployment-row expansion, ordering, and the versioned query result
 - `recipe.py` — `deep_merge()`, `load_recipe()`, `resolve_for_hardware()`, `validate_extra_args()`, `_load_raw_config()`, `_validate_and_build()`
 - `matrix.py` — `expand_matrix()`, `_expand_cross()`, `_expand_zip()`, `filter_combinations()`, `dot_to_nested()`, `build_override()`
 - `engines.py` — `VLLM_FLAG_MAP`, `SGLANG_FLAG_MAP`, `banned_extra_arg_flags()`, `build_engine_args()`
@@ -58,10 +59,43 @@ versioned JSON document produced by `recipe_inventory_document()` adds the direc
 state, and each matrix-expanded deployment's effective context length to the identity, tags, task, and rationale.
 This is the machine interface used by other services: consumers reject unknown `schema_version` values, while Emmy
 may add fields without removing or redefining fields in the current version. Editable installs read the checkout's
-live top-level `recipes/` and wheel installs read their packaged runnable recipes. The CLI deliberately exposes no
-catalog-selection arguments, so every consumer observes the same installation-aware behavior.
+live top-level `recipes/` and wheel installs read their packaged runnable recipes. `recipe list` deliberately exposes
+no catalog-selection arguments, so its consumers observe the same installation-aware behavior.
 `create_recipe_stub()` is likewise shared by `emmy recipe create` and discovery: it validates one to three canonical
 GPU/count setups and writes the minimal disabled shell without duplicating YAML rendering in workflow scripts.
+
+`emmy recipe query` builds normalized rows from the same inventory. A query that references `deployment.*` implicitly
+expands each recipe into one row per unique matrix-expanded GPU/count setup; otherwise it produces one row per recipe.
+An exact `--model` plus `--gpu`/`--gpu-count` replaces the declared deployments with that requested setup, and
+`--allow-missing-model` represents a new model as an onboarding candidate. Every row carries its lifecycle-derived
+operation (`onboarding` or `verification`) and expected post-run lifecycle so automation does not reproduce those
+rules.
+
+The row fields are grouped by ownership:
+
+| Fields | Meaning |
+|---|---|
+| `model_id`, `name`, `recipe_path`, `tags`, `lifecycle`, `task`, `runnable`, `rationale` | Compact catalog metadata |
+| `operation`, `expected_lifecycle` | Lifecycle-derived onboarding or verification action |
+| `deployment.index`, `deployment.gpu`, `deployment.gpu_count`, `deployment.context_length` | One declared or explicitly requested setup |
+| `deployment.availability.cloudrift` | Exact-count capacity reported by CloudRift |
+| `results.path`, `results.last_run_at` | Sibling report path and its last committed change |
+| `provider.cloudrift.team_access` | Whether the configured key can act for the configured team UUID |
+
+The expression grammar is deliberately constrained rather than evaluated as Python. Predicates use a documented
+field, one of `==`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `contains`, or `matches`, and a JSON value. Sorts use
+`FIELD asc|desc` with an optional `nulls-first|nulls-last`, or `FIELD order JSON_ARRAY`. Repeated filters are logical
+AND; repeated sort keys are applied in command order. Requirements use the predicate grammar but fail the query
+instead of removing a candidate. The independent versioned JSON result contains `schema_version` and `rows`; an empty
+result is successful.
+
+Computed fields are resolved only when a predicate or sort references them. `deployment.availability.cloudrift`
+queries current CloudRift capacity and requires `CLOUDRIFT_API_KEY`; it uses the hardware table and requires the exact
+GPU count. `provider.cloudrift.team_access` validates `CLOUDRIFT_TEAM_ID` with the same key before capacity is queried.
+`results.last_run_at` reads the last committed change to the recipe's sibling `RESULTS.md`; a missing report is `null`,
+while requesting the field outside a Git checkout is an error. These annotations are read-only: the query never rents
+hardware, writes workflow outputs, or changes recipes. Computed values that the query does not reference remain
+`null` in its output.
 
 ### Matrix Expansion for Benchmark Sweeps
 

--- a/emmy/recipe/ARCHITECTURE.md
+++ b/emmy/recipe/ARCHITECTURE.md
@@ -66,10 +66,10 @@ GPU/count setups and writes the minimal disabled shell without duplicating YAML 
 
 `emmy recipe query` builds normalized rows from the same inventory. A query that references `deployment.*` implicitly
 expands each recipe into one row per unique matrix-expanded GPU/count setup; otherwise it produces one row per recipe.
-An exact `--model` plus `--gpu`/`--gpu-count` replaces the declared deployments with that requested setup, and
-`--allow-missing-model` represents a new model as an onboarding candidate. Every row carries its lifecycle-derived
-operation (`onboarding` or `verification`) and expected post-run lifecycle so automation does not reproduce those
-rules.
+`--candidate MODEL GPU COUNT` instead supplies one exact external deployment. The query hydrates its
+model metadata from the catalog when present and represents a missing model as onboarding work. Every row carries its
+lifecycle-derived operation (`onboarding` or `verification`) and expected post-run lifecycle so automation does not
+reproduce those rules.
 
 The row fields are grouped by ownership:
 
@@ -85,9 +85,8 @@ The row fields are grouped by ownership:
 The expression grammar is deliberately constrained rather than evaluated as Python. Predicates use a documented
 field, one of `==`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `contains`, or `matches`, and a JSON value. Sorts use
 `FIELD asc|desc` with an optional `nulls-first|nulls-last`, or `FIELD order JSON_ARRAY`. Repeated filters are logical
-AND; repeated sort keys are applied in command order. Requirements use the predicate grammar but fail the query
-instead of removing a candidate. The independent versioned JSON result contains `schema_version` and `rows`; an empty
-result is successful.
+AND; repeated sort keys are applied in command order. The independent versioned JSON result contains `schema_version`
+and `rows`; an empty result is successful, leaving exact-candidate row-count policy to the caller.
 
 Computed fields are resolved only when a predicate or sort references them. `deployment.availability.cloudrift`
 queries current CloudRift capacity and requires `CLOUDRIFT_API_KEY`; it uses the hardware table and requires the exact

--- a/emmy/recipe/query.py
+++ b/emmy/recipe/query.py
@@ -1,0 +1,423 @@
+"""Constrained filtering and ordering for compact recipe inventory rows."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from functools import cmp_to_key
+from pathlib import Path
+from typing import Any
+
+from emmy.provisioning.candidates import iter_candidates
+from emmy.provisioning.cloudrift import list_available_instance_types, validate_team_id_access
+from emmy.recipe.catalog import HF_ID
+from emmy.recipe.lifecycle import BEST_EFFORT_TAG, LIFECYCLE_TAGS, MAINTAINED_TAG, OBSOLETE_TAG
+
+QUERY_SCHEMA_VERSION = 1
+
+_FIELD = r"[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*"
+_PREDICATE = re.compile(rf"^\s*({_FIELD})\s*(==|!=|>=|<=|>|<|in|contains|matches)\s*(.+?)\s*$")
+_ORDER_SORT = re.compile(rf"^\s*({_FIELD})\s+order\s+(.+?)\s*$")
+_DIRECTION_SORT = re.compile(rf"^\s*({_FIELD})\s+(asc|desc)(?:\s+(nulls-first|nulls-last))?\s*$")
+
+RECIPE_FIELDS = frozenset(
+    {
+        "name",
+        "recipe_path",
+        "model_id",
+        "tags",
+        "lifecycle",
+        "task",
+        "runnable",
+        "rationale",
+        "operation",
+        "expected_lifecycle",
+        "deployment.index",
+        "deployment.gpu",
+        "deployment.gpu_count",
+        "deployment.context_length",
+        "deployment.availability.cloudrift",
+        "results.path",
+        "results.last_run_at",
+        "provider.cloudrift.team_access",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Predicate:
+    """One validated row predicate."""
+
+    field: str
+    operator: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class SortExpression:
+    """One validated row sort key."""
+
+    field: str
+    direction: str | None = None
+    nulls: str = "nulls-last"
+    order: tuple[Any, ...] | None = None
+
+
+def _parse_json_value(source: str, *, context: str) -> Any:
+    try:
+        return json.loads(source)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{context} value must be valid JSON: {source!r}") from exc
+
+
+def _validate_field(field: str) -> None:
+    if field not in RECIPE_FIELDS:
+        raise ValueError(f"Unknown recipe query field: {field}")
+
+
+def parse_predicate(source: str) -> Predicate:
+    """Parse one constrained filter or requirement expression."""
+    match = _PREDICATE.fullmatch(source)
+    if match is None:
+        raise ValueError(f"Invalid recipe query predicate: {source!r}")
+    field, operator, raw_value = match.groups()
+    _validate_field(field)
+    value = _parse_json_value(raw_value, context="Predicate")
+    if operator == "in" and not isinstance(value, list):
+        raise ValueError("The 'in' operator requires a JSON array")
+    if operator == "matches":
+        if not isinstance(value, str):
+            raise ValueError("The 'matches' operator requires a JSON string")
+        try:
+            re.compile(value)
+        except re.error as exc:
+            raise ValueError(f"Invalid regular expression: {value!r}") from exc
+    return Predicate(field, operator, value)
+
+
+def parse_sort(source: str) -> SortExpression:
+    """Parse one direction or explicit-order sort expression."""
+    order_match = _ORDER_SORT.fullmatch(source)
+    if order_match is not None:
+        field, raw_order = order_match.groups()
+        _validate_field(field)
+        order = _parse_json_value(raw_order, context="Sort order")
+        if not isinstance(order, list) or not order:
+            raise ValueError("An explicit sort order requires a non-empty JSON array")
+        if any(isinstance(value, (dict, list)) for value in order):
+            raise ValueError("Explicit sort-order values must be JSON scalars")
+        encoded = [json.dumps(value, sort_keys=True) for value in order]
+        if len(encoded) != len(set(encoded)):
+            raise ValueError("Explicit sort-order values must be unique")
+        return SortExpression(field=field, order=tuple(order))
+
+    direction_match = _DIRECTION_SORT.fullmatch(source)
+    if direction_match is None:
+        raise ValueError(f"Invalid recipe query sort: {source!r}")
+    field, direction, nulls = direction_match.groups()
+    _validate_field(field)
+    return SortExpression(field=field, direction=direction, nulls=nulls or "nulls-last")
+
+
+def referenced_fields(
+    filters: list[Predicate],
+    requirements: list[Predicate],
+    sorts: list[SortExpression],
+) -> frozenset[str]:
+    """Return every field needed to evaluate a parsed query."""
+    return frozenset([predicate.field for predicate in [*filters, *requirements]] + [sort.field for sort in sorts])
+
+
+def _lifecycle(tags: list[str]) -> str | None:
+    return next((tag for tag in tags if tag in LIFECYCLE_TAGS), None)
+
+
+def _operation(lifecycle: str | None) -> tuple[str | None, str | None]:
+    if lifecycle == MAINTAINED_TAG:
+        return "verification", MAINTAINED_TAG
+    if lifecycle == BEST_EFFORT_TAG:
+        return "verification", BEST_EFFORT_TAG
+    if lifecycle == OBSOLETE_TAG:
+        return None, None
+    return "onboarding", BEST_EFFORT_TAG
+
+
+def _base_row(record: dict | None, model_id: str) -> dict:
+    tags = list(record["tags"]) if record is not None else []
+    lifecycle = _lifecycle(tags)
+    operation, expected_lifecycle = _operation(lifecycle)
+    recipe_path = record["path"] if record is not None else None
+    results_path = str(Path(recipe_path).with_name("RESULTS.md")) if recipe_path else None
+    return {
+        "name": record["name"] if record is not None else None,
+        "recipe_path": recipe_path,
+        "model_id": model_id,
+        "tags": tags,
+        "lifecycle": lifecycle,
+        "task": record["task"] if record is not None else None,
+        "runnable": record["runnable"] if record is not None else False,
+        "rationale": record["rationale"] if record is not None else None,
+        "operation": operation,
+        "expected_lifecycle": expected_lifecycle,
+        "results": {"path": results_path, "last_run_at": None},
+        "provider": {"cloudrift": {"team_access": None}},
+    }
+
+
+def build_query_rows(
+    inventory: list[dict],
+    *,
+    model_id: str | None = None,
+    allow_missing_model: bool = False,
+    gpu: str | None = None,
+    gpu_count: int | None = None,
+    expand_deployments: bool = False,
+) -> list[dict]:
+    """Build normalized recipe or recipe/deployment rows for query evaluation."""
+    if model_id is not None and HF_ID.fullmatch(model_id) is None:
+        raise ValueError("model_id must be an exact Hugging Face owner/repository ID")
+    if allow_missing_model and model_id is None:
+        raise ValueError("--allow-missing-model requires --model")
+    if (gpu is None) != (gpu_count is None):
+        raise ValueError("--gpu and --gpu-count must be used together")
+    if gpu is not None and model_id is None:
+        raise ValueError("An explicit deployment requires --model")
+    if gpu_count is not None and (isinstance(gpu_count, bool) or gpu_count < 1):
+        raise ValueError("gpu_count must be positive")
+
+    by_model = {record["model_id"]: record for record in inventory}
+    if model_id is not None:
+        record = by_model.get(model_id)
+        if record is None and not allow_missing_model:
+            raise ValueError(f"No recipe found for model {model_id}")
+        records = [(model_id, record)]
+    else:
+        records = [(record["model_id"], record) for record in inventory]
+
+    rows = []
+    for selected_model_id, record in records:
+        base = _base_row(record, selected_model_id)
+        if gpu is not None:
+            deployments = [{"gpu": gpu, "gpu_count": gpu_count, "context_length": None}]
+        elif expand_deployments:
+            deployments = record["deployments"] if record is not None else []
+        else:
+            deployments = [None]
+
+        for index, deployment in enumerate(deployments):
+            row = {
+                **base,
+                "results": dict(base["results"]),
+                "provider": {"cloudrift": dict(base["provider"]["cloudrift"])},
+            }
+            if deployment is None:
+                row["deployment"] = None
+            else:
+                row["deployment"] = {
+                    "index": index,
+                    "gpu": deployment["gpu"],
+                    "gpu_count": deployment["gpu_count"],
+                    "context_length": deployment.get("context_length"),
+                    "availability": {"cloudrift": None},
+                }
+            rows.append(row)
+    return rows
+
+
+def field_value(row: dict, field: str) -> Any:
+    """Read a validated dotted field from a normalized query row."""
+    _validate_field(field)
+    value: Any = row
+    for part in field.split("."):
+        if value is None:
+            return None
+        if not isinstance(value, dict) or part not in value:
+            raise ValueError(f"Recipe query field was not resolved: {field}")
+        value = value[part]
+    return value
+
+
+def _matches(row: dict, predicate: Predicate) -> bool:
+    current = field_value(row, predicate.field)
+    expected = predicate.value
+    operator = predicate.operator
+    if operator == "==":
+        return current == expected
+    if operator == "!=":
+        return current != expected
+    if operator == "in":
+        return current in expected
+    if operator == "contains":
+        try:
+            return expected in current
+        except TypeError as exc:
+            raise ValueError(f"Field {predicate.field} does not support 'contains'") from exc
+    if operator == "matches":
+        if not isinstance(current, str):
+            return False
+        return re.search(expected, current) is not None
+    try:
+        if operator == ">":
+            return current > expected
+        if operator == ">=":
+            return current >= expected
+        if operator == "<":
+            return current < expected
+        if operator == "<=":
+            return current <= expected
+    except TypeError as exc:
+        raise ValueError(f"Field {predicate.field} cannot be compared with {expected!r}") from exc
+    raise AssertionError(f"Unhandled predicate operator: {operator}")
+
+
+def _compare_values(left: Any, right: Any, sort: SortExpression) -> int:
+    if left is None or right is None:
+        if left is right:
+            return 0
+        null_first = sort.nulls == "nulls-first"
+        return -1 if (left is None) == null_first else 1
+
+    if sort.order is not None:
+        ranks = {json.dumps(value, sort_keys=True): index for index, value in enumerate(sort.order)}
+        left_key = json.dumps(left, sort_keys=True)
+        right_key = json.dumps(right, sort_keys=True)
+        left_rank = ranks.get(left_key, len(ranks))
+        right_rank = ranks.get(right_key, len(ranks))
+        if left_rank != right_rank:
+            return -1 if left_rank < right_rank else 1
+        if left_key == right_key:
+            return 0
+        return -1 if left_key < right_key else 1
+
+    try:
+        comparison = (left > right) - (left < right)
+    except TypeError as exc:
+        raise ValueError(f"Field {sort.field} contains values that cannot be ordered together") from exc
+    return -comparison if sort.direction == "desc" else comparison
+
+
+def query_rows(
+    rows: list[dict],
+    *,
+    filters: list[Predicate],
+    requirements: list[Predicate],
+    sorts: list[SortExpression],
+    limit: int | None,
+) -> list[dict]:
+    """Apply requirements, filters, stable lexicographic ordering, and a limit."""
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be positive")
+    for requirement in requirements:
+        failed = list(dict.fromkeys(row["model_id"] for row in rows if not _matches(row, requirement)))
+        if failed:
+            raise ValueError(
+                f"Recipe query requirement failed for {', '.join(failed)}: "
+                f"{requirement.field} {requirement.operator} {json.dumps(requirement.value)}"
+            )
+
+    selected = [row for row in rows if all(_matches(row, predicate) for predicate in filters)]
+
+    def compare(left: dict, right: dict) -> int:
+        for sort in sorts:
+            result = _compare_values(field_value(left, sort.field), field_value(right, sort.field), sort)
+            if result:
+                return result
+        return 0
+
+    if sorts:
+        selected.sort(key=cmp_to_key(compare))
+    if limit is not None:
+        selected = selected[:limit]
+    return selected
+
+
+def _annotate_cloudrift_availability(rows: list[dict], available: set[str]) -> None:
+    for row in rows:
+        deployment = row["deployment"]
+        if deployment is None:
+            continue
+        try:
+            candidates = iter_candidates(
+                deployment["gpu"],
+                deployment["gpu_count"],
+                "cloudrift",
+                exact_gpu_count=True,
+            )
+        except (TypeError, ValueError):
+            deployment["availability"]["cloudrift"] = False
+            continue
+        deployment["availability"]["cloudrift"] = any(candidate.instance_type in available for candidate in candidates)
+
+
+def _git_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise ValueError("results.last_run_at requires a Git checkout with history")
+    return Path(result.stdout.strip()).resolve()
+
+
+def _annotate_last_recipe_runs(rows: list[dict]) -> None:
+    root = _git_root()
+    timestamps: dict[str, str | None] = {}
+    for row in rows:
+        results_path = row["results"]["path"]
+        if results_path is None:
+            continue
+        try:
+            git_path = Path(results_path).resolve().relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"Recipe results path is outside the Git checkout: {results_path}") from exc
+        key = str(git_path)
+        if key not in timestamps:
+            result = subprocess.run(
+                ["git", "-C", str(root), "log", "-1", "--format=%ct", "--", key],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                message = result.stderr.strip() or f"git log failed for {key}"
+                raise ValueError(message)
+            raw_timestamp = result.stdout.strip()
+            if raw_timestamp:
+                timestamps[key] = datetime.fromtimestamp(int(raw_timestamp), tz=UTC).isoformat().replace("+00:00", "Z")
+            else:
+                timestamps[key] = None
+        row["results"]["last_run_at"] = timestamps[key]
+
+
+async def enrich_query_rows(
+    rows: list[dict],
+    fields: frozenset[str],
+    *,
+    cloudrift_api_key: str | None,
+    cloudrift_team_id: str | None,
+) -> None:
+    """Resolve only the provider and Git fields referenced by a query."""
+    needs_team_access = "provider.cloudrift.team_access" in fields
+    needs_availability = "deployment.availability.cloudrift" in fields
+    if needs_team_access or needs_availability:
+        if not cloudrift_api_key:
+            raise ValueError("CLOUDRIFT_API_KEY is required by the requested recipe query fields")
+        if needs_team_access:
+            await validate_team_id_access(cloudrift_api_key, cloudrift_team_id)
+            for row in rows:
+                row["provider"]["cloudrift"]["team_access"] = True
+        if needs_availability:
+            available = await list_available_instance_types(cloudrift_api_key)
+            _annotate_cloudrift_availability(rows, available)
+    if "results.last_run_at" in fields:
+        _annotate_last_recipe_runs(rows)
+
+
+def query_document(rows: list[dict]) -> dict:
+    """Wrap query rows in their versioned machine-readable envelope."""
+    return {"schema_version": QUERY_SCHEMA_VERSION, "rows": rows}

--- a/emmy/recipe/query.py
+++ b/emmy/recipe/query.py
@@ -57,6 +57,15 @@ class Predicate:
 
 
 @dataclass(frozen=True)
+class RecipeCandidate:
+    """One exact model/deployment supplied outside the recipe catalog."""
+
+    model_id: str
+    gpu: str
+    gpu_count: int
+
+
+@dataclass(frozen=True)
 class SortExpression:
     """One validated row sort key."""
 
@@ -79,7 +88,7 @@ def _validate_field(field: str) -> None:
 
 
 def parse_predicate(source: str) -> Predicate:
-    """Parse one constrained filter or requirement expression."""
+    """Parse one constrained filter expression."""
     match = _PREDICATE.fullmatch(source)
     if match is None:
         raise ValueError(f"Invalid recipe query predicate: {source!r}")
@@ -122,13 +131,9 @@ def parse_sort(source: str) -> SortExpression:
     return SortExpression(field=field, direction=direction, nulls=nulls or "nulls-last")
 
 
-def referenced_fields(
-    filters: list[Predicate],
-    requirements: list[Predicate],
-    sorts: list[SortExpression],
-) -> frozenset[str]:
+def referenced_fields(filters: list[Predicate], sorts: list[SortExpression]) -> frozenset[str]:
     """Return every field needed to evaluate a parsed query."""
-    return frozenset([predicate.field for predicate in [*filters, *requirements]] + [sort.field for sort in sorts])
+    return frozenset([predicate.field for predicate in filters] + [sort.field for sort in sorts])
 
 
 def _lifecycle(tags: list[str]) -> str | None:
@@ -170,38 +175,28 @@ def _base_row(record: dict | None, model_id: str) -> dict:
 def build_query_rows(
     inventory: list[dict],
     *,
-    model_id: str | None = None,
-    allow_missing_model: bool = False,
-    gpu: str | None = None,
-    gpu_count: int | None = None,
+    candidate: RecipeCandidate | None = None,
     expand_deployments: bool = False,
 ) -> list[dict]:
     """Build normalized recipe or recipe/deployment rows for query evaluation."""
-    if model_id is not None and HF_ID.fullmatch(model_id) is None:
-        raise ValueError("model_id must be an exact Hugging Face owner/repository ID")
-    if allow_missing_model and model_id is None:
-        raise ValueError("--allow-missing-model requires --model")
-    if (gpu is None) != (gpu_count is None):
-        raise ValueError("--gpu and --gpu-count must be used together")
-    if gpu is not None and model_id is None:
-        raise ValueError("An explicit deployment requires --model")
-    if gpu_count is not None and (isinstance(gpu_count, bool) or gpu_count < 1):
-        raise ValueError("gpu_count must be positive")
-
     by_model = {record["model_id"]: record for record in inventory}
-    if model_id is not None:
-        record = by_model.get(model_id)
-        if record is None and not allow_missing_model:
-            raise ValueError(f"No recipe found for model {model_id}")
-        records = [(model_id, record)]
+    if candidate is not None:
+        if HF_ID.fullmatch(candidate.model_id) is None:
+            raise ValueError("candidate model must be an exact Hugging Face owner/repository ID")
+        if not candidate.gpu:
+            raise ValueError("candidate GPU must be non-empty")
+        if isinstance(candidate.gpu_count, bool) or candidate.gpu_count < 1:
+            raise ValueError("candidate GPU count must be positive")
+        deployment = {"gpu": candidate.gpu, "gpu_count": candidate.gpu_count, "context_length": None}
+        sources = [(candidate.model_id, by_model.get(candidate.model_id), deployment)]
     else:
-        records = [(record["model_id"], record) for record in inventory]
+        sources = [(record["model_id"], record, None) for record in inventory]
 
     rows = []
-    for selected_model_id, record in records:
+    for selected_model_id, record, candidate_deployment in sources:
         base = _base_row(record, selected_model_id)
-        if gpu is not None:
-            deployments = [{"gpu": gpu, "gpu_count": gpu_count, "context_length": None}]
+        if candidate_deployment is not None:
+            deployments = [candidate_deployment]
         elif expand_deployments:
             deployments = record["deployments"] if record is not None else []
         else:
@@ -303,21 +298,12 @@ def query_rows(
     rows: list[dict],
     *,
     filters: list[Predicate],
-    requirements: list[Predicate],
     sorts: list[SortExpression],
     limit: int | None,
 ) -> list[dict]:
-    """Apply requirements, filters, stable lexicographic ordering, and a limit."""
+    """Apply filters, stable lexicographic ordering, and a limit."""
     if limit is not None and limit < 1:
         raise ValueError("limit must be positive")
-    for requirement in requirements:
-        failed = list(dict.fromkeys(row["model_id"] for row in rows if not _matches(row, requirement)))
-        if failed:
-            raise ValueError(
-                f"Recipe query requirement failed for {', '.join(failed)}: "
-                f"{requirement.field} {requirement.operator} {json.dumps(requirement.value)}"
-            )
-
     selected = [row for row in rows if all(_matches(row, predicate) for predicate in filters)]
 
     def compare(left: dict, right: dict) -> int:

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -107,8 +107,10 @@ directly; they never import from another test module or from `conftest.py`.
   tag-filtered inventory, the minimal installation-selected CLI, editable-versus-wheel catalog selection, recipe-name
   materialization, and validated shell creation. Repository-automation tests validate required lifecycle rationales
   and the one-to-three-entry onboarding deployment matrix through that shared library. Notification tests cover the
-  modified-model lifecycle groups and validated deployment/performance summaries. Qualification-manifest tests also
-  pin the requested operation mode, exact model ID, target, preserved lifecycle tag, compact notification evidence,
+  modified-model lifecycle groups and validated deployment/performance summaries. Query tests cover constrained
+  expression parsing, implicit deployment expansion, lifecycle ordering, requirements, and the versioned row result.
+  Qualification-manifest tests also pin the requested operation mode, exact model ID, target, preserved lifecycle tag,
+  compact notification evidence,
   current-platform archive and row records, and isolation from other platform results before artifacts may be staged.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.
 - **Plain functions** — no test classes; tests are grouped by file and separated with comment headers.

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -104,14 +104,14 @@ directly; they never import from another test module or from `conftest.py`.
 - **Recipe lifecycle** — named-model deployment assertions skip when their recipe is disabled; maintained and
   best-effort recipes keep the full serving contract coverage, while obsolete recipes remain covered by lifecycle
   validation. Catalog and command tests cover the versioned JSON inventory, effective deployment metadata,
-  tag-filtered inventory, the minimal installation-selected CLI, editable-versus-wheel catalog selection, recipe-name
+  query-filtered inventory, the minimal installation-selected CLI, editable-versus-wheel catalog selection, recipe-name
   materialization, and validated shell creation. Repository-automation tests validate required lifecycle rationales
   and the one-to-three-entry onboarding deployment matrix through that shared library. Notification tests cover the
   modified-model lifecycle groups and validated deployment/performance summaries. Query tests cover constrained
-  expression parsing, implicit deployment expansion, lifecycle ordering, requirements, and the versioned row result.
-  Qualification-manifest tests also pin the requested operation mode, exact model ID, target, preserved lifecycle tag,
-  compact notification evidence,
-  current-platform archive and row records, and isolation from other platform results before artifacts may be staged.
+  expression parsing, implicit deployment expansion, external candidates, lifecycle ordering, and the versioned row
+  result. Qualification-manifest tests also pin the requested operation mode, exact model ID, target, preserved
+  lifecycle tag, compact notification evidence, current-platform archive and row records, and isolation from other
+  platform results before artifacts may be staged.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.
 - **Plain functions** — no test classes; tests are grouped by file and separated with comment headers.
 - **Assertions on stdout** — dry-run tests verify that the correct commands and messages appear in the expected order.

--- a/tests/commands/test_recipe.py
+++ b/tests/commands/test_recipe.py
@@ -28,25 +28,18 @@ def test_recipe_create(run_cli, tmp_path):
     assert yaml.safe_load(recipe_path.read_text())["matrices"] == [{"deploy.gpu": GPU, "deploy.gpu_count": 1}]
 
 
-def test_recipe_list_by_tag(run_cli):
-    returncode, stdout, stderr = run_cli("recipe", "list", "--tag", "best-effort", "--json")
+def test_recipe_list_json_contains_complete_catalog(run_cli):
+    returncode, stdout, stderr = run_cli("recipe", "list", "--json")
 
     assert returncode == 0, stderr
     document = json.loads(stdout)
     assert document["schema_version"] == 1
     assert document["recipes"]
-    assert all("best-effort" in recipe["tags"] for recipe in document["recipes"])
-
-
-def test_recipe_list_excludes_recipes_without_requested_tag(run_cli):
-    returncode, stdout, stderr = run_cli("recipe", "list", "--tag", "does-not-exist", "--json")
-
-    assert returncode == 0, stderr
-    assert json.loads(stdout) == {"schema_version": 1, "recipes": []}
+    assert all("deployments" in recipe for recipe in document["recipes"])
 
 
 def test_recipe_list_rejects_catalog_selection_arguments(run_cli):
-    for arguments in (("recipes",), ("--bundled",)):
+    for arguments in (("recipes",), ("--bundled",), ("--tag", "maintained")):
         returncode, _stdout, stderr = run_cli("recipe", "list", *arguments, "--json")
 
         assert returncode == 2
@@ -81,3 +74,32 @@ def test_recipe_query_rejects_non_positive_limit(run_cli):
 
     assert returncode == 2
     assert "limit must be positive" in stdout
+
+
+def test_recipe_query_hydrates_external_candidate(run_cli):
+    returncode, stdout, stderr = run_cli(
+        "recipe",
+        "query",
+        "--candidate",
+        "org/new-model",
+        GPU,
+        "1",
+        "--filter",
+        'lifecycle != "obsolete"',
+        "--json",
+    )
+
+    assert returncode == 0, stderr
+    row = json.loads(stdout)["rows"][0]
+    assert row["model_id"] == "org/new-model"
+    assert row["operation"] == "onboarding"
+    assert row["deployment"]["gpu"] == GPU
+
+
+def test_recipe_query_exposes_one_external_candidate_option(run_cli):
+    returncode, stdout, stderr = run_cli("recipe", "query", "--help")
+
+    assert returncode == 0, stderr
+    assert "--candidate MODEL GPU COUNT" in stdout
+    for removed_option in ("--require", "--model MODEL", "--gpu GPU", "--gpu-count", "--allow-missing-model"):
+        assert removed_option not in stdout

--- a/tests/commands/test_recipe.py
+++ b/tests/commands/test_recipe.py
@@ -51,3 +51,33 @@ def test_recipe_list_rejects_catalog_selection_arguments(run_cli):
 
         assert returncode == 2
         assert "unrecognized arguments" in stderr
+
+
+def test_recipe_query_filters_sorts_and_limits_catalog_rows(run_cli):
+    returncode, stdout, stderr = run_cli(
+        "recipe",
+        "query",
+        "--filter",
+        'lifecycle == "best-effort"',
+        "--sort",
+        "results.last_run_at asc nulls-first",
+        "--sort",
+        "model_id asc",
+        "--limit",
+        "2",
+        "--json",
+    )
+
+    assert returncode == 0, stderr
+    document = json.loads(stdout)
+    assert document["schema_version"] == 1
+    assert 0 < len(document["rows"]) <= 2
+    assert all(row["lifecycle"] == "best-effort" for row in document["rows"])
+    assert [row["model_id"] for row in document["rows"]] == sorted(row["model_id"] for row in document["rows"])
+
+
+def test_recipe_query_rejects_non_positive_limit(run_cli):
+    returncode, stdout, _stderr = run_cli("recipe", "query", "--limit", "0", "--json")
+
+    assert returncode == 2
+    assert "limit must be positive" in stdout

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -266,9 +266,21 @@ def test_onboarding_selects_with_generic_recipe_query():
     assert 'lifecycle order ["onboarding", "maintained"]' in script
     assert "results.last_run_at asc nulls-first" in script
     assert "deployment.index asc" in script
-    assert "--allow-missing-model" in script
+    assert "--candidate" in script
     assert 'lifecycle != "obsolete"' in script
+    assert "--require" not in script
     assert "recipe_inventory_document" not in script
+    subprocess.run(["bash", "-n"], input=script, text=True, check=True)
+
+
+def test_discovery_counts_lifecycle_with_recipe_query():
+    document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "discover-model.yml").read_text())
+    script = next(step["run"] for step in document["jobs"]["discover"]["steps"] if step.get("name") == "Validate and apply model lifecycle")
+
+    assert "recipe query" in script
+    assert 'tags contains "maintained"' in script
+    assert 'tags contains "onboarding"' in script
+    assert "recipe list --tag" not in script
     subprocess.run(["bash", "-n"], input=script, text=True, check=True)
 
 

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -254,15 +254,22 @@ def test_onboarding_creates_platform_archive_and_preserves_other_platform(tmp_pa
     assert expected_snapshot <= set(updated_summary["artifacts"])
 
 
-def test_onboarding_consumes_versioned_recipe_inventory():
+def test_onboarding_selects_with_generic_recipe_query():
     document = yaml.safe_load((Path(__file__).parents[2] / ".github" / "workflows" / "onboard-model.yml").read_text())
     script = next(step["run"] for step in document["jobs"]["onboard"]["steps"] if step.get("name") == "Select one available deployment")
 
-    assert 'recipe_inventory_document(Path("recipes"))' in script
-    assert 'inventory_document.get("schema_version") != 1' in script
-    assert 'inventory = inventory_document["recipes"]' in script
-    assert 'deployment.get("gpu", deployment.get("deploy.gpu"))' in script
-    assert 'deployment.get("gpu_count", deployment.get("deploy.gpu_count"))' in script
+    assert "recipe query" in script
+    assert "--root recipes" in script
+    assert "provider.cloudrift.team_access == true" in script
+    assert 'lifecycle in ["onboarding", "maintained"]' in script
+    assert "deployment.availability.cloudrift == true" in script
+    assert 'lifecycle order ["onboarding", "maintained"]' in script
+    assert "results.last_run_at asc nulls-first" in script
+    assert "deployment.index asc" in script
+    assert "--allow-missing-model" in script
+    assert 'lifecycle != "obsolete"' in script
+    assert "recipe_inventory_document" not in script
+    subprocess.run(["bash", "-n"], input=script, text=True, check=True)
 
 
 def test_discovery_prompt_keeps_obsolete_classification_conservative():

--- a/tests/recipe/test_query.py
+++ b/tests/recipe/test_query.py
@@ -1,0 +1,219 @@
+"""Recipe query parsing, row expansion, and ordering."""
+
+import pytest
+
+import emmy.recipe.query as recipe_query
+from emmy.recipe.query import (
+    build_query_rows,
+    parse_predicate,
+    parse_sort,
+    query_document,
+    query_rows,
+    referenced_fields,
+)
+
+
+def _record(model_id, tags, deployments, path=None):
+    name = model_id.split("/", 1)[1]
+    return {
+        "name": name,
+        "path": path or f"recipes/{name}/recipe.yaml",
+        "model_id": model_id,
+        "tags": tags,
+        "task": "generate",
+        "runnable": "onboarding" not in tags,
+        "deployments": deployments,
+        "rationale": f"Qualify {model_id}.",
+    }
+
+
+def _deployment(gpu, count=1):
+    return {"gpu": gpu, "gpu_count": count, "context_length": 8192}
+
+
+def test_query_expands_deployments_and_preserves_declaration_order():
+    inventory = [
+        _record(
+            "org/model",
+            ["onboarding", "untested"],
+            [_deployment("GPU B", 2), _deployment("GPU A")],
+        )
+    ]
+
+    rows = build_query_rows(inventory, expand_deployments=True)
+
+    assert [row["deployment"]["index"] for row in rows] == [0, 1]
+    assert [row["deployment"]["gpu"] for row in rows] == ["GPU B", "GPU A"]
+    assert all(row["operation"] == "onboarding" for row in rows)
+    assert all(row["expected_lifecycle"] == "best-effort" for row in rows)
+
+
+def test_query_filters_and_sorts_lifecycle_then_oldest_results_then_model():
+    inventory = [
+        _record("org/maintained-new", ["maintained"], [_deployment("GPU")]),
+        _record("org/onboarding-b", ["onboarding", "untested"], [_deployment("GPU")]),
+        _record(
+            "org/onboarding-a",
+            ["onboarding", "untested"],
+            [_deployment("Unavailable GPU"), _deployment("Available GPU")],
+        ),
+        _record("org/best-effort", ["best-effort"], [_deployment("GPU")]),
+    ]
+    rows = build_query_rows(inventory, expand_deployments=True)
+    timestamps = {
+        "org/maintained-new": "2026-08-10T00:00:00Z",
+        "org/onboarding-b": "2026-08-01T00:00:00Z",
+        "org/onboarding-a": None,
+        "org/best-effort": None,
+    }
+    for row in rows:
+        row["results"]["last_run_at"] = timestamps[row["model_id"]]
+        row["deployment"]["availability"]["cloudrift"] = row["deployment"]["gpu"] != "Unavailable GPU"
+
+    selected = query_rows(
+        rows,
+        filters=[
+            parse_predicate('lifecycle in ["onboarding", "maintained"]'),
+            parse_predicate("deployment.availability.cloudrift == true"),
+        ],
+        requirements=[],
+        sorts=[
+            parse_sort('lifecycle order ["onboarding", "maintained"]'),
+            parse_sort("results.last_run_at asc nulls-first"),
+            parse_sort("model_id asc"),
+            parse_sort("deployment.index asc"),
+        ],
+        limit=1,
+    )
+
+    assert [row["model_id"] for row in selected] == ["org/onboarding-a"]
+    assert selected[0]["deployment"]["index"] == 1
+
+
+def test_query_manual_missing_model_is_onboarding_candidate():
+    rows = build_query_rows(
+        [],
+        model_id="org/new-model",
+        allow_missing_model=True,
+        gpu="NVIDIA H200 141GB",
+        gpu_count=1,
+        expand_deployments=True,
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["recipe_path"] is None
+    assert rows[0]["lifecycle"] is None
+    assert rows[0]["operation"] == "onboarding"
+    assert rows[0]["expected_lifecycle"] == "best-effort"
+    assert rows[0]["deployment"]["gpu"] == "NVIDIA H200 141GB"
+
+
+def test_query_manual_existing_model_uses_explicit_deployment():
+    inventory = [_record("org/model", ["maintained"], [_deployment("Declared GPU", 8)])]
+
+    rows = build_query_rows(
+        inventory,
+        model_id="org/model",
+        gpu="Requested GPU",
+        gpu_count=2,
+        expand_deployments=True,
+    )
+
+    assert rows[0]["operation"] == "verification"
+    assert rows[0]["expected_lifecycle"] == "maintained"
+    assert rows[0]["deployment"]["gpu"] == "Requested GPU"
+    assert rows[0]["deployment"]["gpu_count"] == 2
+
+
+def test_query_requirement_fails_instead_of_discarding_candidate():
+    rows = build_query_rows(
+        [_record("org/model", ["obsolete"], [_deployment("GPU")])],
+        expand_deployments=True,
+    )
+
+    with pytest.raises(ValueError, match="requirement failed.*lifecycle !="):
+        query_rows(
+            rows,
+            filters=[],
+            requirements=[parse_predicate('lifecycle != "obsolete"')],
+            sorts=[],
+            limit=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("source", "message"),
+    [
+        ('unknown == "value"', "Unknown recipe query field"),
+        ('lifecycle in "maintained"', "requires a JSON array"),
+        ('model_id matches "["', "Invalid regular expression"),
+        ("lifecycle == maintained", "valid JSON"),
+    ],
+)
+def test_query_rejects_invalid_predicates(source, message):
+    with pytest.raises(ValueError, match=message):
+        parse_predicate(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "model_id newest",
+        "unknown asc",
+        "lifecycle order []",
+        'lifecycle order ["maintained", "maintained"]',
+    ],
+)
+def test_query_rejects_invalid_sorts(source):
+    with pytest.raises(ValueError):
+        parse_sort(source)
+
+
+def test_query_referenced_fields_drive_lazy_enrichment():
+    filters = [parse_predicate("deployment.availability.cloudrift == true")]
+    requirements = [parse_predicate("provider.cloudrift.team_access == true")]
+    sorts = [parse_sort("results.last_run_at asc nulls-first")]
+
+    assert referenced_fields(filters, requirements, sorts) == {
+        "deployment.availability.cloudrift",
+        "provider.cloudrift.team_access",
+        "results.last_run_at",
+    }
+
+
+async def test_query_resolves_team_access_before_cloudrift_availability(monkeypatch):
+    calls = []
+
+    async def validate_team(_api_key, _team_id):
+        calls.append("team")
+        return "normalized-team-id"
+
+    async def list_available(_api_key):
+        calls.append("availability")
+        return {"rtx49-10c-kn.1"}
+
+    monkeypatch.setattr(recipe_query, "validate_team_id_access", validate_team)
+    monkeypatch.setattr(recipe_query, "list_available_instance_types", list_available)
+    rows = build_query_rows(
+        [],
+        model_id="org/new-model",
+        allow_missing_model=True,
+        gpu="NVIDIA GeForce RTX 4090",
+        gpu_count=1,
+        expand_deployments=True,
+    )
+
+    await recipe_query.enrich_query_rows(
+        rows,
+        {"provider.cloudrift.team_access", "deployment.availability.cloudrift"},
+        cloudrift_api_key="test-key",
+        cloudrift_team_id="test-team",
+    )
+
+    assert calls == ["team", "availability"]
+    assert rows[0]["provider"]["cloudrift"]["team_access"] is True
+    assert rows[0]["deployment"]["availability"]["cloudrift"] is True
+
+
+def test_query_document_has_independent_versioned_schema():
+    assert query_document([]) == {"schema_version": 1, "rows": []}

--- a/tests/recipe/test_query.py
+++ b/tests/recipe/test_query.py
@@ -4,6 +4,7 @@ import pytest
 
 import emmy.recipe.query as recipe_query
 from emmy.recipe.query import (
+    RecipeCandidate,
     build_query_rows,
     parse_predicate,
     parse_sort,
@@ -76,7 +77,6 @@ def test_query_filters_and_sorts_lifecycle_then_oldest_results_then_model():
             parse_predicate('lifecycle in ["onboarding", "maintained"]'),
             parse_predicate("deployment.availability.cloudrift == true"),
         ],
-        requirements=[],
         sorts=[
             parse_sort('lifecycle order ["onboarding", "maintained"]'),
             parse_sort("results.last_run_at asc nulls-first"),
@@ -93,10 +93,7 @@ def test_query_filters_and_sorts_lifecycle_then_oldest_results_then_model():
 def test_query_manual_missing_model_is_onboarding_candidate():
     rows = build_query_rows(
         [],
-        model_id="org/new-model",
-        allow_missing_model=True,
-        gpu="NVIDIA H200 141GB",
-        gpu_count=1,
+        candidate=RecipeCandidate("org/new-model", "NVIDIA H200 141GB", 1),
         expand_deployments=True,
     )
 
@@ -113,9 +110,7 @@ def test_query_manual_existing_model_uses_explicit_deployment():
 
     rows = build_query_rows(
         inventory,
-        model_id="org/model",
-        gpu="Requested GPU",
-        gpu_count=2,
+        candidate=RecipeCandidate("org/model", "Requested GPU", 2),
         expand_deployments=True,
     )
 
@@ -125,20 +120,35 @@ def test_query_manual_existing_model_uses_explicit_deployment():
     assert rows[0]["deployment"]["gpu_count"] == 2
 
 
-def test_query_requirement_fails_instead_of_discarding_candidate():
+def test_query_filter_discards_obsolete_candidate():
     rows = build_query_rows(
-        [_record("org/model", ["obsolete"], [_deployment("GPU")])],
+        [_record("org/model", ["obsolete"], [_deployment("Declared GPU")])],
+        candidate=RecipeCandidate("org/model", "Requested GPU", 1),
         expand_deployments=True,
     )
 
-    with pytest.raises(ValueError, match="requirement failed.*lifecycle !="):
+    assert (
         query_rows(
             rows,
-            filters=[],
-            requirements=[parse_predicate('lifecycle != "obsolete"')],
+            filters=[parse_predicate('lifecycle != "obsolete"')],
             sorts=[],
             limit=1,
         )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    ("candidate", "message"),
+    [
+        (RecipeCandidate("not-a-model", "GPU", 1), "exact Hugging Face"),
+        (RecipeCandidate("org/model", "", 1), "GPU must be non-empty"),
+        (RecipeCandidate("org/model", "GPU", 0), "GPU count must be positive"),
+    ],
+)
+def test_query_rejects_invalid_candidates(candidate, message):
+    with pytest.raises(ValueError, match=message):
+        build_query_rows([], candidate=candidate, expand_deployments=True)
 
 
 @pytest.mark.parametrize(
@@ -170,11 +180,13 @@ def test_query_rejects_invalid_sorts(source):
 
 
 def test_query_referenced_fields_drive_lazy_enrichment():
-    filters = [parse_predicate("deployment.availability.cloudrift == true")]
-    requirements = [parse_predicate("provider.cloudrift.team_access == true")]
+    filters = [
+        parse_predicate("deployment.availability.cloudrift == true"),
+        parse_predicate("provider.cloudrift.team_access == true"),
+    ]
     sorts = [parse_sort("results.last_run_at asc nulls-first")]
 
-    assert referenced_fields(filters, requirements, sorts) == {
+    assert referenced_fields(filters, sorts) == {
         "deployment.availability.cloudrift",
         "provider.cloudrift.team_access",
         "results.last_run_at",
@@ -196,10 +208,7 @@ async def test_query_resolves_team_access_before_cloudrift_availability(monkeypa
     monkeypatch.setattr(recipe_query, "list_available_instance_types", list_available)
     rows = build_query_rows(
         [],
-        model_id="org/new-model",
-        allow_missing_model=True,
-        gpu="NVIDIA GeForce RTX 4090",
-        gpu_count=1,
+        candidate=RecipeCandidate("org/new-model", "NVIDIA GeForce RTX 4090", 1),
         expand_deployments=True,
     )
 


### PR DESCRIPTION
## Summary

- add a versioned `emmy recipe query` interface with constrained filters, stable sorts, limits, implicit deployment expansion, and one exact `--candidate MODEL GPU COUNT` source
- keep `recipe list` as the aggregate catalog interface and remove its redundant tag selector; query filters own all row selection
- resolve CloudRift exact-count availability, Robots-team access, and committed `RESULTS.md` history only when referenced
- replace the onboarding workflow embedded selector with the generic query and migrate discovery lifecycle counts to query filters
- document the streamlined CLI and cover parsing, ranking, provider ordering, external candidates, CLI output, and workflow shell syntax

## Validation

- `make test` (3202 passed, 652 skipped, 1 xfailed, 1 xpassed)
- `make lint`
- rebased onto `main` at `3c977457` after #527 merged