### PR TITLE
Give onboarding the same shared-prompt setup as discovery

### DIFF
--- a/.agents/skills/discover-models/SKILL.md
+++ b/.agents/skills/discover-models/SKILL.md
@@ -130,8 +130,11 @@ In automated lifecycle mode, follow `prompts/discover-models/lifecycle.md`: invo
 once and in parallel, then invoke `discover-scorer` once per deterministic recipe batch and in parallel. Each source
 investigator stays read-only, uses at most three public-web calls, and returns a compact source-specific candidate
 list. Each scorer follows `prompts/discover-models/score-recipes.md` without doing more research or choosing lifecycle
-state. The parent alone reconciles identities, compares scores globally, selects the maintained set, and proposes new
-onboarding models.
+state. Invoke `discover-fit` once per onboarding model — every new candidate and every existing onboarding shell —
+in parallel; each sizes exactly one checkpoint under `prompts/model-fit.md` and
+`prompts/discover-models/size-deployments.md` and returns that model's deployments. The parent alone reconciles
+identities, compares scores globally, selects the maintained set, and proposes new onboarding models; it relays the
+sized deployments verbatim and authors none of them.
 
 Layer quantitative demand with qualitative mindshare — what people are actually saying. For each top candidate,
 search for:
@@ -188,6 +191,10 @@ read total parameters from `config.json`, the footprint arithmetic, the Mixture 
 tensor-parallel sizing, and the requirement to state the numbers behind every fit claim.
 
 Read canonical GPU names and their `vram_mib` from `emmy/gpu.py`; that registry is the authority on fleet capacity.
+
+In automated lifecycle mode this step belongs to the `discover-fit` subagents, one per onboarding model, so each
+checkpoint is sized on its own evidence rather than alongside the demand signals that selected it. A model whose
+weights no fleet platform can hold yields no deployment and is dropped.
 
 ## Step 5 — Hardware → model matrix (the deliverable)
 

--- a/.agents/skills/discover-models/SKILL.md
+++ b/.agents/skills/discover-models/SKILL.md
@@ -182,49 +182,12 @@ mechanical lists.
 
 ## Step 4 — Hardware requirements per finalist
 
-For each finalist, pull from the HF model card / `config.json` (web search or the repo): **total parameters**,
-**active parameters** (MoE), and the **available quantizations** (is there an FP8 / AWQ / NVFP4 / INT4 repo, or
-only BF16?). Then compute VRAM to fit.
+For each finalist, follow [`prompts/model-fit.md`](../../../prompts/model-fit.md) — the shared VRAM fit contract
+that `onboard-model` follows too, so a proposed platform and a measured one mean the same thing. It defines how to
+read total parameters from `config.json`, the footprint arithmetic, the Mixture of Experts and quantization traps,
+tensor-parallel sizing, and the requirement to state the numbers behind every fit claim.
 
-**VRAM rules of thumb** (weights only; per GPU):
-
-```
-weight VRAM ≈ total_params(B) × bytes_per_param
-    bytes_per_param:  BF16/FP16 = 2  ·  FP8 = 1  ·  AWQ/INT4 ≈ 0.5
-min-to-serve ≈ weight VRAM × 1.3        # + CUDA graphs, activations, a small KV cache at modest context
-long-context / high-concurrency ≈ weight VRAM × 1.5+  (KV cache grows with context × concurrency)
-```
-
-Two traps:
-- **MoE VRAM is governed by TOTAL params** (all experts load into memory), not active params — active params
-  only drive *throughput*. A 235B-A22B MoE needs ~235B worth of weights resident.
-- **Quantization decides the GPU.** The same model in BF16 vs AWQ can be a 4× VRAM difference — always check
-  which quant repos actually exist before assigning a tier.
-
-**Multi-GPU:** if it doesn't fit on one card, tensor-parallel across N (`tensor_parallel_size`): per-GPU need
-≈ `min-to-serve / N` + per-GPU overhead. N must divide the model's attention head count; prefer 2/4/8.
-
-**Fleet VRAM** (single GPU; multiply by `gpu_count` for multi-GPU nodes):
-
-| GPU (hardware.py name) | VRAM | short |
-|---|---|---|
-| `NVIDIA B200` | ~180 GB | b200 |
-| `NVIDIA H200 141GB` | 141 GB | h200 |
-| `NVIDIA H100 80GB` | 80 GB | h100 |
-| `NVIDIA RTX PRO 6000 Blackwell {Workstation/Max-Q/Server} Edition` | 96 GB | pro6000 |
-| `NVIDIA GeForce RTX 5090` | 32 GB | rtx5090 |
-| `NVIDIA GeForce RTX 4090` | 24 GB | rtx4090 |
-
-**Quick fit reference** (weights only — apply ×1.3 for real serving; pick the quant that exists):
-
-| Total params | BF16 (×2) | FP8 (×1) | AWQ/INT4 (×0.5) |
-|---|---|---|---|
-| ~8B | 16 GB → 1×4090(tight)/5090 | 8 GB → 1×4090 | 4 GB → 1×4090 |
-| ~30B | 60 GB → 1×H100/Pro6000 | 30 GB → 1×5090(tight)/Pro6000 | 15 GB → 1×4090(tight)/5090 |
-| ~70B | 140 GB → 1×H200/2×H100 | 70 GB → 1×H100/Pro6000 | 35 GB → 1×Pro6000/5090(tight) |
-| ~120B | 240 GB → 2×H200/2×B200 | 120 GB → 1×B200/2×H100 | 60 GB → 1×H100/Pro6000 |
-| ~235B | 470 GB → 4×B200 | 235 GB → 2×B200/4×H100 | ~120 GB → 1×B200/2×H100 |
-| ~400B+ | 800 GB → 8×B200 | 400 GB → 4×B200/8×H100 | ~200 GB → 2×B200/4×H100 |
+Read canonical GPU names and their `vram_mib` from `emmy/gpu.py`; that registry is the authority on fleet capacity.
 
 ## Step 5 — Hardware → model matrix (the deliverable)
 
@@ -263,14 +226,11 @@ If the user just wanted the survey, stop at the matrix.
 
 - **Don't rank by downloads alone** — it's lagging and size-biased (tiny fine-tuning bases dominate). `trending`
   + arena `elo` + Step-2 hype together are the demand signal.
-- **Don't size MoE by active params.** VRAM follows TOTAL params; active params only set throughput.
-- **Don't assign a GPU tier without checking the quant exists.** "Fits H100 at FP8" is meaningless if only a
-  BF16 repo is published. Verify the AWQ/FP8/NVFP4 repo on HF first.
+- **Don't assign a platform from the model name.** `prompts/model-fit.md` is the contract: total parameters read
+  from `config.json`, a quantization whose repository exists, and the stated arithmetic behind the claim.
 - **Don't treat a blank arena Elo as "bad".** It usually means the model is too new for the last weekly arena
   snapshot — lean on HF `trending` + news there.
 - **Don't spam the script.** HF rate-limits bursts; use `--workers 4` and re-run sparingly (transient failures
   land in the script's "COULD NOT VERIFY" bucket — wait and re-run, don't hammer).
 - **Don't deploy or edit recipes in this skill.** The automated workflow applies a validated lifecycle manifest;
   `onboard-model` owns real deployment and qualification.
-- **Don't forget overhead.** The fit table is weights-only; real serving needs ~1.3× for activations + KV, more
-  for long context / high concurrency.

--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -80,6 +80,10 @@ fail instead of overwriting it.
 Use the model card, `config.json`, and current primary engine documentation to record:
 
 - architecture, modality, total and active parameter counts, dtype and quantization;
+- the VRAM footprint on the requested platform, following [`prompts/model-fit.md`](../../../prompts/model-fit.md) —
+  the shared fit contract `discover-models` also follows, so the platform a recipe proposes and the platform measured
+  here mean the same thing. Record the arithmetic it requires; when the weights cannot fit the requested GPU name and
+  count, report the failed fit gate with those numbers instead of deploying;
 - the immutable Hugging Face commit resolved for this run;
 - native context length and any documented practical cap;
 - current vLLM or SGLang support and the first pinned image version that supports it;

--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -40,6 +40,15 @@ Use only the supplied SSH server. The caller owns VM creation and deletion; this
 must tear them down before returning. Never switch GPU type, count, provider, model quantization, or model checkpoint
 to rescue a failed run.
 
+## Step 0 — Choose the run mode
+
+Use **interactive mode** when a developer drives the run from a checkout: ask for the missing inputs below and report
+in conversation. For a non-interactive **automated run**, read
+[`prompts/onboard-model/qualify.md`](../../../prompts/onboard-model/qualify.md) completely before doing task work.
+That file is the canonical automation prompt and defines the attached task payload, the per-mode recipe policy, the
+caller-owned boundaries, and the artifact and summary contract used by GitHub Actions. Do not ask follow-up questions
+in automated mode.
+
 ## Required inputs
 
 Require:
@@ -122,10 +131,12 @@ Start context testing at the model's native maximum. On an out-of-memory or inva
 retry from a clean deployment. Do not claim a context length from startup alone. Search current upstream issues for
 an unfamiliar error before changing engine or flags, and make one evidence-backed change per retry.
 
-When useful, delegate up to three independent read-only investigations to the caller-provided onboarding subagent.
-Good tasks are model protocol research, official engine/image compatibility research, and diagnosis of one unfamiliar
-failure from already captured logs. The parent agent owns all commands, edits, measurements, and final conclusions;
-never let subagent work consume the time reserved for artifacts and cleanup.
+When useful, delegate up to three independent read-only investigations to the caller-provided onboarding subagent,
+giving each exactly one question and the complete contents of
+[`prompts/onboard-model/investigate.md`](../../../prompts/onboard-model/investigate.md). Good questions are model
+protocol research, official engine/image compatibility research, and diagnosis of one unfamiliar failure from already
+captured logs. The parent agent owns all commands, edits,
+measurements, and final conclusions; never let subagent work consume the time reserved for artifacts and cleanup.
 
 You may implement a small, model-agnostic compatibility fix when it is necessary to qualify the exact requested
 checkpoint and platform. Keep it within `emmy/` plus focused tests and the nearest `ARCHITECTURE.md` updates, prefer an

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -58,26 +58,32 @@ An exact-SHA `emmy recipe query` reads the rolling `recipes/` root and expands i
 tracked `discovery_task.jq` filter groups those rows into recipe records and bounded scoring batches. The skill's
 lifecycle and scoring prompts are attached from that same workflow commit, so the skill and GitHub Actions share one
 prompt source. Three source investigators collect independent demand evidence, then hidden scorer subagents score the
-deterministic batches without selecting lifecycle states. The parent returns only scores, maintained IDs, obsolete
-proposals, and new onboarding models. The tracked `discovery_manifest.jq` filter validates exact score coverage,
-ignores already-inventoried IDs repeated as new candidates, and mechanically assembles the four-list manifest before
-the lifecycle validator applies policy. An exact-SHA recipe query against the rolling root enforces the maintained
-count after application.
+deterministic batches without selecting lifecycle states. Hidden fit subagents size one onboarding model each, in
+parallel, reading that checkpoint's published configuration and the `emmy/gpu.py` capacity registry under the shared
+`prompts/model-fit.md` contract; the parent relays their deployments and authors no hardware itself. The parent
+returns only scores, maintained IDs, obsolete proposals, new onboarding models, and the sized deployments. The tracked
+`discovery_manifest.jq` filter validates exact score coverage, ignores already-inventoried IDs repeated as new
+candidates, and mechanically assembles the four-list manifest before the lifecycle validator applies policy. An
+exact-SHA recipe query against the rolling root enforces the maintained count after application.
 
 The workflow checks that the agent did not modify the checkout, then validates and applies its lifecycle manifest. Its
 artifact worktree remains on the rolling lifecycle branch, while the catalog, workflow scripts, OpenCode agent and
 plugin directory, attached discovery skill, and prompt files come from the exact `github.sha` that started the run.
 This lets a manual dispatch test a workflow PR without copying its implementation commits into the rolling branch or
 silently using an older manifest contract. The manifest filter tolerates a model reasoning wrapper around the JSON
-object, but requires exactly the four expected selection fields before assembling the manifest. The named discovery
-agent denies repository edits and permits only the tracked discovery skill, public-web tools, repository reads,
-read-only Git inspection, the three named read-only source subagents, and the tool-free batch scorer. Parent work caps
-at 64 agentic steps. The Reddit, Hugging Face, and OpenRouter/Arena investigators run as independent bounded sources;
-Reddit can surface a candidate before an exact Hugging Face identity is known. The last complete selection object in
-OpenCode's final completed text event is logged before deterministic assembly so a rejected decision remains
-inspectable; the repository validator remains the authoritative completion gate. The project provider configuration
-selects the configurable CloudRift model through an OpenAI-compatible Chat Completions endpoint and disables the
-model's chat-template thinking mode for the concise JSON result. Discovery never provisions hardware.
+object, but requires exactly the five expected selection fields before assembling the manifest. A sized deployment
+replaces an existing onboarding shell's matrix, so a shell's hardware is corrected as the fleet and the checkpoint's
+published form become better understood. An empty sized result drops a new candidate that nothing in the fleet can
+serve and leaves an existing shell's matrix untouched, which keeps one unreadable checkpoint from failing the run. The
+named discovery agent denies repository edits and permits only the tracked discovery skill, public-web tools,
+repository reads, read-only Git inspection, the three named read-only source subagents, the tool-free batch scorer,
+and the fit subagent. Parent work caps at 64 agentic steps. The Reddit, Hugging Face, and OpenRouter/Arena
+investigators run as independent bounded sources; Reddit can surface a candidate before an exact Hugging Face identity
+is known. The last complete selection object in OpenCode's final completed text event is logged before deterministic
+assembly so a rejected decision remains inspectable; the repository validator remains the authoritative completion
+gate. The project provider configuration selects the configurable CloudRift model through an OpenAI-compatible Chat
+Completions endpoint and disables the model's chat-template thinking mode for the concise JSON result. Discovery never
+provisions hardware.
 
 OpenCode is provisioned on the self-hosted runners rather than maintained inside Emmy. `opencode.json` owns the model
 provider alias, while `.opencode/agents/` owns the separate discovery and onboarding limits and permissions. The

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -183,18 +183,19 @@ The validated manifest tags the ten selected complete recipes `maintained`, keep
 `best-effort`, and uses `obsolete` only when the rationale names the exact ID of an all-around better maintained or
 best-effort replacement for the same task at a comparable or lower practical VRAM footprint, or gives a technical
 reason the recipe should no longer be used. The manifest must classify and score every complete recipe exactly once.
-For decisions with a replacement, the validator compares
-qualified targets and demotes the proposal to `best-effort` unless the replacement is active, serves the same task,
-and its smallest deployment uses no more total physical GPU memory than the old recipe's smallest deployment. A
-replacement described as merely comparable, or whose recipe reduces configured context or concurrency, also defaults
-to `best-effort` while retaining the supplied heat. Unknown or malformed lower-priority model IDs cannot stand in for
-an omitted recipe because every real recipe must still be scored. A checkpoint name is normalized across a missing or
-incorrect organization only when it uniquely identifies one existing recipe; ambiguous or unknown maintained IDs
-still fail validation because all ten selections must resolve exactly. The agent must use
-`best-effort` when the old model retains any material capability or operating advantage. Every complete recipe stores
-the current rationale and heat immediately after `model.huggingface`. Obsolete recipes remain in git but cannot be
-deployed, benchmarked, published, or bundled; a later reassessment may return one to the maintained or best-effort
-set.
+For decisions with a replacement, the validator demotes the proposal to `best-effort` unless the replacement is active
+and serves the same task. A replacement described as merely comparable, or whose recipe reduces configured context or
+concurrency, also defaults to `best-effort` while retaining the supplied heat. No repository code estimates whether a
+checkpoint fits a platform: memory footprint depends on total parameters, quantization, and context, which the recipe
+does not record. `prompts/model-fit.md` is the shared contract where that reasoning happens, attached to both the
+discovery and onboarding agents so a proposed platform and a measured one mean the same thing. Unknown or malformed
+lower-priority model IDs cannot stand in for an omitted recipe because every real recipe must still be scored. A
+checkpoint name is normalized across a missing or incorrect organization only when it uniquely identifies one existing
+recipe; ambiguous or unknown maintained IDs still fail validation because all ten selections must resolve exactly. The
+agent must use `best-effort` when the old model retains any material capability or operating advantage. Every complete
+recipe stores the current rationale and heat immediately after `model.huggingface`. Obsolete recipes remain in git but
+cannot be deployed, benchmarked, published, or bundled; a later reassessment may return one to the maintained or
+best-effort set.
 
 The workflow creates every selected `onboarding`/`untested` shell through the same catalog library that backs
 `emmy recipe create`. Each shell stores its rationale and heat under `model` and a list of one to three candidate

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -136,10 +136,14 @@ The artifact worktree stays on the rolling lifecycle branch, while Python contro
 manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
 The selector runs the exact-SHA catalog logic against the rolling worktree's `recipes/` directory so lifecycle mode
 and priority always reflect the branch that the agent will update.
-The workflow also attaches the exact-SHA `onboard-model`, `tune-kernels`, and `run-experiment` skills as authoritative
-agent inputs; older copies on the rolling branch cannot silently override a proposed artifact contract.
-The named onboarding agent may delegate bounded read-only compatibility research or failure diagnosis to the hidden
-`onboard-investigator` subagent. The parent retains every edit and measurement. When an official engine image tag is
+The workflow also attaches the exact-SHA `onboard-model`, `tune-kernels`, and `run-experiment` skills plus the
+`prompts/onboard-model/` qualification and investigation prompts as authoritative agent inputs, and loads the OpenCode
+agent and plugin directory from that same commit; older copies on the rolling branch cannot silently override a
+proposed artifact contract. As in discovery, the workflow renders only a compact task object — mode, model, exact
+target, SSH handles, deadline, publication authorization, and summary path — while the shared prompt owns the run
+policy, so the skill and GitHub Actions share one prompt source. The named onboarding agent may delegate bounded
+read-only compatibility research or failure diagnosis to the hidden `onboard-investigator` subagent, which follows the
+attached investigation prompt. The parent retains every edit and measurement. When an official engine image tag is
 missing, qualification checks official registries, release notes, and upstream documentation for a renamed repository
 or current compatible tag before failing, then pins the exact working tag or digest. A necessary small,
 model-independent compatibility fix may touch at most eight implementation/test/architecture files and 500 changed

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -70,20 +70,20 @@ The workflow checks that the agent did not modify the checkout, then validates a
 artifact worktree remains on the rolling lifecycle branch, while the catalog, workflow scripts, OpenCode agent and
 plugin directory, attached discovery skill, and prompt files come from the exact `github.sha` that started the run.
 This lets a manual dispatch test a workflow PR without copying its implementation commits into the rolling branch or
-silently using an older manifest contract. The manifest filter tolerates a model reasoning wrapper around the JSON
-object, but requires exactly the five expected selection fields before assembling the manifest. A sized deployment
-replaces an existing onboarding shell's matrix, so a shell's hardware is corrected as the fleet and the checkpoint's
-published form become better understood. An empty sized result drops a new candidate that nothing in the fleet can
-serve and leaves an existing shell's matrix untouched, which keeps one unreadable checkpoint from failing the run. The
-named discovery agent denies repository edits and permits only the tracked discovery skill, public-web tools,
-repository reads, read-only Git inspection, the three named read-only source subagents, the tool-free batch scorer,
-and the fit subagent. Parent work caps at 64 agentic steps. The Reddit, Hugging Face, and OpenRouter/Arena
-investigators run as independent bounded sources; Reddit can surface a candidate before an exact Hugging Face identity
-is known. The last complete selection object in OpenCode's final completed text event is logged before deterministic
-assembly so a rejected decision remains inspectable; the repository validator remains the authoritative completion
-gate. The project provider configuration selects the configurable CloudRift model through an OpenAI-compatible Chat
-Completions endpoint and disables the model's chat-template thinking mode for the concise JSON result. Discovery never
-provisions hardware.
+silently using an older manifest contract. The manifest filter reads the last fenced or bare object carrying exactly
+the five expected selection fields, so reasoning before or after it is tolerated, and requires exactly the five
+expected selection fields before assembling the manifest. A sized deployment replaces an existing onboarding shell's
+matrix, so a shell's hardware is corrected as the fleet and the checkpoint's published form become better understood.
+An empty sized result drops a new candidate that nothing in the fleet can serve and leaves an existing shell's matrix
+untouched, which keeps one unreadable checkpoint from failing the run. The named discovery agent denies repository
+edits and permits only the tracked discovery skill, public-web tools, repository reads, read-only Git inspection, the
+three named read-only source subagents, the tool-free batch scorer, and the fit subagent. Parent work caps at 64
+agentic steps. The Reddit, Hugging Face, and OpenRouter/Arena investigators run as independent bounded sources; Reddit
+can surface a candidate before an exact Hugging Face identity is known. The last complete selection object in
+OpenCode's final completed text event is logged before deterministic assembly so a rejected decision remains
+inspectable; the repository validator remains the authoritative completion gate. The project provider configuration
+selects the configurable CloudRift model through an OpenAI-compatible Chat Completions endpoint and disables the
+model's chat-template thinking mode for the concise JSON result. Discovery never provisions hardware.
 
 OpenCode is provisioned on the self-hosted runners rather than maintained inside Emmy. `opencode.json` owns the model
 provider alias, while `.opencode/agents/` owns the separate discovery and onboarding limits and permissions. The

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -186,6 +186,7 @@ jobs:
             --file "$WORKFLOW_SOURCE/prompts/model-fit.md" \
             --file "$WORKFLOW_SOURCE/prompts/discover-models/lifecycle.md" \
             --file "$WORKFLOW_SOURCE/prompts/discover-models/score-recipes.md" \
+            --file "$WORKFLOW_SOURCE/prompts/discover-models/size-deployments.md" \
             --file "$AGENT_TASK" > "$AGENT_EVENTS"
           agent_status=$?
           set -e

--- a/.github/workflows/discover-model.yml
+++ b/.github/workflows/discover-model.yml
@@ -183,6 +183,7 @@ jobs:
             --model cloudrift/agent \
             --format json \
             --file "$WORKFLOW_SOURCE/.agents/skills/discover-models/SKILL.md" \
+            --file "$WORKFLOW_SOURCE/prompts/model-fit.md" \
             --file "$WORKFLOW_SOURCE/prompts/discover-models/lifecycle.md" \
             --file "$WORKFLOW_SOURCE/prompts/discover-models/score-recipes.md" \
             --file "$AGENT_TASK" > "$AGENT_EVENTS"

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -510,6 +510,7 @@ jobs:
             --model cloudrift/agent \
             --format json \
             --file "$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md" \
+            --file "$WORKFLOW_SOURCE/prompts/model-fit.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md" \
             --file "$AGENT_PROMPT" > "$AGENT_EVENTS"

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -66,7 +66,7 @@ jobs:
       EMMY_RENTAL_TAGS: emmy,workflow:model-verification-onboarding,gh-job:${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
       VM_LEASE: /tmp/emmy-onboard-${{ github.run_id }}-${{ github.run_attempt }}.json
       ONBOARD_SUMMARY: /tmp/emmy-onboard-summary-${{ github.run_id }}-${{ github.run_attempt }}.json
-      AGENT_PROMPT: /tmp/emmy-onboard-prompt-${{ github.run_id }}-${{ github.run_attempt }}.md
+      AGENT_TASK: /tmp/emmy-onboard-task-${{ github.run_id }}-${{ github.run_attempt }}.json
       AGENT_EVENTS: /tmp/emmy-onboard-events-${{ github.run_id }}-${{ github.run_attempt }}.jsonl
       AGENT_OUTPUT: /tmp/emmy-onboard-agent-${{ github.run_id }}-${{ github.run_attempt }}.txt
       PROVIDER_CONFIG: /tmp/emmy-onboard-provider-${{ github.run_id }}-${{ github.run_attempt }}.yaml
@@ -74,6 +74,7 @@ jobs:
       SSH_KEY: /tmp/emmy-onboard-ssh-${{ github.run_id }}-${{ github.run_attempt }}
       APP_KEY_FILE: /tmp/emmy-onboard-app-key-${{ github.run_id }}-${{ github.run_attempt }}.pem
       WORKFLOW_SOURCE: /tmp/emmy-onboard-source-${{ github.run_id }}-${{ github.run_attempt }}
+      OPENCODE_CONFIG_DIR: /tmp/emmy-onboard-source-${{ github.run_id }}-${{ github.run_attempt }}/.opencode
       AGENT_MODEL: ${{ vars.ONBOARD_AGENT_MODEL || 'Qwen/Qwen3.6-35B-A3B-FP8' }}
       CLOUDRIFT_INFERENCE_URL: ${{ vars.CLOUDRIFT_INFERENCE_URL || 'https://inference.cloudrift.ai/v1' }}
       OPENCODE_DISABLE_AUTOUPDATE: "true"
@@ -441,67 +442,27 @@ jobs:
           SSH_USER: ${{ steps.vm.outputs.ssh_user }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          mode = os.environ["ONBOARD_MODE"]
-          if mode == "onboarding":
-              task = (
-                  "Use the existing onboarding/untested recipe shell when present, or create the recipe for a direct "
-                  "manual request. Preserve model.heat and replace onboarding and untested with best-effort after "
-                  "qualification."
-              )
-          else:
-              task = (
-                  "Reverify the existing recipe from its current configuration, refresh its measured artifacts, and "
-                  f"preserve its {os.environ['EXPECTED_LIFECYCLE']} lifecycle tag and model.heat."
-              )
-          prompt = f"""Use the onboard-model skill non-interactively.
-
-          The attached exact-workflow-SHA copies of the onboard-model, tune-kernels, and run-experiment skills are authoritative.
-          Follow them instead of any older skill copies in the artifact worktree.
-
-          Operation mode: {mode}
-          Hugging Face model ID: {os.environ['MODEL_ID']}
-          Exact target: {os.environ['TARGET_GPU']} x {os.environ['TARGET_GPU_COUNT']}
-          SSH target: {os.environ['SSH_TARGET']}
-          Raw SSH host: {os.environ['SSH_HOST']}
-          Raw SSH user: {os.environ['SSH_USER']}
-          SSH port: {os.environ['SSH_PORT']}
-          SSH private key: {os.environ['SSH_KEY']} (pass --ssh-key {os.environ['SSH_KEY']} to every Emmy remote command)
-          Absolute deadline: {os.environ['ONBOARD_DEADLINE']}
-          Multimodal mode: {os.environ['MULTIMODAL_MODE']}
-          Publication authorized: {os.environ['PUBLISH_IMAGE']}
-          Atomic summary output: {os.environ['ONBOARD_SUMMARY']}
-
-          {task}
-          Do not select a model or GPU, provision or delete the VM, commit, push, or open/update a pull request.
-          For missing images or unfamiliar launch failures, investigate current official registries, release notes,
-          engine documentation, and upstream issues. Test an evidence-backed current repository/tag when the configured
-          image moved or disappeared, then pin the exact working tag or digest. You may implement a bounded,
-          model-agnostic compatibility fix with focused tests when it is necessary for this exact qualification.
-          You may delegate independent read-only research or failure diagnosis to the onboard-investigator subagent;
-          retain responsibility for all edits, measurements, and conclusions.
-          Always write the required atomic summary with mode set to {mode}, including experiment_artifacts with
-          the shared experiment recipe and RESULTS.md plus the exact results_<gpu-short>x<gpu-count>.tar.gz archive.
-          The archive must contain the platform's system-only experiment records; do not retain those records as
-          top-level files. Replace only this platform's archive and preserve every other platform archive and
-          RESULTS.md section. Do not retain the ignored dated run directory or onboarding summaries. Update the final
-          recipe's RESULTS.md for this platform while preserving still-valid measurements for its other platforms.
-          Git LFS is already configured through the workflow's local attributes. Verify the named archive reports
-          filter: lfs, but do not run git lfs track and do not modify or list .gitattributes in the summary.
-          Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
-          output. Allowed areas are recipes/ (including the model's golden/ subdirectory), experiments/,
-          docker/vllm-emmy-serve/models/, and a bounded small fix under emmy/ with its focused tests and nearest
-          ARCHITECTURE.md updates.
-          Include one-line deployment_summary and performance_summary values drawn from the exact selected recipe lane.
-          On failure, set failure.regression=true only when a previously qualified behavior or performance lane
-          regressed and the bounded fix attempt could not restore it; include a concise, credential-free message for
-          the Discord notification.
-          """
-          Path(os.environ["AGENT_PROMPT"]).write_text(prompt)
-          PY
+          jq -n \
+            --arg mode "$ONBOARD_MODE" \
+            --arg model_id "$MODEL_ID" \
+            --arg gpu "$TARGET_GPU" \
+            --argjson gpu_count "$TARGET_GPU_COUNT" \
+            --arg ssh_target "$SSH_TARGET" \
+            --arg ssh_host "$SSH_HOST" \
+            --arg ssh_user "$SSH_USER" \
+            --arg ssh_port "$SSH_PORT" \
+            --arg ssh_key "$SSH_KEY" \
+            --arg deadline "$ONBOARD_DEADLINE" \
+            --arg multimodal_mode "$MULTIMODAL_MODE" \
+            --argjson publish_image "$PUBLISH_IMAGE" \
+            --arg summary_path "$ONBOARD_SUMMARY" \
+            --arg expected_lifecycle "$EXPECTED_LIFECYCLE" \
+            '{schema_version: 1, mode: $mode, model_id: $model_id, gpu: $gpu, gpu_count: $gpu_count,
+              ssh_target: $ssh_target, ssh_host: $ssh_host, ssh_user: $ssh_user, ssh_port: $ssh_port,
+              ssh_key: $ssh_key, deadline: $deadline, multimodal_mode: $multimodal_mode,
+              publish_image: $publish_image, summary_path: $summary_path,
+              expected_lifecycle: $expected_lifecycle}' \
+            > "$AGENT_TASK"
 
           set +e
           opencode run \
@@ -511,9 +472,11 @@ jobs:
             --format json \
             --file "$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md" \
             --file "$WORKFLOW_SOURCE/prompts/model-fit.md" \
+            --file "$WORKFLOW_SOURCE/prompts/onboard-model/qualify.md" \
+            --file "$WORKFLOW_SOURCE/prompts/onboard-model/investigate.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md" \
-            --file "$AGENT_PROMPT" > "$AGENT_EVENTS"
+            --file "$AGENT_TASK" > "$AGENT_EVENTS"
           agent_status=$?
           set -e
           jq -s -r '[.[] | select(.type == "text") | .part.text][-1] // empty' \
@@ -872,7 +835,7 @@ jobs:
           rm -f \
             "$APP_KEY_FILE" \
             "$AGENT_EVENTS" \
-            "$AGENT_PROMPT" \
+            "$AGENT_TASK" \
             "$AGENT_OUTPUT" \
             "$ONBOARD_SUMMARY" \
             "$PR_SUMMARY" \

--- a/.github/workflows/scripts/discovery_lifecycle.py
+++ b/.github/workflows/scripts/discovery_lifecycle.py
@@ -9,11 +9,9 @@ import os
 import sys
 from pathlib import Path
 
-from emmy import gpu as gpu_registry
 from emmy.recipe.catalog import (
     HF_ID,
     create_recipe_stub,
-    deployment_setups,
     recipe_catalog,
     validate_model_heat,
     validate_stub_deployments,
@@ -161,18 +159,6 @@ def _retain_best_effort(decision: dict, records: dict[str, dict]) -> dict:
     return {"model_id": model_id, "rationale": _existing_rationale(records[model_id]), "heat": decision["heat"]}
 
 
-def _deployment_footprints(config: dict) -> tuple[int, ...]:
-    """Return total physical VRAM in MiB for every known deployment variant."""
-
-    footprints = []
-    for setup in deployment_setups(config):
-        spec = gpu_registry.by_name(setup["deploy.gpu"])
-        if spec is None or spec.vram_mib is None:
-            continue
-        footprints.append(spec.vram_mib * setup["deploy.gpu_count"])
-    return tuple(footprints)
-
-
 def _serving_capacity(config: dict) -> tuple[object, object]:
     llm = (config.get("engine") or {}).get("llm") or {}
     return llm.get("context_length"), llm.get("max_concurrent_requests")
@@ -267,16 +253,6 @@ def validate_manifest(path: Path, workspace: Path) -> dict:
         model_task = (records[model_id]["config"].get("model") or {}).get("task", "generate")
         replacement_task = (records[replacement]["config"].get("model") or {}).get("task", "generate")
         if model_task != replacement_task:
-            best_effort.append(_retain_best_effort(decision, records))
-            continue
-        model_footprints = _deployment_footprints(records[model_id]["config"])
-        replacement_footprints = _deployment_footprints(records[replacement]["config"])
-        if not model_footprints or not replacement_footprints:
-            best_effort.append(_retain_best_effort(decision, records))
-            continue
-        model_min = min(model_footprints)
-        replacement_min = min(replacement_footprints)
-        if replacement_min > model_min:
             best_effort.append(_retain_best_effort(decision, records))
             continue
         if "comparable" in decision["rationale"].casefold():

--- a/.github/workflows/scripts/discovery_lifecycle.py
+++ b/.github/workflows/scripts/discovery_lifecycle.py
@@ -9,6 +9,8 @@ import os
 import sys
 from pathlib import Path
 
+import yaml
+
 from emmy.recipe.catalog import (
     HF_ID,
     create_recipe_stub,
@@ -201,9 +203,6 @@ def validate_manifest(path: Path, workspace: Path) -> dict:
             existing_task = (config.get("model") or {}).get("task", "generate")
             if candidate["task"] != existing_task:
                 raise ValueError(f"Existing onboarding model {model_id} must retain task {existing_task!r}")
-            existing_deployments = validate_stub_deployments(config.get("matrices"), model_id)
-            if normalized_deployments != existing_deployments:
-                raise ValueError(f"Existing onboarding model {model_id} must retain its deployment matrix")
         candidate_ids.add(model_id)
         normalized_candidates.append(
             {
@@ -330,11 +329,25 @@ def _replace_model_metadata(text: str, rationale: str, heat: int) -> str:
     return "".join(lines)
 
 
-def _set_lifecycle(record: dict, lifecycle: str, rationale: str, heat: int) -> bool:
+def _replace_matrices(text: str, deployments: list[dict[str, object]]) -> str:
+    lines = text.splitlines(keepends=True)
+    start = next((index for index, line in enumerate(lines) if line.startswith("matrices:")), None)
+    if start is None:
+        raise ValueError("Onboarding shell is missing its matrices block")
+    end = start + 1
+    while end < len(lines) and (not lines[end].strip() or lines[end].startswith((" ", "\t", "-"))):
+        end += 1
+    lines[start:end] = [yaml.safe_dump({"matrices": deployments}, sort_keys=False, width=116)]
+    return "".join(lines)
+
+
+def _set_lifecycle(record: dict, lifecycle: str, rationale: str, heat: int, deployments: list | None = None) -> bool:
     path = record["path"]
     before = path.read_text()
     after = _replace_tag_block(before, _tags_with_lifecycle(record["tags"], lifecycle))
     after = _replace_model_metadata(after, rationale, heat)
+    if deployments is not None:
+        after = _replace_matrices(after, deployments)
     if before == after:
         return False
     path.write_text(after)
@@ -415,7 +428,16 @@ def apply_manifest(manifest: dict, workspace: Path, summary_path: Path) -> dict:
         changed = _set_lifecycle(records[decision["model_id"]], OBSOLETE_TAG, decision["rationale"], decision["heat"]) or changed
     for candidate in manifest["onboarding_models"]:
         if candidate["model_id"] in records:
-            changed = _set_lifecycle(records[candidate["model_id"]], ONBOARDING_TAG, candidate["rationale"], candidate["heat"]) or changed
+            changed = (
+                _set_lifecycle(
+                    records[candidate["model_id"]],
+                    ONBOARDING_TAG,
+                    candidate["rationale"],
+                    candidate["heat"],
+                    candidate["deployments"],
+                )
+                or changed
+            )
         else:
             create_recipe_stub(
                 workspace / "recipes",

--- a/.github/workflows/scripts/discovery_manifest.jq
+++ b/.github/workflows/scripts/discovery_manifest.jq
@@ -31,7 +31,7 @@ def model_ids($items):
 | parse_selection as $choice
 | require(
     ($choice | type) == "object"
-      and ($choice | exact_fields(["scores", "maintained_model_ids", "obsolete_models", "new_onboarding_models"]));
+      and ($choice | exact_fields(["scores", "maintained_model_ids", "obsolete_models", "new_onboarding_models", "onboarding_deployments"]));
     "Discovery selection has an invalid shape"
   )
 | require(
@@ -92,6 +92,15 @@ def model_ids($items):
     ($choice.new_onboarding_models | type) == "array";
     "new_onboarding_models must be an array"
   )
+| require(
+    ($choice.onboarding_deployments | type) == "array"
+      and all($choice.onboarding_deployments[]; type == "object" and exact_fields(["model_id", "deployments"]));
+    "Each sized deployment must contain exactly model_id and deployments"
+  )
+| (
+    [$choice.onboarding_deployments[] | select((.deployments | type) == "array" and (.deployments | length) > 0)]
+    | INDEX(.model_id)
+  ) as $sized
 | ($choice.maintained_model_ids | INDEX(.)) as $maintained
 | ($obsolete_ids | INDEX(.)) as $obsolete
 | {
@@ -118,12 +127,17 @@ def model_ids($items):
             task,
             rationale: $scores[.model_id].rationale,
             heat: $scores[.model_id].heat,
-            deployments: [.deployments[] | {"deploy.gpu": .gpu, "deploy.gpu_count": .gpu_count}]
+            deployments: (
+              $sized[.model_id].deployments
+                // [.deployments[] | {"deploy.gpu": .gpu, "deploy.gpu_count": .gpu_count}]
+            )
           }
       ]
       + [
           $choice.new_onboarding_models[]
           | select((.model_id as $model_id | $recipe_ids | index($model_id)) == null)
+          | select($sized[.model_id] != null)
+          | . + {deployments: $sized[.model_id].deployments}
         ]
     )
   }

--- a/.github/workflows/scripts/discovery_manifest.jq
+++ b/.github/workflows/scripts/discovery_manifest.jq
@@ -5,8 +5,20 @@ def require($condition; $message):
 def exact_fields($fields):
   (keys | sort) == ($fields | sort);
 
+# The agent may fence its object, or keep reasoning after it. Prefer the last fenced or bare
+# candidate carrying exactly the selection fields; fall back to the whole text, then to a greedy span.
+def selection_fields:
+  ["scores", "maintained_model_ids", "obsolete_models", "new_onboarding_models", "onboarding_deployments"];
+
 def parse_selection:
-  ($selection | fromjson?) // ($selection | capture("(?s)(?<json>\\{.*\\})").json | fromjson);
+  (
+    [$selection, ($selection | splits("```(?:json)?"))]
+    | map(fromjson?)
+    | map(select(type == "object" and exact_fields(selection_fields)))
+    | last
+  )
+  // ($selection | fromjson?)
+  // ($selection | capture("(?s)(?<json>\\{.*\\})").json | fromjson);
 
 def model_ids($items):
   [$items[]?.model_id];
@@ -31,7 +43,7 @@ def model_ids($items):
 | parse_selection as $choice
 | require(
     ($choice | type) == "object"
-      and ($choice | exact_fields(["scores", "maintained_model_ids", "obsolete_models", "new_onboarding_models", "onboarding_deployments"]));
+      and ($choice | exact_fields(selection_fields));
     "Discovery selection has an invalid shape"
   )
 | require(

--- a/.opencode/agents/discover-fit.md
+++ b/.opencode/agents/discover-fit.md
@@ -1,0 +1,18 @@
+---
+description: Size one candidate checkpoint onto exact GPU deployments from its published configuration
+mode: subagent
+hidden: true
+temperature: 0.1
+steps: 8
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  webfetch: allow
+  websearch: allow
+---
+
+Apply the attached fit contract and deployment prompt to exactly one Hugging Face model ID supplied by the parent.
+Read that checkpoint's published configuration and `emmy/gpu.py`, size the weights, and return only the requested
+deployment JSON. Do not score heat, choose lifecycle states, propose a different model, substitute a sibling
+repository, or reconstruct the model ID.

--- a/.opencode/agents/discover-models.md
+++ b/.opencode/agents/discover-models.md
@@ -13,6 +13,7 @@ permission:
   websearch: allow
   task:
     "*": deny
+    "discover-fit": allow
     "discover-huggingface": allow
     "discover-openrouter": allow
     "discover-reddit": allow

--- a/.opencode/agents/onboard-investigator.md
+++ b/.opencode/agents/onboard-investigator.md
@@ -14,10 +14,6 @@ permission:
   websearch: allow
 ---
 
-Investigate only the model-onboarding question supplied by the parent agent. Use at most four public-web calls and
-prefer current primary sources: official model metadata, engine documentation and release notes, official container
-registries, and upstream issue trackers. For an unavailable image, verify whether the tag moved, the repository was
-renamed, or a newer compatible release exists. For a runtime failure, identify the smallest evidence-backed next
-test. Inspect repository files when useful, but never modify files, invoke another agent, use credentials, or run a
-remote workload. Return concise evidence, source URLs, exact candidate tags or flags, and remaining uncertainty to
-the parent agent.
+Apply the investigation prompt and exact question supplied by the parent agent. Inspect repository files when useful,
+but never modify files, invoke another agent, use credentials, or run a remote workload. Return only the requested
+evidence to the parent agent; do not qualify the model, choose artifacts, or draw the run's conclusions.

--- a/.opencode/agents/onboard-model.md
+++ b/.opencode/agents/onboard-model.md
@@ -22,7 +22,8 @@ permission:
 ---
 
 You are Emmy's non-interactive model qualification agent. Load the `onboard-model` skill before doing task work and
-follow it exactly, including every linked skill and architecture document. Use only the supplied GPU server, finish
-before the supplied deadline, keep only the authorized repository artifacts, write the atomic summary even on
-failure, and never commit, push, or change pull requests. Delegate only bounded, independent read-only research or
-failure diagnosis to `onboard-investigator`; retain responsibility for edits, commands, measurements, and conclusions.
+follow its attached qualification and investigation prompts exactly, including every linked skill and architecture
+document. Use only the supplied GPU server, finish before the supplied deadline, keep only the authorized repository
+artifacts, write the atomic summary even on failure, and never commit, push, or change pull requests. Delegate only
+bounded, independent read-only research or failure diagnosis to `onboard-investigator`; retain responsibility for
+edits, commands, measurements, and conclusions.

--- a/prompts/discover-models/lifecycle.md
+++ b/prompts/discover-models/lifecycle.md
@@ -36,13 +36,20 @@ comparison in the obsolete model's score rationale. When no successor is appropr
 concrete technical limitation.
 
 Add every genuinely promising newly discovered model to `new_onboarding_models`; there is no candidate-count limit.
-Use task `embed` only for embedding models. Give each new model one to three useful deployments containing only
-canonical `deploy.gpu` and positive `deploy.gpu_count` values. Derive every deployment from the attached
-`model-fit.md`: read the checkpoint's total parameters, size the footprint, and compare it against that platform's
-real capacity. No repository code checks this, so an unservable deployment reaches rented hardware unchallenged. Put
-the total parameter count, the quantization, and the resulting footprint in the model's rationale. Do not claim an
-onboarding shell was deployed or benchmarked. Never put an existing recipe ID in `new_onboarding_models`, including an
-existing onboarding shell; an existing ID appears only in `scores`.
+Use task `embed` only for embedding models. Do not give a candidate a deployment: you never author hardware here.
+Never put an existing recipe ID in `new_onboarding_models`, including an existing onboarding shell; an existing ID
+appears only in `scores`. Do not claim an onboarding shell was deployed or benchmarked.
+
+## Deployment sizing
+
+Invoke `discover-fit` once per onboarding model and in parallel: every model in `new_onboarding_models`, plus every
+existing recipe in the inventory tagged `onboarding`. Give each the complete contents of the attached `model-fit.md`
+and `size-deployments.md`, and exactly one model ID. Return every result in `onboarding_deployments`, copying each
+subagent's `model_id` and `deployments` verbatim.
+
+You do not review, adjust, extend, or replace a returned deployment, and you never supply one a subagent did not
+return. An empty `deployments` array is a valid result: repository code drops that new candidate and leaves an
+existing shell's current matrix untouched. A candidate the fleet cannot serve is not worth rented GPU hours.
 
 ## Output
 
@@ -59,13 +66,11 @@ Return exactly one JSON object without prose or a Markdown fence:
     {"model_id": "exact/technically-broken-id"}
   ],
   "new_onboarding_models": [
-    {
-      "model_id": "exact/new-id",
-      "task": "generate",
-      "rationale": "Why this model is worth onboarding.",
-      "heat": 90,
-      "deployments": [{"deploy.gpu": "NVIDIA H200 141GB", "deploy.gpu_count": 1}]
-    }
+    {"model_id": "exact/new-id", "task": "generate", "rationale": "Why this model is worth onboarding.", "heat": 90}
+  ],
+  "onboarding_deployments": [
+    {"model_id": "exact/new-id", "deployments": [{"deploy.gpu": "NVIDIA H200 141GB", "deploy.gpu_count": 1}]},
+    {"model_id": "exact/existing-shell-id", "deployments": []}
   ]
 }
 ```
@@ -73,7 +78,10 @@ Return exactly one JSON object without prose or a Markdown fence:
 `scores` must contain every existing recipe from every batch exactly once, including onboarding shells. Copy each
 existing `model_id` letter for letter. Each score contains exactly `model_id`, `rationale`, and `heat`; heat is an
 integer from 0 through 100. `maintained_model_ids` contains exact IDs only. Each obsolete entry contains `model_id`
-and optionally `replacement_model_id`. `new_onboarding_models` contains new models only.
+and optionally `replacement_model_id`. Each new onboarding entry contains exactly `model_id`, `task`, `rationale`, and
+`heat`; `new_onboarding_models` contains new models only. Each `onboarding_deployments` entry contains exactly
+`model_id` and `deployments`, and the array covers every new candidate and every existing onboarding shell exactly
+once.
 
 Before returning, verify that the scores cover every batch row and that the maintained count is exact. If OpenCode
 requests the final response, return the best complete selection immediately without another tool call.

--- a/prompts/discover-models/lifecycle.md
+++ b/prompts/discover-models/lifecycle.md
@@ -26,19 +26,23 @@ set. Every unselected complete recipe defaults to best-effort; do not return bes
 derives them mechanically.
 
 Propose an obsolete recipe only when a named all-around better complete replacement for the same task is available at
-a comparable or lower practical VRAM footprint, or when a concrete technical limitation means the recipe should no
-longer be used. Before proposing a replacement, read both recipe files and confirm that the old recipe retains no
-advantage in configured context, concurrency, quantization, hardware support, model capability, latency, throughput,
-operating cost, modality, or licensing. A replacement that is merely comparable is not all-around better. Low demand,
-age, and exclusion from the maintained set are not sufficient. Existing obsolete tags are prior proposals, not
-evidence; reassess them under this policy. Put the exact replacement ID and VRAM comparison in the obsolete model's
-score rationale. When no successor is appropriate, the rationale must state the concrete technical limitation.
+a comparable or lower practical VRAM footprint sized by the attached `model-fit.md`, or when a concrete technical
+limitation means the recipe should no longer be used. Before proposing a replacement, read both recipe files and
+confirm that the old recipe retains no advantage in configured context, concurrency, quantization, hardware support,
+model capability, latency, throughput, operating cost, modality, or licensing. A replacement that is merely comparable
+is not all-around better. Low demand, age, and exclusion from the maintained set are not sufficient. Existing obsolete
+tags are prior proposals, not evidence; reassess them under this policy. Put the exact replacement ID and VRAM
+comparison in the obsolete model's score rationale. When no successor is appropriate, the rationale must state the
+concrete technical limitation.
 
 Add every genuinely promising newly discovered model to `new_onboarding_models`; there is no candidate-count limit.
 Use task `embed` only for embedding models. Give each new model one to three useful deployments containing only
-canonical `deploy.gpu` and positive `deploy.gpu_count` values. Do not claim an onboarding shell was deployed or
-benchmarked. Never put an existing recipe ID in `new_onboarding_models`, including an existing onboarding shell; an
-existing ID appears only in `scores`.
+canonical `deploy.gpu` and positive `deploy.gpu_count` values. Derive every deployment from the attached
+`model-fit.md`: read the checkpoint's total parameters, size the footprint, and compare it against that platform's
+real capacity. No repository code checks this, so an unservable deployment reaches rented hardware unchallenged. Put
+the total parameter count, the quantization, and the resulting footprint in the model's rationale. Do not claim an
+onboarding shell was deployed or benchmarked. Never put an existing recipe ID in `new_onboarding_models`, including an
+existing onboarding shell; an existing ID appears only in `scores`.
 
 ## Output
 

--- a/prompts/discover-models/size-deployments.md
+++ b/prompts/discover-models/size-deployments.md
@@ -7,13 +7,25 @@ Read that exact repository's `config.json` and model card. Never substitute a si
 repository — the deployment is for the ID you were given. Read `emmy/gpu.py` for canonical GPU names and their
 `vram_mib`; those spellings are the only accepted values and the registry is the authority on capacity.
 
+`bytes_per_param` describes the repository you were given, not a variant of it. A BF16 repository is sized at 2 bytes
+even when an FP8 sibling exists under another ID; sizing the repository you wish you had is how an unservable platform
+reaches rented hardware.
+
+## Choose a platform the fleet actually rents
+
+`deploy.gpu_count` is 1, 2, 4, 8, or 16 — the node shapes the provider offers. It is not the result of dividing the
+footprint by a card's capacity: 5 GPUs and 12 GPUs are arithmetic, not platforms, and nothing can deploy them. Round
+up to the next shape in that list and confirm the total still holds `min-to-serve`. A multi-GPU count must also divide
+the checkpoint's attention head count, so prefer 2, 4, and 8 over 16.
+
 Return one to three admissible deployments, smallest platform first, each holding `min-to-serve` for the checkpoint as
-it is actually published. Prefer platforms the fleet can plausibly supply over the theoretical minimum.
+it is actually published.
 
 Return an empty `deployments` array when the checkpoint cannot be sized — the repository is gated or unreadable, the
-parameter count cannot be established, or no fleet platform holds the weights. An empty array is a correct, useful
-answer: it drops a new candidate that cannot be served and leaves an existing shell's current matrix alone. Never
-guess a platform to avoid returning nothing, and never infer size from the model ID.
+parameter count cannot be established, or no allowed platform holds the weights. A checkpoint needing more than the
+largest listed shape of the largest fleet GPU has no deployment; say so rather than naming a count nobody can rent. An
+empty array is a correct, useful answer: it drops a new candidate that cannot be served and leaves an existing shell's
+current matrix alone. Never guess a platform to avoid returning nothing, and never infer size from the model ID.
 
 Return exactly one JSON object without prose or a Markdown fence:
 

--- a/prompts/discover-models/size-deployments.md
+++ b/prompts/discover-models/size-deployments.md
@@ -1,0 +1,33 @@
+# Size One Candidate Onto GPU Deployments
+
+Size exactly the one Hugging Face model ID supplied by the parent, following the attached `model-fit.md` contract. Do
+no other work: no heat scoring, no lifecycle states, no alternative model proposals.
+
+Read that exact repository's `config.json` and model card. Never substitute a sibling, quantized, or same-family
+repository — the deployment is for the ID you were given. Read `emmy/gpu.py` for canonical GPU names and their
+`vram_mib`; those spellings are the only accepted values and the registry is the authority on capacity.
+
+Return one to three admissible deployments, smallest platform first, each holding `min-to-serve` for the checkpoint as
+it is actually published. Prefer platforms the fleet can plausibly supply over the theoretical minimum.
+
+Return an empty `deployments` array when the checkpoint cannot be sized — the repository is gated or unreadable, the
+parameter count cannot be established, or no fleet platform holds the weights. An empty array is a correct, useful
+answer: it drops a new candidate that cannot be served and leaves an existing shell's current matrix alone. Never
+guess a platform to avoid returning nothing, and never infer size from the model ID.
+
+Return exactly one JSON object without prose or a Markdown fence:
+
+```json
+{
+  "model_id": "exact/supplied-id",
+  "total_params_b": 109.0,
+  "bytes_per_param": 2,
+  "min_to_serve_gb": 283.4,
+  "deployments": [{"deploy.gpu": "NVIDIA H200 141GB", "deploy.gpu_count": 4}],
+  "note": "109B total / 17B active MoE; only a BF16 repository is published."
+}
+```
+
+Copy `model_id` letter for letter from the parent. `total_params_b`, `bytes_per_param`, and `min_to_serve_gb` are the
+arithmetic behind the answer and must be present whenever `deployments` is non-empty; when it is empty, `note` must
+say why. Keep `note` under 30 words.

--- a/prompts/model-fit.md
+++ b/prompts/model-fit.md
@@ -1,0 +1,56 @@
+# Model VRAM Fit
+
+The single shared definition of "does this checkpoint fit this GPU platform?". The `discover-models` and
+`onboard-model` skills both follow this contract so a proposed deployment and a measured one describe the same
+quantity. No repository code estimates fit; this reasoning is the only place it is decided.
+
+## Read the checkpoint, not the name
+
+A model ID is not evidence of size. Before proposing or accepting any `(GPU name, GPU count)`, read the checkpoint's
+`config.json` and model card and record:
+
+- **total parameters** — every weight that must be resident, including every expert of a Mixture of Experts model;
+- **active parameters** — for a Mixture of Experts model, the subset routed per token;
+- **dtype and quantization**, and which quantized repositories actually exist for this checkpoint;
+- **native context length**.
+
+A name like `...-17B-16E` reports active parameters and expert count, never the total. Resolve the total from
+`config.json` (`num_experts` × expert width, plus the dense remainder) or from an explicit model-card statement.
+
+## Compute the footprint
+
+```
+weight VRAM ≈ total_params(B) × bytes_per_param
+    bytes_per_param:  BF16/FP16 = 2  ·  FP8 = 1  ·  AWQ/INT4 ≈ 0.5
+min-to-serve ≈ weight VRAM × 1.3        # + CUDA graphs, activations, a small KV cache at modest context
+long-context / high-concurrency ≈ weight VRAM × 1.5+   (KV cache grows with context × concurrency)
+```
+
+Two traps:
+
+- **A Mixture of Experts model is sized by TOTAL parameters.** Every expert loads into memory; active parameters
+  drive throughput, not residency. A 109B-total / 17B-active checkpoint needs 109B worth of weights resident.
+- **Quantization decides the GPU.** The same checkpoint in BF16 versus AWQ is a 4× difference. Only count a
+  quantization whose repository exists — a hypothetical FP8 repacking is not a deployment.
+
+**Multi-GPU:** when one card cannot hold `min-to-serve`, tensor-parallel across N GPUs; per-GPU need is
+`min-to-serve / N` plus per-GPU overhead. N must divide the model's attention head count; prefer 2, 4, or 8.
+
+## Compare against real GPU capacity
+
+`emmy/gpu.py` is the authority on canonical GPU names and their `vram_mib`. Read it; do not work from remembered
+capacities or a table copied into a skill. Total platform capacity is that GPU's `vram_mib` × `gpu_count`.
+
+A deployment is admissible only when `min-to-serve` fits the total platform capacity. Tensor parallelism divides one
+model across GPUs — it never lowers the total that must be resident, so it cannot rescue a platform whose combined
+VRAM is below the weight footprint.
+
+## Record the arithmetic
+
+State the numbers you used wherever the fit conclusion lands — a recipe rationale, a shortlist row, or a failure
+report: total parameters, bytes per parameter and the quantization they come from, the resulting `min-to-serve`, and
+the total capacity of the proposed platform. A fit claim without these numbers cannot be checked or disagreed with,
+and a later measurement on real hardware must be comparable to the estimate that proposed it.
+
+When the smallest admissible platform is outside the available fleet, say so plainly and propose no deployment.
+Proposing a platform that cannot hold the weights spends rented GPU hours to rediscover arithmetic.

--- a/prompts/onboard-model/investigate.md
+++ b/prompts/onboard-model/investigate.md
@@ -1,0 +1,15 @@
+# Investigate One Onboarding Question
+
+Investigate exactly the one model-onboarding question supplied by the parent. Do no other work: no repository edits,
+no deployments, no measurements, no conclusions about whether the model qualifies.
+
+Use at most four public-web calls and prefer current primary sources: official model metadata, engine documentation
+and release notes, official container registries, and upstream issue trackers. For an unavailable image, establish
+whether the tag moved, the repository was renamed, or a newer compatible release exists. For a runtime failure,
+identify the smallest evidence-backed next test from the evidence the parent supplied.
+
+Inspect repository files when useful, but never modify a file, invoke another agent, use credentials, or run a remote
+workload.
+
+Return concise evidence, source URLs, exact candidate tags or flags, and the remaining uncertainty. Say plainly when
+the sources do not settle the question; a negative result is a useful answer and a guessed tag is not.

--- a/prompts/onboard-model/qualify.md
+++ b/prompts/onboard-model/qualify.md
@@ -1,0 +1,74 @@
+# Non-Interactive Model Qualification
+
+Use the attached onboarding task as the complete run request. Its fields are the only source of the model, hardware,
+credentials path, and deadline; never select, substitute, or infer any of them. The attached exact-workflow-SHA copies
+of the `onboard-model`, `tune-kernels`, and `run-experiment` skills are authoritative — follow them instead of any
+older skill copy in the checkout. Do not ask follow-up questions; a missing or ambiguous task field is an immediate
+failure.
+
+## Task fields
+
+| Field | Use |
+| --- | --- |
+| `mode` | exactly `onboarding` or `verification`; drives the recipe policy below and is echoed in the summary |
+| `model_id` | the exact Hugging Face model ID to qualify |
+| `gpu` / `gpu_count` | the exact target platform; never change the GPU name, count, quantization, or checkpoint |
+| `ssh_target`, `ssh_host`, `ssh_user`, `ssh_port` | the supplied server; the only host this run may use |
+| `ssh_key` | pass `--ssh-key <value>` to every Emmy remote command |
+| `deadline` | absolute wall-clock deadline for the whole run |
+| `multimodal_mode` | `auto`, `multimodal`, or `text-only` qualification path |
+| `publish_image` | `true` authorizes publishing a verified prebuilt Emmy image; `false` forbids publication |
+| `summary_path` | absolute path for the atomic machine-readable summary, outside the repository |
+| `expected_lifecycle` | in `verification` mode, the lifecycle tag the refreshed recipe must keep |
+
+The task's `publish_image` value is the publication authorization for this run. Do not add a conversational approval
+pause, and do not publish when it is `false`.
+
+## Recipe policy per mode
+
+In `onboarding` mode, use the existing `onboarding`/`untested` recipe shell when present, or create the recipe for a
+direct manual request. Preserve `model.heat` and replace `onboarding` and `untested` with `best-effort` only after
+qualification and artifact completion.
+
+In `verification` mode, begin from the existing recipe's current configuration, refresh its measured artifacts, and
+preserve its `expected_lifecycle` tag and `model.heat`.
+
+## Boundaries
+
+Do not select a model or GPU, provision or delete the VM, commit, push, or open or update a pull request. The caller
+owns those steps. Tear down every deployed workload before returning.
+
+For a missing image or an unfamiliar launch failure, investigate current official registries, release notes, engine
+documentation, and upstream issues. Test an evidence-backed current repository or tag when the configured image moved
+or disappeared, then pin the exact working tag or digest. You may implement a bounded, model-agnostic compatibility
+fix with focused tests when it is necessary for this exact qualification.
+
+Delegate only bounded, independent read-only research or failure diagnosis to the `onboard-investigator` subagent,
+giving it the complete contents of the attached `investigate.md` and exactly one question. Retain responsibility for
+every edit, command, measurement, and conclusion.
+
+## Repository artifacts
+
+Allowed areas are `recipes/` (including the model's `golden/` subdirectory), `experiments/`,
+`docker/vllm-emmy-serve/models/`, and a bounded small fix under `emmy/` with its focused tests and nearest
+`ARCHITECTURE.md` updates.
+
+Replace only this platform's `results_<gpu-short>x<gpu-count>.tar.gz` archive and preserve every other platform
+archive and `RESULTS.md` section. The archive must contain the platform's system-only experiment records; do not
+retain those records as top-level files. Update the final recipe's `RESULTS.md` for this platform while preserving
+still-valid measurements for its other platforms. Do not retain the ignored dated run directory or qualification
+summaries in the checkout.
+
+Git LFS is already configured through the caller's local attributes. Verify that the named archive reports
+`filter: lfs`, but do not run `git lfs track` and do not modify or list `.gitattributes` in the summary.
+
+## Output
+
+Always write the skill's atomic summary to `summary_path`, on success and on failure, with `mode` set to the task's
+mode. List every intended created, modified, or deleted repository file in `artifacts` and no exploratory output.
+Include `experiment_artifacts` with the shared experiment recipe and `RESULTS.md` plus the exact platform archive, and
+one-line `deployment_summary` and `performance_summary` values drawn from the exact selected recipe lane.
+
+On failure, set `failure.regression` to `true` only when a previously qualified behavior or measured performance lane
+regressed and the bounded fix attempt could not restore it. Keep the message concise and credential-free; the caller
+sends it to a chat notification. Print the summary path as the final line and return nonzero for a failed run.

--- a/recipes/ARCHITECTURE.md
+++ b/recipes/ARCHITECTURE.md
@@ -42,13 +42,13 @@ Discovery keeps exactly ten fully configured recipes tagged `maintained` for per
 useful complete recipes are tagged `best-effort`: they remain runnable and bundled, but are not selected for periodic
 work. `obsolete` is reserved for a recipe with an all-around better replacement for the same task at a comparable or
 lower practical VRAM footprint and no retained material advantage in capability or operation, or a clear technical
-reason the recipe should no longer be used. Discovery compares the smallest qualified deployment targets when a
-replacement is named and demotes an invalid obsolete proposal to `best-effort`; it cannot obsolete a recipe in favor
-of one that needs more total physical GPU memory. Each lifecycle decision records its current rationale directly under
-`model`. Discovery also refreshes each recipe's 0-100 `model.heat`, which ranks current onboarding interest without
-changing serving behavior. Obsolete recipes are retained rather than deleted, so their configuration and evidence
-stay available and a later reassessment can return one to the maintained or best-effort set. New discoveries start as
-minimal shells:
+reason the recipe should no longer be used. Discovery demotes an invalid obsolete proposal to `best-effort` when the
+named replacement is inactive or serves a different task; the memory comparison itself is agent reasoning under the
+shared `prompts/model-fit.md` contract, not a repository check. Each lifecycle decision records its current rationale
+directly under `model`. Discovery also refreshes each recipe's 0-100 `model.heat`, which ranks current onboarding
+interest without changing serving behavior. Obsolete recipes are retained rather than deleted, so their configuration
+and evidence stay available and a later reassessment can return one to the maintained or best-effort set. New
+discoveries start as minimal shells:
 
 ```yaml
 tags:

--- a/recipes/ARCHITECTURE.md
+++ b/recipes/ARCHITECTURE.md
@@ -66,8 +66,11 @@ matrices:
     deploy.gpu_count: 2
 ```
 
-The one to three matrix entries are proposed qualification setups, not measured targets. There is no onboarding-shell
-count limit; scheduled onboarding chooses the available shell with the highest heat. The shell is a handoff to model
+The one to three matrix entries are proposed qualification setups, not measured targets. Each is sized by a discovery
+fit subagent from the checkpoint's published configuration, and a later discovery run may re-size a shell that is
+still untested — a shell's hardware is a current estimate, not a commitment. A candidate nothing in the fleet can
+serve yields no shell at all. There is no onboarding-shell count limit; scheduled onboarding chooses the available
+shell with the highest heat. The shell is a handoff to model
 onboarding, not a serving claim. It becomes runnable only after qualification replaces the shell with a complete
 configuration and the `best-effort` lifecycle tag, while preserving its heat until discovery refreshes it.
 

--- a/tests/github/test_discovery_jq.py
+++ b/tests/github/test_discovery_jq.py
@@ -147,7 +147,6 @@ def test_manifest_filter_restores_existing_onboarding_and_filters_repeated_candi
     ]
 
 
-
 def test_manifest_filter_reads_a_fenced_selection_followed_by_more_reasoning():
     ready = _recipe("org/ready")
     selection = _selection([_score("org/ready", 70)], ["org/ready"])

--- a/tests/github/test_discovery_jq.py
+++ b/tests/github/test_discovery_jq.py
@@ -72,12 +72,13 @@ def _score(model_id, heat=50):
     return {"model_id": model_id, "rationale": f"Current evidence for {model_id}.", "heat": heat}
 
 
-def _selection(scores, maintained, obsolete=None, new_onboarding=None):
+def _selection(scores, maintained, obsolete=None, new_onboarding=None, sized=None):
     return {
         "scores": scores,
         "maintained_model_ids": maintained,
         "obsolete_models": obsolete or [],
         "new_onboarding_models": new_onboarding or [],
+        "onboarding_deployments": sized or [],
     }
 
 
@@ -126,9 +127,9 @@ def test_manifest_filter_restores_existing_onboarding_and_filters_repeated_candi
                 "task": "generate",
                 "rationale": "Agent repeated an existing onboarding shell.",
                 "heat": 85,
-                "deployments": [{"deploy.gpu": GPU, "deploy.gpu_count": 2}],
             }
         ],
+        sized=[{"model_id": "org/pending", "deployments": [{"deploy.gpu": GPU, "deploy.gpu_count": 4}]}],
     )
 
     result, manifest = _run_manifest(_task(ready, pending), f"Draft:\n```json\n{json.dumps(selection)}\n```")
@@ -141,9 +142,39 @@ def test_manifest_filter_restores_existing_onboarding_and_filters_repeated_candi
         {
             **_score("org/pending", 85),
             "task": "embed",
-            "deployments": [{"deploy.gpu": GPU, "deploy.gpu_count": 1}],
+            "deployments": [{"deploy.gpu": GPU, "deploy.gpu_count": 4}],
         }
     ]
+
+
+def test_manifest_filter_drops_a_new_candidate_the_fit_agents_could_not_size():
+    ready = _recipe("org/ready")
+    selection = _selection(
+        [_score("org/ready", 70)],
+        ["org/ready"],
+        new_onboarding=[{"model_id": "org/huge", "task": "generate", "rationale": "Promising but oversized.", "heat": 90}],
+        sized=[{"model_id": "org/huge", "deployments": []}],
+    )
+
+    result, manifest = _run_manifest(_task(ready), json.dumps(selection))
+
+    assert result.returncode == 0, result.stderr
+    assert manifest["onboarding_models"] == []
+
+
+def test_manifest_filter_keeps_an_unsized_shell_matrix():
+    ready = _recipe("org/ready")
+    pending = _recipe("org/pending", tags=["onboarding", "untested"], runnable=False)
+    selection = _selection(
+        [_score("org/ready", 70), _score("org/pending", 60)],
+        ["org/ready"],
+        sized=[{"model_id": "org/pending", "deployments": []}],
+    )
+
+    result, manifest = _run_manifest(_task(ready, pending), json.dumps(selection))
+
+    assert result.returncode == 0, result.stderr
+    assert manifest["onboarding_models"][0]["deployments"] == [{"deploy.gpu": GPU, "deploy.gpu_count": 1}]
 
 
 def test_manifest_filter_derives_best_effort_and_obsolete_lists():

--- a/tests/github/test_discovery_jq.py
+++ b/tests/github/test_discovery_jq.py
@@ -147,6 +147,18 @@ def test_manifest_filter_restores_existing_onboarding_and_filters_repeated_candi
     ]
 
 
+
+def test_manifest_filter_reads_a_fenced_selection_followed_by_more_reasoning():
+    ready = _recipe("org/ready")
+    selection = _selection([_score("org/ready", 70)], ["org/ready"])
+    wrapped = f"Here it is:\n```json\n{json.dumps(selection)}\n```\n\nWait - let me re-check the shells:\n- one\n- two\n"
+
+    result, manifest = _run_manifest(_task(ready), wrapped)
+
+    assert result.returncode == 0, result.stderr
+    assert manifest["maintained_models"] == [_score("org/ready", 70)]
+
+
 def test_manifest_filter_drops_a_new_candidate_the_fit_agents_could_not_size():
     ready = _recipe("org/ready")
     selection = _selection(

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -80,6 +80,7 @@ def test_discovery_loads_control_code_and_agents_from_exact_workflow_commit():
     assert '"$WORKFLOW_SOURCE/.github/workflows/scripts/discovery_task.jq"' in agent_script
     assert '"$WORKFLOW_SOURCE/.github/workflows/scripts/discovery_manifest.jq"' in agent_script
     assert '--file "$WORKFLOW_SOURCE/.agents/skills/discover-models/SKILL.md"' in agent_script
+    assert '--file "$WORKFLOW_SOURCE/prompts/model-fit.md"' in agent_script
     assert '--file "$WORKFLOW_SOURCE/prompts/discover-models/lifecycle.md"' in agent_script
     assert '--file "$WORKFLOW_SOURCE/prompts/discover-models/score-recipes.md"' in agent_script
     assert "sed 's/^/discover-models: /' \"$AGENT_SELECTION\"" in agent_script
@@ -362,8 +363,9 @@ def test_discovery_counts_lifecycle_with_recipe_query():
 
 
 def test_discovery_prompt_keeps_obsolete_classification_conservative():
-    prompt = (Path(__file__).parents[2] / "prompts" / "discover-models" / "lifecycle.md").read_text()
+    prompt = " ".join((Path(__file__).parents[2] / "prompts" / "discover-models" / "lifecycle.md").read_text().split())
 
+    assert "Derive every deployment from the attached `model-fit.md`" in prompt
     assert "A replacement that is merely comparable is not" in prompt
     assert "read both recipe files" in prompt
     assert "configured context, concurrency, quantization, hardware support, model capability" in prompt
@@ -423,6 +425,22 @@ def test_discovery_uses_source_subagents_and_scores_every_model():
     assert "prompts/discover-models/lifecycle.md" in skill
     assert "prompts/discover-models/score-recipes.md" in skill
     assert "Path(os.environ" not in script
+
+
+def test_shared_model_fit_prompt_reaches_both_lifecycle_skills():
+    workspace = Path(__file__).parents[2]
+    fit_prompt = (workspace / "prompts" / "model-fit.md").read_text()
+    lifecycle = discovery_lifecycle.__file__
+
+    assert "TOTAL parameters" in fit_prompt
+    assert "emmy/gpu.py" in fit_prompt
+    for skill_name in ("discover-models", "onboard-model"):
+        assert "prompts/model-fit.md" in (workspace / ".agents" / "skills" / skill_name / "SKILL.md").read_text()
+    for workflow_name in ("discover-model.yml", "onboard-model.yml"):
+        document = yaml.safe_load((workspace / ".github" / "workflows" / workflow_name).read_text())
+        scripts = [step.get("run", "") for job in document["jobs"].values() for step in job["steps"]]
+        assert any('--file "$WORKFLOW_SOURCE/prompts/model-fit.md"' in script for script in scripts)
+    assert "vram_mib" not in Path(lifecycle).read_text()
 
 
 def _recipe(workspace, name, model_id, tags=None, leading_comment=False, task=None, gpu=GPU, gpu_count=1, heat=50):
@@ -856,29 +874,6 @@ def test_obsolete_recipe_with_other_task_replacement_defaults_to_best_effort(tmp
 
     assert [decision["model_id"] for decision in manifest["best_effort_models"]] == ["org/old"]
     assert manifest["obsolete_models"] == []
-
-
-def test_obsolete_recipe_with_larger_replacement_defaults_to_best_effort(tmp_path):
-    _recipe(tmp_path, "ready", "org/ready", gpu=GPU)
-    _recipe(tmp_path, "old", "org/old", gpu="NVIDIA GeForce RTX 4090")
-    selection = tmp_path / "selection.json"
-    _manifest(selection, ["org/ready"], obsolete=[_obsolete("org/old", "org/ready")])
-
-    manifest = discovery_lifecycle.validate_manifest(selection, tmp_path)
-
-    assert [decision["model_id"] for decision in manifest["best_effort_models"]] == ["org/old"]
-    assert manifest["obsolete_models"] == []
-
-
-def test_obsolete_recipe_replacement_may_use_less_total_vram(tmp_path):
-    _recipe(tmp_path, "ready", "org/ready", gpu="NVIDIA GeForce RTX 4090")
-    _recipe(tmp_path, "old", "org/old", gpu=GPU)
-    selection = tmp_path / "selection.json"
-    _manifest(selection, ["org/ready"], obsolete=[_obsolete("org/old", "org/ready")])
-
-    manifest = discovery_lifecycle.validate_manifest(selection, tmp_path)
-
-    assert manifest["obsolete_models"][0]["model_id"] == "org/old"
 
 
 def test_comparable_replacement_defaults_to_best_effort(tmp_path):

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -149,6 +149,7 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
     cleanup_script = next(step["run"] for step in steps if step.get("name") == "Remove archived task-local raw results")
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
+    qualify = (workspace / "prompts" / "onboard-model" / "qualify.md").read_text()
 
     assert "lfs_version=3.7.1" in lfs_script
     assert "sha256sum --check" in lfs_script
@@ -162,14 +163,14 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert "tmpfs|ramfs" in host_setup_script
     assert "8388608" in host_setup_script
     subprocess.run(["bash", "-n"], input=host_setup_script, text=True, check=True)
-    assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script
-    assert "preserve every other platform archive" in agent_script
-    assert "do not retain those records as" in agent_script
-    assert "onboard-investigator subagent" in agent_script
+    assert "results_<gpu-short>x<gpu-count>.tar.gz" in qualify
+    assert "preserve every other platform" in qualify
+    assert "do not\nretain those records as top-level files" in qualify
+    assert "`onboard-investigator` subagent" in qualify
+    assert "do not modify or list `.gitattributes`" in qualify
     assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
-    assert "do not modify or list .gitattributes" in agent_script
     assert 'tarfile.open(temporary_archive, "w:gz")' in cleanup_script
     assert "temporary_roots = verify_archive(temporary_archive)" in cleanup_script
     assert "os.replace(temporary_archive, archive)" in cleanup_script
@@ -203,7 +204,9 @@ def test_onboarding_uses_bounded_read_only_investigator():
         "webfetch": "allow",
         "websearch": "allow",
     }
-    assert "Use at most four public-web calls" in " ".join(investigator.splitlines())
+    prompt = " ".join((workspace / "prompts" / "onboard-model" / "investigate.md").read_text().split())
+    assert "Use at most four public-web calls" in prompt
+    assert "never modify a file, invoke another agent, use credentials, or run a remote workload" in prompt
 
 
 def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_path):
@@ -442,6 +445,32 @@ def test_shared_model_fit_prompt_reaches_both_lifecycle_skills():
         scripts = [step.get("run", "") for job in document["jobs"].values() for step in job["steps"]]
         assert any('--file "$WORKFLOW_SOURCE/prompts/model-fit.md"' in script for script in scripts)
     assert "vram_mib" not in Path(lifecycle).read_text()
+
+
+def test_onboarding_agent_reads_shared_prompts_from_a_compact_task():
+    workspace = Path(__file__).parents[2]
+    document = yaml.safe_load((workspace / ".github" / "workflows" / "onboard-model.yml").read_text())
+    job = document["jobs"]["onboard"]
+    script = next(step["run"] for step in job["steps"] if step.get("name") == "Run onboard-model agent")
+    qualify = (workspace / "prompts" / "onboard-model" / "qualify.md").read_text()
+    investigate = (workspace / "prompts" / "onboard-model" / "investigate.md").read_text()
+    skill = (workspace / ".agents" / "skills" / "onboard-model" / "SKILL.md").read_text()
+    investigator = (workspace / ".opencode" / "agents" / "onboard-investigator.md").read_text()
+
+    assert job["env"]["OPENCODE_CONFIG_DIR"] == f"{job['env']['WORKFLOW_SOURCE']}/.opencode"
+    assert '--file "$WORKFLOW_SOURCE/prompts/onboard-model/qualify.md"' in script
+    assert '--file "$WORKFLOW_SOURCE/prompts/onboard-model/investigate.md"' in script
+    assert '--file "$AGENT_TASK"' in script
+    assert "jq -n \\" in script
+    assert "Path(os.environ" not in script
+    assert "prompts/onboard-model/qualify.md" in skill
+    assert "prompts/onboard-model/investigate.md" in skill
+    for field in ("mode", "model_id", "gpu_count", "ssh_key", "deadline", "publish_image", "summary_path"):
+        assert f"{field}:" in script
+        assert f"`{field}`" in qualify
+    assert "Do not select a model or GPU, provision or delete the VM, commit, push" in qualify
+    assert "Use at most four public-web calls" in investigate
+    assert "Apply the investigation prompt" in investigator
 
 
 def test_fit_subagent_sizes_each_onboarding_model_alone():

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -365,7 +365,8 @@ def test_discovery_counts_lifecycle_with_recipe_query():
 def test_discovery_prompt_keeps_obsolete_classification_conservative():
     prompt = " ".join((Path(__file__).parents[2] / "prompts" / "discover-models" / "lifecycle.md").read_text().split())
 
-    assert "Derive every deployment from the attached `model-fit.md`" in prompt
+    assert "Invoke `discover-fit` once per onboarding model and in parallel" in prompt
+    assert "you never author hardware here" in prompt
     assert "A replacement that is merely comparable is not" in prompt
     assert "read both recipe files" in prompt
     assert "configured context, concurrency, quantization, hardware support, model capability" in prompt
@@ -441,6 +442,25 @@ def test_shared_model_fit_prompt_reaches_both_lifecycle_skills():
         scripts = [step.get("run", "") for job in document["jobs"].values() for step in job["steps"]]
         assert any('--file "$WORKFLOW_SOURCE/prompts/model-fit.md"' in script for script in scripts)
     assert "vram_mib" not in Path(lifecycle).read_text()
+
+
+def test_fit_subagent_sizes_each_onboarding_model_alone():
+    workspace = Path(__file__).parents[2]
+    agent = (workspace / ".opencode" / "agents" / "discover-fit.md").read_text()
+    config = yaml.safe_load(agent.split("---", 2)[1])
+    parent = (workspace / ".opencode" / "agents" / "discover-models.md").read_text()
+    prompt = " ".join((workspace / "prompts" / "discover-models" / "size-deployments.md").read_text().split())
+    document = yaml.safe_load((workspace / ".github" / "workflows" / "discover-model.yml").read_text())
+    script = next(step["run"] for step in document["jobs"]["discover"]["steps"] if step.get("name") == "Run discover-models agent")
+
+    assert config["mode"] == "subagent"
+    assert config["hidden"] is True
+    assert config["permission"] == {"*": "deny", "read": "allow", "grep": "allow", "webfetch": "allow", "websearch": "allow"}
+    assert '"discover-fit": allow' in parent
+    assert '--file "$WORKFLOW_SOURCE/prompts/discover-models/size-deployments.md"' in script
+    assert "Never substitute a sibling, quantized, or same-family repository" in prompt
+    assert "Return an empty `deployments` array when the checkpoint cannot be sized" in prompt
+    assert "never infer size from the model ID" in prompt
 
 
 def _recipe(workspace, name, model_id, tags=None, leading_comment=False, task=None, gpu=GPU, gpu_count=1, heat=50):
@@ -642,16 +662,20 @@ def test_preserves_existing_onboarding_shell(tmp_path):
     assert "`NVIDIA H200 141GB x1`" in (tmp_path / "summary.md").read_text()
 
 
-def test_rejects_existing_onboarding_shell_without_deployment_matrix(tmp_path):
+def test_resizes_an_existing_onboarding_shell_matrix(tmp_path):
     _recipe(tmp_path, "ready", "org/ready")
     shell = _recipe(tmp_path, "pending", "org/pending", tags=["onboarding", "untested"])
-    shell.write_text(shell.read_text().replace("matrices:\n  - deploy.gpu: NVIDIA H200 141GB\n    deploy.gpu_count: 1\n", ""))
     selection = tmp_path / "selection.json"
-    pending = _candidate("org/pending", deployments=[{"deploy.gpu": GPU, "deploy.gpu_count": 1}])
-    _manifest(selection, ["org/ready"], onboarding=[pending])
+    resized = [{"deploy.gpu": GPU, "deploy.gpu_count": 4}, {"deploy.gpu": "NVIDIA B200", "deploy.gpu_count": 4}]
+    _manifest(selection, ["org/ready"], onboarding=[_candidate("org/pending", deployments=resized)])
 
-    with pytest.raises(ValueError, match="org/pending needs one to 3 deployments"):
-        discovery_lifecycle.validate_manifest(selection, tmp_path)
+    manifest = discovery_lifecycle.validate_manifest(selection, tmp_path)
+    assert discovery_lifecycle.apply_manifest(manifest, tmp_path, tmp_path / "summary.md") == {"changed": True}
+
+    config = yaml.safe_load(shell.read_text())
+    assert config["matrices"] == resized
+    assert config["tags"] == ["onboarding", "untested"]
+    assert config["model"]["huggingface"] == "org/pending"
 
 
 def test_rewrites_unindented_yaml_tag_lists_without_leaving_duplicate_items(tmp_path):

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -461,6 +461,8 @@ def test_fit_subagent_sizes_each_onboarding_model_alone():
     assert "Never substitute a sibling, quantized, or same-family repository" in prompt
     assert "Return an empty `deployments` array when the checkpoint cannot be sized" in prompt
     assert "never infer size from the model ID" in prompt
+    assert "`deploy.gpu_count` is 1, 2, 4, 8, or 16" in prompt
+    assert "5 GPUs and 12 GPUs are arithmetic, not platforms" in prompt
 
 
 def _recipe(workspace, name, model_id, tags=None, leading_comment=False, task=None, gpu=GPU, gpu_count=1, heat=50):


### PR DESCRIPTION
## Summary

`onboard-model` now follows the same structure as `discover-models`: tracked prompt files own the run policy, and the
workflow renders only a compact task payload.

- **New shared prompts** — `prompts/onboard-model/qualify.md` is the canonical non-interactive contract (task-field
  table, per-mode recipe policy, caller-owned boundaries, image and bounded-fix investigation policy, artifact/LFS
  rules, summary contract). `prompts/onboard-model/investigate.md` is the bounded `onboard-investigator` prompt,
  mirroring `score-recipes.md` and `size-deployments.md`.
- **Workflow** — the ~60-line Python heredoc that built a prose prompt is replaced by a `jq -n` task object
  (`schema_version`, mode, model, exact target, SSH handles, deadline, publication flag, summary path, expected
  lifecycle). Both prompts are attached from the exact workflow SHA alongside the three skills and `model-fit.md`.
- **`OPENCODE_CONFIG_DIR`** is now pinned to the workflow source, as discovery already does, so the onboarding agent
  definitions come from the commit that started the run rather than whatever sits on the rolling branch. This is the
  only behavior change beyond relocation; the artifact worktree still stays on the rolling branch.
- **Skill and agents** — `SKILL.md` gains a "Step 0 — Choose the run mode" section pointing at `qualify.md`, and its
  delegation paragraph hands the investigator `investigate.md`. `onboard-investigator.md` shrinks to an
  "apply the supplied prompt" role like `discover-scorer`/`discover-fit`.

## Testing

- `make test` — 2947 passed, 578 skipped
- `make lint`
- Two existing tests that asserted the prose inside the workflow script now assert it in the prompt files, plus a new
  `test_onboarding_agent_reads_shared_prompts_from_a_compact_task`.
- Rendered the new `jq` step under representative env values and checked the fragment with `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)