### PR TITLE
Tuned golden datasets for the golden-bench kernel corpus (RTX 4090/5090, V100)

### DIFF
--- a/experiments/golden-bench-2026/kernels/RESULTS.md
+++ b/experiments/golden-bench-2026/kernels/RESULTS.md
@@ -1,12 +1,96 @@
-# Golden-bench kernel attempt on H200
+# Golden-bench kernel corpus: tuned golden datasets on RTX 4090 / RTX 5090 / V100 SXM3
 
-## Conclusion
+## What this directory now contains
+
+Per-GPU **tuned golden datasets** for the corpus models, produced so compiler improvements have measured baselines
+to beat — not to claim wins. Each `goldens/<model>_<gpu>.yaml` embeds every post-fusion kernel target of the
+model's layer 0 (seq_len 512 and 1 as separate realizations), the **deployed knobs after tuning**
+(single-kernel targets; multi-kernel targets record `knobs: {}` and their per-kernel breakdown lives in the
+archives), and **median 3-repeat `-O3` measurements**: `emmy_us` vs `reference_us` (`torch-eager`), losses
+included. Raw evidence per platform: `results_<platform>.tar.gz` (traces, tune logs with search feedback,
+per-target verification JSONs incl. `torch.compile` numbers, system info, progress log).
+
+Run: 2026-08-19/20, revision `c1abcc91`, recipe budgets (`--max-candidates 12/8, --patience 4/3, --seed 0`),
+one caller-supplied single-GPU host per platform. Model x GPU cells follow raw memory fit, not the recipe's GPU
+matrix (per request): 0.6B + 0.6B-FP8 everywhere; 32B-FP8 on 4090 + V100; Qwen3.6-27B attempted on V100 only.
+
+## Layer-level summary (sum over kernel targets, median of 3 `-O3` repeats, µs)
+
+`tcompile` is `torch.compile(mode="max-autotune")` and its column sums only the kernels where its lane measured
+(it fails on some SDPA targets), so ratios are approximate but directionally unambiguous.
+
+| platform | model / seq | eager | tcompile | emmy (tuned deploy) |
+| --- | --- | ---: | ---: | ---: |
+| rtx5090x1 | 0.6B s512 / s1 | 918 / 467 | 181 / 42 | 32868 / 11108 |
+| rtx5090x1 | 0.6B-FP8 s512 / s1 | 1789 / 1208 | 153 / 23 | 28835 / 482 |
+| rtx4090x1 | 0.6B s512 / s1 | 1027 / 444 | 210 / 40 | 35285 / 9988 |
+| rtx4090x1 | 0.6B-FP8 s512 / s1 | 2287 / 1452 | 173 / 10 | 34540 / 759 |
+| rtx4090x1 | 32B-FP8 s512 / s1 | 57546 / 48455 | 259 / 19 | 650274 / 2957 |
+| v100x1 | 0.6B s512 / s1 | 4418 / 974 | 899 / 59 | 71727 / 17246 |
+| v100x1 | 0.6B-FP8 s512 / s1 | 7367 / 3320 | 821 / 30 | 147232 / 2628 |
+| v100x1 | 32B-FP8 s512 / s1 | 24357 / 55282 | 3876 / 45 | 408201 / 16696 |
+
+Reading: tuning improves individual reachable kernels (agent-seeded warp/staged proposals were injected per
+linear target before each s512 tune), but the layer totals stay 1-3 orders behind `torch.compile` because the
+dominant kernels cannot enter the search at all (below). These datasets are the baselines that make that gap
+concrete per kernel, per card.
+
+## Failures and defects surfaced (all reproduced in the archives)
+
+1. **MCTS crash on the 32B-FP8 s512 corpus, both sm_89 and sm_70**: `AttributeError: 'NoneType' object has no
+   attribute 'items'` at `emmy/compiler/pipeline/search/policy/mcts.py:518` (`_node_key`), mid-search after ~5
+   shapes. Deterministic across cards on `c1abcc91`. Tune logs: `tune-qwen3-32b-fp8-s512.log` in the rtx4090/v100
+   archives.
+2. **Qwen3.6-27B is untraceable**: `ValueError: cannot map fallback aten.conv1d as elementwise for output shape
+   (1, 10240, 515)` (`emmy/compiler/trace/torch.py`). Frontend coverage gap; no 27B golden exists.
+   Log: `trace-qwen36-27b-s512.log` in the v100 archive.
+3. **Known schedule lockouts dominate the totals** (prior sessions' diagnosis, still true on `c1abcc91`): the
+   q/k-proj kernels fuse a reshape-to-heads that splits the output axis, so the warp tiler offers no rows and the
+   contraction demotes to a scalar loop; SDPA online-softmax splices carry no structural identity and every
+   candidate dies at the `005_stamp` assertion. The goldens record these kernels' measured scalar deploys as the
+   baseline to improve.
+4. **V100 32B-FP8 s512 verification exited nonzero on all 3 repeats** while still writing 16/19 target JSONs;
+   the 4 unmeasured realizations are kept (inventory-only) in `qwen3-32b-fp8_v100.yaml`, which therefore
+   validates at WORKING level; the other seven golden files pass REPOSITORY validation.
+5. Host provisioning traps (recorded for reuse): fresh CloudRift boxes need `apt-get update` before
+   `python3.12-venv`; V100 needs torch cu126 + `cupy-cuda12x==13.6.0` + `fastrlock` (nvrtc 13 dropped Volta).
+
+## Platform sections
+
+### rtx5090x1
+0.6B + 0.6B-FP8 (large models excluded by RAM fit: 30 GB host). 4 traces, 4 tunes, 12 verification runs, zero
+chain failures. Goldens: `qwen3-06b_rtx5090.yaml` (18/18 measured), `qwen3-06b-fp8_rtx5090.yaml` (38/38).
+Archive: `results_rtx5090x1.tar.gz` (root `gb-rtx5090x1/`).
+
+### rtx4090x1
+0.6B, 0.6B-FP8, 32B-FP8. The 32B s512 tune crashed (defect 1); verification still measured every target, so its
+golden records greedy/partially-tuned deploys. Goldens: `qwen3-06b_rtx4090.yaml` (18/18),
+`qwen3-06b-fp8_rtx4090.yaml` (38/38), `qwen3-32b-fp8_rtx4090.yaml` (38/38).
+Archive: `results_rtx4090x1.tar.gz` (root `gb-rtx4090x1/`).
+
+### v100x1
+0.6B, 0.6B-FP8, 32B-FP8 (no fp8-mma on sm_70 — FP8 checkpoints run the dequant path), 27B attempted (defect 2).
+Goldens: `qwen3-06b_v100.yaml` (18/18), `qwen3-06b-fp8_v100.yaml` (38/38), `qwen3-32b-fp8_v100.yaml` (38
+realizations, 34 measured). Archive: `results_v100x1.tar.gz` (root `gb-v100x1/`).
+
+## Limitations
+
+- Layer-0 evidence only; never a whole-model claim (lm_head/embedding uncovered).
+- Tune-lane `-O1` rankings appear inside the working files' `ranking` blocks as search feedback; every number in
+  the goldens' `measurements` and in this file is deployable `-O3`.
+- The tcompile comparison column is partial where its lane failed; per-target values are in the verification JSONs.
+- `knobs: {}` on multi-kernel targets is a format limitation, not "no schedule"; see the archives for per-kernel
+  `record_knobs`.
+
+## Platform h200x8 — earlier failed attempt (retained)
+
+### Conclusion
 
 The latest non-dry invocation failed before tracing, tuning, or kernel benchmarking began. It produced no latency,
 correctness, or coverage measurements and supports no kernel-performance claim. The failure is retained because
 dry-run validation is not a result.
 
-## Protocol and failure
+### Protocol and failure
 
 The invocation selected one `common` row on a pre-allocated host detected as eight NVIDIA H200 141GB GPUs. The task
 used one GPU and targeted `Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca`, layer 0, sequence length 512,
@@ -17,7 +101,7 @@ installed. Its exit trap encountered a second error because `task_dir` was unset
 was never created or retrieved. The command result records exit code 1 and the missing-result transfer error. The
 runner summary is 0/1 successful tasks.
 
-## System and provenance
+### System and provenance
 
 - Hardware detected: NVIDIA H200 141GB x8; the task requested one GPU.
 - Timestamp: `2026-08-13_16-08-20_e1c8d16a`.
@@ -25,7 +109,7 @@ runner summary is 0/1 successful tasks.
 - Workload status: failed before measurement.
 - The legacy command result has no assembled experiment record and no complete typed system-information section.
 
-## Durable files
+### Durable files
 
 - Raw-results archive: `results.tar.gz`.
 - Archived root: `2026-08-13_16-08-20_e1c8d16a/`.

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx4090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx4090.yaml
@@ -1,0 +1,8379 @@
+gpu_name: NVIDIA GeForce RTX 4090
+compute_cap:
+- 8
+- 9
+model: RedHatAI/Qwen3-0.6B-FP8-dynamic@068a9040b238d65f5c1064f10232bb15b96c0ff0
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 2048
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 2048
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 2048
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 2048
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 401.9
+      reference_us: 128.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.7fab792e36b5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5
+      reference_us: 26.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.ff9f086c30d3.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3
+      reference_us: 28.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.a1a76b31bc3e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2
+      reference_us: 32.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_fca85d.00649ff02cee.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 19.0
+      reference_us: 50.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_a32aed.89078f3fbe12.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2325.5
+      reference_us: 155.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_eae85b.f12041cc8017.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 882.7
+      reference_us: 88.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 16710.5
+      reference_us: 473.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_616dc9.f3e66f01fdd9.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 549.4
+      reference_us: 79.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.0e9d9791df45.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7
+      reference_us: 29.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.eb4eaf5ef73c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7
+      reference_us: 42.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_aa889a.5daf04e4b12c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f2x4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 483.8
+      reference_us: 161.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.mul_11.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 401.9
+      reference_us: 128.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.7fab792e36b5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5
+      reference_us: 26.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.ff9f086c30d3.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.3
+      reference_us: 28.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_b17b94.9b1a8cdd20e7.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 11868.2
+      reference_us: 421.9
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.c05e555e4732.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.9
+      reference_us: 31.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.083302be93f5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.1
+      reference_us: 61.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_0edae7.d3c7f8af0a8f.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f2x4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 838.7
+      reference_us: 281.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 35.7
+      reference_us: 76.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.4a374f5b8b0a.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1
+      reference_us: 22.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.97c2838bbc56.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7
+      reference_us: 16.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.3e72e8c99ab4.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f2
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7
+      reference_us: 18.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_1d5287.147152c67795.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.1
+      reference_us: 43.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_470271.724b6dd22d3f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.8
+      reference_us: 113.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_d0696e.5e6adaca2bfd.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 10.3
+      reference_us: 60.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 67.7
+      reference_us: 206.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_5adc5a.3ea87b3c41dd.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 101.9
+      reference_us: 47.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.a63fa759a4b6.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1
+      reference_us: 22.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.bfef47309b2c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7
+      reference_us: 16.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_68727f.bd4224adf5de.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.1
+      reference_us: 115.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.mul_11.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 35.7
+      reference_us: 76.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.4a374f5b8b0a.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1
+      reference_us: 22.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.97c2838bbc56.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7
+      reference_us: 16.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_fb7c04.e6d52e2ec74e.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 191.7
+      reference_us: 346.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.342c8bced758.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.2
+      reference_us: 23.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.33ab592af2af.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.7
+      reference_us: 16.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_fda778.f6a53ae5e40c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 299.0
+      reference_us: 186.4
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx5090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_rtx5090.yaml
@@ -1,0 +1,8379 @@
+gpu_name: NVIDIA GeForce RTX 5090
+compute_cap:
+- 12
+- 0
+model: RedHatAI/Qwen3-0.6B-FP8-dynamic@068a9040b238d65f5c1064f10232bb15b96c0ff0
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 2048
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 2048
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 2048
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 2048
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 456.5
+      reference_us: 107.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.7fab792e36b5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.8
+      reference_us: 27.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.ff9f086c30d3.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.a1a76b31bc3e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.0
+      reference_us: 28.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_fca85d.00649ff02cee.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.3
+      reference_us: 43.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_a32aed.89078f3fbe12.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1138.3
+      reference_us: 124.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_eae85b.f12041cc8017.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 582.5
+      reference_us: 68.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 17799.9
+      reference_us: 432.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_616dc9.f3e66f01fdd9.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 428.2
+      reference_us: 67.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.0e9d9791df45.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.7
+      reference_us: 30.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.eb4eaf5ef73c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 36.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_aa889a.5daf04e4b12c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x16
+      TILE: f4x4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 408.4
+      reference_us: 116.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.mul_11.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 456.5
+      reference_us: 107.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.7fab792e36b5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.8
+      reference_us: 27.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.ff9f086c30d3.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.1
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_b17b94.9b1a8cdd20e7.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7056.2
+      reference_us: 270.9
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.c05e555e4732.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9.6
+      reference_us: 32.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.083302be93f5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.8
+      reference_us: 43.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_0edae7.d3c7f8af0a8f.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f4x8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 454.5
+      reference_us: 175.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 38.2
+      reference_us: 79.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.4a374f5b8b0a.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.6
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.97c2838bbc56.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 18.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.3e72e8c99ab4.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 20.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_1d5287.147152c67795.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t32
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.3
+      reference_us: 38.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_470271.724b6dd22d3f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t32
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.8
+      reference_us: 76.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_d0696e.5e6adaca2bfd.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t32
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.3
+      reference_us: 57.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 73.7
+      reference_us: 216.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_5adc5a.3ea87b3c41dd.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 104.4
+      reference_us: 43.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.a63fa759a4b6.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.4
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.bfef47309b2c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f2
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 18.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_68727f.bd4224adf5de.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.2
+      reference_us: 79.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.mul_11.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 38.2
+      reference_us: 79.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.4a374f5b8b0a.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.6
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.97c2838bbc56.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 18.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_fb7c04.e6d52e2ec74e.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 186.3
+      reference_us: 217.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.342c8bced758.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9.2
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.33ab592af2af.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 18.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_fda778.f6a53ae5e40c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.7
+      reference_us: 126.8
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_v100.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b-fp8_v100.yaml
@@ -1,0 +1,8379 @@
+gpu_name: NVIDIA Tesla V100 SXM3 32GB
+compute_cap:
+- 7
+- 0
+model: RedHatAI/Qwen3-0.6B-FP8-dynamic@068a9040b238d65f5c1064f10232bb15b96c0ff0
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 2048
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 2048
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 2048
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 2048
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 2048
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 2048
+        - 1024
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 3072
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 3072
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 3072
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 2048
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 3072
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 833.5
+      reference_us: 406.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.7fab792e36b5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.8
+      reference_us: 40.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.ff9f086c30d3.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f2
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.2
+      reference_us: 82.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.a1a76b31bc3e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.6
+      reference_us: 90.9
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_fca85d.00649ff02cee.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f4x8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 698.4
+      reference_us: 181.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_a32aed.89078f3fbe12.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9658.4
+      reference_us: 474.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_eae85b.f12041cc8017.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4827.1
+      reference_us: 283.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 80968.7
+      reference_us: 1947.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_616dc9.f3e66f01fdd9.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 1938.4
+      reference_us: 692.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.0e9d9791df45.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.4
+      reference_us: 48.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.eb4eaf5ef73c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 6.3
+      reference_us: 142.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_aa889a.5daf04e4b12c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f4x8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2827.3
+      reference_us: 495.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.mul_11.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 833.5
+      reference_us: 406.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.7fab792e36b5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.7
+      reference_us: 40.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.ff9f086c30d3.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f2
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.2
+      reference_us: 82.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_b17b94.9b1a8cdd20e7.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 40257.5
+      reference_us: 997.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.c05e555e4732.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.7
+      reference_us: 63.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.083302be93f5.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.4
+      reference_us: 201.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_0edae7.d3c7f8af0a8f.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x16
+      TILE: f4x8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4278.3
+      reference_us: 701.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 69.0
+      reference_us: 140.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.4a374f5b8b0a.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7
+      reference_us: 33.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.97c2838bbc56.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 24.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.3e72e8c99ab4.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5
+      reference_us: 29.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_1d5287.147152c67795.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.4
+      reference_us: 139.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_470271.724b6dd22d3f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.3
+      reference_us: 297.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_d0696e.5e6adaca2bfd.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 55.8
+      reference_us: 177.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 119.7
+      reference_us: 418.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_5adc5a.3ea87b3c41dd.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 182.1
+      reference_us: 204.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.a63fa759a4b6.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 8.2
+      reference_us: 34.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.bfef47309b2c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 24.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_68727f.bd4224adf5de.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 624.6
+      reference_us: 299.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.mul_11.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 69.0
+      reference_us: 140.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.4a374f5b8b0a.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7
+      reference_us: 33.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.97c2838bbc56.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 24.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_fb7c04.e6d52e2ec74e.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 454.7
+      reference_us: 804.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.342c8bced758.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 11.6
+      reference_us: 34.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.33ab592af2af.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 25.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_fda778.f6a53ae5e40c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1003.5
+      reference_us: 436.2
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx4090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx4090.yaml
@@ -1,0 +1,5475 @@
+gpu_name: NVIDIA GeForce RTX 4090
+compute_cap:
+- 8
+- 9
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - scaled_dot_product_attention_c3
+      - f16
+      - - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c1
+      - f16
+      - - 1
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c2
+      - f16
+      - - 1
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c1
+      - f16
+      - - 1
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c2
+      - f16
+      - - 1
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c1
+      - f16
+      - - 1
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c2
+      - f16
+      - - 1
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c1
+      - f16
+      - - 1
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c2
+      - f16
+      - - 1
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_1_c1
+      - f16
+      - - 1
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_c1
+      - f16
+      - - 1
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c1
+      - f16
+      - - 1
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c2
+      - f16
+      - - 1
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c1
+      - f16
+      - - 1
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c2
+      - f16
+      - - 1
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c1
+      - f16
+      - - 1
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c2
+      - f16
+      - - 1
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c1
+      - f16
+      - - 1
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c2
+      - f16
+      - - 1
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_1_c1
+      - f16
+      - - 1
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_c1
+      - f16
+      - - 1
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 436.7
+      reference_us: 138.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_06a42b.975d5314f1c7.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f8x2/k8
+      REDUCE: ''
+      STAGE: d2/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16.7
+      reference_us: 9.9
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_84dfe3.29bfa5222c55.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 451.6
+      reference_us: 66.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_7c1c37.43145a209e1e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 228.6
+      reference_us: 42.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 20680.7
+      reference_us: 476.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_c0a378.ace3043c96cf.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 6605.8
+      reference_us: 35.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_e24efe.109440eff691.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 6769.4
+      reference_us: 49.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_dc067d.a2e77bf96bb2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f4x2/k2
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 60.9
+      reference_us: 179.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_6b4b5f.a59ee74a4345.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 54.8
+      reference_us: 25.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 35.6
+      reference_us: 76.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_7ef15d.37e7fb9e7dd5.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9.9
+      reference_us: 4.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_586ad6.12590a0f5a24.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.1
+      reference_us: 21.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_6044db.bfcbc69d30c1.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9.4
+      reference_us: 20.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 67.7
+      reference_us: 206.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_d0f5c0.128c6f715151.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 60.9
+      reference_us: 6.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_14c8c7.b69c5cc0ab9b.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 68.0
+      reference_us: 9.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_549927.f3a20e07e940.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@a0: coop
+      WORK: t8
+      TILE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 9697.3
+      reference_us: 92.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_2dcd0c.28b342e368a5.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 24.5
+      reference_us: 7.5
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx5090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_rtx5090.yaml
@@ -1,0 +1,5475 @@
+gpu_name: NVIDIA GeForce RTX 5090
+compute_cap:
+- 12
+- 0
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - scaled_dot_product_attention_c3
+      - f16
+      - - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c1
+      - f16
+      - - 1
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c2
+      - f16
+      - - 1
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c1
+      - f16
+      - - 1
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c2
+      - f16
+      - - 1
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c1
+      - f16
+      - - 1
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c2
+      - f16
+      - - 1
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c1
+      - f16
+      - - 1
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c2
+      - f16
+      - - 1
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_1_c1
+      - f16
+      - - 1
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_c1
+      - f16
+      - - 1
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c1
+      - f16
+      - - 1
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c2
+      - f16
+      - - 1
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c1
+      - f16
+      - - 1
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c2
+      - f16
+      - - 1
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c1
+      - f16
+      - - 1
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c2
+      - f16
+      - - 1
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c1
+      - f16
+      - - 1
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c2
+      - f16
+      - - 1
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_1_c1
+      - f16
+      - - 1
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_c1
+      - f16
+      - - 1
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 456.5
+      reference_us: 107.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_06a42b.975d5314f1c7.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m16n8k16_f16_f32/f4x2/k8
+      REDUCE: ''
+      STAGE: d1/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.7
+      reference_us: 10.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_84dfe3.29bfa5222c55.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 308.4
+      reference_us: 51.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_7c1c37.43145a209e1e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 157.0
+      reference_us: 34.9
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 17798.3
+      reference_us: 432.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_c0a378.ace3043c96cf.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 6263.6
+      reference_us: 29.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_e24efe.109440eff691.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 6943.3
+      reference_us: 39.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_dc067d.a2e77bf96bb2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w4x1
+      TILE: mma_m16n8k16_f16_f32/f4x8/k8
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 882.3
+      reference_us: 188.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_6b4b5f.a59ee74a4345.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w2x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-tma
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 47.4
+      reference_us: 24.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 38.2
+      reference_us: 79.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_7ef15d.37e7fb9e7dd5.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.4
+      reference_us: 4.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_586ad6.12590a0f5a24.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 19.5
+      reference_us: 22.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_6044db.bfcbc69d30c1.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 11.2
+      reference_us: 22.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 73.7
+      reference_us: 216.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_d0f5c0.128c6f715151.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 59.5
+      reference_us: 8.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_14c8c7.b69c5cc0ab9b.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 76.7
+      reference_us: 12.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_549927.f3a20e07e940.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@a0: coop
+      WORK: t8
+      TILE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 10794.7
+      reference_us: 92.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_2dcd0c.28b342e368a5.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t8
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 30.7
+      reference_us: 8.2
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_v100.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_v100.yaml
@@ -1,0 +1,5475 @@
+gpu_name: NVIDIA Tesla V100 SXM3 32GB
+compute_cap:
+- 7
+- 0
+model: Qwen/Qwen3-0.6B@c1899de289a04d12100db370d81485cdf75e47ca
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: scaled_dot_product_attention_c3
+    op: constant
+    attrs:
+      name: scaled_dot_product_attention_c3
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - scaled_dot_product_attention_c3
+      - f16
+      - - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c1
+      - f16
+      - - 1
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c2
+      - f16
+      - - 1
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c1
+      - f16
+      - - 1
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c2
+      - f16
+      - - 1
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c1
+      - f16
+      - - 1
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c2
+      - f16
+      - - 1
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c1
+      - f16
+      - - 1
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c2
+      - f16
+      - - 1
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_1_c1
+      - f16
+      - - 1
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_c1
+      - f16
+      - - 1
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 1024
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_attn_o_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 2048
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 1024
+        - 2048
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: p_attn_q_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 2048
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 2048
+        - 1024
+  - id: p_attn_v_proj_weight
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 1024
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: p_mlp_down_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 3072
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 1024
+        - 3072
+  - id: p_mlp_gate_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_mlp_up_proj_weight
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 3072
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 3072
+        - 1024
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 1024
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: transpose_1_c1
+    op: constant
+    attrs:
+      name: transpose_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c1
+      - f16
+      - - 1
+  - id: transpose_1_c2
+    op: constant
+    attrs:
+      name: transpose_1_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_1_c2
+      - f16
+      - - 1
+  - id: transpose_2_c1
+    op: constant
+    attrs:
+      name: transpose_2_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c1
+      - f16
+      - - 1
+  - id: transpose_2_c2
+    op: constant
+    attrs:
+      name: transpose_2_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_2_c2
+      - f16
+      - - 1
+  - id: transpose_3_c1
+    op: constant
+    attrs:
+      name: transpose_3_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c1
+      - f16
+      - - 1
+  - id: transpose_3_c2
+    op: constant
+    attrs:
+      name: transpose_3_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_3_c2
+      - f16
+      - - 1
+  - id: transpose_c1
+    op: constant
+    attrs:
+      name: transpose_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c1
+      - f16
+      - - 1
+  - id: transpose_c2
+    op: constant
+    attrs:
+      name: transpose_c2
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - transpose_c2
+      - f16
+      - - 1
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_1_c1
+    op: constant
+    attrs:
+      name: unsqueeze_1_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_1_c1
+      - f16
+      - - 1
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: unsqueeze_c1
+    op: constant
+    attrs:
+      name: unsqueeze_c1
+      value: 1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - unsqueeze_c1
+      - f16
+      - - 1
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 16
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 16
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 16
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 16
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 2048
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 1024
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1024
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 3072
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 1024
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_20f978.3ef4b7a3a671.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 825.3
+      reference_us: 400.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_06a42b.975d5314f1c7.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x16
+      TILE: f4x4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 179.6
+      reference_us: 29.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_84dfe3.29bfa5222c55.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 992.3
+      reference_us: 196.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_7c1c37.43145a209e1e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 484.9
+      reference_us: 119.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_29d3df.171afed452e2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 41006.1
+      reference_us: 1951.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_c0a378.ace3043c96cf.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 12860.4
+      reference_us: 512.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_e24efe.109440eff691.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 14103.6
+      reference_us: 559.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_dc067d.a2e77bf96bb2.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x4
+      TILE: mma_m8n8k4_f16_f32/f8x2
+      REDUCE: ''
+      STAGE: d1/smem
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 678.9
+      reference_us: 567.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_6b4b5f.a59ee74a4345.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f2x4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 583.2
+      reference_us: 77.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_b8e46d.e257b789cd9f.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 68.8
+      reference_us: 139.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+  realizations:
+  - name: k_linear_reduce_7ef15d.37e7fb9e7dd5.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop-t
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.6
+      reference_us: 6.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_586ad6.12590a0f5a24.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 27.7
+      reference_us: 33.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_6044db.bfcbc69d30c1.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 18.3
+      reference_us: 33.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0a2624.e5230d7bf4e8.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 119.4
+      reference_us: 418.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - scaled_dot_product_attention
+    - transpose_2
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_d0f5c0.128c6f715151.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 96.8
+      reference_us: 42.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_3
+  realizations:
+  - name: k_linear_sdpa_reduce_14c8c7.b69c5cc0ab9b.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 127.4
+      reference_us: 45.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - linear_4
+    - linear_5
+    - mean_3
+    - mul_10
+    - mul_11
+    - mul_12
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - silu
+    - to_6
+    - to_7
+  realizations:
+  - name: k_linear_mean_reduce_549927.f3a20e07e940.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      REDUCE@a0: coop
+      WORK: t8
+      TILE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 16730.1
+      reference_us: 243.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+  realizations:
+  - name: k_linear_2dcd0c.28b342e368a5.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t32
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 52.9
+      reference_us: 11.5
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_rtx4090.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_rtx4090.yaml
@@ -1,0 +1,8373 @@
+gpu_name: NVIDIA GeForce RTX 4090
+compute_cap:
+- 8
+- 9
+model: RedHatAI/Qwen3-32B-FP8-dynamic@c6732fc26128341172e4005bad34aafa51c32866
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 8192
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 8192
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 8192
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 25600
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 5120
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 8192
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 8192
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 8192
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 25600
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 5120
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_980b55.b1297990382e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2441.2
+      reference_us: 532.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.bfcdf97f8348.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 13.3
+      reference_us: 36.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.ccd78a75b81c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.9
+      reference_us: 139.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.68d0377ee0b1.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.1
+      reference_us: 160.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_676f18.0c2dc65d5b82.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x2
+      TILE: mma_m16n8k16_f16_f32/f4x4/k2
+      REDUCE: ''
+      STAGE: d2/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 86.4
+      reference_us: 377.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_8c505c.810418ec80f8.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 66156.5
+      reference_us: 4610.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_e1595b.af098967fbfc.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 1933.3
+      reference_us: 410.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0ef4a8.301d3ebcee1f.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 76296.2
+      reference_us: 1954.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_b71bb8.a5dc56bb4b95.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 13039.6
+      reference_us: 435.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.6b3a59b9eb46.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3.2
+      reference_us: 40.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.653f0677c079.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.0
+      reference_us: 301.4
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_950583.555d057fbdc0.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w1x2
+      TILE: mma_m16n8k32_e4m3_f32/f8x2/k4
+      REDUCE: ''
+      STAGE: d1/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 382.5
+      reference_us: 4611.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_980b55.b1297990382e.mul_11.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2441.2
+      reference_us: 532.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.bfcdf97f8348.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 13.3
+      reference_us: 36.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.ccd78a75b81c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.9
+      reference_us: 139.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_517d4d.704d181b5c3a.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 483092.5
+      reference_us: 27078.7
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.f126a66e8b1a.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.3
+      reference_us: 137.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.3e153f6fa626.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 17.5
+      reference_us: 1237.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_e7478c.f5439506dcc1.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: w16x1
+      TILE: mma_m16n8k32_e4m3_f32/f4x4/k2
+      REDUCE: ''
+      STAGE: d1/smem-async
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4311.0
+      reference_us: 14768.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_23801f.52ba14c26d24.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 193.5
+      reference_us: 85.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.8f40f30f8b9c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7
+      reference_us: 23.1
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.3ec6f1312d55.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 16.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.52b8d58ec4cf.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 19.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_a428c6.82753c3daf2e.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t128
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4.4
+      reference_us: 349.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_c4eeb2.eb3382be369c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 19.9
+      reference_us: 4088.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_915f6b.8a13af323c45.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5.1
+      reference_us: 367.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_d5b3b1.9884801707ae.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 203.8
+      reference_us: 208.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_a485a4.75ae2012f865.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 380.6
+      reference_us: 353.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.27c1fcda20d9.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.1
+      reference_us: 23.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.e38bedae3c96.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f2
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 16.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_967a16.81f4e53454f3.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 23.7
+      reference_us: 4082.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_23801f.52ba14c26d24.mul_11.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 193.5
+      reference_us: 85.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.8f40f30f8b9c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.7
+      reference_us: 23.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.3ec6f1312d55.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 16.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_3d74fb.497c078f3db0.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1111.0
+      reference_us: 25757.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.d2aa3748fab0.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 64.6
+      reference_us: 27.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.54577d597a98.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 0.8
+      reference_us: 17.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_45263a.bc04fc3ebca9.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 754.7
+      reference_us: 12888.1
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_v100.yaml
+++ b/experiments/golden-bench-2026/kernels/goldens/qwen3-32b-fp8_v100.yaml
@@ -1,0 +1,8333 @@
+gpu_name: NVIDIA Tesla V100 SXM3 32GB
+compute_cap:
+- 7
+- 0
+model: RedHatAI/Qwen3-32B-FP8-dynamic@c6732fc26128341172e4005bad34aafa51c32866
+programs:
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 8192
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 8192
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 8192
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 25600
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 512
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 512
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 512
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 512
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 512
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 512
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 512
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 64
+        - 512
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 512
+        - 64
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 512
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 8192
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 512
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 512
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 512
+        - 25600
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 512
+        - 5120
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 512
+        - 5120
+- inputs:
+  - hidden_states
+  - position_embeddings_0
+  - position_embeddings_1
+  - attention_mask
+  outputs:
+  - add_7
+  - mul_1_dynamic_fp8_scale
+  - mul_1_dynamic_fp8_bits
+  - reshape_dynamic_fp8_scale
+  - reshape_dynamic_fp8_bits
+  - mul_11_dynamic_fp8_scale
+  - mul_11_dynamic_fp8_bits
+  - mul_12_dynamic_fp8_scale
+  - mul_12_dynamic_fp8_bits
+  nodes:
+  - id: add_1_c1
+    op: constant
+    attrs:
+      name: add_1_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_1_c1
+      - f32
+      - - 1
+  - id: add_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_1_c1
+    outputs:
+    - - add_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: add_2_c1
+    op: constant
+    attrs:
+      name: add_2_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_2_c1
+      - f32
+      - - 1
+  - id: add_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - add_2_c1
+    outputs:
+    - - add_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_6_c1
+    op: constant
+    attrs:
+      name: add_6_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_6_c1
+      - f32
+      - - 1
+  - id: add_6_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_6_c1
+    outputs:
+    - - add_6_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_c1
+    op: constant
+    attrs:
+      name: add_c1
+      value: 1.0e-06
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - add_c1
+      - f32
+      - - 1
+  - id: add_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_c1
+    outputs:
+    - - add_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: attention_mask
+    op: input
+    outputs:
+    - - attention_mask
+      - f32
+      - []
+  - id: cat_1_c2
+    op: constant
+    attrs:
+      name: cat_1_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_1_c2
+      - f16
+      - - 1
+  - id: cat_c2
+    op: constant
+    attrs:
+      name: cat_c2
+      value: -1.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - cat_c2
+      - f16
+      - - 1
+  - id: hidden_states
+    op: input
+    outputs:
+    - - hidden_states
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_finite_max
+    outputs:
+    - - mul_11_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_11_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_11_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_11_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_floor
+    outputs:
+    - - mul_11_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_finite_max
+    outputs:
+    - - mul_12_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_12_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_12_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_12_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_floor
+    outputs:
+    - - mul_12_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_finite_max
+    outputs:
+    - - mul_1_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: mul_1_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - mul_1_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: mul_1_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_floor
+    outputs:
+    - - mul_1_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: p_attn_k_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_k_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_k_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_k_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_k_norm_weight
+    outputs:
+    - - p_attn_k_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: p_attn_k_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_k_proj_weight_bits
+    outputs:
+    - - p_attn_k_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_k_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.k_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_k_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_k_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_k_proj_weight_scale
+    outputs:
+    - - p_attn_k_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_k_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    outputs:
+    - - p_attn_k_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_o_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 8192
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_o_proj_weight_bits
+    outputs:
+    - - p_attn_o_proj_weight_dq
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_o_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.o_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_o_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_attn_o_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_o_proj_weight_scale
+    outputs:
+    - - p_attn_o_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 8192
+  - id: p_attn_o_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    outputs:
+    - - p_attn_o_proj_weight
+      - f16
+      - - 5120
+        - 8192
+  - id: p_attn_q_norm_weight
+    op: constant
+    attrs:
+      name: p_attn_q_norm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_norm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 128
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_attn_q_norm_weight
+      - f16
+      - - 128
+  - id: p_attn_q_norm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_3
+            select: null
+    inputs:
+    - p_attn_q_norm_weight
+    outputs:
+    - - p_attn_q_norm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: p_attn_q_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_bits
+      - f8e4m3
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_q_proj_weight_bits
+    outputs:
+    - - p_attn_q_proj_weight_dq
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_q_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.q_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 8192
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_q_proj_weight_scale
+      - f32
+      - - 8192
+        - 1
+  - id: p_attn_q_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 8192
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_q_proj_weight_scale
+    outputs:
+    - - p_attn_q_proj_weight_scale_bc
+      - f32
+      - - 8192
+        - 5120
+  - id: p_attn_q_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    outputs:
+    - - p_attn_q_proj_weight
+      - f16
+      - - 8192
+        - 5120
+  - id: p_attn_v_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_bits
+      - f8e4m3
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_attn_v_proj_weight_bits
+    outputs:
+    - - p_attn_v_proj_weight_dq
+      - f16
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_attn_v_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.self_attn.v_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 1024
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_attn_v_proj_weight_scale
+      - f32
+      - - 1024
+        - 1
+  - id: p_attn_v_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1024
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_attn_v_proj_weight_scale
+    outputs:
+    - - p_attn_v_proj_weight_scale_bc
+      - f32
+      - - 1024
+        - 5120
+  - id: p_attn_v_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+    outputs:
+    - - p_attn_v_proj_weight
+      - f16
+      - - 1024
+        - 5120
+  - id: p_input_layernorm_weight
+    op: constant
+    attrs:
+      name: p_input_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.input_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_input_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_input_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_input_layernorm_weight
+    outputs:
+    - - p_input_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: p_mlp_down_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 25600
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_bits
+      - f8e4m3
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_down_proj_weight_bits
+    outputs:
+    - - p_mlp_down_proj_weight_dq
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_down_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.down_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_down_proj_weight_scale
+      - f32
+      - - 5120
+        - 1
+  - id: p_mlp_down_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 5120
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_down_proj_weight_scale
+    outputs:
+    - - p_mlp_down_proj_weight_scale_bc
+      - f32
+      - - 5120
+        - 25600
+  - id: p_mlp_down_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_down_proj_weight
+      - f16
+      - - 5120
+        - 25600
+  - id: p_mlp_gate_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_gate_proj_weight_bits
+    outputs:
+    - - p_mlp_gate_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_gate_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.gate_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_gate_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_gate_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_gate_proj_weight_scale
+    outputs:
+    - - p_mlp_gate_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_gate_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_gate_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_bits
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 5120
+      source_dtype: f8e4m3
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_bits
+      - f8e4m3
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_dq
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - p_mlp_up_proj_weight_bits
+    outputs:
+    - - p_mlp_up_proj_weight_dq
+      - f16
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight_scale
+    op: constant
+    attrs:
+      name: p_mlp_up_proj_weight_scale
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.mlp.up_proj.weight_scale
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 25600
+        - 1
+      source_dtype: bf16
+      source_graph: null
+    outputs:
+    - - p_mlp_up_proj_weight_scale
+      - f32
+      - - 25600
+        - 1
+  - id: p_mlp_up_proj_weight_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 25600
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - p_mlp_up_proj_weight_scale
+    outputs:
+    - - p_mlp_up_proj_weight_scale_bc
+      - f32
+      - - 25600
+        - 5120
+  - id: p_mlp_up_proj_weight
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    outputs:
+    - - p_mlp_up_proj_weight
+      - f16
+      - - 25600
+        - 5120
+  - id: p_post_attention_layernorm_weight
+    op: constant
+    attrs:
+      name: p_post_attention_layernorm_weight
+      value: null
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: model.layers.0.post_attention_layernorm.weight
+      source_parts:
+        __tuple__: []
+      source_shape:
+        __tuple__:
+        - 5120
+      source_dtype: float16
+      source_graph: null
+    outputs:
+    - - p_post_attention_layernorm_weight
+      - f16
+      - - 5120
+  - id: p_post_attention_layernorm_weight_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - p_post_attention_layernorm_weight
+    outputs:
+    - - p_post_attention_layernorm_weight_bc
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: position_embeddings_0
+    op: input
+    outputs:
+    - - position_embeddings_0
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: position_embeddings_1
+    op: input
+    outputs:
+    - - position_embeddings_1
+      - f16
+      - - 1
+        - 1
+        - 128
+  - id: pow_1_c1
+    op: constant
+    attrs:
+      name: pow_1_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_1_c1
+      - f32
+      - - 1
+  - id: pow_1_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_1_c1
+    outputs:
+    - - pow_1_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: pow_2_c1
+    op: constant
+    attrs:
+      name: pow_2_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_2_c1
+      - f32
+      - - 1
+  - id: pow_2_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_2_c1
+    outputs:
+    - - pow_2_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: pow_3_c1
+    op: constant
+    attrs:
+      name: pow_3_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_3_c1
+      - f32
+      - - 1
+  - id: pow_3_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_3_c1
+    outputs:
+    - - pow_3_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_4_c1
+    op: constant
+    attrs:
+      name: pow_4_c1
+      value: 2.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - pow_4_c1
+      - f32
+      - - 1
+  - id: pow_4_c1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - pow_4_c1
+    outputs:
+    - - pow_4_c1_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: reshape_dynamic_fp8_finite_max
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_finite_max
+      value: 448.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_finite_max
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_finite_max_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_finite_max
+    outputs:
+    - - reshape_dynamic_fp8_finite_max_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_floor
+    op: constant
+    attrs:
+      name: reshape_dynamic_fp8_floor
+      value: 1.0e-12
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - reshape_dynamic_fp8_floor
+      - f32
+      - - 1
+  - id: reshape_dynamic_fp8_floor_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 1
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_2
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_floor
+    outputs:
+    - - reshape_dynamic_fp8_floor_bc
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: slice_1_c1
+    op: constant
+    attrs:
+      name: slice_1_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c1
+      - f16
+      - - 1
+  - id: slice_1_c2
+    op: constant
+    attrs:
+      name: slice_1_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c2
+      - f16
+      - - 1
+  - id: slice_1_c3
+    op: constant
+    attrs:
+      name: slice_1_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_1_c3
+      - f16
+      - - 1
+  - id: slice_2_c1
+    op: constant
+    attrs:
+      name: slice_2_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c1
+      - f16
+      - - 1
+  - id: slice_2_c2
+    op: constant
+    attrs:
+      name: slice_2_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c2
+      - f16
+      - - 1
+  - id: slice_2_c3
+    op: constant
+    attrs:
+      name: slice_2_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_2_c3
+      - f16
+      - - 1
+  - id: slice_3_c1
+    op: constant
+    attrs:
+      name: slice_3_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c1
+      - f16
+      - - 1
+  - id: slice_3_c2
+    op: constant
+    attrs:
+      name: slice_3_c2
+      value: 0.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c2
+      - f16
+      - - 1
+  - id: slice_3_c3
+    op: constant
+    attrs:
+      name: slice_3_c3
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_3_c3
+      - f16
+      - - 1
+  - id: slice_4_c1
+    op: constant
+    attrs:
+      name: slice_4_c1
+      value: 3.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c1
+      - f16
+      - - 1
+  - id: slice_4_c2
+    op: constant
+    attrs:
+      name: slice_4_c2
+      value: 64.0
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c2
+      - f16
+      - - 1
+  - id: slice_4_c3
+    op: constant
+    attrs:
+      name: slice_4_c3
+      value: 9.223372036854776e+18
+      context_value: null
+      load_ops:
+        __tuple__: []
+      source_path: null
+      source_parts:
+        __tuple__: []
+      source_shape: null
+      source_dtype: null
+      source_graph: null
+    outputs:
+    - - slice_4_c3
+      - f16
+      - - 1
+  - id: to
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - hidden_states
+    outputs:
+    - - to
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: pow_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to
+    - pow_1_c1_bc
+    outputs:
+    - - pow_1
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mean
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_1
+    outputs:
+    - - mean
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean
+    - add_c1_bc
+    outputs:
+    - - add
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add
+    outputs:
+    - - rsqrt
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt
+    outputs:
+    - - rsqrt_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to
+    - rsqrt_bc
+    outputs:
+    - - mul
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: to_1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul
+    outputs:
+    - - to_1
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_input_layernorm_weight_bc
+    - to_1
+    outputs:
+    - - mul_1
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_1
+    outputs:
+    - - mul_1_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_1_dynamic_fp8_abs
+    outputs:
+    - - mul_1_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_1_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1_dynamic_fp8_stable_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_1_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_1_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_1_dynamic_fp8_scale
+    outputs:
+    - - mul_1_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_1
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_normalized
+    outputs:
+    - - mul_1_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_1_dynamic_fp8_bits
+    outputs:
+    - - mul_1_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_1_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_1_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: linear
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_q_proj_weight
+    outputs:
+    - - linear
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: linear_1
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_k_proj_weight
+    outputs:
+    - - linear_1
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: linear_2
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_1_dynamic_fp8_value
+    - p_attn_v_proj_weight
+    outputs:
+    - - linear_2
+      - f16
+      - - 1
+        - 1
+        - 1024
+  - id: unsqueeze
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_0
+    outputs:
+    - - unsqueeze
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n0
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1
+    op: torch.unsqueeze
+    attrs:
+      dim: 1
+    inputs:
+    - position_embeddings_1
+    outputs:
+    - - unsqueeze_1
+      - f16
+      - - 1
+        - 1
+        - 1
+        - 128
+  - id: n1
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: unsqueeze_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze_1
+    outputs:
+    - - unsqueeze_1_bc
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: unsqueeze_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 1
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - literal:
+                value: 0
+                dtype: int
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - unsqueeze
+    outputs:
+    - - unsqueeze_bc
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: view
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear
+    outputs:
+    - - view
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: to_2
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view
+    outputs:
+    - - to_2
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: pow_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_2
+    - pow_2_c1_bc
+    outputs:
+    - - pow_2
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: mean_1
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_2
+    outputs:
+    - - mean_1
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: add_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_1
+    - add_1_c1_bc
+    outputs:
+    - - add_1
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: rsqrt_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_1
+    outputs:
+    - - rsqrt_1
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 1
+  - id: rsqrt_1_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_1
+    outputs:
+    - - rsqrt_1_bc
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: mul_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_2
+    - rsqrt_1_bc
+    outputs:
+    - - mul_2
+      - f32
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: to_3
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 64
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_2
+    outputs:
+    - - to_3
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: mul_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_q_norm_weight_bc
+    - to_3
+    outputs:
+    - - mul_3
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: transpose
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_3
+    outputs:
+    - - transpose
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: mul_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose
+    - unsqueeze_bc
+    outputs:
+    - - mul_6
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: slice_1
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose
+    - slice_1_c1
+    - slice_1_c2
+    - slice_1_c3
+    outputs:
+    - - slice_1
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 64
+  - id: slice_2
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 64
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose
+    - slice_2_c1
+    - slice_2_c2
+    - slice_2_c3
+    outputs:
+    - - slice_2
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 64
+  - id: neg
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_2
+    outputs:
+    - - neg
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 64
+  - id: cat
+    op: torch.cat
+    inputs:
+    - neg
+    - slice_1
+    - cat_c2
+    outputs:
+    - - cat
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: mul_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat
+    - unsqueeze_1_bc
+    outputs:
+    - - mul_7
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: add_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_6
+    - mul_7
+    outputs:
+    - - add_3
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: view_1
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_1
+    outputs:
+    - - view_1
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_4
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - view_1
+    outputs:
+    - - to_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: pow_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_4
+    - pow_3_c1_bc
+    outputs:
+    - - pow_3
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mean_2
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_3
+    outputs:
+    - - mean_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: add_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_2
+    - add_2_c1_bc
+    outputs:
+    - - add_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_2
+    outputs:
+    - - rsqrt_2
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 1
+  - id: rsqrt_2_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_2
+    outputs:
+    - - rsqrt_2_bc
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_4
+    - rsqrt_2_bc
+    outputs:
+    - - mul_4
+      - f32
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: to_5
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8
+        - __dim__: 128
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            - var: out_coord_3
+            select: null
+    inputs:
+    - mul_4
+    outputs:
+    - - to_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: mul_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_attn_k_norm_weight_bc
+    - to_5
+    outputs:
+    - - mul_5
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_1
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - mul_5
+    outputs:
+    - - transpose_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_8
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - transpose_1
+    - n0
+    outputs:
+    - - mul_8
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: slice_3
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 0
+    inputs:
+    - transpose_1
+    - slice_3_c1
+    - slice_3_c2
+    - slice_3_c3
+    outputs:
+    - - slice_3
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: slice_4
+    op: torch.slice
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 8
+        - 1
+        - 64
+      dim: 3
+      start: 64
+    inputs:
+    - transpose_1
+    - slice_4_c1
+    - slice_4_c2
+    - slice_4_c3
+    outputs:
+    - - slice_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: neg_1
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: negative
+    inputs:
+    - slice_4
+    outputs:
+    - - neg_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 64
+  - id: cat_1
+    op: torch.cat
+    inputs:
+    - neg_1
+    - slice_3
+    - cat_1_c2
+    outputs:
+    - - cat_1
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: mul_9
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - cat_1
+    - n1
+    outputs:
+    - - mul_9
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: add_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mul_8
+    - mul_9
+    outputs:
+    - - add_4
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: view_2
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+        - 128
+    inputs:
+    - linear_2
+    outputs:
+    - - view_2
+      - f16
+      - - 1
+        - 1
+        - 8
+        - 128
+  - id: transpose_2
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - view_2
+    outputs:
+    - - transpose_2
+      - f16
+      - - 1
+        - 8
+        - 1
+        - 128
+  - id: scaled_dot_product_attention
+    op: torch.sdpa
+    attrs:
+      is_causal: true
+      sliding_window: null
+      scale: 0.08838834764831845
+    inputs:
+    - add_3
+    - add_4
+    - transpose_2
+    outputs:
+    - - scaled_dot_product_attention
+      - f16
+      - - 1
+        - 64
+        - 1
+        - 128
+  - id: transpose_3
+    op: torch.transpose
+    attrs:
+      axes:
+        __tuple__:
+        - 1
+        - 2
+    inputs:
+    - scaled_dot_product_attention
+    outputs:
+    - - transpose_3
+      - f16
+      - - 1
+        - 1
+        - 64
+        - 128
+  - id: reshape
+    op: torch.reshape
+    attrs:
+      shape:
+        __tuple__:
+        - 1
+        - 1
+        - -1
+    inputs:
+    - transpose_3
+    outputs:
+    - - reshape
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - reshape
+    outputs:
+    - - reshape_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - reshape_dynamic_fp8_abs
+    outputs:
+    - - reshape_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_floor_bc
+    outputs:
+    - - reshape_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape_dynamic_fp8_stable_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    outputs:
+    - - reshape_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: reshape_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 8192
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - reshape_dynamic_fp8_scale
+    outputs:
+    - - reshape_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - reshape
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_normalized
+    outputs:
+    - - reshape_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - reshape_dynamic_fp8_bits
+    outputs:
+    - - reshape_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: reshape_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    outputs:
+    - - reshape_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 8192
+  - id: linear_3
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - reshape_dynamic_fp8_value
+    - p_attn_o_proj_weight
+    outputs:
+    - - linear_3
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: add_5
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - hidden_states
+    - linear_3
+    outputs:
+    - - add_5
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: to_6
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - add_5
+    outputs:
+    - - to_6
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: pow_4
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: pow
+    inputs:
+    - to_6
+    - pow_4_c1_bc
+    outputs:
+    - - pow_4
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mean_3
+    op: torch.mean
+    attrs:
+      axis: -1
+    inputs:
+    - pow_4
+    outputs:
+    - - mean_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: add_6
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - mean_3
+    - add_6_c1_bc
+    outputs:
+    - - add_6
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: rsqrt
+    inputs:
+    - add_6
+    outputs:
+    - - rsqrt_3
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: rsqrt_3_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - rsqrt_3
+    outputs:
+    - - rsqrt_3_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_10
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - to_6
+    - rsqrt_3_bc
+    outputs:
+    - - mul_10
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: to_7
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - var: out_coord_2
+            select: null
+    inputs:
+    - mul_10
+    outputs:
+    - - to_7
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - p_post_attention_layernorm_weight_bc
+    - to_7
+    outputs:
+    - - mul_11
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_11
+    outputs:
+    - - mul_11_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_11_dynamic_fp8_abs
+    outputs:
+    - - mul_11_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_11_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11_dynamic_fp8_stable_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_11_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_11_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 5120
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_11_dynamic_fp8_scale
+    outputs:
+    - - mul_11_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_11
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_normalized
+    outputs:
+    - - mul_11_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_11_dynamic_fp8_bits
+    outputs:
+    - - mul_11_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: mul_11_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_11_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: linear_4
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_gate_proj_weight
+    outputs:
+    - - linear_4
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: linear_5
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_11_dynamic_fp8_value
+    - p_mlp_up_proj_weight
+    outputs:
+    - - linear_5
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: silu
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: silu
+    inputs:
+    - linear_4
+    outputs:
+    - - silu
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - silu
+    - linear_5
+    outputs:
+    - - mul_12
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_abs
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: abs
+    inputs:
+    - mul_12
+    outputs:
+    - - mul_12_dynamic_fp8_abs
+      - f32
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_amax
+    op: tensor.reduce
+    attrs:
+      op:
+        __elementwise__: maximum
+      axis: -1
+    inputs:
+    - mul_12_dynamic_fp8_abs
+    outputs:
+    - - mul_12_dynamic_fp8_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_stable_amax
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: maximum
+    inputs:
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_floor_bc
+    outputs:
+    - - mul_12_dynamic_fp8_stable_amax
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12_dynamic_fp8_stable_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    outputs:
+    - - mul_12_dynamic_fp8_scale
+      - f32
+      - - 1
+        - 1
+        - 1
+  - id: mul_12_dynamic_fp8_scale_bc
+    op: tensor.index_map
+    attrs:
+      out_shape:
+        __tuple__:
+        - __dim__: 1
+        - __dim__: 1
+        - __dim__: 25600
+      sources:
+        __tuple__:
+        - __index_source__:
+            input_idx: 0
+            coord_map:
+            - var: out_coord_0
+            - var: out_coord_1
+            - literal:
+                value: 0
+                dtype: int
+            select: null
+    inputs:
+    - mul_12_dynamic_fp8_scale
+    outputs:
+    - - mul_12_dynamic_fp8_scale_bc
+      - f32
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_normalized
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: divide
+    inputs:
+    - mul_12
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_normalized
+      - f32
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_bits
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: to_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_normalized
+    outputs:
+    - - mul_12_dynamic_fp8_bits
+      - f8e4m3
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_decoded
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: from_f8e4m3
+    inputs:
+    - mul_12_dynamic_fp8_bits
+    outputs:
+    - - mul_12_dynamic_fp8_decoded
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: mul_12_dynamic_fp8_value
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: multiply
+    inputs:
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    outputs:
+    - - mul_12_dynamic_fp8_value
+      - f16
+      - - 1
+        - 1
+        - 25600
+  - id: linear_6
+    op: torch.linear
+    attrs:
+      has_bias: false
+    inputs:
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    outputs:
+    - - linear_6
+      - f16
+      - - 1
+        - 1
+        - 5120
+  - id: add_7
+    op: tensor.elementwise
+    attrs:
+      op:
+        __elementwise__: add
+    inputs:
+    - add_5
+    - linear_6
+    outputs:
+    - - add_7
+      - f16
+      - - 1
+        - 1
+        - 5120
+configs:
+- program: 0
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_980b55.b1297990382e.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4040.7
+      reference_us: 1285.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.bfcdf97f8348.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 22.3
+      reference_us: 91.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.ccd78a75b81c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.3
+      reference_us: 322.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.68d0377ee0b1.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f8
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 13.8
+      reference_us: 363.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_676f18.0c2dc65d5b82.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t16x8
+      TILE: f4x14
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 3566.6
+      reference_us: 709.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_8c505c.810418ec80f8.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 91526.1
+      reference_us: 5573.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_e1595b.af098967fbfc.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 20880.4
+      reference_us: 801.5
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_0ef4a8.301d3ebcee1f.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 119625.7
+      reference_us: 4995.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_b71bb8.a5dc56bb4b95.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 34485.2
+      reference_us: 2401.3
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.6b3a59b9eb46.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 12.1
+      reference_us: 111.0
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.653f0677c079.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 23.0
+      reference_us: 498.8
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_950583.555d057fbdc0.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 129951.7
+      reference_us: 5514.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_980b55.b1297990382e.mul_11.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4040.7
+      reference_us: 1285.1
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.bfcdf97f8348.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 22.2
+      reference_us: 91.2
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.ccd78a75b81c.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: f4
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 15.3
+      reference_us: 322.6
+      reference_backend: torch-eager
+- program: 0
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_517d4d.704d181b5c3a.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.f126a66e8b1a.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+- program: 0
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.3e153f6fa626.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+- program: 0
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_e7478c.f5439506dcc1.s512
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+- program: 1
+  target:
+    origins:
+    - add
+    - add_c1_bc
+    - mean
+    - mul
+    - mul_1
+    - p_input_layernorm_weight_bc
+    - pow_1
+    - rsqrt
+    - rsqrt_bc
+    - to
+    - to_1
+  realizations:
+  - name: k_mean_23801f.52ba14c26d24.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 355.7
+      reference_us: 155.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_abs
+    - mul_1_dynamic_fp8_amax
+    - mul_1_dynamic_fp8_finite_max_bc
+    - mul_1_dynamic_fp8_floor_bc
+    - mul_1_dynamic_fp8_scale
+    - mul_1_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_1_dynamic_fp8_scale_reduce.8f40f30f8b9c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.7
+      reference_us: 34.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_bits
+    - mul_1_dynamic_fp8_normalized
+    - mul_1_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_1_dynamic_fp8_bits_pointwise.3ec6f1312d55.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 25.3
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_1_dynamic_fp8_decoded
+    - mul_1_dynamic_fp8_scale_bc
+    - mul_1_dynamic_fp8_value
+  realizations:
+  - name: k_mul_1_dynamic_fp8_value_pointwise.52b8d58ec4cf.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5
+      reference_us: 29.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - p_attn_v_proj_weight
+    - p_attn_v_proj_weight_dq
+    - p_attn_v_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_reduce_a428c6.82753c3daf2e.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t256
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 25.4
+      reference_us: 615.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear
+    - p_attn_q_proj_weight
+    - p_attn_q_proj_weight_dq
+    - p_attn_q_proj_weight_scale_bc
+    - to_2
+    - view
+  realizations:
+  - name: k_linear_c4eeb2.eb3382be369c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1204.2
+      reference_us: 4660.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_1
+    - p_attn_k_proj_weight
+    - p_attn_k_proj_weight_dq
+    - p_attn_k_proj_weight_scale_bc
+    - to_4
+    - view_1
+  realizations:
+  - name: k_linear_915f6b.8a13af323c45.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1175.6
+      reference_us: 669.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_1
+    - add_1_c1_bc
+    - add_2
+    - add_2_c1_bc
+    - add_3
+    - add_4
+    - cat
+    - cat_1
+    - mean_1
+    - mean_2
+    - mul_2
+    - mul_3
+    - mul_4
+    - mul_5
+    - mul_6
+    - mul_7
+    - mul_8
+    - mul_9
+    - n0
+    - n1
+    - neg
+    - neg_1
+    - p_attn_k_norm_weight_bc
+    - p_attn_q_norm_weight_bc
+    - pow_2
+    - pow_3
+    - rsqrt_1
+    - rsqrt_1_bc
+    - rsqrt_2
+    - rsqrt_2_bc
+    - scaled_dot_product_attention
+    - slice_1
+    - slice_2
+    - slice_3
+    - slice_4
+    - to_3
+    - to_5
+    - transpose
+    - transpose_1
+    - unsqueeze
+    - unsqueeze_1
+    - unsqueeze_1_bc
+    - unsqueeze_bc
+  realizations:
+  - name: k_sdpa_mean_reduce_d5b3b1.9884801707ae.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 373.1
+      reference_us: 423.6
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_2
+    - reshape
+    - scaled_dot_product_attention
+    - transpose_2
+    - transpose_3
+    - view_2
+  realizations:
+  - name: k_sdpa_linear_reduce_a485a4.75ae2012f865.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs: {}
+    measurements:
+      emmy_us: 700.4
+      reference_us: 681.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_abs
+    - reshape_dynamic_fp8_amax
+    - reshape_dynamic_fp8_finite_max_bc
+    - reshape_dynamic_fp8_floor_bc
+    - reshape_dynamic_fp8_scale
+    - reshape_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_reshape_dynamic_fp8_scale_reduce.27c1fcda20d9.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 30.7
+      reference_us: 37.4
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - reshape_dynamic_fp8_bits
+    - reshape_dynamic_fp8_normalized
+    - reshape_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_reshape_dynamic_fp8_bits_pointwise.e38bedae3c96.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 25.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_5
+    - linear_3
+    - p_attn_o_proj_weight
+    - p_attn_o_proj_weight_dq
+    - p_attn_o_proj_weight_scale_bc
+    - reshape_dynamic_fp8_decoded
+    - reshape_dynamic_fp8_scale_bc
+    - reshape_dynamic_fp8_value
+  realizations:
+  - name: k_linear_967a16.81f4e53454f3.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1895.4
+      reference_us: 4643.8
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_6
+    - add_6_c1_bc
+    - mean_3
+    - mul_10
+    - mul_11
+    - p_post_attention_layernorm_weight_bc
+    - pow_4
+    - rsqrt_3
+    - rsqrt_3_bc
+    - to_6
+    - to_7
+  realizations:
+  - name: k_mean_23801f.52ba14c26d24.mul_11.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 355.7
+      reference_us: 155.0
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_abs
+    - mul_11_dynamic_fp8_amax
+    - mul_11_dynamic_fp8_finite_max_bc
+    - mul_11_dynamic_fp8_floor_bc
+    - mul_11_dynamic_fp8_scale
+    - mul_11_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_11_dynamic_fp8_scale_reduce.8f40f30f8b9c.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 2.7
+      reference_us: 34.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_11_dynamic_fp8_bits
+    - mul_11_dynamic_fp8_normalized
+    - mul_11_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_11_dynamic_fp8_bits_pointwise.3ec6f1312d55.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.4
+      reference_us: 25.2
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - linear_4
+    - linear_5
+    - mul_11_dynamic_fp8_decoded
+    - mul_11_dynamic_fp8_scale_bc
+    - mul_11_dynamic_fp8_value
+    - mul_12
+    - p_mlp_gate_proj_weight
+    - p_mlp_gate_proj_weight_dq
+    - p_mlp_gate_proj_weight_scale_bc
+    - p_mlp_up_proj_weight
+    - p_mlp_up_proj_weight_dq
+    - p_mlp_up_proj_weight_scale_bc
+    - silu
+  realizations:
+  - name: k_linear_reduce_3d74fb.497c078f3db0.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 4622.3
+      reference_us: 28703.7
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_abs
+    - mul_12_dynamic_fp8_amax
+    - mul_12_dynamic_fp8_finite_max_bc
+    - mul_12_dynamic_fp8_floor_bc
+    - mul_12_dynamic_fp8_scale
+    - mul_12_dynamic_fp8_stable_amax
+  realizations:
+  - name: k_mul_12_dynamic_fp8_scale_reduce.d2aa3748fab0.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t64
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 7.2
+      reference_us: 36.5
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - mul_12_dynamic_fp8_bits
+    - mul_12_dynamic_fp8_normalized
+    - mul_12_dynamic_fp8_scale_bc
+  realizations:
+  - name: k_mul_12_dynamic_fp8_bits_pointwise.54577d597a98.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: ''
+      TILE: ''
+      REDUCE: ''
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 1.5
+      reference_us: 25.9
+      reference_backend: torch-eager
+- program: 1
+  target:
+    origins:
+    - add_7
+    - linear_6
+    - mul_12_dynamic_fp8_decoded
+    - mul_12_dynamic_fp8_scale_bc
+    - mul_12_dynamic_fp8_value
+    - p_mlp_down_proj_weight
+    - p_mlp_down_proj_weight_dq
+    - p_mlp_down_proj_weight_scale_bc
+  realizations:
+  - name: k_linear_45263a.bc04fc3ebca9.s1
+    bindings: {}
+    pins:
+      FAST_MATH: false
+    knobs:
+      WORK: t4
+      TILE: ''
+      REDUCE: coop
+      STAGE: ''
+      LOOPIFY: '0'
+      RASTER: ''
+    measurements:
+      emmy_us: 5949.4
+      reference_us: 14303.2
+      reference_backend: torch-eager

--- a/experiments/golden-bench-2026/kernels/results_rtx4090x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_rtx4090x1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15786b6987cef25dc2166b8b6a3a5a94b8f2ff2d6f3a1d14eb77e399e0121d2d
+size 679750

--- a/experiments/golden-bench-2026/kernels/results_rtx5090x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_rtx5090x1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b017248d60c6932bcf5875931de678246c30ba291fb1bf88d721da065377428
+size 454828

--- a/experiments/golden-bench-2026/kernels/results_v100x1.tar.gz
+++ b/experiments/golden-bench-2026/kernels/results_v100x1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:484464381d931281325369cda70c682e9c040e4846de53068140dcc4397e846c
+size 334106


### PR DESCRIPTION
## What this is

Committed, measured **golden datasets** for the `experiments/golden-bench-2026/kernels` corpus models on the three
GPUs we have on hand — the improvement baselines requested, not a claim of wins. Revision `c1abcc91`, recipe
budgets, overnight unattended run on three caller-supplied hosts.

## Contents

- `goldens/<model>_<gpu>.yaml` — 8 files (0.6B and 0.6B-FP8 on all three cards; 32B-FP8 on rtx4090 + v100 by
  memory fit). Every kernel target of layer 0 at seq_len 512 and 1, with the **deployed knobs after tuning** and
  **median 3-repeat `-O3` measurements** (`emmy_us` vs `torch-eager`), losses included. 7 files pass full
  REPOSITORY golden validation; the v100 32B file keeps 4 unmeasured inventory rows (its verify pass exited
  nonzero) and validates at WORKING level.
- `RESULTS.md` — per-platform sections, the layer-level summary table, defects, limitations; the earlier H200
  failed-attempt section is retained.
- `results_<platform>.tar.gz` (Git LFS) — raw traces, tune logs with search feedback, per-target verification
  JSONs (including the `torch.compile(mode="max-autotune")` lane), system info, progress logs.

## How it was produced

Per host: trace layer 0 (seq 512 + 1) → inject ≤2 evidence-based warp/staged proposals per linear target (card's
own knob vocabulary) → `emmy tune` at the recipe budget (12/4 small, 8/3 large, seed 0) → 3× `emmy run --golden
--bench` at `EMMY_NVCC_FLAGS=` with the tune DB live, so the verification measures the **tuned deploy** against
eager and torch.compile. Chains were failure-tolerant; every failure is preserved, not hidden.

## Headline reading

Tuning improves the reachable kernels, but layer totals remain 1–3 orders behind torch.compile max-autotune on
every card (full table in RESULTS.md) because the dominant kernels cannot enter the search: the split-N warp-tile
demotion on the fused reshape-to-heads projections, and the online-softmax `005_stamp` structural-identity hole.
These datasets make that gap concrete per kernel, per card, with the exact deployed schedule recorded.

## Defects surfaced (preserved in the archives, not fixed here)

1. **MCTS crash** on the 32B-FP8 s512 corpus, deterministic on both sm_89 and sm_70:
   `AttributeError: 'NoneType' object has no attribute 'items'` at `search/policy/mcts.py:518` (`_node_key`).
2. **Qwen3.6-27B is untraceable**: `cannot map fallback aten.conv1d as elementwise` (frontend coverage gap), so
   no 27B golden exists.
3. Host traps recorded for reuse: fresh boxes need `apt-get update` before `python3.12-venv`; V100 needs torch
   cu126 + `cupy-cuda12x==13.6.0` + `fastrlock` (nvrtc 13 dropped Volta).

## Test plan

- All 8 golden files load through `load_golden_file` (7 REPOSITORY, 1 WORKING as noted)
- `ruff check .` clean; RESULTS.md wrapped ≤120; archives report `filter: lfs`
- No code changes — datasets, report, and evidence only

🤖 Generated with [Claude Code](https://claude.com/claude-code)