### PR TITLE
Improve model onboarding recovery and artifacts

### DIFF
--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -13,25 +13,28 @@ Turn a Hugging Face model ID, an operation mode, and an exact `(GPU name, GPU co
 artifacts:
 
 - one recommended serving recipe under `recipes/<model>/recipe.yaml`;
-- one reusable serving experiment under `experiments/<model>/` with a cumulative report, system-only row records,
-  and one Git LFS raw-results archive per exact GPU platform;
+- one reusable serving experiment under `experiments/<model>/` with a cumulative report and one Git LFS evidence
+  archive, including the system-only row records, per exact GPU platform;
 - one compact, self-contained `recipes/<model>/RESULTS.md` only when a valid final deployment recipe exists;
 - a complete compiler golden under `emmy/compiler/pipeline/search/goldens/` when full coverage qualifies;
 - when Emmy is eligible, tuned kernels and a verified, prebuilt
   `cloudriftai/vllm-emmy-<model-slug>:<tag>` image.
 
 Repository storage retains reproducibility input and durable evidence for each qualified serving platform. In the
-serving experiment root, commit `recipe.yaml`, one cumulative `RESULTS.md`, top-level system-only experiment records,
-and `results_<gpu-short>x<gpu-count>.tar.gz` for each measured exact GPU name/count. Derive `<gpu-short>` with
-`emmy.hardware.gpu_short_name`; for example, a single RTX 4090 uses `results_rtx4090x1.tar.gz`. Track these archives
+serving experiment root, commit `recipe.yaml`, one cumulative `RESULTS.md`, and
+`results_<gpu-short>x<gpu-count>.tar.gz` for each measured exact GPU name/count. Store the system-only experiment
+records inside that platform archive as part of the timestamped raw run; do not commit them as top-level files. Derive
+`<gpu-short>` with `emmy.hardware.gpu_short_name`; for example, a single RTX 4090 uses
+`results_rtx4090x1.tar.gz`. Track these archives
 with Git LFS. When the caller says LFS is configured locally, verify the archive attribute but do not modify or list
 `.gitattributes`; the caller owns that infrastructure file. Do not commit the ignored dated run directory, loose
 benchmark JSON/TXT/logs, plots, compiler run summaries, partial working goldens, or onboarding-summary files.
 
 Use one serving experiment root for all GPU platforms that share the protocol. On a platform-specific run, replace
-only that platform's archive and top-level records, update only its section of the shared experiment `RESULTS.md`, and
-preserve every other platform archive, record, and report section. Reuse the existing serving experiment root when it
-already represents the protocol; otherwise create `experiments/<model>/serving/`.
+only that platform's archive, update only its section of the shared experiment `RESULTS.md`, and preserve every other
+platform archive and report section. Remove legacy top-level records only for the current platform after verifying
+they are retained inside its archive. Reuse the existing serving experiment root when it already represents the
+protocol; otherwise create `experiments/<model>/serving/`.
 
 Use only the supplied SSH server. The caller owns VM creation and deletion; this skill owns deployed workloads and
 must tear them down before returning. Never switch GPU type, count, provider, model quantization, or model checkpoint
@@ -83,9 +86,12 @@ Use the model card, `config.json`, and current primary engine documentation to r
 - required tool-call, reasoning, tokenizer, and multimodal flags;
 - known model-specific launch or correctness issues.
 
-Prefer vLLM when both engines support the checkpoint. Use a moving image tag only for diagnosis, then pin the exact
-working tag or digest. Read `emmy/recipe/ARCHITECTURE.md` before authoring YAML; named recipe fields must not be
-duplicated in `extra_args`.
+Prefer vLLM when both engines support the checkpoint. If a configured image cannot be pulled, do not stop at the first
+missing tag. Check the official registry, release notes, engine documentation, and upstream repository for a renamed
+image repository or a current compatible tag. A registry manifest check or short clean deployment may establish the
+replacement. Use a moving image tag only for diagnosis, then pin the exact working tag or digest. Never substitute an
+unofficial image without explicit caller authorization. Read `emmy/recipe/ARCHITECTURE.md` before authoring YAML;
+named recipe fields must not be duplicated in `extra_args`.
 
 ## 2. Create and validate a conservative baseline
 
@@ -111,6 +117,18 @@ Require all of these before measuring performance:
 Start context testing at the model's native maximum. On an out-of-memory or invalid-capacity failure, halve it and
 retry from a clean deployment. Do not claim a context length from startup alone. Search current upstream issues for
 an unfamiliar error before changing engine or flags, and make one evidence-backed change per retry.
+
+When useful, delegate up to three independent read-only investigations to the caller-provided onboarding subagent.
+Good tasks are model protocol research, official engine/image compatibility research, and diagnosis of one unfamiliar
+failure from already captured logs. The parent agent owns all commands, edits, measurements, and final conclusions;
+never let subagent work consume the time reserved for artifacts and cleanup.
+
+You may implement a small, model-agnostic compatibility fix when it is necessary to qualify the exact requested
+checkpoint and platform. Keep it within `emmy/` plus focused tests and the nearest `ARCHITECTURE.md` updates, prefer an
+existing mechanism, and validate the reproducer before resuming qualification. Do not perform a broad refactor,
+dependency upgrade, validation bypass, workflow change, or model-specific hard-code. If the fix is not bounded, does
+not validate, or cannot finish before the deadline, preserve diagnostics outside the repository and report the gate
+as failed.
 
 Use `emmy ... --teardown` after every failed deployment and before changing a serving configuration. Do not mutate
 the remote checkout or containers manually over SSH; read-only inspection of `nvidia-smi`, container state, and logs
@@ -226,9 +244,10 @@ configuration selected by `recipes/<model>/recipe.yaml`; do not force unrelated 
 
 Commit the canonical experiment `recipe.yaml` when the comparison configuration remains useful. Follow the
 repository's `run-experiment` skill for the final measurement. Store the run as
-`results_<gpu-short>x<gpu-count>.tar.gz`, replace only the current platform's top-level system-only experiment records,
-and update its section in the shared factual experiment `RESULTS.md`, including failed-row evidence. Preserve every
-other platform snapshot. Fold the measured winner into a single-variant serving recipe under
+`results_<gpu-short>x<gpu-count>.tar.gz`, including the system-only experiment records inside the timestamped raw run,
+and update its section in the shared factual experiment `RESULTS.md`, including failed-row evidence. Remove
+current-platform legacy top-level records only after verifying the archive, and preserve every other platform
+snapshot. Fold the measured winner into a single-variant serving recipe under
 `recipes/<model>/recipe.yaml`; recipes have no `benchmark:` block.
 
 ## 7. Write the durable report
@@ -273,7 +292,8 @@ Use measurements only, compare complete runs without cherry-picking, and include
 
 Keep the recipe report useful without the working directory. The recipe is the decision and its report embeds the
 selected lane's compact, best qualified measurements. The experiment directory separately retains reproducibility
-input, raw results, per-row system-only experiment records, and its factual last-run artifact index.
+input, per-platform archives containing raw results and per-row system-only experiment records, and its factual
+last-run artifact index.
 
 ## 8. Verify and hand off
 
@@ -298,8 +318,9 @@ Also verify:
   verified FAST_MATH pack for the exact serving shape;
 - `EMMY_FAST_MATH=1` appears in an Emmy recipe unless its accuracy gate regressed, and never appears in a
   mainstream-only recipe;
-- the experiment snapshot contains the shared `recipe.yaml` and `RESULTS.md`, the exact platform's LFS archive and
-  top-level records, while other platform archives, records, and report sections remain unchanged;
+- the experiment snapshot contains the shared `recipe.yaml` and `RESULTS.md` plus the exact platform's LFS archive;
+  the archive contains the platform's records, no current-platform record remains at the experiment root, and other
+  platform archives and report sections remain unchanged;
 - no ignored dated run directory, loose benchmark output, or onboarding summary is staged;
 - tracked artifacts contain no credentials, absolute scratch paths, or VM identifiers;
 - deployed workloads are torn down and `docker logout` has run.
@@ -317,9 +338,10 @@ durable `RESULTS.md` report.
 Write this JSON object atomically to the caller-supplied summary path outside the repository and print that path as the
 final line. Include the requested mode on success and failure. List every repository file created, modified, or deleted
 by the qualification run in `artifacts`. List only a complete repository golden in `compiler_artifacts`. In
-`experiment_artifacts`, list the shared experiment recipe and report, the current platform's compressed archive, and
-its retained top-level experiment records. List deleted prior records for the current platform in `artifacts`, but not
-in `experiment_artifacts`. Do not list unchanged artifacts from other platforms or the ignored dated run directory.
+`experiment_artifacts`, list only the shared experiment recipe and report plus the current platform's compressed
+archive. List deleted legacy records for the current platform in `artifacts`, but not in `experiment_artifacts`. List
+any bounded implementation fix and its focused tests in `artifacts`. Do not list unchanged artifacts from other
+platforms or the ignored dated run directory.
 
 ```json
 {
@@ -337,8 +359,7 @@ in `experiment_artifacts`. Do not list unchanged artifacts from other platforms 
     "emmy/compiler/pipeline/search/goldens/<gpu-slug>_<compute-cap>_<model-slug>.yaml",
     "experiments/<model>/serving/recipe.yaml",
     "experiments/<model>/serving/RESULTS.md",
-    "experiments/<model>/serving/results_<gpu-short>x<gpu-count>.tar.gz",
-    "experiments/<model>/serving/<gpu-short>x<gpu-count>_<row-id>.experiment.yaml"
+    "experiments/<model>/serving/results_<gpu-short>x<gpu-count>.tar.gz"
   ],
   "compiler_artifacts": [
     "emmy/compiler/pipeline/search/goldens/<gpu-slug>_<compute-cap>_<model-slug>.yaml"
@@ -346,8 +367,7 @@ in `experiment_artifacts`. Do not list unchanged artifacts from other platforms 
   "experiment_artifacts": [
     "experiments/<model>/serving/recipe.yaml",
     "experiments/<model>/serving/RESULTS.md",
-    "experiments/<model>/serving/results_<gpu-short>x<gpu-count>.tar.gz",
-    "experiments/<model>/serving/<gpu-short>x<gpu-count>_<row-id>.experiment.yaml"
+    "experiments/<model>/serving/results_<gpu-short>x<gpu-count>.tar.gz"
   ],
   "report": "recipes/<model>/RESULTS.md",
   "compiler": {
@@ -364,11 +384,14 @@ in `experiment_artifacts`. Do not list unchanged artifacts from other platforms 
 ```
 
 Use `status: "failed"`, nullable serving artifact fields, `deployment_summary: null`, `performance_summary: null`,
-`report: null`, and a `failure` object with `gate` and `message` when no valid serving recipe is produced. Keep a
-complete golden populated if compiler qualification succeeded. Put partial inventories and useful diagnostics in the
-external output location, not the repository. Always write the summary, then return nonzero for a failed run. Do not
-delete the VM. The caller uses the SSH target and its separately captured provider/instance handle to perform and
-verify VM cleanup.
+`report: null`, and a `failure` object with `gate`, `message`, and boolean `regression` when no valid serving recipe is
+produced. Set `regression: true` only when a previously qualified behavior or measured lane no longer meets its prior
+contract and the bounded fix attempt could not restore it. Keep the message concise and credential-free because the
+workflow sends it to the configured Discord channel as a prominent regression notice. A new model that has never
+qualified is a failure, not a regression. Keep a complete golden populated if compiler qualification succeeded. Put
+partial inventories and useful diagnostics in the external output location, not the repository. Always write the
+summary, then return nonzero for a failed run. Do not delete the VM. The caller uses the SSH target and its separately
+captured provider/instance handle to perform and verify VM cleanup.
 
 On any failure, tear down workloads, report the first failed gate and external diagnostic paths, remove task-owned
 measurement output from the checkout, and return nonzero. Never claim partial onboarding as success.

--- a/.agents/skills/run-experiment/SKILL.md
+++ b/.agents/skills/run-experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: run-experiment
 description: >-
   Run or rerun Emmy experiment recipes, including requests to adjust an experiment harness before running it, then
-  preserve per-platform compressed raw results, system-only YAML experiment records, and a thoughtful cumulative
+  preserve per-platform compressed raw results with system-only YAML experiment records and a thoughtful cumulative
   RESULTS.md interpretation. Use for requests such as "run this experiment", "benchmark this recipe", "rerun this on
   a GPU", or "customize and execute this Emmy experiment". Interpret results through intelligent review, never
   repository code.
@@ -53,20 +53,22 @@ For each selected experiment directory and exact GPU name/count:
    stability, failures, correctness evidence, and protocol limitations. Do this as intelligent review, not with code
    added to the experiment recipe or repository.
 3. Derive the platform key as `<gpu-short>x<gpu-count>` with `emmy.hardware.gpu_short_name`, for example `rtx4090x1`.
-   Remove only prior top-level `<platform-key>*.experiment.yaml` files and copy the latest records beside `recipe.yaml`.
-   Preserve every other platform's records and the timestamped local directory exactly as Emmy produced it.
+   Preserve the latest system-only records inside the timestamped raw directory exactly as Emmy produced them. Do not
+   copy them beside `recipe.yaml`.
 4. Replace `<experiment>/results_<platform-key>.tar.gz` with a gzip-compressed tar archive whose root member is the
-   latest timestamped directory. Keep that local directory through archive extraction or byte verification and never
-   delete another platform's archive. If the caller requires an artifact-only checkout, delete the task-owned local
-   directory only after that archive verification. Track `experiments/**/results_*.tar.gz` with Git LFS.
+   latest timestamped directory, including its system-only records. Verify that archive contains every expected row
+   record. Remove legacy top-level `<platform-key>*.experiment.yaml` files only after this verification. Keep the local
+   directory through archive extraction or byte verification and never delete another platform's archive. If the
+   caller requires an artifact-only checkout, delete the task-owned local directory only after that archive
+   verification. Track `experiments/**/results_*.tar.gz` with Git LFS.
 5. Update the current platform section in `<experiment>/RESULTS.md` with a thoughtful, evidence-backed interpretation.
    Preserve other platform sections. Include the question, protocol, result summary, repeat variation, comparisons,
    conclusion, limitations, timestamp, run ID, machine and software information, row status, failures, archive path,
    and member names. Distinguish direct comparisons from directional ones and avoid claims the harness does not
    support.
-6. Ensure the durable experiment contains `recipe.yaml`, one cumulative `RESULTS.md`, and for every retained platform
-   one named archive plus matching top-level records. The current platform's archive, records, and report section must
-   describe the same most recent run; do not modify another platform's snapshot.
+6. Ensure the durable experiment contains `recipe.yaml`, one cumulative `RESULTS.md`, and one named archive for every
+   retained platform. Each archive contains that platform's matching records. The current platform's archive and
+   report section must describe the same most recent run; do not modify another platform's snapshot.
 
 ## Verify and commit
 
@@ -80,9 +82,11 @@ Force-stage only the requested experiments' durable snapshot because `experiment
 git check-attr filter -- experiments/<model>/<experiment>/results_<gpu-short>x<gpu-count>.tar.gz
 git add -f -A -- experiments/<model>/<experiment>/recipe.yaml \
   experiments/<model>/<experiment>/results_<gpu-short>x<gpu-count>.tar.gz \
-  ':(glob)experiments/<model>/<experiment>/<gpu-short>x<gpu-count>*.experiment.yaml' \
   experiments/<model>/<experiment>/RESULTS.md
 ```
+
+When the platform update removes tracked legacy top-level records, stage those exact deleted paths separately with
+`git add -u -- <paths>`.
 
 The archive must report `filter: lfs`. If the repository pattern is missing and the caller permits infrastructure
 changes, add it with `git lfs track "experiments/**/results_*.tar.gz"` and stage `.gitattributes`. If the caller says

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -108,9 +108,10 @@ small remote Python/rsync prerequisite set and
 requires `$HOME/.cache/emmy` to be durable storage with at least 8 GiB free. Compiler staging keeps its checkout,
 venv, cache, and build temporary files there rather than on a small `/tmp` tmpfs. The job has a 24-hour limit and gives
 the agent a 23.5-hour deadline so artifact validation and cleanup retain 30 minutes. The shared serving experiment
-retains one LFS archive and top-level row-record set per exact GPU platform plus one cumulative `RESULTS.md`; a run
-replaces only its platform snapshot. Ignored dated run directories, loose benchmark output, and qualification
-summaries are not repository artifacts. An Emmy-tuned prebuilt image is produced only when every release gate passes.
+retains one LFS archive per exact GPU platform plus one cumulative `RESULTS.md`; each archive includes its system-only
+row records, and a run replaces only its platform snapshot. Ignored dated run directories, loose benchmark output,
+top-level row-record copies, and qualification summaries are not repository artifacts. An Emmy-tuned prebuilt image
+is produced only when every release gate passes.
 Nightly image publication is disabled unless
 `NIGHTLY_ONBOARD_PUBLISH_IMAGE` is `true`; manual dispatch retains an explicit input.
 
@@ -121,17 +122,25 @@ The selector runs the exact-SHA catalog logic against the rolling worktree's `re
 and priority always reflect the branch that the agent will update.
 The workflow also attaches the exact-SHA `onboard-model`, `tune-kernels`, and `run-experiment` skills as authoritative
 agent inputs; older copies on the rolling branch cannot silently override a proposed artifact contract.
+The named onboarding agent may delegate bounded read-only compatibility research or failure diagnosis to the hidden
+`onboard-investigator` subagent. The parent retains every edit and measurement. When an official engine image tag is
+missing, qualification checks official registries, release notes, and upstream documentation for a renamed repository
+or current compatible tag before failing, then pins the exact working tag or digest. A necessary small,
+model-independent compatibility fix may touch at most eight implementation/test/architecture files and 500 changed
+lines, and any Python source change requires a focused test change. Broader changes fail artifact validation and
+remain follow-up work.
 
 The agent returns an atomic manifest. `.github/scripts/onboarding_artifacts.py` accepts only declared changes under the
-allowed recipe, experiment, serving-image, and canonical-golden paths. The validator requires the shared experiment
-recipe and report, the exact `results_<gpu-short>x<gpu-count>.tar.gz` archive, and matching current-platform row
-records.
+allowed recipe, experiment, serving-image, canonical-golden, and bounded implementation/test paths. The validator
+requires the shared experiment recipe and report plus the exact `results_<gpu-short>x<gpu-count>.tar.gz` archive, and
+it opens that archive to require matching current-platform row records.
 It rejects changes to another platform snapshot and requires the current archive to be created or updated. Optional
 outputs must remain in `artifacts`; unmanifested or exploratory output is rejected. The job installs a pinned,
 checksum-verified Git LFS binary in the runner's temporary directory when needed, then configures LFS locally before
 staging so the normal push uploads the archive object with the rolling branch. After the agent returns, the workflow
 requires each task-local timestamp directory to be a root member of the declared platform archive before removing
-that ignored local directory; only the durable archive proceeds to staging.
+that ignored local directory. It deletes current-platform top-level record copies only after the archive passes its
+record and byte-read checks; only the durable archive proceeds to staging.
 The workflow writes the agent's final completed text event to the job log before checking its exit status, preserving
 the failure explanation after temporary output cleanup. The validator also checks the requested mode, exact recipe
 model, expected lifecycle tag, and compact deployment and measured-performance summaries from the selected recipe
@@ -141,9 +150,11 @@ rolling model lifecycle PR using renewable GitHub App credentials for the long-r
 Both lifecycle workflows finish with a separate GitHub-hosted notification job. Discovery groups only recipe entries
 actually modified by the run under their resulting lifecycle, includes each current heat score, and links the run and
 rolling PR. Onboarding includes the selected model, target, operation mode, serving deployment, and measured
-performance from its validated atomic summary. Because the notification job is independent of the self-hosted agent
-job, it still runs after a failure, cancellation, or timeout. Discord delivery retries three times, remains
-non-blocking, and disables all mentions; the workflow run, durable reports, and rolling PR retain the complete
+performance from its validated atomic summary. A failed summary marks a regression only when a previously qualified
+behavior or measured lane cannot be restored by a bounded fix; the isolated notification job then sends a prominent
+red Discord notice with the credential-free gate and message. Because the notification job is independent of the
+self-hosted agent job, it still runs after a failure, cancellation, or timeout. Discord delivery retries three times,
+remains non-blocking, and disables all mentions; the workflow run, durable reports, and rolling PR retain the complete
 evidence.
 
 ### Discovery lifecycle PR

--- a/.github/scripts/discord_notification.py
+++ b/.github/scripts/discord_notification.py
@@ -109,6 +109,10 @@ def _onboard_summary(environment: Mapping[str, str]) -> tuple[str, str, int, lis
         title = "Model onboarding workflow cancelled"
         description = "The model lifecycle workflow was cancelled before it completed."
         color = CANCELLED_COLOR
+    elif environment.get("FAILURE_KIND") == "regression":
+        title = "Model regression needs attention"
+        description = "A previously qualified behavior regressed and the onboarding agent could not restore it."
+        color = FAILURE_COLOR
     else:
         operation = f" {mode}" if mode else ""
         title = f"Model{operation} failed"
@@ -126,6 +130,10 @@ def _onboard_summary(environment: Mapping[str, str]) -> tuple[str, str, int, lis
             fields.append({"name": "Deployment", "value": deployment_summary[:FIELD_VALUE_LIMIT], "inline": False})
         if performance_summary:
             fields.append({"name": "Performance", "value": performance_summary[:FIELD_VALUE_LIMIT], "inline": False})
+    failure_summary = environment.get("FAILURE_SUMMARY", "").strip()
+    if result not in {"success", "cancelled"} and failure_summary:
+        label = "Regression" if environment.get("FAILURE_KIND") == "regression" else "Failure"
+        fields.append({"name": label, "value": failure_summary[:FIELD_VALUE_LIMIT], "inline": False})
     if mode:
         fields.append({"name": "Mode", "value": f"`{mode[:1000]}`", "inline": True})
     return title, description, color, fields
@@ -169,7 +177,7 @@ def build_payload(environment: Mapping[str, str], *, now: datetime | None = None
     if pull_request is not None:
         fields.append(pull_request)
     timestamp = now or datetime.now(UTC)
-    return {
+    payload = {
         "username": "Emmy Robots",
         "allowed_mentions": {"parse": []},
         "embeds": [
@@ -184,6 +192,9 @@ def build_payload(environment: Mapping[str, str], *, now: datetime | None = None
             }
         ],
     }
+    if workflow_kind == "onboard" and environment.get("WORKFLOW_RESULT") == "failure" and environment.get("FAILURE_KIND") == "regression":
+        payload["content"] = "🚨 **Model regression needs attention**"
+    return payload
 
 
 def send_notification(

--- a/.github/scripts/onboarding_artifacts.py
+++ b/.github/scripts/onboarding_artifacts.py
@@ -7,7 +7,8 @@ import argparse
 import json
 import subprocess
 import sys
-from pathlib import Path
+import tarfile
+from pathlib import Path, PurePosixPath
 
 import yaml
 
@@ -18,10 +19,14 @@ from emmy.recipe.lifecycle import validate_recipe_tags
 ALLOWED_ARTIFACT_PREFIXES = (
     "docker/vllm-emmy-serve/models/",
     "emmy/compiler/pipeline/search/goldens/",
+    "emmy/",
     "experiments/",
     "recipes/",
+    "tests/",
 )
 SUMMARY_TEXT_LIMIT = 1000
+MAX_IMPLEMENTATION_FILES = 8
+MAX_IMPLEMENTATION_CHANGED_LINES = 500
 
 
 def _summary_text(summary: dict, field: str) -> str:
@@ -55,14 +60,13 @@ def _is_platform_record(path: Path, platform: str) -> bool:
 
 def _is_durable_experiment_artifact(path: Path) -> bool:
     named_archive = path.name.startswith("results_") and path.name.endswith(".tar.gz")
-    return path.name in {"recipe.yaml", "RESULTS.md"} or path.name.endswith(".experiment.yaml") or named_archive
+    return path.name in {"recipe.yaml", "RESULTS.md"} or named_archive
 
 
 def _relative_experiment_artifact(workspace: Path, raw_path: str, experiment_dir: Path, platform: str) -> Path:
     path = _relative_file(workspace, raw_path, ("experiments/",))
     allowed_names = {"recipe.yaml", "RESULTS.md", f"results_{platform}.tar.gz"}
-    allowed_for_platform = path.name in allowed_names or _is_platform_record(path, platform)
-    if path.parent != experiment_dir or not allowed_for_platform:
+    if path.parent != experiment_dir or path.name not in allowed_names:
         raise ValueError(f"Artifact is outside the {platform} durable experiment snapshot: {raw_path}")
     return path
 
@@ -83,18 +87,91 @@ def _relative_artifact(workspace: Path, raw_path: str) -> Path:
     normalized = path.as_posix()
     if path.is_absolute() or ".." in path.parts:
         raise ValueError(f"Artifact path is not repository-relative: {raw_path}")
-    if normalized.startswith(ALLOWED_ARTIFACT_PREFIXES) and ((workspace / path).is_file() or _is_tracked_deletion(workspace, path)):
+    is_golden = normalized.startswith("emmy/compiler/pipeline/search/goldens/")
+    allowed_implementation_file = (
+        is_golden or path.parts[0] not in {"emmy", "tests"} or path.suffix == ".py" or path.name == "ARCHITECTURE.md"
+    )
+    if (
+        normalized.startswith(ALLOWED_ARTIFACT_PREFIXES)
+        and allowed_implementation_file
+        and ((workspace / path).is_file() or _is_tracked_deletion(workspace, path))
+    ):
         return path
     raise ValueError(f"Artifact path is outside the allowed onboarding areas or does not exist: {raw_path}")
 
 
-def _invalid_result_artifacts(artifacts: list[Path]) -> list[Path]:
+def _invalid_result_artifacts(workspace: Path, artifacts: list[Path]) -> list[Path]:
     return [
         path
         for path in artifacts
-        if (path.parts[0] == "experiments" and not _is_durable_experiment_artifact(path))
+        if (
+            path.parts[0] == "experiments"
+            and not _is_durable_experiment_artifact(path)
+            and not (path.name.endswith(".experiment.yaml") and _is_tracked_deletion(workspace, path))
+        )
         or (path.parts[0] == "recipes" and path.name not in {"recipe.yaml", "RESULTS.md"})
     ]
+
+
+def _archive_platform_records(workspace: Path, archive: Path, platform: str) -> list[PurePosixPath]:
+    records = []
+    with tarfile.open(workspace / archive, "r:gz") as source:
+        for member in source.getmembers():
+            member_path = PurePosixPath(member.name.removeprefix("./"))
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise ValueError(f"Unsafe member in exact platform archive: {member.name}")
+            if not member.isfile() or not _is_platform_record(Path(member_path.name), platform):
+                continue
+            contents = source.extractfile(member)
+            if contents is None or not isinstance(yaml.safe_load(contents), dict):
+                raise ValueError(f"Invalid experiment record in exact platform archive: {member.name}")
+            records.append(member_path)
+    if not records:
+        raise ValueError(f"Exact platform archive contains no {platform} experiment records: {archive}")
+    return records
+
+
+def _is_implementation_artifact(path: Path) -> bool:
+    return (
+        bool(path.parts) and path.parts[0] in {"emmy", "tests"} and not path.as_posix().startswith("emmy/compiler/pipeline/search/goldens/")
+    )
+
+
+def _validate_implementation_patch(workspace: Path, changed: set[str]) -> None:
+    implementation = sorted(Path(path) for path in changed if _is_implementation_artifact(Path(path)))
+    if len(implementation) > MAX_IMPLEMENTATION_FILES:
+        raise ValueError(f"Onboarding small fix changes too many implementation files: {len(implementation)}")
+    if not implementation:
+        return
+    source_changes = [path for path in implementation if path.parts[0] == "emmy" and path.suffix == ".py"]
+    test_changes = [path for path in implementation if path.parts[0] == "tests" and path.suffix == ".py"]
+    if source_changes and not test_changes:
+        raise ValueError("Onboarding small fix must include a focused test change")
+
+    result = subprocess.run(
+        ["git", "diff", "--numstat", "--no-renames", "HEAD", "--", *(str(path) for path in implementation)],
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    changed_lines = 0
+    counted = set()
+    for line in result.stdout.splitlines():
+        added, deleted, raw_path = line.split("\t", 2)
+        if added == "-" or deleted == "-":
+            raise ValueError(f"Onboarding small fix must not add binary implementation artifacts: {raw_path}")
+        changed_lines += int(added) + int(deleted)
+        counted.add(raw_path)
+    for path in implementation:
+        if path.as_posix() in counted or not (workspace / path).is_file():
+            continue
+        contents = (workspace / path).read_bytes()
+        if b"\0" in contents:
+            raise ValueError(f"Onboarding small fix must not add binary implementation artifacts: {path}")
+        changed_lines += len(contents.splitlines())
+    if changed_lines > MAX_IMPLEMENTATION_CHANGED_LINES:
+        raise ValueError(f"Onboarding small fix changes too many implementation lines: {changed_lines}")
 
 
 def validate_summary(
@@ -162,8 +239,7 @@ def validate_summary(
     experiment_archive = experiment_dir / f"results_{platform}.tar.gz"
     if experiment_archive not in experiment_artifacts:
         raise ValueError(f"The exact platform archive must be included in experiment_artifacts: {experiment_archive}")
-    if not any(_is_platform_record(path, platform) for path in experiment_artifacts):
-        raise ValueError(f"At least one {platform} experiment record must be included in experiment_artifacts")
+    _archive_platform_records(workspace, experiment_archive, platform)
     raw_artifacts = summary.get("artifacts")
     if not isinstance(raw_artifacts, list) or not raw_artifacts:
         raise ValueError("Summary must include a non-empty artifacts list")
@@ -177,7 +253,7 @@ def validate_summary(
             ]
         )
     )
-    invalid_result_artifacts = _invalid_result_artifacts(artifacts)
+    invalid_result_artifacts = _invalid_result_artifacts(workspace, artifacts)
     if invalid_result_artifacts:
         raise ValueError(f"Only durable recipe and experiment artifacts may be retained: {invalid_result_artifacts}")
     invalid_experiment_artifacts = [
@@ -186,7 +262,10 @@ def validate_summary(
         if path.parts[0] == "experiments"
         and not (
             path.parent == experiment_dir
-            and (path.name in {"recipe.yaml", "RESULTS.md", experiment_archive.name} or _is_platform_record(path, platform))
+            and (
+                path.name in {"recipe.yaml", "RESULTS.md", experiment_archive.name}
+                or (_is_platform_record(path, platform) and _is_tracked_deletion(workspace, path))
+            )
         )
     ]
     if invalid_experiment_artifacts:
@@ -197,7 +276,7 @@ def validate_summary(
 
 
 def stage_artifacts(workspace: Path, artifacts: list[Path], required_archive: Path | None = None) -> None:
-    invalid_result_artifacts = _invalid_result_artifacts(artifacts)
+    invalid_result_artifacts = _invalid_result_artifacts(workspace, artifacts)
     if invalid_result_artifacts:
         raise ValueError(f"Only durable recipe and experiment artifacts may be retained: {invalid_result_artifacts}")
     tracked_changes = subprocess.run(
@@ -226,6 +305,7 @@ def stage_artifacts(workspace: Path, artifacts: list[Path], required_archive: Pa
     if unexpected:
         raise ValueError(f"Agent changed paths outside its artifact manifest: {sorted(unexpected)}")
     changed = set(tracked_changes) | set(untracked) | set(ignored_experiments)
+    _validate_implementation_patch(workspace, changed)
     if required_archive is not None and required_archive.as_posix() not in changed:
         raise ValueError(f"Exact platform results archive was not created or updated: {required_archive}")
     if required_archive is not None:

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -51,6 +51,8 @@ jobs:
       mode: ${{ steps.selection.outputs.mode }}
       deployment_summary: ${{ steps.artifacts.outputs.deployment_summary }}
       performance_summary: ${{ steps.artifacts.outputs.performance_summary }}
+      failure_kind: ${{ steps.notice.outputs.failure_kind }}
+      failure_summary: ${{ steps.notice.outputs.failure_summary }}
       pr_number: ${{ steps.lifecycle-pr.outputs.number || steps.rolling.outputs.number }}
     env:
       GH_REPO: ${{ github.repository }}
@@ -475,17 +477,27 @@ jobs:
 
           {task}
           Do not select a model or GPU, provision or delete the VM, commit, push, or open/update a pull request.
+          For missing images or unfamiliar launch failures, investigate current official registries, release notes,
+          engine documentation, and upstream issues. Test an evidence-backed current repository/tag when the configured
+          image moved or disappeared, then pin the exact working tag or digest. You may implement a bounded,
+          model-agnostic compatibility fix with focused tests when it is necessary for this exact qualification.
+          You may delegate independent read-only research or failure diagnosis to the onboard-investigator subagent;
+          retain responsibility for all edits, measurements, and conclusions.
           Always write the required atomic summary with mode set to {mode}, including experiment_artifacts with
-          the shared experiment recipe and RESULTS.md, the exact results_<gpu-short>x<gpu-count>.tar.gz archive, and
-          the retained top-level experiment records for this platform. Replace only this platform's archive and
-          records; preserve every other platform archive, record, and RESULTS.md section. Do not retain the ignored
-          dated run directory or onboarding summaries. Update the final recipe's RESULTS.md for this platform while
-          preserving still-valid measurements for its other platforms.
+          the shared experiment recipe and RESULTS.md plus the exact results_<gpu-short>x<gpu-count>.tar.gz archive.
+          The archive must contain the platform's system-only experiment records; do not retain those records as
+          top-level files. Replace only this platform's archive and preserve every other platform archive and
+          RESULTS.md section. Do not retain the ignored dated run directory or onboarding summaries. Update the final
+          recipe's RESULTS.md for this platform while preserving still-valid measurements for its other platforms.
           Git LFS is already configured through the workflow's local attributes. Verify the named archive reports
           filter: lfs, but do not run git lfs track and do not modify or list .gitattributes in the summary.
           Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
-          output. Allowed areas are recipes/, experiments/, docker/vllm-emmy-serve/models/, and canonical golden YAML.
+          output. Allowed areas are recipes/, experiments/, docker/vllm-emmy-serve/models/, canonical golden YAML,
+          and a bounded small fix under emmy/ with its focused tests and nearest ARCHITECTURE.md updates.
           Include one-line deployment_summary and performance_summary values drawn from the exact selected recipe lane.
+          On failure, set failure.regression=true only when a previously qualified behavior or performance lane
+          regressed and the bounded fix attempt could not restore it; include a concise, credential-free message for
+          the Discord notification.
           """
           Path(os.environ["AGENT_PROMPT"]).write_text(prompt)
           PY
@@ -511,6 +523,35 @@ jobs:
           fi
           exit "$agent_status"
 
+      - name: Collect onboarding failure notice
+        id: notice
+        if: always() && steps.vm.outcome == 'success'
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          kind = ""
+          message = ""
+          summary_path = Path(os.environ["ONBOARD_SUMMARY"])
+          try:
+              summary = json.loads(summary_path.read_text())
+              failure = summary.get("failure") or {}
+              if summary.get("status") == "failed" and isinstance(failure, dict):
+                  kind = "regression" if failure.get("regression") is True else "failure"
+                  gate = failure.get("gate")
+                  detail = failure.get("message")
+                  parts = [value.strip() for value in (gate, detail) if isinstance(value, str) and value.strip()]
+                  message = ": ".join(parts)
+          except (OSError, ValueError, json.JSONDecodeError):
+              pass
+          message = " ".join(message.split())[:1000]
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              output.write(f"failure_kind={kind}\n")
+              output.write(f"failure_summary={message}\n")
+          PY
+
       - name: Remove archived task-local raw results
         if: steps.vm.outcome == 'success'
         run: |
@@ -519,6 +560,7 @@ jobs:
           import os
           import re
           import shutil
+          import subprocess
           import tarfile
           from pathlib import Path, PurePosixPath
 
@@ -550,14 +592,29 @@ jobs:
               member_paths = []
               with tarfile.open(path, "r:gz") as source:
                   for member in source.getmembers():
-                      member_paths.append(PurePosixPath(member.name.removeprefix("./")))
+                      member_path = PurePosixPath(member.name.removeprefix("./"))
+                      if member_path.is_absolute() or ".." in member_path.parts:
+                          raise SystemExit(f"Unsafe archive member: {member.name}")
+                      member_paths.append(member_path)
                       if member.isfile():
                           contents = source.extractfile(member)
                           if contents is None:
                               raise SystemExit(f"Could not read archived file: {member.name}")
                           while contents.read(1024 * 1024):
                               pass
-              return {path.parts[0] for path in member_paths if path.parts}
+              roots = {member_path.parts[0] for member_path in member_paths if member_path.parts}
+              records = {
+                  member_path
+                  for member_path in member_paths
+                  if member_path.name == f"{platform}.experiment.yaml"
+                  or (
+                      member_path.name.startswith(f"{platform}_")
+                      and member_path.name.endswith(".experiment.yaml")
+                  )
+              }
+              if not records:
+                  raise SystemExit(f"Results archive contains no {platform} experiment records: {path}")
+              return roots
 
           if raw_directories:
               temporary_archive = archive.with_name(f".{archive.name}.{os.getpid()}.tmp")
@@ -600,19 +657,36 @@ jobs:
               experiment_recipe,
               experiment_report,
               archive_path,
-              *platform_records,
           ]
           missing = [path for path in durable_snapshot if not (workspace / path).is_file()]
           if missing:
               raise SystemExit(f"Current-platform durable snapshot is incomplete: {missing}")
+
+          tracked_record_deletions = []
+          for record in platform_records:
+              tracked = subprocess.run(
+                  ["git", "ls-files", "--error-unmatch", "--", str(record)],
+                  cwd=workspace,
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+                  check=False,
+              ).returncode == 0
+              (workspace / record).unlink()
+              if tracked:
+                  tracked_record_deletions.append(record)
 
           legacy_path = experiment_recipe.parent / "results.tar.gz"
           for key in ("experiment_artifacts", "artifacts"):
               existing = summary.get(key) or []
               if not isinstance(existing, list):
                   raise SystemExit(f"Summary {key} must be a list")
-              retained = [path for path in existing if Path(path) != legacy_path]
-              summary[key] = list(dict.fromkeys([*retained, *(path.as_posix() for path in durable_snapshot)]))
+              retained = [
+                  path
+                  for path in existing
+                  if Path(path) != legacy_path and Path(path) not in platform_records
+              ]
+              additions = durable_snapshot if key == "experiment_artifacts" else [*durable_snapshot, *tracked_record_deletions]
+              summary[key] = list(dict.fromkeys([*retained, *(path.as_posix() for path in additions)]))
 
           temporary_summary = summary_path.with_name(f".{summary_path.name}.{os.getpid()}.tmp")
           try:
@@ -829,6 +903,8 @@ jobs:
       ONBOARD_MODE: ${{ needs.onboard.outputs.mode }}
       DEPLOYMENT_SUMMARY: ${{ needs.onboard.outputs.deployment_summary }}
       PERFORMANCE_SUMMARY: ${{ needs.onboard.outputs.performance_summary }}
+      FAILURE_KIND: ${{ needs.onboard.outputs.failure_kind }}
+      FAILURE_SUMMARY: ${{ needs.onboard.outputs.failure_summary }}
       PR_NUMBER: ${{ needs.onboard.outputs.pr_number }}
     steps:
       - name: Checkout exact workflow source

--- a/.opencode/agents/onboard-investigator.md
+++ b/.opencode/agents/onboard-investigator.md
@@ -1,0 +1,23 @@
+---
+description: Investigate one bounded model-onboarding compatibility or failure question
+mode: subagent
+hidden: true
+temperature: 0.1
+steps: 20
+permission:
+  "*": deny
+  read: allow
+  glob: allow
+  grep: allow
+  list: allow
+  webfetch: allow
+  websearch: allow
+---
+
+Investigate only the model-onboarding question supplied by the parent agent. Use at most four public-web calls and
+prefer current primary sources: official model metadata, engine documentation and release notes, official container
+registries, and upstream issue trackers. For an unavailable image, verify whether the tag moved, the repository was
+renamed, or a newer compatible release exists. For a runtime failure, identify the smallest evidence-backed next
+test. Inspect repository files when useful, but never modify files, invoke another agent, use credentials, or run a
+remote workload. Return concise evidence, source URLs, exact candidate tags or flags, and remaining uncertainty to
+the parent agent.

--- a/.opencode/agents/onboard-model.md
+++ b/.opencode/agents/onboard-model.md
@@ -6,7 +6,9 @@ steps: 160
 permission:
   "*": allow
   question: deny
-  task: deny
+  task:
+    "*": deny
+    "onboard-investigator": allow
   external_directory:
     "*": deny
     "/tmp/*": allow
@@ -22,4 +24,5 @@ permission:
 You are Emmy's non-interactive model qualification agent. Load the `onboard-model` skill before doing task work and
 follow it exactly, including every linked skill and architecture document. Use only the supplied GPU server, finish
 before the supplied deadline, keep only the authorized repository artifacts, write the atomic summary even on
-failure, and never commit, push, or change pull requests.
+failure, and never commit, push, or change pull requests. Delegate only bounded, independent read-only research or
+failure diagnosis to `onboard-investigator`; retain responsibility for edits, commands, measurements, and conclusions.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -154,7 +154,8 @@ describe how a term is used in Emmy; they are not meant to replace a full textbo
   information. It never contains interpreted or parsed experiment measurements.
 - **Raw experiment results** — Logs and declared measurement files preserved in an ignored timestamped local run
   directory. Each exact GPU platform's last run is committed as an LFS-backed
-  `results_<gpu-short>x<gpu-count>.tar.gz`, not as a second structured result format.
+  `results_<gpu-short>x<gpu-count>.tar.gz`, including its system-only experiment records, not as a second structured
+  result format or top-level record copy.
 - **Benchmark** — A controlled measurement of speed, latency, throughput, or resource use.
 - **Latency** — The time needed to complete one operation or request. Lower latency is faster.
 - **Throughput** — The amount of work completed per unit of time, such as requests per second. Higher throughput is

--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ emmy bench experiments/gemma-4-12B/* --ssh user@host1 --ssh user@host2  # Pre-al
 
 Each real run creates a timestamped raw-results directory and writes one system-only YAML experiment record per
 matrix row. Use `$run-experiment` to run or customize an experiment, replace the platform's LFS-backed
-`results_<gpu-short>x<gpu-count>.tar.gz`, assemble its records, update the shared `RESULTS.md` interpretation, and
-commit the durable platform snapshot. Other platform snapshots remain unchanged. The runner and experiment code never
-interpret measurements; the skill reviews the raw evidence. The timestamped directory is ignored and may be deleted
-after its archive has been extracted or byte-checked against the raw files.
+`results_<gpu-short>x<gpu-count>.tar.gz`, verify its included records, update the shared `RESULTS.md` interpretation,
+and commit the durable platform snapshot. Records remain inside the archive rather than as top-level experiment files.
+Other platform snapshots remain unchanged. The runner and experiment code never interpret measurements; the skill
+reviews the raw evidence. The timestamped directory is ignored and may be deleted after its archive has been extracted
+or byte-checked against the raw files.
 
 ## Deploy
 

--- a/emmy/benchmark/ARCHITECTURE.md
+++ b/emmy/benchmark/ARCHITECTURE.md
@@ -53,11 +53,11 @@ Command records preserve timing, status, errors, and system information. `comman
 worktree, every declared result file, GPU identity, NVCC, and cuBLAS. A failed command still attempts to retrieve
 declared results.
 
-The repository `run-experiment` skill validates row coverage, copies the latest records beside the recipe, writes a
-thoughtful interpretation grounded in the raw evidence, replaces the exact GPU platform's named Git LFS raw-results
-archive, and commits its archive and records with the shared `RESULTS.md`. Other platform snapshots remain unchanged.
-The timestamped raw directory stays local and ignored. Interpretation belongs to the skill's intelligent review,
-never the runner or a repository script.
+The repository `run-experiment` skill validates row coverage, keeps the latest records inside the archived raw-run
+tree, writes a thoughtful interpretation grounded in the raw evidence, replaces the exact GPU platform's named Git
+LFS raw-results archive, and commits it with the shared `RESULTS.md`. Other platform snapshots remain unchanged. The
+timestamped raw directory stays local and ignored. Interpretation belongs to the skill's intelligent review, never
+the runner or a repository script.
 
 `commands.bench` owns orchestration, `execution` runs execution groups, `experiment_record` owns the typed record
 schema and YAML serialization, top-level `system_info` owns the typed host schema plus the one shared generic/PCI

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -654,8 +654,7 @@ one durable snapshot per exact GPU platform:
 experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090/
   recipe.yaml
   <YYYY-MM-DD_HH-MM-SS>/  # ignored local raw output
-  results_rtx5090x1.tar.gz  # Git LFS archive of the platform's last run
-  rtx5090x1_<row>.experiment.yaml
+  results_rtx5090x1.tar.gz  # Git LFS archive of the platform's last run and row records
   RESULTS.md                # one interpretation across retained platforms
 ```
 
@@ -664,9 +663,10 @@ emmy bench experiments/Qwen3-Coder-30B-A3B-Instruct-AWQ/optimal_mcr_rtx5090
 ```
 
 Use the repository `run-experiment` skill to select/customize the harness, execute Emmy, validate every row, replace
-the platform's named raw-results archive and system-only records, update its section in the shared `RESULTS.md`, and
-commit the complete platform snapshot without changing other platform results. The CLI and experiment code do not
-interpret measurements; the skill performs the intelligent review and the CLI itself performs no Git operation.
+the platform's named raw-results archive containing its system-only records, update its section in the shared
+`RESULTS.md`, and commit the complete platform snapshot without changing other platform results. The CLI and
+experiment code do not interpret measurements; the skill performs the intelligent review and the CLI itself performs
+no Git operation.
 
 ## Adding a New VM Provider
 

--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -23,8 +23,9 @@ commands/publish ─► publish (image naming, metadata, collision and digest ga
   runner
 - `emmy/serving/release.py` — shell-free pinned serving-config parsing and the exact realization matrix shared by
   trace and eval
-- `emmy/logging_setup.py` — CLI logging setup (`setup_cli_logging()`), plus `ensure_plugin_logging()` — makes emmy
-  INFO logs visible when nothing configured logging (a bare vLLM entrypoint; called by `emmy.serving.register()`)
+- `emmy/logging_setup.py` — CLI logging setup (`setup_cli_logging()`), which suppresses routine HTTP request INFO
+  records so versioned JSON remains parseable, plus `ensure_plugin_logging()` — makes emmy INFO logs visible when
+  nothing configured logging (a bare vLLM entrypoint; called by `emmy.serving.register()`)
 - `emmy/config.py` — the single owner of `os.environ` for all `EMMY_*` config vars. Typed getters
   (`tune_db_path`, `nvcc_flags`, `debug_enabled`, `dump_dir`, `tune_patience`, `bench_backends_raw`, `cubin_cache_dir`,
   …) read the env live; `set_nvcc_flags(cli_value, default)` holds the `--nvcc-flags` > env > command-default precedence

--- a/emmy/logging_setup.py
+++ b/emmy/logging_setup.py
@@ -19,6 +19,10 @@ def setup_cli_logging():
     handler.setFormatter(logging.Formatter("%(message)s"))
     install_redaction(handler)
     root.addHandler(handler)
+    # httpx logs every successful request at INFO. That routine transport noise
+    # otherwise precedes versioned JSON emitted by commands such as
+    # ``recipe query --json`` and breaks their machine-readable stdout contract.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 def ensure_plugin_logging():

--- a/experiments/ARCHITECTURE.md
+++ b/experiments/ARCHITECTURE.md
@@ -9,8 +9,7 @@ An experiment answers a comparison or qualification question. It uses the recipe
 experiments/<model>/<workload_or_question>/
   recipe.yaml
   <YYYY-MM-DD_HH-MM-SS>/                    # temporary ignored raw output
-  results_<gpu-short>x<gpu-count>.tar.gz    # one Git LFS archive per exact platform
-  <gpu-short>x<gpu-count>_<row>.experiment.yaml
+  results_<gpu-short>x<gpu-count>.tar.gz    # one Git LFS archive per exact platform, including row records
   RESULTS.md                                # one interpretation across all platforms
 ```
 
@@ -26,11 +25,11 @@ expanded row there. It keeps raw client/server logs and every declared command r
 writes legacy JSON/TXT wrappers, a task/instance manifest, or a report. Dry runs do not create a directory.
 
 Use the repository `run-experiment` skill to finish a requested run. The skill checks matrix-row coverage, system
-information, declared command-result presence, and terminal status; copies the platform's records beside
-`recipe.yaml`; replaces its Git LFS-backed named archive; updates its section in `RESULTS.md`; and commits the complete
-durable snapshot. Once the archive has been extracted or byte-checked against the raw files, the ignored timestamped
-directory may be deleted; the archive is the durable raw copy. Each platform's records, archive, and report section
-always describe that platform's most recent run. Updating one platform preserves every other platform snapshot.
+information, declared command-result presence, and terminal status; retains the platform's records inside the raw-run
+tree; replaces its Git LFS-backed named archive; updates its section in `RESULTS.md`; and commits the complete durable
+snapshot. Once the archive has been extracted or byte-checked against the raw files, the ignored timestamped directory
+may be deleted; the archive is the durable raw copy. Each platform's records inside that archive and its report section
+describe the same most recent run. Updating one platform preserves every other platform snapshot.
 
 `RESULTS.md` is an intelligent review across the retained platform runs. Each platform section reports the protocol,
 measurements, repeat variation, comparisons, conclusion, limitations, system, status, and archive location, with every

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -114,8 +114,8 @@ directly; they never import from another test module or from `conftest.py`.
   validated deployment/performance summaries. Query tests cover constrained expression parsing, implicit deployment
   expansion, external candidates, heat ordering, lifecycle ordering, and the versioned row result.
   Qualification-manifest tests also pin the requested operation mode, exact model ID, target, preserved lifecycle tag
-  and heat, compact notification evidence, current-platform archive and row records, and isolation from other platform
-  results before artifacts may be staged.
+  and heat, compact notification evidence, current-platform records inside the named archive, bounded compatibility
+  fixes, regression notices, and isolation from other platform results before artifacts may be staged.
 - **Temp recipes** — unit tests and multi-instance edge cases create throwaway recipes via `tmp_path`.
 - **Plain functions** — no test classes; tests are grouped by file and separated with comment headers.
 - **Assertions on stdout** — dry-run tests verify that the correct commands and messages appear in the expected order.

--- a/tests/ARCHITECTURE.md
+++ b/tests/ARCHITECTURE.md
@@ -8,9 +8,9 @@ All tests use **pytest** with **pytest-asyncio** (`asyncio_mode = "auto"` in `py
 
 `tests/` mirrors the `emmy/` source tree: a test directory exists because a source package does, and a test
 module is named for the source module it covers. To find the tests for `emmy/<a>/<b>.py`, look in
-`tests/<a>/test_<b>.py`. Two files sit at the root: `conftest.py` — shared fixtures plus the CUDA / LPT xdist
-routing hook (see **Running**) — and `test_emmy.py`, which mirrors `emmy/emmy.py`, the CLI entrypoint that belongs
-to no subpackage.
+`tests/<a>/test_<b>.py`. Three files sit at the root: `conftest.py` — shared fixtures plus the CUDA / LPT xdist routing
+hook (see **Running**) — `test_emmy.py`, which mirrors `emmy/emmy.py`, the CLI entrypoint that belongs to no package,
+and `test_logging_setup.py`, which covers the process-wide CLI and serving-plugin logging boundary.
 
 Mirroring is the rule, not a coincidence — when a source package grows subpackages, the test directory follows.
 `tests/compiler/pipeline/search/` is the worked example: its `data/`, `policy/`, and `prior/` subdirectories exist

--- a/tests/github/test_discord_notification.py
+++ b/tests/github/test_discord_notification.py
@@ -123,6 +123,34 @@ def test_no_eligible_onboarding_is_a_neutral_summary():
     assert embed["color"] == discord_notification.NEUTRAL_COLOR
 
 
+def test_unresolved_onboarding_regression_is_prominent_and_non_pinging():
+    environment = {
+        **BASE_ENVIRONMENT,
+        "WORKFLOW_KIND": "onboard",
+        "WORKFLOW_RESULT": "failure",
+        "SELECTED": "true",
+        "MODEL_ID": "Qwen/Qwen3-Embedding-8B",
+        "TARGET_GPU": "NVIDIA GeForce RTX 4090",
+        "TARGET_GPU_COUNT": "1",
+        "ONBOARD_MODE": "verification",
+        "FAILURE_KIND": "regression",
+        "FAILURE_SUMMARY": "serving: the official image replacement still fails its health check",
+    }
+
+    payload = discord_notification.build_payload(environment)
+    embed = payload["embeds"][0]
+
+    assert payload["content"] == "🚨 **Model regression needs attention**"
+    assert payload["allowed_mentions"] == {"parse": []}
+    assert embed["title"] == "Model regression needs attention"
+    assert embed["color"] == discord_notification.FAILURE_COLOR
+    assert {
+        "name": "Regression",
+        "value": "serving: the official image replacement still fails its health check",
+        "inline": False,
+    } in embed["fields"]
+
+
 def test_delivery_retries_and_requests_a_confirmed_discord_response():
     calls = []
     sleeps = []

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -119,8 +119,15 @@ def test_model_lifecycle_workflow_posts_discord_summary_from_separate_job(workfl
         assert lifecycle["outputs"]["performance_summary"] == "${{ steps.artifacts.outputs.performance_summary }}"
         assert notify["env"]["DEPLOYMENT_SUMMARY"] == "${{ needs.onboard.outputs.deployment_summary }}"
         assert notify["env"]["PERFORMANCE_SUMMARY"] == "${{ needs.onboard.outputs.performance_summary }}"
+        assert lifecycle["outputs"]["failure_kind"] == "${{ steps.notice.outputs.failure_kind }}"
+        assert lifecycle["outputs"]["failure_summary"] == "${{ steps.notice.outputs.failure_summary }}"
+        assert notify["env"]["FAILURE_KIND"] == "${{ needs.onboard.outputs.failure_kind }}"
+        assert notify["env"]["FAILURE_SUMMARY"] == "${{ needs.onboard.outputs.failure_summary }}"
         assert "deployment_summary=$(jq -r .deployment_summary" in artifacts["run"]
         assert "performance_summary=$(jq -r .performance_summary" in artifacts["run"]
+        notice = next(step for step in lifecycle["steps"] if step.get("id") == "notice")
+        assert notice["if"] == "always() && steps.vm.outcome == 'success'"
+        assert 'failure.get("regression") is True' in notice["run"]
     assert "DISCORD_EMMY_ROBOTS_ALERT_ROLE_ID" not in (Path(__file__).parents[2] / ".github" / "workflows" / workflow).read_text()
 
 
@@ -148,6 +155,8 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     subprocess.run(["bash", "-n"], input=host_setup_script, text=True, check=True)
     assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script
     assert "preserve every other platform archive" in agent_script
+    assert "do not retain those records as" in agent_script
+    assert "onboard-investigator subagent" in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
@@ -155,12 +164,37 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert 'tarfile.open(temporary_archive, "w:gz")' in cleanup_script
     assert "temporary_roots = verify_archive(temporary_archive)" in cleanup_script
     assert "os.replace(temporary_archive, archive)" in cleanup_script
+    assert "Results archive contains no" in cleanup_script
+    assert "(workspace / record).unlink()" in cleanup_script
     assert 'tarfile.open(path, "r:gz")' in cleanup_script
     assert "contents.read(1024 * 1024)" in cleanup_script
     assert "raw_directory.name not in member_roots" in cleanup_script
     assert "shutil.rmtree(raw_directory)" in cleanup_script
     assert "git lfs status" in validation_script
     assert "experiments/**/results_*.tar.gz filter=lfs" in (workspace / ".gitattributes").read_text()
+
+
+def test_onboarding_uses_bounded_read_only_investigator():
+    workspace = Path(__file__).parents[2]
+    parent = (workspace / ".opencode" / "agents" / "onboard-model.md").read_text()
+    investigator = (workspace / ".opencode" / "agents" / "onboard-investigator.md").read_text()
+    parent_config = yaml.safe_load(parent.split("---", 2)[1])
+    investigator_config = yaml.safe_load(investigator.split("---", 2)[1])
+
+    assert parent_config["permission"]["task"] == {"*": "deny", "onboard-investigator": "allow"}
+    assert investigator_config["mode"] == "subagent"
+    assert investigator_config["hidden"] is True
+    assert investigator_config["steps"] == 20
+    assert investigator_config["permission"] == {
+        "*": "deny",
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "list": "allow",
+        "webfetch": "allow",
+        "websearch": "allow",
+    }
+    assert "Use at most four public-web calls" in " ".join(investigator.splitlines())
 
 
 def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_path):
@@ -172,6 +206,7 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
     raw_directory = experiment_dir / "2026-08-16_14-41-08"
     raw_directory.mkdir(parents=True)
     (raw_directory / "benchmark.log").write_text("measured\n")
+    (raw_directory / "rtx4090x1_serving.experiment.yaml").write_text("status: succeeded\n")
     (experiment_dir / "recipe.yaml").write_text("name: serving\n")
     (experiment_dir / "RESULTS.md").write_text("# Results\n")
     (experiment_dir / "rtx4090x1_serving.experiment.yaml").write_text("status: succeeded\n")
@@ -209,10 +244,12 @@ def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_p
 
     assert not raw_directory.exists()
     assert archive.is_file()
+    assert not (experiment_dir / "rtx4090x1_serving.experiment.yaml").exists()
     updated_summary = json.loads(summary.read_text())
     archive_path = "experiments/Model/serving/results_rtx4090x1.tar.gz"
     assert archive_path in updated_summary["experiment_artifacts"]
     assert archive_path in updated_summary["artifacts"]
+    assert not any(path.endswith(".experiment.yaml") for path in updated_summary["experiment_artifacts"])
 
 
 def test_onboarding_creates_platform_archive_and_preserves_other_platform(tmp_path):
@@ -224,6 +261,7 @@ def test_onboarding_creates_platform_archive_and_preserves_other_platform(tmp_pa
     raw_directory = experiment_dir / "2026-08-16_14-41-08"
     raw_directory.mkdir(parents=True)
     (raw_directory / "benchmark.log").write_text("measured\n")
+    (raw_directory / "rtx4090x1_serving.experiment.yaml").write_text("status: succeeded\n")
     (experiment_dir / "recipe.yaml").write_text("name: serving\n")
     (experiment_dir / "RESULTS.md").write_text("# Results\n")
     (experiment_dir / "rtx4090x1_serving.experiment.yaml").write_text("status: succeeded\n")
@@ -267,18 +305,20 @@ def test_onboarding_creates_platform_archive_and_preserves_other_platform(tmp_pa
     assert archive.is_file()
     with tarfile.open(archive, "r:gz") as source:
         assert "2026-08-16_14-41-08/benchmark.log" in source.getnames()
+        assert "2026-08-16_14-41-08/rtx4090x1_serving.experiment.yaml" in source.getnames()
         assert "2026-08-01_00-00-00/obsolete.log" not in source.getnames()
     assert not raw_directory.exists()
+    assert not (experiment_dir / "rtx4090x1_serving.experiment.yaml").exists()
     assert other_archive.read_bytes() == b"preserved platform"
     updated_summary = json.loads(summary.read_text())
     expected_snapshot = {
         "experiments/Model/serving/recipe.yaml",
         "experiments/Model/serving/RESULTS.md",
         "experiments/Model/serving/results_rtx4090x1.tar.gz",
-        "experiments/Model/serving/rtx4090x1_serving.experiment.yaml",
     }
     assert expected_snapshot <= set(updated_summary["experiment_artifacts"])
     assert expected_snapshot <= set(updated_summary["artifacts"])
+    assert not any(path.endswith(".experiment.yaml") for path in updated_summary["experiment_artifacts"])
 
 
 def test_onboarding_selects_with_generic_recipe_query():

--- a/tests/github/test_onboarding_artifacts.py
+++ b/tests/github/test_onboarding_artifacts.py
@@ -1,6 +1,8 @@
 import importlib.util
+import io
 import json
 import subprocess
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,15 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(onboarding_artifacts)
 
 
+def _write_archive(path, platform="h200x1", marker="current"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    contents = f"status: succeeded\nmarker: {marker}\n".encode()
+    record = tarfile.TarInfo(f"2026-08-16_00-00-00/{platform}_np8_deadbeef.experiment.yaml")
+    record.size = len(contents)
+    with tarfile.open(path, "w:gz") as output:
+        output.addfile(record, io.BytesIO(contents))
+
+
 def _write_artifacts(workspace):
     paths = [
         "recipes/Model/recipe.yaml",
@@ -19,7 +30,6 @@ def _write_artifacts(workspace):
         "experiments/Model/serving/recipe.yaml",
         "experiments/Model/serving/RESULTS.md",
         "experiments/Model/serving/results_h200x1.tar.gz",
-        "experiments/Model/serving/h200x1_np8_deadbeef.experiment.yaml",
     ]
     for raw_path in paths:
         path = workspace / raw_path
@@ -27,7 +37,7 @@ def _write_artifacts(workspace):
         if raw_path == paths[0]:
             path.write_text("tags: [best-effort]\nmodel:\n  huggingface: org/Model\n  heat: 77\n")
         elif path.suffixes == [".tar", ".gz"]:
-            path.write_bytes(b"compressed results")
+            _write_archive(path)
         else:
             path.write_text("result\n")
     return paths
@@ -141,7 +151,7 @@ def test_validate_summary_requires_exact_platform_archive(tmp_path):
                 "recipe": paths[0],
                 "report": paths[1],
                 "experiment": paths[2],
-                "experiment_artifacts": [paths[2], paths[3], paths[5]],
+                "experiment_artifacts": [paths[2], paths[3]],
                 "artifacts": paths,
                 "cleanup": {"workloads": "complete", "docker_logout": True},
             }
@@ -149,6 +159,85 @@ def test_validate_summary_requires_exact_platform_archive(tmp_path):
     )
 
     with pytest.raises(ValueError, match="exact platform archive"):
+        onboarding_artifacts.validate_summary(
+            summary_path,
+            tmp_path,
+            "org/Model",
+            "NVIDIA H200 141GB",
+            1,
+            "user@host",
+            "onboarding",
+            "best-effort",
+        )
+
+
+def test_validate_summary_requires_platform_record_inside_archive(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    archive = tmp_path / paths[4]
+    with tarfile.open(archive, "w:gz") as output:
+        contents = b"measured\n"
+        result = tarfile.TarInfo("2026-08-16_00-00-00/benchmark.log")
+        result.size = len(contents)
+        output.addfile(result, io.BytesIO(contents))
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": paths[2:],
+                "artifacts": paths,
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="archive contains no h200x1 experiment records"):
+        onboarding_artifacts.validate_summary(
+            summary_path,
+            tmp_path,
+            "org/Model",
+            "NVIDIA H200 141GB",
+            1,
+            "user@host",
+            "onboarding",
+            "best-effort",
+        )
+
+
+def test_validate_summary_rejects_top_level_experiment_record(tmp_path):
+    paths = _write_artifacts(tmp_path)
+    record = tmp_path / "experiments" / "Model" / "serving" / "h200x1_np8_deadbeef.experiment.yaml"
+    record.write_text("status: succeeded\n")
+    record_path = str(record.relative_to(tmp_path))
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "mode": "onboarding",
+                "model_id": "org/Model",
+                "target": {"gpu": "NVIDIA H200 141GB", "gpu_count": 1, "ssh": "user@host"},
+                "deployment_summary": "vLLM 0.22.1, 32K context, concurrency 8",
+                "performance_summary": "100 requests, 2,400 output tok/s, p50 TTFT 42 ms, 0 failures",
+                "recipe": paths[0],
+                "report": paths[1],
+                "experiment": paths[2],
+                "experiment_artifacts": [*paths[2:], record_path],
+                "artifacts": [*paths, record_path],
+                "cleanup": {"workloads": "complete", "docker_logout": True},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="durable experiment snapshot"):
         onboarding_artifacts.validate_summary(
             summary_path,
             tmp_path,
@@ -413,6 +502,78 @@ def test_stage_artifacts_rejects_unmanifested_ignored_experiment(tmp_path):
         onboarding_artifacts.stage_artifacts(tmp_path, [Path("experiments/Model/recipe.yaml")])
 
 
+def test_stage_artifacts_accepts_bounded_implementation_fix(tmp_path):
+    _init_repo(tmp_path)
+    implementation = tmp_path / "emmy" / "compatibility.py"
+    test = tmp_path / "tests" / "test_compatibility.py"
+    implementation.parent.mkdir()
+    test.parent.mkdir()
+    implementation.write_text("VALUE = 'before'\n")
+    test.write_text("def test_value():\n    assert True\n")
+    subprocess.run(["git", "add", "emmy/compatibility.py", "tests/test_compatibility.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+    implementation.write_text("VALUE = 'after'\n")
+    test.write_text("def test_value():\n    assert 'after' != 'before'\n")
+
+    onboarding_artifacts.stage_artifacts(
+        tmp_path,
+        [Path("emmy/compatibility.py"), Path("tests/test_compatibility.py")],
+    )
+
+    staged = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert staged == ["emmy/compatibility.py", "tests/test_compatibility.py"]
+
+
+def test_stage_artifacts_requires_focused_test_for_implementation_fix(tmp_path):
+    _init_repo(tmp_path)
+    implementation = tmp_path / "emmy" / "compatibility.py"
+    implementation.parent.mkdir()
+    implementation.write_text("VALUE = 'before'\n")
+    subprocess.run(["git", "add", "emmy/compatibility.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+    implementation.write_text("VALUE = 'after'\n")
+
+    with pytest.raises(ValueError, match="focused test change"):
+        onboarding_artifacts.stage_artifacts(tmp_path, [Path("emmy/compatibility.py")])
+
+
+def test_stage_artifacts_rejects_large_implementation_fix(tmp_path):
+    _init_repo(tmp_path)
+    baseline = tmp_path / "README.md"
+    baseline.write_text("baseline\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+    artifacts = []
+    for index in range(onboarding_artifacts.MAX_IMPLEMENTATION_FILES + 1):
+        path = tmp_path / "tests" / f"test_fix_{index}.py"
+        path.parent.mkdir(exist_ok=True)
+        path.write_text("def test_fix():\n    assert True\n")
+        artifacts.append(path.relative_to(tmp_path))
+
+    with pytest.raises(ValueError, match="too many implementation files"):
+        onboarding_artifacts.stage_artifacts(tmp_path, artifacts)
+
+
+def test_stage_artifacts_rejects_large_implementation_line_count(tmp_path):
+    _init_repo(tmp_path)
+    baseline = tmp_path / "README.md"
+    baseline.write_text("baseline\n")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
+    test = tmp_path / "tests" / "test_large_fix.py"
+    test.parent.mkdir()
+    test.write_text("\n".join(f"VALUE_{index} = {index}" for index in range(501)) + "\n")
+
+    with pytest.raises(ValueError, match="too many implementation lines"):
+        onboarding_artifacts.stage_artifacts(tmp_path, [Path("tests/test_large_fix.py")])
+
+
 def test_stage_artifacts_requires_updated_platform_archive(tmp_path):
     _init_repo(tmp_path)
     (tmp_path / ".gitattributes").write_text("experiments/**/results_*.tar.gz filter=lfs diff=lfs merge=lfs -text\n")
@@ -466,8 +627,7 @@ def test_platform_update_preserves_other_platform_snapshot(tmp_path):
     subprocess.run(["git", "commit", "-qm", "baseline"], cwd=tmp_path, check=True)
 
     (tmp_path / paths[3]).write_text("H200 updated; RTX 4090 preserved\n")
-    (tmp_path / paths[4]).write_bytes(b"new H200 archive")
-    (tmp_path / paths[5]).write_text("new H200 record\n")
+    _write_archive(tmp_path / paths[4], marker="updated")
     old_record.unlink()
     old_record_path = str(old_record.relative_to(tmp_path))
     summary_path = tmp_path.parent / f"{tmp_path.name}-summary.json"

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -9,6 +9,19 @@ import sys
 from emmy.logging_setup import ensure_plugin_logging
 
 
+def test_cli_logging_keeps_routine_http_requests_out_of_machine_output():
+    code = (
+        "import logging\n"
+        "from emmy.logging_setup import setup_cli_logging\n"
+        "setup_cli_logging()\n"
+        "logging.getLogger('httpx').info('HTTP Request: POST https://api.test')\n"
+        "logging.getLogger('emmy.commands.recipe').info('{\\\"schema_version\\\": 1, \\\"rows\\\": []}')\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == '{"schema_version": 1, "rows": []}'
+
+
 def test_attaches_handler_when_unconfigured():
     # A subprocess is the faithful simulation: in-process, pytest's own logging plugin
     # keeps a capture handler on root, so the "nothing configured" state never exists here.


### PR DESCRIPTION
## Summary

- keep system-only experiment records inside each platform results archive and remove current-platform top-level copies only after archive verification
- let onboarding investigate official image repository/tag changes, apply bounded compatibility fixes with focused tests, and delegate read-only investigations
- forward unresolved verified regressions to the existing Discord notification job as a prominent non-pinging notice

## Validation

- `make test` (3,224 passed, 652 skipped, 1 xfailed, 1 xpassed)
- `make lint`
- focused GitHub automation tests (85 passed)