### PR TITLE
FA restoration: the composed score reads, binds, and reaches the tensor core

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -58,10 +58,13 @@ program; the schedule slices, the root stores and the knobs are the `TileOp`'s, 
 A composed step — flash's `Σ Q·K` ahead of its `Σ_j P·V`, split-K's sliced contraction — used to be
 the argument for `Stmt`-hood: it has to appear at a POSITION in the emitted step stream. It does not
 need to be a statement to get there. The tree already carries it: a composed node is an entry in
-`operands`, and its position is produced by the derivation — `_twisted_derived_step` heads the
-inline-node edges, and `splice_operands` places each edge's body before the first read of its bound
-name. `Fold.loop` passes that mixed term/stmt sequence to `_flatten_nodes` as a plain tuple; the
-only place terms become statements is `Fold.lower()`.
+`operands`, and its position is produced by the derivation — `_twisted_derived_step` PLACES each
+inline-node edge before the first stmt that reads its bound name (lift body or merge), and
+`splice_operands` applies the same first-use rule to every other edge. Placement, not prepending, is
+what lets a step whose pure prologue precedes its producer (a loop-invariant scale `Load` ahead of
+attention's score contraction) re-derive to the program it was read from. `Fold.loop` passes that
+mixed term/stmt sequence to `_flatten_nodes` as a plain tuple; the only place terms become statements
+is `Fold.lower()`.
 
 `Fold` does keep a small structural protocol whose names it shares with `Stmt` — `nested()` for its
 children, `rewrite()` for α-renaming, `defines()` for the bilinear reading's channel accumulators.

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -159,8 +159,18 @@ def _twisted_derived_step(fold: Fold) -> tuple[Stmt, ...]:
         edge = by_param.get(term)
         if isinstance(edge, Load):
             merge = _split_expect(merge, nm, term, edge)
-    head = tuple(e for e in fold.operands if isinstance(e, Fold))
-    return (*head, *lam.body, *merge)
+    # The inline-node edges are PLACED, not prepended: each lands immediately before the first
+    # stmt (lift body or merge) that reads its bound name, ties in operand order — the same
+    # first-use rule :func:`splice_operands` applies to every other edge, with the node itself
+    # riding the sequence (``_flatten_nodes`` lowers it later). Prepending unconditionally would
+    # reorder a step whose pure prologue precedes the producer (a loop-invariant scale ``Load``
+    # ahead of attention's score contraction), and the byte-identity gate reads that as a
+    # different program.
+    steps: list[Stmt] = [*lam.body, *merge]
+    for edge in reversed([e for e in fold.operands if isinstance(e, Fold)]):
+        nm = operand_name(edge)
+        steps.insert(next((i for i, st in enumerate(steps) if nm in deep_reads([st])), 0), edge)
+    return tuple(steps)
 
 
 def _fold_derived_step(fold: Fold) -> tuple[Stmt, ...]:

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -117,8 +117,9 @@ bands name a kernel the wire format cannot tell apart, and admitting both produc
 and a candidate the enumeration offers must be one materialization can build: `splitk_computed_b_site` is asked at
 enumeration, not only inside `_splitk_option` where it is enforced with `pinned=True` and would turn an unpinned
 offered candidate into a raise. That predicate is also where the nested-key rule bites the other way — the split
-σ-reindexes both operand edges through `_sliced_edge`, and rewriting a COMPUTED cone replaces the nodes inside it, so
-a cone carrying a scheduling site of its own would lose the slice keyed by that node's identity.
+σ-reindexes both operand edges through `_sliced_edge`, and rewriting a COMPUTED cone replaces the nodes inside it —
+its body stmts and every K-VARYING producer edge it composes, since the slice's own k coordinate reaches gmem through
+that node — so a cone carrying a scheduling site of its own would lose the slice keyed by that node's identity.
 
 Three layers own three different questions, and keeping them apart is what stops a rule being stated twice:
 
@@ -461,8 +462,9 @@ twist family is selected STRUCTURALLY — the stored combine must BE the exp/LSE
 formation; the state-component roles read off the singleton shape: pivot = component 0, literal-1 = denominator,
 value name = expectation). The COMPOSED evaluations derive too (step 7): a twisted fold with a `Load`-bound
 expectation operand derives its blocked evaluation with the expectation contraction SYNTHESIZED — and memoized, one
-identity per stored fold — (`ir._twisted_derived_step`; no recognizer builds the operand-edge form today — the
-online-softmax pairing's `(m, d, o…)` expectation channels keep their value loads inline in the lift body); split-K's
+identity per stored fold — (`ir._twisted_derived_step`; the online-softmax pairing's `(m, d, o…)` expectation channels
+keep their value loads inline in the lift body, but a step that COMPOSES a producer it computes itself does arrive in
+operand-edge form — the composed-step reading, below); split-K's
 outer reduce is the
 IDENTITY-LIFT composition over its one inline sliced contraction node (combine at that singleton embeds the operand
 verbatim — no outer `Accum`s; `Fold.composed` is the one read of the composition, shared by `Fold.role` and
@@ -472,7 +474,12 @@ goes through; `.loop` splices only the operand edges the derived step did not co
 escape, an impure-bodied zero-axis fold), and its identity gate compares the derived body/axis/unroll only —
 the role annotation is the fold's own derived read, so an unbindable matvec captures a CONTRACTION-shaped loop and
 derives `PLANAR` (the 1l
-demotion, now a formation fact; `_extract_lift` accepts any PURE prefix). The inverse — un-hoisting a computed
+demotion, now a formation fact; `_extract_lift` accepts any PURE prefix, and lifts a nested reduce `Loop` in that
+prefix to an operand EDGE — the COMPOSED STEP, `_fromloop._hoist_step_nodes`, recursively through the same parser:
+attention's per-key score contraction inside the streaming softmax statistic reads as a producer the step consumes,
+so a merged attention cell keeps its schedule tiers instead of falling to the escape. The identity gate compares
+role-blind for the same reason it compares at the canonical SSA spelling — the `AxisRole` is derived, and the raw
+pre-annotation body does not carry it). The inverse — un-hoisting a computed
 edge back into the lift body — has no implementation at present: its only caller was the scheduler's collapse arm,
 and it returns with the enumerator. Kernel identity is the α-INVARIANT TERM HASH (`Fold.structural_key`: canonical
 renumbering in first-appearance walk order plus hash-time ANF body-order canonicalization — the stored term is never

--- a/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
+++ b/emmy/compiler/pipeline/passes/loop/fusion/_merge.py
@@ -40,9 +40,18 @@ def _walk_leaf_costs(loop_op: LoopOp):
 
 def _nests_reduce(loop_op: LoopOp) -> bool:
     """Whether the body carries a reduce ``Loop`` (transitively) inside another reduce ``Loop``.
-    That shape is unreadable downstream: ``_lift_cell`` keeps only the raw-loop escape for a
-    cell with more than one top-level reduce or a reduce nested in a reduce, so no schedule
-    tier beyond option-0 exists and no ``PLACE`` seam can split it back apart."""
+
+    The refusal's criterion is REVERSIBILITY, not readability alone: a merge evidence cannot price
+    the split back out of is one the compiler can never undo. Attention is the case that makes the
+    distinction sharp. Its ``Q·Kᵀ`` producer has TWO consumers in the merged cell (the streaming
+    softmax statistic and the weight cone), so splicing it duplicates the producer at each demand
+    site — and no ``PLACE`` cut puts that back: a cut fragment serves ONE consumer (an operand edge
+    is inline, and there is no let table), so cutting both seams mints two score kernels, never the
+    one shared producer the unmerged graph had. The merged cell is READABLE downstream — recognition
+    lifts each spliced producer to an operand edge of the step's fold
+    (``lowering/tile/_fromloop``), it binds as a computed-A cone over a computed score and it runs —
+    but until that fused form is realized at the tensor-core tier it is far slower than the
+    two-kernel graph this refusal preserves, and evidence has no way back."""
     reduce_names = loop_op.reduce_axis_names
 
     def walk(stmts: Body, inside: bool) -> bool:

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -211,10 +211,16 @@ transport prologue
 (`_stage.sync_stat_fill` — one row per WARP: the 32 lanes stride the row's reduce coalesced and close the fold with
 the stat fold's shuffle butterfly (`emit_combine` off the threaded `Reduction`), lane 0 writing the bridged stat into its smem row; one barrier);
 the per-cell compute fill reads the bridged values back from the stat rows. A cone edge that DOES index K (attention's
-score contraction, read by the cone's `exp(s − m)`) is per-cell instead: it splices into the fill's cell and is
-evaluated inline, from lowered loop IR, so it takes no schedule slice of its own (a scalar dot per slab cell —
-computing that tile on the warp tier, and keeping it resident across the statistic and the weight, is what a
-single-kernel flash still needs). Geometry: exact cover on N only. A
+score contraction, read by the cone's `exp(s − m)`) is the **CHAINED** fill where it reads as a CONTRACTION and the
+atom can mma it (`_atom.chain_a_fill`): the slab comes from a nested contraction — `mma(Q, Kᵀ)` into C fragments, the
+cone folded into their fragment store (`RegStore` + `RegEpilogue`, its statistics read at each element's own row) and
+written straight into the slab the `ldmatrix` drain reads. There is no second mma emitter: the score is a contraction,
+so it is built out of the SAME atom strategy (`_atom_ops` on the score node — `state` declares the fragments, `reduce`
+emits the gmem-direct `ldmatrix` + `mma.sync` K-loop, `store` writes them), namespaced (`_AtomOps.frag_ns`) so the
+nested fragments never shadow the accumulators the enclosing drain carries across the same loop. The slab stays
+NONE-swizzle there — a fragment store applies no address XOR. Where the edge is not a bindable contraction (or the atom
+has no modeled C layout) it stays per-cell: spliced into the fill's cell and evaluated inline from lowered loop IR, a
+scalar dot per slab cell. Geometry: exact cover on N only. A
 masked / symbolic **M** clamp-reads (the A / stat-prologue σ ride `_clamp_last`; the overhang store is discarded by
 the `RegStore` guard). A symbolic **K** rides the fill's own **K MASK** — the same clamp-to-identity discipline on
 the contraction axis: the cone's reads clamp in-bounds and every slab lane whose k index reaches past the runtime
@@ -278,9 +284,16 @@ the operand's own index evaluated at the tile base — an offset operand lands t
 
 ## A TWISTED carrier lowers through the generic reduce tiers
 
-There is no attention emitter and no fragment-residence realizer for a `TWISTED` reduce: the online-softmax fold
-lowers at scalar residence through the same reduce-axis tiling every `PLANAR` fold takes (`_tile_reduce_axis` —
-coop lanes / ILP chains / serial), its multi-component streaming merge regenerated off the node's `Reduction` view.
+There is no attention emitter. A `TWISTED` reduce lowers at scalar residence through the same reduce-axis tiling every
+`PLANAR` fold takes (`_tile_reduce_axis` — coop lanes / ILP chains / serial), its multi-component streaming merge
+regenerated off the node's `Reduction` view — with ONE fragment-residence arm, and it is a fill, not an emitter: a
+computed-A cone's per-row statistic over a COMPOSED score sweeps at fragment residence
+(`_atom.chain_stat_fill`). Per KV block the tile's scores land in mma C-fragments (the same `_score_block` the chained
+A fill uses), the block's row statistic comes off them through the layout's shuffle butterfly (`FragmentRowReduce`),
+and the carrier's OWN generated program merges the block into the running state — `exp_merge` at a BLOCK singleton
+`(rowmax, rowsum)` instead of an element singleton, the same generator and the same stability certificate. Each lane
+ends holding the statistic for the two rows the fragment layout gives it, and one lane per column group publishes them
+to the stat rows the weight fill reads. Everything else about the fold is unchanged.
 The fold MOVE itself is never re-decided per site: `ReduceStage.combine` (`ir/schedule.py`) is the ONE
 placement-keyed selector — within-warp → `SHFL`, within-block → `SHFL`+`SMEM` tree, cross-CTA → `ATOMIC`/`KERNEL`
 (a multi-component carrier is kernel-finalize only) — and every emitter consumes its output (`emit_combine` at

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -15,11 +15,20 @@ atom supplies only descriptor reads: the four gmem leaf constructors (:meth:`gme
 slab drain leaf (:meth:`staged_drain`), and the slab element dtype. This IS the "atom as
 descriptor" seam: one factory, one loop over atoms, no scattered ``isinstance``.
 
+A computed-A cone that COMPOSES a score contraction (attention) reaches the tensor core through that
+same seam, twice, without a second emitter: the **CHAINED A fill** (:func:`chain_a_fill`) computes
+the slab with a nested contraction and folds the cone into its fragment store, and the **CHAINED
+statistic** (:func:`chain_stat_fill`) sweeps the cone's per-row reduce at fragment residence over KV
+blocks. Both are :func:`_atom_ops` on the SCORE node (:func:`_score_block`), namespaced by
+:attr:`_AtomOps.frag_ns` so a nested emission never shadows the enclosing drain's accumulators; both
+decline (and leave the per-cell / cooperative-row form standing) wherever the score does not read as
+a contraction or the atom has no modeled C-fragment layout.
+
 Leading ``_`` so the pass loader (globs ``*.py``, skips ``_``-prefixed) skips it."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from emmy.compiler.backend.cuda.dtype import cuda_name
 from emmy.compiler.dim import Dim
@@ -29,15 +38,24 @@ from emmy.compiler.ir.axis import Axis
 from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, Expr, Literal, TernaryExpr, Var
 from emmy.compiler.ir.kernel.ir import (
+    FRAG,
+    ROW,
+    UNIFORM,
     EpilogueLoad,
+    FragmentApply,
     FragmentPromote,
+    FragmentRowReduce,
     LdmatrixLoad,
     MmaSyncPtx,
     RegEpilogue,
     RegFragment,
     RegStore,
+    Smem,
+    Sync,
+    frag_layout,
 )
-from emmy.compiler.ir.pure.fold import Fold, operand_body, operand_name
+from emmy.compiler.ir.pure.carrier import exp_merge
+from emmy.compiler.ir.pure.fold import Fold, edge_refs_axis, is_contraction, operand_body, operand_name
 from emmy.compiler.ir.schedule import Side, Stage, TilePlan
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Cond, Init, Load, Loop, Select, SelectBranch, Stmt, StridedLoop, Write
@@ -54,6 +72,7 @@ from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
     staged_kloop,
     sync_stat_fill,
 )
+from emmy.compiler.pipeline.passes.lowering.kernel._tiling import AxisOffset
 from emmy.compiler.pipeline.search.space import UNROLL
 
 #: The contraction semiring — multiply ⊗ then accumulate ⊕ (add). The same multiply-add ``mma.sync``
@@ -540,6 +559,223 @@ def _k_masked(stmts: list[Stmt], value: str, k: Expr, k_ext: Expr | None) -> tup
     )
 
 
+def _chain_of(*, c, score, mn, atom, bk_elems, slab, stats, lead):
+    """The chained fill CLOSURE — ``chain(k0)`` for the transport, deferring the emission until the
+    skeleton knows its chunk base."""
+
+    def chain(k0):
+        return chain_a_fill(c=c, score=score, mn=mn, atom=atom, bk_elems=bk_elems, k0=k0, slab=slab, stats=stats, lead=lead)
+
+    return chain
+
+
+def chain_edge(cone, k_name: str):
+    """The cone's K-VARYING producer edge when it is a CONTRACTION over its own axis — the score
+    the CHAINED fill realizes on the tensor core — or ``None`` (no such edge, or it is not a
+    contraction, so only the per-cell evaluation exists)."""
+    if not isinstance(cone, Fold) or cone.axis is not None:
+        return None
+    kv = [e for e in cone.operands if isinstance(e, Fold) and e.axis is not None and edge_refs_axis(e, k_name)]
+    return kv[0] if len(kv) == 1 and is_contraction(kv[0]) and isinstance(kv[0].a, Load) else None
+
+
+def _lane_group(lay) -> Expr:
+    """The lane's fragment ROW GROUP (``_g``) written over ``_lane`` — the same value the fragment
+    store's ``lane_decl`` binds, for a reader that is not a fragment store."""
+    return BinaryExpr("/", BinaryExpr("%", Var("_lane"), Literal(32, "int")), Literal(lay.n_elems, "int"))
+
+
+@dataclass(frozen=True)
+class _ChainCols:
+    """The score tile's COLUMN offset — the K block it covers. Duck-types :class:`AxisOffset`'s one
+    reader (:meth:`base`): a block column has no grid block and no unit, only the block base."""
+
+    atom_dim: int
+    k0: Expr
+
+    def base(self, r: int) -> Expr:
+        return BinaryExpr("+", self.k0, Literal(r * self.atom_dim, "int")) if r else self.k0
+
+
+def _score_block(*, n_axis: Axis, score: Fold, mn: tuple[Side, Side], atom, cols: int, k0: Expr, lead: tuple, ns: str, epilogue=None):
+    """One BLOCK of the composed score, on the tensor core — ``mma(Q, Kᵀ)`` over the score's own
+    axis into C fragments covering ``tile_m × cols`` of the enclosing contraction's ``(m, K)`` plane.
+
+    Built out of the SAME atom strategy every tiled contraction dispatches through
+    (:func:`_atom_ops` on the score node), so there is no second mma emitter here: its ``state``
+    declares the fragments, its ``reduce`` emits the gmem-direct ``ldmatrix`` + ``mma.sync`` K-loop
+    over the score's own axis, and its ``store`` — when the caller supplies an ``epilogue`` — writes
+    them out. ``ns`` namespaces the fragments, so a nested emission never shadows the accumulators
+    the enclosing drain carries across the same loop.
+
+    The ROWS are the enclosing tile's own, warp-partitioned and ABSOLUTE (the score of a query row
+    belongs to that row, whichever warp owns it); the COLUMNS are the block, ``cols / atom_n``
+    register columns wide. Returns ``(ops, cells, offset, mn, stmts, frags)`` with ``frags[i]`` the
+    register row ``i``'s column fragments in column order."""
+    m, _ = mn
+    n_reg = cols // atom.atom_n
+    tile = TilePlan(atom=atom, units=(m.units, 1), regs=(m.reg, n_reg)).at(m.axis, replace(n_axis, extent=Dim(cols)))
+    ops = _atom_ops(score, tile, epilogue=epilogue, lead=lead, frag_ns=ns)
+    offset = (
+        AxisOffset(atom_dim=atom.atom_m, reg=m.reg, block_var=m.block, unit_var=m.unit, unit_count=m.units),
+        _ChainCols(atom_dim=atom.atom_n, k0=k0),
+    )
+    cells = [(i, j) for i in range(m.reg) for j in range(n_reg)]
+    decls = list(ops.state(cells))
+    _, region = ops.reduce(cells, offset, tile.mn)
+    frags = tuple(tuple(ops.frag(f"_c{i}_{j}") for j in range(n_reg)) for i in range(m.reg))
+    return ops, cells, offset, tile.mn, [*decls, *region], frags
+
+
+def _frag_lift(body, frags: tuple[tuple[str, ...], ...], acc: str) -> list[Stmt] | None:
+    """The score's own lift (its scale, a mask factor) re-expressed over the score FRAGMENTS — the
+    fragment-tier sibling of the scalar ``Assign``, one :class:`FragmentApply` per fragment. The
+    fragment operand is the score accumulator; every other argument is cell-uniform. Declines
+    (empty) for a lift stmt that does not read the accumulator — nothing else is expressible here."""
+    out: list[Stmt] = []
+    frag_names = {acc}
+    for s in body:
+        if not (set(s.deps()) & frag_names):
+            out.append(s)  # a cell-uniform stmt of the lift (the scale ``Load``) — scalar, once
+            continue
+        if not isinstance(s, Assign) or s.args[0] not in frag_names:
+            return None  # a shape the fragment tier cannot express — the caller keeps the scalar sweep
+        frag_names |= set(s.defines())
+        for row in frags:
+            for f in row:
+                out.append(
+                    FragmentApply(
+                        out=f,
+                        op=s.op,
+                        args=tuple(f if a in frag_names else (a if isinstance(a, str) else repr(a)) for a in s.args),
+                        kinds=tuple(FRAG if a in frag_names else UNIFORM for a in s.args),
+                        in_place=True,
+                    )
+                )
+    return out
+
+
+def chain_a_fill(
+    *, c: Fold, score: Fold, mn: tuple[Side, Side], atom, bk_elems: int, k0: Expr, slab: str, stats: tuple[str, ...], lead: tuple
+):
+    """The **CHAINED A fill** — the score contraction the cone composes, realized on the TENSOR CORE
+    with the cone as its store epilogue: ``mma(Q, Kᵀ) → C fragments → exp(s − m)·(1/d) → the A slab``
+    the ordinary ``ldmatrix`` drain then reads. The one fill that computes its slab with a nested
+    contraction instead of per-cell scalar code.
+
+    The statistics the cone reads arrive at each fragment element's own ROW, out of the stat rows
+    the prologue bridged; the slab ``Write`` lands at the element's LOCAL ``(row, col)`` — σ folds
+    the absolute cell coordinate back to the slab's own. Returns the fill stmts."""
+    m, _ = mn
+    row_base = _side_base(m)
+    local_row = BinaryExpr("-", Var(m.axis.name), row_base)
+    local_col = BinaryExpr("-", Var(c.axis.name), k0)
+    epilogue = Body(
+        (
+            *(Load(names=(nm,), input=_stat_slab(nm), index=(local_row,)) for nm in stats),
+            *c.a.body,
+            Write(output=slab, index=(local_row, local_col), value=c.a.out),
+        )
+    )
+    ops, cells, offset, smn, stmts, _ = _score_block(
+        n_axis=c.axis, score=score, mn=mn, atom=atom, cols=bk_elems, k0=k0, lead=lead, ns="_s", epilogue=epilogue
+    )
+    return [*stmts, *(s for i, j in cells for s in ops.store(i, j, offset, smn))]
+
+
+def chain_stat_fill(*, c: Fold, mn: tuple[Side, Side], atom, cols: int, stats: tuple[str, ...], lead: tuple) -> list[Stmt] | None:
+    """The **CHAINED statistic** — the cone's per-row streaming reduce swept at FRAGMENT residence.
+
+    The scalar prologue (:func:`sync_stat_fill`) folds one tile row per warp with the 32 lanes
+    striding it: it computes the same score the weight cone computes, one element at a time. Here
+    the sweep is BLOCKED and the score is a contraction like any other — per block the tile's
+    scores land in mma C-fragments (:func:`_score_block`), the block's row statistic comes off those
+    fragments through the layout's shuffle butterfly (:class:`FragmentRowReduce`), and the
+    carrier's OWN generated program merges the block into the running state: ``exp_merge`` at a
+    BLOCK singleton ``(rowmax, rowsum)`` instead of an element singleton — the same generator, the
+    same stability certificate, no attention vocabulary.
+
+    Each lane ends holding the statistic for the two rows the fragment layout gives it, so one lane
+    per column group publishes them to the stat rows the weight fill reads. ``None`` when this is
+    not that shape (no bindable producer, an expectation channel, a carrier the block merge cannot
+    spell) — the scalar prologue stands."""
+    cone = c.a
+    if not (isinstance(cone, Fold) and cone.axis is None and cone.operands):
+        return None
+    pro_node = cone.operands[0]
+    if not (isinstance(pro_node, Fold) and pro_node.axis is None and pro_node.operands):
+        return None
+    stat = pro_node.operands[0]
+    score = stat.operands[0] if isinstance(stat, Fold) and stat.axis is not None and len(stat.operands) == 1 else None
+    if not (isinstance(score, Fold) and score.axis is not None and is_contraction(score) and isinstance(score.a, Load)):
+        return None
+    names = tuple(stat.combine.results) if stat.combine is not None else ()
+    if len(names) != 2 or len(stat.lift.results) != 2 or stat.lift.results[1] != 1.0:
+        return None  # the (m, d) pair only — an expectation channel is the streaming form, not this
+    if not stat.axis.extent.is_static or stat.axis.extent.as_static() % cols:
+        return None  # the block sweep unrolls whole blocks
+    m, _ = mn
+    try:
+        lay = frag_layout(atom.atom_m, atom.atom_n)
+    except NotImplementedError:
+        return None  # an atom whose C layout the fragment tier does not model — the scalar prologue stands
+    if lay.rows_per_lane != 2:
+        return None
+    k0 = Var("_sb")
+    _ops, _cells, _off, _smn, stmts, frags = _score_block(
+        n_axis=stat.axis, score=score, mn=mn, atom=atom, cols=cols, k0=k0, lead=lead, ns="_t"
+    )
+    lift = _frag_lift(stat.lift.body, frags, score.acc)
+    if lift is None:
+        return None
+    body = [*stmts, *lift]
+    state = [[tuple(f"_ss{i}_{r}_{x}" for x in range(2)) for r in range(2)] for i in range(m.reg)]
+    for i in range(m.reg):
+        rmax, rsum, pw = (f"_rm{i}_0", f"_rm{i}_1"), (f"_rs{i}_0", f"_rs{i}_1"), tuple(f"_p{i}_{j}" for j in range(len(frags[i])))
+        body += [
+            FragmentRowReduce(top=rmax[0], bot=rmax[1], frags=frags[i], op=ElementwiseImpl("maximum"), group=lay.reduce_group),
+            *(
+                FragmentApply(out=pw[j], op=ElementwiseImpl("subtract"), args=(f, rmax), kinds=(FRAG, ROW), post=(ElementwiseImpl("exp"),))
+                for j, f in enumerate(frags[i])
+            ),
+            FragmentRowReduce(top=rsum[0], bot=rsum[1], frags=pw, op=ElementwiseImpl("add"), group=lay.reduce_group),
+        ]
+        for r in range(2):
+            body += list(exp_merge(state[i][r], (rmax[r], rsum[r]), key=state[i][r][0]))
+    # The stat rows the weight fill reads back — declared here, as the scalar prologue declares
+    # them; the carrier's own state is seeded by the sweep loop's ``Accum``\ s.
+    out: list[Stmt] = [Smem(name=_stat_slab(nm), extents=(mn[0].tile,), dtype="float") for nm in stats]
+    out.append(
+        StridedLoop(
+            axis=Axis(name=k0.name, extent=stat.axis.extent),
+            start=Literal(0, "int"),
+            step=Literal(cols, "int"),
+            body=Body(tuple(body)),
+            unroll=False,
+        )
+    )
+    # Publish: the statistic's scalar epilogue per owned row, then one lane per column group writes
+    # each bridged value into its stat row.
+    writes: list[Stmt] = []
+    for i in range(m.reg):
+        for r in range(2):
+            sfx = f"__r{i}{r}"
+            ren = dict(zip(names, state[i][r], strict=True))
+            for s in pro_node.body:
+                ren.update({d: f"{d}{sfx}" for d in s.defines()})
+                writes.append(s.rewrite(lambda nm, ren=ren: ren.get(nm, nm)))
+            local = BinaryExpr("+", BinaryExpr("*", Var(m.unit), Literal(m.reg * atom.atom_m, "int")), Literal(i * atom.atom_m, "int"))
+            # The layout's in-tile row offset, over ``_lane`` — this publish is a plain ``Write``,
+            # not a fragment store, so the ``lane_decl`` locals its ``Expr``\ s name are not in scope.
+            local = BinaryExpr("+", local, lay.row_off[r].substitute({"_g": _lane_group(lay)}))
+            writes += [Write(output=_stat_slab(nm), index=(local,), value=ren.get(nm, nm)) for nm in stats]
+    out.append(
+        Cond(cond=BinaryExpr("==", BinaryExpr("%", Var("_lane"), Literal(lay.reduce_group, "int")), Literal(0, "int")), body=tuple(writes))
+    )
+    out.append(Sync())
+    return out
+
+
 def _sync_operands(
     c: Fold,
     bk_elems: int,
@@ -548,6 +784,8 @@ def _sync_operands(
     swizzles: tuple[str, str] = ("NONE", "NONE"),
     channels=(),
     seam: tuple = ((), (), ()),
+    atom=None,
+    lead: tuple = (),
 ) -> tuple[tuple, tuple[SyncOperand, ...], tuple[Operand, ...], list[Stmt]]:
     """The ``smem`` compute fill's drain-ordered, computed, copied, and prologue operands.
 
@@ -595,12 +833,17 @@ def _sync_operands(
 
     prologue: list[Stmt] = []
     if stats:
+        # The CHAINED statistic first — the same score the weight fill mma's, swept at fragment
+        # residence, so the prologue is not the one half of attention left at scalar residence.
+        prologue = chain_stat_fill(c=c, mn=mn, atom=atom, cols=bk_elems, stats=stats, lead=lead) if isinstance(atom, AtomKind) else None
+    if stats and prologue is None:
         row_axis = Axis(name="_sr", extent=mn[0].tile)
         sigma = Sigma({m_name: m_coord(Var(row_axis.name))})
         row_body = [s.rewrite(lambda nm: nm, sigma) for s in pro]
         prologue = sync_stat_fill(
             stats=stats, slab_of=_stat_slab, row_axis=row_axis, row_body=row_body, cta=cta, stat=Reduction.of_cone_stat(c.a)
         )
+    prologue = prologue or []
     # One B slab per fold channel (the multi-B node fills each projection's weights alongside the
     # one compute-filled A slab); drain order is (A, B0, B1, …) regardless of which fill each rides.
     # ``swizzles`` are the per-operand slab modes (the mma tier's ``slab_swizzles``; NONE elsewhere):
@@ -625,7 +868,16 @@ def _sync_operands(
         )
         async_ops.append(a_op)
     else:
-        a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, swizzle=swizzles[0])
+        # The CHAINED fill where the cone composes a score CONTRACTION and the atom can mma it: the
+        # slab comes from one nested contraction (fragments → the cone's epilogue → the slab), not
+        # per-cell scalar code. NONE-swizzle by construction — the fragment store applies no XOR, so
+        # the drain must read the plain row-major slab.
+        score = chain_edge(c.a, c.axis.name) if isinstance(atom, AtomKind) else None
+        if score is not None:
+            chain = _chain_of(c=c, score=score, mn=mn, atom=atom, bk_elems=bk_elems, slab="_a_smem", stats=stats, lead=lead)
+            a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, chain=chain, swizzle="NONE")
+        else:
+            a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, swizzle=swizzles[0])
         sync_ops.append(a_op)
     drain.append(a_op)
 
@@ -689,7 +941,7 @@ def _staged(ops: _AtomOps, cells, offset, mn: tuple[Side, Side]):
         # that work — with ``cp.async``, or with the blocking vector copy on an atom whose target
         # has none. A term with no inline edge at all lands here too: then it is only the copy.
         operands, sync_ops, copy_ops, stat_pro = _sync_operands(
-            c, stage.bk_elems, mn, cta, ops.slab_swizzles(mn, elem.nbytes), ops.channels, ops.cone
+            c, stage.bk_elems, mn, cta, ops.slab_swizzles(mn, elem.nbytes), ops.channels, ops.cone, tile.atom, ops.lead
         )
         transport = SyncTransport(
             operands=sync_ops,
@@ -931,6 +1183,15 @@ class _AtomOps:
     # (``ops.cone_seam``). ``None`` for a
     # plain gmem-``Load`` A — its whole body is the per-cell fill.
     seam: tuple | None = None
+    # The register-fragment NAMESPACE. Empty for the kernel's own contraction; a NESTED one (the
+    # chained A fill's score, emitted inside the enclosing K-loop) prefixes its fragments so its
+    # ``_a`` / ``_b`` / ``_c`` do not shadow the accumulators the enclosing drain carries across
+    # that same loop.
+    frag_ns: str = ""
+
+    def frag(self, name: str) -> str:
+        """``name`` in this emission's fragment namespace (:attr:`frag_ns`)."""
+        return f"{self.frag_ns}{name}"
 
     @property
     def channels(self) -> tuple:
@@ -1063,7 +1324,7 @@ class _MmaOps(_AtomOps):
                 dtype=atom.operand_dtype("a"),
                 nregs=atom.fragment_nregs("a"),
             )
-            for nm in frags(lambda i: f"_a{i}", m.reg)
+            for nm in frags(lambda i: self.frag(f"_a{i}"), m.reg)
         ]
         for f in range(n_folds):
             decls += [
@@ -1074,11 +1335,11 @@ class _MmaOps(_AtomOps):
                     dtype=atom.operand_dtype("b"),
                     nregs=atom.fragment_nregs("b"),
                 )
-                for nm in frags(lambda i, ff=f: _fold_frag(f"_b{i}", ff), n.reg)
+                for nm in frags(lambda i, ff=f: _fold_frag(self.frag(f"_b{i}"), ff), n.reg)
             ]
         decls += [
             RegFragment(
-                name=_fold_frag(_mma_c_base(atom, i, j), f),
+                name=_fold_frag(self.frag(_mma_c_base(atom, i, j)), f),
                 role="c",
                 shape=atom.ptx_shape,
                 dtype=atom.operand_dtype("c"),
@@ -1092,7 +1353,7 @@ class _MmaOps(_AtomOps):
             # The f32 shadow accumulators — they keep the ``_c{i}_{j}`` names the store reads;
             # the packed f16 mma targets above are the ``_ch{i}_{j}`` family FragmentPromote folds.
             decls += [
-                RegFragment(name=_fold_frag(f"_c{i}_{j}", f), role="c", shape=atom.shape, dtype=F32)
+                RegFragment(name=_fold_frag(self.frag(f"_c{i}_{j}"), f), role="c", shape=atom.shape, dtype=F32)
                 for f in range(n_folds)
                 for i in range(m.reg)
                 for j in range(n.reg)
@@ -1122,7 +1383,7 @@ class _MmaOps(_AtomOps):
             idx = tuple(Sigma({m.axis.name: cell}).apply(e) for e in a_load.index)
             return [
                 LdmatrixLoad(
-                    frag=f"_a{i}",
+                    frag=self.frag(f"_a{i}"),
                     src_buffer=a_load.input,
                     src_index=idx,
                     role="a",
@@ -1138,7 +1399,7 @@ class _MmaOps(_AtomOps):
             idx = tuple(Sigma({n.axis.name: cell}).apply(e) for e in b_load.index)
             return [
                 LdmatrixLoad(
-                    frag=f"_b{j}",
+                    frag=self.frag(f"_b{j}"),
                     src_buffer=b_load.input,
                     src_index=idx,
                     role="b",
@@ -1153,9 +1414,9 @@ class _MmaOps(_AtomOps):
         def contract(i, j):
             return [
                 MmaSyncPtx(
-                    c_frag=_mma_c_base(atom, i, j),
-                    a_frag=f"_a{i}",
-                    b_frag=f"_b{j}",
+                    c_frag=self.frag(_mma_c_base(atom, i, j)),
+                    a_frag=self.frag(f"_a{i}"),
+                    b_frag=self.frag(f"_b{j}"),
                     shape=atom.ptx_shape,
                     ab_dtype=atom.ab_dtype,
                     c_dtype=atom.operand_dtype("c").name,
@@ -1193,7 +1454,7 @@ class _MmaOps(_AtomOps):
         sigma = Sigma({m.axis.name: mcell, n.axis.name: ncell})
         chans = self.channels
         accs = tuple(acc for _, acc in chans)
-        frags = (f"_c{i}_{j}", *(_fold_frag(f"_c{i}_{j}", f) for f in range(1, len(chans))))
+        frags = (self.frag(f"_c{i}_{j}"), *(_fold_frag(self.frag(f"_c{i}_{j}"), f) for f in range(1, len(chans))))
         writes = [s for s in tail if isinstance(s, Write)]
         if len(chans) > 1 and len(tail) == len(writes) == len(chans) and {w.value for w in writes} == set(accs):
             # RAW per-channel stores — the split-K partial's epilogue is one workspace ``Write``
@@ -1215,14 +1476,14 @@ class _MmaOps(_AtomOps):
                 for acc, frag in zip(accs, frags, strict=True)
             ]
         write = next(s for s in writes)
-        extra = tuple((acc, _fold_frag(f"_c{i}_{j}", f)) for f, (_, acc) in enumerate(chans[1:], 1))
+        extra = tuple((acc, _fold_frag(self.frag(f"_c{i}_{j}"), f)) for f, (_, acc) in enumerate(chans[1:], 1))
         epi = _warp_epilogue(tail, c.acc, m.axis.name, n.axis.name, sigma, extra_accs=extra)
         assert len(chans) == 1 or epi is not None, "a fused sibling group's projection must combine the accumulators"
         return [
             RegStore(
                 dst_buffer=write.output,
                 dst_index=tuple(sigma.apply(e) for e in write.index),
-                frag=f"_c{i}_{j}",
+                frag=self.frag(f"_c{i}_{j}"),
                 shape=atom.shape,
                 epilogue=epi,
                 m_guard=_guard(m, mcell),
@@ -1345,6 +1606,7 @@ def _atom_ops(
     epilogue: Body | None = None,
     seam=None,
     lead: tuple = (),
+    frag_ns: str = "",
 ) -> _AtomOps:
     """The **one** atom dispatch — select the codegen strategy off the atom kind. ``c`` is the
     stored algebra, ``tile`` the PLACED schedule slice (``TilePlan.at``) the geometry derives from.
@@ -1366,7 +1628,7 @@ def _atom_ops(
 
         c = Fold.contraction(k_axis=c.axis, a=make_cone([c.a], c.axis.name), channels=c.channels)
     cls = _MmaOps if isinstance(tile.atom, AtomKind) else _ScalarOps
-    return cls(c, tile, stage, inputs, workers, lead, Body(()) if epilogue is None else epilogue, seam)
+    return cls(c, tile, stage, inputs, workers, lead, Body(()) if epilogue is None else epilogue, seam, frag_ns)
 
 
 def reduce_codegen(c: Fold, tile: TilePlan, stage: Stage | None = None, inputs=None, workers=None, seam=None, lead: tuple = ()):

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -407,6 +407,10 @@ class SyncOperand:
     tag: str  # "a" / "b" — the smem-slab suffix
     shape: tuple[int, int]  # (rows, cols) of one ring slot
     value: Callable[[Expr, Expr, Expr], tuple[list[Stmt], str]]  # (k0, row, col) -> (stmts, name)
+    # The CHAINED fill: ``chain(k0)`` is the whole slab's stmts, computed by a NESTED CONTRACTION on
+    # the tensor core instead of per-thread cell code (``_atom.chain_a_fill`` — attention's score
+    # mma, the cone folded into its fragment store). Set ⇒ ``value`` is never called.
+    chain: Callable[[Expr], list[Stmt]] | None = None
     # Smem swizzle mode this slab is written with ("NONE"/"B32"/"B64"/"B128") — the mma tier's
     # `_MmaOps.slab_swizzles`, applied by the fill's ``Write`` (the same flattened-index XOR the
     # cp.async fill uses) and read back by the ``ldmatrix`` drain. NONE outside the mma tier
@@ -574,6 +578,9 @@ class SyncTransport:
         if k0_cur is None:
             return out
         for op in self.operands:
+            if op.chain is not None:
+                out += op.chain(k0_cur)  # the whole slab from one nested contraction — no per-cell run
+                continue
             rows, cols = op.shape
             v = _cp_async_width(cols, self.elem_bytes)
             fe = Axis(name=f"_f{op.tag}", extent=(rows * cols) // v)

--- a/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/010_recognize.py
@@ -24,17 +24,21 @@ step unconditional — no knobs):
    into one streaming online-softmax loop: a ``TWISTED`` reduce ``Loop`` carrying the
    exp-family merge dissolved in the body. The carrier is N-channel: a further sibling additive
    fold whose lifted value is the pair's weight × a value cone joins the same loop as an
-   EXPECTATION channel (loop-invariant factors split off, multiplied back after the loop), and
-   a pair whose channels sit inside a following free output sweep (fused softmax·V) sinks into
-   that sweep first. The ``_softmax`` helper (``_fuse``).
+   EXPECTATION channel (loop-invariant factors split off, multiplied back after the loop). A pair
+   whose channels sit inside a following free output sweep (fused softmax·V) stays at its own
+   level and is that sweep's per-row statistic. A pair whose step COMPOSES its score (the spliced
+   ``Q·Kᵀ`` producer) pairs on the cones' content, so the fused stream carries one copy of the
+   producer. The ``_softmax`` helper (``_fuse``).
 3. **Lift** — peel the free (parallel) axes off the kernel and lift the per-cell compute into a
    zero-axis ``Fold`` whose body holds the annotated reduce ``Loop`` + projection: a pure pointwise body is a
    flat zero-axis fold; a single flat reduce is annotated in place — ``CONTRACTION`` (clean contraction)
    / ``PLANAR`` (plain ``sum`` / ``max`` / ``mean``) / pre-annotated ``TWISTED`` (online softmax) —
-   with the projection after it. The free axes ride on
+   with the projection after it. A reduce nested in the reduce is the COMPOSED STEP where the
+   parser can read it as an operand edge (``_fromloop``), and the raw-loop escape where it cannot.
+   The free axes ride on
    the ``TileOp``'s schedule (the root's concern); ``_schedule`` maps them onto the grid. A cell
-   the lift can't cleanly factor (no reduce, several reduces, or a nested non-flash reduce) stays a
-   flat un-annotated zero-axis ``Fold`` (→ the scalar tier).
+   the lift can't cleanly factor (no reduce, several reduces, or a nested reduce the parser cannot
+   read) stays a flat un-annotated zero-axis ``Fold`` (→ the scalar tier).
 4. **The MONOID-producer composition** — a lifted ``Fold.projection(source=Fold)`` whose body is the
    statistic's scalar epilogue + a fresh free (column) ``Loop`` over one or more ⊗-folds of ONE
    shared A value reading the statistic (the fused norm→linear edge ``rmsnorm(x)·nw @ w``; its
@@ -47,7 +51,7 @@ step unconditional — no knobs):
    The schedule re-derives it and merges both forms' candidates into ONE fork, because which
    of the two a row realizes is a decision about the SCHEDULE.
 
-Flash must precede online-softmax which must precede the lift: each later step consumes the
+Online softmax must precede the lift: each later step consumes the
 ``Accum``\\ s an earlier one matches. A **symbolic** axis (dynamic ``seq_len``) is left
 un-lifted (the scalar ``Tile`` decode needs static extents) — the ``LoopOp`` stays put for
 the dynamic-shape tier.

--- a/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
@@ -26,6 +26,8 @@ geometry."""
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from emmy.compiler.ir.axis import Axis, AxisRole
 from emmy.compiler.ir.pure.fold import Channel, Fold, _operand_result_names, deep_reads, edge_refs_axis, refs_axis
 from emmy.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Write
@@ -109,6 +111,34 @@ def map_cone(body: list, root: str) -> list | None:
             continue
         return None  # an Accum / Loop in the cone — not a pure MAP producer
     return sorted(cone, key=lambda st: order[id(st)])
+
+
+def bound_producer(node: Fold, free: tuple, n_name: str) -> Fold | None:
+    """A producer the cone composes, re-read as a CONTRACTION — or ``None`` when it is not one.
+
+    The loop→fold parser stores a producer with its loads INLINE in the lift (an unbindable
+    contraction derives ``PLANAR`` — the formation fact), because node-locally nothing tells the
+    ``(m, n)`` roles apart. Here the roles ARE known: the cone's rows are one of the kernel's ``free``
+    axes and its columns are the enclosing contraction's ``n_name``, so the ONE ⊗-lift reading
+    (:func:`bind_contraction`) binds attention's score ``Σ_d Q·K`` as A = Q, B = Kᵀ. Storing it bound
+    is what lets the SCHEDULE see a contraction there instead of a scalar fold — the tile catalog is
+    keyed on the bilinear reading, and an inline node that never derives it can only be evaluated
+    per cell.
+
+    Tried against each free axis in turn: which one plays m is a property of the producer's own
+    operand indices, and asking the binder is cheaper than re-deriving that here."""
+    loop = node.loop
+    for ax in free:
+        if ax.name == n_name:
+            continue
+        try:
+            a_load, b_load, acc, _ = bind_contraction(loop, ax.name, n_name, Body())
+        except LoweringError:
+            continue
+        if not (isinstance(a_load, Load) and isinstance(b_load, Load)):
+            continue  # a producer with its OWN computed operand cone is not this shape
+        return Fold.contraction(k_axis=loop.axis, a=a_load, channels=(Channel(b=b_load, acc=acc),))
+    return None
 
 
 def make_cone(cell: list, k_name: str, stat=None, sweep=()) -> Fold:
@@ -408,6 +438,13 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Fold, Axis, tuple] | Non
         return None  # the statistic is a projected reduce; WHICH carrier it folds is not this binding's business
     if red.composed is not None:
         return None  # split-K's identity-lift reassociation is a partition, not a per-row statistic
+    # The statistic's OWN producer binds too, by the same reading — attention's streaming softmax
+    # composes the same score its weight cone does, and the schedule has to see a contraction in
+    # both places or the statistic stays a scalar sweep while the weight reaches the tensor core.
+    if len(red.operands) == 1 and isinstance(red.operands[0], Fold) and red.operands[0].axis is not None:
+        stat_score = bound_producer(red.operands[0], free, red.axis.name)
+        if stat_score is not None:
+            red = replace(red, operands=(stat_score,))
     body = list(op.body)
     if not body or not isinstance(body[-1], Loop) or body[-1].is_reduce:
         return None
@@ -445,6 +482,9 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Fold, Axis, tuple] | Non
     cone = map_cone(kbody, a_names[0])
     if cone is None or not cone:
         return None
+    # A producer the cone composes is stored BOUND where it reads as a contraction, so the schedule
+    # sees the bilinear reading (attention's score) instead of a scalar fold.
+    cone = [(bound_producer(st, free, k_ax.name) or st) if isinstance(st, Fold) and st.axis is not None else st for st in cone]
     for st in cone:
         if isinstance(st, Load) and n_ax.name in {v for e in st.index for v in e.free_vars()}:
             return None  # the cone must be (m, k)-indexed — an n-dependent producer isn't the A tile

--- a/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_atomize.py
@@ -27,7 +27,7 @@ geometry."""
 from __future__ import annotations
 
 from emmy.compiler.ir.axis import Axis, AxisRole
-from emmy.compiler.ir.pure.fold import Channel, Fold, refs_axis
+from emmy.compiler.ir.pure.fold import Channel, Fold, _operand_result_names, deep_reads, edge_refs_axis, refs_axis
 from emmy.compiler.ir.stmt import Accum, Assign, Load, Loop, Select, Write
 from emmy.compiler.ir.stmt.base import Stmt
 from emmy.compiler.ir.stmt.body import Body
@@ -57,11 +57,24 @@ def map_cone(body: list, root: str) -> list | None:
     coordinate-predicated ``Select`` (a pure MAP cone — a reduce-bearing cone, e.g. an rmsnorm
     scale, is not compute-fillable per cell). A ``Select`` is a pure value binding of the cell's
     own coordinates (an attention mask's additive term), so it fills per cell like any other
-    pointwise stmt; its coordinates decide the K seam through :func:`~emmy.compiler.ir.pure.fold.refs_axis`."""
+    pointwise stmt; its coordinates decide the K seam through :func:`~emmy.compiler.ir.pure.fold.refs_axis`.
+
+    One shape is not a MAP stmt and still belongs: a reduce ``Loop`` the cell READS (attention's
+    per-key score contraction). It enters the cone as a NODE, and :func:`make_cone` hangs it off the
+    cone's operands."""
+    from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop  # noqa: PLC0415 — parser, imported on demand
+
     defs: dict[str, Stmt] = {}
     for st in body:
         for d in st.defines():
             defs[d] = st
+        if isinstance(st, Loop) and st.is_reduce:
+            # A reduce ``Loop`` binds its carried states through the ``Accum``\ s in its body, so
+            # the cone walk has to learn that binding from the body rather than from ``defines``.
+            for a in st.body:
+                if isinstance(a, Accum):
+                    defs[a.name] = st
+    order = {id(st): i for i, st in enumerate(body)}
     need, cone, seen = [root], [], set()
     while need:
         nm = need.pop()
@@ -82,8 +95,19 @@ def map_cone(body: list, root: str) -> list | None:
             cone.append(st)
             need.extend(st.deps())
             continue
+        if isinstance(st, Loop) and st.is_reduce:
+            # A PRODUCER the cone composes (attention's per-key score contraction ``Σ_d Q·K``):
+            # not a pure MAP stmt but a node the cell READS, so it enters the cone as a node and
+            # :func:`make_cone` hangs it off the cone's operands, where the K seam reads it as the
+            # per-cell producer edge. Unreadable as a term ⇒ no cone (the raw-loop escape stands).
+            node = fold_from_loop(st)
+            if node is None:
+                return None
+            order[id(node)] = order[id(st)]  # the node stands in for its loop in body order
+            cone.append(node)
+            need.extend(deep_reads([st]) - {a.name for a in st.body if isinstance(a, Accum)})
+            continue
         return None  # an Accum / Loop in the cone — not a pure MAP producer
-    order = {id(st): i for i, st in enumerate(body)}
     return sorted(cone, key=lambda st: order[id(st)])
 
 
@@ -97,14 +121,28 @@ def make_cone(cell: list, k_name: str, stat=None, sweep=()) -> Fold:
     projected reduce, exactly the RMSNorm shape; the k-varying remainder is the cone's ``body``, the
     per-cell normalize. Everything downstream then READS that boundary (``ops.cone_seam``) instead of
     re-scanning stmts: the scheduler sizes the stat smem rows off it, the materializer runs the
-    prologue once per tile row and the body per cell."""
+    prologue once per tile row and the body per cell.
+
+    A producer NODE in ``cell`` is not a stmt of either side: it hangs off the cone's OPERANDS,
+    where ``cone_seam`` splits it by the same K seam — k-varying, so it is the per-cell producer
+    spliced ahead of its first use."""
+    # A PRODUCER NODE the cone composes hangs off the cone's OPERANDS, never its body (a term is
+    # an edge, not a statement of the cell): ``cone_seam`` then splits it by the same K seam it
+    # splits the stmts with — k-varying, so it is the per-cell producer spliced ahead of first use.
+    nodes = tuple(s for s in cell if isinstance(s, Fold))
+    cell = [s for s in cell if not isinstance(s, Fold)]
+    # A stmt READING a k-varying producer varies with k as surely as one that indexes it: the K
+    # seam is a dependency question, not only an index question. Without this, attention's
+    # ``exp(s − m)`` chain — which names the score rather than the KV axis — hoists into the
+    # row-invariant prologue, where the per-cell score it reads is not yet defined.
+    varying = {nm for n in nodes if edge_refs_axis(n, k_name) for nm in _operand_result_names(n)}
     pro: list = []
     rest = list(cell)
-    while rest and not refs_axis(rest[0], k_name):
+    while rest and not refs_axis(rest[0], k_name) and not (set(rest[0].deps()) & varying):
         pro.append(rest.pop(0))
     prologue = Fold.projection(body=Body((*sweep, *pro)), operands=() if stat is None else (stat,))
     src = (prologue,) if (pro or sweep or stat is not None) else ()
-    return Fold.projection(body=Body(tuple(rest)), operands=src)
+    return Fold.projection(body=Body(tuple(rest)), operands=(*src, *nodes))
 
 
 def _hoist_k_invariant_factors(body: list, lift: Assign, a_leaf: Load, b_leaf: Load, k_name: str, acc: str, epilogue: Body):
@@ -368,8 +406,8 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Fold, Axis, tuple] | Non
     red = op.operands[0]
     if red.role not in (AxisRole.PLANAR, AxisRole.TWISTED):
         return None  # the statistic is a projected reduce; WHICH carrier it folds is not this binding's business
-    if any(isinstance(s, Fold) for s in red.step_stmts()) or any(isinstance(e, Fold) for e in red.operands):
-        return None  # a composed reduce (its partial or an operand edge holds a node) is not the bare statistic shape
+    if red.composed is not None:
+        return None  # split-K's identity-lift reassociation is a partition, not a per-row statistic
     body = list(op.body)
     if not body or not isinstance(body[-1], Loop) or body[-1].is_reduce:
         return None
@@ -413,7 +451,9 @@ def bind_prologue_contraction(op, free: tuple) -> tuple[Fold, Axis, tuple] | Non
     # Every free SSA name the cone reads must be a statistic (the source reduce's carried state or
     # its scalar epilogue) — anything else is a shape this binding doesn't understand.
     stat_defs = {red.out} | {nm for s in stat_epi for nm in s.defines()}
-    cone_defs = {nm for st in cone for nm in st.defines()}
+    # A producer NODE in the cone binds through its own carried state, not ``defines`` — the same
+    # reading the operand binding uses (``_operand_result_names``).
+    cone_defs = {nm for st in cone for nm in (_operand_result_names(st) if isinstance(st, Fold) else st.defines())}
     free_refs = {a for st in cone if isinstance(st, (Assign, Select)) for a in st.deps() if a not in cone_defs}
     if not free_refs or not free_refs <= stat_defs:
         return None  # a stat-free cone is the demoted option's shape, not ours

--- a/emmy/compiler/pipeline/passes/lowering/tile/_fromloop.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_fromloop.py
@@ -5,15 +5,41 @@ This is a PARSER, not part of the term vocabulary — it belongs with the passes
 body's own ``Accum``\\s, so a loop carries no side-band algebra; the byte-identity gate in
 :func:`fold_from_loop` is what lets the extractors stay shape-strict without a correctness burden
 — a shape that does not read off cleanly returns ``None`` and the caller keeps the raw-loop-IR
-escape."""
+escape.
+
+A step is not always flat. A reduce whose per-element step COMPOSES producers it computes itself —
+attention's per-key score contraction ``Σ_d Q·K`` inside the streaming softmax statistic — reads
+with each producer lifted to an operand EDGE (:func:`_hoist_step_nodes`, recursively through this
+same parser), the lift binding its carried state positionally. That is the shape the derived step
+already spells on the way out (``Fold._twisted_derived_step`` places an inline-node edge at its
+first use and ``_flatten_nodes`` lowers it back), so the byte-identity gate validates the composed
+reading exactly as it validates a flat one — and a merged attention cell keeps its schedule tiers
+instead of falling to the escape."""
 
 from __future__ import annotations
 
+from dataclasses import replace
+
+from emmy.compiler.ir.axis import AxisRole
 from emmy.compiler.ir.pure import Lambda, M, component_ops
-from emmy.compiler.ir.pure.fold import Fold, is_contraction
-from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Select
+from emmy.compiler.ir.pure.fold import Fold, _operand_result_names, is_contraction
+from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Select, Stmt
 from emmy.compiler.ir.stmt.normalize import rename_ssa_sequential
 from emmy.compiler.ir.tile.ops import head, reduce_loop
+
+
+def _unannotated(body) -> tuple:
+    """``body`` with every nested reduce ``Loop``'s :class:`AxisRole` annotation stripped, deep.
+
+    The role is a DERIVED read of the algebra, never stored (``ir/tile``'s one loop annotation), so
+    a composed step's producer loop carries it in the RE-DERIVED spelling and not in the raw
+    pre-annotation body the parser reads. Comparing role-blind keeps the byte-identity proof about
+    the program and drops the accidental dependence on whether a nested loop happens to have been
+    annotated yet — the same reason :func:`_same_program` compares at the canonical SSA spelling."""
+    out: list[Stmt] = []
+    for s in Body.coerce(body):
+        out.append(replace(s, role=AxisRole.FREE, body=Body(_unannotated(s.body))) if isinstance(s, Loop) else s)
+    return tuple(out)
 
 
 def _same_program(a, b) -> bool:
@@ -24,18 +50,46 @@ def _same_program(a, b) -> bool:
     regenerating and comparing, loses every carrier that has been lowered and re-lifted. Comparing
     at the canonical spelling keeps the proof and drops the accidental dependence on which pass
     happened to name the temps."""
-    a, b = Body.coerce(a), Body.coerce(b)
+    a, b = Body(_unannotated(a)), Body(_unannotated(b))
     return a == b or rename_ssa_sequential(a) == rename_ssa_sequential(b)
 
 
-def _extract_lift(loop: Loop, like: Fold | None = None) -> tuple[Lambda, tuple, Lambda] | None:
+def _hoist_step_nodes(prefix: list[Stmt]) -> tuple[tuple, list[Stmt]] | None:
+    """Split a reduce step's prefix into ``(inline-node operand edges, pure stmts)`` — the
+    COMPOSED-step reading.
+
+    A nested reduce ``Loop`` in the step (attention's per-key score contraction ``Σ_d Q·K``) is not
+    a statement of the lift: it is a producer the step READS, so it lifts to an operand EDGE
+    through this same parser, recursively, and the lift binds its accumulator name positionally.
+    Returns ``None`` when a nested loop does not read off cleanly — the caller keeps the raw-loop
+    escape. Nothing here has to prove the placement: the derived step re-splices every edge ahead
+    of the first read of its bound name (``splice_operands``) and flattens it back to its own loop
+    nest, so :func:`fold_from_loop`'s byte-identity gate validates the whole reading."""
+    edges: list[Fold] = []
+    pure: list[Stmt] = []
+    for s in prefix:
+        if isinstance(s, Fold):
+            edges.append(s)  # already a node (a step the pairing composed) — an edge as it stands
+            continue
+        if isinstance(s, Loop) and s.is_reduce:
+            node = fold_from_loop(s)
+            if node is None:
+                return None
+            edges.append(node)
+            continue
+        pure.append(s)
+    return tuple(edges), pure
+
+
+def _extract_lift(loop: Loop, like: Fold | None = None) -> tuple[Lambda, tuple, Lambda, tuple] | None:
     """Read the λ spelling off a reduce ``Loop`` whose body is the dissolved ``[pure lift stmts…,
     Accum folds]`` sequence — ANNOTATION-FREE: every fact (accumulator names, channel ops, folded
     values) is read off the body's ``Accum``\\ s themselves, and threads into
     :func:`~emmy.compiler.ir.pure.algebra.M` with the loop's REAL accumulator names. Returns
-    ``(lift, init, combine)`` — the flat ⊕ pair — or ``None`` when the shape does not read
-    off cleanly (a composed step, an effectful stmt, an identity-less op) — the caller keeps the
-    raw-loop escape. A TWISTED (exp-family) loop has no self-describing ``Accum`` spelling (its
+    ``(lift, init, combine, operand edges)`` — the flat ⊕ pair plus the producers the step composes
+    (:func:`_hoist_step_nodes`) — or ``None`` when the shape does not read off cleanly (an
+    effectful stmt, an identity-less op, a nested producer this parser cannot read) — the caller
+    keeps the raw-loop escape. A TWISTED (exp-family) loop has no self-describing ``Accum`` spelling (its
     merge interleaves ``base``-``Accum`` folds with ψ rescales), so it extracts only against a
     ``like`` fold carrying the algebra (:func:`_extract_twisted_lift` — the 030 split-partial
     path; recognition builds twisted folds directly, never through here). :meth:`Fold.from_loop`
@@ -51,11 +105,16 @@ def _extract_lift(loop: Loop, like: Fold | None = None) -> tuple[Lambda, tuple, 
         # A ``base``-``Accum`` is the ψ-rescale signature of a dissolved exp-family merge — the
         # twisted spelling reconstructs from the body alone (the byte-compare is the validator).
         return _extract_twisted_self(loop)
+    hoisted = _hoist_step_nodes(prefix)
+    if hoisted is None:
+        return None  # a nested producer this parser cannot read — the flat zero-axis escape
+    edges, prefix = hoisted
     if any(not s.pure for s in prefix):
         return None  # an effectful / raw-block step is not λ-representable (the flat zero-axis escape)
     names = tuple(a.name for a in accums)
+    bound = tuple(n for e in edges for n in _operand_result_names(e))
     try:
-        lift = Lambda(params=(loop.axis.name,), body=Body(tuple(prefix)), results=tuple(a.value for a in accums))
+        lift = Lambda(params=(loop.axis.name, *bound), body=Body(tuple(prefix)), results=tuple(a.value for a in accums))
         init, combine = M(*(a.op for a in accums), names=names)
     except ValueError:
         return None  # an undefined result / identity-less op — not the canonical dissolved shape
@@ -64,19 +123,20 @@ def _extract_lift(loop: Loop, like: Fold | None = None) -> tuple[Lambda, tuple, 
         # ``Accum``\\ s come back dtype-free, so the byte-identity gate would reject the fold
         # anyway. Decline here and keep the raw-loop escape rather than silently dropping it.
         return None
-    return lift, init, combine
+    return lift, init, combine, edges
 
 
-def _extract_twisted_self(loop: Loop) -> tuple[Lambda, tuple, Lambda] | None:
+def _extract_twisted_self(loop: Loop) -> tuple[Lambda, tuple, Lambda, tuple] | None:
     """Reconstruct the exp-family λ spelling from a TWISTED reduce ``Loop``'s body ALONE — no
     side-band algebra: the state is ``(the maximum-Accum, the add-Accums in body order)`` (the
     generator emits them exactly there), the pivot term is the maximum's folded score, and each
     non-pivot term is either the literal ``1.0`` (a denominator) or an external value name (an
     expectation) — resolved by regenerating the streaming merge per candidate and comparing it
     against the body's tail up to SSA temp names (:func:`_same_program`; ``exp_merge`` is
-    deterministic, so equality is proof). The pure
-    prefix ahead of the merge becomes the ``lift`` body. Returns ``None`` when no candidate
-    matches — a composed step (flash's in-step folds) or a foreign merge spelling.
+    deterministic, so equality is proof). The prefix ahead of the merge splits into the producers
+    the step composes (operand edges) and the pure stmts that become the ``lift`` body. Returns
+    ``None`` when no candidate matches — a foreign merge spelling, or a nested producer this parser
+    cannot read.
 
     The prefix is the pure score cone, ``Select`` included: a coordinate-predicated value binding
     (an attention mask's additive term) is an ordinary pure stmt of the score, and the merge over
@@ -107,19 +167,24 @@ def _extract_twisted_self(loop: Loop) -> tuple[Lambda, tuple, Lambda] | None:
         prefix = body[: -len(merge)]
         if not _same_program((*prefix, *merge), body):
             continue
-        if any(not isinstance(s, (Load, Assign, Select)) for s in prefix):
-            return None  # a composed step keeps the raw-loop escape
+        hoisted = _hoist_step_nodes(list(prefix))
+        if hoisted is None:
+            return None  # a nested producer this parser cannot read — the raw-loop escape
+        edges, pure = hoisted
+        if any(not isinstance(s, (Load, Assign, Select)) for s in pure):
+            return None  # an effectful / raw-block step keeps the raw-loop escape
+        bound = tuple(n for e in edges for n in _operand_result_names(e))
         try:
-            lift = Lambda(params=(loop.axis.name,), body=Body(prefix), results=(score, *combo))
+            lift = Lambda(params=(loop.axis.name, *bound), body=Body(tuple(pure)), results=(score, *combo))
         except ValueError:
             return None
         other = tuple(f"{n}__o" for n in names)
         combine = Lambda(params=names + other, body=Body(exp_combine_states(names, other)), results=names)
-        return lift, (float("-inf"),) + (0.0,) * len(adds), combine
+        return lift, (float("-inf"),) + (0.0,) * len(adds), combine, edges
     return None
 
 
-def _extract_twisted_lift(loop: Loop, like: Fold) -> tuple[Lambda, tuple, Lambda] | None:
+def _extract_twisted_lift(loop: Loop, like: Fold) -> tuple[Lambda, tuple, Lambda, tuple] | None:
     """Read the λ spelling off an exp-family TWISTED reduce ``Loop`` against the ``like`` fold
     that carries its algebra (the 030 split partial — the sliced loop's state names are the
     original fold's): the body must be ``[pure score prefix…, the dissolved streaming merge]``
@@ -151,7 +216,7 @@ def _extract_twisted_lift(loop: Loop, like: Fold) -> tuple[Lambda, tuple, Lambda
         lift = Lambda(params=(loop.axis.name,), body=Body(prefix), results=terms)
     except ValueError:
         return None
-    return lift, (float("-inf"),) + (0.0,) * (len(names) - 1), like.combine
+    return lift, (float("-inf"),) + (0.0,) * (len(names) - 1), like.combine, ()
 
 
 def fold_from_loop(loop: Loop, like: Fold | None = None) -> Fold | None:
@@ -169,8 +234,8 @@ def fold_from_loop(loop: Loop, like: Fold | None = None) -> Fold | None:
     lifted = _extract_lift(loop, like)
     if lifted is None:
         return None
-    lift, init, combine = lifted
-    fold = Fold(axis=loop.axis, unroll=loop.unroll, lift=lift, init=init, combine=combine)
+    lift, init, combine, edges = lifted
+    fold = Fold(axis=loop.axis, unroll=loop.unroll, operands=edges, lift=lift, init=init, combine=combine)
     # The byte-identity gate — a non-reproducible BODY keeps the raw-loop escape. The role
     # annotation is the fold's own DERIVED read, deliberately excluded: an unbindable matvec
     # captures a CONTRACTION-shaped loop and derives PLANAR — the 1l demotion, now a

--- a/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
@@ -149,14 +149,19 @@ def _lift_cell(cell: list[Stmt], free: list, output: str) -> tuple[Fold, tuple]:
     reduce ``Loop`` in place (``CONTRACTION`` / ``PLANAR`` / pre-annotated ``TWISTED``), its body
     holding the reduce loop followed by the projection — stripped to just the loop when the only
     epilogue is the grid-cell ``Write`` (materialize stores ``out`` as glue). A cell with no, or
-    several, or a nested reduce stays a flat zero-axis fold (un-annotated → the scalar tier)."""
+    several, reduces stays a flat zero-axis fold (un-annotated → the scalar tier), and so does one
+    whose nested reduce the parser cannot read as a COMPOSED STEP (an operand edge of the step's
+    fold — ``_fromloop``; attention's spliced score contraction is the one it can)."""
     reduces = [i for i, s in enumerate(cell) if isinstance(s, Loop) and s.is_reduce]
     if len(reduces) != 1:
         return _flat_cell(cell)
     idx = reduces[0]
     rloop = cell[idx]
-    if _reduce_in(list(rloop.body)):
-        return _flat_cell(cell)  # nested (non-flash) reduce — keep loop-IR form
+    if _reduce_in(list(rloop.body)) and fold_from_loop(rloop) is None:
+        # A nested reduce this parser cannot read as a COMPOSED STEP — keep loop-IR form. One it
+        # CAN read (attention's per-key score contraction inside the streaming statistic) lifts
+        # with the producer as an operand edge, so the cell keeps a schedule tier.
+        return _flat_cell(cell)
     # Route the loop-invariant prologue (stmts above the reduce, sans the regenerated ``Init``
     # seeds) one dependency cone at a time: stmts feeding the reduce move INTO the loop
     # (``pre_reduce``), while independent stmts feeding only the epilogue stay after it. Treating

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -78,7 +78,7 @@ from emmy.compiler.ir.atom import atoms_for
 from emmy.compiler.ir.axis import Axis, Window
 from emmy.compiler.ir.expr import BinaryExpr, Literal, Var
 from emmy.compiler.ir.pure import Lambda, M
-from emmy.compiler.ir.pure.fold import Fold, is_contraction, operand_body
+from emmy.compiler.ir.pure.fold import Fold, edge_refs_axis, is_contraction, operand_body
 from emmy.compiler.ir.schedule import Level as _ReduceLevel
 from emmy.compiler.ir.schedule import (
     Raster,
@@ -1508,16 +1508,20 @@ def _factor_k(k_axis: Axis, w: int) -> tuple[Axis, Axis, Sigma]:
     return ksplit, kslice, sigma
 
 
-def _sliced_edge(edge, sigma: Sigma):
+def _sliced_edge(edge, sigma: Sigma, k_name: str):
     """An operand edge σ-reindexed to absolute k for a split partition — the SAME rule on either
     edge. A MATERIALIZED edge rewrites its gmem index; a COMPUTED cone rewrites its per-cell BODY
-    only — the REDUNDANT-STATISTIC split: the cone's row-invariant prologue (the per-row statistic,
-    the K seam ``ops.cone_seam`` reads off the node boundary) spans the whole row and stays
-    FULL-ROW in every partition, each recomputing it. That redundancy is what the split trades for
-    parallelism; whether it pays on a given shape is evidence's decision."""
+    and every K-VARYING producer edge it composes (attention's per-cell score contraction — the
+    slice's own k coordinate reaches gmem through that node, so leaving it unreindexed makes every
+    partition recompute partition 0's scores). The cone's row-invariant prologue (the per-row
+    statistic, the K seam ``ops.cone_seam`` reads off the node boundary) spans the whole row and
+    stays FULL-ROW in every partition, each recomputing it — the REDUNDANT-STATISTIC split. That
+    redundancy is what the split trades for parallelism; whether it pays on a given shape is
+    evidence's decision."""
     if isinstance(edge, Load):
         return replace(edge, index=tuple(sigma.apply(e) for e in edge.index))
-    return edge.with_bodies((Body(tuple(s.rewrite(lambda nm: nm, sigma) for s in edge.body)),))
+    ops = tuple(e.rewrite(lambda nm: nm, sigma) if edge_refs_axis(e, k_name) else e for e in edge.operands)
+    return replace(edge, operands=ops).with_bodies((Body(tuple(s.rewrite(lambda nm: nm, sigma) for s in edge.body)),))
 
 
 def _splitk_option(term: _Term, plan: TilePlan, node, rplan: ReducePlan, name: str, knobs: dict, nested: Sequence[tuple] = ()) -> TileOp:
@@ -1541,8 +1545,8 @@ def _splitk_option(term: _Term, plan: TilePlan, node, rplan: ReducePlan, name: s
     ksplit, kslice, sigma = _factor_k(node.axis, rplan.cta)
     inner = Fold.contraction(
         k_axis=kslice,
-        a=_sliced_edge(node.a, sigma),
-        channels=tuple(replace(ch, b=_sliced_edge(ch.b, sigma)) for ch in node.channels),
+        a=_sliced_edge(node.a, sigma, node.axis.name),
+        channels=tuple(replace(ch, b=_sliced_edge(ch.b, sigma, node.axis.name)) for ch in node.channels),
     )
     # ONE composition rule: the outer reduce is the IDENTITY lift over the sliced contraction
     # operand, its combine the componentwise additive ⊕ over the same accumulator names — the

--- a/emmy/compiler/pipeline/passes/lowering/tile/_softmax.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_softmax.py
@@ -41,6 +41,13 @@ the same binding the norm→linear edge uses (``_atomize.bind_prologue_contracti
 puts the region on the contraction schedule catalog — the warp/mma tier, the staged transports and
 split-K — instead of a per-cell serial fold, and it is why the pair must NOT be pushed into the
 sweep: inside it the statistic is recomputed once per output column.
+
+A pair's score is whatever its step produces. It is usually a ``Load``; when the step COMPOSES the
+score instead (loop fusion spliced the ``Q·Kᵀ`` producer into it), the cone's one source is that
+producer NODE and the pairing compares the two passes' cones by CONTENT — every bound name and
+each nested loop's iteration var α-renamed in walk order (:func:`_cone_canon`), since two
+separately-traced copies of one score differ in exactly those. The fused stream then carries ONE
+copy of the producer where the pair carried two.
 """
 
 from __future__ import annotations
@@ -54,6 +61,7 @@ from emmy.compiler.ir.expr import Var
 from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.pure import component_ops
 from emmy.compiler.ir.pure.carrier import exp_merge
+from emmy.compiler.ir.pure.fold import Fold, operand_name
 from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop, Select
 from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
@@ -77,35 +85,58 @@ def _fold_of(loop: Loop, canon: str):
     ops = component_ops(f.combine)
     if ops is None or [op.reduce_canon for op in ops] != [canon]:
         return None
-    return f.combine.results[0], f.lift.results[0], list(f.lift.body)
+    # The step's own producer NODES ride back as body members (the COLLAPSE view,
+    # :meth:`Fold.demoted` — each edge inline as the structural node, before its first read): a
+    # composed step (attention's per-key score contraction) reads as an operand edge, and the
+    # pairing's cone walk reads a producer the same way whether it is a ``Load`` or a node.
+    return f.combine.results[0], f.lift.results[0], list(f.demoted().lift.body)
 
 
-def _score_cone(body: list, result: str) -> tuple[list, Load] | None:
+def _score_cone(body: list, result: str) -> tuple[list, object] | None:
     """The pure elementwise cone producing ``result`` from a pair-loop body: the
     :meth:`Body.backward_cone` members (body order) restricted to ``Load``/``Assign``/``Select``
-    reaching exactly ONE ``Load``. Names defined outside the loop (an enclosing-scope value, an
-    axis var) surface as external reads and stay free. ``None`` when the value depends on
+    reaching exactly ONE SOURCE — a ``Load``, or a producer NODE the step composes (attention's
+    per-key score contraction), which leads the returned cone. Names defined outside the loop (an
+    enclosing-scope value, an axis var) surface as external reads and stay free. ``None`` when the value depends on
     anything else — the pairing then declines and the cell keeps its current reading."""
-    cone = Body.coerce(tuple(s for s in body if not isinstance(s, Accum))).backward_cone([result])
+    nodes = {operand_name(s): s for s in body if isinstance(s, Fold)}
+    if result in nodes:
+        return [nodes[result]], nodes[result]  # the bare node score — the degenerate cone
+    cone = Body.coerce(tuple(s for s in body if not isinstance(s, (Accum, Fold)))).backward_cone([result])
     stmts = list(cone.members)
     if not stmts or any(not isinstance(s, (Load, Assign, Select)) for s in stmts):
         return None
-    loads = [s for s in stmts if isinstance(s, Load)]
-    if len(loads) != 1:
+    used = [n for n in nodes if n in {a for s in stmts for a in s.deps()}]
+    srcs = [s for s in stmts if isinstance(s, Load)] + [nodes[n] for n in used]
+    if len(srcs) != 1:
         return None
-    return stmts, loads[0]
+    return [*(nodes[n] for n in used), *stmts], srcs[0]
+
+
+def _cone_names(stmts: list, mapping: dict) -> None:
+    """Number every name a cone BINDS, deep — the stmts' defs plus each nested loop's iteration
+    var — in walk order. A composed cone's producer node carries its own axis and temps, and two
+    separately-traced copies of one score differ in exactly those, so identity has to see through
+    them (the key digest cannot: axis names are recognition-canonical and part of it)."""
+    for s in stmts:
+        if isinstance(s, Loop):
+            mapping.setdefault(s.axis.name, f"_c{len(mapping)}")
+        for n in s.defines():
+            mapping.setdefault(n, f"_c{len(mapping)}")
+        for b in s.nested():
+            _cone_names(list(b), mapping)
 
 
 def _cone_canon(stmts: list, result: str, axis_name: str) -> str:
-    """An α-renamed rendering of a score cone — locally-defined names canonicalize in definition
-    order, the loop axis to a fixed placeholder, free names verbatim — so the two pair loops'
-    recomputed score cones compare by content, exactly as the byte-identity λ gate compares
-    lift bodies."""
+    """An α-renamed rendering of a score cone — every bound name canonicalizes in walk order
+    (:func:`_cone_names`), the loop axis to a fixed placeholder, free names verbatim — so the two
+    pair loops' recomputed score cones compare by content, exactly as the byte-identity λ gate
+    compares lift bodies. A producer NODE in the cone renders through its own lowered nest, so a
+    composed score compares like any other."""
+    flat = [t for s in stmts for t in (s.lower() if isinstance(s, Fold) else [s])]
     mapping = {axis_name: "_ax"}
-    for s in stmts:
-        for n in s.defines():
-            mapping.setdefault(n, f"_c{len(mapping)}")
-    text = repr(tuple(stmts)) + "|" + mapping.get(result, result)
+    _cone_names(flat, mapping)
+    text = repr(tuple(flat)) + "|" + mapping.get(result, result)
     for old, new in mapping.items():
         text = re.sub(f"'{re.escape(old)}'", f"'{new}'", text)
     return text
@@ -230,16 +261,20 @@ def _deep_reads(stmts) -> set[str]:
     return out
 
 
-def _score_head(maxacc: str, score: str, cone: list, ld: Load) -> tuple[str, tuple]:
+def _score_head(maxacc: str, score: str, cone: list, ld) -> tuple[str, tuple]:
     """The fused loop's streaming score prefix. A bare-``Load`` score keeps the historical
-    renamed spelling; a composite score cone rides verbatim."""
-    if len(cone) == 1:
+    renamed spelling; a composite score cone — and a cone whose one source is a producer NODE
+    (attention's per-key score contraction) — rides verbatim."""
+    if len(cone) == 1 and isinstance(ld, Load):
         src = f"{maxacc}__osin"
         return src, (Load(name=src, input=ld.input, index=ld.index),)
-    return score, tuple(cone)
+    # The emitted prefix is LOOP IR: a producer node in the cone rides as its own loop nest (a
+    # ``Fold`` may only be a child of a ``Fold``, never a member of a raw ``Loop`` body). The
+    # twisted reading hoists it straight back to an operand edge (``_fromloop._hoist_step_nodes``).
+    return score, tuple(t for s in cone for t in (s.lower() if isinstance(s, Fold) else [s]))
 
 
-def _twist(s: Loop, maxacc: str, sumacc: str, score: str, cone: list, ld: Load, canon: str, rest: list) -> tuple[list, int]:
+def _twist(s: Loop, maxacc: str, sumacc: str, score: str, cone: list, ld, canon: str, rest: list) -> tuple[list, int]:
     """Emit the fused streaming loop for a matched ``(rowmax, Σexp)`` pair, joining every
     EXPECTATION channel that follows. Returns ``(emitted stmts, extra stmts consumed from
     ``rest``)``.
@@ -293,7 +328,7 @@ def _last_channel(region: list) -> int:
     return max(i + 1 for i, (t, _) in enumerate(region) if t is not None)
 
 
-def _emit_channels(s: Loop, maxacc: str, sumacc: str, score: str, cone: list, ld: Load, region: list) -> list | None:
+def _emit_channels(s: Loop, maxacc: str, sumacc: str, score: str, cone: list, ld, region: list) -> list | None:
     """Build the N-channel fused loop + its epilogue for a pair and its joined channels.
     ``region`` interleaves held-back pure stmts (re-emitted after the loop, original order)
     with ``(channel loop, channel read)`` entries. Declines (``None``) when a held-back

--- a/plans/fa-chained-a-fill.md
+++ b/plans/fa-chained-a-fill.md
@@ -1,0 +1,82 @@
+# FA restoration — the chained A fill
+
+Continues the FA-through-the-codec campaign (Stage 1 N-channel pairing, Stage 2 TWISTED computed-A bind, Stage 3's
+lowering half). This plan covers what is left after the COMPOSED STEP landed: the realization that makes the fused
+single-kernel form worth deploying.
+
+## What landed with this plan's first commit
+
+Recognition of the single-kernel form is complete, end to end from a real SDPA trace:
+
+- **The composed step reads.** `lowering/tile/_fromloop._hoist_step_nodes` lifts a nested reduce `Loop` in a step's
+  prefix to an operand EDGE (recursively through the same parser); `_same_program` compares role-blind, because the
+  `AxisRole` is a derived read the raw pre-annotation body does not carry. `Fold._twisted_derived_step` PLACES its
+  inline-node edges at first use instead of prepending, so a loop-invariant prologue ahead of the producer survives
+  the byte-identity gate.
+- **The pairing matches composed passes.** `_softmax._score_cone` accepts one SOURCE that may be a producer node;
+  `_cone_canon` α-renames every bound name and each nested loop's iteration var in walk order, so two
+  separately-traced copies of one score compare equal. The fused stream carries ONE copy of the producer.
+- **The cone binds over a computed score.** `_atomize.map_cone` nodifies a producer the cone reads;
+  `make_cone` hangs it off the cone's OPERANDS (never its body) and the K seam treats a stmt reading a k-varying
+  producer as k-varying; `bind_prologue_contraction`'s bare-statistic gate now refuses only the identity-lift
+  (split-K) composition.
+- **Split-K reindexes it.** `_schedule._sliced_edge` σ-rewrites the cone's k-varying producer edges — without it every
+  partition recomputed partition 0's scores (wrong results, not slow ones).
+
+Verified: with `loop/fusion/_merge`'s reduce-in-reduce and multi-statistic refusals lifted, SDPA lowers to ONE kernel
+and matches torch at `(1,1,32,16)` and `(1,2,64,16)` f16 on a 5090 (`D = 128` stops at a PARTIAL merge — see the
+blowup bound below — and also matches). `scripts/digest_kernels.py` is byte-identical on all 30 cases (the corpus does
+not reach the new arm), and `tests/` is green but for the quant e2e failure that reproduces on `main`.
+
+## Why fusion still refuses
+
+`_merge._nests_reduce` stays as it was, and the criterion is REVERSIBILITY. `Q·Kᵀ` has two consumers in the merged
+cell (the streaming statistic and the weight cone); splicing duplicates it at each demand site and no `PLACE` cut puts
+it back — a cut fragment serves ONE consumer, so cutting both seams mints two score kernels, never the one shared
+producer the unmerged graph had. Measured on the 5090 at `(1,8,512,128)` f16 with both refusals lifted: 1360 µs — a
+1352 µs statistic kernel whose score is a scalar dot per element, plus a 7.7 µs PV kernel — against 21.6 µs for the
+two-kernel graph the refusal preserves. Lift the refusal only when the fill below makes the fused form win.
+
+## The OTHER refusal: `_total_work`'s blowup bound
+
+`_merge`'s cost metric counts arithmetic leaves times their enclosing iteration product, and in LOOP IR the merged
+score sits inside the output-column sweep — `for n { for kv { for d } } }` — so it counts `D` times over. The realized
+fill computes it once per `(m, kv)` slab cell and shares it across the column tile, but the pass cannot see that.
+Measured: `D = 16` merges (ratio at the `_BLOWUP_FACTOR = 8` bound), `D = 128` is refused outright. Any plan that lifts
+`_nests_reduce` has to answer this too — either the metric learns that a k-invariant-in-`n` producer does not replay
+per column, or the merge is offered at the seam rather than judged by leaf count.
+
+## The work: score mma → cone epilogue on the C fragments → A slab
+
+The fill EVALUATES the cone's k-varying producer per slab cell (`_atom._sync_operands.a_value` splices the lowered
+loop into each cell), so the score is a scalar dot per cell — and it is computed twice, once in the row statistic and
+once in the weight. Both halves are the same defect: a score contraction realized at scalar residence.
+
+1. **Give the producer edge a schedule site.** `1a47f4fc` made an inline node carry no slice family (`Site.inline`) —
+   correct while the fill can only evaluate it per cell, wrong once the fill can TILE it. The edge needs a `TILE`
+   slice (its own `(m, kv)` geometry over the slab) plus a `STAGE` for its own Q / K operands.
+2. **Emit the chain.** In the `smem` fill: `ldmatrix` Q once per query tile, mma the score into C fragments over the
+   head-dim, apply the cone body on those fragments, store into the A slab the existing `_MmaOps.staged_drain` reads.
+   The Kernel IR for the fragment half survived the flash deletion and is still dead code kept for this:
+   `FragmentApply`, `FragmentRowReduce`, `FragmentMask`, `FragmentBiasAdd`, `FragmentRepack`.
+3. **Block the statistic.** The row statistic cannot come from the fragments while it spans the whole KV row, so the
+   twisted fold blocks: `exp_merge` at a BLOCK singleton `(m_b, d_b, o_b)` — the SAME generator, `_certify` still
+   passes — with the per-block quantities reduced off the score fragments (`FragmentRowReduce`) and the outer step
+   rescaling the O fragments by α. That is FA-2, and `tests/compiler/e2e/test_attention_coverage.py`'s hand-written
+   `fa2` kernel is its executable spec (lane layouts, the C→A handoff, the 4-lane butterfly).
+4. **Schedule + legality.** `_schedule._row_stream_tiles` and `_warp_stream_place` are live orphans from the flash era
+   — the materialization half of the `(score, P@V)` streaming pair and its grid (query axis shrunk to its CTA-block
+   count, value axis folded into the P@V fragment, KV walked serially per CTA). The enumeration half (`_stream_tiles`)
+   was deleted and has to come back. Legality: the score tile must fit in C fragments.
+5. **Then** lift `_merge._nests_reduce`'s refusal and let evidence price fused against cut.
+
+### Rejected, do not redo
+
+`Fold.hoisted()` (the inverse of `demoted()`) — `_derived_expect_fold` hardcodes `Axis("pj", Dim(1))` so
+`legal.warp_k_step` can never pass, `_has_computed_operand` closes the scalar-tile tier, and `_schedule._keeps_children`
+prunes the site. Measured and reverted once already.
+
+### Open question
+
+`_derived_expect_fold`'s `pj` singleton is what makes the twisted fold's own PV a rank-1 update. Re-axing it to the KV
+block is step 3's other half; the flash era did it with `Fold.with_axis`, which no longer exists.

--- a/plans/fa-chained-a-fill.md
+++ b/plans/fa-chained-a-fill.md
@@ -63,16 +63,25 @@ emitter, no attention vocabulary:
 
 Measured on a 5090, f16 `(1, 8, 512, D)`, cold greedy, fused arm vs the two-kernel graph vs torch:
 
-| D | torch | two-kernel | fused, per-cell | fused, chained |
+| shape | torch | two-kernel | fused, per-cell | fused, chained |
 | --- | --- | --- | --- | --- |
-| 16 | 8 µs | 38.3 µs | 219 µs | **14.0 µs** |
-| 32 | 8 µs | 24.9 µs | — | **13.8 µs** |
-| 64 | 10 µs | 28.7 µs | — | 29.7 µs |
-| 128 | 19 µs | 21.6 µs | — | 69.2 µs |
+| S=512 D=16 | 8 µs | 38.3 µs | 219 µs | **14.0 µs** |
+| S=512 D=32 | 8 µs | 24.9 µs | — | **13.8 µs** |
+| S=512 D=64 | 10 µs | 28.7 µs | — | 29.7 µs |
+| S=512 D=128 | 19 µs | 21.6 µs | — | 69.2 µs |
+| S=1024 D=128 | 45 µs | 72.1 µs | — | 370.6 µs |
+| S=2048 D=128 | 145 µs | 179.5 µs | — | 1039.3 µs |
 
-So the chained fused form WINS at small head dims (2.7× / 1.8×), ties at 64 and LOSES 3.2× at 128 — because it still
-computes `Q·Kᵀ` TWICE (once for the statistic, once for the weight), and that duplicate grows with D. That is why
-fusion still refuses: real models are D = 64 / 128.
+So the chained fused form WINS at small head dims (2.7× / 1.8× at D ≤ 32) and loses badly as either D or S grows. Two
+distinct causes, and the second is the bigger one:
+
+1. It computes `Q·Kᵀ` TWICE (statistic, then weight) — a fixed 1.5× flop penalty that grows in absolute terms with D.
+2. **The nested score is gmem-direct.** `_score_block` passes `stage=None`, so both the statistic sweep and the weight
+   fill read Q and K straight from gmem with no slab and no reuse: per query tile the statistic re-reads the WHOLE KV
+   row of K. At S=2048 D=128 that is 512 KB of K per query tile × 1024 query tiles ≈ 512 MB of reads, against the
+   two-kernel `Q·Kᵀ` kernel's staged, tiled, TMA-fed slabs. That is why the gap WIDENS with S rather than closing.
+
+That is why fusion still refuses: real models are D = 64 / 128 at long sequence.
 
 ## What makes it win at every D: the SINGLE-PASS sweep
 
@@ -89,9 +98,13 @@ FA-2 computes the score once. Two things stand between here and that, and the ma
 That removes the second `Q·Kᵀ` and the statistic prologue entirely. Then re-measure the table above and, if the fused
 arm wins at D = 64 / 128, lift `_merge._nests_reduce` (and the blowup bound below) so evidence prices it.
 
-## Still open
+## Still open, in the order that pays
 
-- **The single-pass sweep** (above) — the one thing that makes the fused arm win at D = 64 / 128.
+- **Stage the nested score's operands.** The biggest lever, and the reason the gap widens with S: `_score_block` runs
+  gmem-direct. Its K needs a slab (and its Q a fragment held across the KV sweep — today Q is re-loaded per KV chunk
+  per D-chunk). Note the nesting: `_staged` inside a fill puts a `__syncthreads()` inside the outer K-loop body, which
+  is legal only because every thread reaches the fill — check that before relying on it.
+- **The single-pass sweep** (above) — removes the second `Q·Kᵀ` and, with it, the second pass over K.
 - **A schedule site for the score.** `1a47f4fc` made an inline node carry no slice family (`Site.inline`), which was
   right while the fill could only evaluate it per cell. The chained fill derives the score's tile from the enclosing
   one instead, so nothing is pinnable there yet: its `bk`, its own staging, and the warp split of its rows are all

--- a/plans/fa-chained-a-fill.md
+++ b/plans/fa-chained-a-fill.md
@@ -46,29 +46,60 @@ Measured: `D = 16` merges (ratio at the `_BLOWUP_FACTOR = 8` bound), `D = 128` i
 `_nests_reduce` has to answer this too — either the metric learns that a k-invariant-in-`n` producer does not replay
 per column, or the merge is offered at the seam rather than judged by leaf count.
 
-## The work: score mma → cone epilogue on the C fragments → A slab
+## LANDED: the chained fill and the chained statistic
 
-The fill EVALUATES the cone's k-varying producer per slab cell (`_atom._sync_operands.a_value` splices the lowered
-loop into each cell), so the score is a scalar dot per cell — and it is computed twice, once in the row statistic and
-once in the weight. Both halves are the same defect: a score contraction realized at scalar residence.
+Both halves of the composed score now reach the tensor core, through `_atom_ops` on the score node — no second mma
+emitter, no attention vocabulary:
 
-1. **Give the producer edge a schedule site.** `1a47f4fc` made an inline node carry no slice family (`Site.inline`) —
-   correct while the fill can only evaluate it per cell, wrong once the fill can TILE it. The edge needs a `TILE`
-   slice (its own `(m, kv)` geometry over the slab) plus a `STAGE` for its own Q / K operands.
-2. **Emit the chain.** In the `smem` fill: `ldmatrix` Q once per query tile, mma the score into C fragments over the
-   head-dim, apply the cone body on those fragments, store into the A slab the existing `_MmaOps.staged_drain` reads.
-   The Kernel IR for the fragment half survived the flash deletion and is still dead code kept for this:
-   `FragmentApply`, `FragmentRowReduce`, `FragmentMask`, `FragmentBiasAdd`, `FragmentRepack`.
-3. **Block the statistic.** The row statistic cannot come from the fragments while it spans the whole KV row, so the
-   twisted fold blocks: `exp_merge` at a BLOCK singleton `(m_b, d_b, o_b)` — the SAME generator, `_certify` still
-   passes — with the per-block quantities reduced off the score fragments (`FragmentRowReduce`) and the outer step
-   rescaling the O fragments by α. That is FA-2, and `tests/compiler/e2e/test_attention_coverage.py`'s hand-written
-   `fa2` kernel is its executable spec (lane layouts, the C→A handoff, the 4-lane butterfly).
-4. **Schedule + legality.** `_schedule._row_stream_tiles` and `_warp_stream_place` are live orphans from the flash era
-   — the materialization half of the `(score, P@V)` streaming pair and its grid (query axis shrunk to its CTA-block
-   count, value axis folded into the P@V fragment, KV walked serially per CTA). The enumeration half (`_stream_tiles`)
-   was deleted and has to come back. Legality: the score tile must fit in C fragments.
-5. **Then** lift `_merge._nests_reduce`'s refusal and let evidence price fused against cut.
+- **`_score_block`** — one block of the composed score as C fragments, built from the same atom strategy every tiled
+  contraction dispatches through, namespaced by `_AtomOps.frag_ns` so a nested emission never shadows the enclosing
+  drain's accumulators.
+- **`chain_a_fill`** — the A slab from that block, the cone folded into its fragment store (`RegStore` + `RegEpilogue`,
+  statistics read at each element's own row). NONE-swizzle: a fragment store applies no address XOR.
+- **`chain_stat_fill`** — the per-row statistic swept at fragment residence: `FragmentRowReduce` off the score
+  fragments, then `exp_merge` at a BLOCK singleton `(rowmax, rowsum)` — the same generator, the same certificate.
+- Recognition stores BOTH score sites bound as contractions (`_atomize.bound_producer`), which is what lets the
+  schedule see a contraction instead of a scalar fold.
+
+Measured on a 5090, f16 `(1, 8, 512, D)`, cold greedy, fused arm vs the two-kernel graph vs torch:
+
+| D | torch | two-kernel | fused, per-cell | fused, chained |
+| --- | --- | --- | --- | --- |
+| 16 | 8 µs | 38.3 µs | 219 µs | **14.0 µs** |
+| 32 | 8 µs | 24.9 µs | — | **13.8 µs** |
+| 64 | 10 µs | 28.7 µs | — | 29.7 µs |
+| 128 | 19 µs | 21.6 µs | — | 69.2 µs |
+
+So the chained fused form WINS at small head dims (2.7× / 1.8×), ties at 64 and LOSES 3.2× at 128 — because it still
+computes `Q·Kᵀ` TWICE (once for the statistic, once for the weight), and that duplicate grows with D. That is why
+fusion still refuses: real models are D = 64 / 128.
+
+## What makes it win at every D: the SINGLE-PASS sweep
+
+FA-2 computes the score once. Two things stand between here and that, and the machinery for both now exists:
+
+1. **Hoist the `1/d` out of the cone.** `Σ_kv (exp(s−m)/d)·V = (1/d)·Σ_kv exp(s−m)·V` — the invariant-factor split
+   Stage 1 already built (`_softmax.split_invariant_factors`), applied to the cone rather than to a sibling fold. The
+   weight the A slab carries must not name a `d` that is not final yet.
+2. **Carry the statistic in the weight loop.** Per KV block: score fragments → rowmax → merge into the running
+   `(m, d)` → `P = exp(s − M)` → the A slab → rescale the OUTER C fragments by `α = exp(m_old − M)`
+   (`FragmentApply(in_place=True)` over `_c{i}_{j}` — they are in scope inside the K-loop) → the PV drain. The final
+   `O / d` lands in the output store's epilogue.
+
+That removes the second `Q·Kᵀ` and the statistic prologue entirely. Then re-measure the table above and, if the fused
+arm wins at D = 64 / 128, lift `_merge._nests_reduce` (and the blowup bound below) so evidence prices it.
+
+## Still open
+
+- **The single-pass sweep** (above) — the one thing that makes the fused arm win at D = 64 / 128.
+- **A schedule site for the score.** `1a47f4fc` made an inline node carry no slice family (`Site.inline`), which was
+  right while the fill could only evaluate it per cell. The chained fill derives the score's tile from the enclosing
+  one instead, so nothing is pinnable there yet: its `bk`, its own staging, and the warp split of its rows are all
+  implied. A `TILE` / `STAGE` slice on the producer edge is what makes them searchable.
+- **`units_n > 1` duplicates the fill.** Warps that differ only in their N unit own the same A-slab rows and each
+  compute them — same values, wasted work. Guard it, or require `units_n == 1` in legality.
+- **`_schedule._row_stream_tiles` / `_warp_stream_place`** are still live orphans from the flash era (the `(score,
+  P@V)` streaming pair's materialization half and its grid). The single-pass sweep is where they come back.
 
 ### Rejected, do not redo
 

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -25,13 +25,15 @@ softmax reduce. This file pins every tier of it:
   into the A slab) and the CHAINED statistic (``_atom.chain_stat_fill``: ``FragmentRowReduce`` off
   those fragments, ``exp_merge`` at a BLOCK singleton). Measured on a 5090 at f16 (1,8,512,16):
   219 µs per-cell → 108 µs with the fill chained → **14.0 µs** with both, against 38.3 µs for the
-  two-kernel graph and 8 µs for torch. What is still missing is the SINGLE PASS: the fused form
-  computes ``Q·Kᵀ`` twice (statistic, then weight), and that duplicate grows with the head dim — it
-  wins 2.7× at D=16, ties at 64 and loses 3.2× at 128, which is why loop fusion still refuses to
-  nest the score reduce inside the softmax reduce (``loop/fusion/_merge._nests_reduce`` — the
-  refusal is REVERSIBILITY: no ``PLACE`` cut puts a two-consumer producer back together). Closing it
-  is FA-2 proper: hoist the ``1/d`` out of the cone and carry the statistic in the weight loop,
-  rescaling the output fragments per block (the reference kernel below is the executable spec).
+  two-kernel graph and 8 µs for torch. The fused arm wins 2.7× / 1.8× at D ≤ 32 and loses as either
+  the head dim or the sequence grows (S=512 D=128: 69 vs 21.6; S=2048 D=128: 1039 vs 180), for two
+  reasons: it computes ``Q·Kᵀ`` twice (statistic, then weight), and the nested score is gmem-direct,
+  so the statistic re-reads the whole KV row of K per query tile where the two-kernel ``Q·Kᵀ``
+  streams staged slabs. That is why loop fusion still refuses to nest the score reduce inside the
+  softmax reduce (``loop/fusion/_merge._nests_reduce`` — the refusal is REVERSIBILITY: no ``PLACE``
+  cut puts a two-consumer producer back together). Closing it needs the nested score STAGED and the
+  sweep made SINGLE-pass (hoist the ``1/d`` out of the cone, carry the statistic in the weight loop,
+  rescale the output fragments per block) — the reference kernel below is that form's spec.
 - **validated FA-2 reference** — a hand-written fused tensor-core flash kernel, the executable spec a
   future through-the-contraction-path tensor-core flash tier must reproduce.
 - **model attention chains** — TinyLlama ``LlamaAttention`` bisection (chained Linears → QKV+SDPA →

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -14,14 +14,20 @@ softmax reduce. This file pins every tier of it:
   ``softmax·V`` half of SDPA is one contraction over the KV axis and takes the warp/mma tier, the
   staged transports and split-K wherever the target's atoms admit a compute-filled ``a`` edge
   (sm_80+; Volta's atoms are materialized-edges-only). The score contraction still lands in its own
-  kernel. The TERM for the single-kernel form needs nothing new — a score contraction on the cone's
-  per-cell edge lowers, schedules and runs (``test_cone_per_cell_edge_is_evaluated_inline_and_carries_no_slice``) —
-  but the fill EVALUATES that edge per slab cell, so the score is computed scalar, and twice (once
-  for the row statistic, once for the weight). Measured on a V100 that fused form is 5× slower than
-  the two-kernel split at S=32/D=16 and far worse as S grows, which is why loop fusion still refuses
-  to nest the score reduce inside the softmax reduce. What closes the gap is RESIDENCE, not algebra:
-  the block's score must stay in C fragments across both consumers (the reference kernel below) —
-  the warp chain (score mma, fragment online-softmax, C->A repack) the flash deletion removed.
+  kernel. RECOGNITION of the single-kernel form is complete: a reduce whose step composes its own
+  producer reads with that producer on an operand edge (``lowering/tile/_fromloop`` — the COMPOSED
+  STEP), the online-softmax pair matches on the two passes' score cones by content, and the sweep
+  binds as one computed-A contraction whose cone reads a COMPUTED score
+  (``test_cone_per_cell_edge_is_evaluated_inline_and_carries_no_slice``); with the merge allowed,
+  SDPA lowers to ONE kernel and matches torch. What is missing is the REALIZATION: the fill
+  EVALUATES the score edge per slab cell, so it is computed scalar, and twice (once for the row
+  statistic, once for the weight). Measured on a V100 that fused form is 5× slower than the
+  two-kernel split at S=32/D=16 and far worse as S grows, which is why loop fusion still refuses to
+  nest the score reduce inside the softmax reduce (``loop/fusion/_merge._nests_reduce`` — the
+  refusal is REVERSIBILITY: no ``PLACE`` cut puts a two-consumer producer back together). What
+  closes the gap is RESIDENCE, not algebra: the block's score must stay in C fragments across both
+  consumers (the reference kernel below) — the warp chain (score mma, fragment online-softmax,
+  C->A repack) the flash deletion removed.
 - **validated FA-2 reference** — a hand-written fused tensor-core flash kernel, the executable spec a
   future through-the-contraction-path tensor-core flash tier must reproduce.
 - **model attention chains** — TinyLlama ``LlamaAttention`` bisection (chained Linears → QKV+SDPA →
@@ -162,6 +168,46 @@ def test_scalar_flash_matches_torch(monkeypatch, variant):
             assert "fmaxf" in srcs and "expf" in srcs, "the kernel set should carry the softmax (max + exp)"
         md = _max_diff(backend, compiled, feed, ref)
         assert md < 1e-4, f"{variant}{cfg}: sdpa vs torch max_diff={md:.6e}"
+
+
+@requires_cuda
+@pytest.mark.parametrize("cfg", [(1, 1, 32, 16), (1, 2, 64, 16)])
+def test_fused_single_kernel_sdpa_matches_torch(monkeypatch, cfg):
+    """SDPA lowers to ONE kernel and matches torch when the merge is allowed.
+
+    Loop fusion refuses to nest the score reduce inside the softmax reduce, and that refusal is a
+    REVERSIBILITY judgement, not a capability one (``loop/fusion/_merge._nests_reduce``: the
+    ``Q·Kᵀ`` producer has two consumers in the merged cell, so splicing duplicates it and no
+    ``PLACE`` cut puts it back). Lifting the refusal here pins the capability behind it — the
+    COMPOSED-STEP reading (``lowering/tile/_fromloop``), the pairing on composed score cones, the
+    computed-A bind over a COMPUTED score, and split-K's σ-reindex of the cone's producer edge —
+    so the recognition path cannot rot while the fill that makes the fused form worth deploying is
+    built. Perf is deliberately not asserted: the fill evaluates the score per slab cell, which is
+    why fusion still refuses (see this module's docstring).
+
+    The configs stay at ``D = 16`` because the other refusal — ``_total_work``'s blowup bound — is
+    real here: in LOOP IR the merged score sits inside the output-column sweep, so its cost counts
+    ``D`` times even though the realized fill computes it once per ``(m, kv)`` slab cell and shares
+    it across the column tile. At ``D = 128`` the bound refuses the merge outright."""
+    from emmy.compiler.pipeline.passes.loop.fusion import _merge  # noqa: PLC0415
+
+    monkeypatch.setattr(_merge, "_nests_reduce", lambda _op: False)
+    monkeypatch.setattr(_merge, "_entangled_multi_stat", lambda _op: False)
+    monkeypatch.setenv("EMMY_PLACE", "fuse")  # authoritative: keep the merged tree whole, so the count is not greedy's
+    torch.manual_seed(0)
+    B, H, S, D = cfg
+    q, k, v = (torch.randn(B, H, S, D, dtype=torch.float16) for _ in range(3))
+    feed = {"q": q.numpy(), "k": k.numpy(), "v": v.numpy()}
+    cuda = {n: torch.from_numpy(a).cuda() for n, a in feed.items()}
+
+    def ref():
+        with torch.no_grad():
+            return F.scaled_dot_product_attention(cuda["q"], cuda["k"], cuda["v"]).cpu().flatten().float().numpy()
+
+    backend, compiled, _graph, kernels = _trace(_Sdpa(), (q, k, v))
+    assert len(kernels) == 1, f"the merged cell must lower to ONE kernel, got {len(kernels)}: {kernels}"
+    md = _max_diff(backend, compiled, feed, ref)
+    assert md < 4e-3, f"fused sdpa{cfg} vs torch max_diff={md:.6e}"
 
 
 @requires_cuda

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -19,15 +19,19 @@ softmax reduce. This file pins every tier of it:
   STEP), the online-softmax pair matches on the two passes' score cones by content, and the sweep
   binds as one computed-A contraction whose cone reads a COMPUTED score
   (``test_cone_per_cell_edge_is_evaluated_inline_and_carries_no_slice``); with the merge allowed,
-  SDPA lowers to ONE kernel and matches torch. What is missing is the REALIZATION: the fill
-  EVALUATES the score edge per slab cell, so it is computed scalar, and twice (once for the row
-  statistic, once for the weight). Measured on a V100 that fused form is 5× slower than the
-  two-kernel split at S=32/D=16 and far worse as S grows, which is why loop fusion still refuses to
+  SDPA lowers to ONE kernel and matches torch. The REALIZATION follows it: both halves of the
+  composed score reach the tensor core through ``_atom_ops`` on the score node — the CHAINED A fill
+  (``_atom.chain_a_fill``: mma into C fragments, the cone folded into their fragment store, straight
+  into the A slab) and the CHAINED statistic (``_atom.chain_stat_fill``: ``FragmentRowReduce`` off
+  those fragments, ``exp_merge`` at a BLOCK singleton). Measured on a 5090 at f16 (1,8,512,16):
+  219 µs per-cell → 108 µs with the fill chained → **14.0 µs** with both, against 38.3 µs for the
+  two-kernel graph and 8 µs for torch. What is still missing is the SINGLE PASS: the fused form
+  computes ``Q·Kᵀ`` twice (statistic, then weight), and that duplicate grows with the head dim — it
+  wins 2.7× at D=16, ties at 64 and loses 3.2× at 128, which is why loop fusion still refuses to
   nest the score reduce inside the softmax reduce (``loop/fusion/_merge._nests_reduce`` — the
-  refusal is REVERSIBILITY: no ``PLACE`` cut puts a two-consumer producer back together). What
-  closes the gap is RESIDENCE, not algebra: the block's score must stay in C fragments across both
-  consumers (the reference kernel below) — the warp chain (score mma, fragment online-softmax,
-  C->A repack) the flash deletion removed.
+  refusal is REVERSIBILITY: no ``PLACE`` cut puts a two-consumer producer back together). Closing it
+  is FA-2 proper: hoist the ``1/d`` out of the cone and carry the statistic in the weight loop,
+  rescaling the output fragments per block (the reference kernel below is the executable spec).
 - **validated FA-2 reference** — a hand-written fused tensor-core flash kernel, the executable spec a
   future through-the-contraction-path tensor-core flash tier must reproduce.
 - **model attention chains** — TinyLlama ``LlamaAttention`` bisection (chained Linears → QKV+SDPA →
@@ -206,6 +210,13 @@ def test_fused_single_kernel_sdpa_matches_torch(monkeypatch, cfg):
 
     backend, compiled, _graph, kernels = _trace(_Sdpa(), (q, k, v))
     assert len(kernels) == 1, f"the merged cell must lower to ONE kernel, got {len(kernels)}: {kernels}"
+    src = compiled.nodes[kernels[0]].op.kernel_source
+    # Both halves of the composed score reach the TENSOR CORE: the score's transposed-B fragment
+    # load (its own mma, not the enclosing P@V's staged drain) and the statistic's fragment
+    # row-reduce butterfly. Without these the score is a scalar dot per element — 15x slower, and a
+    # silent regression a numerics assert would never catch.
+    assert "emmy_mma_load_b_gmem_trans" in src, "the composed score is not on the mma tier (chained A fill)"
+    assert "__shfl_xor_sync" in src, "the statistic is not at fragment residence (chained statistic)"
     md = _max_diff(backend, compiled, feed, ref)
     assert md < 4e-3, f"fused sdpa{cfg} vs torch max_diff={md:.6e}"
 

--- a/tests/compiler/ir/tile/test_path_codec.py
+++ b/tests/compiler/ir/tile/test_path_codec.py
@@ -68,7 +68,11 @@ def _flash_tree() -> tuple[Fold, Fold, Fold, Fold]:
     """The flash shape, λ-spelled (step 7 — mirroring ``_flash._flash_op``): the stream fold
     reduces ``kv`` with the QK (axis ``dd``) score fold hoisted as ``operands[0]`` and the value
     ``Load`` as ``operands[1]``; the PV (axis ``pj``) contraction is DERIVED — synthesized into
-    the blocked evaluation, found among ``stream.step_stmts()``."""
+    the blocked evaluation, found among ``stream.step_stmts()``.
+
+    Both are read by AXIS, not by position: the derived step PLACES an inline-node edge at the
+    first read of its bound name, so the score sits after any lift stmt that precedes it (here the
+    ``scale`` ``Load``)."""
     from emmy.compiler.ir.pure import Lambda
     from emmy.compiler.ir.pure.carrier import exp_combine_states
 
@@ -87,7 +91,7 @@ def _flash_tree() -> tuple[Fold, Fold, Fold, Fold]:
         init=(float("-inf"), 0.0, 0.0),
         combine=Lambda(params=names + other, body=Body(exp_combine_states(names, other)), results=names),
     )
-    pv = next(s for s in stream.step_stmts()[1:] if isinstance(s, Fold) and s.role is AxisRole.CONTRACTION)  # the derived PV site
+    pv = next(s for s in stream.step_stmts() if isinstance(s, Fold) and s.axis.name == "pj")  # the derived PV site
     root = Fold.projection(body=Body((Write(output="y", value="O_i", index=(Var("m"), Var("d"))),)), operands=(stream,))
     return root, stream, qk, pv
 

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -28,7 +28,7 @@ from emmy.compiler.ir.tensor.ir import ElementwiseOp, ReduceOp
 from emmy.compiler.ir.tile import TileOp
 from emmy.compiler.pipeline import TILE_PASSES, Pipeline
 from emmy.compiler.pipeline.fork import flatten_leaves
-from emmy.compiler.pipeline.passes.lowering.tile._fromloop import fold_from_loop
+from emmy.compiler.pipeline.passes.lowering.tile._fromloop import _same_program, fold_from_loop
 from emmy.compiler.pipeline.pipeline import Run
 
 
@@ -430,6 +430,116 @@ def test_cone_per_cell_edge_reaches_the_per_cell_emitter():
     defined = {nm for s in body for nm in deep_defines(s)} | stmt_axis_names(body) | {"m", "n", "kvb"}
     assert "s2" in defined, "the cone's score edge never reached the emitted body"
     assert deep_reads(list(body)) <= defined, f"the emitted body reads an undefined name: {deep_reads(list(body)) - defined}"
+
+
+# --------------------------------------------------------------------------------------------- #
+# The COMPOSED STEP — a reduce whose per-element step reads a producer it computes itself
+# (attention's per-key score contraction ``Σ_d Q·K`` inside the streaming softmax statistic).
+# --------------------------------------------------------------------------------------------- #
+
+
+def _score_loop(kv: str, dd: str, acc: str, tag: str) -> Loop:
+    """``Σ_dd Q[m, dd]·K[kv, dd]`` as a raw reduce ``Loop`` — the per-key score, spelled the way
+    loop fusion leaves it when it splices the QK producer into its consumer's step."""
+    return Loop(
+        axis=Axis(dd, Dim(16)),
+        body=Body(
+            (
+                Load(names=(f"kl{tag}",), input="k", index=(Var(kv), Var(dd))),
+                Load(names=(f"ql{tag}",), input="q", index=(Var("m"), Var(dd))),
+                Assign(name=f"pr{tag}", op="multiply", args=(f"kl{tag}", f"ql{tag}")),
+                Accum(name=acc, value=f"pr{tag}", op="add", axes=(dd,)),
+            )
+        ),
+    )
+
+
+def _composed_rowmax() -> Loop:
+    """The row-max pass over a COMPUTED score: ``max_kv (Σ_d Q·K)·scale``."""
+    return Loop(
+        axis=Axis("kv", Dim(32)),
+        body=Body(
+            (
+                _score_loop("kv", "d0", "s0", "0"),
+                Assign(name="sc0", op="multiply", args=("s0", 0.25)),
+                Accum(name="mx", value="sc0", op="maximum", axes=("kv",)),
+            )
+        ),
+    )
+
+
+def _composed_sumexp() -> Loop:
+    """The ``Σ exp(score − mx)`` pass over its own copy of the same computed score."""
+    return Loop(
+        axis=Axis("kv", Dim(32)),
+        body=Body(
+            (
+                _score_loop("kv", "d1", "s1", "1"),
+                Assign(name="sc1", op="multiply", args=("s1", 0.25)),
+                Assign(name="df", op="subtract", args=("sc1", "mx")),
+                Assign(name="ex", op="exp", args=("df",)),
+                Accum(name="dn", value="ex", op="add", axes=("kv",)),
+            )
+        ),
+    )
+
+
+def test_composed_step_reads_its_producer_as_an_operand_edge():
+    """A reduce whose step computes what it folds reads as a fold with the producer on an OPERAND
+    EDGE — not as the raw-loop escape. The lift binds the producer's carried state positionally,
+    and ``fold_from_loop``'s byte-identity gate proves the reading: the derived step re-places the
+    edge ahead of its first use and flattens it back to the identical nest."""
+    loop = _composed_rowmax()
+    fold = fold_from_loop(loop)
+    assert fold is not None, "the composed step fell to the raw-loop escape"
+    (edge,) = fold.operands
+    assert isinstance(edge, Fold) and edge.axis.name == "d0", "the score producer is an operand edge"
+    assert fold.lift.params == ("kv", "s0"), f"the lift binds the producer's state positionally: {fold.lift.params}"
+    assert [type(s).__name__ for s in fold.lift.body] == ["Assign"], "only the scale survives in the lift body"
+    # Role-blind: the ``AxisRole`` is a DERIVED read, so the re-derived producer carries one where
+    # the raw pre-annotation loop does not. The program is what has to match.
+    assert _same_program(fold.loop.body, loop.body), "the derived loop is not the captured program"
+
+
+def test_composed_step_keeps_a_row_invariant_prologue_ahead_of_its_producer():
+    """An edge is PLACED at its first use, not prepended: a loop-invariant scalar ahead of the
+    producer keeps its position, so the byte-identity gate still accepts. Prepending unconditionally
+    read this step as a different program and cost it every schedule tier."""
+    loop = _composed_rowmax()
+    body = Body((Load(names=("sv",), input="scale", index=(Literal(0, "int"),)), *loop.body))
+    fold = fold_from_loop(Loop(axis=loop.axis, body=body))
+    assert fold is not None and _same_program(fold.loop.body, body)
+
+
+def test_online_softmax_pairs_two_composed_passes():
+    """The pairing compares the two passes' score cones by CONTENT, so two separately-traced copies
+    of one score — different bound axis, different temps — pair and fuse into ONE twisted stream.
+    Without that the fused attention cell keeps three passes over the score instead of two."""
+    from emmy.compiler.pipeline.passes.lowering.tile._softmax import _fuse
+
+    fused, changed = _fuse(Body((_composed_rowmax(), _composed_sumexp())))
+    assert changed, "the composed pair did not fuse"
+    loops = [s for s in fused if isinstance(s, Loop)]
+    assert len(loops) == 1 and loops[0].role is AxisRole.TWISTED, "the pair must collapse to one TWISTED stream"
+    assert any(isinstance(s, Loop) and s.is_reduce for s in loops[0].body), "the fused stream keeps ONE score producer"
+
+
+def test_split_k_reindexes_the_cones_producer_edge():
+    """A split partition σ-reindexes the cone's K-VARYING producer edge, not only its body stmts:
+    the slice's own k coordinate reaches gmem THROUGH that node. Leaving it alone makes every
+    partition recompute partition 0's scores (a silently wrong result, not a slow one)."""
+    from emmy.compiler.ir.expr import BinaryExpr
+    from emmy.compiler.ir.sigma import Sigma
+    from emmy.compiler.pipeline.passes.lowering.tile._schedule import _sliced_edge
+
+    _root, cone = _attention_cone_term()
+    sigma = Sigma({"kvb": BinaryExpr("+", Var("_ks"), Var("kvb"))})
+    sliced = _sliced_edge(cone, sigma, "kvb")
+    score = sliced.operands[1]
+    assert [e.pretty() for ld in score.lower()[0].body if isinstance(ld, Load) for e in ld.index if "_ks" in e.pretty()], (
+        "the producer edge kept partition 0's k coordinate"
+    )
+    assert sliced.operands[0] == cone.operands[0], "the row-invariant statistic stays FULL-ROW in every partition"
 
 
 def test_norm_linear_fp32_keeps_map_rows_only():


### PR DESCRIPTION
Restores flash-attention's capability through the ONE codec, in two verified steps, and measures where it pays. **The default path does not move**: loop fusion still refuses the attention merge, and `scripts/digest_kernels.py` is byte-identical on all 30 cases.

Continues the FA-through-the-codec campaign (Stage 1 N-channel pairing `085a5b56`, Stage 2 TWISTED computed-A bind `d27d46f4`, Stage 3's lowering half `1a47f4fc`). Stage 3 measured the fused form from an *injected* term; this is the path from a traced module to that term, plus its realization.

## 1. The composed step reads (`39055a63`)

A reduce whose per-element step computes what it folds — attention's per-key score contraction inside the streaming softmax statistic — is not the raw-loop escape. Each producer lifts to an operand EDGE through the same byte-identity-gated parser, recursively (`_fromloop._hoist_step_nodes`). Two readings had to give:

- **`_same_program` compares role-blind.** The `AxisRole` is a derived read, so the re-derived producer loop carries one where the raw pre-annotation body does not; a byte compare read that as a different program and cost the step every schedule tier.
- **`_twisted_derived_step` PLACES its inline-node edges at first use** instead of prepending — the same rule `splice_operands` applies to every other edge. Prepending reordered a step whose pure prologue precedes the producer (the loop-invariant scale `Load` ahead of the score).

The pair then fuses on CONTENT (`_score_cone` accepts a producer NODE as its one source; `_cone_canon` α-renames every bound name plus each nested loop's iteration var, since two separately-traced copies of one score differ in exactly those), and the sweep binds as one computed-A contraction over a COMPUTED score (`map_cone` nodifies the producer, `make_cone` hangs it off the cone's OPERANDS, and the K seam treats a stmt *reading* a k-varying producer as k-varying).

**One latent correctness fix**: `_sliced_edge` now σ-reindexes the cone's K-varying producer edges, not only its body stmts. The slice's own k coordinate reaches gmem THROUGH that node, so every split-K partition was recomputing partition 0's scores — silently wrong output, not slow output.

## 2. It reaches the tensor core, both halves (`39809d75`)

- **`_score_block`** — one block of the composed score as C fragments, built from `_atom_ops` on the score node (the same seam every tiled contraction dispatches through: `state` declares the fragments, `reduce` emits the ldmatrix + mma.sync K-loop, `store` writes them). `_AtomOps.frag_ns` namespaces them so a nested emission never shadows the accumulators the enclosing drain carries across that loop.
- **`chain_a_fill`** — the A slab from that block with the cone folded into its fragment store (`RegStore` + `RegEpilogue`; statistics read at each element's own ROW, the slab Write at its LOCAL (row, col)).
- **`chain_stat_fill`** — the per-row statistic swept at FRAGMENT residence: `FragmentRowReduce` off the score fragments, then the carrier's OWN generated program merging the block into the running state — `exp_merge` at a BLOCK singleton `(rowmax, rowsum)`. Same generator, same stability certificate.
- **`bound_producer`** — a producer the cone composes is STORED bound as a contraction where it reads as one, in both of attention's score sites; the tile catalog is keyed on the bilinear reading, so an unbound producer can only ever be evaluated per cell.

No second mma emitter, no attention vocabulary. Every arm declines cleanly (no bindable producer, an atom with no modeled C-fragment layout, a carrier the block merge cannot spell) and leaves the per-cell fill / cooperative-row prologue exactly as it was.

## 3. Where it pays, and why fusion still refuses (`bcfa9044`)

5090, f16, `(1, 8, S, D)`, cold greedy:

| shape | torch | two-kernel | fused, per-cell | fused, chained |
| --- | --- | --- | --- | --- |
| S=512 D=16 | 8 µs | 38.3 µs | 219 µs | **14.0 µs** |
| S=512 D=32 | 8 µs | 24.9 µs | — | **13.8 µs** |
| S=512 D=64 | 10 µs | 28.7 µs | — | 29.7 µs |
| S=512 D=128 | 19 µs | 21.6 µs | — | 69.2 µs |
| S=1024 D=128 | 45 µs | 72.1 µs | — | 370.6 µs |
| S=2048 D=128 | 145 µs | 179.5 µs | — | 1039.3 µs |

The chained realization is a 15× improvement on the fused arm itself (219 → 14.0 at D=16) and beats the two-kernel graph 2.7× / 1.8× at D ≤ 32. It loses as D or S grows, for two reasons — one fixed, one not:

1. it computes `Q·Kᵀ` TWICE (statistic, then weight) — a 1.5× flop penalty;
2. **the nested score is gmem-direct** — `_score_block` passes `stage=None`, so per query tile the statistic re-reads the whole KV row of K with per-lane strided loads (≈512 MB at S=2048 D=128) where the two-kernel `Q·Kᵀ` streams staged, tiled, TMA-fed slabs. That is why the gap WIDENS with S.

So `_merge._nests_reduce` keeps refusing the merge, and its docstring now states the criterion: REVERSIBILITY. `Q·Kᵀ` has two consumers in the merged cell, so splicing duplicates it and no `PLACE` cut puts it back (a cut fragment serves one consumer). Real models are D = 64 / 128 at long sequence.

The remaining work, in the order that pays — stage the nested score's operands, then make the sweep single-pass — is written up in `plans/fa-chained-a-fill.md`.

## Tests

- `test_composed_step_reads_its_producer_as_an_operand_edge`, `…keeps_a_row_invariant_prologue_ahead_of_its_producer`, `test_online_softmax_pairs_two_composed_passes`, `test_split_k_reindexes_the_cones_producer_edge`.
- `test_fused_single_kernel_sdpa_matches_torch` — lifts the refusal and pins the capability behind it: ONE kernel, the mma markers for both chained halves, and GPU numerics vs torch. It asserts the markers and not just the numerics because a silent fall back to the per-cell fill is a 15× regression numbers alone would not catch. It is also what caught the split-K defect above.
- `test_path_codec`'s flash fixture reads its two contraction sites by AXIS instead of by position.

## Gates

`tests/` **3705 passed / 1 failed** — `test_quantized_checkpoint_e2e_cuda`, verified to fail identically on `main`. `scripts/digest_kernels.py` byte-identical on all 30 cases. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
