### PR TITLE
Write a working golden's pools once per tune, not once per target

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -924,6 +924,14 @@ rows feed the shared prior immediately, so the following MCTS can use their evid
 the working file as soon as proposal measurement finishes, before MCTS. A multi-CudaOp result records realized knobs
 only when their union is conflict-free; otherwise the ranking is explicitly ambiguous.
 
+Each of those per-target persists rewrites the whole file, so its cost is the size of the inventory rather than of
+the entry that changed, and a whole-model sweep pays it once per target. They are written **incrementally**: the
+program and loop pools are nearly all of such a file by size and no persist mutates them, so an incremental write
+keeps the text they were already serialized to and reserializes only the configurations. The document is still
+validated in full and the bytes written are the ones a full dump writes; canonical and promotion dumps simply
+reserialize everything. On the 279-target DeepSeek V4 Flash V100 inventory a persist is 2.5 s before and 0.24 s
+after — the sweep's write path was most of its wall time.
+
 `--max-candidates N` is a hard per-kernel budget. Each supplied proposal reserves one slot even if its measurement is
 already cached, which makes hybrid-vs-MCTS comparisons charge LLM proposals consistently. MCTS receives the remaining
 slots and counts only terminals that reached a live backend; cached replay observations update the tree without

--- a/emmy/compiler/pipeline/search/golden.py
+++ b/emmy/compiler/pipeline/search/golden.py
@@ -361,11 +361,6 @@ def validate_golden_file(
     configs = document.get("configs")
     if not isinstance(configs, list) or not configs:
         raise ValueError("configs must be a non-empty list")
-    # A whole-model inventory points many configs at the same few programs (279 configs
-    # over 13 programs here), and decoding one is the expensive part of this check. Decode
-    # each distinct program once per call: `tune` re-validates the whole document on every
-    # incremental persist, so the redundancy is quadratic in the number of targets.
-    decoded_programs: dict[int, None] = {}
     strict = validation in (GoldenFileValidation.PROMOTION, GoldenFileValidation.REPOSITORY)
     for index, entry in enumerate(configs):
         where = f"configs[{index}]"
@@ -377,12 +372,8 @@ def validate_golden_file(
         program_ref = entry.get("program")
         if isinstance(program_ref, bool) or not isinstance(program_ref, int) or not 0 <= program_ref < len(programs):
             raise ValueError(f"{where}.program does not resolve in this document: {program_ref!r}")
-        if program_ref not in decoded_programs:
-            try:
-                graph_from_wire(programs[program_ref])
-            except ValueError as exc:
-                raise ValueError(f"{where}.program {program_ref}: {exc}") from exc
-            decoded_programs[program_ref] = None
+        # The pool check above already decoded every program. A whole-model inventory points
+        # hundreds of configurations at a handful of programs, so do not decode again per config.
         _validate_target(entry.get("target"), index=index, program_wire=programs[program_ref], loops=loops)
         realizations = entry.get("realizations")
         if not isinstance(realizations, list) or not realizations:
@@ -878,23 +869,56 @@ def _derive_structural_features(record: GoldenRecord) -> tuple[tuple[str, float]
     return result
 
 
+_POOL_KEYS = ("programs", "loops")
+_POOL_CACHE: tuple[list, dict[str, str]] | None = None
+
+
+def _dump_block(key: str, value: object) -> str:
+    """One top-level key as YAML. Block-style keys concatenate into exactly the document
+    ``yaml.dump`` writes for the whole mapping, so a block can be reused verbatim."""
+    return yaml.dump({key: value}, Dumper=_GoldenDumper, sort_keys=False, width=140)
+
+
+def _pool_blocks(document: Mapping, *, reuse: bool) -> dict[str, str]:
+    """The serialized program and loop pools, kept across repeated persists of one document.
+
+    Keyed by pool identity, and the cache holds the pools it serialized: a document whose pools
+    are the very objects that were dumped last has the same bytes for them.
+    """
+    global _POOL_CACHE
+
+    pools = [document.get(key) for key in _POOL_KEYS]
+    if reuse and _POOL_CACHE is not None and all(cached is pool for cached, pool in zip(_POOL_CACHE[0], pools, strict=True)):
+        return _POOL_CACHE[1]
+    blocks = {key: _dump_block(key, [_style_program(program) for program in document[key]]) for key in _POOL_KEYS if key in document}
+    if reuse:
+        _POOL_CACHE = (pools, blocks)
+    return blocks
+
+
 def dump_golden_file(
     document: Mapping,
     path: str | Path,
     *,
     validation: GoldenFileValidation = GoldenFileValidation.WORKING,
     overwrite: bool = False,
+    incremental: bool = False,
 ) -> Path:
+    """Write one golden document, atomically.
+
+    ``incremental`` is for the repeated working-golden persists of a single loaded document that
+    ``tune`` makes as it records ranking feedback per target: those persists mutate realizations
+    only, so the program and loop pools keep the text they were serialized to instead of being
+    reserialized once per target. The whole document is still validated, and the bytes written are
+    the ones a full dump writes. Canonical and promotion dumps leave it off and reserialize everything.
+    """
     validate_golden_file(document, validation=validation)
     destination = Path(path)
     if destination.exists() and not overwrite:
         raise FileExistsError(f"{destination} already exists; pass overwrite=True to replace it")
     destination.parent.mkdir(parents=True, exist_ok=True)
-    styled = dict(document)
-    styled["programs"] = [_style_program(program) for program in document["programs"]]
-    if "loops" in document:
-        styled["loops"] = [_style_program(program) for program in document["loops"]]
-    payload = yaml.dump(styled, Dumper=_GoldenDumper, sort_keys=False, width=140)
+    blocks = _pool_blocks(document, reuse=incremental)
+    payload = "".join(blocks[key] if key in blocks else _dump_block(key, value) for key, value in document.items())
     temporary = None
     mode = destination.stat().st_mode & 0o777 if destination.exists() else 0o644
     try:

--- a/emmy/compiler/pipeline/search/working_golden.py
+++ b/emmy/compiler/pipeline/search/working_golden.py
@@ -399,14 +399,14 @@ async def measure_proposals(graph, proposals, *, backend, db, ctx, max_candidate
 
 
 def persist_proposal_rankings(path: str | Path, document: dict, target: WorkingGoldenTarget, rankings: list[dict]) -> None:
-    """Atomically persist measured proposal feedback."""
+    """Atomically persist measured proposal feedback for one target of a loaded document."""
     configs = document["configs"]
     for ((entry_index, realization_index), _pins), ranking in zip(target.proposals, rankings, strict=True):
         realization = configs[entry_index]["realizations"][realization_index]
         if golden_entry_state(realization) == GoldenEntryState.VERIFIED:
             continue
         realization["ranking"] = {**ranking, "source": "proposal"}
-    dump_golden_file(document, path, overwrite=True)
+    dump_golden_file(document, path, overwrite=True, incremental=True)
 
 
 def persist_tune_winner(
@@ -417,7 +417,7 @@ def persist_tune_winner(
     *,
     compile_flags: str,
 ) -> None:
-    """Atomically persist one unambiguous directly searched winner."""
+    """Atomically persist one unambiguous directly searched winner into a loaded document."""
     from emmy.compiler.pipeline.knob import canonical_row_key  # noqa: PLC0415
 
     configs = document["configs"]
@@ -458,4 +458,4 @@ def persist_tune_winner(
             seed["ranking"] = {**winner_ranking, "tune_winner": True}
             configs[config_index]["realizations"].append(seed)
             target.entry_indexes.append((config_index, len(configs[config_index]["realizations"]) - 1))
-    dump_golden_file(document, path, overwrite=True)
+    dump_golden_file(document, path, overwrite=True, incremental=True)

--- a/tests/compiler/cli/test_tune_golden_file.py
+++ b/tests/compiler/cli/test_tune_golden_file.py
@@ -181,6 +181,25 @@ def test_ranking_write_preserves_verified_and_records_actual_searched_winner(tmp
     assert "measurements" not in winner
 
 
+def test_incremental_persist_matches_a_full_dump_and_still_checks_realizations(tmp_path):
+    path = tmp_path / "working.yaml"
+    dump_golden_file(_document(_matmul("mm"), _matmul("mm", knobs={"TILE": "f2x2"})), path)
+    document, targets = load_working_targets(path)
+    target = targets[0]
+    rankings = [{"status": "ok", "latency_us": 8.0, "compile_flags": "-O1", "measured_knobs": {"TILE": "f2x2"}}] * len(target.proposals)
+
+    # ``tune`` persists per target and reuses the pools it loaded; the file must still be the
+    # one a full revalidating dump of the same document writes.
+    persist_proposal_rankings(path, document, target, rankings)
+    canonical = tmp_path / "canonical.yaml"
+    dump_golden_file(document, canonical)
+    assert path.read_bytes() == canonical.read_bytes()
+
+    document["configs"][0]["realizations"][0]["pins"] = "not-a-mapping"
+    with pytest.raises(ValueError, match="pins must be a mapping"):
+        persist_proposal_rankings(path, document, target, rankings)
+
+
 def test_ambiguous_multi_cuda_winner_is_not_annotated(tmp_path):
     path = tmp_path / "working.yaml"
     dump_golden_file(_document(_matmul("mm")), path)


### PR DESCRIPTION
## Problem

`emmy tune --golden-file` persists ranking feedback and the searched winner per target, and each
persist rewrites the entire 3.4 MB document. On the 279-target DeepSeek V4 Flash V100 inventory
(`recipes/DeepSeek-V4-Flash-0731/golden/v100_sm70.yaml`) that is ~558 writes with the GPUs idle for
them.

#558 fixed the decode half of this — validation went 4.5 s → 1.5 s. The serialization half is what
is left, and a persist still costs **2.48 s**.

## Serialize the immutable pools once

The program and loop pools are 3.36 MB of that 3.4 MB and no persist mutates them; the
configurations that do change reserialize in 0.05 s. `dump_golden_file(..., incremental=True)` keeps
the text the pools were already serialized to and reserializes only the rest.

**A persist goes 2.48 s → 0.24 s**, and the sweep's write path stops scaling with the target count.

Top-level block dumps concatenate into exactly the document `yaml.dump` writes for the whole
mapping, so the cached blocks splice back verbatim. The cache is keyed by pool identity and holds
the pools it serialized, so a freed pool cannot hand its id to a later document.

**The whole document is still validated on every write, incremental or not** — the flag only touches
serialization, so no dump of any level skips a check.

## Drop the per-config decode instead of memoizing it

`validate_program_pool` decodes every program in the pool before the configuration loop starts, so
the decode *inside* the loop cannot fail where the pool check did not. It is redundant outright, not
just per call — which means #558's `decoded_programs` memo can go with it rather than being kept.
Validation 0.24 s → 0.18 s.

## Testing

- New test pins an incremental persist to a full dump byte for byte, and asserts it still rejects a
  malformed realization.
- `tests/compiler/{cli,pipeline,loader,backend}`: 644 passed, 89 skipped.
- `ruff check` + `ruff format --check` clean.
- Reviewed by Codex (`codex review --base origin/main`): no actionable correctness issues.
- Pre-existing on this machine and unrelated (verified identical on a clean tree at the base commit):
  `tests/compiler/{e2e,ir,passes,trace}` segfault at interpreter shutdown *after* their tests pass,
  and `tests/serving` has 2 failures (`test_moe_split.py`, `test_attention_split.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)