### PR TITLE
Lower conv1d and einsum in the frontend decomposition

### DIFF
--- a/emmy/compiler/ir/frontend/ir.py
+++ b/emmy/compiler/ir/frontend/ir.py
@@ -11,8 +11,10 @@ Two groups:
 1. **Layout-only ops** — ``TransposeOp``, ``ReshapeOp``, ``SliceOp``,
    ``CatOp``, ``UnsqueezeOp``. Rewritten to a single ``IndexMapOp`` each.
 2. **Compound math ops** — ``LinearOp``, ``MatmulOp``, ``SdpaOp``,
-   ``MeanOp``. Rewritten to elementwise/reduce chains (sometimes with
-   inserted ``IndexMapOp`` unsqueezes so the broadcast contraction works).
+   ``MeanOp``, ``EinsumOp``, ``Conv1dOp``. Rewritten to elementwise/reduce chains
+   (sometimes with inserted ``IndexMapOp`` unsqueezes so the broadcast contraction
+   works). The last two are captured only in the forms their rules can lower, so the
+   tracer rejects the rest rather than leaving an op with no decomposition.
 """
 
 from __future__ import annotations
@@ -380,3 +382,86 @@ class SoftmaxOp(Op):
         m = np.max(x, axis=self.axis, keepdims=True)
         e = np.exp(x - m)
         return e / np.sum(e, axis=self.axis, keepdims=True)
+
+
+@dataclass
+class EinsumOp(Op):
+    """PyTorch ``aten.einsum`` over exactly two operands.
+
+    ``equation`` is the normalized explicit form (``"bij,bjk->bik"``): whitespace
+    stripped and torch's implicit output spelled out. The decomposition reads the
+    label sets rather than the string, so the only thing stored is the contract.
+
+    The tracer admits only the shape this op promises to decompose — one contracted
+    label, one free label per side, any number of shared batch labels. That subset is
+    a pure permute-and-contract, so the rule is transposes plus one ``MatmulOp`` and
+    never a reshape, which is what keeps it correct under symbolic dimensions.
+    """
+
+    equation: str = ""
+
+    def _terms(self) -> tuple[str, str, str]:
+        lhs, rhs = self.equation.split("->")
+        a, b = lhs.split(",")
+        return a, b, rhs
+
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+        a_labels, b_labels, out_labels = self._terms()
+        sizes: dict[str, object] = {}
+        for labels, shape in ((a_labels, input_shapes[0]), (b_labels, input_shapes[1])):
+            for label, extent in zip(labels, shape, strict=True):
+                sizes.setdefault(label, extent)
+        return tuple(sizes[label] for label in out_labels)
+
+    def forward(self, *inputs):
+        return np.einsum(self.equation, inputs[0], inputs[1])
+
+
+@dataclass
+class Conv1dOp(Op):
+    """PyTorch ``aten.conv1d`` over ``(N, C_in, L)`` with a ``(C_out, C_in / groups, K)`` weight.
+
+    Captured whole so the decomposition can pick its form from ``groups``. The two
+    forms are genuinely different shapes of computation, not one with a special case:
+
+    * ``groups == 1`` is the im2col identity — gather the ``K`` shifted windows into a
+      ``(N, C_in * K, L_out)`` matrix and contract it with the flattened weight in one
+      ``MatmulOp``, so the convolution reaches the same GEMM path as any projection.
+    * ``groups == C_in`` (depthwise) has no shared reduction across channels, so im2col
+      would build a block-diagonal weight that is ``C_in`` times mostly zero. It lowers
+      instead to ``K`` shifted slices scaled by their per-channel tap and summed.
+
+    Anything between those two is rejected at trace time rather than silently lowered.
+    """
+
+    stride: int = 1
+    padding: int = 0
+    dilation: int = 1
+    groups: int = 1
+
+    def infer_output_shape(self, input_shapes: list[tuple]) -> tuple:
+        x_shape, w_shape = input_shapes[0], input_shapes[1]
+        length = x_shape[-1]
+        span = self.dilation * (int(w_shape[-1]) - 1)
+        static = length.as_static() if isinstance(length, Dim) and length.is_static else (length if isinstance(length, int) else None)
+        if static is None:
+            return tuple(x_shape[:-2]) + (w_shape[0], length)
+        return tuple(x_shape[:-2]) + (w_shape[0], (static + 2 * self.padding - span - 1) // self.stride + 1)
+
+    def forward(self, *inputs):
+        x, w = inputs[0], inputs[1]
+        bias = inputs[2] if len(inputs) > 2 else None
+        if self.padding:
+            x = np.pad(x, ((0, 0), (0, 0), (self.padding, self.padding)))
+        n, _, _ = x.shape
+        c_out, c_in_per_group, k = w.shape
+        length = (x.shape[-1] - self.dilation * (k - 1) - 1) // self.stride + 1
+        out = np.zeros((n, c_out, length), dtype=x.dtype)
+        per_group_out = c_out // self.groups
+        for g in range(self.groups):
+            x_g = x[:, g * c_in_per_group : (g + 1) * c_in_per_group, :]
+            w_g = w[g * per_group_out : (g + 1) * per_group_out]
+            for tap in range(k):
+                window = x_g[:, :, tap * self.dilation : tap * self.dilation + length * self.stride : self.stride]
+                out[:, g * per_group_out : (g + 1) * per_group_out, :] += np.einsum("ncl,oc->nol", window, w_g[:, :, tap])
+        return out if bias is None else out + bias.reshape(1, -1, 1)

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/005_einsum.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/005_einsum.py
@@ -1,0 +1,75 @@
+"""Decompose a two-operand EinsumOp into transpose → MatmulOp → transpose.
+
+An einsum over two operands is a permutation followed by a contraction, so the
+whole rule is: line the shared batch labels up in the same order on both sides,
+put the contracted label last on A and first on B, hand that to ``MatmulOp``, and
+permute the result into the requested output order.
+
+Deliberately no reshape. Grouping several free labels into one matrix axis would
+need the product of their extents, which is not expressible when one of them is
+symbolic — and a linear-attention einsum is exactly where a symbolic sequence
+length shows up. The tracer therefore admits only the single-label form this rule
+handles, so an equation that would need reshaping never reaches here.
+"""
+
+from emmy.compiler.graph import Graph, Node, Tensor
+from emmy.compiler.ir.frontend.ir import EinsumOp, MatmulOp, TransposeOp
+from emmy.compiler.pipeline import Match, Pattern
+from emmy.compiler.pipeline.passes.frontend.decomposition._helpers import open_fragment
+
+PATTERN = [Pattern("root", EinsumOp)]
+
+
+def _aligned(frag: Graph, src: Node, labels: str, wanted: str, *, name: str) -> Node | str:
+    """Permute ``src`` from ``labels`` order into ``wanted`` order (identity stays put)."""
+    axes = tuple(labels.index(label) for label in wanted)
+    if axes == tuple(range(len(axes))):
+        return src
+    shape = tuple(src.output.shape[axis] for axis in axes)
+    nid = frag.add_node(
+        op=TransposeOp(axes=axes),
+        inputs=[src],
+        output=Tensor(name, shape, src.output.dtype),
+    )
+    return frag.nodes[nid]
+
+
+def rewrite(match: Match, root: Node, inp_a: Node, inp_b: Node, out: Tensor) -> Graph | None:
+    graph = match.graph
+    a_labels, b_labels, out_labels = root.op._terms()
+
+    contracted = [label for label in a_labels if label in b_labels and label not in out_labels]
+    batch = [label for label in out_labels if label in a_labels and label in b_labels]
+    free_a = [label for label in out_labels if label in a_labels and label not in b_labels]
+    free_b = [label for label in out_labels if label in b_labels and label not in a_labels]
+
+    frag = open_fragment(graph, [inp_a, inp_b])
+    batch_order = "".join(batch)
+    lhs = _aligned(frag, inp_a, a_labels, batch_order + "".join(free_a) + "".join(contracted), name=f"{out.name}_a")
+    rhs = _aligned(frag, inp_b, b_labels, batch_order + "".join(contracted) + "".join(free_b), name=f"{out.name}_b")
+
+    # MatmulOp contracts A's last axis with B's second-to-last and broadcasts the batch
+    # prefix, so the product is already in ``batch + free_a + free_b`` label order.
+    product_labels = batch_order + "".join(free_a) + "".join(free_b)
+    lhs_node = lhs if isinstance(lhs, Node) else frag.nodes[lhs]
+    rhs_node = rhs if isinstance(rhs, Node) else frag.nodes[rhs]
+    product_shape = tuple(lhs_node.output.shape[:-1]) + (rhs_node.output.shape[-1],)
+    needs_permute = product_labels != out_labels
+    mm_id = frag.add_node(
+        op=MatmulOp(),
+        inputs=[lhs, rhs],
+        output=Tensor(f"{out.name}_mm" if needs_permute else out.name, product_shape, out.dtype),
+    )
+
+    if not needs_permute:
+        frag.outputs = [mm_id]
+        return frag
+
+    axes = tuple(product_labels.index(label) for label in out_labels)
+    out_id = frag.add_node(
+        op=TransposeOp(axes=axes),
+        inputs=[mm_id],
+        output=Tensor(out.name, out.shape, out.dtype),
+    )
+    frag.outputs = [out_id]
+    return frag

--- a/emmy/compiler/pipeline/passes/frontend/decomposition/007_conv1d.py
+++ b/emmy/compiler/pipeline/passes/frontend/decomposition/007_conv1d.py
@@ -1,0 +1,179 @@
+"""Decompose Conv1dOp into its two honest forms: im2col for dense, shifted taps for depthwise.
+
+Every read of the input is one ``IndexMapOp`` whose length coordinate is
+``l * stride + tap * dilation - padding``. Stride, dilation and padding are therefore all
+paid for in the same expression, and nothing else in the rule has to know about them.
+Padding specifically is a second source rather than a materialized zero-padded tensor: the
+map selects the input where that coordinate is in range and a zero constant where it is
+not, which is the same shape of trick ``150_cat`` uses and costs no extra buffer.
+
+The two forms differ in what they do with those reads:
+
+* **Dense** (``groups == 1``) builds the im2col matrix ``(N, C_in * K, L_out)`` in a single
+  map — the stacked channel ``ck`` splits into ``tap = ck / C_in`` and ``ci = ck % C_in`` —
+  and contracts it against the flattened weight with one ``MatmulOp``. A convolution then
+  reaches exactly the GEMM path every other projection takes.
+* **Depthwise** (``groups == C_in``) has no reduction across channels at all. im2col would
+  build a ``(C_out, C_in * K)`` weight that is zero except for one band per channel, making
+  the GEMM do ``C_in`` times the necessary work. It instead scales each of the ``K`` window
+  reads by that tap's per-channel weight and sums them — pure elementwise, which also lets
+  the chain fuse into its neighbours.
+"""
+
+from emmy.compiler.dim import Dim
+from emmy.compiler.graph import Graph, Node, Tensor
+from emmy.compiler.ir.base import ConstantOp
+from emmy.compiler.ir.expr import BinaryExpr, Literal, TernaryExpr, placeholder
+from emmy.compiler.ir.frontend.ir import Conv1dOp, MatmulOp, ReshapeOp, TransposeOp
+from emmy.compiler.ir.tensor.ir import ElementwiseOp, IndexMapOp, IndexSource
+from emmy.compiler.pipeline import Match, Pattern
+from emmy.compiler.pipeline.passes.frontend.decomposition._helpers import open_fragment, single_indexmap
+
+PATTERN = [Pattern("root", Conv1dOp)]
+
+
+def _static(extent) -> int:
+    """Unwrap a channel/tap extent to int. These axes are weight-derived and never symbolic."""
+    if isinstance(extent, Dim):
+        if not extent.is_static:
+            raise NotImplementedError(f"aten.conv1d requires static channel and tap extents, got {extent}")
+        return extent.as_static()
+    return int(extent)
+
+
+def _read(frag: Graph, x: Node, *, out_shape: tuple, channel: object, length: object, in_length: int, name: str) -> Node:
+    """Read ``x[n, channel, length]`` over ``out_shape``, yielding zero where ``length`` is padded off the end."""
+    coords = (placeholder(0), channel, length)
+    if isinstance(length, Literal) or in_length <= 0:
+        return single_indexmap(frag, x, out_shape=out_shape, coord_map=coords, name=name)
+
+    in_bounds = BinaryExpr("&&", BinaryExpr(">=", length, Literal(0, "int")), BinaryExpr("<", length, Literal(in_length, "int")))
+    # Clamp the off-domain coord so the post-fusion unconditional Load stays in range; the
+    # select is what actually discards the value.
+    clamped = TernaryExpr(cond=in_bounds, if_true=length, if_false=Literal(0, "int"))
+    zero_id = frag.add_node(
+        op=ConstantOp(name=f"{name}_zero", value=0.0),
+        inputs=[],
+        output=Tensor(f"{name}_zero", (1,), x.output.dtype),
+    )
+    nid = frag.add_node(
+        op=IndexMapOp(
+            out_shape=tuple(out_shape),
+            sources=(
+                IndexSource(input_idx=0, coord_map=(placeholder(0), channel, clamped), select=in_bounds),
+                IndexSource(input_idx=1, coord_map=(Literal(0, "int"),)),
+            ),
+        ),
+        inputs=[x, zero_id],
+        output=Tensor(name, tuple(out_shape), x.output.dtype),
+    )
+    return frag.nodes[nid]
+
+
+def _length_at(tap: object, *, stride: int, dilation: int, padding: int) -> object:
+    """``l * stride + tap * dilation - padding`` for a constant or computed ``tap``."""
+    expr = placeholder(2)
+    if stride != 1:
+        expr = BinaryExpr("*", expr, Literal(stride, "int"))
+    shift = tap if isinstance(tap, int) else None
+    if shift is not None:
+        offset = shift * dilation - padding
+        return expr if offset == 0 else BinaryExpr("+", expr, Literal(offset, "int"))
+    scaled = tap if dilation == 1 else BinaryExpr("*", tap, Literal(dilation, "int"))
+    expr = BinaryExpr("+", expr, scaled)
+    return expr if padding == 0 else BinaryExpr("-", expr, Literal(padding, "int"))
+
+
+def rewrite(match: Match, root: Node, inp_x: Node, inp_w: Node, inp_bias: Node | None, out: Tensor) -> Graph | None:
+    graph = match.graph
+    op: Conv1dOp = root.op
+    frag = open_fragment(graph, [inp_x, inp_w] + ([inp_bias] if inp_bias else []))
+
+    taps = _static(inp_w.output.shape[-1])
+    channels = _static(inp_x.output.shape[-2])
+    # The input length is only needed to bound a padded read. Without padding every
+    # coordinate is in range by construction of L_out, so a symbolic length is fine there.
+    in_length = 0
+    if op.padding:
+        extent = inp_x.output.shape[-1]
+        if isinstance(extent, Dim) and not extent.is_static:
+            raise NotImplementedError(f"aten.conv1d with padding needs a static input length to bound the pad, got {extent}")
+        in_length = _static(extent)
+    out_shape = tuple(out.shape)
+    geometry = {"stride": op.stride, "dilation": op.dilation, "padding": op.padding}
+
+    if op.groups == 1:
+        # One map builds the whole im2col matrix: ck = tap * C_in + ci, tap-major.
+        stacked = channels * taps
+        stacked_coord = placeholder(1)
+        tap_expr = BinaryExpr("/", stacked_coord, Literal(channels, "int"))
+        col = _read(
+            frag,
+            inp_x,
+            out_shape=(out_shape[0], stacked, out_shape[-1]),
+            channel=BinaryExpr("%", stacked_coord, Literal(channels, "int")),
+            length=_length_at(tap_expr, **geometry),
+            in_length=in_length,
+            name=f"{out.name}_im2col",
+        )
+        w_shape = tuple(_static(d) for d in inp_w.output.shape)
+        w_t = frag.add_node(
+            op=TransposeOp(axes=(0, 2, 1)),
+            inputs=[inp_w],
+            output=Tensor(f"{out.name}_w_t", (w_shape[0], w_shape[2], w_shape[1]), inp_w.output.dtype),
+        )
+        flat_w = frag.add_node(
+            op=ReshapeOp(shape=(w_shape[0], stacked)),
+            inputs=[w_t],
+            output=Tensor(f"{out.name}_w_flat", (w_shape[0], stacked), inp_w.output.dtype),
+        )
+        acc: Node | str = frag.add_node(
+            op=MatmulOp(),
+            inputs=[flat_w, col],
+            output=Tensor(f"{out.name}_mm" if inp_bias else out.name, out_shape, out.dtype),
+        )
+    else:
+        acc = None
+        for tap in range(taps):
+            window = _read(
+                frag,
+                inp_x,
+                out_shape=out_shape,
+                channel=placeholder(1),
+                length=_length_at(tap, **geometry),
+                in_length=in_length,
+                name=f"{out.name}_win{tap}",
+            )
+            # out[n, c, l] scales by weight[c, 0, tap] — channel-indexed, constant in n and l.
+            tap_w = single_indexmap(
+                frag,
+                inp_w,
+                out_shape=out_shape,
+                coord_map=[placeholder(1), Literal(0, "int"), Literal(tap, "int")],
+                name=f"{out.name}_w{tap}",
+            )
+            scaled = frag.add_node(
+                op=ElementwiseOp(op="multiply"),
+                inputs=[window, tap_w],
+                output=Tensor(f"{out.name}_scaled{tap}", out_shape, out.dtype),
+            )
+            if acc is None:
+                acc = scaled
+                continue
+            last = tap == taps - 1 and not inp_bias
+            acc = frag.add_node(
+                op=ElementwiseOp(op="add"),
+                inputs=[acc, scaled],
+                output=Tensor(out.name if last else f"{out.name}_acc{tap}", out_shape, out.dtype),
+            )
+
+    if inp_bias:
+        shaped = single_indexmap(frag, inp_bias, out_shape=out_shape, coord_map=[placeholder(1)], name=f"{out.name}_bias")
+        acc = frag.add_node(
+            op=ElementwiseOp(op="add"),
+            inputs=[acc, shaped],
+            output=Tensor(out.name, out_shape, out.dtype),
+        )
+
+    frag.outputs = [acc.id if isinstance(acc, Node) else acc]
+    return frag

--- a/emmy/compiler/trace/torch.py
+++ b/emmy/compiler/trace/torch.py
@@ -20,6 +20,8 @@ from emmy.compiler.ir.elementwise import ElementwiseImpl
 from emmy.compiler.ir.expr import BinaryExpr, Literal, TernaryExpr, placeholder
 from emmy.compiler.ir.frontend.ir import (
     CatOp,
+    Conv1dOp,
+    EinsumOp,
     LayerNormOp,
     LinearOp,
     MatmulOp,
@@ -1032,6 +1034,115 @@ def _handle_max_dim_values(
     node_map[fx_node.name] = (value_id,)
 
 
+def _normalize_einsum(equation: str, ranks: list[int]) -> tuple[list[str], str]:
+    """Split an einsum equation into its operand terms and an explicit output term.
+
+    torch's implicit form (no ``->``) outputs every label appearing exactly once, in
+    alphabetical order; spelling it out here keeps the op's stored equation explicit.
+    """
+    eq = equation.replace(" ", "")
+    if "..." in eq:
+        raise NotImplementedError("aten.einsum with an ellipsis is not supported; write the batch labels explicitly")
+    if "->" in eq:
+        lhs, out_labels = eq.split("->")
+    else:
+        lhs = eq
+        counts: dict[str, int] = {}
+        for label in lhs.replace(",", ""):
+            counts[label] = counts.get(label, 0) + 1
+        out_labels = "".join(sorted(label for label, count in counts.items() if count == 1))
+    terms = lhs.split(",")
+    if len(terms) != len(ranks):
+        raise NotImplementedError(f"aten.einsum equation {equation!r} declares {len(terms)} operands for {len(ranks)} tensors")
+    for term, rank in zip(terms, ranks, strict=True):
+        if len(term) != rank:
+            raise NotImplementedError(f"aten.einsum term {term!r} does not match its rank-{rank} operand")
+        if len(set(term)) != len(term):
+            raise NotImplementedError(f"aten.einsum term {term!r} repeats a label (a diagonal), which has no contraction form")
+    return terms, out_labels
+
+
+def _handle_einsum(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], *, sym_rename: dict[str, str] | None = None) -> None:
+    """Capture a two-operand einsum whose contraction is a plain permute-and-matmul."""
+    equation = fx_node.args[0]
+    if not isinstance(equation, str):
+        raise NotImplementedError("aten.einsum requires a static equation string")
+    operands = fx_node.args[1] if len(fx_node.args) > 1 else []
+    if not isinstance(operands, (list, tuple)):
+        operands = list(fx_node.args[1:])
+    input_ids = [node_map[o.name] for o in operands if hasattr(o, "name") and o.name in node_map]
+    if len(input_ids) != 2:
+        raise NotImplementedError(f"aten.einsum supports exactly two operands, got {len(input_ids)}")
+
+    ranks = [len(g.nodes[i].output.shape) for i in input_ids]
+    terms, out_labels = _normalize_einsum(equation, ranks)
+    a_labels, b_labels = terms
+    contracted = [c for c in a_labels if c in b_labels and c not in out_labels]
+    free_a = [c for c in a_labels if c not in b_labels]
+    free_b = [c for c in b_labels if c not in a_labels]
+    unknown = [c for c in out_labels if c not in a_labels and c not in b_labels]
+    if unknown:
+        raise NotImplementedError(f"aten.einsum output label {unknown[0]!r} appears in no operand")
+    if len(contracted) != 1 or len(free_a) != 1 or len(free_b) != 1:
+        raise NotImplementedError(
+            f"aten.einsum {equation!r} needs exactly one contracted and one free label per operand to lower without a "
+            f"reshape (got {len(contracted)} contracted, {len(free_a)}/{len(free_b)} free)"
+        )
+    if any(c not in out_labels for c in free_a + free_b):
+        raise NotImplementedError(f"aten.einsum {equation!r} drops a free label, which is a reduction rather than a contraction")
+
+    name = fx_node.name
+    nid = g.add_node(
+        op=EinsumOp(equation=f"{a_labels},{b_labels}->{out_labels}"),
+        inputs=input_ids,
+        output=Tensor(name, _get_shape(fx_node, sym_rename), _get_dtype(fx_node)),
+        node_id=name,
+    )
+    node_map[name] = nid
+
+
+def _conv_attr(fx_node: Any, index: int, key: str, default: int) -> int:
+    """Read a conv attribute that torch spells as either a scalar or a one-element list."""
+    raw = fx_node.args[index] if len(fx_node.args) > index else (fx_node.kwargs or {}).get(key, default)
+    if isinstance(raw, (list, tuple)):
+        if len(raw) != 1:
+            raise NotImplementedError(f"aten.conv1d expects a 1-D {key}, got {raw!r}")
+        raw = raw[0]
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        raise NotImplementedError(f"aten.conv1d requires a static integer {key}, got {raw!r}")
+    return raw
+
+
+def _handle_conv1d(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], *, sym_rename: dict[str, str] | None = None) -> None:
+    """Capture conv1d in the two forms the decomposition can lower: dense and depthwise."""
+    args = fx_node.args
+    tensor_ids = [node_map[a.name] for a in args[:3] if hasattr(a, "name") and a.name in node_map]
+    if len(tensor_ids) < 2:
+        raise ValueError("aten.conv1d requires an input and a weight")
+    groups = _conv_attr(fx_node, 6, "groups", 1)
+    in_channels = g.nodes[tensor_ids[0]].output.shape[-2]
+    in_channels = in_channels.as_static() if hasattr(in_channels, "as_static") else in_channels
+    if groups != 1 and groups != in_channels:
+        raise NotImplementedError(
+            f"aten.conv1d supports dense (groups=1) and depthwise (groups=C_in={in_channels}) convolutions; "
+            f"grouped convolutions with groups={groups} have no decomposition yet"
+        )
+
+    name = fx_node.name
+    nid = g.add_node(
+        op=Conv1dOp(
+            stride=_conv_attr(fx_node, 3, "stride", 1),
+            padding=_conv_attr(fx_node, 4, "padding", 0),
+            dilation=_conv_attr(fx_node, 5, "dilation", 1),
+            groups=groups,
+        ),
+        inputs=tensor_ids,
+        output=Tensor(name, _get_shape(fx_node, sym_rename), _get_dtype(fx_node)),
+        node_id=name,
+    )
+    node_map[name] = nid
+
+
 def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], *, sym_rename: dict[str, str] | None = None) -> None:
     """Handle call_function nodes — faithful 1:1 capture of FX ops."""
     if fx_node.target is operator.getitem:
@@ -1047,6 +1158,12 @@ def _handle_call_function(g: Graph, fx_node: Any, node_map: dict[str, NodeRef], 
         return
     if op_name == "unbind":
         _handle_unbind(g, fx_node, node_map, sym_rename=sym_rename)
+        return
+    if op_name == "einsum":
+        _handle_einsum(g, fx_node, node_map, sym_rename=sym_rename)
+        return
+    if op_name in ("conv1d", "convolution") and len(_get_shape(fx_node, sym_rename)) == 3:
+        _handle_conv1d(g, fx_node, node_map, sym_rename=sym_rename)
         return
     if op_name == "max" and isinstance(fx_node.meta.get("val"), (list, tuple)):
         _handle_max_dim_values(g, fx_node, node_map, sym_rename=sym_rename)

--- a/experiments/golden-bench-2026/README.md
+++ b/experiments/golden-bench-2026/README.md
@@ -145,10 +145,11 @@ math is outside this preregistered suite; the exact `FP8_MMA` pin is confined to
 traces and does not establish a W8A8-only result without the deferred target filter.
 
 The RTX 4090 row is stock-only for a structural reason rather than a scheduling one. Qwen3.8-27B is a hybrid
-checkpoint whose 48 Gated DeltaNet linear-attention layers need a depthwise causal `conv1d`, and Emmy's compiler
-frontend has no convolution operation in its Tensor IR at all. That path therefore cannot lower, so this row admits
-no matched Emmy arm until that gap closes; its 16 full-attention layers, MLP, norms, and head do lower. Treat the
-row as consumer-platform system qualification only.
+checkpoint whose 48 Gated DeltaNet linear-attention layers do not lower, so this row admits no matched Emmy arm; its
+16 full-attention layers, MLP, norms, and head do. The depthwise `conv1d` and the delta-rule `einsum` those layers
+open with now decompose, but the chunked delta rule behind them still does not: it builds its chunk masks with
+`triu`/`tril`, which have no tracer mapping, and then unrolls a sequential 64-step recurrence. That is an algorithm
+to absorb rather than an operation to add, so treat the row as consumer-platform system qualification only.
 
 The Gemma stock and Emmy arms use identical per-workload `--max-num-batched-tokens` settings and the same immutable
 `cloudriftai/vllm-emmy-gemma-4-12b-it@sha256:5add12d3b7f4673790b435b76635082433538e3615fbc40227fa1c0db64c9ff3`

--- a/experiments/golden-bench-2026/serving_qwen38_27b_awq_rtx4090/recipe.yaml
+++ b/experiments/golden-bench-2026/serving_qwen38_27b_awq_rtx4090/recipe.yaml
@@ -2,8 +2,8 @@
 # as an Emmy end-to-end speedup by itself.
 #
 # Qwen3.8-27B is a hybrid checkpoint: 48 of its 64 layers are Gated DeltaNet linear attention and 16 are full
-# attention. Emmy's compiler frontend has no `conv1d` operation, so the linear-attention path does not lower and no
-# Emmy arm can exist for this row yet; see the model's onboarding report for the exact unsupported operations.
+# attention. The linear-attention path does not lower, so no Emmy arm can exist for this row yet; see the model's
+# onboarding report for where it now stops.
 #
 # The pinned image is a vLLM nightly rather than the `qwen38` release tag: that tag predates this checkpoint revision
 # and fails to build the tokenizer backend inside the engine process.

--- a/recipes/Qwen3.8-27B-AWQ-INT4/RESULTS.md
+++ b/recipes/Qwen3.8-27B-AWQ-INT4/RESULTS.md
@@ -59,9 +59,7 @@ rely on this field until an upstream parser lands.
 ## Emmy eligibility: ineligible
 
 The blocking gate is compiler coverage. Qwen3.8 is a hybrid checkpoint: 48 of its 64 layers are `linear_attention`
-(`Qwen3_5GatedDeltaNet`) and 16 are `full_attention`. The Gated DeltaNet path opens with a depthwise causal
-convolution, and Emmy's frontend has no mapping for `aten.conv1d` — there is no convolution operation anywhere in the
-Tensor IR, so the operation falls through to the elementwise fallback and raises.
+(`Qwen3_5GatedDeltaNet`) and 16 are `full_attention`. The linear-attention path does not lower.
 
 Traced against the real modules built from the pinned configuration, at FP16 and sequence length 512:
 
@@ -72,37 +70,27 @@ Traced against the real modules built from the pinned configuration, at FP16 and
 | `lm_head` | traces (3 nodes) |
 | dense MLP | traces (9 nodes) |
 | decoder layer 3 — full attention, 16 of 64 layers | traces (196 nodes) |
-| decoder layer 0 — linear attention, 48 of 64 layers | **fails** on `aten.conv1d` |
-
-Reproducer, which needs no GPU because the gap is in the frontend:
-
-```bash
-emmy compile --ir torch -c "F.conv1d(torch.randn(1,10240,512), torch.randn(10240,1,4), groups=10240, padding=3)"
-```
-
-```
-ValueError: cannot map fallback aten.conv1d as elementwise for output shape (1, 10240, 515)
-```
-
-The shape is the model's own: `conv_dim` is 10,240 (`2 x 16 x 128` key channels plus `48 x 128` value channels) and
-the kernel is 4 wide with padding 3.
+| decoder layer 0 — linear attention, 48 of 64 layers | **fails** in the chunked delta rule |
 
 Coverage is therefore **partial**, so this recipe intentionally has no `golden/` directory — a partial inventory is
-not repository evidence. Because gate 4 fails, gates 3 and 5 (the W4A16 loader path and representative kernel
+not repository evidence. Because that gate fails, gates 3 and 5 (the W4A16 loader path and representative kernel
 correctness) were not evaluated for this checkpoint.
 
-### Second, independent gap
+### Where the path stops
 
-`aten.einsum` is not decomposed into permute plus matmul, so it fails broadcasting even for a plain batched product,
-while the identical contraction written as `torch.matmul` traces. This one is a missing decomposition rather than a
-missing capability:
+The two operations the layer opens with — a depthwise causal `conv1d` and the delta-rule `einsum` — used to stop the
+tracer outright and now decompose; see `compiler/pipeline/passes/frontend/decomposition/`. What remains is not
+another missing operation of the same kind:
 
-```bash
-emmy compile --ir torch -c "torch.einsum('bij,bjk->bik', torch.randn(48,512,128), torch.randn(48,128,512))"
-```
+- `torch.triu` / `Tensor.tril` have no tracer mapping, and the chunked delta rule builds its per-chunk causal masks
+  with them.
+- Behind that, the rule unrolls a sequential recurrence over the 64-wide chunk in Python, reading and writing
+  overlapping slices each step. That is an algorithm the frontend would have to absorb, not an operation to add.
+- This is the pure-torch reference path, which is what traces when `flash-linear-attention` is absent. With the fast
+  path installed the same layer dispatches to an opaque custom CUDA kernel instead, which `torch.export` does not see
+  through at all. Closing the reference path therefore does not by itself make the deployed path traceable.
 
-Both gaps sit on the linear-attention path, so closing `conv1d` alone may not be sufficient to qualify the model;
-closing it is the prerequisite that unblocks measuring what follows.
+Treat the remaining work as qualifying Gated DeltaNet as a whole, not as finishing a short list of operators.
 
 ## Reproduce
 

--- a/tests/compiler/passes/test_conv1d_einsum_rules.py
+++ b/tests/compiler/passes/test_conv1d_einsum_rules.py
@@ -1,0 +1,138 @@
+"""Conv1d and einsum reach the tensor dialect with torch's numbers.
+
+Both ops used to stop the tracer dead — ``aten.conv1d`` had no mapping at all, and
+``aten.einsum`` fell into the elementwise fallback and failed to broadcast. They are the
+two operations Qwen3.8's Gated DeltaNet layers open with, so the interesting cases here
+are that model's: a depthwise convolution with a causal left pad, and a batched
+contraction.
+
+The weights are graph inputs rather than module parameters so the comparison feeds them
+directly instead of going through constant rebinding, which is a different mechanism and
+already has its own tests.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _decompose(module, inputs):
+    """Trace ``module`` and run the frontend decomposition, returning the tensor-dialect graph."""
+    from emmy.compiler.pipeline import TENSOR_PASSES, Pipeline
+    from emmy.compiler.trace.torch import trace_module
+
+    return Pipeline.build(TENSOR_PASSES).run(trace_module(module, inputs))
+
+
+def _assert_matches_eager(run_graph, module, tensors, *, tol=2e-6):
+    """The decomposed graph and eager torch agree on the same inputs."""
+    import torch
+
+    graph = _decompose(module, tensors)
+    with torch.no_grad():
+        expected = module(*tensors).numpy()
+    feed = {name: tensor.numpy() for name, tensor in zip(graph.inputs, tensors, strict=True)}
+    outputs = run_graph(graph, feed)
+    got = np.asarray(next(iter(outputs.values()))).reshape(expected.shape)
+    np.testing.assert_allclose(got, expected, rtol=tol, atol=tol)
+
+
+@pytest.fixture
+def conv_module():
+    import torch.nn as nn
+    import torch.nn.functional as F  # noqa: N812
+
+    class Conv(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            self.kwargs = kwargs
+
+        def forward(self, x, w):
+            return F.conv1d(x, w, **self.kwargs)
+
+    return Conv
+
+
+def test_depthwise_conv1d_matches_eager(run_graph, conv_module) -> None:
+    """Qwen3.8's linear-attention convolution: depthwise, kernel 4, causal left pad."""
+    import torch
+
+    torch.manual_seed(0)
+    # Batch 2 on purpose: a batch of 1 hides an index map that wrongly reads the batch
+    # coordinate when indexing the per-channel weight.
+    x, w = torch.randn(2, 8, 16), torch.randn(8, 1, 4)
+    _assert_matches_eager(run_graph, conv_module(groups=8, padding=3), (x, w))
+
+
+def test_dense_conv1d_im2col_matches_eager(run_graph, conv_module) -> None:
+    """The im2col form, with the stride and dilation that make the window map non-trivial."""
+    import torch
+
+    torch.manual_seed(0)
+    x, w = torch.randn(2, 5, 16), torch.randn(7, 5, 3)
+    _assert_matches_eager(run_graph, conv_module(stride=2, padding=1, dilation=2), (x, w))
+
+
+def test_conv1d_rejects_a_grouped_convolution(conv_module) -> None:
+    """Neither form covers 1 < groups < C_in, and the tracer says so instead of guessing."""
+    import torch
+
+    x, w = torch.randn(1, 8, 16), torch.randn(8, 2, 4)
+    with pytest.raises(NotImplementedError, match="groups=4"):
+        _decompose(conv_module(groups=4), (x, w))
+
+
+@pytest.fixture
+def einsum_module():
+    import torch
+    import torch.nn as nn
+
+    class Einsum(nn.Module):
+        def __init__(self, equation):
+            super().__init__()
+            self.equation = equation
+
+        def forward(self, a, b):
+            return torch.einsum(self.equation, a, b)
+
+    return Einsum
+
+
+@pytest.mark.parametrize(
+    "equation",
+    [
+        "bij,bjk->bik",  # the plain batched contraction
+        "bij,bjk->bki",  # output labels permuted away from the product order
+        "bhld,bhdm->bhlm",  # two batch labels, the delta-rule shape
+    ],
+)
+def test_einsum_matches_eager(run_graph, einsum_module, equation) -> None:
+    import torch
+
+    torch.manual_seed(0)
+    sizes = {"b": 2, "h": 3, "i": 4, "j": 5, "k": 6, "l": 4, "d": 5, "m": 6}
+    a_labels, rest = equation.split(",")
+    b_labels = rest.split("->")[0]
+    a = torch.randn(*[sizes[label] for label in a_labels])
+    b = torch.randn(*[sizes[label] for label in b_labels])
+    _assert_matches_eager(run_graph, einsum_module(equation), (a, b))
+
+
+@pytest.mark.parametrize(
+    ("equation", "a_shape", "b_shape", "message"),
+    [
+        ("bii,bij->bj", (2, 5, 5), (2, 5, 6), "repeats a label"),
+        ("...ij,...jk->...ik", (2, 4, 5), (2, 5, 6), "ellipsis"),
+        ("bij,bjk->b", (2, 4, 5), (2, 5, 6), "free label"),
+        ("bij,bjk->bijk", (2, 4, 5), (2, 5, 6), "one contracted"),
+    ],
+)
+def test_einsum_rejects_forms_it_cannot_lower(einsum_module, equation, a_shape, b_shape, message) -> None:
+    """A diagonal, an ellipsis, a reduction, or anything needing a reshape is refused by name."""
+    import torch
+
+    torch.manual_seed(0)
+    a, b = torch.randn(*a_shape), torch.randn(*b_shape)
+    with pytest.raises(NotImplementedError, match=message):
+        _decompose(einsum_module(equation), (a, b))


### PR DESCRIPTION
## What

Two operations that stopped the tracer outright now decompose to Tensor-IR primitives:

- `aten.conv1d` had **no mapping at all**, and there is no convolution operation anywhere in the Tensor IR — it fell
  through to the elementwise fallback and raised.
- `aten.einsum` was never decomposed into permute + matmul, so it failed broadcasting even for a plain batched
  product, while the identical contraction written as `torch.matmul` traced fine.

They are the two operations Qwen3.8's Gated DeltaNet layers open with, which is where they were found.

Each is captured whole and rewritten by a rule, matching `SdpaOp` — not lowered inside the tracer, whose docstring
promises faithful capture only.

## einsum → transpose · MatmulOp · transpose

Line the shared batch labels up in the same order on both operands, put the contracted label where `MatmulOp` wants
it, permute the result into the requested output order.

**Deliberately no reshape.** Grouping several free labels into one matrix axis needs the product of their extents,
which is not expressible when one of them is symbolic — and a linear-attention einsum is exactly where a symbolic
sequence length shows up. The tracer therefore admits only the single-label form, so an equation that would need a
reshape is refused by name rather than mis-lowered.

## conv1d → im2col (dense) or shifted taps (depthwise)

Every input read is one `IndexMapOp` whose length coordinate is `l * stride + tap * dilation - padding`, so all three
geometry parameters are paid for in one expression and nothing else in the rule knows about them. Padding is a second
source selected out of bounds — the same trick `150_cat` uses — rather than a materialized zero-padded buffer.

The two group forms are genuinely different computations, not one with a special case:

| Form | Lowering | Why |
| --- | --- | --- |
| `groups == 1` | im2col matrix in a single map, then one `MatmulOp` | a convolution reaches the same GEMM path as any projection |
| `groups == C_in` | K window reads scaled by their per-channel tap, summed | no reduction across channels exists to contract |

im2col is **not** used for depthwise on purpose: it would build a `(C_out, C_in * K)` weight that is zero except one
band per channel, making the GEMM do `C_in` times the necessary work. At Qwen3.8's `C_in` of 10,240 that is not a
tradeoff. Anything between the two forms is rejected at trace time rather than silently lowered.

## Tests

15 cases compare both rules against eager torch on the numpy and loop backends, plus every rejection path. Two notes
for the reviewer, because both are load-bearing:

- The depthwise case runs at **batch 2 on purpose**. Batch 1 hides an index map that wrongly reads the batch
  coordinate when indexing the per-channel weight — an earlier revision of this rule did exactly that.
- An earlier revision also used `CatOp`, which takes only two tensors plus a leading dim-constant and defaults to the
  last axis; a K-way channel-axis concat silently concatenated along length, and the depthwise test passed anyway
  because the undecomposed `CatOp` executed on the numpy backend. It would have failed on CUDA. `CatOp` is gone from
  this rule entirely.

`make test`: 2,888 passed / 578 skipped / 1 xfailed / 0 failed. `make lint` clean.

## This does not qualify Qwen3.8

Its linear-attention layers now trace **past** conv1d and stop further in, in the chunked delta rule:

- `torch.triu` / `Tensor.tril` have no tracer mapping, and the rule builds its per-chunk causal masks with them.
- Behind that it unrolls a sequential 64-step recurrence in Python over overlapping slices — an algorithm the
  frontend would have to absorb, not an operator to add.
- That is the pure-torch reference path. With `flash-linear-attention` installed the same layer dispatches to an
  opaque custom CUDA kernel `torch.export` cannot see through, so closing the reference path does not by itself make
  the deployed path traceable.

The golden-bench 4090 row and `recipes/Qwen3.8-27B-AWQ-INT4/RESULTS.md` previously named conv1d as *the* blocker.
That was too narrow, so both are corrected here. Their conclusion — no Emmy arm for that row — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
