### PR TITLE
Skip an unrealized bench-failed leaf in the node-record walk

### DIFF
--- a/emmy/compiler/pipeline/search/policy/mcts.py
+++ b/emmy/compiler/pipeline/search/policy/mcts.py
@@ -653,7 +653,11 @@ class TuningSearch(Search):
                                 run_id=run_id,
                             )
                         )
-                elif is_leaf and node.bench_status == "bench_fail" and stats is not None:
+                elif is_leaf and node.bench_status == "bench_fail" and stats is not None and node.realized_knobs is not None:
+                    # ``skip`` above sends an unrealized leaf here, so the same
+                    # nothing-to-key-on rule has to hold: a variant that bench-failed before
+                    # its knobs were realized (a run-stage timeout, a missing bench input)
+                    # carries ``realized_knobs is None`` and cannot be keyed at all.
                     # Sentinel latency from the failed bench; NOT a value anchor — no
                     # assert, no parent_value update, children keep the inherited nk.
                     emit(

--- a/tests/compiler/pipeline/search/test_node_record_collection.py
+++ b/tests/compiler/pipeline/search/test_node_record_collection.py
@@ -1,0 +1,62 @@
+"""The post-search node walk survives a leaf that bench-failed before realizing its knobs.
+
+``observe`` sets ``bench_stats`` / ``bench_status`` alongside ``realized_knobs``, but a
+variant killed in the run stage — a GPU-time timeout, a missing bench input — records the
+failure without ever realizing a knob set. ``_collect_node_records`` keys every row it emits
+on those knobs, so such a leaf has nothing to key on and must be skipped rather than
+crashing the walk.
+
+This is not hypothetical: it ended a 13-target tune of Qwen3.8's full-attention layer on an
+RTX 4090 at target 12, after six run-stage timeouts had produced exactly this node.
+"""
+
+from __future__ import annotations
+
+from emmy.compiler.pipeline.search.db import PerfStats
+from emmy.compiler.pipeline.search.policy.mcts import SearchNode, SearchTree, TuningSearch
+
+
+def _bench_fail_leaf(*, realized_knobs: dict | None) -> SearchNode:
+    """A leaf whose bench failed, with or without a realized knob set."""
+    node = SearchNode(candidate=object())
+    node.visits = 1
+    node.best_reward = 0.0  # a failed bench anchors no value
+    node.realized_knobs = realized_knobs
+    node.bench_status = "bench_fail"
+    node.bench_stats = PerfStats(median=2_000_000.0, min=2_000_000.0, max=2_000_000.0, mean=2_000_000.0, variance=0.0, n_samples=1)
+    return node
+
+
+def _collect(tree: SearchTree):
+    search = TuningSearch.__new__(TuningSearch)
+    search.tree = tree
+    return search._collect_node_records(context_key="cc89/o1", op_sig="k_linear", gpu="NVIDIA GeForce RTX 4090")
+
+
+def test_unrealized_bench_fail_leaf_is_skipped_not_keyed() -> None:
+    """The walk completes and emits nothing for a leaf with no knobs to key on."""
+    tree = SearchTree()
+    tree.root.children = [_bench_fail_leaf(realized_knobs=None)]
+
+    assert _collect(tree) == []
+
+
+def test_realized_bench_fail_leaf_still_records_its_sentinel() -> None:
+    """The guard is narrow: a bench failure that did realize its knobs keeps its row."""
+    tree = SearchTree()
+    tree.root.children = [_bench_fail_leaf(realized_knobs={"WORK": "w2x2", "TILE": "mma_m16n8k16_f16_f32/f4x4/k2"})]
+
+    [row] = _collect(tree)
+    assert row.status == "bench_fail"
+    assert row.value_us == 2_000_000.0
+    assert row.features == {"WORK": "w2x2", "TILE": "mma_m16n8k16_f16_f32/f4x4/k2"}
+
+
+def test_a_healthy_sibling_survives_an_unrealized_failure() -> None:
+    """One unkeyable leaf does not cost the rest of the tree its records."""
+    tree = SearchTree()
+    good = _bench_fail_leaf(realized_knobs={"WORK": "w4x2"})
+    tree.root.children = [_bench_fail_leaf(realized_knobs=None), good]
+
+    rows = _collect(tree)
+    assert [row.features for row in rows] == [{"WORK": "w4x2"}]


### PR DESCRIPTION
## What

A run-ending crash in the MCTS post-search node walk. A 13-target tune of Qwen3.8's full-attention layer on an
RTX 4090 died at target 12 of 13:

```
File "emmy/compiler/pipeline/search/policy/mcts.py", line 533, in _node_key
    tun = tuple(sorted((k, str(v)) for k, v in feats.items() if not k.startswith(("S_", "H_"))))
AttributeError: 'NoneType' object has no attribute 'items'
```

Every target after the failure is lost, along with the node records for the whole run.

## Why it happens

`_collect_node_records` already knows about this case. Its `if` branch computes

```python
skip = is_leaf and node.realized_knobs is None
```

commented as: *a benched leaf with no single row has nothing to key a node record on*.

A skipped leaf then falls through to the `elif is_leaf and node.bench_status == "bench_fail"` branch, which calls
`_node_key(node.realized_knobs, ...)` **without** that guard.

`SearchNode` documents `realized_knobs` as set on directly-benched leaves in `observe`, with `bench_stats` /
`bench_status` set alongside. A variant killed in the run stage — a GPU-time timeout, a missing bench input —
records the failure but never realizes a knob set, so it reaches the `elif` with `realized_knobs is None` and the
walk raises.

That is not a rare corner: the run that hit it had already logged six run-stage timeouts, each of which creates
exactly this node.

## The fix

Apply the same guard to the `elif`. One condition, plus a comment explaining that `skip` is what routes an
unrealized leaf there.

The rerun completed 13/13 with **9** bench_fail variants and **zero** AttributeErrors.

## Tests

Three regressions pin both directions:

- an unrealized bench_fail leaf is skipped rather than keyed;
- a healthy sibling still gets its record, so one unkeyable leaf does not cost the rest of the tree;
- a bench_fail that *did* realize its knobs still keeps its sentinel row, so the guard stays narrow.

Verified they catch the bug: reverting the fix fails two of the three; restoring it passes all three.

`make test`: 2,891 passed / 578 skipped / 1 xfailed / 0 failed. `make lint` clean.

## Reviewer note

Found while tuning Qwen3.8 kernels, but unrelated to that model — any target set where a variant exceeds the
benchmark run-stage GPU-time budget can hit it. Kept separate from the Qwen work for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
