### PR TITLE
Fuse reshape-split free axes across a fused transpose (loop/canonicalize)

### DIFF
--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -313,14 +313,17 @@ splits one of the kernel's output axes into a nest of two (an attention projecti
 original axis through a composite index (`wt[k, h*D + d]`). Downstream that split is an eligibility lockout,
 not a slowdown: contraction binding reads the trailing free-axis pair as `(m, n)`, so the split kernel binds
 the wrong row, the weight load carries a third grid axis, and the warp/mma tiers are never enumerated — no
-search budget can reach a schedule family that does not exist. The canonicalization re-fuses an adjacent free
-pair via the bijective reindexing `p → f/Q, q → f%Q` (semantics-preserving unconditionally) and keeps the
-result only when every access folds clean: operand composites collapse to the bare fused axis (the
-`(f/Q)·Q + f%Q → f` recomposition fold in `Expr.simplify`), and a store spelling the pair as separate buffer
-dims keeps the honest `[…, f/Q, f%Q]` — accepted only when the buffer's row-major flatten folds it back to an
-affine address. Any surviving residue (an axis addressed alone, a permuted-stride split, a predicate over the
-pair) declines the pair and the nest stands. Split and unsplit spellings of one contraction thereby converge
-to ONE canonical nest — one kernel identity, one shape key, one golden family.
+search budget can reach a schedule family that does not exist. The canonicalization re-fuses a free pair via
+the bijective reindexing `p → f/Q, q → f%Q` (semantics-preserving unconditionally) and keeps the result only
+when every access folds clean: operand composites collapse to the bare fused axis (the `(f/Q)·Q + f%Q → f`
+recomposition fold in `Expr.simplify`), and a store spelling the pair as separate buffer dims keeps the honest
+split-store spelling — `[…, f/Q, f%Q]` when the buffer's row-major flatten folds it back to an affine address,
+or the permuted `[…, f/Q, …, f%Q]` of a transposed output. The pair need not be adjacent: free loops are
+parallel, so the perfectly-nested free loops between them (the `transpose(1, 2)` every attention projection
+fuses after its view puts `seq` between `heads` and `head_dim`) interchange outward and the fused axis takes
+the inner loop's place. Any surviving residue elsewhere (an axis addressed alone, a predicate over the pair)
+declines the pair and the nest stands. Split and unsplit spellings of one contraction thereby converge to ONE
+canonical nest — one kernel identity, one shape key, one golden family.
 
 It runs as its own pass between `loop/fusion` and `loop/stamp`, not inside `normalize_body` and not as a
 fusion rule. `normalize_body` is a pure body→body transform with no buffer shapes (the store-side stride
@@ -330,12 +333,20 @@ seam was recorded against the unfused nest. And canonicalizing a producer that s
 re-spell the very indices the splicer composes through, so it waits for fusion's fixpoint; running before
 `loop/stamp` means kernel identity and everything downstream see only the canonical spelling.
 
-Three consumers had assumed "one output axis per buffer dim" and were generalized with it: the lift's
-output-ordering reads an axis's store position through the index exprs' free vars (the fused axis reaches the
-store as its `f/Q, f%Q` pair); the mma `RegStore`'s auto row stride derives from the store template's
-innermost M-carrying dim (`row_dim`) instead of assuming the inner extent — under a split store, `shape[-1]`
-is not the row stride; and `080_vectorize_stores` re-reads a run its per-dim matching declines by the
-row-major flat address when a div/mod residue is present, so a split store keeps its vectorized transactions.
+The consumers that had assumed "one output axis per buffer dim" were generalized with it, all on one
+reading — an axis's unit step moves its INNERMOST carrying dim (the `%` dim of a split pair): the lift's
+output-ordering positions an axis at that dim (under the permuted store the quotient dim sits outside another
+axis entirely, and positioning there would make the fused axis the row and the stride-`Q` axis the column);
+the mma `RegStore`'s auto row stride derives from the store template's innermost M-carrying dim (`row_dim`)
+instead of assuming the inner extent; an epilogue load's per-dim role (`_warp_roles`) moves only that dim;
+and `080_vectorize_stores` re-reads a run its per-dim matching declines by the row-major flat address when a
+div/mod residue is present, so a row-major split store keeps its vectorized transactions (the permuted one
+stores scalar on the scalar tiers — exact, unvectorized). The warp tier's fragment store evaluates the cell
+base once per atom and adds `col` / `row · ldm` across it, so a split pair is mma-addressable only when the
+row-major flatten recomposes it, or when the `%` dim is the innermost carrier (contiguous for `n`) with `Q` a
+multiple of the atom extent — an aligned atom never straddles a `Q` boundary. That is the `warp_split_store`
+legality predicate: dropped by the unpinned catalog, raised on a pin, like every other tile gate; the scalar
+tiers, which evaluate every element's index, are always exact.
 
 ## Resolve the hardware-atom binding once, structurally, at the tile level
 

--- a/emmy/compiler/pipeline/passes/loop/canonicalize/010_fuse_split_free_axes.py
+++ b/emmy/compiler/pipeline/passes/loop/canonicalize/010_fuse_split_free_axes.py
@@ -8,17 +8,22 @@ not a slowdown: contraction binding assigns ``(m, n)`` to the trailing free-axis
 kernel binds the wrong row, the weight load carries a third grid axis, and the warp/mma tier is
 never enumerated — the kernel stays a scalar reduce no amount of tuning can rescue.
 
-This rule restores the canonical spelling: two adjacent free loops ``p`` (extent P) over ``q``
-(extent Q) — perfectly nested, both static — fuse into one axis of extent P·Q via the bijective
+This rule restores the canonical spelling: two free loops ``p`` (extent P) over ``q`` (extent
+Q) — perfectly nested, both static — fuse into one axis of extent P·Q via the bijective
 reindexing ``p → f / Q``, ``q → f % Q``, with every coordinate expression σ-substituted and
-re-simplified. The substitution is semantics-preserving unconditionally; whether it lands is a
-PROFITABILITY gate checked after the fact: every rewritten access must fold clean. A composite
-operand index collapses to the bare axis (``(f/Q)·Q + f%Q → f``, the recomposition fold in
-``Expr.simplify``); a store that indexes the pair as separate buffer dims keeps the honest
-``[…, f/Q, f%Q]`` spelling, accepted only when the buffer's row-major flatten folds it back to an
-affine address (the strides match the split, so the emitted address is byte-identical). Any access
-where a div/mod residue would survive — an axis used alone, a permuted-stride split, a predicate
-over the pair — declines the pair, and the nest stands.
+re-simplified. The pair need not be adjacent: free loops are parallel by definition, so a
+perfectly-nested run of free loops between them (the ``transpose(1, 2)`` every attention
+projection fuses after its view puts ``seq`` between ``heads`` and ``head_dim``) interchanges
+outward and the fused axis takes ``q``'s place under it. The substitution is semantics-preserving
+unconditionally; whether it lands is a PROFITABILITY gate checked after the fact: every rewritten
+access must fold clean. A composite operand index collapses to the bare axis (``(f/Q)·Q + f%Q →
+f``, the recomposition fold in ``Expr.simplify``); a store that indexes the pair as separate
+buffer dims keeps the honest split-store spelling — ``[…, f/Q, f%Q]`` when the buffer's
+row-major flatten folds it back to an affine address, or the permuted ``[…, f/Q, …, f%Q]`` of a
+transposed output, whose address is per-element exact on every scalar tier and whose warp-tier
+addressability is the scheduler's legality question (``warp_split_store``). Any access where a
+div/mod residue would otherwise survive — an axis used alone, a predicate over the pair —
+declines the pair, and the nest stands.
 
 Runs to fixpoint inside one rewrite (a three-way split fuses pairwise), AFTER ``loop/fusion`` is
 quiescent — canonicalizing a producer that still awaits a merge could re-spell the very indices the
@@ -39,6 +44,7 @@ from emmy.compiler.ir.sigma import Sigma
 from emmy.compiler.ir.stmt import Body, Load, Loop, Write
 from emmy.compiler.ir.stmt.passes import simplify as _simplify_stmt
 from emmy.compiler.pipeline import Match, Pattern, RuleSkipped
+from emmy.compiler.pipeline.passes.lowering._addr import split_pair
 
 PATTERN = [Pattern("root", LoopOp)]
 
@@ -58,11 +64,15 @@ def _no_divmod_on(e: Expr, name: str) -> bool:
     return True
 
 
-def _access_ok(index: tuple, shape, fname: str) -> bool:
+def _access_ok(index: tuple, shape, fname: str, store: bool = False) -> bool:
     """A rewritten access folds clean when its index exprs carry no div/mod residue on the fused
     axis, or — the split-store spelling ``[…, f/Q, f%Q]`` — when the buffer's row-major flatten
-    recomposes the residue to an affine address (needs the full static shape)."""
+    recomposes the residue to an affine address (needs the full static shape). A ``store`` may
+    also keep the bare pair at permuted strides (``[…, f/Q, …, f%Q]``): every tier addresses an
+    output element at its own coordinate, so the spelling is exact by construction."""
     if all(_no_divmod_on(e, fname) for e in index if fname in e.free_vars()):
+        return True
+    if store and split_pair(index, fname) is not None:
         return True
     if shape is None or len(shape) != len(index) or not all(getattr(d, "is_static", False) for d in shape):
         return False
@@ -80,15 +90,17 @@ def _folds_clean(fused: Loop, fname: str, shapes: dict) -> bool:
             if not _access_ok(s.index, shapes.get(s.input), fname):
                 return False
         elif isinstance(s, Write):
-            if not _access_ok(s.index, shapes.get(s.output), fname):
+            if not _access_ok(s.index, shapes.get(s.output), fname, store=True):
                 return False
         elif any(fname in e.free_vars() and not _no_divmod_on(e, fname) for e in s.exprs()):
             return False
     return True
 
 
-def _fuse_pair(outer: Loop, inner: Loop, shapes: dict) -> Loop | None:
-    """The fused loop for a perfectly-nested free pair, or ``None`` when the pair declines."""
+def _fuse_pair(outer: Loop, inner: Loop, shapes: dict, between: tuple[Loop, ...] = ()) -> Loop | None:
+    """The fused nest for a perfectly-nested free pair, or ``None`` when the pair declines. The
+    free loops ``between`` them (outermost first) interchange outward: the fused axis sits where
+    ``inner`` was, under them."""
     p, q = outer.axis, inner.axis
     if p.name == q.name or p.window is not None or q.window is not None:
         return None
@@ -107,18 +119,31 @@ def _fuse_pair(outer: Loop, inner: Loop, shapes: dict) -> Loop | None:
     body = Body(tuple(s.rewrite(lambda n: n, sigma) for s in inner.body))
     fused = Loop(axis=Axis(q.name, big * small), body=body, unroll=outer.unroll or inner.unroll, role=AxisRole.FREE, seed=inner.seed)
     fused = _simplify_stmt(fused, SimplifyCtx.empty())
-    return fused if _folds_clean(fused, q.name, shapes) else None
+    if not _folds_clean(fused, q.name, shapes):
+        return None
+    for mid in reversed(between):
+        fused = replace(mid, body=Body((fused,)))
+    return fused
+
+
+def _free_chain(loop: Loop) -> list[Loop]:
+    """``loop`` and the perfectly-nested free loops under it, outermost first."""
+    out = [loop]
+    while len(out[-1].body) == 1 and isinstance(out[-1].body[0], Loop) and not out[-1].body[0].is_reduce:
+        out.append(out[-1].body[0])
+    return out
 
 
 def _fuse_once(body: Body, shapes: dict) -> Body | None:
-    """The body with ONE pair fused (outermost-first, depth-first), or ``None`` when no pair
-    fuses. The caller iterates to fixpoint, so an outer pair exposed by an inner fusion is
-    picked up on the next round."""
+    """The body with ONE pair fused (outermost-first, depth-first, the nearest partner first), or
+    ``None`` when no pair fuses. The caller iterates to fixpoint, so an outer pair exposed by an
+    inner fusion is picked up on the next round."""
     for i, s in enumerate(body):
         if not isinstance(s, Loop) or s.is_reduce:
             continue
-        if len(s.body) == 1 and isinstance(s.body[0], Loop) and not s.body[0].is_reduce:
-            fused = _fuse_pair(s, s.body[0], shapes)
+        chain = _free_chain(s)
+        for j in range(1, len(chain)):
+            fused = _fuse_pair(s, chain[j], shapes, tuple(chain[1:j]))
             if fused is not None:
                 return Body((*body[:i], fused, *body[i + 1 :]))
         inner = _fuse_once(s.body, shapes)

--- a/emmy/compiler/pipeline/passes/lowering/_addr.py
+++ b/emmy/compiler/pipeline/passes/lowering/_addr.py
@@ -1,6 +1,7 @@
 """Flat-address `Expr` builders — fold-aware `sum` / `product` over int / `Expr` terms, used to
 construct σ-tiled load/store indices in the lowering passes (`enumeration/_build` warp-tier σ-tiling,
-`assembly/_assemble` carrier realization), plus `gmem_axis_step` / `gmem_row_stride` — how a gmem
+`assembly/_assemble` carrier realization), plus `split_pair` — the re-fused split-store spelling of an
+axis across two buffer dims — and `gmem_axis_step` / `gmem_row_stride` — how a gmem
 `Load`'s flat address moves along one axis, the row step (`ldm`) a fragment loader reads off the
 index and buffer shape and the contiguity its columns need, plus `BYTE_SLAB_PAD` — the smem row pad
 a cp.async-staged byte slab carries. Generic Expr / addressing algebra — no flash / attention /
@@ -233,3 +234,18 @@ def _delinearized(index: tuple, shape: tuple) -> Expr | None:
         elif e != flat:
             return None  # the coordinates delinearize DIFFERENT expressions — not one reshape
     return flat
+
+
+def split_pair(index: tuple, name: str) -> int | None:
+    """``Q`` when the exprs of ``index`` mentioning ``name`` are exactly one ``name // Q`` and one
+    ``name % Q`` (the split-store spelling a re-fused axis reaches a buffer with, in either dim
+    order), else ``None``."""
+    carrying = [e for e in index if name in e.free_vars()]
+    if len(carrying) != 2:
+        return None
+    parts: dict[str, int] = {}
+    for e in carrying:
+        if not (isinstance(e, BinaryExpr) and e.op in ("//", "%") and e.left == Var(name) and isinstance(e.right, Literal)):
+            return None
+        parts[e.op] = int(e.right.value)
+    return parts["//"] if set(parts) == {"//", "%"} and parts["//"] == parts["%"] else None

--- a/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
+++ b/emmy/compiler/pipeline/passes/lowering/kernel/_atom.py
@@ -158,12 +158,17 @@ def _cells(mn: tuple, offset, i: int, j: int):
 
 # ---- warp/mma tier ----------------------------------------------------------------------------- #
 def _warp_roles(index, m_name: str, n_name: str) -> tuple[str, ...]:
-    """Per-dim epilogue-load role: ``"m"`` / ``"n"`` for a dim varying with the output row /
-    col axis, else ``"fixed"`` (batch / grid literal — uniform across the fragment cell)."""
-    roles = []
-    for e in index:
-        fv = e.free_vars()
-        roles.append("m" if m_name in fv else "n" if n_name in fv else "fixed")
+    """Per-dim epilogue-load role: ``"m"`` / ``"n"`` for the dim the output row / col axis moves
+    within the fragment cell, else ``"fixed"`` (batch / grid literal — uniform across the cell).
+    Only the INNERMOST dim carrying an axis moves (the same reading as :func:`_row_dim`): a
+    re-fused split axis reaches the load as ``[…, f/Q, …, f%Q]``, and within an atom the
+    quotient dim is uniform — giving both dims the role would add the lane offset at two
+    strides."""
+    roles = ["fixed"] * len(index)
+    for role, name in (("n", n_name), ("m", m_name)):
+        dims = [d for d, e in enumerate(index) if name in e.free_vars()]
+        if dims:
+            roles[dims[-1]] = role
     return tuple(roles)
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_legality.py
@@ -34,12 +34,13 @@ from __future__ import annotations
 from dataclasses import replace
 
 from emmy.compiler.ir.axis import Axis
+from emmy.compiler.ir.expr import BinaryExpr
 from emmy.compiler.ir.pure.fold import Fold, operand_name
 from emmy.compiler.ir.schedule import ReducePlan, Stage, TilePlan, WarpSpec
-from emmy.compiler.ir.stmt import Body, Load, Loop
+from emmy.compiler.ir.stmt import Body, Load, Loop, Write
 from emmy.compiler.ir.stmt.passes import has_contraction_tail
 from emmy.compiler.ir.tile.ops import chain_edge, cone_seam
-from emmy.compiler.pipeline.passes.lowering._addr import BYTE_SLAB_PAD, gmem_axis_step
+from emmy.compiler.pipeline.passes.lowering._addr import BYTE_SLAB_PAD, gmem_axis_step, split_pair
 from emmy.compiler.pipeline.search.space import MAX_BLOCK_THREADS, WARP_LANES
 
 # TMA hardware: every box dim must fall in 1..256, and the swizzle-split box caps the operand rank
@@ -290,6 +291,55 @@ def fragment_epilogue(epilogue: Body) -> str | None:
                 "token to use the scalar tier."
             )
         defs.update(s.defines())
+    return None
+
+
+def _split_addressable(index: tuple, shape, name: str, atom_ext: int, trailing: bool) -> str | None:
+    """Whether the fragment store's per-cell addressing — the cell base evaluated once at the atom
+    origin, then ``+ col`` / ``+ row · ldm`` across the atom — is exact for an axis that reaches the
+    buffer as a split dim pair. It is when the row-major flatten recomposes the pair to an affine
+    address (the strides match the split), or when the ``%`` dim is the innermost carrier and its
+    modulus is a multiple of the atom extent, so an aligned atom never straddles a ``Q`` boundary."""
+    dims = [d for d, e in enumerate(index) if name in e.free_vars()]
+    if len(dims) < 2:
+        return None
+    q = split_pair(index, name)
+    if q is None:
+        return "not a bare f/Q, f%Q pair"
+    inner = index[dims[1]]
+    if not (isinstance(inner, BinaryExpr) and inner.op == "%"):
+        return "the quotient dim is the inner one"
+    if trailing and dims[1] != len(index) - 1:
+        return "the remainder dim is not the contiguous one"
+    if shape is not None and len(shape) == len(index) and all(getattr(d, "is_static", False) for d in shape):
+        stride, strides = 1, [1] * len(index)
+        for d in reversed(range(len(index))):
+            strides[d] = stride
+            stride *= shape[d].as_static()
+        if strides[dims[0]] == q * strides[dims[1]]:
+            return None  # row-major recomposition — the address is affine in the axis
+    if q % atom_ext:
+        return f"Q={q} is not a multiple of the {atom_ext}-wide atom cell"
+    return None
+
+
+def warp_split_store(tail: list, free: tuple, atom_shape: tuple, shapes: dict) -> str | None:
+    """The fragment epilogue addresses the output (and each epilogue load) per ATOM: the cell base
+    is evaluated once at the atom origin and the lanes add ``col`` / ``row · ldm``. A re-fused
+    split axis spells its coordinate across two buffer dims (``[…, f/Q, …, f%Q]``), and that is
+    addressable only under :func:`_split_addressable`; otherwise the scalar tiers, which evaluate
+    every element's index, are the kernel's tiers."""
+    roles = [(free[-1].name, atom_shape[1], "n", True)]
+    if len(free) >= 2:
+        roles.append((free[-2].name, atom_shape[0], "m", False))
+    for s in tail:
+        if not isinstance(s, (Write, Load)):
+            continue
+        buf = s.output if isinstance(s, Write) else s.input
+        for name, ext, role, trailing in roles:
+            why = _split_addressable(s.index, getattr(shapes.get(buf), "shape", None), name, ext, trailing)
+            if why is not None:
+                return f"warp TILE: the {role} axis reaches {buf} as a split dim pair the fragment store cannot address ({why})"
     return None
 
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_lift.py
@@ -180,12 +180,14 @@ def _order_free_by_output(node, free: list, stores: tuple = ()) -> tuple:
         write = next((st.write for st in stores if st.sweep is None), None)
     if write is None:
         return tuple(free)
-    # Position by index-expr membership, not bare-Var identity: a re-fused axis reaches the
-    # store as the split pair ``[…, f/Q, f%Q]``, and its position is the outer of the two.
+    # Position by index-expr membership, not bare-Var identity, at the INNERMOST dim carrying the
+    # axis: a re-fused axis reaches the store as the split pair ``f/Q`` … ``f%Q``, and the
+    # remainder dim is the one its unit step moves — under a transposed output
+    # (``[…, f/Q, s, f%Q]``) the quotient dim sits outside another axis entirely.
     pos: dict[str, int] = {}
     for i, e in enumerate(write.index):
         for v in e.free_vars():
-            pos.setdefault(v, i)
+            pos[v] = i
     order = list(free)
     return tuple(sorted(free, key=lambda ax: (1, pos[ax.name]) if ax.name in pos else (0, order.index(ax))))
 

--- a/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_schedule.py
@@ -542,6 +542,9 @@ def _tile_ok(term: _Term, node, plan: TilePlan) -> bool:
     ``_legality`` predicates, dropped here and RAISED on a pin (:func:`_contraction_values`)."""
     if not legal.enforce(legal.warp_atom_target(plan.atom, term.ctx), pinned=False):
         return False
+    shapes = {**term.tile.inputs, **term.tile.outputs}
+    if not legal.enforce(legal.warp_split_store(projection_tail(term.tile), term.place.free, plan.atom.shape, shapes), pinned=False):
+        return False
     conv = _converting_a(node, plan.atom, term.tile.inputs)
     # The converting fill reads A per element through its own σ — the fragment loader's contiguous
     # K-column requirement is a gmem-direct/byte-transport fact and does not apply to it.
@@ -1029,6 +1032,8 @@ def _contraction_blocks(term: _Term, node, work: Workers | None) -> list[Block]:
                     legal.enforce(legal.warp_a_columns(node, plan, term.tile.inputs), pinned=True)
                 legal.enforce(legal.warp_k_step(node, plan), pinned=True)
                 legal.enforce(legal.fragment_epilogue(term.proj), pinned=True)
+                shapes = {**term.tile.inputs, **term.tile.outputs}
+                legal.enforce(legal.warp_split_store(projection_tail(term.tile), term.place.free, plan.atom.shape, shapes), pinned=True)
                 if _has_computed_operand(node) or conv:
                     legal.enforce(legal.computed_operand_cover(node, plan.placed_on(term.place), converting_a=conv), pinned=True)
                     legal.enforce(

--- a/tests/compiler/passes/test_fuse_split_free_axes.py
+++ b/tests/compiler/passes/test_fuse_split_free_axes.py
@@ -4,8 +4,10 @@ A view fused into a contraction iterates the post-view axes while the operand lo
 producer's single axis through a composite index — which locks the kernel out of contraction
 binding (the trailing free pair reads the wrong row and the weight load carries a third grid
 axis). The canonicalization restores the single-axis spelling; these tests pin the fuse cases
-(N split, M split), the decline cases (an axis addressed alone, a permuted-stride split), the
-downstream classification of the canonical nest, and the binder's per-expr role purity."""
+(N split, M split, the pair across an intervening free loop — the transposed projection, the
+permuted split store), the decline case (an axis addressed alone), the downstream classification
+of the canonical nest, the warp tier's split-store addressability, and the binder's per-expr
+role purity."""
 
 from __future__ import annotations
 
@@ -142,11 +144,75 @@ def test_axis_addressed_alone_declines():
     assert [ln.axis.extent for ln in _free_chain(op)] == [Dim(M), Dim(H), Dim(D)], "the pair must decline"
 
 
-def test_permuted_split_declines():
+def test_permuted_split_fuses_with_the_split_store():
     """A store whose dims transpose the split (``[…, d, h]`` under an ``h*D + d`` operand index)
-    has no matching stride — the flatten cannot fold the residue, so the pair declines."""
+    still fuses: the output keeps the honest ``f%D, f//D`` pair — exact per element on every
+    scalar tier; whether the warp tier can address it is the scheduler's legality question."""
     op = _run(_graph(_split_n_body((Literal(0, "int"), Var("a0"), Var("a2"), Var("a1"))), (1, M, D, H)))
-    assert [ln.axis.extent for ln in _free_chain(op)] == [Dim(M), Dim(H), Dim(D)]
+    chain = _free_chain(op)
+    assert [ln.axis.extent for ln in chain] == [Dim(M), Dim(H * D)]
+    n = chain[1].axis.name
+    wr = next(s for s in op.body.iter() if isinstance(s, Write))
+    assert wr.index[2] == BinaryExpr("%", Var(n), Literal(D, "int"))
+    assert wr.index[3] == BinaryExpr("//", Var(n), Literal(D, "int"))
+
+
+def _transposed_body() -> Body:
+    """The attention projection's ``view(b, s, h, d).transpose(1, 2)``: free (h, s, d) — the
+    split pair (h, d) is NOT adjacent, ``s`` sits between — with the weight addressed
+    ``w[h*D + d, k]`` and the output stored ``[0, h, s, d]``."""
+    comp = BinaryExpr("+", BinaryExpr("*", Var("a0"), Literal(D, "int")), Var("a2"))
+    kloop = Loop(
+        axis=Axis("k", Dim(K)),
+        body=Body(
+            (
+                Load(name="wv", input="w", index=(comp, Var("k"))),
+                Load(name="xv", input="x", index=(Literal(0, "int"), Var("a1"), Var("k"))),
+                Assign(name="prod", op=ElementwiseImpl("multiply"), args=("wv", "xv")),
+                Accum(name="acc", value="prod", op=ElementwiseImpl("add"), axes=("k",)),
+            )
+        ),
+    )
+    cell = (kloop, Write(output="out", index=(Literal(0, "int"), Var("a0"), Var("a1"), Var("a2")), value="acc"))
+    nest = Loop(
+        axis=Axis("a0", Dim(H)),
+        body=Body((Loop(axis=Axis("a1", Dim(M)), body=Body((Loop(axis=Axis("a2", Dim(D)), body=Body(cell)),))),)),
+    )
+    return Body((nest,))
+
+
+def test_split_pair_fuses_across_an_intervening_free_loop():
+    """The transposed projection: the pair interchanges past ``s`` (free loops are parallel) and
+    fuses under it — the weight load collapses to the bare axis, the store keeps the permuted
+    ``[0, f//D, s, f%D]``."""
+    op = _run(_graph(_transposed_body(), (1, H, M, D)))
+    chain = _free_chain(op)
+    assert [ln.axis.extent for ln in chain] == [Dim(M), Dim(H * D)], "s stays outer; the (h, d) pair fuses under it"
+    n = chain[1].axis.name
+    wv = next(s for s in op.body.iter() if isinstance(s, Load) and s.input == "w")
+    assert wv.index == (Var(n), Var(_reduce_name(op)))
+    wr = next(s for s in op.body.iter() if isinstance(s, Write))
+    s_name = chain[0].axis.name
+    assert wr.index == (
+        Literal(0, "int"),
+        BinaryExpr("//", Var(n), Literal(D, "int")),
+        Var(s_name),
+        BinaryExpr("%", Var(n), Literal(D, "int")),
+    )
+
+
+def test_transposed_canonical_nest_orders_free_by_the_remainder_dim():
+    """Downstream: the lift positions an axis by the INNERMOST store dim carrying it, so under
+    the permuted store the fused axis stays the trailing ``n`` (its ``%`` dim is the contiguous
+    one) and the contraction binds with the weight as B. Positioning by the quotient dim would
+    make the fused axis ``m`` and the stride-``D`` ``s`` the column — the mma store's ``+ col``
+    would then address the wrong element (and did: a hang on the GPU)."""
+    op = _run(_graph(_transposed_body(), (1, H, M, D)))
+    tile = recognized_tile(op)
+    assert [a.extent for a in tile.place.free] == [Dim(M), Dim(H * D)]
+    node = tile.op
+    assert node.axis is not None and node.role is AxisRole.CONTRACTION
+    assert isinstance(node.b, Load) and node.b.input == "w"
 
 
 def test_canonical_nest_classifies_as_contraction():
@@ -220,3 +286,50 @@ def test_bind_bilinear_declines_composite_role_expr():
         con, _ = r
         for ch in con.channels:
             assert not isinstance(ch.b, Load), "the impure composite must not become a direct slab load"
+
+
+# --- the warp tier's split-store addressability --------------------------------------------------- #
+
+
+def _split_store_ok(index: tuple, shape: tuple, free_names=("m", "n"), atom=(16, 8, 16)) -> str | None:
+    from emmy.compiler.pipeline.passes.lowering.tile import _legality as legal
+
+    free = tuple(Axis(nm, Dim(4)) for nm in free_names)
+    shapes = {"out": Tensor("out", shape)}
+    return legal.warp_split_store([Write(output="out", index=index, value="acc")], free, atom, shapes)
+
+
+def _pair(name: str, q: int, op: str):
+    return BinaryExpr(op, Var(name), Literal(q, "int"))
+
+
+def test_warp_split_store_legality():
+    """The fragment store evaluates the cell base once per atom and adds ``col`` / ``row·ldm``:
+    a split dim pair is addressable when the row-major flatten recomposes it (strides match the
+    split, any ``Q``), or when the ``%`` dim is the innermost carrier, contiguous for ``n``, with
+    ``Q`` a multiple of the atom extent — an aligned atom never straddles a ``Q`` boundary."""
+    lit0 = Literal(0, "int")
+    # #561's row-major N split: affine recomposition, Q=4 is fine.
+    assert _split_store_ok((lit0, Var("m"), _pair("n", 4, "//"), _pair("n", 4, "%")), (1, 8, 3, 4)) is None
+    # The transposed projection: permuted strides, Q % 8 == 0.
+    assert _split_store_ok((lit0, _pair("n", 32, "//"), Var("m"), _pair("n", 32, "%")), (1, 2, 8, 32)) is None
+    # Permuted with Q=12: an 8-wide atom straddles a head boundary.
+    assert "Q=12" in _split_store_ok((lit0, _pair("n", 12, "//"), Var("m"), _pair("n", 12, "%")), (1, 4, 8, 12))
+    # The within-pair transpose (quotient dim inner) never addresses — in either stride regime.
+    assert "quotient" in _split_store_ok((lit0, Var("m"), _pair("n", 32, "%"), _pair("n", 32, "//")), (1, 8, 32, 2))
+    # An M-side permuted split (a batch dim between the row's pair) needs 16-row atoms inside
+    # one ``P`` block.
+    assert _split_store_ok((lit0, _pair("m", 32, "//"), Var("b"), _pair("m", 32, "%"), Var("n")), (1, 2, 3, 32, 16)) is None
+    assert "Q=8" in _split_store_ok((lit0, _pair("m", 8, "//"), Var("b"), _pair("m", 8, "%"), Var("n")), (1, 2, 3, 8, 16))
+
+
+def test_warp_roles_move_only_the_innermost_carrier():
+    """An epilogue load under a split store carries ``n`` in two dims; only the innermost (the
+    ``%`` dim) moves within the atom — both dims moving would add the lane offset at two
+    strides."""
+    from emmy.compiler.pipeline.passes.lowering.kernel._atom import _warp_roles
+
+    lit0 = Literal(0, "int")
+    assert _warp_roles((lit0, Var("m"), _pair("n", 32, "//"), _pair("n", 32, "%")), "m", "n") == ("fixed", "m", "fixed", "n")
+    assert _warp_roles((_pair("n", 32, "//"), Var("m"), _pair("n", 32, "%")), "m", "n") == ("fixed", "m", "n")
+    assert _warp_roles((Var("b"), Var("m"), Var("n")), "m", "n") == ("fixed", "m", "n")


### PR DESCRIPTION
## The lockout

The report's leftover split-N projection (`k_linear_38c5ad`, 0.07x eager after #561) was not the f16->f32 widening
it was attributed to. Reproduced as a snippet: `linear(x, w).view(1, 512, 24, 512).float()` already rides mma on
`main`; `linear(x, w).view(1, 512, 24, 512).transpose(1, 2)` (with or without the widening) does not — 0.03x eager,
thread inventories only. The fused `transpose(1, 2)` every attention projection applies after its view puts `seq`
between the split `(heads, head_dim)` pair, so #561's adjacent-pair rule never fired and the weight load kept its
composite `h*512 + d` index.

## The fix

- **`loop/canonicalize`** fuses the pair across intervening perfectly-nested free loops (free loops are parallel, so
  they interchange outward and the fused axis takes the inner loop's place) and keeps the permuted split store
  `[…, f/Q, s, f%Q]` — exact per element on every scalar tier.
- **The lift orders free axes by the INNERMOST store dim carrying them.** The first-occurrence reading made the fused
  axis the row and the stride-`Q` `seq` axis the mma column, so the fragment store's `+ col` addressed the wrong
  element — a GPU hang on the first try.
- **`_warp_roles` moves only the innermost carrier.** Both pair dims carried the `n` role, adding the lane offset at
  two strides — latent in #561's row-major case too (the bias-epilogue cases below exercise it).
- **`warp_split_store` legality** (dropped by the unpinned catalog, raised on a pin, like every tile gate): the
  fragment store evaluates the cell base once per atom and adds `col` / `row · ldm`, so a split pair is
  mma-addressable only when the row-major flatten recomposes it, or when the `%` dim is the innermost carrier with
  `Q` a multiple of the atom extent. `head_dim = 12` declines loudly; before wiring it into the pinned block it
  miscompiled under a `TILE` pin (mean_diff 3.3).

## Verification (RTX 4090, sm_89)

| snippet | before | after |
| --- | ---: | ---: |
| `linear(x,w).view(1,512,24,512).transpose(1,2)` pinned `w2x2 f4x4/k2 d2/smem-async` | 0.03x (no warp tier) | **419 us, 0.87x** |
| same `.float()` | 0.07x | 421 us, 0.90x |
| `view(1,64,8,8).transpose(1,2)` (tile wider than `Q`) | — | 1.29x, accuracy OK |
| `view(1,64,2,32) + b[2,32]` / transposed `+ b[2,1,32]`, serial reduce (single-kernel `RegStore` epilogue) | — | accuracy OK |
| `view(1,64,4,12).transpose(1,2)` | — | warp tier declined (`Q=12`), scalar tiers exact |

- `scripts/digest_kernels.py`: byte-identical to `main` (run back-to-back on both trees).
- Full suite: 3488 passed, 31 skipped, 18 xfailed. 6 new tests (interchange fusion, permuted split store, the
  innermost-dim free ordering through `recognized_tile`, the legality predicate's regimes, `_warp_roles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
