### PR TITLE
Qwen3-0.6B kernel-tuning findings: 2 verified wins, 2 compiler gaps behind torch.compile

### DIFF
--- a/plans/qwen3-golden-bench-kernel-tuning-findings.md
+++ b/plans/qwen3-golden-bench-kernel-tuning-findings.md
@@ -94,6 +94,33 @@ stamp-hole reason as BF16. So the FP8 corpus exhibits the same two compiler gaps
 fragmentation. No proposal lane was run — the hybrid-vs-MCTS question was already answered on the BF16 corpus,
 and fp8-tier knob spellings were not evidenced enough to propose without wasting reserved slots.
 
+Per-kernel FP8 detail (5090; baseline at `-O3`, tuned best at `-O1` ranking with the tier it reached —
+`scalar`/`knobless` means the tensor-core tier was never reached):
+
+| kernel | eager | tcompile | emmy cold | tuned best (tier) |
+| --- | ---: | ---: | ---: | --- |
+| `k_linear_0edae7` | 182 | 29 | 33 | 5626 (scalar) |
+| `k_linear_a32aed` | 128 | 21 | 852 | 7760 (knobless) |
+| `k_linear_aa889a` | 125 | 21 | 23 | 1818 (scalar) |
+| `k_linear_eae85b` | 72 | 13 | 435 | 2511 (knobless) |
+| `k_linear_reduce_b17b94` | 278 | — | 7274 | 30422 (knobless) |
+| `k_linear_reduce_fca85d` | 45 | 12 | 14 | 682 (scalar) |
+| `k_mean_20f978` | 111 | 6 | 4 | 35 (scalar) |
+| `k_mul_11_dynamic_fp8_bits_pointwise` | 27 | 2 | 1 | 2 (scalar) |
+| `k_mul_11_dynamic_fp8_scale_reduce` | 29 | 2 | 2 | 20 (scalar) |
+| `k_mul_12_dynamic_fp8_bits_pointwise` | 45 | 2 | 2 | 4 (scalar) |
+| `k_mul_12_dynamic_fp8_scale_reduce` | 33 | 2 | 2 | 57 (scalar) |
+| `k_mul_1_dynamic_fp8_bits_pointwise` | 27 | 2 | 1 | 2 (scalar) |
+| `k_mul_1_dynamic_fp8_scale_reduce` | 29 | 2 | 2 | 20 (scalar) |
+| `k_mul_1_dynamic_fp8_value_pointwise` | 30 | 2 | 1 | 2 (scalar) |
+| `k_reshape_dynamic_fp8_bits_pointwise` | 37 | — | 1 | 3 (scalar) |
+| `k_reshape_dynamic_fp8_scale_reduce` | 31 | 2 | 3 | 38 (scalar) |
+| `k_sdpa_linear_reduce_616dc9` | 70 | 35 | 4816 | no result (stamp hole) |
+| `k_sdpa_mean_reduce_29d3df` | 419 | — | 23501 | no result (stamp hole) |
+
+**Scope note:** FP8 ran on the RTX 5090 only. The recipe's `fp8-common` matrix also lists the RTX 4090; that row
+was NOT run in this session (the 4090 host carried only the BF16 corpus) and remains open work.
+
 **Watchdog rejections** (2 s bench cap on some fused computed-A candidates) are the tuner working as intended,
 listed only for completeness.
 

--- a/plans/qwen3-golden-bench-kernel-tuning-findings.md
+++ b/plans/qwen3-golden-bench-kernel-tuning-findings.md
@@ -1,0 +1,118 @@
+# Qwen3-0.6B kernel tuning on RTX 4090 / RTX 5090 / V100: two wins, two compiler gaps
+
+Status: complete (FP8 tune noted below). Date: 2026-08-19. Revision: `f184aa4d`. Workflow: the `tune-kernels`
+skill over the model corpus named by `experiments/golden-bench-2026/kernels/recipe.yaml`, on three caller-supplied
+single-GPU hosts: RTX 4090 (sm_89, CUDA 13.3), RTX 5090 (sm_120, CUDA 13.0), Tesla V100-SXM3-32GB (sm_70,
+CUDA 12.9). Recipe budget throughout: `--max-candidates 12 --patience 4 --seed 0`. The tune ranking lane compiles
+at `-Xcicc -O1`; every performance conclusion below is a fresh `-O3` measurement (3 repeats, spreads 0.1-3.4%).
+
+## The question
+
+The recipe's models are `Qwen/Qwen3-0.6B@c1899de2` (BF16) and `RedHatAI/Qwen3-0.6B-FP8-dynamic@068a9040`
+(per the recipe's GPU matrices: BF16 on all three cards, FP8 on sm_89+ only — Volta has no FP8 mma). The ask:
+trace the models to extract their golden kernel sets, tune them, and where emmy trails
+`torch.compile(mode="max-autotune")`, either fix by tuning or identify the gap.
+
+## What tracing produced
+
+`emmy trace <model> --layer 0 --seq-len 512` embeds one post-fusion inventory per card. One transformer layer of
+the BF16 model compiles to **9 fused kernels** (identical set on all three cards): the input RMSNorm, three
+projection linears (q: 512x1024->2048, k/v: 512x1024->1024), a q/k-norm + RoPE fusion, two SDPA fusions, the fused
+post-attention norm + gate/up (the computed-A path #545 restored), and down_proj + residual. Layer 0 is
+representative by construction: Qwen3-0.6B's 28 layers are structurally identical and the tuner dedupes kernels
+by structure, so tuning layer 0 covers every layer (embedding and lm_head sit outside the block and are not
+covered). The FP8 checkpoint traces to **19 kernels** for the same layer: per-tensor dynamic quantization emits a
+`*_dynamic_fp8_scale_reduce` + `*_dynamic_fp8_bits_pointwise` pair around each linear, fragmenting the block.
+
+## Baseline: a cold machine deploys catastrophically, and the bar is torch.compile
+
+Whole-layer totals at `-O3` on a fresh host (empty tune DB, no goldens for these targets — "cold greedy"):
+
+| card | eager | torch.compile | emmy cold greedy |
+| --- | ---: | ---: | ---: |
+| RTX 4090 | 1056 | 223 | 49209 |
+| RTX 5090 | 896 | 188 | 38801 |
+| V100 SXM3 | 4315 | 876 | 57369 |
+| RTX 5090, FP8 (19 kernels) | 1827 | 159 | 36971 |
+
+(µs; the tcompile totals each exclude one kernel whose torch.compile lane failed to measure.) Two readings:
+at these shapes `torch.compile` beats eager ~5x, so **eager parity is the wrong goal — 188-876 µs is the bar**;
+and cold greedy misdeploys by up to 250x on individual kernels (q_proj: 10026 µs vs tcompile 18 on the 5090),
+which is the strongest live demonstration yet that unseeded deploys need golden evidence.
+
+## How the tuning worked, and what it found
+
+Per card, two equal-budget searches from the same inventory: `mcts.yaml` (pure MCTS) and `hybrid.yaml` (MCTS plus
+a handful of agent proposals seeded from canonical goldens at the same M=512 shapes, in each card's own knob
+vocabulary — `d2/smem-async` staging on sm_89, `d2/smem-tma` on sm_120, `d*/sync` on sm_70). Identical DB, prior,
+seed, budget, cubin caches per arm. Winners were then re-measured at deployable `-O3` with exact `--ab` pins,
+3 repeats, against the greedy incumbent, eager, and torch.compile.
+
+Of the 9 BF16 kernels per card, **5 produced tunable search results; 4 could not be tuned at all** (reasons in
+the gaps section). Hybrid beat pure MCTS wherever the tensor-core tier was reachable. `-O3` verification:
+
+| card | kernel | greedy | tuned | verdict |
+| --- | --- | ---: | ---: | --- |
+| 4090 | down_proj (`k_linear_6b4b5f`) | 170.8 | **62.5** | **promote (2.7x)** — still 0.44x of tcompile |
+| 4090 | v_proj (`k_linear_reduce_06a42b`) | 31.3 | **19.9** | **promote (1.6x)** — still 0.52x of tcompile |
+| 5090 | down_proj (TMA candidate) | 36.4 | 48.6 | reject — 1.34x WORSE at `-O3` |
+| 5090 | v_proj (TMA candidate) | 12.9 | 12.9 | reject — tie |
+| V100 | down_proj (scalar candidate) | 301.4 | 913.4 | reject — 3x WORSE at `-O3` |
+
+So: **10 arm runs across 3 cards, 5 tunable targets each, 5 verification candidates, 2 promoted wins (both on
+the 4090)**. The rejected rows are the `-O1`->`-O3` inversion at work — the TMA candidate ranked 5.8x ahead at
+`-O1` and lost at `-O3`; the ranking lane orders search, it does not predict deployment. Every conclusion here
+survived 3-repeat `-O3` measurement or was rejected by it.
+
+## The gaps: why 4 of 9 kernels cannot be tuned (and why they hold ~90% of the loss)
+
+**Gap 1 — split-N contraction demotion (q_proj, k_proj; ~15000 µs/card).** The traced kernels fuse the
+reshape-to-heads and an f32 cast onto the projection linears. The reshape splits the output axis (N=2048 becomes
+16x128), so the weight is indexed by the composite `(a1*128)+a2`. The recognizer still classifies the kernel as a
+contraction — but the warp-tile placer needs a single (m, n) axis pair, finds no single n, offers zero warp rows,
+and by design "a contraction form with no legal row demotes back to the PLANAR reduce"
+(`lowering/tile/010_recognize.py`). Result: a scalar gmem loop, ~200x off. Dtypes are innocent (both operands
+f16), and the control case is in the same layer: the identical-class linear WITHOUT the fused view (`linear_2`)
+gets the full warp tier and tuned 11x. **Support to add, three candidate shapes:** (a) an axis-refusion
+canonicalization — the split is contiguous (`a1*128+a2`, a2 extent 128 ≡ one 2048-wide axis), so merging is
+mechanical; (b) stop fusing rank-changing views into contraction stores; (c) offer a placement cut at the view
+edge. (a) is smallest and keeps the fusion.
+
+**Gap 2 — SDPA fusions cannot enter the tuner (~23000-29000 µs/card).** Every candidate for the online-softmax
+kernels dies at scheduling with `"scheduling a kernel with no structural identity — 005_stamp must run first"`.
+This is a *documented* hole: `lowering/tile/005_stamp_structural_features.py` states that terms `010_recognize`
+splices as a `Graph` — "the online-softmax form" — have "carried no structural identity since it was written — a
+separate hole." Until those splices are stamped, the SDPA fusions are unreachable by search on every card.
+
+**FP8 fragmentation (5090).** The dynamic-FP8 checkpoint's 19-kernel layer runs 36971 µs cold vs tcompile's
+159 µs. The per-linear quantize pairs are pointwise/reduce kernels the search can order but not fuse; the
+structural cost is set at trace/fusion time. An MCTS tune of this corpus (budget 12, seed 0) completed with
+17/19 targets ranked: the quantize-pair kernels tune fine (cheap pointwise/reduce work, 2-57 µs), but **every
+FP8 linear ended on a scalar tier or a knobless row** — the tensor-core tier was never reached on any of them
+(worst: `k_linear_reduce_b17b94` at 30422 µs `-O1`), and the two SDPA targets are missing for the same
+stamp-hole reason as BF16. So the FP8 corpus exhibits the same two compiler gaps plus its own fusion
+fragmentation. No proposal lane was run — the hybrid-vs-MCTS question was already answered on the BF16 corpus,
+and fp8-tier knob spellings were not evidenced enough to propose without wasting reserved slots.
+
+**Watchdog rejections** (2 s bench cap on some fused computed-A candidates) are the tuner working as intended,
+listed only for completeness.
+
+## Answer to the original goal
+
+Emmy trails torch.compile max-autotune on this corpus, and the split is now exact: **tuning recovers the
+reachable minority** (two verified promotions; the other tunable kernels are already at or near their
+offered-space best — e.g. 5090 down_proj greedy 36 µs vs tcompile 25 µs is fusion/launch structure, not tile
+choice), while **~90% of the gap sits behind the two compiler gaps above**, which no search budget can cross.
+Re-running the tune will not change this: same seed replays deterministically, and the lockouts are structural.
+The two promoted 4090 configurations are preserved in the working goldens (`_tune/qwen3-4090/`); canonical
+promotion is deferred to the model-onboarding flow since no `recipes/Qwen3-0.6B/` lane exists yet.
+
+## Workflow notes
+
+- Datacenter hosts needed dependency rescues before any GPU work: V100 requires torch cu126 (cu130 wheels ship
+  no sm_70 kernels) and `cupy-cuda12x==13.6.0` + `fastrlock` (cupy 14.x bundles nvrtc 13.0, which dropped Volta —
+  `cp.full()` on any constant buffer dies). A `cp.full((4,),1.5,dtype=float16)` canary before tuning catches both.
+- `-O1` ranking magnitudes inverted against `-O3` on 3 of 5 verification candidates this run (and in previous
+  sessions); never report an `-O1` gain as a result.
+- Raw artifacts (traces, arm files with rankings, tune logs, `-O3` verification JSONs, baselines) are preserved
+  locally under `_tune/qwen3-{4090,5090,v100}/`; hosts are caller-owned and disposable after this report.


### PR DESCRIPTION
## What this is

Findings from running the `tune-kernels` workflow over the model corpus named by
`experiments/golden-bench-2026/kernels/recipe.yaml` — `Qwen/Qwen3-0.6B@c1899de2` (BF16) on RTX 4090, RTX 5090,
and Tesla V100-SXM3, plus `RedHatAI/Qwen3-0.6B-FP8-dynamic@068a9040` on the 5090 — at the recipe's own budget
(`--max-candidates 12 --patience 4 --seed 0`), revision `f184aa4d`. One tracked file:
`plans/qwen3-golden-bench-kernel-tuning-findings.md`.

## How it was done

1. **Trace** — `emmy trace <model> --layer 0 --seq-len 512` per card extracted the golden kernel set: one
   transformer layer = **9 fused kernels** (BF16; identical set on all three cards). The FP8 checkpoint traces the
   same layer into **19 kernels** — per-tensor dynamic quantization emits a scale-reduce + bits-pointwise pair
   around every linear. Layer 0 covers all 28 layers: they are structurally identical and the tuner dedupes by
   structure (embedding/lm_head excluded).
2. **Baseline** — every kernel benched at deployable `-O3` against eager and `torch.compile(mode="max-autotune")`.
3. **Tune** — seven `emmy tune` invocations: equal-budget `mcts` vs `hybrid` (agent-seeded proposals in each
   card's own knob vocabulary) per card, plus an FP8 MCTS pass. All 9 shapes searched per invocation.
4. **Verify** — every candidate winner re-measured at `-O3` with exact `--ab` pins, 3 repeats (spreads 0.1-3.4%).

## Headline numbers

Whole-layer totals, cold machine (µs):

| card | eager | torch.compile | emmy cold greedy |
| --- | ---: | ---: | ---: |
| RTX 4090 | 1056 | 223 | 49209 |
| RTX 5090 | 896 | 188 | 38801 |
| V100 SXM3 | 4315 | 876 | 57369 |
| 5090 FP8 (19 kernels) | 1827 | 159 | 36971 |

At these shapes torch.compile beats eager ~5x, so **tcompile is the bar**. Cold greedy misdeploys up to 250x per
kernel on a fresh host — the strongest live case yet for golden evidence on cold deploys.

## Tuning outcome: 5 of 9 kernels tunable; 2 verified wins

Of 9 kernels per card, 5 produced search results; hybrid beat pure MCTS wherever the tensor-core tier was
reachable. `-O3` verification (3 reps): **promote 2** — 4090 down_proj 170.8→62.5 µs (**2.7x**) and v_proj
31.3→19.9 µs (**1.6x**) — and **reject 3**: the 5090 TMA candidate ranked 5.8x ahead at `-O1` and measured
**1.34x worse** at `-O3`; the V100 candidate measured 3x worse; one tie. (`-O1` ranking inverted at `-O3` on
every rejected candidate — ranking numbers are never results.)

## The gaps (~90% of the remaining distance; not fixable by tuning)

1. **Split-N contraction demotion (q/k-proj, ~15 ms/card).** The fused reshape-to-heads splits the output axis
   (N=2048 → 16x128), the weight index becomes composite, the warp-tile placer finds no single n axis, offers
   zero warp rows, and the kernel demotes to a scalar loop by design (`lowering/tile/010_recognize.py`). Control:
   the identical-class linear without the fused view tunes 11x on the warp tier. Smallest fix: an axis-refusion
   canonicalization (the split is contiguous — mechanically re-mergeable).
2. **Online-softmax stamp hole (SDPA fusions, ~23-29 ms/card).** Every candidate dies at scheduling:
   `"scheduling a kernel with no structural identity — 005_stamp must run first"`. Documented in
   `005_stamp_structural_features.py` as "a separate hole" for Graph-spliced online-softmax terms. Until stamped,
   SDPA is unreachable by search on every card.

Both gaps reproduce identically on all three architectures and on the FP8 corpus (whose linears additionally
never reached the fp8 tensor-core tier; its quantize pairs tune fine but are structurally unfusable today).

## Also fixed along the way

Datacenter-host toolchain traps, recorded in the report's workflow notes: V100 needs torch cu126 (cu130 ships no
sm_70 kernels) and `cupy-cuda12x==13.6.0` + `fastrlock` (cupy 14.x bundles nvrtc 13.0, which dropped Volta). A
one-line `cp.full` canary now precedes any budget spend.

## Test plan

- `ruff check .` clean; findings wrapped to ≤120 chars; plans/ cap respected (10/10)
- No code changes — findings document only; raw artifacts preserved locally under `_tune/qwen3-*/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)