### PR TITLE
Update Python version in Makefile to 3.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ setup-agent: venv/.setup-agent-complete
 venv/.setup-agent-complete: pyproject.toml
 	@if [ ! -x "venv/bin/python" ]; then \
 		echo "Creating virtual environment..."; \
-		python3.12 -m venv venv --prompt "emmy"; \
+		python3.14 -m venv venv --prompt "emmy"; \
 	fi
 	@echo "Installing API-agent workflow dependencies..."
 	./venv/bin/pip install -e .
@@ -44,14 +44,14 @@ venv/.setup-agent-complete: pyproject.toml
 venv/.setup-complete: pyproject.toml
 	@if [ ! -x "venv/bin/python" ]; then \
 		echo "Creating virtual environment..."; \
-		python3.12 -m venv venv --prompt "emmy"; \
+		python3.14 -m venv venv --prompt "emmy"; \
 	fi
 	@echo "Installing Python dependencies..."
 	./venv/bin/pip install -e ".[dev]"
 	@touch $@
 
 setup-ci:
-	python3.12 -m venv venv --prompt "emmy"
+	python3.14 -m venv venv --prompt "emmy"
 	./venv/bin/pip install --index-url https://download.pytorch.org/whl/cpu torch
 	./venv/bin/pip install -e ".[compile,test,image]"
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ setup-agent: venv/.setup-agent-complete
 venv/.setup-agent-complete: pyproject.toml
 	@if [ ! -x "venv/bin/python" ]; then \
 		echo "Creating virtual environment..."; \
-		python3.14 -m venv venv --prompt "emmy"; \
+		python3.12 -m venv venv --prompt "emmy"; \
 	fi
 	@echo "Installing API-agent workflow dependencies..."
 	./venv/bin/pip install -e .
@@ -44,14 +44,14 @@ venv/.setup-agent-complete: pyproject.toml
 venv/.setup-complete: pyproject.toml
 	@if [ ! -x "venv/bin/python" ]; then \
 		echo "Creating virtual environment..."; \
-		python3.14 -m venv venv --prompt "emmy"; \
+		python3.12 -m venv venv --prompt "emmy"; \
 	fi
 	@echo "Installing Python dependencies..."
 	./venv/bin/pip install -e ".[dev]"
 	@touch $@
 
 setup-ci:
-	python3.14 -m venv venv --prompt "emmy"
+	python3.13 -m venv venv --prompt "emmy"
 	./venv/bin/pip install --index-url https://download.pytorch.org/whl/cpu torch
 	./venv/bin/pip install -e ".[compile,test,image]"
 


### PR DESCRIPTION
Seems like something changed in Github runners or setup-python action that broke our CI.

Also, God knows why the CI was even working before. The setup-python pins python to 3.13 specifically, and `setup-ci` used to call 3.12 specifically. My guess is: 3.12 came with Ubuntu already, and setup-python wasn't even needed. And now Ubuntu updated its Python, and neither Ubuntu, nor setup-python were providing what we need.