### PR TITLE
Give onboarding the same shared-prompt setup as discovery

### DIFF
--- a/.agents/skills/onboard-model/SKILL.md
+++ b/.agents/skills/onboard-model/SKILL.md
@@ -40,6 +40,15 @@ Use only the supplied SSH server. The caller owns VM creation and deletion; this
 must tear them down before returning. Never switch GPU type, count, provider, model quantization, or model checkpoint
 to rescue a failed run.
 
+## Step 0 — Choose the run mode
+
+Use **interactive mode** when a developer drives the run from a checkout: ask for the missing inputs below and report
+in conversation. For a non-interactive **automated run**, read
+[`prompts/onboard-model/qualify.md`](../../../prompts/onboard-model/qualify.md) completely before doing task work.
+That file is the canonical automation prompt and defines the attached task payload, the per-mode recipe policy, the
+caller-owned boundaries, and the artifact and summary contract used by GitHub Actions. Do not ask follow-up questions
+in automated mode.
+
 ## Required inputs
 
 Require:
@@ -122,10 +131,12 @@ Start context testing at the model's native maximum. On an out-of-memory or inva
 retry from a clean deployment. Do not claim a context length from startup alone. Search current upstream issues for
 an unfamiliar error before changing engine or flags, and make one evidence-backed change per retry.
 
-When useful, delegate up to three independent read-only investigations to the caller-provided onboarding subagent.
-Good tasks are model protocol research, official engine/image compatibility research, and diagnosis of one unfamiliar
-failure from already captured logs. The parent agent owns all commands, edits, measurements, and final conclusions;
-never let subagent work consume the time reserved for artifacts and cleanup.
+When useful, delegate up to three independent read-only investigations to the caller-provided onboarding subagent,
+giving each exactly one question and the complete contents of
+[`prompts/onboard-model/investigate.md`](../../../prompts/onboard-model/investigate.md). Good questions are model
+protocol research, official engine/image compatibility research, and diagnosis of one unfamiliar failure from already
+captured logs. The parent agent owns all commands, edits,
+measurements, and final conclusions; never let subagent work consume the time reserved for artifacts and cleanup.
 
 You may implement a small, model-agnostic compatibility fix when it is necessary to qualify the exact requested
 checkpoint and platform. Keep it within `emmy/` plus focused tests and the nearest `ARCHITECTURE.md` updates, prefer an

--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -136,10 +136,14 @@ The artifact worktree stays on the rolling lifecycle branch, while Python contro
 manual dispatch test a workflow PR without leaking that PR's implementation commits into the model-artifact branch.
 The selector runs the exact-SHA catalog logic against the rolling worktree's `recipes/` directory so lifecycle mode
 and priority always reflect the branch that the agent will update.
-The workflow also attaches the exact-SHA `onboard-model`, `tune-kernels`, and `run-experiment` skills as authoritative
-agent inputs; older copies on the rolling branch cannot silently override a proposed artifact contract.
-The named onboarding agent may delegate bounded read-only compatibility research or failure diagnosis to the hidden
-`onboard-investigator` subagent. The parent retains every edit and measurement. When an official engine image tag is
+The workflow also attaches the exact-SHA `onboard-model`, `tune-kernels`, and `run-experiment` skills plus the
+`prompts/onboard-model/` qualification and investigation prompts as authoritative agent inputs, and loads the OpenCode
+agent and plugin directory from that same commit; older copies on the rolling branch cannot silently override a
+proposed artifact contract. As in discovery, the workflow renders only a compact task object — mode, model, exact
+target, SSH handles, deadline, publication authorization, and summary path — while the shared prompt owns the run
+policy, so the skill and GitHub Actions share one prompt source. The named onboarding agent may delegate bounded
+read-only compatibility research or failure diagnosis to the hidden `onboard-investigator` subagent, which follows the
+attached investigation prompt. The parent retains every edit and measurement. When an official engine image tag is
 missing, qualification checks official registries, release notes, and upstream documentation for a renamed repository
 or current compatible tag before failing, then pins the exact working tag or digest. A necessary small,
 model-independent compatibility fix may touch at most eight implementation/test/architecture files and 500 changed

--- a/.github/workflows/onboard-model.yml
+++ b/.github/workflows/onboard-model.yml
@@ -66,7 +66,7 @@ jobs:
       EMMY_RENTAL_TAGS: emmy,workflow:model-verification-onboarding,gh-job:${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
       VM_LEASE: /tmp/emmy-onboard-${{ github.run_id }}-${{ github.run_attempt }}.json
       ONBOARD_SUMMARY: /tmp/emmy-onboard-summary-${{ github.run_id }}-${{ github.run_attempt }}.json
-      AGENT_PROMPT: /tmp/emmy-onboard-prompt-${{ github.run_id }}-${{ github.run_attempt }}.md
+      AGENT_TASK: /tmp/emmy-onboard-task-${{ github.run_id }}-${{ github.run_attempt }}.json
       AGENT_EVENTS: /tmp/emmy-onboard-events-${{ github.run_id }}-${{ github.run_attempt }}.jsonl
       AGENT_OUTPUT: /tmp/emmy-onboard-agent-${{ github.run_id }}-${{ github.run_attempt }}.txt
       PROVIDER_CONFIG: /tmp/emmy-onboard-provider-${{ github.run_id }}-${{ github.run_attempt }}.yaml
@@ -74,6 +74,7 @@ jobs:
       SSH_KEY: /tmp/emmy-onboard-ssh-${{ github.run_id }}-${{ github.run_attempt }}
       APP_KEY_FILE: /tmp/emmy-onboard-app-key-${{ github.run_id }}-${{ github.run_attempt }}.pem
       WORKFLOW_SOURCE: /tmp/emmy-onboard-source-${{ github.run_id }}-${{ github.run_attempt }}
+      OPENCODE_CONFIG_DIR: /tmp/emmy-onboard-source-${{ github.run_id }}-${{ github.run_attempt }}/.opencode
       AGENT_MODEL: ${{ vars.ONBOARD_AGENT_MODEL || 'Qwen/Qwen3.6-35B-A3B-FP8' }}
       CLOUDRIFT_INFERENCE_URL: ${{ vars.CLOUDRIFT_INFERENCE_URL || 'https://inference.cloudrift.ai/v1' }}
       OPENCODE_DISABLE_AUTOUPDATE: "true"
@@ -441,67 +442,27 @@ jobs:
           SSH_USER: ${{ steps.vm.outputs.ssh_user }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          mode = os.environ["ONBOARD_MODE"]
-          if mode == "onboarding":
-              task = (
-                  "Use the existing onboarding/untested recipe shell when present, or create the recipe for a direct "
-                  "manual request. Preserve model.heat and replace onboarding and untested with best-effort after "
-                  "qualification."
-              )
-          else:
-              task = (
-                  "Reverify the existing recipe from its current configuration, refresh its measured artifacts, and "
-                  f"preserve its {os.environ['EXPECTED_LIFECYCLE']} lifecycle tag and model.heat."
-              )
-          prompt = f"""Use the onboard-model skill non-interactively.
-
-          The attached exact-workflow-SHA copies of the onboard-model, tune-kernels, and run-experiment skills are authoritative.
-          Follow them instead of any older skill copies in the artifact worktree.
-
-          Operation mode: {mode}
-          Hugging Face model ID: {os.environ['MODEL_ID']}
-          Exact target: {os.environ['TARGET_GPU']} x {os.environ['TARGET_GPU_COUNT']}
-          SSH target: {os.environ['SSH_TARGET']}
-          Raw SSH host: {os.environ['SSH_HOST']}
-          Raw SSH user: {os.environ['SSH_USER']}
-          SSH port: {os.environ['SSH_PORT']}
-          SSH private key: {os.environ['SSH_KEY']} (pass --ssh-key {os.environ['SSH_KEY']} to every Emmy remote command)
-          Absolute deadline: {os.environ['ONBOARD_DEADLINE']}
-          Multimodal mode: {os.environ['MULTIMODAL_MODE']}
-          Publication authorized: {os.environ['PUBLISH_IMAGE']}
-          Atomic summary output: {os.environ['ONBOARD_SUMMARY']}
-
-          {task}
-          Do not select a model or GPU, provision or delete the VM, commit, push, or open/update a pull request.
-          For missing images or unfamiliar launch failures, investigate current official registries, release notes,
-          engine documentation, and upstream issues. Test an evidence-backed current repository/tag when the configured
-          image moved or disappeared, then pin the exact working tag or digest. You may implement a bounded,
-          model-agnostic compatibility fix with focused tests when it is necessary for this exact qualification.
-          You may delegate independent read-only research or failure diagnosis to the onboard-investigator subagent;
-          retain responsibility for all edits, measurements, and conclusions.
-          Always write the required atomic summary with mode set to {mode}, including experiment_artifacts with
-          the shared experiment recipe and RESULTS.md plus the exact results_<gpu-short>x<gpu-count>.tar.gz archive.
-          The archive must contain the platform's system-only experiment records; do not retain those records as
-          top-level files. Replace only this platform's archive and preserve every other platform archive and
-          RESULTS.md section. Do not retain the ignored dated run directory or onboarding summaries. Update the final
-          recipe's RESULTS.md for this platform while preserving still-valid measurements for its other platforms.
-          Git LFS is already configured through the workflow's local attributes. Verify the named archive reports
-          filter: lfs, but do not run git lfs track and do not modify or list .gitattributes in the summary.
-          Include artifacts listing every intended created, modified, or deleted repository file and no exploratory
-          output. Allowed areas are recipes/ (including the model's golden/ subdirectory), experiments/,
-          docker/vllm-emmy-serve/models/, and a bounded small fix under emmy/ with its focused tests and nearest
-          ARCHITECTURE.md updates.
-          Include one-line deployment_summary and performance_summary values drawn from the exact selected recipe lane.
-          On failure, set failure.regression=true only when a previously qualified behavior or performance lane
-          regressed and the bounded fix attempt could not restore it; include a concise, credential-free message for
-          the Discord notification.
-          """
-          Path(os.environ["AGENT_PROMPT"]).write_text(prompt)
-          PY
+          jq -n \
+            --arg mode "$ONBOARD_MODE" \
+            --arg model_id "$MODEL_ID" \
+            --arg gpu "$TARGET_GPU" \
+            --argjson gpu_count "$TARGET_GPU_COUNT" \
+            --arg ssh_target "$SSH_TARGET" \
+            --arg ssh_host "$SSH_HOST" \
+            --arg ssh_user "$SSH_USER" \
+            --arg ssh_port "$SSH_PORT" \
+            --arg ssh_key "$SSH_KEY" \
+            --arg deadline "$ONBOARD_DEADLINE" \
+            --arg multimodal_mode "$MULTIMODAL_MODE" \
+            --argjson publish_image "$PUBLISH_IMAGE" \
+            --arg summary_path "$ONBOARD_SUMMARY" \
+            --arg expected_lifecycle "$EXPECTED_LIFECYCLE" \
+            '{schema_version: 1, mode: $mode, model_id: $model_id, gpu: $gpu, gpu_count: $gpu_count,
+              ssh_target: $ssh_target, ssh_host: $ssh_host, ssh_user: $ssh_user, ssh_port: $ssh_port,
+              ssh_key: $ssh_key, deadline: $deadline, multimodal_mode: $multimodal_mode,
+              publish_image: $publish_image, summary_path: $summary_path,
+              expected_lifecycle: $expected_lifecycle}' \
+            > "$AGENT_TASK"
 
           set +e
           opencode run \
@@ -511,9 +472,11 @@ jobs:
             --format json \
             --file "$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md" \
             --file "$WORKFLOW_SOURCE/prompts/model-fit.md" \
+            --file "$WORKFLOW_SOURCE/prompts/onboard-model/qualify.md" \
+            --file "$WORKFLOW_SOURCE/prompts/onboard-model/investigate.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md" \
             --file "$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md" \
-            --file "$AGENT_PROMPT" > "$AGENT_EVENTS"
+            --file "$AGENT_TASK" > "$AGENT_EVENTS"
           agent_status=$?
           set -e
           jq -s -r '[.[] | select(.type == "text") | .part.text][-1] // empty' \
@@ -872,7 +835,7 @@ jobs:
           rm -f \
             "$APP_KEY_FILE" \
             "$AGENT_EVENTS" \
-            "$AGENT_PROMPT" \
+            "$AGENT_TASK" \
             "$AGENT_OUTPUT" \
             "$ONBOARD_SUMMARY" \
             "$PR_SUMMARY" \

--- a/.opencode/agents/onboard-investigator.md
+++ b/.opencode/agents/onboard-investigator.md
@@ -14,10 +14,6 @@ permission:
   websearch: allow
 ---
 
-Investigate only the model-onboarding question supplied by the parent agent. Use at most four public-web calls and
-prefer current primary sources: official model metadata, engine documentation and release notes, official container
-registries, and upstream issue trackers. For an unavailable image, verify whether the tag moved, the repository was
-renamed, or a newer compatible release exists. For a runtime failure, identify the smallest evidence-backed next
-test. Inspect repository files when useful, but never modify files, invoke another agent, use credentials, or run a
-remote workload. Return concise evidence, source URLs, exact candidate tags or flags, and remaining uncertainty to
-the parent agent.
+Apply the investigation prompt and exact question supplied by the parent agent. Inspect repository files when useful,
+but never modify files, invoke another agent, use credentials, or run a remote workload. Return only the requested
+evidence to the parent agent; do not qualify the model, choose artifacts, or draw the run's conclusions.

--- a/.opencode/agents/onboard-model.md
+++ b/.opencode/agents/onboard-model.md
@@ -22,7 +22,8 @@ permission:
 ---
 
 You are Emmy's non-interactive model qualification agent. Load the `onboard-model` skill before doing task work and
-follow it exactly, including every linked skill and architecture document. Use only the supplied GPU server, finish
-before the supplied deadline, keep only the authorized repository artifacts, write the atomic summary even on
-failure, and never commit, push, or change pull requests. Delegate only bounded, independent read-only research or
-failure diagnosis to `onboard-investigator`; retain responsibility for edits, commands, measurements, and conclusions.
+follow its attached qualification and investigation prompts exactly, including every linked skill and architecture
+document. Use only the supplied GPU server, finish before the supplied deadline, keep only the authorized repository
+artifacts, write the atomic summary even on failure, and never commit, push, or change pull requests. Delegate only
+bounded, independent read-only research or failure diagnosis to `onboard-investigator`; retain responsibility for
+edits, commands, measurements, and conclusions.

--- a/prompts/onboard-model/investigate.md
+++ b/prompts/onboard-model/investigate.md
@@ -1,0 +1,15 @@
+# Investigate One Onboarding Question
+
+Investigate exactly the one model-onboarding question supplied by the parent. Do no other work: no repository edits,
+no deployments, no measurements, no conclusions about whether the model qualifies.
+
+Use at most four public-web calls and prefer current primary sources: official model metadata, engine documentation
+and release notes, official container registries, and upstream issue trackers. For an unavailable image, establish
+whether the tag moved, the repository was renamed, or a newer compatible release exists. For a runtime failure,
+identify the smallest evidence-backed next test from the evidence the parent supplied.
+
+Inspect repository files when useful, but never modify a file, invoke another agent, use credentials, or run a remote
+workload.
+
+Return concise evidence, source URLs, exact candidate tags or flags, and the remaining uncertainty. Say plainly when
+the sources do not settle the question; a negative result is a useful answer and a guessed tag is not.

--- a/prompts/onboard-model/qualify.md
+++ b/prompts/onboard-model/qualify.md
@@ -1,0 +1,74 @@
+# Non-Interactive Model Qualification
+
+Use the attached onboarding task as the complete run request. Its fields are the only source of the model, hardware,
+credentials path, and deadline; never select, substitute, or infer any of them. The attached exact-workflow-SHA copies
+of the `onboard-model`, `tune-kernels`, and `run-experiment` skills are authoritative — follow them instead of any
+older skill copy in the checkout. Do not ask follow-up questions; a missing or ambiguous task field is an immediate
+failure.
+
+## Task fields
+
+| Field | Use |
+| --- | --- |
+| `mode` | exactly `onboarding` or `verification`; drives the recipe policy below and is echoed in the summary |
+| `model_id` | the exact Hugging Face model ID to qualify |
+| `gpu` / `gpu_count` | the exact target platform; never change the GPU name, count, quantization, or checkpoint |
+| `ssh_target`, `ssh_host`, `ssh_user`, `ssh_port` | the supplied server; the only host this run may use |
+| `ssh_key` | pass `--ssh-key <value>` to every Emmy remote command |
+| `deadline` | absolute wall-clock deadline for the whole run |
+| `multimodal_mode` | `auto`, `multimodal`, or `text-only` qualification path |
+| `publish_image` | `true` authorizes publishing a verified prebuilt Emmy image; `false` forbids publication |
+| `summary_path` | absolute path for the atomic machine-readable summary, outside the repository |
+| `expected_lifecycle` | in `verification` mode, the lifecycle tag the refreshed recipe must keep |
+
+The task's `publish_image` value is the publication authorization for this run. Do not add a conversational approval
+pause, and do not publish when it is `false`.
+
+## Recipe policy per mode
+
+In `onboarding` mode, use the existing `onboarding`/`untested` recipe shell when present, or create the recipe for a
+direct manual request. Preserve `model.heat` and replace `onboarding` and `untested` with `best-effort` only after
+qualification and artifact completion.
+
+In `verification` mode, begin from the existing recipe's current configuration, refresh its measured artifacts, and
+preserve its `expected_lifecycle` tag and `model.heat`.
+
+## Boundaries
+
+Do not select a model or GPU, provision or delete the VM, commit, push, or open or update a pull request. The caller
+owns those steps. Tear down every deployed workload before returning.
+
+For a missing image or an unfamiliar launch failure, investigate current official registries, release notes, engine
+documentation, and upstream issues. Test an evidence-backed current repository or tag when the configured image moved
+or disappeared, then pin the exact working tag or digest. You may implement a bounded, model-agnostic compatibility
+fix with focused tests when it is necessary for this exact qualification.
+
+Delegate only bounded, independent read-only research or failure diagnosis to the `onboard-investigator` subagent,
+giving it the complete contents of the attached `investigate.md` and exactly one question. Retain responsibility for
+every edit, command, measurement, and conclusion.
+
+## Repository artifacts
+
+Allowed areas are `recipes/` (including the model's `golden/` subdirectory), `experiments/`,
+`docker/vllm-emmy-serve/models/`, and a bounded small fix under `emmy/` with its focused tests and nearest
+`ARCHITECTURE.md` updates.
+
+Replace only this platform's `results_<gpu-short>x<gpu-count>.tar.gz` archive and preserve every other platform
+archive and `RESULTS.md` section. The archive must contain the platform's system-only experiment records; do not
+retain those records as top-level files. Update the final recipe's `RESULTS.md` for this platform while preserving
+still-valid measurements for its other platforms. Do not retain the ignored dated run directory or qualification
+summaries in the checkout.
+
+Git LFS is already configured through the caller's local attributes. Verify that the named archive reports
+`filter: lfs`, but do not run `git lfs track` and do not modify or list `.gitattributes` in the summary.
+
+## Output
+
+Always write the skill's atomic summary to `summary_path`, on success and on failure, with `mode` set to the task's
+mode. List every intended created, modified, or deleted repository file in `artifacts` and no exploratory output.
+Include `experiment_artifacts` with the shared experiment recipe and `RESULTS.md` plus the exact platform archive, and
+one-line `deployment_summary` and `performance_summary` values drawn from the exact selected recipe lane.
+
+On failure, set `failure.regression` to `true` only when a previously qualified behavior or measured performance lane
+regressed and the bounded fix attempt could not restore it. Keep the message concise and credential-free; the caller
+sends it to a chat notification. Print the summary path as the final line and return nonzero for a failed run.

--- a/prompts/onboard-model/qualify.md
+++ b/prompts/onboard-model/qualify.md
@@ -53,6 +53,10 @@ Allowed areas are `recipes/` (including the model's `golden/` subdirectory), `ex
 `docker/vllm-emmy-serve/models/`, and a bounded small fix under `emmy/` with its focused tests and nearest
 `ARCHITECTURE.md` updates.
 
+Every platform shares one serving experiment root, `experiments/<model>/serving/`; reuse it when it exists and
+never create a platform-suffixed root. The platform appears in the archive filename, not in a directory name. The
+summary's `experiment` field is that root's `recipe.yaml` path, never a directory.
+
 Replace only this platform's `results_<gpu-short>x<gpu-count>.tar.gz` archive and preserve every other platform
 archive and `RESULTS.md` section. The archive must contain the platform's system-only experiment records; do not
 retain those records as top-level files. Update the final recipe's `RESULTS.md` for this platform while preserving

--- a/prompts/onboard-model/qualify.md
+++ b/prompts/onboard-model/qualify.md
@@ -53,9 +53,10 @@ Allowed areas are `recipes/` (including the model's `golden/` subdirectory), `ex
 `docker/vllm-emmy-serve/models/`, and a bounded small fix under `emmy/` with its focused tests and nearest
 `ARCHITECTURE.md` updates.
 
-Every platform shares one serving experiment root, `experiments/<model>/serving/`; reuse it when it exists and
-never create a platform-suffixed root. The platform appears in the archive filename, not in a directory name. The
-summary's `experiment` field is that root's `recipe.yaml` path, never a directory.
+Reuse this model's existing serving experiment root when it already represents the protocol; many models keep a
+platform-named root such as `serving_v100_sxm2_16gb`. Create `experiments/<model>/serving/` only when the model has
+no such root, and never add a second root for a platform an existing one already covers. The summary's `experiment`
+field is that root's `recipe.yaml` path, never a directory.
 
 Replace only this platform's `results_<gpu-short>x<gpu-count>.tar.gz` archive and preserve every other platform
 archive and `RESULTS.md` section. The archive must contain the platform's system-only experiment records; do not

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -469,7 +469,7 @@ def test_onboarding_agent_reads_shared_prompts_from_a_compact_task():
         assert f"{field}:" in script
         assert f"`{field}`" in qualify
     assert "Do not select a model or GPU, provision or delete the VM, commit, push" in qualify
-    assert "never create a platform-suffixed root" in qualify
+    assert "never add a second root for a platform an existing one already covers" in qualify
     assert "`recipe.yaml` path, never a directory" in qualify
     assert "Use at most four public-web calls" in investigate
     assert "Apply the investigation prompt" in investigator

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -149,6 +149,7 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     agent_script = next(step["run"] for step in steps if step.get("name") == "Run onboard-model agent")
     cleanup_script = next(step["run"] for step in steps if step.get("name") == "Remove archived task-local raw results")
     validation_script = next(step["run"] for step in steps if step.get("name") == "Validate and stage model artifacts")
+    qualify = (workspace / "prompts" / "onboard-model" / "qualify.md").read_text()
 
     assert "lfs_version=3.7.1" in lfs_script
     assert "sha256sum --check" in lfs_script
@@ -162,14 +163,14 @@ def test_onboarding_requires_platform_results_snapshot_and_git_lfs():
     assert "tmpfs|ramfs" in host_setup_script
     assert "8388608" in host_setup_script
     subprocess.run(["bash", "-n"], input=host_setup_script, text=True, check=True)
-    assert "results_<gpu-short>x<gpu-count>.tar.gz" in agent_script
-    assert "preserve every other platform archive" in agent_script
-    assert "do not retain those records as" in agent_script
-    assert "onboard-investigator subagent" in agent_script
+    assert "results_<gpu-short>x<gpu-count>.tar.gz" in qualify
+    assert "preserve every other platform" in qualify
+    assert "do not\nretain those records as top-level files" in qualify
+    assert "`onboard-investigator` subagent" in qualify
+    assert "do not modify or list `.gitattributes`" in qualify
     assert '"$WORKFLOW_SOURCE/.agents/skills/onboard-model/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/tune-kernels/SKILL.md"' in agent_script
     assert '"$WORKFLOW_SOURCE/.agents/skills/run-experiment/SKILL.md"' in agent_script
-    assert "do not modify or list .gitattributes" in agent_script
     assert 'tarfile.open(temporary_archive, "w:gz")' in cleanup_script
     assert "temporary_roots = verify_archive(temporary_archive)" in cleanup_script
     assert "os.replace(temporary_archive, archive)" in cleanup_script
@@ -203,7 +204,9 @@ def test_onboarding_uses_bounded_read_only_investigator():
         "webfetch": "allow",
         "websearch": "allow",
     }
-    assert "Use at most four public-web calls" in " ".join(investigator.splitlines())
+    prompt = " ".join((workspace / "prompts" / "onboard-model" / "investigate.md").read_text().split())
+    assert "Use at most four public-web calls" in prompt
+    assert "never modify a file, invoke another agent, use credentials, or run a remote workload" in prompt
 
 
 def test_onboarding_removes_only_raw_results_preserved_by_platform_archive(tmp_path):
@@ -442,6 +445,32 @@ def test_shared_model_fit_prompt_reaches_both_lifecycle_skills():
         scripts = [step.get("run", "") for job in document["jobs"].values() for step in job["steps"]]
         assert any('--file "$WORKFLOW_SOURCE/prompts/model-fit.md"' in script for script in scripts)
     assert "vram_mib" not in Path(lifecycle).read_text()
+
+
+def test_onboarding_agent_reads_shared_prompts_from_a_compact_task():
+    workspace = Path(__file__).parents[2]
+    document = yaml.safe_load((workspace / ".github" / "workflows" / "onboard-model.yml").read_text())
+    job = document["jobs"]["onboard"]
+    script = next(step["run"] for step in job["steps"] if step.get("name") == "Run onboard-model agent")
+    qualify = (workspace / "prompts" / "onboard-model" / "qualify.md").read_text()
+    investigate = (workspace / "prompts" / "onboard-model" / "investigate.md").read_text()
+    skill = (workspace / ".agents" / "skills" / "onboard-model" / "SKILL.md").read_text()
+    investigator = (workspace / ".opencode" / "agents" / "onboard-investigator.md").read_text()
+
+    assert job["env"]["OPENCODE_CONFIG_DIR"] == f"{job['env']['WORKFLOW_SOURCE']}/.opencode"
+    assert '--file "$WORKFLOW_SOURCE/prompts/onboard-model/qualify.md"' in script
+    assert '--file "$WORKFLOW_SOURCE/prompts/onboard-model/investigate.md"' in script
+    assert '--file "$AGENT_TASK"' in script
+    assert "jq -n \\" in script
+    assert "Path(os.environ" not in script
+    assert "prompts/onboard-model/qualify.md" in skill
+    assert "prompts/onboard-model/investigate.md" in skill
+    for field in ("mode", "model_id", "gpu_count", "ssh_key", "deadline", "publish_image", "summary_path"):
+        assert f"{field}:" in script
+        assert f"`{field}`" in qualify
+    assert "Do not select a model or GPU, provision or delete the VM, commit, push" in qualify
+    assert "Use at most four public-web calls" in investigate
+    assert "Apply the investigation prompt" in investigator
 
 
 def test_fit_subagent_sizes_each_onboarding_model_alone():

--- a/tests/github/test_discovery_lifecycle.py
+++ b/tests/github/test_discovery_lifecycle.py
@@ -469,6 +469,8 @@ def test_onboarding_agent_reads_shared_prompts_from_a_compact_task():
         assert f"{field}:" in script
         assert f"`{field}`" in qualify
     assert "Do not select a model or GPU, provision or delete the VM, commit, push" in qualify
+    assert "never create a platform-suffixed root" in qualify
+    assert "`recipe.yaml` path, never a directory" in qualify
     assert "Use at most four public-web calls" in investigate
     assert "Apply the investigation prompt" in investigator
 


### PR DESCRIPTION
## Summary

`onboard-model` now follows the same structure as `discover-models`: tracked prompt files own the run policy, and the
workflow renders only a compact task payload.

- **New shared prompts** — `prompts/onboard-model/qualify.md` is the canonical non-interactive contract (task-field
  table, per-mode recipe policy, caller-owned boundaries, image and bounded-fix investigation policy, artifact/LFS
  rules, summary contract). `prompts/onboard-model/investigate.md` is the bounded `onboard-investigator` prompt,
  mirroring `score-recipes.md` and `size-deployments.md`.
- **Workflow** — the ~60-line Python heredoc that built a prose prompt is replaced by a `jq -n` task object
  (`schema_version`, mode, model, exact target, SSH handles, deadline, publication flag, summary path, expected
  lifecycle). Both prompts are attached from the exact workflow SHA alongside the three skills and `model-fit.md`.
- **`OPENCODE_CONFIG_DIR`** is now pinned to the workflow source, as discovery already does, so the onboarding agent
  definitions come from the commit that started the run rather than whatever sits on the rolling branch. This is the
  only behavior change beyond relocation; the artifact worktree still stays on the rolling branch.
- **Skill and agents** — `SKILL.md` gains a "Step 0 — Choose the run mode" section pointing at `qualify.md`, and its
  delegation paragraph hands the investigator `investigate.md`. `onboard-investigator.md` shrinks to an
  "apply the supplied prompt" role like `discover-scorer`/`discover-fit`.

## Testing

- `make test` — 2947 passed, 578 skipped; `make lint` clean.
- Two existing tests that asserted the prose inside the workflow script now assert it in the prompt files, plus a new
  `test_onboarding_agent_reads_shared_prompts_from_a_compact_task`.
- Rendered the new `jq` step under representative env values and checked the fragment with `bash -n`.
- A live `workflow_dispatch` of **Verify or onboard model** on this branch could not exercise the agent step: every
  attempt (OLMoE-1B-7B on RTX 4090 and RTX 5090, and Llama-4-Scout-17B-16E on RTX 4090 — the exact pair this
  morning's nightly selected) stopped at "Select one available deployment" with no available exact CloudRift VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)