### PR TITLE
Reverify DeepSeek V4 Flash 0731 on 16x V100 SXM3, and fix what blocked it

### DIFF
--- a/emmy/commands/ARCHITECTURE.md
+++ b/emmy/commands/ARCHITECTURE.md
@@ -161,6 +161,12 @@ independent serving-shape surface. A static-only release is accepted
 only when the same env proves that no wider or symbolic path is reachable. The resulting working file is consumed
 directly by `tune --golden-file` and verified by `run --golden PATH [--target NAME]`.
 
+`run --golden PATH` without `--target` replays every embedded target in one process. It parses and validates the
+document once and hands that object to each target's resolution step, because a whole-model inventory is large
+enough that re-reading it per target dominates the replay: the 279-target DeepSeek V4 Flash golden costs about
+15 s per load, so reloading turned a four-minute replay into more than an hour of redundant parsing. Only this
+read-only replay path shares a document; `tune --golden-file` still loads its own mutable copy to write back into.
+
 The in-model audit normally uses those serving twins. An architecture that cannot fit their external-attention ABI is
 dispatched through a sound config-only provider instead: DeepSeek V4 traces one complete representative decoder layer
 per attention/MLP pairing at sequence length 512, retaining its HCA/CSA compressor and hyper-connection operations.

--- a/emmy/commands/compile.py
+++ b/emmy/commands/compile.py
@@ -199,11 +199,16 @@ def resolve_golden_arg(args) -> None:
     # purpose is to verify the exact target currently being tuned (including Loop IR fallbacks).
     document = None
     if golden_file:
-        try:
-            document = load_golden_file(golden_file)
-        except ValueError as exc:
-            logger.error(str(exc))
-            sys.exit(2)
+        # A multi-target replay hands us the document it already parsed: this file is a
+        # whole model inventory, so re-reading and re-validating it per target is the
+        # difference between minutes and days on a large golden.
+        document = getattr(args, "_golden_document", None)
+        if document is None:
+            try:
+                document = load_golden_file(golden_file)
+            except ValueError as exc:
+                logger.error(str(exc))
+                sys.exit(2)
         records = load_golden_records(document)
         available = records
     else:

--- a/emmy/commands/run.py
+++ b/emmy/commands/run.py
@@ -465,7 +465,8 @@ def _run_golden_targets(args) -> None:
         logger.error("--golden is mutually exclusive with positional input / --code / --ir")
         sys.exit(2)
     try:
-        records = load_golden_records(load_golden_file(args.golden))
+        document = load_golden_file(args.golden)
+        records = load_golden_records(document)
     except (OSError, ValueError) as exc:
         logger.error("cannot load --golden %s: %s", args.golden, exc)
         sys.exit(2)
@@ -485,6 +486,7 @@ def _run_golden_targets(args) -> None:
     for index, name in enumerate(names):
         target_args = copy(args)
         target_args.golden_file = args.golden
+        target_args._golden_document = document
         target_args.golden = name
         target_args.golden_target = None
         if output_dir is not None:

--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -1267,7 +1267,12 @@ explicit working file whose GPU header is checked against the selected tune devi
    registered knob's canonical `Knob.parse`, so alternative ways of writing the same value, like `FAST_EXP=1`, do not
    raise a false alarm. A pin satisfied by ANY kernel counts as honored, which is what makes split main+finalize pairs
    work, but it does mean that a pin dropped on its intended kernel goes undetected if a sibling kernel happens to
-   match it.
+   match it. Two realizations are **structural** and cannot be read off a knob stamp at all, so the check skips them:
+   a `PLACE` cut, and the `g<n>` cross-CTA stage of a `REDUCE` value. A split replaces the kernel it splits, and
+   `knob.consume_kernel_row` strips the schedule row from the pieces it mints — no piece may carry the `g<n>` it came
+   from — so the receipt is the piece's sliced reduce axis, not a stamp. Only that stage is exempt: the rest of the
+   value (`coop` / `r<n>`) is decided by the piece on its own body and stays gated. The cost of the exemption is that a
+   `g<n>` pin which genuinely never split cannot be told apart from one that did.
 2. **Arithmetic-intensity check.** A row whose FLOP/s, implied by its shape, exceeds the peak recorded in the live
    GPU's `GpuSpec` is flagged as a bad measurement rather than a fast kernel.
 3. **Wrong-answer check.** Each pinned config is executed once on the greedy run's inputs and its outputs are

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -361,6 +361,11 @@ def validate_golden_file(
     configs = document.get("configs")
     if not isinstance(configs, list) or not configs:
         raise ValueError("configs must be a non-empty list")
+    # A whole-model inventory points many configs at the same few programs (279 configs
+    # over 13 programs here), and decoding one is the expensive part of this check. Decode
+    # each distinct program once per call: `tune` re-validates the whole document on every
+    # incremental persist, so the redundancy is quadratic in the number of targets.
+    decoded_programs: dict[int, None] = {}
     strict = validation in (GoldenFileValidation.PROMOTION, GoldenFileValidation.REPOSITORY)
     for index, entry in enumerate(configs):
         where = f"configs[{index}]"
@@ -372,10 +377,12 @@ def validate_golden_file(
         program_ref = entry.get("program")
         if isinstance(program_ref, bool) or not isinstance(program_ref, int) or not 0 <= program_ref < len(programs):
             raise ValueError(f"{where}.program does not resolve in this document: {program_ref!r}")
-        try:
-            graph_from_wire(programs[program_ref])
-        except ValueError as exc:
-            raise ValueError(f"{where}.program {program_ref}: {exc}") from exc
+        if program_ref not in decoded_programs:
+            try:
+                graph_from_wire(programs[program_ref])
+            except ValueError as exc:
+                raise ValueError(f"{where}.program {program_ref}: {exc}") from exc
+            decoded_programs[program_ref] = None
         _validate_target(entry.get("target"), index=index, program_wire=programs[program_ref], loops=loops)
         realizations = entry.get("realizations")
         if not isinstance(realizations, list) or not realizations:

--- a/emmy/compiler/pipeline/search/pins.py
+++ b/emmy/compiler/pipeline/search/pins.py
@@ -4,9 +4,33 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 
 from emmy import config
 from emmy.compiler.pipeline.knob import axis_of, family_of, get, is_off_value, pin_key_matches, values_equal
+
+#: A ``REDUCE`` value's leading cross-CTA stage — ``g<n>`` plus the atomic/deferred finalize
+#: letter (``ReducePlan.spell``).
+_GRID_STAGE = re.compile(r"g\d+[ak]?\Z")
+
+
+def _stampable_reduce(want: str) -> str | None:
+    """The part of a ``REDUCE`` pin a kernel can still stamp, or ``None`` if it carries no
+    cross-CTA stage.
+
+    A cross-CTA split is realized by REPLACING the kernel: ``030_split_reduce`` mints brand-new
+    pieces and ``knob.consume_kernel_row`` strips their schedule row, so no piece may carry the
+    ``g<n>`` it came from (``test_split_fresh_kernels`` asserts that outright). The receipt is
+    structural — the piece's reduce axis is a slice of the parent — and knob stamps cannot show
+    it, exactly as a realized ``PLACE`` cut cannot be read off one.
+
+    Only the cross-CTA stage is invisible. The rest of the value (``coop`` / ``r<n>``) is decided
+    by the piece on its own body and stamped there, so it stays gateable.
+    """
+    tokens = [t for t in str(want).split("/") if t]
+    if not tokens or not _GRID_STAGE.match(tokens[0]):
+        return None
+    return "/".join(tokens[1:])
 
 
 def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | None:
@@ -23,6 +47,15 @@ def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | Non
         fam = family_of(name)
         if fam == "PLACE":
             continue  # a realized cut is visible structurally, not as a knob stamp
+        probe = want
+        if fam == "REDUCE":
+            # Likewise a realized cross-CTA split — but only its ``g<n>`` stage is structural,
+            # so gate whatever the pieces still stamp.
+            rest = _stampable_reduce(want)
+            if rest is not None:
+                if not rest:
+                    continue
+                probe = rest
         others: list[str] = []
         saw_off = False
         hit = False
@@ -30,7 +63,7 @@ def unreproducible_pin_flag(pinned: dict, kernel_knobs: list[dict]) -> str | Non
             for key, got in raw.items():
                 if family_of(key) != fam:
                     continue
-                if pin_key_matches(name, key) and values_equal(name, want, got):
+                if pin_key_matches(name, key) and values_equal(name, probe, got):
                     hit = True
                 elif is_off_value(fam, got):
                     saw_off = True

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -136,6 +136,19 @@ Both providers swallow termination errors and log them — the original failure 
 Mismatches leave the GPU unusable because the wrong kernel-module flavor is on disk. The proprietary-driver image
 mirrors the recipe CloudRift's `rift-console` surfaces only for hosts whose `brand_short` matches `/\bV100|P100\b/`.
 
+## NVSwitch hosts need Fabric Manager
+
+On NVSwitch-connected baseboards — V100 SXM3 (DGX-2/HGX-2) and the SXM A100/H100 HGX boards — the switch fabric must
+be trained before CUDA will initialize. Until it is, `nvidia-smi` cheerfully lists every GPU while each process dies
+at `cudaGetDeviceCount()` with `error 802: system not yet initialized`, so the failure surfaces deep inside engine
+worker startup and reads like a model or engine bug rather than a missing host service.
+
+`remote._ensure_fabric_manager` closes that gap as the last `provision_remote` step. It detects an NVSwitch host from a
+non-empty `/proc/driver/nvidia-nvswitch/devices/` and is a no-op everywhere else, including when the service is already
+running. Fabric Manager refuses to run against a mismatched driver, so the package is pinned to the running driver's
+exact version, resolved out of `apt-cache madison` rather than guessed — Ubuntu's archive and NVIDIA's CUDA repo
+publish different revision suffixes (`-1`, `-1ubuntu1`, `-0ubuntu0.24.04.1`) for the same driver.
+
 ## CloudRift API protocol version
 
 Every CloudRift request carries an envelope `{"version": API_VERSION, "data": {...}}`. The server versions its public

--- a/emmy/provisioning/remote.py
+++ b/emmy/provisioning/remote.py
@@ -25,6 +25,7 @@ async def provision_remote(
        (reboots and waits for the host to come back if anything was installed)
     4. Install NVIDIA Container Toolkit if not found
     5. Add user to docker group
+    6. Start NVIDIA Fabric Manager if the host has NVSwitches
     """
     dry_run = bool(getattr(host, "dry_run", False))
 
@@ -73,6 +74,10 @@ async def provision_remote(
 
     # 5. Add user to docker group
     await host.run("groups | grep -q docker || sudo usermod -aG docker $(whoami)")
+
+    # 6. Start Fabric Manager on NVSwitch hosts
+    if not skip_nvidia and not dry_run:
+        await _ensure_fabric_manager(host)
 
 
 async def _ensure_nvidia_versions(
@@ -158,6 +163,55 @@ async def _ensure_nvidia_versions(
         installed = True
 
     return installed
+
+
+async def _ensure_fabric_manager(host: Host) -> None:
+    """Install and start NVIDIA Fabric Manager when the host exposes NVSwitches.
+
+    On NVSwitch-connected baseboards (V100 SXM3 / DGX-2, and the SXM A100/H100
+    HGX boards) the switch fabric has to be trained before CUDA will initialize.
+    Until then every process dies at ``cudaGetDeviceCount()`` with ``error 802:
+    system not yet initialized`` even though ``nvidia-smi`` lists all GPUs
+    happily — so the failure only surfaces deep inside engine worker startup,
+    where it reads like a model or engine bug rather than a missing host
+    service. Fabric Manager refuses to run against a mismatched driver, so the
+    package is pinned to the running driver's exact version.
+    """
+    rc, _ = await host.run("ls /proc/driver/nvidia-nvswitch/devices/ 2>/dev/null | grep -q .", capture=True)
+    if rc != 0:
+        return
+
+    rc, _ = await host.run("systemctl is-active --quiet nvidia-fabricmanager", capture=True)
+    if rc == 0:
+        logger.info(f"{host.name}: NVIDIA Fabric Manager already running")
+        return
+
+    driver = await _current_driver_version(host)
+    if not driver:
+        raise RuntimeError(f"{host.name}: host has NVSwitches but the NVIDIA driver version could not be read")
+
+    logger.info(f"{host.name}: NVSwitch host detected, installing Fabric Manager {driver}")
+    await _setup_nvidia_cuda_repo(host)
+    # Ubuntu's archive and NVIDIA's cuda repo use different revision suffixes
+    # ("-1", "-1ubuntu1", "-0ubuntu0.24.04.1"), so resolve the packaged version
+    # that matches this driver instead of guessing one.
+    script = (
+        "set -e; "
+        f'driver="{driver}"; '
+        "ver=$(apt-cache madison nvidia-fabricmanager | cut -d'|' -f2 | tr -d ' ' "
+        '| grep -m1 "^${driver}-" || true); '
+        'if [ -z "$ver" ]; then echo "no nvidia-fabricmanager package matching driver $driver" >&2; exit 1; fi; '
+        'DEBIAN_FRONTEND=noninteractive apt-get install -y "nvidia-fabricmanager=$ver"; '
+        "systemctl enable --now nvidia-fabricmanager"
+    )
+    rc, out = await host.run(script, sudo=True, timeout=900, capture=True)
+    if rc != 0:
+        tail = "\n".join(out.splitlines()[-20:]) if out else ""
+        raise RuntimeError(f"{host.name}: installing Fabric Manager {driver} failed (rc={rc}). Last lines:\n{tail}")
+
+    rc, _ = await host.run("systemctl is-active --quiet nvidia-fabricmanager", capture=True)
+    if rc != 0:
+        raise RuntimeError(f"{host.name}: Fabric Manager {driver} installed but the service is not active")
 
 
 async def _purge_existing_nvidia(host: Host) -> None:

--- a/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/RESULTS.md
+++ b/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/RESULTS.md
@@ -1,0 +1,97 @@
+# DeepSeek V4 Flash 0731 — serving experiment results
+
+One representative short-context workload for the zero-JIT TP8×PP2 configuration, run per exact GPU platform. Each
+platform section below describes the archive named in it and nothing else.
+
+## NVIDIA Tesla V100 SXM3 32GB × 16 — `results_v100x16.tar.gz`
+
+**Question.** Does the maintained TP8×PP2 recipe still deploy, serve, and perform on a 16× V100 SXM3 host, and how
+stable is the result across repeats?
+
+**Protocol.** `emmy bench experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3` against a pre-allocated 16× V100 SXM3
+host over SSH. One matrix row (`v100x16`). Four client repeats, each preceded by 8 warm-up requests; each repeat sends
+8 unique 1,024-token prompts at concurrency 8 and requests 64 output tokens with greedy decoding (`temperature: 0.0`,
+`seed: 731`) and `ignore_eos`, so every request produces exactly 64 tokens. Repeat 1 primes the prompt set after
+deployment; repeats 2–4 are the steady-state result. Spread is the population standard deviation across those three
+repeats.
+
+**Run.** Timestamp `2026-08-19T19:14:45Z`, run ID `20260819T191445Z`, repository revision `12bb850e` (clean tree),
+row `v100x16` / `661253606d45`, status `succeeded`. Archive members:
+
+```
+2026-08-19_19-14-45/benchmark.log
+2026-08-19_19-14-45/benchmark_v100_x_16.log
+2026-08-19_19-14-45/v100x16_661253606d45.benchmark.log
+2026-08-19_19-14-45/v100x16_661253606d45.experiment.yaml
+2026-08-19_19-14-45/v100x16_661253606d45.server.log
+```
+
+**Machine and software.** Ubuntu 24.04.1, kernel 6.8.0-124-generic, 2× Intel Xeon Platinum 8168 (80 logical CPUs),
+1.44 TB RAM, 16× Tesla V100-SXM3-32GB behind 12 NVSwitches, driver 580.159.03, CUDA 13.0. Engine image
+`cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608`
+(`sha256:276240257b224097876b5b6db8f0d32484dff6a6f168d6b03d6df188e5c65bc1`), vLLM
+`1.2.3.dev87+gd76126608.d20260810`. Model revision `7872f01b1d1fe23eabc4c98b48bffcef5a386062`, FP16 weights with
+`deepseek_v4_fp8` quantization and an FP8 KV cache, TP8 × PP2, context 1,048,576, `gpu_memory_utilization` 0.90.
+
+**Result.** The row succeeded. All 32 requests across the four repeats completed; 0 failed.
+
+| Repeat | Duration (s) | req/s | Output tok/s | Total tok/s | Mean TTFT (ms) | Mean TPOT (ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 (priming) | 23.72 | 0.34 | 21.59 | 367.00 | 8,266.85 | 243.89 |
+| 2 | 16.59 | 0.48 | 30.86 | 524.56 | 3,876.69 | 201.79 |
+| 3 | 16.47 | 0.49 | 31.09 | 528.57 | 3,821.34 | 200.67 |
+| 4 | 16.52 | 0.48 | 30.99 | 526.78 | 3,817.99 | 201.62 |
+
+Steady state over repeats 2–4 (24 requests, 0 failures):
+
+| Metric | Mean ± population SD |
+| --- | ---: |
+| Benchmark duration | 16.5267 ± 0.0492 s |
+| Request throughput | 0.4833 ± 0.0047 req/s |
+| Output token throughput | 30.9800 ± 0.0942 tok/s |
+| Total token throughput | 526.6367 ± 1.6402 tok/s |
+| Mean TTFT | 3,838.6733 ± 26.9166 ms |
+| Mean TPOT / ITL | 201.3600 ± 0.4928 ms |
+
+**Repeat variation.** Repeats 2–4 are very tight: duration varies by 0.3%, output throughput by 0.3%, and mean TPOT by
+0.2%. The priming repeat is a clear outlier (44% longer, TTFT 2.2× the steady mean) and is excluded, which the protocol
+anticipates.
+
+**Deployment timing.** `remote_provision` 7.04 s, `image_pull` 2.36 s and `model_download` 3.41 s (both cached from an
+earlier deployment on this host), `weights_load` 24.32 s, `cuda_graph_capture` 7.00 s, `engine_warmup` 22.52 s,
+`startup` 92.09 s, `model_load_and_warmup` 145.92 s, `smoke_test` 4.10 s, `benchmark` 242.21 s, `total` 405.04 s.
+
+**Comparison with the 2026-08-11 qualification.** That run measured the same recipe and workload on a *different* 16×
+V100 SXM3 host running driver 580.173.02. This is a directional comparison across two machines, not a controlled A/B:
+only one variable was intended to change (the host), but driver version changed with it.
+
+| Metric | 2026-08-11 | 2026-08-19 | Change |
+| --- | ---: | ---: | ---: |
+| Benchmark duration | 14.9793 s | 16.5267 s | +10.3% |
+| Request throughput | 0.5341 req/s | 0.4833 req/s | −9.5% |
+| Output token throughput | 34.1830 tok/s | 30.9800 tok/s | −9.4% |
+| Total token throughput | 581.1111 tok/s | 526.6367 tok/s | −9.4% |
+| Mean TTFT | 2,580.88 ms | 3,838.67 ms | +48.7% |
+| Mean TPOT / ITL | 195.949 ms | 201.360 ms | +2.8% |
+
+The gap is concentrated in prefill: decode cost (TPOT) is within 2.8%, while TTFT is roughly half again as large. Both
+runs are internally stable, so the difference is a property of the two machines rather than measurement noise. The
+harness does not isolate host from driver, so this experiment cannot attribute the prefill difference to either one.
+
+**Zero-JIT claim.** The recipe describes this configuration as having a zero-JIT request cache. That does not hold on
+this deployment: the server log records eight distinct Triton kernels JIT-compiling during inference —
+`_build_c128a_topk_metadata_kernel`, `_build_prefill_chunk_metadata_kernel`, `_combine_topk_swa_indices_kernel`,
+`_compute_prefill_metadata_kernel`, `_dequantize_and_gather_k_kernel`, `_sm70_qnorm_rope_kernel`,
+`_sm70_sparse_gathered_kernel`, and `quantize_and_insert_k_kernel`. All of them compile once,
+during the first repeat's warm-up phase, and none recurs; they inflate the priming repeat and leave repeats 2–4
+unaffected.
+
+**Conclusion.** The maintained recipe deploys and serves correctly on 16× V100 SXM3 with zero failed requests and
+highly reproducible steady-state throughput. Short-context performance on this host is about 9% below the 2026-08-11
+measurement, with the shortfall almost entirely in prefill latency.
+
+**Limitations.** One workload shape only (1,024 in / 64 out, concurrency 8) on one matrix row — it justifies the
+recommended configuration but says nothing about long-context or high-concurrency behaviour. `emmy bench` deployed a
+fresh server for this run, so the numbers are cold-cache-then-warmed, not steady-state under sustained production load.
+The cross-run comparison above changes two variables at once. No Emmy lane exists for this model, so there is no
+compiler-vs-stock comparison to report.

--- a/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/recipe.yaml
+++ b/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/recipe.yaml
@@ -1,5 +1,5 @@
-# Representative workload for the zero-JIT TP8xPP2 configuration qualified on 16x V100 SXM3 32GB.
-# The tag was validated locally; image publication requires approval and cloudriftai namespace access.
+# Representative workload for the TP8xPP2 configuration qualified on 16x V100 SXM3 32GB.
+# The pinned image is published on Docker Hub. Repeat 1 primes the prompt set; repeats 2-4 are the steady result.
 model:
   huggingface: "deepseek-ai/DeepSeek-V4-Flash-0731"
   revision: 7872f01b1d1fe23eabc4c98b48bffcef5a386062

--- a/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/results_v100x16.tar.gz
+++ b/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/results_v100x16.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9102d5d7674da9356333f0a8fa9a7630b2566b2142a3b4a14ffa14f2e1a64b7e
+size 18750

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -118,13 +118,38 @@ therefore ran against the committed inventory rather than a freshly re-derived o
 | Strict decode of every realization | committed file | 279 / 279 |
 | Reconstruct and lower every target | Tesla V100-SXM3-32GB (sm_70) | 279 / 279, exit 0, 3 min 54 s |
 
-### `REDUCE=g2a` was a recorded pessimization, and no longer realizes at all
+### `REDUCE=g2a`: a validator false negative, now fixed and re-measured
 
-Every one of the 9 realizations the golden pinned to `REDUCE=g2a` measured slower than Emmy's own greedy pick, with a
-median ratio of 0.549× against 1.009× for `REDUCE=coop` and 1.425× for the default — about 27.6 ms of recorded but
-avoidable latency. Under the current compiler those pins do not reproduce at all: an exact `--ab` pin reports
-`unreproducible pin: REDUCE=g2a realized (off)`, so the planner silently selects a different schedule and the recorded
-`emmy_us` values for those rows cannot be measured today.
+The nine realizations the golden pinned to `REDUCE=g2a` all recorded worse-than-greedy numbers, and an exact `--ab`
+pin reported `unreproducible pin: REDUCE=g2a realized (off)`, so the row would not bench at all. Neither symptom
+meant what it looked like.
+
+`g2a` decodes as a cross-CTA split of width 2 with atomic finalize, and it does realize: pinning it halves the
+emitted K loop from 16,384 to 8,192, adds the partition axis and closes with `atomicAdd`. What changed is where the
+receipt lives. #539 made a split mint brand-new kernels and had `knob.consume_kernel_row` strip their schedule row,
+so no piece may carry the `g<n>` it came from — `test_split_fresh_kernels` asserts that outright. The partition is
+recorded by the piece's sliced reduce axis, not by a stamp, exactly as a realized `PLACE` cut is. The
+realized-vs-pinned gate reads only stamps, so it saw the pieces' `REDUCE=(off)` and called a realized pin dropped.
+The golden was recorded 2026-08-11, seven days before #539, which is why its rows predate the problem.
+
+The gate now skips the `g<n>` stage the way it already skips `PLACE`, and still gates the rest of the value. With
+that, all eight surviving `g2a` rows bench cleanly (16/16 runs, no unreproducible-pin error) and were re-measured on
+the target GPU. `g2a` and greedy are indistinguishable on every one of them:
+
+| Realization | `g2a` (µs) | greedy (µs) |
+| --- | ---: | ---: |
+| `layer0.i003` | 913.4 | 914.4 |
+| `layer0.i052` | 914.4 | 916.5 |
+| `layer2.i003` | 914.4 | 914.4 |
+| `layer2.i063` | 916.5 | 916.5 |
+| `layer3.i003` | 914.4 | 916.5 |
+| `layer3.i064` | 915.5 | 915.5 |
+| `layer4.i003` | 915.5 | 916.5 |
+| `layer4.i063` | 912.4 | 912.4 |
+
+Each row keeps its `g2a` knobs — the configuration is real and ties with greedy — and carries the slowest of its two
+runs on each side. Across the file, realizations materially slower than greedy fall from 41 to 11, and the remaining
+eleven are sub-microsecond pointwise kernels.
 
 ### Tuning: equal-budget hybrid versus MCTS-only
 
@@ -155,11 +180,9 @@ The hybrid proposal wins decisively on the one target with real headroom — 2.8
 and use the cooperative reduce with a thread work inventory. It is promoted into the golden with its two O3
 measurements.
 
-The eight `k_linear_reduce_f6a146` realizations are deliberately **not** repinned. Greedy already beats every
-searched and proposed candidate there by roughly 2.7×, and pinning greedy's own displayed knobs (`TILE=f2x2,
-WORK=t16x8`) measures 1,641 µs against greedy's 909 µs at a different grid — so no knob spelling in this schema
-faithfully records what greedy actually does. Their recorded `g2a` knobs remain unreproducible and should be
-re-derived by a compiler-side fix rather than hand-edited.
+The eight `k_linear_reduce_f6a146` realizations keep their `g2a` knobs. No searched or proposed candidate beat
+greedy there, and once the validator fix let the incumbent bench, `g2a` measured as a tie with greedy on all
+eight — so the recorded configuration stands and only its stale measurements needed refreshing.
 
 ### Reproducing the compiler work
 

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -88,14 +88,15 @@ The [canonical V100 golden](golden/v100_sm70.yaml) contains 279 exact Loop reali
 positive deployable O3 and reference timings. Coverage spans the layer paths and the non-layer seams (`layer0`,
 `layer2`, `layer3`, `layer4`, and `model-seam` targets).
 
-Verified on 2026-08-19 against the exact target hardware:
+This run reverified that committed golden. It did **not** retrace the model and did **not** retune any kernel: the
+inventory, knobs, and recorded timings are unchanged from the 2026-08-11 tuning run, and the file is byte-identical.
 
-| Gate | Result |
-| --- | --- |
-| Repository-level validation | passes |
-| Strict decode of every realization | 279 / 279 |
-| Paired positive O3 / reference timings | 279 / 279 |
-| Whole-file replay on Tesla V100-SXM3-32GB (sm_70) | all 279 targets reconstructed and lowered, exit 0 |
+| Gate | Checked against | Result |
+| --- | --- | --- |
+| Repository-level validation | committed file | passes |
+| Strict decode of every realization | committed file | 279 / 279 |
+| Paired positive O3 / reference timings, recorded 2026-08-11 | committed file | 279 / 279 present and positive |
+| Reconstruct and lower every target | Tesla V100-SXM3-32GB (sm_70) | 279 / 279, exit 0 |
 
 `emmy run --golden recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml` completed in 4 min 19 s with no compile,
 lowering, or execution failure, using the CUDA 12.9 toolchain (CUDA 13 cannot target sm_70). Emmy serving eligibility

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -84,33 +84,91 @@ benchmark run.
 
 ## Compiler qualification
 
-The [canonical V100 golden](golden/v100_sm70.yaml) contains 279 exact Loop realizations across 13 programs, each with
-positive deployable O3 and reference timings. Coverage spans the layer paths and the non-layer seams (`layer0`,
-`layer2`, `layer3`, `layer4`, and `model-seam` targets).
+### Coverage
 
-This run reverified that committed golden. It did **not** retrace the model and did **not** retune any kernel: the
-inventory, knobs, and recorded timings are unchanged from the 2026-08-11 tuning run, and the file is byte-identical.
+All 43 decoder layers reduce to three distinct traced graphs, set by `compress_ratios` in the model config. Tracing
+seven layers and comparing Graph IR node counts closes the manifest empirically:
+
+| Class | `compress_ratio` | Representative | Graph IR nodes | Verified identical |
+| --- | ---: | --- | ---: | --- |
+| layers 0–1 | 0 | layer 0 | 945 | layer 1 |
+| even layers 2–42 | 4 | layer 2 | 1,156 | layers 4, 42 |
+| odd layers 3–41 | 128 | layer 3 | 1,087 | layer 41 |
+
+Layer 41 and layer 42 are `dspark_target_layer_ids`, and they trace identically to their ordinary siblings, so the
+dspark specialization is not visible as a distinct architecture path. The committed golden's fourth representative
+(layer 4) is redundant with layer 2. Non-layer seams are covered by the `model-seam` targets.
+
+One path is **not** covered: the model declares `num_nextn_predict_layers: 1`, but the MTP head is not exposed as a
+decoder layer — `emmy trace --layer 43` fails with "layer 43 not found (model has 43 layers)" — so it cannot be
+traced through this interface. The committed golden does not contain it either.
+
+A whole-model architecture trace is not bounded on this checkpoint: it grew past 830 GiB of host RAM, climbing about
+45 GiB/minute, before it was stopped. Per-layer tracing is bounded (about 1 GiB), which is why the inventory is built
+from representatives. Per-layer tracing is nonetheless dominated by merge-region dependency resolution in the Loop
+splicer (`ir/loop/splicer.py`, `_ensure_dep` under `build_merged_region`); three representative layers ran 4h45m in
+that phase without emitting a post-fusion inventory, confirming the 2026-08-11 report's attribution. The tuning below
+therefore ran against the committed inventory rather than a freshly re-derived one.
+
+### Verification on the target GPU
 
 | Gate | Checked against | Result |
 | --- | --- | --- |
 | Repository-level validation | committed file | passes |
 | Strict decode of every realization | committed file | 279 / 279 |
-| Paired positive O3 / reference timings, recorded 2026-08-11 | committed file | 279 / 279 present and positive |
-| Reconstruct and lower every target | Tesla V100-SXM3-32GB (sm_70) | 279 / 279, exit 0 |
+| Reconstruct and lower every target | Tesla V100-SXM3-32GB (sm_70) | 279 / 279, exit 0, 3 min 54 s |
 
-`emmy run --golden recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml` completed in 4 min 19 s with no compile,
-lowering, or execution failure, using the CUDA 12.9 toolchain (CUDA 13 cannot target sm_70). Emmy serving eligibility
-is unchanged, and this compiler evidence does not establish an Emmy serving path for the checkpoint.
+### `REDUCE=g2a` was a recorded pessimization, and no longer realizes at all
 
-Reaching that verdict required fixing the replay itself. `emmy run --golden` re-read and re-validated the whole
-document once per target; at roughly 15 s per load for this 3.4 MB inventory, a 279-target replay spent over an hour
-re-parsing the same file before doing any useful work. That is consistent with the 2026-08-11 note that the in-model
-audit returned no verdict within a bounded 106-minute replay, which was attributed to the Loop splicer. The replay now
-parses the document once and shares it across targets.
+Every one of the 9 realizations the golden pinned to `REDUCE=g2a` measured slower than Emmy's own greedy pick, with a
+median ratio of 0.549× against 1.009× for `REDUCE=coop` and 1.425× for the default — about 27.6 ms of recorded but
+avoidable latency. Under the current compiler those pins do not reproduce at all: an exact `--ab` pin reports
+`unreproducible pin: REDUCE=g2a realized (off)`, so the planner silently selects a different schedule and the recorded
+`emmy_us` values for those rows cannot be measured today.
 
-Two host conditions also matter for anyone reproducing this: Emmy needs `nvcc` on `PATH`, and the CUDA 12.9 toolkit
-must be selected because CUDA 13 dropped Volta; and PyYAML silently falls back to its pure-Python loader when
-`libyaml` is absent, which alone cost more than 13 minutes per parse on this host before it was corrected.
+### Tuning: equal-budget hybrid versus MCTS-only
+
+Scope: the 9 `g2a` realizations. The other 270 are at or above greedy and carry no headroom, and a full 279-target arm
+measured out at roughly ten hours per arm. This is a scoped kernel result, not a whole-model performance claim.
+
+Both arms started from the same inventory-only base (no knobs, timings, or ranking), an empty tune DB and online prior,
+separate empty cubin caches, `--max-candidates 8`, `--patience 4`, `--seed 731`, 9 GPUs, same compiler revision, MCTS
+arm first. The hybrid arm added 4 knob proposals per target, each reserving a candidate slot before MCTS. MCTS
+completed 9/9 targets with 145 benches; hybrid 9/9 with 171. On the O1 ranking lane MCTS produced the better candidate
+on 6 targets, hybrid on 1, with 2 ties.
+
+The O1 ranking lane misranks this model badly, so every conclusion below is from repeated deployable O3 measurement:
+
+| Target | Candidate | O3 run 1 | O3 run 2 |
+| --- | --- | ---: | ---: |
+| `model-seam.k_linear_db1eb0` | greedy (isolated) | 2,854.9 µs | 2,855.9 µs |
+| | MCTS winner `TILE=f2x8, WORK=t64x8` | 2,804.7 µs | 2,510.8 µs |
+| | **hybrid proposal `REDUCE=coop, WORK=t128`** | **1,014.8 µs** | **902.1 µs** |
+| `layer0.i003.k_linear_reduce_f6a146` | greedy (isolated) | 910.3 µs | 910.3 µs |
+| | MCTS winner `TILE=f1x2, WORK=t32x8` | 2,526.2 µs | 2,520.1 µs |
+| | hybrid `REDUCE=coop, TILE=f2x2, WORK=t16x8` | 2,367.5 µs | 2,487.3 µs |
+| `layer3.i064.k_linear_reduce_f6a146` | greedy (isolated) | 912.4 µs | 909.3 µs |
+| | MCTS winner `TILE=f1x2, WORK=t32x8` | 2,401.3 µs | 2,522.1 µs |
+
+The hybrid proposal wins decisively on the one target with real headroom — 2.8–3.2× faster than greedy and about
+2.5× faster than the MCTS-only winner — and it is exactly the hypothesis the `g2a` evidence suggested: drop `g2a`
+and use the cooperative reduce with a thread work inventory. It is promoted into the golden with its two O3
+measurements.
+
+The eight `k_linear_reduce_f6a146` realizations are deliberately **not** repinned. Greedy already beats every
+searched and proposed candidate there by roughly 2.7×, and pinning greedy's own displayed knobs (`TILE=f2x2,
+WORK=t16x8`) measures 1,641 µs against greedy's 909 µs at a different grid — so no knob spelling in this schema
+faithfully records what greedy actually does. Their recorded `g2a` knobs remain unreproducible and should be
+re-derived by a compiler-side fix rather than hand-edited.
+
+### Reproducing the compiler work
+
+Emmy needs `nvcc` on `PATH`, and the CUDA **12.9** toolkit specifically: CUDA 13 dropped Volta. Two further host
+conditions cost hours before they were found. PyYAML silently falls back to its pure-Python loader without `libyaml`,
+which alone cost more than 13 minutes per parse of this 3.4 MB golden. And `torch 2.13` installs
+`nvidia-cuda-nvrtc 13.0.88`, which `cupy-cuda12x` then resolves in preference to any CUDA 12 NVRTC; because CUDA 13
+has no Volta support, every CuPy JIT path dies with `invalid value for --gpu-architecture` and all benchmarking fails.
+Running with `LD_PRELOAD=/usr/local/cuda-12.9/lib64/libnvrtc.so.12` restores it.
 
 ## Reproduce
 

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -1,7 +1,8 @@
 # DeepSeek V4 Flash 0731 on 16× V100 SXM3 32 GB
 
-Status: serving-qualified with the 1Cat/vLLM engine pinned by the recipe. Emmy serving is ineligible because the
-DeepSeek V4 compressor and hyper-connection path has no executable external-attention serving ABI.
+Status: serving-qualified with the 1Cat/vLLM engine pinned by the recipe. Verification refresh of 2026-08-19 on a
+second 16× V100 SXM3 host. Emmy serving remains ineligible: the DeepSeek V4 compressor and hyper-connection path has
+no executable external-attention serving ABI, so `EMMY_FAST_MATH` is not set and there is no Emmy comparison lane.
 
 ## Qualified deployment
 
@@ -9,61 +10,120 @@ DeepSeek V4 compressor and hyper-connection path has no executable external-atte
 | --- | --- |
 | Model | `deepseek-ai/DeepSeek-V4-Flash-0731` |
 | Model revision | `7872f01b1d1fe23eabc4c98b48bffcef5a386062` |
-| Hardware | 16× Tesla V100-SXM3-32GB, compute capability 7.0 |
-| Driver / CUDA | 580.173.02 / 13.0 |
-| Engine | 1Cat/vLLM `d76126608155c334df7c2fb9b75096f879624859` |
+| Hardware | 16× Tesla V100-SXM3-32GB, compute capability 7.0, 12 NVSwitches |
+| Driver / CUDA | 580.159.03 / 13.0 |
+| Engine | 1Cat/vLLM `1.2.3.dev87+gd76126608.d20260810` |
 | Image | `cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608` |
+| Image digest | `sha256:276240257b224097876b5b6db8f0d32484dff6a6f168d6b03d6df188e5c65bc1` |
 | Serving shape | TP8, PP2, context 1,048,576, concurrency 8, FP8 KV cache |
 
-The recipe disables process-local SM70 MXFP4 small-shape timing selection. The timed selector chose different W13
-expert GEMM configurations after fresh starts and changed greedy output. The fixed default dispatch returned the exact
-same token and logits in six probes across three fresh TP8×PP2 processes, and again after the final full-context
-restart. `EMMY_FAST_MATH` is not set because this is not an Emmy serving engine.
+The recipe disables process-local SM70 MXFP4 small-shape timing selection, because the timed selector chose different
+W13 expert GEMM configurations after fresh starts and changed greedy output. Greedy decoding was stable across this
+run's probes.
+
+### Host prerequisite: NVIDIA Fabric Manager
+
+These 16 GPUs sit behind 12 NVSwitches. Until Fabric Manager trains that fabric, `nvidia-smi` lists all 16 GPUs while
+every engine worker dies at `cudaGetDeviceCount()` with `error 802: system not yet initialized`, which reads like an
+engine or model fault rather than a missing host service. A freshly provisioned host for this run had no Fabric Manager
+installed and could not deploy at all. `emmy deploy` now installs and starts it automatically on NVSwitch hosts, pinned
+to the running driver's exact version; no recipe change is required. Anyone deploying this recipe outside Emmy must
+ensure `nvidia-fabricmanager` matching the driver is running first.
 
 ## Best recipe performance
 
-Measured 2026-08-11 with the final 1,048,576-context recipe. The reported three steady repeats followed one
-unreported post-restart priming repeat. Each repeat used eight unique 1,024-token prompts at concurrency 8 and
-requested 64 output tokens with greedy decoding and ignored EOS. All 24 reported requests completed with exact token
-counts. Spread is the population standard deviation across the three repeats.
+Measured 2026-08-19 with the pinned 1,048,576-context recipe at repository revision `12bb850e`. Four client repeats;
+the first primes the prompt set after deployment and is excluded. Each repeat used eight unique 1,024-token prompts at
+concurrency 8 and requested 64 output tokens with greedy decoding and ignored EOS. All 24 reported requests completed
+with exact token counts. Spread is the population standard deviation across the three steady repeats.
 
 | Metric | Three-repeat mean ± standard deviation |
 | --- | ---: |
 | Successful / failed requests | 24 / 0 |
-| Benchmark duration | 14.9793 ± 0.1260 s |
-| Request throughput | 0.5341 ± 0.0045 requests/s |
-| Output throughput | 34.1830 ± 0.2886 tokens/s |
-| Total token throughput | 581.1111 ± 4.9058 tokens/s |
-| Mean TTFT | 2,580.88 ± 163.94 ms |
-| Mean TPOT / ITL | 195.949 ± 4.113 ms |
+| Benchmark duration | 16.5267 ± 0.0492 s |
+| Request throughput | 0.4833 ± 0.0047 requests/s |
+| Output throughput | 30.9800 ± 0.0942 tokens/s |
+| Total token throughput | 526.6367 ± 1.6402 tokens/s |
+| Mean TTFT | 3,838.67 ± 26.92 ms |
+| Mean TPOT / ITL | 201.360 ± 0.493 ms |
+
+This is about 9% below the 2026-08-11 qualification on the previous 16× V100 host (driver 580.173.02), which measured
+34.1830 ± 0.2886 output tokens/s. Decode cost is nearly unchanged (TPOT 201.36 ms vs 195.949 ms, +2.8%); essentially
+all of the gap is prefill (TTFT 3,838.67 ms vs 2,580.88 ms, +48.7%). Both runs are internally stable, so this is a
+machine-level difference rather than noise; the two runs differ in both host and driver version, and this evidence
+cannot separate them.
+
+The recipe's zero-JIT intent is not fully met. Eight Triton kernels JIT-compile once during the first repeat's
+warm-up — including the prefill-metadata and SM70 quantized-attention paths — and none recurs, so they cost the
+priming repeat only. The per-kernel list is in the experiment report.
 
 ## Context and accuracy
 
-The engine allocated KV capacity for 4,184,221 tokens on PP0 and 4,220,292 tokens on PP1. An exact
-1,048,575-token prompt plus one decode token completed with HTTP 200 in 909.724 seconds and reported 1,048,576 total
-tokens. Peak physical allocation left 361 MiB on PP0 and 589 MiB on PP1; the run had zero preemptions, allocator
-errors, or OOMs.
+The engine allocated KV capacity for 4,244,903 tokens on PP0 and 4,281,497 tokens on PP1, reporting 4.05×/4.08×
+maximum concurrency at the full 1,048,576-token context. An exact 1,048,575-token prompt plus one decode token
+completed with HTTP 200 in 1,331.6 s and reported 1,048,576 total tokens, with no preemption, allocator error, or OOM;
+peak physical allocation reached 32,206 MiB of 32,768 MiB per GPU. The prompt used random token IDs so that
+prefix-cache block deduplication could not shrink the KV footprint under test.
 
-The exact arithmetic probe returned `323` with identical logits twice before the boundary request, twice immediately
-after it, and twice after a fresh full-context restart. The same deployment passed factual completion, thinking-off
-chat, separated reasoning, and structured tool-call probes. The tool parser returned `multiply(a=17, b=19)`.
+Capability probes on the same pinned recipe: factual completion returned `Paris`; the exact arithmetic probe returned
+`323` identically across repeated requests; tool calling returned a structured `multiply(a=17, b=19)` call; and
+reasoning was separated into the engine's `reasoning` field (400 characters of reasoning against 197 characters of
+content).
+
+Reasoning separation is opt-in per request. The `deepseek_v4` reasoning parser resolves to vLLM's
+`DeepSeekV3ReasoningParser`, which delegates to the R1 parser only when the request passes
+`chat_template_kwargs: {"thinking": true}` (or `enable_thinking`); otherwise it installs the identity parser and
+returns `reasoning: null`. With thinking explicitly disabled, the identity parser also leaves the template's stray
+closing `</think>` marker at the head of `content`. Both behaviours are upstream parser semantics, not recipe faults,
+but clients that expect separated reasoning must send the flag. The server logs a benign startup warning
+(`Auto-initialization of reasoning token IDs failed`) because the identity parser exposes no reasoning delimiters.
+
+These probes and the context measurement were taken on a separate deployment of this exact recipe, image, and serving
+shape, immediately before the benchmark deployment; the performance table above comes solely from the archived
+benchmark run.
 
 ## Compiler qualification
 
-The [canonical V100 golden](golden/v100_sm70.yaml)
-contains 279 exact Loop realizations across 13 programs. Every retained realization has positive deployable O3 and
-reference timings. The current schema passed all 279 stored-record and offer checks. The in-model audit traced four
-exact representative DeepSeek graphs with 945, 1,156, 1,087, and 1,156 Graph IR nodes, but `audit_card` returned no
-verdict within the bounded 106-minute replay. External sampling localized the compile-time hotspot to merge-region
-dependency resolution in the Loop splicer. In-model compiler qualification therefore remains incomplete, and this
-compiler evidence does not establish an Emmy serving path for the checkpoint.
+The [canonical V100 golden](golden/v100_sm70.yaml) contains 279 exact Loop realizations across 13 programs, each with
+positive deployable O3 and reference timings. Coverage spans the layer paths and the non-layer seams (`layer0`,
+`layer2`, `layer3`, `layer4`, and `model-seam` targets).
+
+Verified on 2026-08-19 against the exact target hardware:
+
+| Gate | Result |
+| --- | --- |
+| Repository-level validation | passes |
+| Strict decode of every realization | 279 / 279 |
+| Paired positive O3 / reference timings | 279 / 279 |
+| Whole-file replay on Tesla V100-SXM3-32GB (sm_70) | all 279 targets reconstructed and lowered, exit 0 |
+
+`emmy run --golden recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml` completed in 4 min 19 s with no compile,
+lowering, or execution failure, using the CUDA 12.9 toolchain (CUDA 13 cannot target sm_70). Emmy serving eligibility
+is unchanged, and this compiler evidence does not establish an Emmy serving path for the checkpoint.
+
+Reaching that verdict required fixing the replay itself. `emmy run --golden` re-read and re-validated the whole
+document once per target; at roughly 15 s per load for this 3.4 MB inventory, a 279-target replay spent over an hour
+re-parsing the same file before doing any useful work. That is consistent with the 2026-08-11 note that the in-model
+audit returned no verdict within a bounded 106-minute replay, which was attributed to the Loop splicer. The replay now
+parses the document once and shares it across targets.
+
+Two host conditions also matter for anyone reproducing this: Emmy needs `nvcc` on `PATH`, and the CUDA 12.9 toolkit
+must be selected because CUDA 13 dropped Volta; and PyYAML silently falls back to its pure-Python loader when
+`libyaml` is absent, which alone cost more than 13 minutes per parse on this host before it was corrected.
 
 ## Reproduce
 
 ```bash
-emmy bench experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3 --ssh riftuser@185.165.50.61
+emmy bench experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3 --ssh <user>@<16x-v100-host>
 ```
 
 The experiment runs four client repeats. The first warms the complete unique prompt set after deployment; use repeats
 two through four to reproduce the reported steady result. Use `$run-experiment` to retain the latest raw results,
 system-only experiment records, and factual artifact index.
+
+## Limitations
+
+The performance table covers one short-context shape (1,024 in / 64 out at concurrency 8); long-context and
+high-concurrency serving are validated for capacity and correctness but not for throughput. The cross-run comparison
+against 2026-08-11 changes host and driver together. No Emmy lane exists for this checkpoint, so no compiler-versus-
+stock comparison is available.

--- a/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
+++ b/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
@@ -86886,8 +86886,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 872.9600012302399
-      reference_us: 478.9760112762451
+      emmy_us: 913.4
+      reference_us: 914.4
       reference_backend: emmy-greedy
 - program: 0
   target:
@@ -87778,8 +87778,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 862.7199828624725
-      reference_us: 478.4640073776245
+      emmy_us: 914.4
+      reference_us: 916.5
       reference_backend: emmy-greedy
 - program: 0
   target:
@@ -88253,8 +88253,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 827.3919820785522
-      reference_us: 477.6960015296936
+      emmy_us: 914.4
+      reference_us: 914.4
       reference_backend: emmy-greedy
 - program: 1
   target:
@@ -89145,8 +89145,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 837.6320004463196
-      reference_us: 478.2080054283142
+      emmy_us: 916.5
+      reference_us: 916.5
       reference_backend: emmy-greedy
 - program: 1
   target:
@@ -89620,8 +89620,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 863.2319867610931
-      reference_us: 478.2080054283142
+      emmy_us: 914.4
+      reference_us: 916.5
       reference_backend: emmy-greedy
 - program: 2
   target:
@@ -90379,8 +90379,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 828.4159898757935
-      reference_us: 438.01601231098175
+      emmy_us: 915.5
+      reference_us: 915.5
       reference_backend: emmy-greedy
 - program: 2
   target:
@@ -90854,8 +90854,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 873.4719753265381
-      reference_us: 478.7200093269348
+      emmy_us: 915.5
+      reference_us: 916.5
       reference_backend: emmy-greedy
 - program: 3
   target:
@@ -91347,8 +91347,8 @@ configs:
       TILE: f2x2
       WORK: t16x8
     measurements:
-      emmy_us: 823.8080143928528
-      reference_us: 447.2320079803467
+      emmy_us: 912.4
+      reference_us: 912.4
       reference_backend: emmy-greedy
 - program: 3
   target:

--- a/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
+++ b/recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml
@@ -91836,13 +91836,13 @@ configs:
     knobs:
       LOOPIFY: '0'
       RASTER: ''
-      REDUCE: g2a
+      REDUCE: coop
       STAGE: ''
-      TILE: mma_m8n8k4_f16_f32/f1x8/k8
-      WORK: w8x1
+      TILE: ''
+      WORK: t128
     measurements:
-      emmy_us: 2480.128049850464
-      reference_us: 328.92597348939205
+      emmy_us: 1014.8
+      reference_us: 2860.0
       reference_backend: emmy-greedy
 - program: 12
   target:

--- a/recipes/DeepSeek-V4-Flash-0731/recipe.yaml
+++ b/recipes/DeepSeek-V4-Flash-0731/recipe.yaml
@@ -1,5 +1,8 @@
-# Qualified on 16x V100 SXM3 32GB with a zero-JIT request cache and CUDA graphs. The tag was validated locally;
-# image publication requires approval and cloudriftai namespace access.
+# Qualified on 16x V100 SXM3 32GB with CUDA graphs. The image below is published; reverified 2026-08-19.
+# The request cache is not fully zero-JIT: eight Triton kernels compile once during the first warm-up and then
+# stay cached, so only the priming requests pay for them (see RESULTS.md).
+# The 16 GPUs sit behind NVSwitches: without a running nvidia-fabricmanager matching the driver, every worker
+# fails at cudaGetDeviceCount() with error 802. `emmy deploy` installs and starts it automatically.
 tags:
   - maintained
 

--- a/tests/compiler/cli/test_run.py
+++ b/tests/compiler/cli/test_run.py
@@ -1486,3 +1486,34 @@ def test_write_ab_json_uses_whole_program_time_for_multi_launch_pinned_row(tmp_p
     assert pinned["timing_semantics"] == "whole_program_e2e"
     assert pinned["captured"] is True
     assert pinned["num_launches"] == 2
+
+
+def test_unreproducible_pin_flag_reads_a_cross_cta_split_structurally(monkeypatch):
+    """A realized cross-CTA ``REDUCE`` split leaves no knob stamp, so the gate must not read one.
+
+    ``030_split_reduce`` mints brand-new pieces and ``knob.consume_kernel_row`` strips their
+    schedule row, so no piece may carry the ``g<n>`` it came from — ``test_split_fresh_kernels``
+    asserts exactly that. The receipt is the piece's sliced reduce axis, which knob stamps cannot
+    show, so a ``g2a`` pin that DID realize used to be reported ``realized (off)`` and its row went
+    unbenched. What the pieces still stamp is the rest of the row, and that stays gateable.
+    """
+    from emmy.compiler.pipeline import knob as knob_mod
+    from emmy.compiler.pipeline.knob import Knob, KnobType
+    from emmy.compiler.pipeline.search.pins import unreproducible_pin_flag
+
+    monkeypatch.setattr(
+        knob_mod,
+        "_REGISTRY",
+        {"REDUCE": Knob("REDUCE", KnobType.STR, off=""), "WORK": Knob("WORK", KnobType.STR, off="")},
+    )
+
+    # Wholly structural: the whole value is the cross-CTA stage, so there is nothing left to gate.
+    assert unreproducible_pin_flag({"REDUCE": "g2a"}, [{"REDUCE": "", "WORK": "t16x8"}]) is None
+    assert unreproducible_pin_flag({"REDUCE": "g4k"}, [{"REDUCE": "", "WORK": "t16x8"}]) is None
+    # The remainder is still gated: ``coop`` is stamped by the piece that realizes it.
+    assert unreproducible_pin_flag({"REDUCE": "g2k/coop"}, [{"REDUCE": "coop"}]) is None
+    flag = unreproducible_pin_flag({"REDUCE": "g2k/coop"}, [{"REDUCE": ""}])
+    assert flag is not None and "REDUCE=g2k/coop" in flag
+    # A value with no cross-CTA stage is unaffected — the old behaviour stands.
+    assert "unreproducible pin" in unreproducible_pin_flag({"REDUCE": "coop"}, [{"REDUCE": ""}])
+    assert unreproducible_pin_flag({"REDUCE": "coop"}, [{"REDUCE": "coop"}]) is None

--- a/tests/compiler/cli/test_run_golden.py
+++ b/tests/compiler/cli/test_run_golden.py
@@ -4,6 +4,8 @@ import argparse
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from emmy.commands import run as run_mod
 
 
@@ -120,3 +122,47 @@ def test_strict_result_requires_every_requested_exact_row():
     errors = run_mod._strict_benchmark_errors(args, {"Emmy": 10.0}, bench, True, proof, [])
 
     assert "expected 1 exact --ab row(s), got 0" in errors
+
+
+def test_golden_document_is_parsed_once_for_every_target(monkeypatch, tmp_path):
+    """A whole-model inventory must not be re-read and re-validated per target."""
+    from emmy.compiler.pipeline.search import golden
+
+    loads = []
+    document = {"configs": []}
+    monkeypatch.setattr(golden, "load_golden_file", lambda _path: loads.append(_path) or document)
+    monkeypatch.setattr(golden, "load_golden_records", lambda _document: [SimpleNamespace(name=name) for name in ("a", "b", "c")])
+    calls = []
+    monkeypatch.setattr(run_mod, "_handle_run_once", calls.append)
+
+    run_mod._run_golden_targets(_args(tmp_path))
+
+    assert len(loads) == 1
+    assert [args._golden_document for args in calls] == [document] * 3
+
+
+def test_resolve_golden_arg_prefers_the_document_the_caller_loaded(monkeypatch, tmp_path):
+    """With a document supplied, resolution must not touch the file at all."""
+    from emmy.commands import compile as compile_mod
+    from emmy.compiler.pipeline.search import golden
+
+    def _explode(_path, **_kwargs):
+        raise AssertionError("load_golden_file must not be called when a document is supplied")
+
+    monkeypatch.setattr(golden, "load_golden_file", _explode)
+    monkeypatch.setattr(golden, "load_golden_records", lambda _document: [])
+
+    args = SimpleNamespace(
+        golden="missing",
+        golden_file=str(tmp_path / "absent.yaml"),
+        _golden_document={"configs": []},
+        input=None,
+        code=None,
+        ir=None,
+        dynamic=None,
+    )
+    # No record matches "missing", so resolution exits 2 — reaching that exit proves it
+    # resolved against the supplied document instead of reading the absent file.
+    with pytest.raises(SystemExit) as excinfo:
+        compile_mod.resolve_golden_arg(args)
+    assert excinfo.value.code == 2

--- a/tests/provisioning/test_fabric_manager.py
+++ b/tests/provisioning/test_fabric_manager.py
@@ -1,0 +1,66 @@
+"""Fabric Manager provisioning: NVSwitch hosts need it before CUDA will initialize."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from emmy.provisioning.remote import _ensure_fabric_manager
+
+
+class FakeHost:
+    """Records commands and answers the two probe commands from a script."""
+
+    name = "fake"
+
+    def __init__(self, *, has_nvswitch: bool, active: list[bool]):
+        self.has_nvswitch = has_nvswitch
+        self.active = list(active)
+        self.commands: list[str] = []
+
+    async def run(self, cmd, *, sudo=False, capture=False, timeout=600):
+        self.commands.append(cmd)
+        if "nvidia-nvswitch" in cmd:
+            return (0 if self.has_nvswitch else 1), ""
+        if "systemctl is-active" in cmd:
+            return (0 if self.active.pop(0) else 1), ""
+        return 0, ""
+
+
+@pytest.fixture
+def patched():
+    with (
+        patch("emmy.provisioning.remote._current_driver_version", AsyncMock(return_value="580.159.03")),
+        patch("emmy.provisioning.remote._setup_nvidia_cuda_repo", AsyncMock()) as repo,
+    ):
+        yield repo
+
+
+async def test_no_nvswitch_host_is_left_alone(patched):
+    host = FakeHost(has_nvswitch=False, active=[])
+    await _ensure_fabric_manager(host)
+    assert not any("apt-get install" in c for c in host.commands)
+    patched.assert_not_awaited()
+
+
+async def test_already_running_service_is_not_reinstalled(patched):
+    host = FakeHost(has_nvswitch=True, active=[True])
+    await _ensure_fabric_manager(host)
+    assert not any("apt-get install" in c for c in host.commands)
+
+
+async def test_nvswitch_host_installs_version_matched_service(patched):
+    host = FakeHost(has_nvswitch=True, active=[False, True])
+    await _ensure_fabric_manager(host)
+
+    install = next(c for c in host.commands if "apt-get install" in c)
+    # Pinned to the running driver, not to a guessed package revision suffix.
+    assert 'driver="580.159.03"' in install
+    assert 'apt-get install -y "nvidia-fabricmanager=$ver"' in install
+    assert "systemctl enable --now nvidia-fabricmanager" in install
+    patched.assert_awaited_once()
+
+
+async def test_service_that_does_not_come_up_is_an_error(patched):
+    host = FakeHost(has_nvswitch=True, active=[False, False])
+    with pytest.raises(RuntimeError, match="not active"):
+        await _ensure_fabric_manager(host)


### PR DESCRIPTION
Reverifies the maintained DeepSeek V4 Flash 0731 recipe on 16× V100 SXM3, and fixes the three defects that reverification turned up. Every number below was measured on the supplied host.

## Serving

The recipe qualifies: 24/24 requests over three steady repeats, 0 failures, 30.98 ± 0.09 output tok/s, mean TPOT 201.4 ± 0.5 ms. An exact 1,048,576-token request returned HTTP 200. Tool calling and separated reasoning both verified — reasoning separation is opt-in per request via `chat_template_kwargs`, which the report now documents.

Short-context throughput is ~9% below the 2026-08-11 qualification on the previous host, concentrated almost entirely in prefill (TTFT +48.7%, TPOT +2.8%). Both runs are internally stable, but host and driver changed together, so the report states the delta without attributing it.

Two stale recipe comments corrected: the pinned image *is* published, and the configuration is not fully zero-JIT (eight Triton kernels compile once during the first warm-up).

## Three defects fixed

**A fresh 16× V100 host could not deploy at all.** Every vLLM worker died at `cudaGetDeviceCount()` with `error 802: system not yet initialized` while `nvidia-smi` listed all 16 GPUs. The GPUs sit behind 12 NVSwitches and NVIDIA Fabric Manager was never installed — nothing in `provision_remote` installed it. Added as the last provisioning step, gated on a non-empty `/proc/driver/nvidia-nvswitch/devices/`, pinned to the running driver's exact version resolved from `apt-cache madison` (Ubuntu and NVIDIA publish different revision suffixes).

**`emmy run --golden` re-parsed the whole inventory once per target.** At ~15 s per load for this 3.4 MB, 279-target golden, the replay spent over an hour re-parsing before doing useful work. `_run_golden_targets` already holds the parsed document, so it now hands it to each target. Full replay: **4 min 19 s**. Separately, `validate_golden_file` rebuilt a program graph per *config* though only 13 distinct programs exist — deduped, validation drops 4.5 s → 1.5 s.

**A realized cross-CTA `REDUCE` split was reported as unrealized.** Pinning `REDUCE=g2a` always failed the realized-vs-pinned gate — `"REDUCE=g2a realized (off)"`, row left unbenched — even though the split did happen: the emitted CUDA halves the K loop from 16,384 to 8,192, adds the partition axis and closes with `atomicAdd`. #539 made a split mint brand-new kernels and had `knob.consume_kernel_row` strip their schedule row, so no piece may carry the `g<n>` it came from (`test_split_fresh_kernels` asserts exactly that). The receipt is the piece's sliced reduce axis, exactly as a realized `PLACE` cut is structural. The gate now skips that stage the way it already skips `PLACE`, and keeps gating the rest of the value. Emitted CUDA is byte-identical — codegen untouched.

## Compiler golden

Coverage was re-derived from the model config and confirmed by tracing seven layers: all 43 decoder layers reduce to **three** distinct graphs (`compress_ratio` 0 / 4 / 128, at 945 / 1,156 / 1,087 IR nodes). Layers 41–42 (`dspark_target_layer_ids`) trace identically to their ordinary siblings, and the old golden's fourth representative was redundant. The MTP head (`num_nextn_predict_layers: 1`) is **not** traceable — it is not exposed as a decoder layer — and the golden does not contain it.

An equal-budget hybrid-vs-MCTS search ran over the nine realizations that had headroom (same inventory-only base, empty DB/prior, separate cubin caches, `--max-candidates 8 --patience 4 --seed 731`, MCTS first). The O1 ranking lane misranks this model badly, so all conclusions come from repeated deployable O3:

| Target | greedy | MCTS winner | hybrid proposal |
| --- | ---: | ---: | ---: |
| `model-seam.k_linear_db1eb0` | 2,855 / 2,856 µs | 2,805 / 2,511 µs | **1,015 / 902 µs** |
| `layer0.i003.k_linear_reduce_f6a146` | **910 / 910 µs** | 2,526 / 2,520 µs | 2,368 / 2,487 µs |

One target promoted: `REDUCE=coop, WORK=t128` on the model-seam projection, 2.8–3.2× faster than greedy. With the gate fixed, the eight `k_linear_reduce_f6a146` rows benched for the first time since #539 (16/16 runs, no unreproducible-pin error) and were re-measured; `g2a` ties with greedy on all eight, so their configuration stands and only the stale 2026-08-11 measurements needed refreshing.

Across the golden, realizations materially slower than greedy fall **41 → 11**, and the eleven that remain are sub-microsecond pointwise kernels. The file repository-validates, strictly decodes 279/279, and replays every target on sm_70.

## Known limits

- The exemption above means a `g<n>` pin that genuinely never split can no longer be told apart from one that did — knob stamps carry no evidence either way. Documented in `emmy/compiler/pipeline/ARCHITECTURE.md`.
- Tuning ran against the committed inventory, not a freshly re-derived one: three representative traces ran 4h45m in the Loop splicer (`_ensure_dep` under `build_merged_region`) without emitting post-fusion targets. Coverage is proven at the graph level, not the post-fusion target level. A whole-model trace is unbounded here — it passed 830 GiB RSS before being stopped.
- The A/B was scoped to the nine targets with headroom; a full 279-target arm measured out at ~10 h per arm. It is labelled a scoped kernel result, not a whole-model performance claim.
- On a Volta host, `torch 2.13` pulls `nvidia-cuda-nvrtc 13.0.88` and `cupy-cuda12x` prefers it; CUDA 13 dropped sm_70, so every CuPy JIT path fails with `invalid value for --gpu-architecture`. Worked around with `LD_PRELOAD` of the CUDA 12.9 NVRTC. Not fixed here — tracked separately.

## Testing

`make test` cannot complete on macOS/arm64: `tests/compiler` collection segfaults (exit 139), reproduced on a clean tree at the base commit. Everything else passes locally (1,077 passed, 76 skipped), `tests/compiler/passes` + `ir` pass file-by-file (785 passed, 0 failures), and the full suite including `tests/compiler` was run on the Linux V100 host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
