### PR TITLE
Warn when the boot roofline audit cannot take the GPU lock

### DIFF
--- a/emmy/serving/ARCHITECTURE.md
+++ b/emmy/serving/ARCHITECTURE.md
@@ -79,7 +79,9 @@ checkpoint, tokenizer, and sentence-transformers pooling config still come from 
   Logs a loud WARNING naming any program >10x over it, with the `emmy tune` pointer. Conservative by construction
   (each floor is a true lower bound for its regime, both calibrations undershoot peak, quantized weights only
   underestimate the compute floor, and FAST_MATH kernels can only sit *under* the f32-acc-calibrated compute floor),
-  advisory only (never raises, never blocks boot). Born from the 2026-07-29 TinyLlama/4080 incident: a cold deploy
+  advisory only (never raises, never blocks boot). A measurement failure is swallowed to debug, but an unusable
+  `EMMY_GPU_LOCK` path is not — taking the lock is setup, not measurement, so that WARNs and an environment fault
+  never reads as a clean audit. Born from the 2026-07-29 TinyLlama/4080 incident: a cold deploy
   served a fused-norm kernel ~150x off the floor (54x TPOT gap) with zero boot-time signal.
   **Two structural blind spots, and a compressed model lands in both.** The audit times ONE layer per attention
   class, and `MIN_FLOOR_US` drops anything whose weights stream in under 20 µs — so on GLM-4.5-Air at 2.25 bpw it

--- a/emmy/serving/roofline.py
+++ b/emmy/serving/roofline.py
@@ -23,12 +23,14 @@ matmul lane, i.e. sit under the compute floor — the same silent direction. Sym
 skipped: at boot their buffers sit at capacity, not at a serving width, so a timing there measures
 the wrong shape.
 
-The audit is advisory only — it logs and never raises; any failure inside it is swallowed (a boot
-warning must not become a boot blocker).
+The audit is advisory only — it logs and never raises (a boot warning must not become a boot
+blocker). A measurement failure is swallowed to debug; an unusable ``EMMY_GPU_LOCK`` path is not —
+taking the lock is setup, not measurement, so that fault warns instead of reading as a clean audit.
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
 
 logger = logging.getLogger(__name__)
@@ -127,10 +129,17 @@ def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
     plus the weight INPUTS an expert program takes per launch. ``m_tokens`` is the program's static
     token width, ``dtype_bytes`` the weight itemsize — together they turn ``weight_bytes`` into the
     matmul FLOP estimate ``2 * weight_elems * m_tokens``. Never raises."""
-    try:
-        from emmy.compiler.backend.gpu_lock import gpu_lock
+    from emmy import config
+    from emmy.compiler.backend.gpu_lock import gpu_lock
 
-        with gpu_lock():
+    with contextlib.ExitStack() as stack:
+        try:
+            stack.enter_context(gpu_lock())
+        except Exception:  # noqa: BLE001 — taking the lock is setup, not measurement: an unusable
+            # lock path is an environment fault and must not read as a clean audit at debug level.
+            logger.warning("[roofline] boot audit skipped: GPU lock %r unusable", config.gpu_lock_path(), exc_info=True)
+            return
+        try:
             bw = measure_copy_bw()
             try:
                 flops_per_s = measure_matmul_flops()
@@ -143,18 +152,19 @@ def audit_boot_programs(named_programs, dtype_bytes: int = 2) -> None:
                 if verdict is not None:
                     floor_us, ratio = verdict
                     flagged.append((label, floor_us, ratio))
-        for label, floor_us, ratio in flagged:
-            logger.warning(
-                "[roofline] %s runs %.0fx over its roofline floor (~%.0f us) — a deployed kernel pick "
-                "is far off the weight-streaming/compute floor for this model/GPU. Capture and tune the "
-                "serving twins (`emmy tune`; see emmy/serving/ARCHITECTURE.md → 'Tuning what serving "
-                "actually runs').",
-                label,
-                ratio,
-                floor_us,
-            )
-        if named_programs and not flagged:
-            n = len(named_programs)
-            logger.info("[roofline] boot audit clean: %d static program(s) within %sx of the roofline floor", n, int(WARN_RATIO))
-    except Exception:  # noqa: BLE001 — advisory only, never a boot blocker
-        logger.debug("[roofline] boot audit skipped", exc_info=True)
+        except Exception:  # noqa: BLE001 — advisory only, never a boot blocker
+            logger.debug("[roofline] boot audit skipped", exc_info=True)
+            return
+    for label, floor_us, ratio in flagged:
+        logger.warning(
+            "[roofline] %s runs %.0fx over its roofline floor (~%.0f us) — a deployed kernel pick "
+            "is far off the weight-streaming/compute floor for this model/GPU. Capture and tune the "
+            "serving twins (`emmy tune`; see emmy/serving/ARCHITECTURE.md → 'Tuning what serving "
+            "actually runs').",
+            label,
+            ratio,
+            floor_us,
+        )
+    if named_programs and not flagged:
+        n = len(named_programs)
+        logger.info("[roofline] boot audit clean: %d static program(s) within %sx of the roofline floor", n, int(WARN_RATIO))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,10 @@ import yaml
 # without this serialization, peer-worker CUDA activity interleaves
 # with our kernels and the per-position fp32 rounding drift breaks
 # the accuracy comparison.
-os.environ.setdefault("EMMY_GPU_LOCK", "/tmp/emmy-gpu.lock")
+# Per-uid path: on a multi-user runner the first user's lock file (mode 0644, sticky /tmp)
+# is unopenable by everyone else, so a shared path fails the run with PermissionError
+# instead of serializing (CI run 32339655489). Cross-user serialization was never real.
+os.environ.setdefault("EMMY_GPU_LOCK", f"/tmp/emmy-gpu-{os.getuid()}.lock")
 
 
 # ── CUDA context poisoning containment ──────────────────────────────

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -49,7 +49,10 @@ _RESULTS_DIR = Path(__file__).resolve().parent / ".results"
 # compile, dump-write all run unlocked — only the kernel-launch phase
 # serializes. Override with ``EMMY_GPU_LOCK`` before invoking
 # ``make bench-kernels`` if a different path is desired.
-os.environ.setdefault("EMMY_GPU_LOCK", "/tmp/emmy-gpu.lock")
+# Per-uid path: on a multi-user runner the first user's lock file (mode 0644, sticky /tmp)
+# is unopenable by everyone else, so a shared path fails the run with PermissionError
+# instead of serializing (CI run 32339655489). Cross-user serialization was never real.
+os.environ.setdefault("EMMY_GPU_LOCK", f"/tmp/emmy-gpu-{os.getuid()}.lock")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/serving/test_roofline.py
+++ b/tests/serving/test_roofline.py
@@ -3,10 +3,21 @@ Pure CPU: the CUDA-touching measurement helpers are stubbed."""
 
 import logging
 
+import pytest
+
+from emmy.compiler.backend import gpu_lock as gpu_lock_mod
 from emmy.serving import roofline
 from emmy.serving.roofline import audit_boot_programs, flag_ratio
 
 GB = 1e9
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_gpu_lock(monkeypatch):
+    """These tests audit decision logic, not locking. ``tests/conftest.py`` exports
+    ``EMMY_GPU_LOCK`` suite-wide; an unusable path there (a stale lock file owned by another user on
+    a shared runner) would otherwise skip every audit and read as a decision-logic regression."""
+    monkeypatch.delenv("EMMY_GPU_LOCK", raising=False)
 
 
 class _Prog:
@@ -108,6 +119,19 @@ def test_audit_degrades_to_weight_floor_without_matmul_calibration(monkeypatch, 
         audit_boot_programs([("L0.post.decode.m8", _Prog(100_000_000), 8)])
     assert len(caplog.records) == 1
     assert "L0.post.decode.m8" in caplog.text
+
+
+def test_audit_warns_when_gpu_lock_unusable(monkeypatch, caplog):
+    """An unusable lock path is an environment fault, not a clean audit — it must be visible at
+    warning level (the CI incident: a stale ``/tmp/emmy-gpu.lock`` owned by another user)."""
+    monkeypatch.setattr(
+        gpu_lock_mod, "gpu_lock", lambda: (_ for _ in ()).throw(PermissionError(13, "Permission denied", "/tmp/emmy-gpu.lock"))
+    )
+    monkeypatch.setattr(roofline, "measure_copy_bw", lambda: 1000 * GB)
+    with caplog.at_level(logging.WARNING, logger="emmy.serving.roofline"):
+        audit_boot_programs([("L0.post.decode.m8", _Prog(100_000_000), 8)])
+    assert len(caplog.records) == 1
+    assert "GPU lock" in caplog.text
 
 
 def test_audit_never_raises(monkeypatch, caplog):


### PR DESCRIPTION
## Problem

`audit_boot_programs` acquired `gpu_lock()` **inside** the try whose handler is `logger.debug("[roofline] boot audit skipped")`. So an unusable `EMMY_GPU_LOCK` path skipped the entire audit — the measurement *and* the outlier `logger.warning` loop — and the only trace was a DEBUG record. An environment fault read exactly like "audit ran and found nothing".

It surfaced as four `assert 0 == 1` failures in a different file:

```bash
EMMY_GPU_LOCK=/emmy-gpu.lock ./venv/bin/pytest tests/serving/test_roofline.py tests/serving/generation/test_gen_plan_template_cache.py -q
```

→ `5 failed, 5 passed`; unset the var and all 10 pass. CI run 32339655489 on #558 failed this way because the shared runner `github-runner-cpu-2` had a stale `/tmp/emmy-gpu.lock` owned by another user (`PermissionError: [Errno 13]`); a re-run passed with no code change.

## Changes

- **`emmy/serving/roofline.py`** — the lock is entered through a `contextlib.ExitStack` under its own handler. Taking the lock is setup, not measurement, so that failure WARNs and names the path (with `exc_info`), while a measurement failure keeps its debug-level swallow. The audit still never raises and never blocks boot.
- **`tests/serving/test_roofline.py`** — an autouse fixture drops ambient `EMMY_GPU_LOCK` (these tests audit decision logic, not locking), plus one test covering the lock-fault path.
- **`tests/conftest.py`, `tests/perf/conftest.py`** — the default lock path is now per-uid. On a multi-user runner the first user's lock file (mode 0644 under sticky `/tmp`) is unopenable by everyone else, so the shared path failed the run with `PermissionError` rather than serializing; cross-user serialization was never real there.

Nothing changed in `emmy/compiler/backend/gpu_lock.py`: the library never picks a path (unset = no-op), the shared path came from the test harness, and the `OSError` already names the file.

## Verification

On a V100 box (`Tesla V100-SXM3-32GB`), with a mode-000 lock file standing in for the stale one:

| | unpatched | patched |
| --- | --- | --- |
| hostile `EMMY_GPU_LOCK` | 5 failed, 5 passed | 1 failed, 10 passed (only the test that genuinely takes the lock) |
| normal env | 10 passed | 11 passed |

The audit itself, real `FileLock` held and 874 GB/s D2D calibration measured on the card, still logs both verdicts (`boot audit clean` / `runs 395x over its roofline floor`), and under the unusable lock logs `[roofline] boot audit skipped: GPU lock '…' unusable` and continues.

Suites: `tests/serving` 164 passed / 48 skipped and `tests/compiler/backend + tests/serving` 289 passed / 84 skipped on the V100 box; 289 passed / 84 skipped locally. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)