### PR TITLE
Point the V100 entries at the instance types CloudRift stocks

### DIFF
--- a/emmy/hardware.py
+++ b/emmy/hardware.py
@@ -62,7 +62,12 @@ GPU_INSTANCE_TYPES = {
     "AMD Instinct MI350X": [
         ("cloudrift", "mi350x-15-250-1000-gv"),
     ],
+    "NVIDIA Tesla V100 SXM2 16GB": [
+        ("cloudrift", "v100-6-52-400-generic"),
+    ],
     "NVIDIA Tesla V100 SXM3 32GB": [
+        # The RAID 6 DGX-2 pair sells 400 GiB of disk per GPU; the RAID 0 pair sells 800.
+        ("cloudrift", "v100-5-85-400-generic"),
         ("cloudrift", "v100-5-85-800-generic"),
     ],
 }

--- a/emmy/provisioning/ARCHITECTURE.md
+++ b/emmy/provisioning/ARCHITECTURE.md
@@ -36,6 +36,11 @@ provisioning/
    * **CloudRift** → one candidate per base type.
    * **GCP** → one candidate per zone in `hardware.GPU_GCP_ZONES[gpu_name]` (falls back to `DEFAULT_GCP_ZONE`); all zones for the current base type before advancing to the next entry.
 
+A GPU missing from `GPU_INSTANCE_TYPES`, or mapped only to base types the provider no longer stocks, is
+unreachable: `iter_candidates()` raises or yields instance types with no nodes, and the recipe-query availability
+annotation quietly reports the deployment as unavailable rather than failing. Every GPU a recipe declares must
+therefore have a current entry, and the entries stay ordered with the stocked base type first.
+
 The orchestrator tries candidates in this order until one succeeds or all are exhausted. Without a provider filter,
 fallback follows the hardware table across providers. An explicit `--provider` restricts the entire candidate list,
 so callers that request CloudRift are never silently relocated to GCP.

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,6 +1,11 @@
 """Unit tests for hardware lookup tables."""
 
+from pathlib import Path
+
+import yaml
+
 from emmy.hardware import GPU_INSTANCE_TYPES, GPU_SHORT_NAMES, gpu_short_name, resolve_instance_type
+from emmy.recipe.catalog import deployment_setups
 
 # ── resolve_instance_type ────────────────────────────────────────
 
@@ -62,3 +67,13 @@ def test_gpu_short_names_covers_all_instance_types():
     """Every GPU in GPU_INSTANCE_TYPES has a short name."""
     for gpu_name in GPU_INSTANCE_TYPES:
         assert gpu_name in GPU_SHORT_NAMES, f"GPU '{gpu_name}' missing from GPU_SHORT_NAMES"
+
+
+def test_every_declared_recipe_deployment_is_provisionable():
+    """A recipe deployment naming a GPU absent from the table can never be rented or selected."""
+    recipes = Path(__file__).parents[1] / "recipes"
+    for recipe_path in sorted(recipes.glob("*/recipe.yaml")):
+        config = yaml.safe_load(recipe_path.read_text()) or {}
+        for setup in deployment_setups(config):
+            gpu_name = setup["deploy.gpu"]
+            assert gpu_name in GPU_INSTANCE_TYPES, f"{recipe_path} declares '{gpu_name}', missing from GPU_INSTANCE_TYPES"


### PR DESCRIPTION
## Problem

Onboarding could not select any V100 deployment even while CloudRift had V100 nodes free. The cause is the hardware
table, not the recipes or the selector:

- `NVIDIA Tesla V100 SXM2 16GB` had **no entry** in `GPU_INSTANCE_TYPES`, so `iter_candidates()` raised
  `Unknown GPU ... not in hardware table` for the deployment `recipes/Meta-Llama-3.1-8B-Instruct-AWQ-INT4` declares.
- `NVIDIA Tesla V100 SXM3 32GB` mapped only to `v100-5-85-800-generic`, which currently reports **zero nodes**. Cato's
  RAID 6 DGX-2 pair sells through `v100-5-85-400-generic` (same GPU, 400 GiB of disk per GPU instead of 800).

`_annotate_cloudrift_availability` catches the `ValueError` and reports the deployment as unavailable, so both cases
surfaced only as the selector's generic "obsolete or has no available exact CloudRift VM".

## Fix

Map SXM2 16GB to `v100-6-52-400-generic` (Cato `usny01_a01`, 8× V100 SXM2 16GB boxes) and put the stocked
`v100-5-85-400-generic` ahead of the 800 GiB RAID 0 type for SXM3.

## Verification

Against the live CloudRift catalog, `emmy recipe query --filter 'deployment.availability.cloudrift == true'` returned
zero rows before and four after:

```
NousResearch/Meta-Llama-3.1-8B-Instruct            :: V100 SXM3 32GB x1
hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4 :: V100 SXM2 16GB x1
hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4 :: V100 SXM3 32GB x1
QuantTrio/Qwen3.6-35B-A3B-AWQ                      :: V100 SXM3 32GB x1
```

The new `test_every_declared_recipe_deployment_is_provisionable` asserts every GPU a bundled recipe declares is in the
table; it fails on the missing SXM2 entry without this change. The stale SXM3 mapping depends on live provider stock
and is not testable offline, which is why the architecture note spells out the invariant instead.

`tests/test_hardware.py`, `tests/provisioning`, `tests/recipe`, `tests/commands` pass; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)