### PR TITLE
Stamp a minted piece before anything recognizes it

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -599,6 +599,15 @@ The fragment idiom's re-entry semantics are shared, not per-rule: every rule han
 scan, and `005_stamp_structural_features` / `010_recognize` / `020_schedule` pick up whatever is un-stamped,
 un-recognized or unmapped. The shared fixpoint is what lets such rules compose without knowing about each other.
 
+**A piece is stamped before it is recognized, and that order is enforced by `010_recognize`, not by the scan.** The
+scan returns to rule 0 only when it wraps past the LAST rule, and a fork's option is applied by the caller
+(`Candidate.apply`), which advances the rule cursor only if the applied match closed its batch. A cut taken at an
+UNPINNED placement fork with another kernel still pending therefore leaves the cursor on `010_recognize`, which
+re-matches its own fresh pieces on the next step — ahead of `005`. So `010` DEFERS an unstamped `LoopOp`
+(`RuleSkipped`); the batch ends, the scan wraps, and the piece is stamped first. Without that guard the piece lifts
+with no `S_*` and `020_schedule` asserts on the empty structural identity — which is what a whole-model compile with a
+discovered (rather than pinned) cut hit.
+
 `005_stamp_structural_features` duplicates `loop/stamp/020_stamp_structural_features` rather than replacing it,
 because a kernel is stamped in the pass where it is BORN. The loop-dialect pass owns the kernels the fusion end
 produces; it cannot reach one minted later, since `Cursor.advance` only restarts a scan WITHIN the current pass and

--- a/emmy/compiler/pipeline/passes/lowering/tile/005_stamp_structural_features.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/005_stamp_structural_features.py
@@ -15,13 +15,18 @@ cut's fragments, which are freshly-built ``LoopOp``\\ s with no knobs at all. Th
 ``010_recognize`` and ``020_schedule`` carrying their own identity, like any kernel, and no rule
 had to be told they were fragments.
 
+**Reaching them is a guarantee, not an ordering accident.** The restart only comes when the scan
+wraps past the LAST rule, and a fork's option is applied by the CALLER (``Candidate.apply``), which
+advances the rule cursor only if the applied match closed its batch. So a cut taken at an UNPINNED
+placement fork with another kernel still pending leaves the cursor on ``010_recognize``, which
+re-matches the pieces on the next step — ahead of this rule. ``010`` therefore DEFERS an unstamped
+``LoopOp`` (``RuleSkipped``): the batch ends, the scan wraps, and the piece is stamped here before
+anything recognizes it.
+
 **``LoopOp`` covers every kernel a rule mints**, because every rule mints in the loop dialect: a
 placement cut's fragments and a cross-CTA split's pieces are both plain ``LoopOp`` nodes, built that
 way precisely so they re-enter the pipeline where a freshly fused kernel does. Nothing needs a
-tile-dialect arm. The one thing this does NOT reach is a term ``010_recognize`` splices as a
-``Graph`` rather than rebinding (the online-softmax form), which has carried no structural identity
-since it was written — a separate hole, and not one this rule should paper over by growing a second
-way to read a body.
+tile-dialect arm, and there is no kernel-minting path left that skips this rule.
 """
 
 from __future__ import annotations

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -13,7 +13,9 @@ axes onto the grid and offers the scheduling forks; materialization back to loop
 Nothing here reads a knob or a pin — recognition is structure, and every choice it makes is
 unconditional. (The one exception is PLACEMENT, step 3.5: a ``PLACE`` pin
 cuts the recognized tree into a fragment of un-mapped ``LoopOp``\\ s, and it must resolve BEFORE any
-schedule fork exists, so it cannot wait for ``020``.)
+schedule fork exists, so it cannot wait for ``020``.) An unstamped ``LoopOp`` is DEFERRED rather
+than recognized — that is the ``005_stamp_structural_features`` ordering, read off the stamp itself
+rather than assumed from the scan; see the guard below.
 
 All recognition lives in THIS one rule (no separate softmax pass), in order (each
 step unconditional — no knobs):
@@ -67,6 +69,7 @@ from emmy.compiler.graph import Graph, Node
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.pipeline import Match, Pattern
+from emmy.compiler.pipeline.knob import STRUCT_PREFIX
 from emmy.compiler.pipeline.passes.lowering.tile._atomize import bind_prologue_contraction
 from emmy.compiler.pipeline.passes.lowering.tile._cut import cuttable_seams, realize_cut, route_cut
 from emmy.compiler.pipeline.passes.lowering.tile._lift import recognized_tile
@@ -77,6 +80,15 @@ PATTERN = [Pattern("root", LoopOp)]
 
 def rewrite(match: Match, root: Node, ctx=None) -> TileOp | Graph | None:
     loop: LoopOp = root.op
+    # A kernel is RECOGNIZED only once it has an identity. ``005_stamp_structural_features`` runs
+    # first in this pass, so an unstamped ``LoopOp`` here is a kernel this pass MINTED — a cut's
+    # fragment or a split's piece — that the scan reached before wrapping back to rule 0. Deferring
+    # is what makes the pass order a guarantee rather than a coincidence: a fork's option is applied
+    # by the CALLER (``Candidate.apply``), which advances the rule cursor only when the applied match
+    # closed its batch, so an un-deferred piece is re-matched HERE on the very next step and lifted
+    # with no ``S_*`` — the empty structural identity ``020_schedule`` then asserts on.
+    if not any(k.startswith(STRUCT_PREFIX) for k in loop.knobs):
+        raise RuleSkipped("kernel minted in this pass is not stamped yet — 005_stamp_structural_features runs first")
     # Steps (1)–(3) — softmax fusion, the free-axis peel, the cell lift / nodification — are the
     # pure recognition core (:func:`._lift.recognized_tile`), shared verbatim with the strict
     # golden decode's record-side identity derivation.

--- a/emmy/compiler/pipeline/passes/lowering/tile/__init__.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/__init__.py
@@ -5,7 +5,9 @@
    the kernel to a ``TileOp`` carrying ONE op-tree — a ``Fold`` / contraction term — with an
    **unmapped** placement (its parallel ``free`` axes). After this nothing downstream traffics
    in ``LoopOp``. The ``_softmax`` helper holds the streaming-softmax fusion, ``_atomize`` the
-   algebra→atom binding, ``_cut`` the placement cut.
+   algebra→atom binding, ``_cut`` the placement cut. An UNSTAMPED ``LoopOp`` is deferred — a kernel
+   minted here reaches ``005`` before anything recognizes it, which the scan alone does not
+   guarantee.
 2. **Schedule** (``020_schedule``) — decide that op's ``place`` (free axes → grid) and its per-node
    ``schedule`` slices, and offer them as a fork. ONE generic row enumerator (``_schedule``): the
    kernel's single ``WORK`` inventory is CHOSEN first, then a recursive walk of the site tree hands

--- a/tests/compiler/loader/test_exl3.py
+++ b/tests/compiler/loader/test_exl3.py
@@ -1207,11 +1207,6 @@ def test_exl3_twin_carries_decoded_weights(tmp_path):
         np.testing.assert_array_equal(bound[nid], wrapper_state[op.source_path].detach().float().numpy())
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="split pieces are minted in the loop dialect (this PR); a kernel reaches 020_schedule unstamped "
-    "(TileOp with an all-LoopOp source chain and no knobs), tripping its structural-identity assert",
-)
 @requires_cuda
 def test_exl3_checkpoint_e2e_cuda(tmp_path):
     """Whole tiny EXL3 model through the same seam ``emmy compile`` / ``emmy run`` use, compiled

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -181,4 +181,40 @@ def test_pin_naming_no_seam_is_skipped(monkeypatch) -> None:
     assert len(_kernel_ids(out)) == 1
 
 
+def test_a_cut_taken_at_a_fork_mid_batch_still_reaches_the_stamp(monkeypatch) -> None:
+    """An UNPINNED cut is a fork option, and a fork's option is applied by the CALLER — which
+    advances the rule cursor only when the applied match closed its batch. With a second kernel
+    still pending, the cursor stays on ``010_recognize``, so the pieces it just minted are
+    re-matched on the very next step, BEFORE the scan wraps back to ``005_stamp_structural_features``.
+    Recognizing them there lifts kernels with no ``S_*`` and ``020_schedule`` asserts. Two chains,
+    the first one cut, is the smallest graph that puts a cut match ahead of another kernel's."""
+    monkeypatch.delenv("EMMY_KNOBS", raising=False)
+    monkeypatch.delenv("EMMY_PLACE", raising=False)
+    g = Graph()
+    for tag in ("a", "b"):
+        _inp(g, f"x{tag}", (1, 2, 16))
+        _inp(g, f"wn{tag}", (16,))
+        _inp(g, f"w{tag}", (16, 16))
+        g.add_node(RmsNormOp(), [f"x{tag}", f"wn{tag}"], Tensor(f"xn{tag}", (Dim(1), Dim(2), Dim(16)), dtype=F16), node_id=f"xn{tag}")
+        g.add_node(MatmulOp(), [f"xn{tag}", f"w{tag}"], Tensor(f"y{tag}", (Dim(1), Dim(2), Dim(16)), dtype=F16), node_id=f"y{tag}")
+    g.inputs = [f"{n}{tag}" for tag in ("a", "b") for n in ("x", "wn", "w")]
+    g.outputs = ["ya", "yb"]
+
+    taken: list[str] = []
+
+    def cut_once(fp):
+        leaves = flatten_leaves(fp.options)
+        cut = next((o for o in leaves if isinstance(o, Graph)), None) if not taken else None
+        if cut is None:
+            return leaves[0]
+        taken.append("cut")
+        return cut
+
+    out, _ = Run(pipeline=Pipeline.build(CUDA_PASSES), ctx=Context.from_target((12, 0))).resolve(g, cut_once)
+    kernels = _kernel_ids(out)
+    assert taken, "no placement fork offered a cut — the graph no longer exercises the ordering"
+    assert any("__cut_" in k for k in kernels), kernels
+    assert {"ya", "yb"} <= set(kernels), kernels
+
+
 # --- routing entries drive the same realizer -------------------------------------------------------


### PR DESCRIPTION
A kernel minted inside `lowering/tile` — a placement cut's fragment, a cross-CTA split's piece — is a loop-dialect
`LoopOp` precisely so it re-enters where a freshly fused kernel does: `005_stamp_structural_features` stamps it,
`010_recognize` lifts it, `020_schedule` forks it. That order was the design, but nothing enforced it, and one path
skipped the stamp.

## The defect

The rule scan returns to rule 0 only when it wraps past the **last** rule, and a fork's option is applied by the
CALLER (`Candidate.apply`), which advances the rule cursor only if the applied match closed its batch. So an
**unpinned** placement cut taken with another kernel still pending in the batch leaves the cursor on
`010_recognize`, which re-matches the two pieces it just minted on the very next step — ahead of `005`. They lift
with no `S_*`, and `020_schedule` asserts on the empty structural identity:

```
AssertionError: '': scheduling a kernel with no structural identity — 005_stamp must run first
```

Measured on the EXL3 whole-model compile — the applied cut, then both pieces arriving at recognition unstamped:

```
CUT MINT:   linear_core_reduce -> linear_core_reduce__cut_v36 + linear_core_reduce (is_last=False)
UNSTAMPED at 010: node='linear_core_reduce__cut_v36'  knobs=[]
UNSTAMPED at 010: node='linear_core_reduce'           knobs=['PLACE@b']
```

Pinned cuts never hit it — a pin returns a single `Graph`, applied inline, so the batch finishes and the scan wraps —
and neither does `030_split_reduce`, which always returns a single `Graph`. What it does hit is the discovered-cut
path: a cold compile or a tune where a cut wins its fork in a multi-kernel graph.
`test_exl3_checkpoint_e2e_cuda` was xfailed for exactly this.

## The fix

`010_recognize` DEFERS an unstamped `LoopOp` (`RuleSkipped`): the batch ends, the scan wraps, `005` stamps the piece,
and only then is it recognized. The precondition is read off the stamp itself rather than assumed from the scan;
`020`'s assert stays as the backstop.

Stamping at mint instead was rejected — it is a second way to derive identity, and a worse one: `structure_features`
folds operand dtypes off the graph, and at mint time the workspace buffer is not spliced yet, so a piece would carry
`S_dtype_?` where `005` reads the real dtype. An engine-level "restart the scan after every structural splice" was
rejected too: it rewrites `Cursor`'s contract for every pass to fix one rule's precondition.

## Verification

| | before | after |
| --- | --- | --- |
| `tests/compiler` | 2574 passed, 17 xfailed, 1 failed | **2576 passed, 16 xfailed, 1 failed** |
| full `pytest tests/` | 3697 passed, 1 failed | **3699 passed, 31 skipped, 16 xfailed, 2 xpassed, 1 failed** |

`test_exl3_checkpoint_e2e_cuda` passes and its strict `xfail` marker is removed. The remaining failure is
`test_quantized_checkpoint_e2e_cuda` — the fp8 dequant tolerance failure identical on clean `main`. The 2 xpassed are
pre-existing non-strict serving-GPU xfails outside `tests/compiler` (that suite alone reports zero).

`test_a_cut_taken_at_a_fork_mid_batch_still_reaches_the_stamp` reproduces the assert in 0.18 s on the CPU lane without
the guard and passes with it — the e2e coverage is all `@requires_cuda` and skips there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)