### PR TITLE
Fix bench_golden_set resolution; promote O3-verified 4090/V100 kernel goldens

### DIFF
--- a/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
+++ b/emmy/compiler/pipeline/search/goldens/rtx4090_sm89_gemma4.yaml
@@ -2515,6 +2515,34 @@ programs:
     attrs: {has_bias: false}
     inputs: [x0, x1]
     outputs: [[matmul, f16, [1, 3840]]]
+- inputs: [x0, x1]
+  outputs: [linear]
+  nodes:
+  - id: x0
+    op: input
+    outputs: [[x0, f16, [512, 3840]]]
+  - id: x1
+    op: input
+    outputs: [[x1, f16, [30720, 3840]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [x0, x1]
+    outputs: [[linear, f16, [512, 30720]]]
+- inputs: [x0, x1]
+  outputs: [linear]
+  nodes:
+  - id: x0
+    op: input
+    outputs: [[x0, f16, [2048, 3840]]]
+  - id: x1
+    op: input
+    outputs: [[x1, f16, [30720, 3840]]]
+  - id: linear
+    op: torch.linear
+    attrs: {has_bias: false}
+    inputs: [x0, x1]
+    outputs: [[linear, f16, [2048, 30720]]]
 configs:
 - program: 0
   target:
@@ -3048,15 +3076,15 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x8/k2
       REDUCE: ''
-      RASTER: ''
+      RASTER: gm8
       STAGE: d2/cp
     measurements:
-      emmy_us: 4347.0
-      reference_us: 2945.0
-      reference_backend: cublas
+      emmy_us: 3001.3
+      reference_us: 2833.3
+      reference_backend: torch-eager
   - name: gemma4_12b.mlp_gate_up.s2048
     bindings:
       num_tokens: 2048
@@ -3899,15 +3927,15 @@ configs:
     pins:
       FAST_MATH: false
     knobs:
-      WORK: w4x2
-      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x8/k2
       REDUCE: ''
-      RASTER: ''
+      RASTER: gm8
       STAGE: d2/cp
     measurements:
-      emmy_us: 4910.1
-      reference_us: 2888.7
-      reference_backend: cublas
+      emmy_us: 3080.4
+      reference_us: 2796.7
+      reference_backend: torch-eager
   - name: gemma4_12b.mlp_gate_up_split.m4096.lin
     bindings:
       num_tokens: 4096
@@ -6482,7 +6510,7 @@ configs:
       reference_us: 1639.4
       reference_backend: cublas
 - program: 141
-  target:
+  target: &id001
     origins:
     - linear
   realizations:
@@ -6656,3 +6684,39 @@ configs:
       emmy_us: 129.0
       reference_us: 138.2
       reference_backend: cublas
+- target: *id001
+  program: 149
+  realizations:
+  - name: gemma4_12b.gate_up_cat.m512.lin
+    bindings:
+      num_tokens: 512
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x2
+      TILE: mma_m16n8k16_f16_f32/f2x4/k2
+      REDUCE: ''
+      RASTER: gm8
+      STAGE: d2/cp
+    measurements:
+      emmy_us: 850.0
+      reference_us: 726.5
+      reference_backend: torch-eager
+- target: *id001
+  program: 150
+  realizations:
+  - name: gemma4_12b.gate_up_cat.m2048.lin
+    bindings:
+      num_tokens: 2048
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f2x8/k2
+      REDUCE: ''
+      RASTER: gm8
+      STAGE: d2/cp
+    measurements:
+      emmy_us: 3073.5
+      reference_us: 2791.9
+      reference_backend: torch-eager

--- a/emmy/compiler/pipeline/search/goldens/v100_sm70_qwen35_122b.yaml
+++ b/emmy/compiler/pipeline/search/goldens/v100_sm70_qwen35_122b.yaml
@@ -696,13 +696,13 @@ configs:
       WORK: w4x2
       TILE: mma_m8n8k4_f16_f32/f4x4/k2
       REDUCE: g2a
-      STAGE: ''
+      STAGE: d1/sync
       LOOPIFY: '0'
       RASTER: ''
     measurements:
-      emmy_us: 7615.488
-      reference_us: 668.16
-      reference_backend: cublas
+      emmy_us: 1850.4
+      reference_us: 665.6
+      reference_backend: torch-eager
 - program: 4
   target:
     origins:

--- a/plans/gemma4-4090-v100-kernel-gap-findings.md
+++ b/plans/gemma4-4090-v100-kernel-gap-findings.md
@@ -1,0 +1,126 @@
+# Kernel-gap tuning: RTX 4090 (gemma-4-12B) and V100 SXM3 (qwen35 / laguna / deepseek)
+
+Status: complete. Date: 2026-08-15. Revision: `c74bed48`. Hardware: CloudRift RTX 4090 (sm_89, driver 580.159.03)
+and Tesla V100-SXM3-32GB (sm_70, driver 580.159.03), one GPU each, caller-supplied.
+
+Scope: verify the recorded per-kernel gaps on both cards, tune the worst families, and classify every gap that
+survives. Compile lanes are labelled throughout: `-Xcicc -O1` is the tune ranking lane, `-O3` (`EMMY_NVCC_FLAGS=`)
+is the deployable lane. Only `-O3` numbers back a conclusion.
+
+## Headline
+
+Five configurations reproduced a deployable win across two repeated `-O3` runs and were promoted. The `-O1` search
+ranking **systematically overstated** those wins — the largest ranked gain (3.45x) did not verify at all, and the
+best verified gain is 1.89x. On both cards emmy still trails eager cuBLAS on every wide-N matmul tested.
+
+| card | targets tuned | ranked gains >1.15x (`-O1`) | verified >1.05x (`-O3`) | promoted |
+| --- | ---: | ---: | ---: | ---: |
+| RTX 4090 | 16 | 12 | 4 | 4 |
+| V100 SXM3 | 61 | 23 | 1 | 1 |
+
+## RTX 4090 — the wide-N MLP block
+
+### Baseline
+
+`scripts/bench_golden_set.py --filter gemma4_12b`, backends `eager,tcompile,emmy`, `torch.compile` at
+`mode="max-autotune"`: 150 cases, 146 measured, 4 failed.
+
+- **vs `torch.compile` max-autotune: emmy wins 67 of 81** comparable cases. The 14 losses are led by
+  `mlp_gate_up_split.m4096.lin` (0.44x) and the `attention.hd512` family (0.56–0.81x).
+- **vs eager cuBLAS: 88 of 146 losing.** cuBLAS, not `torch.compile`, is the bar that matters on this card.
+
+### What was tuned and what verified
+
+Equal-budget arms (`--max-candidates 24 --seed 7`, separate DB / prior / cubin cache per arm) over 16 targets: the
+three worst families plus six new realizations filling the m512 / m1024 / m2048 coverage hole (the recorded set
+jumped from m256 straight to m4096).
+
+The hybrid arm beat MCTS-only on 13 of 16 targets at `-O1`. Every hybrid winner carried `RASTER: gm8` — the
+L2-friendly grouping that the one parity-reaching family (`mlp_gate_up`) already used and that every big loser
+lacked — plus a wider `f2x8/k2` fragment and real staging (`d2/cp`).
+
+At deployable `-O3`, over two repeated runs each (spread <= 3.9%):
+
+| target | eager | golden | tuned | vs golden | vs eager | `-O1` had claimed |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `mlp_gate_up.s2048` | 2833.3 | 5684.7 | 3001.3 | **1.89x** | 0.94x | 3.38x |
+| `mlp_gate_up_split.m4096.lin` | 2796.7 | 4170.7 | 3080.4 | **1.35x** | 0.91x | 3.07x |
+| `gate_up_cat.m512.lin` | 726.5 | 990.2 | 850.0 | **1.16x** | 0.85x | 2.45x |
+| `gate_up_cat.m2048.lin` | 2791.9 | 3467.9 | 3073.5 | **1.13x** | 0.91x | 1.31x |
+| `gate_up_cat.m1024.lin` | 1467.7 | 1533.5 | 1510.0 | 1.02x | — | 1.36x |
+| `gate_up_cat.m64.lin` | 287.7 | 274.9 | 276.6 | 0.99x | — | — |
+
+The direction is right and the schedule family is now established; the magnitude was largely an `-O1` artifact.
+**No tuned 4090 configuration reaches eager** — the best is 0.94x, so roughly half the recorded gap remains.
+
+## V100 SXM3 — staging is offered, and mostly already found
+
+The recorded V100 goldens all carry `STAGE: ''` (no shared-memory staging) on their losing rows, which suggested a
+uniform search shortfall. A direct `-O3` A/B on `attn_kv.m512.lin` confirmed staging is legal and large on Volta:
+527.9 us recorded config -> **217.9 us** with `STAGE=d2/sync` pinned, same other knobs (2.4x).
+
+That result does **not** generalize. Across 61 tuned targets, 23 ranked >1.15x at `-O1` and exactly one survived
+`-O3` verification:
+
+| target | eager | golden | tuned | vs golden |
+| --- | ---: | ---: | ---: | ---: |
+| `qwen35_122b.attn_q.lin.dynM` | 665.6 | 2774.0 | 1850.4 | **1.50x** |
+| 10 others verified | — | — | — | 0.99–1.03x |
+
+Baseline (348 cases, 327 measured): where a torch reference exists at all, **39 of 40 lose to eager**, worst
+`gdn_qkv.m512.lin` at 0.02x (41689 us vs 634 us). The promoted target still runs at 0.36x of eager. Volta's
+synchronous-only copy path (no `cp.async` below sm_80) and the older `m8n8k4` atom are codegen-tier limits that a
+knob search cannot remove; this is the classification for the V100 gap as a whole.
+
+**Recorded-vs-measured drift**: `attn_q.lin.dynM` records `emmy_us: 7615.488` but its recorded configuration
+measured 2774.0 us here — a 2.7x discrepancy on the same knobs. The other rows reproduced. Worth an audit pass;
+the promoted row carries this session's measurement.
+
+## Gaps that blocked promotion
+
+1. **m4096 miscompile (correctness, not performance).** Four cases fail the accuracy check on `c74bed48`:
+   `mlp_geglu.m4096` differs on **12.0%** of elements (greatest absolute difference 96.0), `mlp_geglu.m4096.lin` on
+   0.5% (32.0); `gate_up_cat.m4096.lin` and `norm_gate_up.m4096.lin` fail pinned-Loop verification for want of a
+   valid greedy baseline. This is the single largest recorded-loss family, so its gap cannot be closed until the
+   miscompile is fixed. Repro logs: `_tune/4090-gaps/repro/`. **Classification: codegen correctness bug.**
+2. **`pin_unmatched` on three `norm_gate_up` targets** (`m1024`, `m2048`, `lin.dynM`): neither the recorded golden
+   nor the tuned candidate could be realized — the compiler no longer offers those knobs at these shapes. A golden
+   the compiler cannot produce is worse than none, so these need an eligibility review before re-recording.
+   **Classification: eligibility / optimization lockout.**
+3. **`greedy (isolated)` watchdog failures.** On several wide-N shapes the greedy pick is catastrophic —
+   `gate_up_cat.m1024.lin` deploys `w8x2/f4x8/k8` with no staging and no raster at **95687 us** against a 1467 us
+   eager baseline (65x), tripping the 10 s bench watchdog. The golden tier masks this in normal deploys; it is
+   visible only when a golden is absent or unmatched. **Classification: search shortfall, and the strongest
+   argument that the fix belongs in the prior rather than in per-card goldens.**
+4. **Laguna FP8 could not be tuned at all — environment, not compiler.** All three targets die in
+   `cp.full()` (`emmy/compiler/backend/cuda/program.py`, the constant-buffer path) with
+   `nvrtc: invalid value for --gpu-architecture`. Cause: `cupy-cuda12x 14.1.1` bundles **nvrtc 13.0, and CUDA 13
+   dropped Volta**. Emmy's own kernels are unaffected (system `nvcc 12.9` still accepts `sm_70`), so only
+   constant-buffer kernels fail. Fix: pin `cupy-cuda12x==13.6.0` on any sm_70 host.
+
+## Tooling fixes made during the run
+
+`scripts/bench_golden_set.py` was broken in two ways and produced no usable output before these:
+
+- it passed a golden **name** to `emmy run --golden`, which takes a **path** plus `--target` — every case failed
+  instantly with "invalid golden file";
+- it compared `torch.cuda.get_device_name(0)` directly against the recorded `gpu_name`, which never matches on
+  datacenter cards (`Tesla V100-SXM3-32GB` vs `NVIDIA Tesla V100 SXM3 32GB`), so the V100 corpus resolved to zero
+  names. Now canonicalized through `emmy.gpu.by_name`, matching the deploy-time join.
+
+## Recommendations
+
+1. **Fix the m4096 miscompile first.** It blocks the largest gap on the 4090 and is a correctness defect.
+2. **Treat the wide-N schedule as a prior problem.** `RASTER: gm8` + `f2x8/k2` + `d2/cp` won on every wide-N shape
+   tuned, yet greedy deploys `w8x2/f4x8/k8` with neither staging nor raster and lands 65x off. Per-card goldens
+   paper over this one shape at a time; the prior should learn it.
+3. **Do not trust `-O1` ranking magnitudes.** Ranked gains ran 1.8–3x optimistic here, and one 3.45x ranked winner
+   failed to realize. Budget `-O3` verification into every tuning session.
+4. **Pin `cupy-cuda12x==13.6.0` for sm_70** in the V100 setup notes.
+5. **V100 expectations should be reset.** Its goldens are already near the search's reach; the remaining 2–50x gap
+   to cuBLAS is codegen-tier (no `cp.async`, `m8n8k4` atom), not something tuning will close.
+
+## Artifacts
+
+`_tune/4090-gaps/` and `_tune/v100-gaps/` (untracked): baselines, both arms per corpus, tune logs, `-O3`
+verification JSON/logs, and the miscompile repro logs.

--- a/scripts/bench_golden_set.py
+++ b/scripts/bench_golden_set.py
@@ -33,16 +33,16 @@ from pathlib import Path
 # repo-root on sys.path so this script runs without ``pip install -e``.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from emmy.compiler.pipeline.search.golden import GOLDEN_RECORDS  # noqa: E402
+from emmy.compiler.pipeline.search.golden import _GOLDENS_DIR, load_golden_file, load_golden_records  # noqa: E402
 
 _BIN = Path(sys.executable).parent
 _ROW = re.compile(r"^(Eager PyTorch|torch\.compile|Emmy)\s+([\d.]+)")
 
 
-def _bench(name: str, backends: str, timeout: int) -> dict[str, float] | str:
-    """One ``run --bench --golden`` invocation → ``{backend: us}``, or an error string."""
+def _bench(path: Path, name: str, backends: str, timeout: int) -> dict[str, float] | str:
+    """One ``run --bench --golden PATH --target NAME`` invocation → ``{backend: us}``, or an error string."""
     proc = subprocess.run(
-        [str(_BIN / "emmy"), "run", "--bench", "--golden", name, "--bench-backends", backends],
+        [str(_BIN / "emmy"), "run", "--bench", "--golden", str(path), "--target", name, "--bench-backends", backends],
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -68,18 +68,33 @@ def main() -> None:
 
     import torch
 
-    gpu = torch.cuda.get_device_name(0)
-    names = sorted({c.name for c in GOLDEN_RECORDS if args.filter in c.name and c.gpu_name == gpu})
+    from emmy.gpu import by_name
+
+    # canonicalize like the deploy-time golden join: the torch name differs from the recorded
+    # gpu_name on datacenter cards (e.g. "Tesla V100-SXM3-32GB" vs "NVIDIA Tesla V100 SXM3 32GB").
+    torch_name = torch.cuda.get_device_name(0)
+    known = by_name(torch_name)
+    gpu = known.name if known is not None else torch_name
+    # ``run --golden`` takes a file path (name resolution is per-file via --target), so map each
+    # card-scoped matching name to the canonical file that records it (first file wins on a dup).
+    sources: dict[str, Path] = {}
+    cards: set[str] = set()
+    for path in sorted(_GOLDENS_DIR.rglob("*.yaml")):
+        for record in load_golden_records(load_golden_file(path)):
+            if args.filter in record.name:
+                cards.add(record.gpu_name)
+                if record.gpu_name == gpu:
+                    sources.setdefault(record.name, path)
+    names = sorted(sources)
     if not names:
-        cards = sorted({c.gpu_name for c in GOLDEN_RECORDS if args.filter in c.name})
-        print(f"no golden names match {args.filter!r} on {gpu!r} (matching cards: {cards})", file=sys.stderr)
+        print(f"no golden names match {args.filter!r} on {gpu!r} (matching cards: {sorted(cards)})", file=sys.stderr)
         sys.exit(1)
 
     results: dict[str, dict[str, float] | str] = {}
     for i, name in enumerate(names, 1):
         print(f"[{i}/{len(names)}] {name} …", flush=True)
         try:
-            results[name] = _bench(name, args.backends, args.timeout)
+            results[name] = _bench(sources[name], name, args.backends, args.timeout)
         except subprocess.TimeoutExpired:
             results[name] = f"timeout after {args.timeout}s"
         print(f"    {results[name]}", flush=True)


### PR DESCRIPTION
## Summary

Kernel-gap tuning session on an RTX 4090 (sm_89, gemma-4-12B) and a Tesla V100 SXM3 (sm_70, qwen35-122B /
Laguna FP8 / DeepSeek V4), per the `tune-kernels` workflow. Fixes the per-kernel bench harness, promotes the
five configurations that reproduced a deployable win, and records the gaps that blocked the rest.

## `scripts/bench_golden_set.py` was producing nothing

Two independent bugs, either one fatal:

- it passed a golden **name** to `emmy run --golden`, which takes a **path** plus `--target` — every case failed
  instantly with `invalid golden file`;
- it compared `torch.cuda.get_device_name(0)` directly against the recorded `gpu_name`, which never matches on
  datacenter cards (`Tesla V100-SXM3-32GB` vs `NVIDIA Tesla V100 SXM3 32GB`), so the whole V100 corpus resolved to
  zero names. Now canonicalized through `emmy.gpu.by_name`, matching the deploy-time golden join.

## Promoted (5 rows, each reproduced across two repeated `-O3` runs, spread <= 3.9%)

| card | target | golden | tuned | vs golden | vs eager |
| --- | --- | ---: | ---: | ---: | ---: |
| 4090 | `mlp_gate_up.s2048` | 5684.7 | 3001.3 | **1.89x** | 0.94x |
| 4090 | `mlp_gate_up_split.m4096.lin` | 4170.7 | 3080.4 | **1.35x** | 0.91x |
| 4090 | `gate_up_cat.m512.lin` (new width) | 990.2 | 850.0 | **1.16x** | 0.85x |
| 4090 | `gate_up_cat.m2048.lin` (new width) | 3467.9 | 3073.5 | **1.13x** | 0.91x |
| V100 | `qwen35_122b.attn_q.lin.dynM` | 2774.0 | 1850.4 | **1.50x** | 0.36x |

Every 4090 winner carries `RASTER: gm8` + `f2x8/k2` + `d2/cp` — the schedule family the one parity-reaching
family already used and every big loser lacked. The two new `gate_up_cat` widths fill the recorded set's
m256 -> m4096 coverage hole. The V100 win is shared-memory staging (`STAGE: d1/sync`) where the row had none.

## Caveat on magnitudes

The `-O1` tune ranking **overstated these gains 1.8-3x**, and several ranked winners (up to 3.45x) did not verify
at all. Only `-O3` numbers are recorded here. Against `torch.compile(mode="max-autotune")` emmy already wins 67 of
81 comparable 4090 cases; the real bar is eager cuBLAS, and **no tuned configuration reaches it** (best 0.94x).

## Blocking defect: the m4096 fused-MLP miscompile

Called out separately because it is a **correctness bug**, it is **not fixed here**, and it blocks the largest
recorded-loss family on **both** cards — so it likely outranks further tuning as the next piece of work.

On `c74bed48`, four m4096 cases fail their accuracy check on the RTX 4090:

| case | symptom |
| --- | --- |
| `gemma4_12b.mlp_geglu.m4096` | **12.0%** of elements differ (7534505 / 62914560), greatest absolute difference **96.0** |
| `gemma4_12b.mlp_geglu.m4096.lin` | 0.5% of elements differ (286533 / 62914560), greatest absolute difference 32.0 |
| `gemma4_12b.gate_up_cat.m4096.lin` | pinned embedded-Loop verification has no valid greedy baseline |
| `gemma4_12b.norm_gate_up.m4096.lin` | pinned embedded-Loop verification has no valid greedy baseline |

Why it matters beyond the four cases: `mlp_geglu` is the **single largest recorded loss on both cards**
(4090 15373 us across 2 losing rows; 5090 9340 us across 4, worst 0.48x). No golden can be recorded over a
wrong-answer kernel, so that gap cannot be closed until this is fixed. The 5090 run in progress will confirm
whether the same shapes miscompile on sm_120; the recorded 5090 rows for this family exist, so the defect may be
newer than the recording.

Repro logs: `_tune/4090-gaps/repro/` (captured with `emmy run --bench --golden <yaml> --target <name> -v`).

## Gaps recorded, not fixed here

1. **m4096 miscompile** — see the dedicated section above.
2. **65x greedy misdeploy** — `gate_up_cat.m1024.lin` greedily picks `w8x2/f4x8/k8` with no staging and no raster:
   95687 us vs 1467 us eager. Goldens mask it; it surfaces whenever one is absent. Argues the wide-N schedule
   belongs in the prior, not per-card goldens.
3. **Three `norm_gate_up` targets `pin_unmatched`** — neither golden nor candidate realizable; eligibility review
   needed before re-recording.
4. **Laguna FP8 untunable for environment reasons** — `cupy-cuda12x 14.1.1` bundles nvrtc 13.0 and CUDA 13 dropped
   Volta, so `cp.full()` on constant buffers dies with `invalid value for --gpu-architecture`. Pin
   `cupy-cuda12x==13.6.0` on sm_70 hosts.
5. **Recorded-vs-measured drift** — `attn_q.lin.dynM` records `emmy_us: 7615.488`; its recorded config measured
   2774.0 us here. Worth an audit pass.

Full analysis: `plans/gemma4-4090-v100-kernel-gap-findings.md`.

## Test plan

- `pytest tests/compiler` — 2113 passed, 577 skipped, 2 xfailed
- `pytest tests/compiler/test_golden_configs.py tests/scripts` — 103 passed
- `ruff check .` / `ruff format --check` — clean
- Both promoted golden files validate under `GoldenFileValidation.REPOSITORY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)