### PR TITLE
Add search-seeding and agent-kernel experiment shells to golden-bench-2026

### DIFF
--- a/experiments/golden-bench-2026/README.md
+++ b/experiments/golden-bench-2026/README.md
@@ -16,6 +16,8 @@ artifacts exist and an intelligent reviewer accepts them against the checklist b
 | End-to-end serving | Pinned recipes below | Consumer single GPU; datacenter TP8 except the V100 TP8xPP2 lane | System performance for explicitly matched stock and Emmy arms |
 | Megakernel decode pair | Qwen3-8B, one 128/512 single-stream point | A100 | Cross-harness kernel-launch-overhead comparison |
 | Neptune compiler comparison | 10 artifact operators and a five-operator Emmy/PyTorch subset | A100 80GB | One archived cross-compiler result |
+| Search seeding | Sequence-512 common corpus, MCTS alone versus MCTS seeded with proposed knob rows | RTX 5090, A100 | Equal-budget search-seeding diagnostic; no input to the headline mean |
+| Agent-generated kernels | Common-corpus targets with committed kernels from an LLM-driven generator | RTX 5090, A100 | Per-target comparison of one generator's committed kernels against eager, Inductor, and tuned Emmy |
 
 The BF16 sets produce separate tables and separate geometric means. The unsharded large-layer corpus is not TP8,
 quantization, or serving evidence and cannot explain an end-to-end result. Dynamic-FP8 layer traces are preserved as
@@ -184,6 +186,39 @@ performance outlier is removed. A machine-readable deployment, client, or networ
 may trigger one rerun of the entire stock/Emmy pair for that workload/repeat; retain and disclose both failed
 originals. A second failure makes the point incomplete. A semantic mismatch or post-metric performance anomaly is
 never a rerun reason; after a code/configuration fix, restart the entire 40-task matrix under a new source ID.
+
+## Search seeding lane: proposals versus MCTS alone
+
+`search_hybrid_vs_mcts` asks what a model-proposed starting set buys an equal search budget. The tune-kernels skill
+produces, per GPU, two working golden files from one inventory-only trace of Qwen3-0.6B layer 0 at sequence 512:
+`arms/<gpu-short>/mcts.yaml` with no knob rows and `arms/<gpu-short>/hybrid.yaml` with the skill's proposed rows
+added to the same inventory. The recipe copies the committed arm, tunes it with `--max-candidates 12 --patience 4
+--seed 0` from an empty task-local tuning DB, online checkpoint, and cubin cache, and verifies the searched winner
+five times at deployable `-O3` exactly as the `kernels` recipe does. Every proposal reserves one budget slot before
+MCTS, so the two arms spend the same number of candidates. Report per-target winner latency, the number of live
+measurements each arm spent, and how many hybrid winners were proposed rows rather than searched ones. The lane is
+a search diagnostic beside the budget ablation; it adds nothing to the headline geometric mean and supports no
+compiler-versus-compiler claim.
+
+## Agent-generated kernel lane
+
+`compiler_agent_kernels` places the LLM-driven kernel generators on the same targets as the compiler comparison.
+These systems (KernelBench-style agents, contrastive-RL generators, evolutionary searches) write a kernel per
+problem with the generator's own budget and report speedups over eager or `torch.compile` on single-operator
+benchmarks. The lane does not run a generator: a generator session is run outside the recipe, and its finished
+kernels are committed under `kernels/<agent>/<target>/` as a KernelBench-style `reference.py` (`Model`,
+`get_inputs`, `get_init_inputs`, transcribed from the target's Torch IR in the common-corpus golden file) and
+`kernel.py` (`ModelNew`), with a `MANIFEST.yaml` recording the generator, its revision, model, budget, date, and
+host GPU. The recipe measures the agent kernel, eager, and Inductor in one process with the suite's `rtol = atol =
+1e-3` gate against `Model`, and replays the committed common-corpus golden for the same target through `emmy run
+--target` at deployable `-O3`.
+
+Intelligent review must confirm, per target, that `reference.py` matches the golden's Torch IR (shapes, dtypes,
+and semantics) and that the agent kernel passed the correctness gate; an incorrect or non-matching kernel stays in
+the denominator as a failure. The result is a per-target table for one committed generator set and supports no
+ranking of generators against each other, since each set carries its own budget and model. It is also not an
+input to the kernel-corpus geometric mean: the generator's cost (model calls, wall time, human steering) is part
+of the record, not a normalized quantity.
 
 ## Megakernel comparison lane
 

--- a/experiments/golden-bench-2026/compiler_agent_kernels/kernels/README.md
+++ b/experiments/golden-bench-2026/compiler_agent_kernels/kernels/README.md
@@ -1,0 +1,6 @@
+# Committed agent kernel sets
+
+One directory per generator run, `kernels/<agent>/`, holding `MANIFEST.yaml` (generator name, revision, model,
+budget, date, host GPU) and one `<target>/` directory per common-corpus golden target with `reference.py` and
+`kernel.py` in the KernelBench module convention. The recipe measures what is committed here and generates
+nothing; see `../recipe.yaml`.

--- a/experiments/golden-bench-2026/compiler_agent_kernels/recipe.yaml
+++ b/experiments/golden-bench-2026/compiler_agent_kernels/recipe.yaml
@@ -1,0 +1,99 @@
+# Agent-generated kernels against eager PyTorch, Inductor, and tuned Emmy on the common-corpus targets.
+# One row per (GPU, agent); the row measures every target the agent's committed kernel set covers.
+#
+#   EXP=experiments/golden-bench-2026/compiler_agent_kernels
+#   emmy bench $EXP --filter agent=kernelagent
+#
+# The recipe generates nothing. An LLM-driven kernel generator (KernelAgent, CUDA-L1, an evolutionary
+# search, or a human-driven agent session) is run outside the recipe with its own budget and
+# hardware, and its finished kernels are committed as inputs:
+#   kernels/<agent>/MANIFEST.yaml            generator name, revision, model, budget, date, host GPU
+#   kernels/<agent>/<target>/reference.py    KernelBench-style `Model`, `get_inputs`, `get_init_inputs`
+#                                            transcribed from the target's Torch IR in the common-corpus
+#                                            golden file (same shapes, dtypes, and semantics)
+#   kernels/<agent>/<target>/kernel.py       the generator's `ModelNew` for that reference
+# <target> is the golden target name (`k_linear_reduce_06a42b.975d5314f1c7.s512`), so the Emmy row
+# for the same target replays the committed common-corpus golden through `emmy run --target`.
+# The agent kernel, eager, and Inductor are measured by run_agent_kernels.py with the suite's
+# correctness gate (rtol = atol = 1e-3 against `Model`) and the same CUDA-graph timing method the
+# Neptune lane uses. A target whose reference.py does not match the golden's Torch IR is a broken
+# input and is rejected at review, not here.
+command:
+  stage:
+    - emmy
+    - pyproject.toml
+    - requirements.txt
+    - Makefile
+    - experiments/golden-bench-2026/compiler_agent_kernels/recipe.yaml
+    - experiments/golden-bench-2026/compiler_agent_kernels/run_agent_kernels.py
+    - experiments/golden-bench-2026/compiler_agent_kernels/kernels
+    - experiments/golden-bench-2026/kernels/goldens
+  strict: true
+  run: |
+    set -euo pipefail
+    export PATH=/usr/local/cuda/bin:$$PATH
+    cd $repo_dir
+    mkdir -p $task_dir/agent $task_dir/emmy $task_dir/logs
+    finalize() {
+      final_status=$$?
+      trap - EXIT
+      if [ -x ./venv/bin/pip ]; then
+        ./venv/bin/pip freeze --all > $task_dir/requirements.freeze.txt || final_status=1
+      else
+        echo "venv pip unavailable" > $task_dir/requirements.freeze.txt
+        final_status=1
+      fi
+      printf 'agent=%s\nstatus=%s\n' "$agent" "$$final_status" > $task_dir/status.txt
+      archive_tmp=$${task_dir}.artifacts.tar.gz
+      tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
+      mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
+      exit "$$final_status"
+    }
+    trap finalize EXIT
+
+    [ -d venv ] || make setup
+    export CUDA_VISIBLE_DEVICES=$gpu_device_ids
+    # Task-local search state: the Emmy row replays the committed golden and searches nothing.
+    export EMMY_TUNE_DB=$task_dir/autotune.db
+    export EMMY_ONLINE_FILE=$task_dir/online.json
+    export EMMY_CUBIN_CACHE=$task_dir/cubins
+
+    EXPERIMENT=$repo_dir/experiments/golden-bench-2026/compiler_agent_kernels
+    gpu_short=$$(./venv/bin/python -c 'from emmy.hardware import gpu_short_name; print(gpu_short_name("'"$gpu"'"))')
+    golden=$repo_dir/experiments/golden-bench-2026/kernels/goldens/qwen3-06b_$$gpu_short.yaml
+    agent_dir=$$EXPERIMENT/kernels/$agent
+    test -f "$$agent_dir/MANIFEST.yaml"
+    test -f "$$golden"
+    cp "$$agent_dir/MANIFEST.yaml" $task_dir/
+    find "$$agent_dir" -type f -print0 | sort -z | xargs -0 sha256sum > $task_dir/agent-kernels.sha256
+    sha256sum "$$golden" > $task_dir/golden.sha256
+    nvidia-smi -q > $task_dir/nvidia-smi.txt
+
+    status_file=$task_dir/target-status.tsv
+    printf 'target\temmy_status\n' > "$$status_file"
+    for target_dir in "$$agent_dir"/*/; do
+      target=$$(basename "$$target_dir")
+      if EMMY_NVCC_FLAGS= timeout --signal=TERM --kill-after=30s 1800s ./venv/bin/emmy run \
+        --golden "$$golden" --target "$$target" --bench --strict --no-record-nodes \
+        --bench-backends eager,tcompile,emmy --warmup 10 --iters 100 \
+        --json $task_dir/emmy/$$target 2>&1 | tee $task_dir/logs/emmy-$$target.log; then
+        printf '%s\tok\n' "$$target" >> "$$status_file"
+      else
+        printf '%s\tfailed:%s\n' "$$target" "$$?" >> "$$status_file"
+      fi
+    done
+
+    ./venv/bin/python "$$EXPERIMENT/run_agent_kernels.py" "$$agent_dir" $task_dir/agent \
+      --warmup 10 --iters 100 --rtol 1e-3 --atol 1e-3 2>&1 | tee $task_dir/logs/agent.log
+  result_files:
+    - artifacts.tar.gz
+  timeout: 43200
+
+matrices:
+  - cross:
+      agent: [kernelagent]
+      zip:
+        deploy.gpu:
+          - "NVIDIA GeForce RTX 5090"
+          - "NVIDIA A100 80GB"
+        deploy.gpu_count: 1

--- a/experiments/golden-bench-2026/compiler_agent_kernels/run_agent_kernels.py
+++ b/experiments/golden-bench-2026/compiler_agent_kernels/run_agent_kernels.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Measure committed agent-generated kernels against eager PyTorch and Inductor, one JSON per target.
+
+Each ``<agent>/<target>/`` directory holds ``reference.py`` (``Model``, ``get_inputs``,
+``get_init_inputs``) and ``kernel.py`` (``ModelNew``) in the KernelBench module convention. The
+agent kernel must match ``Model`` on the same inputs within the suite's tolerance before it is timed;
+a mismatch is recorded as a failure, never dropped. Timings replay a captured CUDA graph when every
+backend captures, and fall back together to direct launches otherwise, so the three numbers in one
+record always share a method.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import statistics
+import sys
+import traceback
+from pathlib import Path
+
+import torch
+
+
+def _load(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem + "_" + path.parent.name.replace(".", "_"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _to_cuda(values):
+    return [v.cuda() if isinstance(v, torch.Tensor) else v for v in values]
+
+
+def _capture(fn):
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side), torch.no_grad():
+        for _ in range(3):
+            fn()
+    torch.cuda.current_stream().wait_stream(side)
+    graph = torch.cuda.CUDAGraph()
+    with torch.no_grad(), torch.cuda.graph(graph):
+        fn()
+    return graph, graph.replay
+
+
+def _measure(functions: dict, warmup: int, iters: int) -> tuple[dict, bool]:
+    graphs, replays = [], {}
+    try:
+        for name, fn in functions.items():
+            graph, replay = _capture(fn)
+            graphs.append(graph)
+            replays[name] = replay
+    except Exception:  # noqa: BLE001 - all backends fall back together to keep the timing method shared
+        captured = False
+    else:
+        functions, captured = replays, True
+    samples = {name: [] for name in functions}
+    for iteration in range(warmup + iters):
+        for name, fn in functions.items():
+            start, stop = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+            with torch.no_grad():
+                start.record()
+                fn()
+                stop.record()
+            stop.synchronize()
+            if iteration >= warmup:
+                samples[name].append(start.elapsed_time(stop) * 1000.0)
+    return {name: statistics.median(values) for name, values in samples.items()}, captured
+
+
+def _run_target(target_dir: Path, args) -> dict:
+    record = {"target": target_dir.name, "status": "ok"}
+    reference = _load(target_dir / "reference.py")
+    kernel = _load(target_dir / "kernel.py")
+    torch.manual_seed(0)
+    init_inputs = _to_cuda(reference.get_init_inputs())
+    inputs = _to_cuda(reference.get_inputs())
+    model = reference.Model(*init_inputs).cuda().eval()
+    agent = kernel.ModelNew(*init_inputs).cuda().eval()
+    with torch.no_grad():
+        expected = model(*inputs)
+        actual = agent(*inputs)
+    record["max_abs_error"] = float((actual.float() - expected.float()).abs().max())
+    if not torch.allclose(actual.float(), expected.float(), rtol=args.rtol, atol=args.atol):
+        record["status"] = "agent-incorrect"
+        return record
+    compiled = torch.compile(model, mode="max-autotune-no-cudagraphs", fullgraph=True)
+    with torch.no_grad():
+        compiled_out = compiled(*inputs)
+    record["tcompile_matches_eager"] = bool(torch.allclose(compiled_out.float(), expected.float(), rtol=args.rtol, atol=args.atol))
+    functions = {
+        "eager_us": lambda: model(*inputs),
+        "tcompile_us": lambda: compiled(*inputs),
+        "agent_us": lambda: agent(*inputs),
+    }
+    timings, captured = _measure(functions, args.warmup, args.iters)
+    record.update(timings)
+    record["cuda_graph"] = captured
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("agent_dir", type=Path)
+    parser.add_argument("results_dir", type=Path)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument("--rtol", type=float, default=1e-3)
+    parser.add_argument("--atol", type=float, default=1e-3)
+    args = parser.parse_args()
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    targets = sorted(p for p in args.agent_dir.iterdir() if (p / "kernel.py").exists())
+    if not targets:
+        print(f"no <target>/kernel.py under {args.agent_dir}", file=sys.stderr)
+        return 2
+    measured = 0
+    for target_dir in targets:
+        try:
+            record = _run_target(target_dir, args)
+        except Exception:  # noqa: BLE001 - a failing target is a recorded result, not an aborted sweep
+            record = {"target": target_dir.name, "status": "failed", "traceback": traceback.format_exc()}
+        (args.results_dir / f"{target_dir.name}.json").write_text(json.dumps(record, indent=2))
+        print(f"{record['target']}\t{record['status']}")
+        measured += record["status"] == "ok"
+    return 0 if measured else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/golden-bench-2026/search_hybrid_vs_mcts/arms/README.md
+++ b/experiments/golden-bench-2026/search_hybrid_vs_mcts/arms/README.md
@@ -1,0 +1,5 @@
+# Committed search arms
+
+`arms/<gpu-short>/mcts.yaml` and `arms/<gpu-short>/hybrid.yaml`, both derived by the tune-kernels skill from one
+inventory-only trace of the sequence-512 common corpus; only the hybrid file carries proposed knob rows. The
+recipe measures what is committed here and traces nothing; see `../recipe.yaml`.

--- a/experiments/golden-bench-2026/search_hybrid_vs_mcts/recipe.yaml
+++ b/experiments/golden-bench-2026/search_hybrid_vs_mcts/recipe.yaml
@@ -1,0 +1,93 @@
+# Equal-budget search seeding: MCTS alone against MCTS seeded with model-proposed knob rows, on the
+# sequence-512 common corpus. One row per (GPU, arm); both arms of one GPU share an execution group.
+#
+#   EXP=experiments/golden-bench-2026/search_hybrid_vs_mcts
+#   emmy bench $EXP --filter deploy.gpu="NVIDIA GeForce RTX 5090"
+#   emmy bench $EXP --filter arm=hybrid
+#
+# The recipe does not trace and does not write proposals. The tune-kernels skill produces, per GPU,
+# two working golden files from ONE inventory-only trace of Qwen3-0.6B layer 0 at sequence 512:
+#   arms/<gpu-short>/mcts.yaml    the inventory with no knob rows
+#   arms/<gpu-short>/hybrid.yaml  the same inventory plus the skill's proposed knob rows
+# and commits them here. The two files must hold the same targets; the only difference is the
+# proposals. A missing arm file fails the row: the lane measures a committed input, it never
+# substitutes a fresh trace for it.
+#
+# Fairness is the recipe's: task-local empty tuning DB, online checkpoint, and cubin cache for every
+# row; the same --max-candidates, --patience, --seed, and compiler flags on both arms. Every supplied
+# proposal reserves one of the budget's slots before MCTS runs (see `emmy tune --help`), so a hybrid
+# win is a win at equal budget. Canonical repository goldens remain the common implicit deploy
+# context of both arms and are not copied into either file.
+command:
+  stage:
+    - emmy
+    - pyproject.toml
+    - requirements.txt
+    - Makefile
+    - experiments/golden-bench-2026/search_hybrid_vs_mcts/recipe.yaml
+    - experiments/golden-bench-2026/search_hybrid_vs_mcts/arms
+  strict: true
+  run: |
+    set -euo pipefail
+    export PATH=/usr/local/cuda/bin:$$PATH
+    cd $repo_dir
+    mkdir -p $task_dir/verification
+    finalize() {
+      final_status=$$?
+      trap - EXIT
+      if [ -x ./venv/bin/pip ]; then
+        ./venv/bin/pip freeze --all > $task_dir/requirements.freeze.txt || final_status=1
+      else
+        echo "venv pip unavailable" > $task_dir/requirements.freeze.txt
+        final_status=1
+      fi
+      printf 'arm=%s\nstatus=%s\n' "$arm" "$$final_status" > $task_dir/status.txt
+      archive_tmp=$${task_dir}.artifacts.tar.gz
+      tar -C $task_dir -czf "$$archive_tmp" . || final_status=1
+      mv "$$archive_tmp" $task_dir/artifacts.tar.gz || final_status=1
+      exit "$$final_status"
+    }
+    trap finalize EXIT
+
+    [ -d venv ] || make setup
+    export EMMY_TUNE_DB=$task_dir/autotune.db
+    export EMMY_ONLINE_FILE=$task_dir/online.json
+    export EMMY_CUBIN_CACHE=$task_dir/cubins
+    devices="$gpu_device_ids"
+    first_device=$${devices%%,*}
+
+    gpu_short=$$(./venv/bin/python -c 'from emmy.hardware import gpu_short_name; print(gpu_short_name("'"$gpu"'"))')
+    arms=$repo_dir/experiments/golden-bench-2026/search_hybrid_vs_mcts/arms/$$gpu_short
+    arm_file=$$arms/$arm.yaml
+    if [ ! -f "$$arm_file" ]; then
+      echo "missing committed arm file: $$arm_file (produce both arms with the tune-kernels skill)" >&2
+      exit 2
+    fi
+    sha256sum "$$arms"/*.yaml > $task_dir/arms.sha256
+    cp "$$arm_file" $task_dir/working.yaml
+
+    ./venv/bin/emmy tune --golden-file $task_dir/working.yaml --clean \
+      --devices "$$devices" --max-candidates "$budget" --patience "$patience" --seed "$seed" \
+      --dump-dir $task_dir/dump 2>&1 | tee $task_dir/tune.log
+
+    for repeat in 0 1 2 3 4; do
+      EMMY_NVCC_FLAGS= CUDA_VISIBLE_DEVICES="$$first_device" ./venv/bin/emmy run \
+        --golden $task_dir/working.yaml --bench --strict \
+        --json $task_dir/verification/repeat-$$repeat --warmup 10 --iters 100 \
+        --bench-backends eager,tcompile,emmy 2>&1 | tee $task_dir/verification-$$repeat.log
+    done
+  result_files:
+    - artifacts.tar.gz
+  timeout: 86400
+
+matrices:
+  - cross:
+      arm: [mcts, hybrid]
+      budget: 12
+      patience: 4
+      seed: 0
+      zip:
+        deploy.gpu:
+          - "NVIDIA GeForce RTX 5090"
+          - "NVIDIA A100 80GB"
+        deploy.gpu_count: 1

--- a/tests/benchmark/models/test_golden_bench_2026.py
+++ b/tests/benchmark/models/test_golden_bench_2026.py
@@ -402,7 +402,7 @@ def test_every_command_variant_renders(project_root) -> None:
             assert "/task" in command
             subprocess.run(["bash", "-n"], input=command, text=True, check=True)
             rendered += 1
-    assert rendered == 58
+    assert rendered == 64
 
 
 def test_gemma_serving_ab_has_four_points_per_lane(project_root) -> None:
@@ -464,3 +464,72 @@ def test_gemma_arms_share_one_immutable_image(project_root) -> None:
         for task in tasks
         if task.variant.params["arm"] == "emmy"
     )
+
+
+def test_search_seeding_lane_is_equal_budget(project_root) -> None:
+    directory = _experiment(project_root, "search_hybrid_vs_mcts")
+    recipe = load_recipe(directory)
+    tasks = enumerate_tasks([directory])
+    assert len(tasks) == 4
+    assert {(task.recipe.deploy.gpu, task.variant.params["arm"]) for task in tasks} == {
+        ("NVIDIA GeForce RTX 5090", "mcts"),
+        ("NVIDIA GeForce RTX 5090", "hybrid"),
+        ("NVIDIA A100 80GB", "mcts"),
+        ("NVIDIA A100 80GB", "hybrid"),
+    }
+    # Both arms run the same search under the same budget; only the committed input differs.
+    assert {(task.variant.params["budget"], task.variant.params["patience"], task.variant.params["seed"]) for task in tasks} == {(12, 4, 0)}
+    run = recipe.command.run
+    assert "emmy trace" not in run
+    assert 'cp "$$arm_file" $task_dir/working.yaml' in run
+    assert "./venv/bin/emmy tune --golden-file $task_dir/working.yaml --clean" in run
+    assert "for repeat in 0 1 2 3 4" in run
+    assert "--golden $task_dir/working.yaml --bench --strict" in run
+    assert "EMMY_TUNE_DB=$task_dir/autotune.db" in run
+    assert "EMMY_ONLINE_FILE=$task_dir/online.json" in run
+    assert "experiments/golden-bench-2026/search_hybrid_vs_mcts/arms" in recipe.command.stage
+    for task in tasks:
+        command = render_command(task.recipe.command.run, build_substitution_map(task.variant, [0], "/repo", "/task"))
+        assert f"arm_file=$arms/{task.variant.params['arm']}.yaml" in command
+    # Committed arm pairs share their targets and only the hybrid file carries proposals.
+    import yaml
+
+    for hybrid in (Path(directory) / "arms").glob("*/hybrid.yaml"):
+        mcts = hybrid.with_name("mcts.yaml")
+        assert mcts.exists()
+        hybrid_doc, mcts_doc = yaml.safe_load(hybrid.read_text()), yaml.safe_load(mcts.read_text())
+        names = lambda doc: [entry["name"] for program in doc["programs"] for entry in program["target"]]  # noqa: E731
+        assert names(hybrid_doc) == names(mcts_doc)
+        assert not any(
+            realization.get("knobs")
+            for program in mcts_doc["programs"]
+            for entry in program["target"]
+            for realization in entry.get("realizations", [])
+        )
+
+
+def test_agent_kernel_lane_measures_committed_kernels(project_root) -> None:
+    directory = _experiment(project_root, "compiler_agent_kernels")
+    recipe = load_recipe(directory)
+    tasks = enumerate_tasks([directory])
+    assert {(task.recipe.deploy.gpu, task.variant.params["agent"]) for task in tasks} == {
+        ("NVIDIA GeForce RTX 5090", "kernelagent"),
+        ("NVIDIA A100 80GB", "kernelagent"),
+    }
+    run = recipe.command.run
+    # Generation happens outside the recipe; the lane replays committed kernels and the common-corpus golden.
+    assert "emmy tune" not in run
+    assert "emmy trace" not in run
+    assert 'test -f "$$agent_dir/MANIFEST.yaml"' in run
+    assert '--golden "$$golden" --target "$$target" --bench --strict' in run
+    assert "run_agent_kernels.py" in run
+    assert "--rtol 1e-3 --atol 1e-3" in run
+    assert "experiments/golden-bench-2026/kernels/goldens" in recipe.command.stage
+    assert "experiments/golden-bench-2026/compiler_agent_kernels/kernels" in recipe.command.stage
+    runner = (Path(directory) / "run_agent_kernels.py").read_text()
+    assert "ModelNew" in runner and "get_init_inputs" in runner
+    assert "agent-incorrect" in runner
+    for manifest in (Path(directory) / "kernels").glob("*/MANIFEST.yaml"):
+        for target in manifest.parent.iterdir():
+            if target.is_dir():
+                assert (target / "reference.py").exists() and (target / "kernel.py").exists()


### PR DESCRIPTION
## Summary
- `experiments/golden-bench-2026/search_hybrid_vs_mcts`: equal-budget search-seeding lane. Per GPU (RTX 5090, A100) the tune-kernels skill commits `arms/<gpu>/mcts.yaml` and `hybrid.yaml` from one inventory-only sequence-512 common-corpus trace; the recipe tunes the committed arm from empty task-local evidence at budget 12 / patience 4 / seed 0 and verifies the winner five times at `-O3`, exactly like the `kernels` recipe.
- `experiments/golden-bench-2026/compiler_agent_kernels`: committed LLM-generated kernels (`kernels/<agent>/<target>/{reference,kernel}.py` in the KernelBench module convention plus a `MANIFEST.yaml`) measured against eager and Inductor in one process with the suite's `1e-3` gate, beside `emmy run --target` replaying the common-corpus golden for the same target. `run_agent_kernels.py` is the one helper; it measures and records, it interprets nothing.
- README evidence-set rows and claim boundaries for both lanes; recipe tests cover task expansion, equal-budget parity, committed-input discipline, and rendering (58 → 64 rendered command variants).

Neither recipe traces, tunes proposals, or runs a generator: both measure committed inputs, so the judgment stays with the skill/agent session and the harness stays mechanical.

## Test plan
- [x] `./venv/bin/pytest tests/benchmark/models/test_golden_bench_2026.py` (17 passed)
- [x] `make lint`
- [ ] Produce `arms/rtx5090/{mcts,hybrid}.yaml` with the tune-kernels skill and run the seeding lane on one RTX 5090
- [ ] Commit one generator's kernel set and run the agent lane on the same card

🤖 Generated with [Claude Code](https://claude.com/claude-code)