### PR TITLE
Swizzle every slab the fused flash kernel reads

### DIFF
--- a/emmy/compiler/ir/kernel/ir.py
+++ b/emmy/compiler/ir/kernel/ir.py
@@ -23,7 +23,7 @@ Tile IR and are materialized away before reaching this layer. A
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import cached_property
 
 from emmy.compiler.dtype import F32, DataType
@@ -479,7 +479,7 @@ class CpAsyncCopy(Stmt):
     def pretty(self, indent: str = "") -> list[str]:
         smem_idx = ", ".join(e.pretty() for e in self.smem_index)
         src_idx = ", ".join(e.pretty() for e in self.src_index)
-        swz = f" swz={self.swizzle}" if self.swizzle in LDMATRIX_SWIZZLE_XOR else ""
+        swz = f" swz={self.swizzle}" if swizzle_xor(self.swizzle) else ""
         return [f"{indent}cp.async[{self.nbytes}B] {self.smem}[{smem_idx}]{swz} <- {self.src}[{src_idx}]"]
 
     def render(self, ctx: RenderCtx) -> list[str]:
@@ -487,8 +487,8 @@ class CpAsyncCopy(Stmt):
 
         smem_flat = render_index(self.smem, self.smem_index, ctx)
         src_flat = render_index(self.src, self.src_index, ctx)
-        if self.swizzle in LDMATRIX_SWIZZLE_XOR:
-            smem_flat = f"emmy_swizzle_{self.swizzle.lower()}({smem_flat})"
+        if swizzle_xor(self.swizzle):
+            smem_flat = f"{swizzle_fn(self.swizzle)}({smem_flat})"
         pad = _pad(ctx.indent)
         # ``emmy_cp_async_{cg,ca}`` (the cp.async prelude) does the ``cvta`` internally, so this is a
         # single call — no ``_smem_addr`` local and no wrapping ``{ }`` block. .cg is 16-byte-only.
@@ -1362,6 +1362,40 @@ LDMATRIX_SWIZZLE_XOR: dict[str, tuple[int, int]] = {
     "B32": (6, 0x1),
 }
 
+#: A SOFTWARE-swizzled mode may override the element shift, spelled ``<mode>@<shift>``. The shift
+#: above is ``log2(atom elems)``, which reads the row index only while a slab row IS one swizzle
+#: atom. A WIDER row (the flash slabs: a 128-elem fp16 head-dim row is two 128 B atoms) leaves the
+#: atom bit inside the shifted field, so consecutive rows collapse onto a quarter of the chunk
+#: positions and an ``ldmatrix`` over 16 rows drains multi-way bank-conflicted (measured 7.8-way at
+#: ``D = 128``, none at ``D = 64``). Taking the shift from the slab's OWN row stride restores
+#: row-mod-8, hence the full chunk spread. Hardware (TMA) slabs keep the plain spelling: there the
+#: copy engine fixes the permutation, and the descriptor already splits its box down to the atom.
+_SWIZZLE_SHIFT_SEP = "@"
+
+
+def swizzle_xor(mode: str) -> tuple[int, int] | None:
+    """``(element shift, row mask)`` for a swizzle mode spelling, or ``None`` when the mode carries
+    no XOR (``"NONE"`` / an unknown spelling). Accepts the plain mode and the software
+    ``<mode>@<shift>`` override."""
+    base, _, shift = mode.partition(_SWIZZLE_SHIFT_SEP)
+    xor = LDMATRIX_SWIZZLE_XOR.get(base)
+    if xor is None:
+        return None
+    return (int(shift), xor[1]) if shift else xor
+
+
+def swizzle_base(mode: str) -> str:
+    """The hardware mode name behind a (possibly shift-overridden) spelling — what the swizzle's
+    slab alignment and TMA descriptor are keyed on."""
+    return mode.partition(_SWIZZLE_SHIFT_SEP)[0]
+
+
+def swizzle_fn(mode: str) -> str:
+    """The ``emmy_swizzle_*`` helper name for a mode spelling — one helper per distinct
+    ``(mask, shift)`` pair, so two slabs sharing a spelling share the emitted function."""
+    base = swizzle_base(mode)
+    return f"emmy_swizzle_{base.lower()}" + ("" if mode == base else f"_s{swizzle_xor(mode)[0]}")
+
 
 @dataclass(frozen=True)
 class LdmatrixLoad(Stmt):
@@ -1625,12 +1659,12 @@ class LdmatrixLoad(Stmt):
         return [f"{_pad(ctx.indent)}emmy_ldmatrix_x2_trans({self.frag}, {addr});"]
 
     def _swizzled_addr(self, elem: str) -> str:
-        if self.swizzle not in LDMATRIX_SWIZZLE_XOR:
+        if not swizzle_xor(self.swizzle):
             return f"&{self.src_buffer}[{elem}]"
         # ``emmy_swizzle_<mode>`` (preamble, built from ``LDMATRIX_SWIZZLE_XOR``) applies
         # ``e ^ (((e >> shift) & mask) << 3)`` — the helper spells the (often long) element
         # index once instead of inlining it twice around the XOR.
-        return f"&{self.src_buffer}[emmy_swizzle_{self.swizzle.lower()}({elem})]"
+        return f"&{self.src_buffer}[{swizzle_fn(self.swizzle)}({elem})]"
 
 
 @dataclass(frozen=True)
@@ -1828,6 +1862,14 @@ class RegStore(Stmt):
     n_guard: tuple[Expr, Expr] | None = None
     atomic: bool = False
     fragment_layout: str = "m16n8k16"
+    # Software smem slab swizzle mode ("NONE"/"B32"/"B64"/"B128") — the fragment fill's producer
+    # side, when this store's destination is a swizzled smem SLAB rather than the kernel's output
+    # (the fused flash weight tile: the score's C fragments land in the A slab the ``ldmatrix``
+    # drain reads). The flattened store address passes through ``emmy_swizzle_<mode>`` exactly like
+    # a :class:`CpAsyncCopy` fill, so the drain's identical XOR reads the tile back. The lane's two
+    # columns are contiguous and even-based, so the XOR (which passes intra-chunk bits 0..2
+    # through) keeps a vectorized pair inside its relocated 16-byte chunk. "NONE" is inert.
+    swizzle: str = "NONE"
 
     def deps(self) -> tuple[str, ...]:
         extra = () if self.epilogue is None else tuple(fr for _, fr in self.epilogue.extra_accs)
@@ -1865,10 +1907,15 @@ class RegStore(Stmt):
         acc = " (atomic)" if self.atomic else ""
         return [f"{indent}RegStore {self.dst_buffer}[{idx}] <- {self.frag}{epi}{guards}{acc} (ldm={self.ldm or 'auto'})"]
 
+    def _swz(self, addr: str) -> str:
+        """The store address, XOR-permuted through the slab's swizzle helper when this store
+        targets a swizzled smem slab — inert at the default ``"NONE"``."""
+        return addr if not swizzle_xor(self.swizzle) else f"{swizzle_fn(self.swizzle)}({addr})"
+
     def _pair_store(self, addr: str, v0: str, v1: str, vec2: str, packer: str) -> str:
         """One vectorized row-pair store line — a plain assign, or (``atomic``) the packed-pair
         ``atomicAdd`` (native f16x2 / bf16x2 red; the caller keeps f32 off this path pre-sm90)."""
-        tgt = f"reinterpret_cast<{vec2}*>(&{self.dst_buffer}[{addr}])"
+        tgt = f"reinterpret_cast<{vec2}*>(&{self.dst_buffer}[{self._swz(addr)}])"
         if self.atomic:
             return f"atomicAdd({tgt}, {packer}({v0}, {v1}));"
         return f"*{tgt} = {packer}({v0}, {v1});"
@@ -1880,7 +1927,7 @@ class RegStore(Stmt):
         if self.atomic:
             conv = {"f16": "__float2half({})", "bf16": "__float2bfloat16({})"}.get(dst_dt, "{}")
             return f"atomicAdd(&{self.dst_buffer}[{addr}], {conv.format(val)});"
-        return f"{self.dst_buffer}[{addr}] = {val};"
+        return f"{self.dst_buffer}[{self._swz(addr)}] = {val};"
 
     def _element_coords(self) -> list[tuple[str, str, Expr, Expr]]:
         """Per-lane ``(row C text, col C text, row Expr, col Expr)`` for this fragment layout."""
@@ -2590,20 +2637,19 @@ def _(s: RegStore, rename, sigma, axis_fn):
     def _sub_guard(g):  # noqa: ANN001, ANN202 — tuple[Expr, Expr] | None
         return None if g is None else (sigma.apply(g[0]), sigma.apply(g[1]))
 
-    return RegStore(
-        dst_buffer=s.dst_buffer,
+    # ``replace`` — NOT a field-by-field rebuild. Every field this rewrite does not touch is a
+    # POLICY the store carries, and defaulting one silently produces a numerically-wrong kernel with
+    # no loud failure: a dropped ``atomic`` degraded a rewritten (e.g. loopify-rolled) split-K store
+    # to racing plain assigns, and a dropped ``swizzle`` left the flash weight tile stored
+    # row-major under a drain that reads it XOR-permuted. Naming only what changes cannot regress
+    # that way when a field is added.
+    return replace(
+        s,
         dst_index=tuple(sigma.apply(e) for e in s.dst_index),
         frag=rename(s.frag),
-        shape=s.shape,
-        ldm=s.ldm,
         epilogue=epilogue,
         m_guard=_sub_guard(s.m_guard),
         n_guard=_sub_guard(s.n_guard),
-        # ``atomic`` MUST thread through: dropping it here silently degraded a rewritten (e.g.
-        # loopify-rolled) atomic split-K store to racing plain assigns — the partitions then
-        # clobber instead of accumulate, a numerically-wrong kernel with no loud failure.
-        atomic=s.atomic,
-        fragment_layout=s.fragment_layout,
     )
 
 

--- a/emmy/compiler/ir/kernel/render.py
+++ b/emmy/compiler/ir/kernel/render.py
@@ -12,7 +12,17 @@ from emmy.compiler.backend.cuda.dtype import cuda_includes, cuda_name
 from emmy.compiler.backend.cuda.dtype import nbytes_of as _nbytes_of
 from emmy.compiler.backend.cuda.render_target import CudaRenderTarget
 from emmy.compiler.dtype import F32
-from emmy.compiler.ir.kernel.ir import LDMATRIX_SWIZZLE_XOR, CpAsyncCopy, KernelOp, LdmatrixLoad, Smem, TmaDescriptor, pack_smem
+from emmy.compiler.ir.kernel.ir import (
+    CpAsyncCopy,
+    KernelOp,
+    LdmatrixLoad,
+    RegStore,
+    Smem,
+    TmaDescriptor,
+    pack_smem,
+    swizzle_fn,
+    swizzle_xor,
+)
 from emmy.compiler.ir.stmt import RenderCtx, render_body
 from emmy.compiler.ir.stmt.leaves import Assign, Write
 from emmy.compiler.tensor import Tensor
@@ -822,25 +832,22 @@ def _swizzle_prelude(kernel_op: KernelOp) -> str:
     """One ``emmy_swizzle_<mode>`` helper per swizzle mode the body uses — on ``LdmatrixLoad``
     drains (undoing the TMA hardware in-copy permutation, or reading back a software-swizzled
     slab), on ``CpAsyncCopy`` fills (the software swizzle's producer side), and on swizzled
-    slab ``Write``\\ s (the sync compute-fill's producer side). Built from
-    ``LDMATRIX_SWIZZLE_XOR`` (the single source of the shift/mask), so the call sites spell their
+    slab ``Write``\\ s / ``RegStore``\\ s (the sync compute-fill's producer side, per-thread and
+    at fragment residence). Built from
+    :func:`swizzle_xor` (the single source of the shift/mask), so the call sites spell their
     (often long) element index once instead of inlining it twice around the XOR.
     ``__forceinline__``; same SASS as the inlined form."""
     modes = sorted(
-        {
-            s.swizzle
-            for s in kernel_op.body.iter()
-            if isinstance(s, (LdmatrixLoad, CpAsyncCopy, Write)) and s.swizzle in LDMATRIX_SWIZZLE_XOR
-        }
+        {s.swizzle for s in kernel_op.body.iter() if isinstance(s, (LdmatrixLoad, CpAsyncCopy, RegStore, Write)) and swizzle_xor(s.swizzle)}
     )
     chunks = []
     for mode in modes:
-        shift, mask = LDMATRIX_SWIZZLE_XOR[mode]
+        shift, mask = swizzle_xor(mode)
         chunks.append(
             f"// {mode} slab swizzle: XOR a b16 smem element index the way the fill permuted the\n"
             f"// 16-byte chunks (TMA in-copy, or the same XOR on a cp.async fill destination);\n"
             f"// the ldmatrix drain must read them back through the identical permutation.\n"
-            f"static __device__ __forceinline__ int emmy_swizzle_{mode.lower()}(int e) {{\n"
+            f"static __device__ __forceinline__ int {swizzle_fn(mode)}(int e) {{\n"
             f"    return e ^ (((e >> {shift}) & {mask}) << 3);\n"
             f"}}\n\n"
         )

--- a/emmy/compiler/ir/stmt/leaves.py
+++ b/emmy/compiler/ir/stmt/leaves.py
@@ -806,7 +806,9 @@ class Write(Stmt):
         """The flattened store index, XOR-permuted through the slab's swizzle helper when this
         Write targets a swizzled smem slab (the sync compute-fill's producer side) — inert at
         the default ``"NONE"``."""
-        return flat if self.swizzle == "NONE" else f"emmy_swizzle_{self.swizzle.lower()}({flat})"
+        from emmy.compiler.ir.kernel.ir import swizzle_fn, swizzle_xor  # noqa: PLC0415 — kernel IR imports this module
+
+        return flat if not swizzle_xor(self.swizzle) else f"{swizzle_fn(self.swizzle)}({flat})"
 
     def pretty(self, indent: str = "") -> list[str]:
         idx = ", ".join(e.pretty() for e in self.index)

--- a/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md
@@ -217,7 +217,10 @@ fragment store (`RegStore` + `RegEpilogue`) and written straight into the slab t
 second mma emitter: the score is a contraction, so it is built out of the SAME atom strategy (`_atom_ops` on the score
 node — `state` declares the fragments, `reduce` emits the `ldmatrix` + `mma.sync` K-loop, `store` writes them),
 namespaced (`_AtomOps.frag_ns`) so the nested fragments never shadow the accumulators the enclosing drain carries
-across the same loop. The slab stays NONE-swizzle there — a fragment store applies no address XOR.
+across the same loop. That slab SWIZZLES like every other one: the fragment store applies the same flattened-index XOR
+the `ldmatrix` drain undoes (`RegStore.swizzle`, stamped through the fill's `Write`), so the weight tile costs no more
+bank conflicts than the operands beside it. The nested score's own staged operands (its per-chunk keys, its
+loop-invariant query tile) carry their mode on the cp.async fill the same way.
 
 The chained fill takes one of two forms, and the first is preferred wherever it reads:
 

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -82,6 +82,7 @@ from emmy.compiler.pipeline.passes.lowering.kernel._stage import (
     SyncTransport,
     TmaTransport,
     pick_swizzle_atom,
+    software_swizzle,
     staged_kloop,
     sync_stat_fill,
 )
@@ -573,12 +574,24 @@ def _k_masked(stmts: list[Stmt], value: str, k: Expr, k_ext: Expr | None) -> tup
     )
 
 
-def _chain_of(*, c, score, mn, atom, bk_elems, slab, stats, lead, slabs):
+def _chain_of(*, c, score, mn, atom, bk_elems, slab, stats, lead, slabs, slab_swizzle):
     """The chained fill CLOSURE — ``chain(k0)`` for the transport, deferring the emission until the
     skeleton knows its chunk base."""
 
     def chain(k0):
-        return chain_a_fill(c=c, score=score, mn=mn, atom=atom, bk_elems=bk_elems, k0=k0, slab=slab, stats=stats, lead=lead, slabs=slabs)
+        return chain_a_fill(
+            c=c,
+            score=score,
+            mn=mn,
+            atom=atom,
+            bk_elems=bk_elems,
+            k0=k0,
+            slab=slab,
+            stats=stats,
+            lead=lead,
+            slabs=slabs,
+            slab_swizzle=slab_swizzle,
+        )
 
     return chain
 
@@ -618,7 +631,15 @@ def score_key_operand(*, c: Fold, score: Fold, atom, m_name: str, cols: int) -> 
     def coords(k0):
         return tuple(Sigma({c.axis.name: k0, score.axis.name: Literal(0, "int")}).apply(e) for e in b.index)
 
-    return Operand(tag=_KEY_TAG, buf=b.input, shape=(cols, k_ext), index=index, coords=coords, trans=True)
+    return Operand(
+        tag=_KEY_TAG,
+        buf=b.input,
+        shape=(cols, k_ext),
+        index=index,
+        coords=coords,
+        trans=True,
+        swizzle=software_swizzle(k_ext, atom.operand_dtype("b").nbytes),
+    )
 
 
 def score_query_operand(*, score: Fold, atom, m: Side, k_name: str) -> Operand | None:
@@ -648,7 +669,14 @@ def score_query_operand(*, score: Fold, atom, m: Side, k_name: str) -> Operand |
     def coords(_k0):
         return tuple(Sigma({m.axis.name: row_base, k_name: Literal(0, "int")}).apply(e) for e in a.index)
 
-    return Operand(tag=_QUERY_TAG, buf=a.input, shape=(m.tile, k_ext), index=index, coords=coords)
+    return Operand(
+        tag=_QUERY_TAG,
+        buf=a.input,
+        shape=(m.tile, k_ext),
+        index=index,
+        coords=coords,
+        swizzle=software_swizzle(k_ext, atom.operand_dtype("a").nbytes),
+    )
 
 
 def _lane_group(lay) -> Expr:
@@ -760,6 +788,7 @@ def chain_a_fill(
     stats: tuple[str, ...],
     lead: tuple,
     slabs: tuple = (None, None),
+    slab_swizzle: str = "NONE",
 ):
     """The **CHAINED A fill** — the score contraction the cone composes, realized on the TENSOR CORE
     with the cone as its store epilogue: ``mma(Q, Kᵀ) → C fragments → exp(s − m)·(1/d) → the A slab``
@@ -777,7 +806,7 @@ def chain_a_fill(
         (
             *(Load(names=(nm,), input=_stat_slab(nm), index=(local_row,)) for nm in stats),
             *c.a.body,
-            Write(output=slab, index=(local_row, local_col), value=c.a.out),
+            Write(output=slab, index=(local_row, local_col), value=c.a.out, swizzle=slab_swizzle),
         )
     )
     ops, cells, offset, smn, stmts, _ = _score_block(
@@ -935,6 +964,7 @@ def chain_stream_fill(
     out_frags: tuple,
     lead: tuple,
     slabs: tuple = (None, None),
+    slab_swizzle: str = "NONE",
 ):
     """The **SINGLE-PASS chained sweep** — the statistic and the weight off ONE pass of the score.
 
@@ -1008,7 +1038,7 @@ def chain_stream_fill(
         # The weight lands at the element's LOCAL slab ``(row, col)`` — σ folds the absolute cell
         # coordinate back to the slab's own.
         local = (BinaryExpr("-", Var(m.axis.name), row_base), BinaryExpr("-", Var(c.axis.name), k0))
-        epilogue = Body((Write(output=slab, index=local, value=score.acc),))
+        epilogue = Body((Write(output=slab, index=local, value=score.acc, swizzle=slab_swizzle),))
         ops, cells, offset, smn, stmts, frags = _score_block(
             n_axis=c.axis, score=score, mn=mn, atom=atom, cols=bk_elems, k0=k0, lead=lead, ns="_s", epilogue=epilogue, slabs=slabs
         )
@@ -1134,8 +1164,8 @@ def _sync_operands(
     key_op = score_key_operand(c=c, score=score_edge, atom=atom, m_name=m_name, cols=bk_elems) if score_edge is not None else None
     query_op = score_query_operand(score=score_edge, atom=atom, m=mn[0], k_name=score_edge.axis.name) if score_edge is not None else None
     slabs = (
-        (query_op.slab, query_op.shape[1]) if query_op is not None else None,
-        (key_op.slab, key_op.shape[1]) if key_op is not None else None,
+        (query_op.slab, query_op.shape[1], query_op.swizzle) if query_op is not None else None,
+        (key_op.slab, key_op.shape[1], key_op.swizzle) if key_op is not None else None,
     )
     if score_edge is not None:
         stream = chain_stream_fill(
@@ -1148,6 +1178,7 @@ def _sync_operands(
             out_frags=out_frags,
             lead=lead,
             slabs=slabs,
+            slab_swizzle=swizzles[0],
         )
     if stream is not None:
         prologue, stream_fill, finalize = stream
@@ -1195,15 +1226,26 @@ def _sync_operands(
     else:
         # The CHAINED fill where the cone composes a score CONTRACTION and the atom can mma it: the
         # slab comes from one nested contraction (fragments → the cone's epilogue → the slab), not
-        # per-cell scalar code. NONE-swizzle by construction — the fragment store applies no XOR, so
-        # the drain must read the plain row-major slab.
+        # per-cell scalar code. It swizzles like every other slab: the fragment store applies the
+        # same flattened-index XOR the ldmatrix drain undoes (``RegStore.swizzle``, stamped through
+        # the fill's ``Write``), so the weight tile costs no more bank conflicts than the operands
+        # beside it — unswizzled its 256 B rows drained ~32-way conflicted.
         if stream is not None:
-            a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, chain=stream_fill, swizzle="NONE")
+            a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, chain=stream_fill, swizzle=swizzles[0])
         elif score_edge is not None:
             chain = _chain_of(
-                c=c, score=score_edge, mn=mn, atom=atom, bk_elems=bk_elems, slab="_a_smem", stats=stats, lead=lead, slabs=slabs
+                c=c,
+                score=score_edge,
+                mn=mn,
+                atom=atom,
+                bk_elems=bk_elems,
+                slab="_a_smem",
+                stats=stats,
+                lead=lead,
+                slabs=slabs,
+                slab_swizzle=swizzles[0],
             )
-            a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, chain=chain, swizzle="NONE")
+            a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, chain=chain, swizzle=swizzles[0])
         else:
             a_op = SyncOperand(tag="a", shape=(mn[0].tile, bk_elems), value=a_value, swizzle=swizzles[0])
         sync_ops.append(a_op)
@@ -1540,12 +1582,14 @@ class _AtomOps:
     # ``_a`` / ``_b`` / ``_c`` do not shadow the accumulators the enclosing drain carries across
     # that same loop.
     frag_ns: str = ""
-    # Per-operand ``(slab, ldm)`` when the caller's own transport already STAGED it — the nested
-    # score's query and key slabs, filled by the enclosing loop's pipeline instead of re-read per
-    # warp through the gmem fragment loaders. Both are the operand's own gmem orientation (so
-    # ``ldm`` is the score's K extent either way), NONE-swizzle, one chunk: the read is the
-    # ordinary staged ``LdmatrixLoad``, only its slab comes from outside. ``None`` = gmem-direct.
-    slabs: tuple[tuple[str, int] | None, tuple[str, int] | None] = (None, None)
+    # Per-operand ``(slab, ldm, swizzle)`` when the caller's own transport already STAGED it — the
+    # nested score's query and key slabs, filled by the enclosing loop's pipeline instead of re-read
+    # per warp through the gmem fragment loaders. Both are the operand's own gmem orientation (so
+    # ``ldm`` is the score's K extent either way), one chunk: the read is the ordinary staged
+    # ``LdmatrixLoad``, only its slab comes from outside. ``swizzle`` is the mode the fill wrote the
+    # slab with (:func:`~._stage.software_swizzle` on the score's K span) — the drain applies the matching
+    # XOR, exactly like the enclosing contraction's own operands. ``None`` = gmem-direct.
+    slabs: tuple[tuple[str, int, str] | None, tuple[str, int, str] | None] = (None, None)
 
     def frag(self, name: str) -> str:
         """``name`` in this emission's fragment namespace (:attr:`frag_ns`)."""
@@ -1655,10 +1699,17 @@ class _MmaOps(_AtomOps):
         if self.tile.atom.fragment_layout == "m8n8k4":
             return ("NONE", "NONE")
         b_inner = self.stage.bk_elems if self.c.b_trans else mn[1].tile
-        return tuple(
-            "NONE" if e.nbytes == 1 else pick_swizzle_atom(inner, e.nbytes)[1]
-            for e, inner in zip(self.slab_elems(), (self.stage.bk_elems, b_inner), strict=True)
-        )
+        # A TMA slab keeps the hardware spelling (the copy engine fixes its permutation, and the
+        # descriptor splits its box down to the atom); every other transport writes the slab in
+        # software, so its XOR reads the row index at the slab's OWN stride.
+        hardware = self.stage.transport == "smem-tma"
+
+        def mode(inner: int, nbytes: int) -> str:
+            if nbytes == 1:
+                return "NONE"
+            return pick_swizzle_atom(inner, nbytes)[1] if hardware else software_swizzle(inner, nbytes)
+
+        return tuple(mode(inner, e.nbytes) for e, inner in zip(self.slab_elems(), (self.stage.bk_elems, b_inner), strict=True))
 
     def state(self, cells):
         """The mma operand/accumulator register fragments — one ``_a``/``_b`` per register row/col and
@@ -1740,7 +1791,7 @@ class _MmaOps(_AtomOps):
             if self.slabs[0] is not None:
                 # Already staged: the slab covers exactly this tile's M span, so the read is the
                 # warp's own within-tile row and the K-loop's column.
-                slab, ldm = self.slabs[0]
+                slab, ldm, swz = self.slabs[0]
                 prim = BinaryExpr("+", BinaryExpr("*", Var(m.unit), Literal(m.reg * atom.atom_m, "int")), Literal(i * atom.atom_m, "int"))
                 return [
                     LdmatrixLoad(
@@ -1750,6 +1801,7 @@ class _MmaOps(_AtomOps):
                         role="a",
                         staged=True,
                         ldm=ldm,
+                        swizzle=swz,
                         fragment_layout=atom.fragment_layout,
                     )
                 ]
@@ -1772,7 +1824,7 @@ class _MmaOps(_AtomOps):
             if self.slabs[1] is not None:
                 # Already staged: read the slab at the cell's LOCAL column (the slab covers exactly
                 # this tile's N span, so the absolute base drops out) and the K-loop's own row.
-                slab, ldm = self.slabs[1]
+                slab, ldm, swz = self.slabs[1]
                 return [
                     LdmatrixLoad(
                         frag=self.frag(f"_b{j}"),
@@ -1782,6 +1834,7 @@ class _MmaOps(_AtomOps):
                         staged=True,
                         ldm=ldm,
                         b_trans=True,
+                        swizzle=swz,
                         fragment_layout=atom.fragment_layout,
                     )
                 ]
@@ -1861,6 +1914,7 @@ class _MmaOps(_AtomOps):
                     m_guard=_guard(m, mcell),
                     n_guard=_guard(n, ncell),
                     atomic=by_acc[acc].atomic,
+                    swizzle=by_acc[acc].swizzle,
                     fragment_layout=atom.fragment_layout,
                 )
                 for acc, frag in zip(accs, frags, strict=True)
@@ -1879,6 +1933,7 @@ class _MmaOps(_AtomOps):
                 m_guard=_guard(m, mcell),
                 n_guard=_guard(n, ncell),
                 atomic=write.atomic,
+                swizzle=write.swizzle,
                 fragment_layout=atom.fragment_layout,
             )
         ]

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_stage.py
@@ -20,13 +20,19 @@ walk over its three tagged segments) — driven by a :class:`Transport` strategy
 (:class:`SyncTransport` / :class:`CpAsyncTransport` / :class:`TmaTransport`) — the three
 producers put behind one ``fill``/``commit``/``wait`` seam. The
 slab feeds the same staged ``LdmatrixLoad`` / scalar ``Load`` drain regardless of which producer
-(synchronous copy / cp.async / TMA) filled it. A modern slab feeding an mma drain is **swizzled** (:func:`pick_swizzle_atom`
-per operand): TMA permutes the 16 B chunks in hardware during the box copy, a cp.async fill applies
-the identical XOR in software on its destination index, and each staged ``LdmatrixLoad`` reads back
-through the matching address XOR — which is what keeps the ldmatrix drain free of smem bank
+(synchronous copy / cp.async / TMA) filled it. A modern slab feeding an mma drain is **swizzled** (per operand): TMA
+permutes the 16 B chunks in hardware during the box copy (:func:`pick_swizzle_atom`), every other producer applies the
+identical XOR in software on its destination index (:func:`software_swizzle`), and each staged ``LdmatrixLoad`` reads
+back through the matching address XOR — which is what keeps the ldmatrix drain free of smem bank
 conflicts (the unswizzled cp path was 4-way conflicted on 64 B rows / 8-way on 128 B ones — the
-sm_89 gap to cuBLAS). The sync compute-fill applies the same XOR on its slab ``Write`` stores (one
-vector store per 16 B run), and its per-cell producer-cone replication is planned by
+sm_89 gap to cuBLAS). The two derivations differ in ONE place, and only for a slab whose row is
+wider than the swizzle atom: the XOR must read the slab's ROW index, so a software fill shifts by
+the slab's own stride while a TMA slab keeps the atom's (its descriptor already splits the box down
+to the atom). Shifting by the atom on a two-atom row collapses consecutive rows onto a quarter of
+the chunk positions — the 7.8-way flash drain conflict at ``D = 128`` that vanished at ``D = 64``.
+The sync compute-fill applies the same XOR on its slab ``Write`` stores (one
+vector store per 16 B run) and on the fragment ``RegStore``\\ s of a chained fill, and its per-cell
+producer-cone replication is planned by
 :meth:`SyncTransport._run_plans` — run-invariant stmts hoist once, a stride-1 k-indexed gmem
 ``Load`` merges into one vector ``Load`` per run. Scalar-``Load``-drained slabs stay plain
 row-major (NONE-swizzle, linear writes and reads).
@@ -58,6 +64,7 @@ from emmy.compiler.ir.kernel.ir import (
     Sync,
     TmaDescriptor,
     TmaLoad,
+    swizzle_base,
 )
 from emmy.compiler.ir.pure.fold import deep_defines
 from emmy.compiler.ir.stmt import Body, Cond, Load, Loop, Stmt, StridedLoop, Write
@@ -269,6 +276,15 @@ def sync_stat_fill(
 TMA_SLAB_ALIGN = 128
 _SWIZZLE_SLAB_ALIGN = {"NONE": TMA_SLAB_ALIGN, "B32": 256, "B64": 512, "B128": 1024}
 
+
+def _swizzle_align(swizzle: str) -> int:
+    """The slab base alignment a SOFTWARE-filled slab needs — the same swizzle-atom alignment the
+    TMA table gives, keyed on the hardware mode behind a shift-overridden spelling. ``NONE`` keeps
+    the NATURAL alignment (``0``), not the TMA entry: nothing faults on an unaligned software fill,
+    so an unswizzled slab packs exactly where it did before this table reached the sync path."""
+    return 0 if swizzle == "NONE" else _SWIZZLE_SLAB_ALIGN[swizzle_base(swizzle)]
+
+
 # TMA hardware-swizzle atom widths in bytes, widest-first. The widest atom that divides a
 # slab's inner-row byte span wins (best bank-conflict spread on the ldmatrix drain).
 _SWIZZLE_BY_BYTES: tuple[tuple[int, str], ...] = ((128, "B128"), (64, "B64"), (32, "B32"))
@@ -292,6 +308,26 @@ def pick_swizzle_atom(inner_elems: int, elem_bytes: int) -> tuple[int, str]:
         if 1 <= we <= inner_elems and inner_elems % we == 0 and inner_bytes % wb == 0:
             return we, mode
     return inner_elems, "NONE"
+
+
+def software_swizzle(inner_elems: int, elem_bytes: int) -> str:
+    """The swizzle mode for a slab a SOFTWARE fill writes (``cp.async`` / the sync compute fill's
+    ``Write`` / ``RegStore``) and an ``ldmatrix`` drain reads back.
+
+    Same atom derivation as :func:`pick_swizzle_atom`, plus the shift the XOR must read the ROW
+    index at: the default shift is ``log2(atom elems)``, which IS the row only while a slab row is
+    exactly one atom. A wider row (a 128-elem fp16 head-dim row is two 128 B atoms) must shift by
+    its own stride or consecutive rows collapse onto a quarter of the chunk positions — the
+    measured 7.8-way ldmatrix conflict at ``D = 128`` that vanishes at ``D = 64``. A row that is
+    one atom (or not a power of two, where no row bit is extractable) keeps the plain spelling, so
+    every slab that already drained conflict-free emits byte-identically.
+
+    Hardware (TMA) slabs are NOT this: the copy engine fixes their permutation, and their
+    descriptor already splits its box down to the atom — they keep :func:`pick_swizzle_atom`."""
+    atom, mode = pick_swizzle_atom(inner_elems, elem_bytes)
+    if mode == "NONE" or inner_elems == atom or inner_elems & (inner_elems - 1):
+        return mode
+    return f"{mode}@{inner_elems.bit_length() - 1}"
 
 
 def tma_descriptor(name: str, src: str, box: tuple[int, int], dtype: str, *, swizzle: str = "NONE", elem_bytes: int = 4) -> TmaDescriptor:
@@ -484,9 +520,15 @@ class SyncTransport:
         # Sync-filled slabs are single-buffer (see :meth:`SyncOperand.slot_row`); only the
         # copied peer slabs allocate the ring.
         return [
-            *(slab_smem(op.slab, op.shape[0], op.shape[1], self.slab_dtype) for op in self.operands),
-            *(slab_smem(op.slab, ring * op.shape[0], op.shape[1], op.dtype or self.slab_dtype) for op in self.copy_operands),
-            *(slab_smem(op.slab, op.shape[0], op.shape[1], op.dtype or self.slab_dtype) for op in self.invariant_operands),
+            *(slab_smem(op.slab, op.shape[0], op.shape[1], self.slab_dtype, align=_swizzle_align(op.swizzle)) for op in self.operands),
+            *(
+                slab_smem(op.slab, ring * op.shape[0], op.shape[1], op.dtype or self.slab_dtype, align=_swizzle_align(op.swizzle))
+                for op in self.copy_operands
+            ),
+            *(
+                slab_smem(op.slab, op.shape[0], op.shape[1], op.dtype or self.slab_dtype, align=_swizzle_align(op.swizzle))
+                for op in self.invariant_operands
+            ),
         ]
 
     def prologue(self, ring: int) -> list[Stmt]:  # noqa: ARG002
@@ -769,6 +811,8 @@ class TmaTransport:
             for op in self.operands
         ]
         decls += [
+            # TMA keeps the full table, NONE included: the box copy faults on an unaligned
+            # destination, so an unswizzled TMA slab still pins 128 B (:data:`TMA_SLAB_ALIGN`).
             slab_smem(op.slab, ring * op.shape[0], op.shape[1], op.dtype or self.slab_dtype, align=_SWIZZLE_SLAB_ALIGN[op.swizzle])
             for op in self.operands
         ]

--- a/plans/fa-single-pass-residual.md
+++ b/plans/fa-single-pass-residual.md
@@ -2,30 +2,36 @@
 
 The FA-through-the-codec campaign (Stage 1 N-channel pairing, Stage 2 TWISTED computed-A bind, Stage 3's lowering
 half, the chained A fill + chained statistic, the SINGLE-PASS sweep, and now the nested score's own STAGED operands)
-has taken the fused single-kernel form past the two-kernel graph at every `D ≤ 64` and past torch at every `D` at
-`S = 512`. Loop fusion still refuses the merge, because `D = 128` still loses. This plan is the residual.
+has taken the fused single-kernel form past the two-kernel graph at every `D ≤ 64`, and the slab swizzles have taken
+it past torch at `D = 128` too on an A100 at `S ≤ 512`. Loop fusion still refuses the merge — pricing fused against
+cut needs the CUT arm's own schedule evidence, which nothing has measured yet. This plan is the residual.
 
 Measurements, gates, and the mechanism live in `tests/compiler/e2e/test_attention_coverage.py`'s module docstring and
 `emmy/compiler/pipeline/passes/lowering/kernel/ARCHITECTURE.md` — read those first; nothing here repeats them.
 
-## The wall at `D = 128` is now the TILE, not the memory path
+## The wall at `D = 128` was the SHARED path, and it is now cleared
 
-Staging the score took L1/TEX from 96% to 89% and the gmem fragment loaders out of the kernel entirely. What is left
-at `(1, 8, 2048, 128)` f16 on a 5090 is the tile's own footprint: **254 registers per thread and four slabs
-(A, V, score-K, score-Q) cap the kernel at ONE block per SM**, with compute utilization at 16%.
+The register reading was wrong. On an A100 the `D = 128` kernel was **shared-memory bank-conflict bound** — 78% of its
+shared wavefronts were conflict replays, L1/TEX at 80% against 7% compute — and registers never bound it (ncu's block
+limit from registers was 2, with negligible local traffic). Three slabs drained plain row-major, and the swizzle the
+fourth used under-spread a row wider than its atom. All three are fixed; the measurements and the mechanism are in the
+docstring and `ARCHITECTURE.md`. The A100 fused arm now beats torch at `S ≤ 512` and is at parity at `S = 1024`.
 
-Levers, in the order that pays:
+What is left, in the order that pays:
 
-1. **Hold the score's C fragments in fewer registers.** At `bk = 128` the score block alone is `bk/atom_n = 16`
-   C-fragments (64 registers) on top of the output tile's 16 (another 64), and `_contract_kloop` reads ALL register-col
-   B fragments before contracting, which is 32 more. Halving `bk` halves the first two but measured WORSE (209.5 vs
-   190.8 at `f1x16/k4` vs `k8`) — the chunk count and its barriers cost more than the registers save. The real fix is
-   a drain that interleaves the reads with the mma instead of hoisting them all.
-2. **Reuse ONE slab for the score's keys and the drain's values** where the two operands are the same buffer. They are
-   not in attention (K and V differ), so this is a no-op there — noted only so it is not re-derived.
+1. **The two long shapes.** `S = 1024` is at parity and `S = 2048` is ~1.35x behind, and the residual grows with `S` —
+   so it is not a fixed overhead. Profile the long shape on its own before assuming it is the same term as the short
+   one; L1/TEX is down to 61% and compute up to 24%, so neither is obviously the bound any more.
+2. **The P round trip itself.** The weight tile still goes C fragments → smem → `ldmatrix` → A fragments, costing
+   two `__syncthreads` and a slab per chunk. FA-2 recasts the C fragments into A fragments IN REGISTERS: for
+   `m16n8k16`, C tiles `j = 2k, 2k+1` hold exactly the A fragment for k-block `k`, so the recast is an f32→f16 pack
+   with no lane shuffle. That frees the slab (occupancy) and both barriers. Bigger than anything left below.
 3. **`units_n > 1`** still makes every `n` warp recompute the whole score for the same rows (323 cold vs 190.8 pinned
-   at S=2048 D=128). Sharing one warp band's statistic with the rest needs the ψ-rescale published through an smem row
-   and applied AFTER the transport's barrier — the `LeadSegment` seam now exists, so this is a second segment away.
+   at S=2048 D=128 on the 5090). Sharing one warp band's statistic with the rest needs the ψ-rescale published through
+   an smem row and applied AFTER the transport's barrier — the `LeadSegment` seam now exists, so this is a second
+   segment away.
+4. **Reuse ONE slab for the score's keys and the drain's values** where the two operands are the same buffer. They are
+   not in attention (K and V differ), so this is a no-op there — noted only so it is not re-derived.
 
 ## Schedule forks the cold pick lands on badly
 

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -50,6 +50,25 @@ softmax reduce. This file pins every tier of it:
   refuse the merge (``loop/fusion/_merge._nests_reduce`` — the refusal is REVERSIBILITY: no
   ``PLACE`` cut puts a two-consumer producer back together).
 
+  On an **A100-SXM4-80GB** (f16, ``(1, 8, S, 128)``, the same measurement protocol) the ``D = 128``
+  conclusion does NOT hold — the fused arm wins there once the schedule is right, and the cold pick
+  is what loses:
+
+  | shape        | torch | two-kernel | fused (cold pick) | fused (best ``WORK`` pinned) |
+  | ------------ | ----- | ---------- | ----------------- | ---------------------------- |
+  | S=256 D=128  |  14   |       45   |          **20.8** | **20.8** (``w4x1``)          |
+  | S=512 D=128  |  27   |      131   |             295   | **56.9** (``w4x1``)          |
+  | S=1024 D=128 |  54   |      188   |             310   |   226   (``w8x1``)           |
+
+  The cold pick lands on ``w8x2`` (129.5 KB of slabs, one block per SM) where ``w4x1`` takes 80 KB;
+  that one knob is 5.2x at ``S = 512``. Two consequences for the campaign: the fused form is already
+  worth deploying at ``D = 128`` on this card, and what stands between it and the default is the
+  schedule pick rather than the kernel. Structurally the merged tree IS reversible here —
+  with the merge allowed, ``EMMY_PLACE=cut`` lowers back to two kernels and both arms pass
+  ``run --bench --strict`` — but the recovered split is not the good one (909 us at ``S = 256``
+  against the default's 45), so pricing fused against cut needs the cut arm's own schedule
+  evidence before the refusal can be lifted.
+
   The fused column is the best schedule measured, and two forks the COLD pick can land on cost most
   of it: a split-K partition falls back to the two-pass pair (25.9 vs 14.3 at S=512 D=64), and an
   ``n``-unit split of the output tile makes every ``n`` warp recompute the whole score (323 cold vs

--- a/tests/compiler/e2e/test_attention_coverage.py
+++ b/tests/compiler/e2e/test_attention_coverage.py
@@ -45,37 +45,54 @@ softmax reduce. This file pins every tier of it:
   | S=2048 D=64  |  60.6 |      140.8 | 97.0  |               148.3 |
   | S=2048 D=128 | 117   |      162   | 190.8 |               273   |
 
-  So the fused arm beats the graph the refusal preserves at every ``D ≤ 64`` and beats torch at
-  every ``D`` at ``S = 512``, and still loses at ``D = 128`` — which is why loop fusion continues to
-  refuse the merge (``loop/fusion/_merge._nests_reduce`` — the refusal is REVERSIBILITY: no
-  ``PLACE`` cut puts a two-consumer producer back together).
+  So on that card the fused arm beat the graph the refusal preserves at every ``D ≤ 64`` and beat
+  torch at every ``D`` at ``S = 512``, and lost at ``D = 128`` — which is why loop fusion continues
+  to refuse the merge (``loop/fusion/_merge._nests_reduce`` — the refusal is REVERSIBILITY: no
+  ``PLACE`` cut puts a two-consumer producer back together). Those rows PREDATE the slab-swizzle
+  fix below and have not been re-measured; the A100 rows have.
 
-  On an **A100-SXM4-80GB** (f16, ``(1, 8, S, 128)``, the same measurement protocol) the ``D = 128``
-  conclusion does NOT hold — the fused arm wins there once the schedule is right, and the cold pick
-  is what loses:
+  All four of the fused kernel's slabs SWIZZLE. Three of them did not: the score's own staged
+  operands and the weight tile the ``ldmatrix`` drain reads were left plain row-major, and at
+  ``D = 128`` their 256 B rows drained ~32-way bank-conflicted — 78% of the kernel's shared
+  wavefronts were conflict replays, L1/TEX sat at 80% against 7% compute, and THAT, not the tile,
+  was the ``D = 128`` wall. Three things had to hold at once, each worth measuring on its own
+  (A100, f16, ``(1, 8, 1024, 128)``, ``w4x1``/``f1x16``/``k8``): the score's key and query slabs
+  swizzling on their ``cp.async`` fill (108.7 → 84.8 us), the weight tile swizzling on its FRAGMENT
+  store (84.8 → 64.9 — its ``RegStore`` had no mode to carry, and the per-cell store rewrite
+  dropped the one it was given), and the XOR shifting by the slab's own ROW rather than by the
+  swizzle atom (64.9 → 50.1 at the best schedule). The last is why the D-sweep above looks the way
+  it does: the fixed shift reads the row index only while a slab row IS one 128 B atom, so
+  ``D ≤ 64`` was always conflict-free and only ``D = 128`` paid — ncu measures 7.8-way at
+  ``D = 128`` and none at ``D = 64`` on the same kernel.
 
-  | shape        | torch | two-kernel | fused (cold pick) | fused (best ``WORK`` pinned) |
-  | ------------ | ----- | ---------- | ----------------- | ---------------------------- |
-  | S=256 D=128  |  14   |       45   |          **20.8** | **20.8** (``w4x1``)          |
-  | S=512 D=128  |  27   |      131   |             295   | **56.9** (``w4x1``)          |
-  | S=1024 D=128 |  54   |      188   |             310   |   226   (``w8x1``)           |
+  On an **A100-SXM4-80GB** (f16, ``(1, 8, S, 128)``, ``EMMY_PLACE=fuse``, serial ``REDUCE``, empty
+  tune DB and prior) the ``D = 128`` conclusion does NOT hold — the fused arm beats torch at the
+  short shapes and reaches parity at ``S = 1024``:
 
-  The cold pick lands on ``w8x2`` (129.5 KB of slabs, one block per SM) where ``w4x1`` takes 80 KB;
-  that one knob is 5.2x at ``S = 512``. Two consequences for the campaign: the fused form is already
-  worth deploying at ``D = 128`` on this card, and what stands between it and the default is the
-  schedule pick rather than the kernel. Structurally the merged tree IS reversible here —
-  with the merge allowed, ``EMMY_PLACE=cut`` lowers back to two kernels and both arms pass
-  ``run --bench --strict`` — but the recovered split is not the good one (909 us at ``S = 256``
-  against the default's 45), so pricing fused against cut needs the cut arm's own schedule
-  evidence before the refusal can be lifted.
+  | shape        | torch | fused (best schedule pinned)     |
+  | ------------ | ----- | -------------------------------- |
+  | S=256 D=128  |  13   | **9.0**  (``w4x1``/``f1x8/k8``)  |
+  | S=512 D=128  |  24   | **19.0** (``w4x1``/``f1x16/k8``) |
+  | S=1024 D=128 |  48   |   50.1   (``w8x1``/``f1x16/k8``) |
+  | S=2048 D=128 | 133   |  179.0   (``w4x1``/``f1x16/k8``) |
+
+  Emmy's column repeats to ±0.2 us across runs; torch's drifts a few percent, and more at
+  ``S = 2048`` (132-148 observed). The COLD pick is a separate matter and this changed nothing
+  about it: unpinned it lands on ``f1x8`` at every shape, which happens to be the best schedule at
+  ``S = 256`` (9.0) and is 231 us at ``S = 512``.
+
+  Structurally the merged tree IS reversible here — with the merge allowed, ``EMMY_PLACE=cut``
+  lowers back to two kernels and both arms pass ``run --bench --strict`` — but the recovered split
+  is not the good one (909 us at ``S = 256`` against the default's 45), so pricing fused against cut
+  needs the cut arm's own schedule evidence before the refusal can be lifted.
 
   The fused column is the best schedule measured, and two forks the COLD pick can land on cost most
   of it: a split-K partition falls back to the two-pass pair (25.9 vs 14.3 at S=512 D=64), and an
   ``n``-unit split of the output tile makes every ``n`` warp recompute the whole score (323 cold vs
-  190.8 at S=2048 D=128). Both are schedule forks evidence prices, not defects. What is left after
-  them at ``D = 128`` is no longer the score's memory path — staging took L1/TEX from 96% to 89% —
-  but the tile itself: 254 registers per thread and four slabs cap the kernel at ONE block per SM,
-  and compute utilization sits at 16%. The reference kernel below is the target form's spec.
+  190.8 at S=2048 D=128). Both are schedule forks evidence prices, not defects. What is left at
+  ``D = 128`` after the swizzles is no longer the shared path either: L1/TEX fell from 80% to 61%
+  and compute rose from 7% to 24%, and the residual grows with ``S`` — the two long shapes are
+  where the fused arm still trails. The reference kernel below is the target form's spec.
 - **validated FA-2 reference** — a hand-written fused tensor-core flash kernel, the executable spec a
   future through-the-contraction-path tensor-core flash tier must reproduce.
 - **model attention chains** — TinyLlama ``LlamaAttention`` bisection (chained Linears → QKV+SDPA →
@@ -85,6 +102,8 @@ GPU accuracy in the correctness lane; the warp-tier needs sm_90+ where pinned.
 """
 
 from __future__ import annotations
+
+import re
 
 import numpy as np
 import pytest
@@ -262,6 +281,18 @@ def test_fused_single_kernel_sdpa_matches_torch(monkeypatch, cfg):
     # silent regression a numerics assert would never catch.
     assert "emmy_mma_load_b_gmem_trans" in src, "the composed score is not on the mma tier (chained A fill)"
     assert "__shfl_xor_sync" in src, "the statistic is not at fragment residence (chained statistic)"
+    # Every slab is addressed through ONE swizzle mode — all of its uses XOR, or none do. Which
+    # mode a slab picks is the schedule's business (a row too narrow for any atom stays NONE), but
+    # a MIXED slab is a silently WRONG kernel, not a slow one: it stores row-major under a drain
+    # that reads permuted. The weight tile is where that bites, because its producer is a fragment
+    # store rather than a copy — its mode rides ``RegStore.swizzle``, and the per-cell store
+    # rewrite dropped exactly that field.
+    slabs = set(re.findall(r"__shared__[^;]*?(\w+_smem)\[", src))
+    assert slabs, "the fused kernel stages no slab"
+    for slab in slabs:
+        uses = len(re.findall(rf"(?<!\w){slab}\[", src)) - 1  # every use but the declaration
+        swizzled = len(re.findall(rf"(?<!\w){slab}\[emmy_swizzle_", src))
+        assert swizzled in (0, uses), f"{slab}: {swizzled} of {uses} uses swizzle — producer and drain disagree"
     md = _max_diff(backend, compiled, feed, ref)
     assert md < 4e-3, f"fused sdpa{cfg} vs torch max_diff={md:.6e}"
 

--- a/tests/compiler/passes/test_sync_transport.py
+++ b/tests/compiler/passes/test_sync_transport.py
@@ -3,8 +3,9 @@
 from emmy.compiler.ir.axis import Axis, AxisRole
 from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import Literal, Var
+from emmy.compiler.ir.kernel.ir import swizzle_fn, swizzle_xor
 from emmy.compiler.ir.stmt import Accum, Assign, Body, Load, Loop
-from emmy.compiler.pipeline.passes.lowering.kernel._stage import CtaTile, SyncOperand, SyncTransport
+from emmy.compiler.pipeline.passes.lowering.kernel._stage import CtaTile, SyncOperand, SyncTransport, software_swizzle
 
 
 def test_compute_fill_suffixes_nested_ssa_for_every_vector_cell() -> None:
@@ -32,3 +33,31 @@ def test_compute_fill_suffixes_nested_ssa_for_every_vector_cell() -> None:
     assert {acc.name for acc in fill.accums} == {f"acc__c{i}" for i in range(8)}
     assert {load.names[0] for load in fill.loads if load.input == "x"} == {f"value__c{i}" for i in range(8)}
     assert {assign.name for assign in fill.iter_of_type(Assign)} == {f"out__c{i}" for i in range(8)}
+
+
+def test_software_swizzle_shifts_by_the_slab_row_not_the_atom() -> None:
+    """A software-filled slab's XOR reads its ROW index — which needs the slab's OWN stride once a
+    row is wider than one swizzle atom.
+
+    The mode's default element shift is ``log2(atom elems)``; that IS the row only while a row is
+    exactly one atom. A 128-elem fp16 row (the flash slabs' head dim) is TWO 128 B atoms, so the
+    atom bit stays inside the shifted field, consecutive rows collapse onto a quarter of the chunk
+    positions, and the ``ldmatrix`` drain over 16 rows goes multi-way bank-conflicted (measured
+    7.8-way at ``D = 128`` on an A100, none at ``D = 64``). A one-atom row — and a non-power-of-two
+    one, where no row bit is extractable — keeps the PLAIN spelling, so every slab that already
+    drained conflict-free renders byte-identically.
+    """
+    assert software_swizzle(64, 2) == "B128"  # one 128 B atom: the default shift already is the row
+    assert software_swizzle(32, 2) == "B64"  # one 64 B atom
+    assert software_swizzle(128, 2) == "B128@7"  # two atoms: shift by the row (2**7 elems), not the atom
+    assert software_swizzle(256, 2) == "B128@8"
+    assert software_swizzle(96, 2) == "B64"  # not a power of two — no row bit to shift by
+    assert software_swizzle(4, 2) == "NONE"  # no atom fits
+
+    assert swizzle_xor("B128") == (6, 0x7)
+    assert swizzle_xor("B128@7") == (7, 0x7)  # the override moves the shift, never the row mask
+    assert swizzle_xor("NONE") is None
+    # One emitted helper per distinct (mask, shift): the plain mode keeps its name, so an
+    # unchanged slab's kernel source is unchanged.
+    assert swizzle_fn("B128") == "emmy_swizzle_b128"
+    assert swizzle_fn("B128@7") == "emmy_swizzle_b128_s7"


### PR DESCRIPTION
## What

The fused single-kernel flash arm at `D = 128` was **shared-memory bank-conflict bound**, not tile bound. Three of its four slabs drained plain row-major, and the swizzle the fourth used under-spread a row wider than its atom. This swizzles all four and fixes the derivation.

Supersedes this PR's original scope (recording the A100 measurements) — the table it recorded no longer describes the kernel.

## Why the old reading was wrong

The plan said the wall was the tile: 254 registers, four slabs, one block per SM, 16% compute. ncu on an A100 says otherwise — **78% of the kernel's shared wavefronts were conflict replays**, L1/TEX at 80% against 7% compute, ncu's block limit from registers was 2, and local (spill) traffic was negligible.

## The three fixes

Each measured on its own, `(1, 8, 1024, 128)` f16, `w4x1`/`f1x16/k8`:

| change | us |
| --- | ---: |
| baseline | 108.7 |
| the score's staged key + query slabs swizzle on their `cp.async` fill | 84.8 |
| the weight tile swizzles on its FRAGMENT store (`RegStore.swizzle`) | 64.9 |
| the XOR shifts by the slab's own ROW stride, not the swizzle atom | 50.1 (best schedule) |

The third is why the wall was `D = 128` **specifically**. The XOR's shift is `log2(atom elems)`, which reads the row index only while a slab row IS one 128 B atom. A 128-elem fp16 head-dim row is two atoms, so consecutive rows collapsed onto a quarter of the chunk positions. ncu measures 7.8-way at `D = 128` and **no load conflict at all** at `D = 64` on the same kernel — that was the decisive experiment.

Hardware (TMA) slabs keep the atom shift: the copy engine fixes their permutation and their descriptor already splits its box down to the atom. A row that is one atom keeps the plain spelling, so **every slab that already drained conflict-free renders byte-identically**.

## Result — A100-SXM4-80GB, f16, `(1, 8, S, 128)`, best schedule pinned

| S | torch | fused | |
| --- | ---: | ---: | --- |
| 256 | 13 | **9.0** | `w4x1`/`f1x8/k8` |
| 512 | 24 | **19.0** | `w4x1`/`f1x16/k8` |
| 1024 | 48 | 50.1 | `w8x1`/`f1x16/k8` |
| 2048 | 133 | 179.0 | `w4x1`/`f1x16/k8` |

Beats torch at `S ≤ 512`, parity at `S = 1024`, still 1.35x behind at `S = 2048` — and the residual grows with `S`, so it is not a fixed overhead. L1/TEX is down to 61% and compute up to 24%; the next lever (the P round trip, which FA-2 keeps in registers) is recorded in the plan.

The COLD pick is untouched by this and still lands badly: unpinned it takes `f1x8` at every shape, which happens to be best at `S = 256` (9.0) and is 231 us at `S = 512`. That is the schedule-evidence problem the docstring already documents.

## A bug found on the way

The per-cell `RegStore` rewrite rebuilt the node field by field, so it silently dropped the new `swizzle` — leaving the weight tile stored row-major under a drain that reads it XOR-permuted. A **wrong kernel with no loud failure**, and the same trap had already cost `atomic` once. It is a `dataclasses.replace` now, which cannot regress that way when a field is added.

## Verification

- `make test` on the A100: **3550 passed**. The 7 failures are pre-existing on this box (fp8 needs sm_89+; two are environment) and reproduce identically on a pristine `HEAD` checkout.
- Every number above is `emmy run --bench --strict` (correctness checked against eager), `EMMY_NVCC_FLAGS=` (O3), empty tune DB and prior. Emmy's timings repeat to ±0.2 us across runs; torch's drift a few percent, more at `S = 2048` (132-148 observed).
- New tests: the swizzle-shift derivation (`software_swizzle` / `swizzle_xor` spellings, incl. the byte-identity cases), and a schedule-independent assertion that every slab in the fused kernel is addressed through ONE mode — all uses XOR or none do, which is exactly what the `RegStore` field-drop broke.
- The 5090 table in the docstring predates this and has NOT been re-measured; it is marked as such.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)