### PR TITLE
Route Emmy workflows to organization runner groups

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -1,15 +1,15 @@
 # GitHub Actions architecture
 
-GitHub Actions owns pull-request checks, package publication, and automated model discovery and onboarding. Workflows
-that only inspect or build the repository use GitHub-hosted runners. Agent-driven
-model work uses the organization-level `agent-runners` group with the `agents` label because it can exceed ordinary
-hosted-runner limits and needs the tracked skills and CloudRift inference endpoint.
+GitHub Actions owns pull-request checks, package publication, and automated model discovery and onboarding.
+Pull-request checks use the organization-level `ubuntu-runners` builder group, while package publication remains on
+GitHub-hosted runners. Agent-driven model work uses the separate `agent-runners` group with the `agents` label because
+it can exceed ordinary hosted-runner limits and needs the tracked skills and CloudRift inference endpoint.
 
 ## Workflow overview
 
 | Workflow | Trigger | Runner | Result |
 | --- | --- | --- | --- |
-| **Tests** | Pull request to `main` | GitHub-hosted | Runs Ruff, the complete test suite, and a PyPI package dry run. |
+| **Tests** | Pull request to `main` | `ubuntu-runners` | Runs Ruff, the complete test suite, and a PyPI package dry run. |
 | **Publish to PyPI** | Manual dispatch or published GitHub release | GitHub-hosted | Tests, builds, publishes to PyPI, and optionally creates the release. |
 | **Verify or onboard model** | Nightly schedule or manual dispatch | `agent-runners` / `agents` | Qualifies one available exact model/GPU deployment and updates the rolling lifecycle PR. |
 | **Discover model** | Nightly schedule or manual dispatch | `agent-runners` / `agents` | Refreshes recipe lifecycle tags and onboarding shells in one rolling PR without renting a VM. |
@@ -19,11 +19,13 @@ from a developer checkout through the tracked `.agents/skills/run-experiment` sk
 
 ## Pull-request checks
 
-**Tests** installs the CI dependency set on Python 3.13. Its lint job runs Ruff check and format verification; its test
-job runs `make test`, including `tests/github/` coverage for helpers under `.github/scripts/`. Hugging Face downloads
-used by tests are cached because anonymous shared-runner traffic is rate-limited. A separate bare-Python job runs
-`make pypi-dist`, the exact non-publishing build path used by the release workflow, and requires one wheel and one
-source distribution. This workflow has no write permission and does not use deployment credentials.
+**Tests** runs three parallel jobs in the organization `ubuntu-runners` builder group and installs the CI dependency
+set on Python 3.13. A newer commit cancels the previous run for the same pull request. The lint job runs Ruff check and
+format verification; the test job runs `make test`, including `tests/github/` coverage for helpers under
+`.github/scripts/`. Hugging Face downloads used by tests are cached because anonymous shared-runner traffic is
+rate-limited. A separate bare-Python job runs `make pypi-dist`, the exact non-publishing build path used by the release
+workflow, and requires one wheel and one source distribution. This workflow has no write permission and does not use
+deployment credentials.
 
 ## Package publication
 

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 GitHub Actions owns pull-request checks, package publication, and automated model discovery and onboarding. Workflows
 that only inspect or build the repository use GitHub-hosted runners. Agent-driven
-model work uses the self-hosted `agents` runner because it can exceed ordinary hosted-runner limits and needs the
-tracked skills and CloudRift inference endpoint.
+model work uses the organization-level `agent-runners` group with the `agents` label because it can exceed ordinary
+hosted-runner limits and needs the tracked skills and CloudRift inference endpoint.
 
 ## Workflow overview
 
@@ -11,8 +11,8 @@ tracked skills and CloudRift inference endpoint.
 | --- | --- | --- | --- |
 | **Tests** | Pull request to `main` | GitHub-hosted | Runs Ruff, the complete test suite, and a PyPI package dry run. |
 | **Publish to PyPI** | Manual dispatch or published GitHub release | GitHub-hosted | Tests, builds, publishes to PyPI, and optionally creates the release. |
-| **Verify or onboard model** | Nightly schedule or manual dispatch | Self-hosted `agents` | Qualifies one available exact model/GPU deployment and updates the rolling lifecycle PR. |
-| **Discover model** | Nightly schedule or manual dispatch | Self-hosted `agents` | Refreshes recipe lifecycle tags and onboarding shells in one rolling PR without renting a VM. |
+| **Verify or onboard model** | Nightly schedule or manual dispatch | `agent-runners` / `agents` | Qualifies one available exact model/GPU deployment and updates the rolling lifecycle PR. |
+| **Discover model** | Nightly schedule or manual dispatch | `agent-runners` / `agents` | Refreshes recipe lifecycle tags and onboarding shells in one rolling PR without renting a VM. |
 
 There is no generic experiment workflow or GitHub dispatch input for `emmy bench`. Requested experiment runs start
 from a developer checkout through the tracked `.agents/skills/run-experiment` skill.

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -1,15 +1,16 @@
 # GitHub Actions architecture
 
 GitHub Actions owns pull-request checks, package publication, and automated model discovery and onboarding.
-Pull-request checks use the organization-level `ubuntu-runners` builder group, while package publication remains on
-GitHub-hosted runners. Agent-driven model work uses the separate `agent-runners` group with the `agents` label because
-it can exceed ordinary hosted-runner limits and needs the tracked skills and CloudRift inference endpoint.
+Pull-request lint and packaging use GitHub-hosted runners, while the compiler-heavy test job uses the organization-level
+`ubuntu-runners` builder group. Package publication remains GitHub-hosted. Agent-driven model work uses the separate
+`agent-runners` group with the `agents` label because it can exceed ordinary hosted-runner limits and needs the tracked
+skills and CloudRift inference endpoint.
 
 ## Workflow overview
 
 | Workflow | Trigger | Runner | Result |
 | --- | --- | --- | --- |
-| **Tests** | Pull request to `main` | `ubuntu-runners` | Runs Ruff, the complete test suite, and a PyPI package dry run. |
+| **Tests** | Pull request to `main` | GitHub-hosted + `ubuntu-runners` | Runs Ruff, the complete test suite, and a PyPI package dry run. |
 | **Publish to PyPI** | Manual dispatch or published GitHub release | GitHub-hosted | Tests, builds, publishes to PyPI, and optionally creates the release. |
 | **Verify or onboard model** | Nightly schedule or manual dispatch | `agent-runners` / `agents` | Qualifies one available exact model/GPU deployment and updates the rolling lifecycle PR. |
 | **Discover model** | Nightly schedule or manual dispatch | `agent-runners` / `agents` | Refreshes recipe lifecycle tags and onboarding shells in one rolling PR without renting a VM. |
@@ -19,13 +20,13 @@ from a developer checkout through the tracked `.agents/skills/run-experiment` sk
 
 ## Pull-request checks
 
-**Tests** runs three parallel jobs in the organization `ubuntu-runners` builder group and installs the CI dependency
-set on Python 3.13. A newer commit cancels the previous run for the same pull request. The lint job runs Ruff check and
-format verification; the test job runs `make test`, including `tests/github/` coverage for helpers under
+**Tests** runs three parallel jobs and installs the CI dependency set on Python 3.13. A newer commit cancels the
+previous run for the same pull request. The GitHub-hosted lint job runs Ruff check and format verification. The
+compiler-heavy job uses `ubuntu-runners` for `make test`, including `tests/github/` coverage for helpers under
 `.github/scripts/`. Hugging Face downloads used by tests are cached because anonymous shared-runner traffic is
-rate-limited. A separate bare-Python job runs `make pypi-dist`, the exact non-publishing build path used by the release
-workflow, and requires one wheel and one source distribution. This workflow has no write permission and does not use
-deployment credentials.
+rate-limited. A separate GitHub-hosted bare-Python job runs `make pypi-dist`, the exact non-publishing build path used
+by the release workflow, and requires one wheel and one source distribution. This workflow has no write permission
+and does not use deployment credentials.
 
 ## Package publication
 

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -11,7 +11,9 @@ concurrency:
 
 jobs:
   discover:
-    runs-on: [self-hosted, agents]
+    runs-on:
+      group: agent-runners
+      labels: agents
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -36,7 +36,9 @@ concurrency:
 
 jobs:
   onboard:
-    runs-on: [self-hosted, agents]
+    runs-on:
+      group: agent-runners
+      labels: agents
     timeout-minutes: 1440
     permissions:
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,15 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-flight test runs when a new commit lands on the same pull request.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ubuntu-runners
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +30,8 @@ jobs:
         run: ./venv/bin/ruff format --check
 
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ubuntu-runners
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +59,8 @@ jobs:
 
   package:
     name: PyPI package dry run
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ubuntu-runners
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on:
-      group: ubuntu-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -59,8 +58,7 @@ jobs:
 
   package:
     name: PyPI package dry run
-    runs-on:
-      group: ubuntu-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- route model discovery and onboarding through the organization-level `agent-runners` group while retaining the `agents` capability label
- run only the compiler-heavy full-test PR job on the more powerful `ubuntu-runners` builder group
- keep the lightweight lint and package-dry-run PR jobs on `ubuntu-latest`
- cancel an in-flight test workflow when a newer commit lands on the same pull request, following Cloudrift's concurrency pattern
- document both organization runner groups in the GitHub Actions architecture overview

`ubuntu-runners` grants selected-repository access to Cloudrift and Emmy. `agent-runners` grants access only to Emmy.

## Validation

- `make test` — 3,165 passed, 652 skipped, 1 xfailed, 1 xpassed
- `make lint`
- workflow YAML parsing and `git diff --check`
- GitHub Actions assignment and execution through the organization runner groups

## Security note

Emmy is public, so enabling its full-test job on organization builders permits PR code to execute on organization-owned runner hosts. The group is limited to Cloudrift and Emmy, but the normal GitHub warning for public repositories and self-hosted runners still applies.
