### PR TITLE
Close the computed-A cone's per-cell lambda (statistic passes through the prologue)

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -619,9 +619,11 @@ non-empty (`λ() [captures m_i__t5] -> (…)`) — the free names that are not i
 closure predicate applies (`axis_names`, relocated to `tile/ops.py` so the dump and `_cut._captured_values` share one
 definition; the iteration space is the term's axes ∪ the placement's free/grid ∪ the boundary stores' sweep axes).
 Without a capture set a λ reads as closed, and closure is precisely what decides whether a subtree can hoist to an
-operand edge — combine-derived material captures the carrier's running state, which is why its seam is not cuttable. The
-set is measured only when the owning `TileOp` is supplied; a bare term has no placement, so the annotation is omitted
-rather than reporting grid coordinates as captures.
+operand edge. No stored term carries one: the computed-A cone (`ops.make_cone`) passes every statistic value its
+per-cell normalize reads through the prologue's results (softmax's `m`, read by `exp(s − m)`), so the cell binds it
+positionally and the seam between statistic and normalize is a positional edge like any other. The set is measured only
+when the owning `TileOp` is supplied; a bare term has no placement, so the annotation is omitted rather than reporting
+grid coordinates as captures.
 
 **Nothing DERIVED is printed** — not the per-cell step, not the nodes synthesized inside it, not the lowered nest.
 The structure is already complete in the stored tree: the operand edges and their nesting say it, and a derived

--- a/emmy/compiler/ir/pure/fold.py
+++ b/emmy/compiler/ir/pure/fold.py
@@ -500,7 +500,7 @@ class Fold:
         return cls(axis=k_axis, operands=operands, lift=lift, init=init, combine=combine)
 
     @classmethod
-    def projection(cls, operands: tuple = (), *, body=None) -> Fold:
+    def projection(cls, operands: tuple = (), *, body=None, results: tuple | None = None) -> Fold:
         """A ZERO-AXIS fold — the pointwise / projection cell (what the zero-axis fold kind was).
         No axis and no monoid: the synthesized binder IS the ``lift`` and IS the per-cell compute,
         so softmax's normalize, the relu epilogue and flash's ``divide(O, l)`` are this node over
@@ -510,12 +510,16 @@ class Fold:
         binds every channel accumulator, so the geglu combine's second read is a bound param and
         never a free name. ``body`` is the raw-loop-IR arm, where :func:`_loop_ir_fn` tolerates an
         impure body; its params come from the operands' components and its results from the last
-        def. A caller holding a ready ``Lambda`` constructs ``Fold(axis=None, ...)`` directly —
-        this builder exists for the body form, which is the only one anything spells."""
+        def unless ``results`` names them (a prologue passing a bound statistic through to the
+        consumer that reads it — :func:`~emmy.compiler.ir.tile.ops.make_cone`). A caller holding
+        a ready ``Lambda`` constructs ``Fold(axis=None, ...)`` directly — this builder exists for
+        the body form, which is the only one anything spells."""
         operands = tuple(operands)
         b = Body.coerce(body) if body is not None else Body()
         params = tuple(n for s in operands for n in _operand_result_names(s))
-        return cls(axis=None, operands=operands, lift=_loop_ir_fn(params, b, _map_results(b) or params[:1]))
+        if results is None:
+            results = _map_results(b) or params[:1]
+        return cls(axis=None, operands=operands, lift=_loop_ir_fn(params, b, tuple(results)))
 
     def external_reads(self) -> tuple[str, ...]:
         """Every input buffer read anywhere under this node's operand edges (deep — an inline

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -79,10 +79,10 @@ class _Ctx:
         """The VALUE names ``lam``'s body reads but neither binds nor takes from the iteration
         space — the same reading the cut's closure predicate applies
         (``_cut._captured_values``). Non-empty means the λ is NOT closed, which is exactly what
-        makes a subtree unhoistable to an operand edge: flash's ``P = exp(s − m)`` reads the
-        online-softmax carrier's running max, so it can never be an edge and its seam is not
-        cuttable. Empty when the iteration space is unknown (no owning ``TileOp``) — an unanswered
-        question prints as no annotation, never as "closed"."""
+        makes a subtree unhoistable to an operand edge; no stored term prints one (the computed-A
+        cone binds the statistic's ``m`` positionally — ``ops.make_cone``), so an annotation marks
+        a hand-built tree. Empty when the iteration space is unknown (no owning ``TileOp``) — an
+        unanswered question prints as no annotation, never as "closed"."""
         return () if self.axes is None else tuple(sorted(lam.free_names() - self.axes))
 
     def note(self, node) -> str:

--- a/emmy/compiler/ir/tile/ops.py
+++ b/emmy/compiler/ir/tile/ops.py
@@ -96,7 +96,13 @@ def make_cone(cell: list, k_name: str, stat=None, sweep=()) -> Fold:
 
     A producer NODE in ``cell`` is not a stmt of either side: it hangs off the cone's OPERANDS,
     where ``cone_seam`` splits it by the same K seam — k-varying, so it is the per-cell producer
-    spliced ahead of its first use."""
+    spliced ahead of its first use.
+
+    The cell's λ is CLOSED: every prologue value it reads — a statistic component the prologue
+    binds (softmax's ``m``, read by the per-cell ``exp(s − m)``) or a row-invariant def — passes
+    through as a further prologue RESULT, so the cell binds it positionally like any operand.
+    Nothing in a stored term captures; the seam between statistic and normalize is then a
+    positional edge like every other, and ``cone_seam``'s bridge is that edge's extra results."""
     nodes = tuple(s for s in cell if isinstance(s, Fold))
     cell = [s for s in cell if not isinstance(s, Fold)]
     # A stmt READING a k-varying producer varies with k as surely as one that indexes it: the K
@@ -108,7 +114,14 @@ def make_cone(cell: list, k_name: str, stat=None, sweep=()) -> Fold:
     rest = list(cell)
     while rest and not refs_axis(rest[0], k_name) and not (set(rest[0].deps()) & varying):
         pro.append(rest.pop(0))
-    prologue = Fold.projection(body=Body((*sweep, *pro)), operands=() if stat is None else (stat,))
+    pro_body = Body((*sweep, *pro))
+    pro_ops = () if stat is None else (stat,)
+    prologue = Fold.projection(body=pro_body, operands=pro_ops)
+    cell_reads = deep_reads(rest)
+    bound = (*(n for e in pro_ops for n in _operand_result_names(e)), *(n for s in pro_body for n in s.defines()))
+    bridged = tuple(n for n in dict.fromkeys(bound) if n in cell_reads and n not in prologue.lift.results)
+    if bridged:
+        prologue = Fold.projection(body=pro_body, operands=pro_ops, results=(*prologue.lift.results, *bridged))
     src = (prologue,) if (pro or sweep or stat is not None) else ()
     return Fold.projection(body=Body(tuple(rest)), operands=(*src, *nodes))
 

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -398,7 +398,9 @@ failing several passes later:
   validation reading (1q) and lives with its one consumer, the cut (`_cut._captured_values`); closure is the precondition for lifting any subtree into its own kernel (a placement
   cut). A twisted fold's streaming merge is `combine`'s derived singleton-specialization internals — material BELOW
   the seam lattice, never a cut target: a value defined inside the merge captures the carrier's running state, so it
-  can never hoist to an edge. The same edge vocabulary applies to **B**: a pure, closed B
+  can never hoist to an edge. The STORED cone itself is closed: `make_cone` passes every statistic value the per-cell
+  normalize reads (softmax's `m`) through the prologue's results, so no λ in a stored term captures and the
+  statistic/normalize seam is a positional edge like any other. The same edge vocabulary applies to **B**: a pure, closed B
   producer can remain inline and fill the Tensor Core B slab directly. This is a generic producer-to-contraction
   fusion over ordinary tensor algebra; storage-format reconstruction must already have decomposed before this band.
   Binding off the lift rather than off "the first (m, k)-indexed `Load`" is load-bearing: a cone-INTERNAL load is
@@ -698,8 +700,8 @@ recursively: a deeper `PLACE` key can cut the cone piece again, yielding the cas
 matmul, every piece joining an EXISTING golden kind's evidence at its own schedule forks.
 A compile that cannot price the fork (nothing measured, no useful prior) decides nothing here and ranks the cut
 fragments beside the fused form like any other leaves — the fused form is not held back for it.
-Cut legality is structural: single-component CLOSED children only (`_captured_values`
-in its demoted validation role — combine-derived material that captures carrier state is simply not cuttable), and
+Cut legality is structural: single-component CLOSED children only (`_captured_values` in its demoted validation
+role; the multi-result prologue of a cone that passes its statistic through stays uncut by the component gate), and
 the pure-copy degenerate
 (cutting an empty-body root projection's only operand, whose parent would merely copy the workspace out — the
 non-terminating case) is refused. Loop fusion stops at `__cut_` workspace producers — a decided placement is not

--- a/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_cut.py
@@ -66,10 +66,9 @@ def _captured_values(root, axes: set[str]) -> tuple[str, ...]:
     DEMOTED to a validation check at 1q: operands bind POSITIONALLY to lift params, so an edge
     cannot see the fold's state or its siblings — **edge iff closed holds by construction** — and
     the cut is the one decision that still consults the scan. It is the executable statement of
-    that invariant, and the honest reading of the one legal capture: flash's ``P = exp(s − m)``
-    genuinely reads the online-softmax carrier's running max, updated by the merge stmts of the
-    very loop step that consumes it (legal: an inline operand's one home is always inside the
-    scope it captures from) — which is why that seam is not cuttable.
+    that invariant. No stored term captures: the computed-A cone passes every statistic value its
+    per-cell normalize reads through the prologue's results (``ops.make_cone``), so softmax's
+    ``exp(s − m)`` binds ``m`` positionally; only a hand-built tree can fail this check.
 
     Returned sorted, so callers can put it straight into an error message."""
     stmts = list(root.lower())
@@ -85,9 +84,7 @@ def _cuttable(root, site: Site, stores: tuple, free: tuple) -> bool:
     - the child produces ONE component (a product fold's per-component separation is
       deliberately forfeited at tile level — the sanctioned cut for the fused edge is the
       shared ``a`` operand, never a channel);
-    - the child is CLOSED over values (:func:`_captured_values` — its demoted validation role: a
-      state-capturing composition like flash's ``P`` sits in the step at its semantic position
-      and is simply not cuttable);
+    - the child is CLOSED over values (:func:`_captured_values` — its demoted validation role);
     - the seam is not the pure-copy degenerate: cutting a root zero-axis fold's only source when the
       projection body is empty and the store is a plain write leaves a parent that merely
       copies the workspace back out — the child IS the kernel, the tree does not shrink, and

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -385,7 +385,9 @@ def _attention_cone_term() -> tuple[Fold, Fold]:
         init=(float("-inf"), 0.0),
         combine=Lambda(params=names + other, body=Body(exp_combine_states(names, other)), results=names),
     )
-    prologue = Fold.projection(body=Body((Assign(name="rd", op="reciprocal", args=("dn",)),)), operands=(stat,))
+    # The prologue passes ``mx`` through beside its own ``rd``: the cell binds both positionally
+    # (``make_cone``'s closure rule), so no λ in the tree captures.
+    prologue = Fold.projection(body=Body((Assign(name="rd", op="reciprocal", args=("dn",)),)), operands=(stat,), results=("rd", "mx"))
     cone = Fold.projection(
         body=Body(
             (
@@ -437,6 +439,30 @@ def test_cone_per_cell_edge_is_evaluated_inline_and_carries_no_slice():
     # …and the statistic edge keeps its own reduce site — it is realized per tile ROW, not per cell.
     stat = cone.operands[0].operands[0]
     assert any(s.node is stat for s in family_sites("REDUCE", all_sites))
+
+
+@pytest.mark.parametrize("shape", ["sdpa", "norm_linear"])
+def test_cone_cell_lambda_is_closed(shape):
+    """Every λ in a stored term is CLOSED: the per-cell normalize reads the statistic it
+    normalizes against (softmax's ``m``, RMSNorm's ``rsqrt``) through the prologue's RESULTS,
+    bound positionally, never as a captured name. The seam between statistic and normalize is
+    then a positional edge like every other; what bridges through the stat smem rows is exactly
+    that edge's results."""
+    from emmy.compiler.ir.tile.ops import cone_seam
+    from emmy.compiler.pipeline.passes.lowering.tile._cut import _captured_values
+
+    _, tile = _resolve_sdpa(is_causal=True) if shape == "sdpa" else _resolve(_norm_linear_graph(), pick=_is_warp_row)
+    fold = tile.op.operands[0] if (isinstance(tile.op, Fold) and tile.op.axis is None) else tile.op
+    cone = fold.a
+    prologue = cone.operands[0]
+    assert "captures" not in tile.pretty_body()
+    assert cone.lift.params == prologue.lift.results, "the cell binds every prologue result positionally"
+    if shape == "sdpa":  # ``exp(s − m)`` reads the carrier's ``m`` itself; RMSNorm's cell reads only the projected rsqrt
+        assert set(prologue.operands[0].combine.results) & set(prologue.lift.results), "the statistic's own state passes through"
+    _, _, stats = cone_seam(cone, fold.axis.name)
+    assert set(stats) == set(prologue.lift.results), f"the bridge is the prologue's results: {stats} vs {prologue.lift.results}"
+    axes = stmt_axis_names(cone.lower()) | {a.name for a in (*tile.place.free, *tile.place.grid)} | {fold.axis.name}
+    assert not _captured_values(cone, axes) and not _captured_values(prologue, axes)
 
 
 def test_cone_per_cell_edge_reaches_the_per_cell_emitter():

--- a/tests/durations.json
+++ b/tests/durations.json
@@ -228,6 +228,8 @@
  "tests/compiler/passes/test_pool_space.py::test_the_traversal_is_pinned_element_wise[reduce_matvec]": 0.02,
  "tests/compiler/passes/test_pool_space.py::test_the_traversal_is_pinned_element_wise[scalar_matmul]": 0.31,
  "tests/compiler/passes/test_pool_space.py::test_the_traversal_is_pinned_element_wise[warp_matmul]": 3.1,
+ "tests/compiler/passes/test_recognize_boundary_rules.py::test_cone_cell_lambda_is_closed[norm_linear]": 2.05,
+ "tests/compiler/passes/test_recognize_boundary_rules.py::test_cone_cell_lambda_is_closed[sdpa]": 1.37,
  "tests/compiler/passes/test_recognize_boundary_rules.py::test_masked_score_cone_keeps_its_predicate_per_cell": 1.47,
  "tests/compiler/passes/test_recognize_boundary_rules.py::test_masked_sdpa_reaches_the_computed_a_contraction[False]": 1.15,
  "tests/compiler/passes/test_recognize_boundary_rules.py::test_masked_sdpa_reaches_the_computed_a_contraction[True]": 1.18,


### PR DESCRIPTION
## Summary
- The computed-A cone's per-cell normalize read the statistic's state (softmax's `m` in `exp(s − m)`, the row-invariant mask constants) as **captured** names — the only unclosed λ in a stored tile term. `make_cone` now passes every prologue-bound or -defined name the cell reads through the prologue's `results`, so the cell binds it positionally like any operand edge.
- `Fold.projection` gains an explicit `results=` hook; `cone_seam`'s bridge (computed on lowered defs) is unchanged; the cut's closure scan stays as the validation check for hand-built trees.
- Stale "the one legal capture" prose refreshed in `_cut`, `_dump`, `ir/ARCHITECTURE.md`, `passes/ARCHITECTURE.md`.

## Verification
- Kernel-source digest A/B (`scripts/digest_kernels.py`, 30 kernels, `PYTHONPATH` pinned to the worktree): **byte-identical** before/after; the script's pre-existing liveness notes are identical on both sides.
- New `test_cone_cell_lambda_is_closed[sdpa|norm_linear]`: no `captures` in the dump, cell params == prologue results, bridge == prologue results, `_captured_values` empty for cone and prologue. Hand-built attention cone in the tests updated to the closed spelling.
- `make test` equivalent: 3506 passed, 31 skipped, 18 xfailed. `make lint` clean.

## Notes
- Structural keys of computed-A fused tiles change (results tuple grew), so tune-DB rows keyed by their old `cache_key` go stale. The golden join (`deploy_identity`) recomputes both sides through recognition and is unaffected.
- The statistic/normalize seam is now a positional edge, but the cut's single-component gate still declines the multi-result prologue, so no new fork is enumerated by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01449NhXZExPTi3V2j78URPy