### PR TITLE
Name the gate a declined compute-fill pin actually hit

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -186,7 +186,9 @@ own term — a 16-bit atom, a resolvable fill, an inventory a value can spell ag
 term variant, the reduce partition, and the contraction's tile × stage × reduce × raster product over the scalar and
 warp tiers, with split-K routing through the structural `Fold ⊃ Fold` composition `030_split_reduce` consumes — and
 the COMPUTED `a` edge with them: the fused cone's contraction offers the warp tier over the MANDATORY resolved `smem`
-compute fill (`d1` plus the asymmetric B-only prefetch ring at `d2`), its split-K is the redundant-statistic form (the
+compute fill (`d1` plus the asymmetric B-only prefetch ring at `d2` — the fill's asynchrony is that depth, not a
+`smem-async` spelling, and a pin naming a byte transport is refused rather than read as its depth alone), its
+split-K is the redundant-statistic form (the
 k-invariant prologue stays full-row in every partition, only the per-cell cone σ-reindexes), and the cone's own
 statistic site is a nested site under the same inventory — the nested site is why the enumerator recurses. SDPA
 carries no family of its own: its two matmuls schedule as plain contractions and the online-softmax `TWISTED` fold

--- a/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
@@ -52,6 +52,12 @@ _TMA_ALIGN = 16  # the NONE-swizzle box-copy rule: 16 B-aligned inner dim and in
 _CP_ASYNC_MIN_ELEMS = 2
 
 
+def decline(why: list[str] | None, reason: str) -> None:
+    """Record a tier's refusal reason for a caller that will report it (a pinned candidate)."""
+    if why is not None:
+        why.append(reason)
+
+
 def enforce(reason: str | None, *, pinned: bool) -> bool:
     """Resolve a refusal into a decision: ``True`` when legal, ``False`` when the candidate should
     be dropped, and a ``ValueError`` when it was PINNED — a pin names a specific kernel, so refusing
@@ -487,7 +493,9 @@ def computed_operand_copy_dtype(c: Fold, tile: TilePlan, inputs, *, converting_a
     return None
 
 
-def resolve_fill_stage(c: Fold, tile: TilePlan, budget: int, want_depth: int = 1, inputs=None) -> Stage | None:
+def resolve_fill_stage(
+    c: Fold, tile: TilePlan, budget: int, want_depth: int = 1, inputs=None, why: list[str] | None = None
+) -> Stage | None:
     """The ``smem`` compute-fill :class:`Stage` for a computed-operand warp contraction under ``tile``
     — MANDATORY for this form (the gmem-direct mma leaf refuses a computed A, and the byte-copy /
     cp.async / TMA transports move bytes and cannot evaluate a producer cone), so it has no
@@ -501,13 +509,24 @@ def resolve_fill_stage(c: Fold, tile: TilePlan, budget: int, want_depth: int = 1
     overlap, it runs on the drain's own threads. Measured on the gemma gate_up edge at M=512 (5090)
     the ring LOSES (897 vs 665 µs) — the extra B slot alone crosses the smem occupancy quantization
     — but at decode M (``tile_m ≤ 32``) the A slab and stat rows are tiny and the tradeoff inverts,
-    so both depths are enumerated as fork siblings and measured per shape."""
+    so both depths are enumerated as fork siblings and measured per shape.
+
+    ``why`` collects the decline reason when the tier refuses, so a PINNED caller reports the gate it
+    actually hit instead of one catch-all sentence."""
     atom = tile.atom
     if atom.operand_dtype("a").nbytes < 2:
-        return None  # fp8 atoms: the compute fill's slab store + ldmatrix drain are 16-bit-only
+        # fp8 atoms: the compute fill's slab store + ldmatrix drain are 16-bit-only
+        decline(why, f"the smem compute fill is 16-bit-only, but this atom's a operand is {atom.operand_dtype('a').nbytes}-byte")
+        return None
     bk_elems = tile.bk * atom.atom_k
     if c.axis.extent.is_static and c.axis.extent.as_static() % bk_elems:
-        return None  # the staged driver unrolls WHOLE K chunks — the same rule the copy transports state on their own
+        # the staged driver unrolls WHOLE K chunks — the same rule the copy transports state on their own
+        decline(
+            why,
+            f"the smem compute fill unrolls whole K chunks, but its {bk_elems}-element chunk "
+            f"does not divide the contraction K={c.axis.extent.as_static()}",
+        )
+        return None
     a_nbytes = atom.operand_dtype("a").nbytes
     b_nbytes = atom.operand_dtype("b").nbytes
     _, _, stats = cone_seam(c.a, c.axis.name) if not isinstance(c.a, Load) else ((), (), ())
@@ -529,6 +548,7 @@ def resolve_fill_stage(c: Fold, tile: TilePlan, budget: int, want_depth: int = 1
         else:
             sync_bytes += tile.n.tile * bk_elems * b_nbytes
     if sync_bytes + async_bytes > budget:
+        decline(why, f"the smem compute fill's slabs need {sync_bytes + async_bytes} B, over the {budget} B smem budget")
         return None
     depth = want_depth if want_depth >= 2 and async_bytes and sync_bytes + want_depth * async_bytes <= budget else 1
     computed = [operand_name(c.a)] if a_converts or not isinstance(c.a, Load) else []
@@ -592,6 +612,7 @@ __all__ = [
     "producer_band",
     "producer_transport",
     "resolve_scalar_stage",
+    "decline",
     "resolve_fill_stage",
     "resolve_warp_stage",
     "scalar_block_threads",

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -787,7 +787,7 @@ def _band_of(plan: ReducePlan) -> Workers | None:
 # --- the contraction: tile x stage x reduce ---
 
 
-def _resolve_stage(term: _Term, node, tile: TilePlan, want: Stage | None) -> Stage | None:
+def _resolve_stage(term: _Term, node, tile: TilePlan, want: Stage | None, why: list[str] | None = None) -> Stage | None:
     """The ONE transport-resolver dispatch — which operand edges and tier select.
 
     Any COMPUTED contraction operand takes the smem compute fill, which is MANDATORY (no byte
@@ -805,10 +805,16 @@ def _resolve_stage(term: _Term, node, tile: TilePlan, want: Stage | None) -> Sta
     if _needs_fill(term, node, tile):
         # A computed (or converting materialized) edge takes only the ``smem`` compute fill — a
         # want naming an asynchronous byte transport declines rather than silently resolving to
-        # the fill.
+        # the fill. The fill IS asynchronous on its B slabs; that ring is its own depth 2, so the
+        # decline names that spelling instead of leaving the caller hunting a smem budget.
         if want is not None and want.transport != "smem":
+            legal.decline(
+                why,
+                f"the smem compute fill has no {want.transport} sibling: a computed operand cannot ride a byte "
+                f"transport, and the fill's own asynchronous B-slab prefetch ring is spelled d2/smem",
+            )
             return None
-        return legal.resolve_fill_stage(node, tile, budget, want.depth if want is not None else 1, inputs=term.tile.inputs)
+        return legal.resolve_fill_stage(node, tile, budget, want.depth if want is not None else 1, inputs=term.tile.inputs, why=why)
     if want is None or (want.transport == "smem-tma" and not term.ctx.has_tma):
         return None
     if tile.is_warp:
@@ -844,14 +850,27 @@ def _fill_values(term: _Term, node, tile: TilePlan) -> list[Stage | None]:
     :func:`_legality.resolve_fill_stage`) — and a ``d2`` that clamps back to ``d1`` under the smem
     budget spells identically, so it dedupes to one row."""
     pin = term.pin("STAGE", node)
+    if pin:
+        # A pinned spelling names a kernel, so its TRANSPORT cannot be quietly dropped and read as
+        # depth alone: the fill has no byte-transport sibling, and its own asynchronous B-slab
+        # prefetch ring is the depth-2 ``smem`` row, not ``smem-async``.
+        pinned_stage = Stage.parse(pin)
+        if pinned_stage.transport != "smem":
+            legal.enforce(
+                f"the smem compute fill has no {pinned_stage.transport} sibling: a computed operand cannot ride a "
+                f"byte transport (nothing but the fill can evaluate a producer cone). Its own asynchronous B-slab "
+                f"prefetch ring is spelled d2/smem.",
+                pinned=True,
+            )
     depths = [Stage.parse(pin).depth] if pin else [1, 2]
 
     def resolve(st: Stage) -> Stage | None:
-        r = _resolve_stage(term, node, tile, st)
-        if r is None:  # per DECLINED depth, so a pin that fits no depth names its own budget
+        why: list[str] = []
+        r = _resolve_stage(term, node, tile, st, why=why)
+        if r is None:  # per DECLINED depth, so a pin that fits no depth names the gate it hit
             legal.enforce(
-                f"the smem compute fill does not resolve at depth {st.depth}: its slabs must fit the "
-                f"{term.ctx.max_dynamic_smem} B smem budget and its K chunk must tile the contraction K",
+                f"the smem compute fill does not resolve at depth {st.depth}: "
+                + (why[-1] if why else f"its slabs must fit the {term.ctx.max_dynamic_smem} B smem budget"),
                 pinned=pin is not None,
             )
         return r

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -285,7 +285,7 @@ def test_twisted_statistic_contraction_realizes_the_warp_tier(monkeypatch) -> No
     assert src.count("expf") >= 2, "the streaming merge and the cone's exp both survive into the kernel"
 
 
-def _sdpa_graph(heads: int = 4, seq: int = 64, head_dim: int = 128):
+def _sdpa_graph(heads: int = 1, seq: int = 32, head_dim: int = 128):
     """One fp16 attention program — the shape whose QK/PV kernels stage through the compute fill."""
     from emmy.compiler.ir.frontend.ir import SdpaOp
 
@@ -332,12 +332,12 @@ def test_fill_decline_names_the_gate_it_actually_hit(monkeypatch) -> None:
     target_mod.set_target((8, 0))
     try:
         with pytest.raises(ValueError) as excinfo:
-            Pipeline.build(CUDA_PASSES).run(_sdpa_graph(seq=64))
+            Pipeline.build(CUDA_PASSES).run(_sdpa_graph(seq=32))
     finally:
         target_mod.set_target(None)
     message = str(excinfo.value)
     assert "whole K chunks" in message, message
-    assert "K=64" in message, message
+    assert "K=32" in message, message
 
 
 def test_multi_stat_entangled_with_expanding_tail_still_refuses() -> None:

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -285,6 +285,61 @@ def test_twisted_statistic_contraction_realizes_the_warp_tier(monkeypatch) -> No
     assert src.count("expf") >= 2, "the streaming merge and the cone's exp both survive into the kernel"
 
 
+def _sdpa_graph(heads: int = 4, seq: int = 64, head_dim: int = 128):
+    """One fp16 attention program — the shape whose QK/PV kernels stage through the compute fill."""
+    from emmy.compiler.ir.frontend.ir import SdpaOp
+
+    g = Graph()
+    for name in ("q", "k", "v"):
+        g.add_node(InputOp(), [], Tensor(name, (1, heads, seq, head_dim), dtype=F16), node_id=name)
+    g.add_node(SdpaOp(), ["q", "k", "v"], Tensor("o", (1, heads, seq, head_dim), dtype=F16), node_id="o")
+    g.inputs, g.outputs = ["q", "k", "v"], ["o"]
+    return g
+
+
+def test_fill_rejects_a_pinned_byte_transport_by_naming_its_own_ring(monkeypatch) -> None:
+    """A computed operand can only ride the smem compute fill, so a pin naming a byte transport must
+    be refused rather than silently read as its depth alone. The fill IS asynchronous on its B slabs,
+    but that ring is its own ``d2/smem`` depth, so the refusal names that spelling."""
+    import pytest
+
+    from emmy.compiler import target as target_mod
+    from emmy.compiler.backend.cuda.backend import CUDA_PASSES
+
+    monkeypatch.setenv("EMMY_STAGE", "d1/smem-async")  # the per-knob var: the aggregate splats at import time
+    target_mod.set_target((8, 0))
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            Pipeline.build(CUDA_PASSES).run(_sdpa_graph())
+    finally:
+        target_mod.set_target(None)
+    message = str(excinfo.value)
+    assert "no smem-async sibling" in message, message
+    assert "d2/smem" in message, message
+    assert "smem budget" not in message, f"the budget was never the gate here: {message}"
+
+
+def test_fill_decline_names_the_gate_it_actually_hit(monkeypatch) -> None:
+    """The depth declines carry their own reason too. K=64 against a 128-element slab chunk is the
+    whole-K-chunk rule, not the smem budget — the catch-all message used to blame the budget and
+    send a reader hunting a capacity limit the pin never reached."""
+    import pytest
+
+    from emmy.compiler import target as target_mod
+    from emmy.compiler.backend.cuda.backend import CUDA_PASSES
+
+    monkeypatch.setenv("EMMY_STAGE", "d1/smem")
+    target_mod.set_target((8, 0))
+    try:
+        with pytest.raises(ValueError) as excinfo:
+            Pipeline.build(CUDA_PASSES).run(_sdpa_graph(seq=64))
+    finally:
+        target_mod.set_target(None)
+    message = str(excinfo.value)
+    assert "whole K chunks" in message, message
+    assert "K=64" in message, message
+
+
 def test_multi_stat_entangled_with_expanding_tail_still_refuses() -> None:
     # The readable-seam refusals live in ``_merge``, the splice both merge passes share; the rule
     # modules are thin predicates over it, so a plain import reaches them (no digit-led module name).

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -206,6 +206,8 @@
  "tests/compiler/passes/test_move_catalog.py::test_two_site_rows_are_distinct_and_materialize_both_sites": 0.19,
  "tests/compiler/passes/test_move_catalog.py::test_two_site_term_merges_both_sites_under_one_inventory": 0.19,
  "tests/compiler/passes/test_move_catalog.py::test_warp_staged_rows_fit_the_smem_budget": 3.56,
+ "tests/compiler/passes/test_online_softmax_channels.py::test_fill_decline_names_the_gate_it_actually_hit": 8.5,
+ "tests/compiler/passes/test_online_softmax_channels.py::test_fill_rejects_a_pinned_byte_transport_by_naming_its_own_ring": 9.1,
  "tests/compiler/passes/test_online_softmax_channels.py::test_twisted_statistic_contraction_realizes_the_warp_tier": 1.93,
  "tests/compiler/passes/test_placement_routing.py::test_norm_linear_cone_cut_recurses_to_the_full_cascade": 5.05,
  "tests/compiler/passes/test_recognize_boundary_rules.py::test_masked_score_cone_keeps_its_predicate_per_cell": 1.47,


### PR DESCRIPTION
## What

The smem compute fill declined for four different reasons — fp8 atom, whole-K-chunk rule, smem budget, and (for a pinned byte transport) tier mismatch — but reported a single catch-all message blaming the budget and the K chunk. A pinned `STAGE` transport was also dropped silently: `d1/smem-async` was read as "depth 1", never as "smem-async".

- `resolve_fill_stage` records its refusal reason where the decision is made (new `decline` helper, `why` out-param).
- `_fill_values` reports that reason instead of the catch-all.
- A pinned transport the fill tier cannot honour is now refused outright, naming the fill's own asynchronous B-slab prefetch ring (`d2/smem`).

## Why

Pinning `STAGE=d1/smem-async` on A100 attention kernels reported a smem budget the pin had never reached. That message cost a tuning session two rounds of GPU time chasing a capacity limit that did not exist — the actual answer was that the fill's asynchrony *is* `d2/smem`.

Before / after on the same A100 pins (`prefill_global`, s256, `emmy run --code … --ab`):

| pin | before | after |
| --- | --- | --- |
| `STAGE=d1/smem-async` | `does not resolve at depth 1: its slabs must fit the 166912 B smem budget and its K chunk must tile the contraction K` | `has no smem-async sibling: a computed operand cannot ride a byte transport … Its own asynchronous B-slab prefetch ring is spelled d2/smem.` |
| `STAGE=d2` | same catch-all | `slabs need 167936 B, over the 166912 B smem budget` |

The second one is 1 KB over — actionable, and `WORK=w4x2,STAGE=d2` does fit, measuring 30.7 µs against 32.6 µs at `d1`.

## Verification

- New tests in `tests/compiler/passes/test_online_softmax_channels.py`: one asserts the transport refusal names `d2/smem` and does *not* mention the budget; one asserts a depth decline names the whole-K-chunk rule with the actual `K=64`. Both fail on the pre-fix message.
- `tests/compiler`: 2091 passed, 495 skipped, 3 xfailed. `ruff check` / `format --check` clean.
- Both messages reproduced on the A100 (`NVIDIA A100-SXM4-80GB`, torch 2.13.0+cu130) against the real pins.

No behaviour change beyond diagnostics, except that a pinned non-`smem` transport at a fill site now errors instead of silently compiling a different kernel than the pin named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)