### PR TITLE
search: offer the smem→register double-buffer on the TMA transport

### DIFF
--- a/emmy/compiler/pipeline/search/space.py
+++ b/emmy/compiler/pipeline/search/space.py
@@ -457,7 +457,7 @@ def stage_moves(*, warp: bool) -> list[Stage]:
     if not warp:
         return depths
     smems = [Stage.parse(s) for s in ("d1/smem", "d2/smem", "d3/smem", "d4/smem", "d1/smem/p2", "d2/smem/p2")]
-    return [*smems, *depths, Stage.parse("d2/smem-async/p2")]
+    return [*smems, *depths, Stage.parse("d2/smem-async/p2"), Stage.parse("d2/smem-tma/p2")]
 
 
 # Cross-CTA split-K widths (the ``REDUCE`` codec's ``g<w>`` field). Divisor legality — the width


### PR DESCRIPTION
`stage_moves` handed out `p2` on the plain smem and `smem-async` transports but never on `smem-tma`, so `d2/smem-tma/p2` was reachable only by an explicit pin and never by enumeration. Nothing gated it: the warp resolver clamps `reg_depth` to `tile.bk` on the path every transport shares, and the only constraint the docs state on `p2` is that it is warp-only, which TMA rows satisfy. The combination has never existed in the tree, so it was not measured and rejected — the catalog grew `p2` for cp.async, later for the Volta sync path, and TMA was not revisited either time.

A hand-driven pinned sweep over ten goldenless Qwen3-1.7B matmul shapes on an RTX 5090 chose `d2/smem-tma/p2` as the best config on three of them: gate_up.m512 124.03 → 122.01 µs, qk_proj.m512 40.12 → 39.71, o_proj.m32 4.2465 → 4.222. Those configs were invisible to the offline prior and unreachable by `emmy tune`. Offered, both shipped artifacts rank them near the top of the pool — gate_up.m512 at 21 and 85 of 131,624 rows.

The depth clamp yields `d1/smem-tma/p2` from the same entry, so one move covers both depths.