### PR TITLE
Pin a target context in the trace-inventory tests

### DIFF
--- a/tests/compiler/cli/test_trace.py
+++ b/tests/compiler/cli/test_trace.py
@@ -8,6 +8,7 @@ import pytest
 from emmy.commands.trace import handle_trace, register_trace_command, trace_inline_code
 from emmy.compiler import provenance
 from emmy.compiler.backend import torch_ref
+from emmy.compiler.context import Context
 from emmy.compiler.graph import Graph, Tensor
 from emmy.compiler.ir.base import InputOp
 from emmy.compiler.ir.frontend.ir import LinearOp
@@ -15,6 +16,12 @@ from emmy.compiler.ir.loop import LoopOp
 from emmy.compiler.ir.tensor.ir import CastOp, ElementwiseOp, GatherOp
 from emmy.compiler.pipeline.search.golden import load_golden_file, load_golden_records
 from emmy.compiler.pipeline.search.working_golden import load_working_targets, write_trace_inventories, write_trace_inventory
+
+# An inventory stamps the card its context is for, and reading a record back reconstructs that
+# card from the ``emmy.gpu`` registry — where an unregistered card is a hard error, not a
+# fallback. Probing the live device would make these tests depend on whichever GPU the runner
+# happens to have, so pin a target context the way ``test_golden_file_replay`` does.
+_TARGET_CTX = Context.from_target((8, 9))
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -186,8 +193,8 @@ def test_trace_accepts_debug_graph_json_as_input_but_emits_yaml(monkeypatch, tmp
 def test_trace_writes_deterministic_self_contained_programs(tmp_path) -> None:
     graph = trace_inline_code("torch.relu(torch.randn(16,32))")["graph"]
     first, second = tmp_path / "first.yaml", tmp_path / "second.yaml"
-    write_trace_inventory(graph.copy(), first, model="org/model")
-    write_trace_inventory(graph.copy(), second, model="org/model")
+    write_trace_inventory(graph.copy(), first, model="org/model", ctx=_TARGET_CTX)
+    write_trace_inventory(graph.copy(), second, model="org/model", ctx=_TARGET_CTX)
     first_doc, second_doc = load_golden_file(first), load_golden_file(second)
     assert first_doc == second_doc
     assert first_doc["programs"] and first_doc["configs"]
@@ -208,6 +215,7 @@ def test_trace_keeps_materialized_storage_outputs_and_quant_digest(tmp_path) -> 
     result = write_trace_inventory(
         graph,
         path,
+        ctx=_TARGET_CTX,
         model_quant_digest="0123456789abcdef",
     )
     document = load_golden_file(path)
@@ -228,7 +236,7 @@ def test_trace_target_resolves_in_original_multi_op_fusion_context(tmp_path) -> 
     graph.inputs, graph.outputs = ["x", "w1", "w2"], ["out"]
 
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path)
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     document = load_golden_file(path)
     (record,) = load_golden_records(document)
 
@@ -246,7 +254,7 @@ def test_trace_inventory_lists_each_sdpa_split_kernel_as_a_target(tmp_path) -> N
         "F.scaled_dot_product_attention(torch.randn(1,2,8,16), torch.randn(1,2,8,16), torch.randn(1,2,8,16), is_causal=True)"
     )["graph"]
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path)
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     records = load_golden_records(load_golden_file(path))
     assert len(records) == 2
     assert [record.loop_index for record in records] == [0, 1]
@@ -262,7 +270,7 @@ def test_trace_serializes_target_without_a_torch_reference_mapping(tmp_path) -> 
     assert torch_ref.is_runnable(graph) is False
 
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path)
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     (record,) = load_golden_records(load_golden_file(path))
     assert record.origin_ops == ("tensor.gather",)
     assert record.program.nodes["gather"].op == GatherOp(axis=1)
@@ -278,7 +286,7 @@ def test_trace_inventory_keeps_every_kernel_even_without_cache_keys(monkeypatch,
     monkeypatch.setattr(LoopOp, "cache_key", lambda _self: None)
 
     path = tmp_path / "working.yaml"
-    result = write_trace_inventory(graph, path)
+    result = write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     records = load_golden_records(load_golden_file(path))
 
     assert result.target_count == 2
@@ -294,11 +302,11 @@ def test_trace_inventory_embeds_loop_ir_when_frontend_provenance_is_missing(monk
     monkeypatch.setattr(provenance, "seed", lambda _graph: None)
 
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path)
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     document = load_golden_file(path)
     (record,) = load_golden_records(document)
 
-    assert set(document) - {"gpu_name"} == {"compute_cap", "programs", "loops", "configs"}
+    assert set(document) == {"compute_cap", "programs", "loops", "configs"}
     assert document["configs"][0]["target"] == {"loop": 0}
     assert record.origins == ()
     assert isinstance(record.target_program.nodes["y"].op, LoopOp)
@@ -308,6 +316,16 @@ def test_trace_inventory_embeds_loop_ir_when_frontend_provenance_is_missing(monk
     assert isinstance(targets[0].program.nodes["y"].op, LoopOp)
 
 
+def test_trace_inventory_stamps_the_card_its_context_is_for(tmp_path) -> None:
+    """The pinned contexts above leave ``gpu_name`` out, so one test names a registered card
+    and checks the stamp deterministically, instead of it depending on the runner's device."""
+    graph = trace_inline_code("torch.relu(torch.randn(8))")["graph"]
+    path = tmp_path / "working.yaml"
+    write_trace_inventory(graph, path, ctx=Context.from_target((8, 9), gpu_name="NVIDIA GeForce RTX 4090"))
+
+    assert load_golden_file(path)["gpu_name"] == "NVIDIA GeForce RTX 4090"
+
+
 def test_trace_inventory_can_force_exact_loop_targets(tmp_path) -> None:
     graph = Graph()
     graph.add_node(InputOp(), [], Tensor("x", (16,)), node_id="x")
@@ -315,7 +333,7 @@ def test_trace_inventory_can_force_exact_loop_targets(tmp_path) -> None:
     graph.inputs, graph.outputs = ["x"], ["y"]
 
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path, force_loop_targets=True)
+    write_trace_inventory(graph, path, force_loop_targets=True, ctx=_TARGET_CTX)
     (record,) = load_golden_records(load_golden_file(path))
 
     assert record.origins == ()
@@ -347,7 +365,7 @@ def test_exact_loop_targets_disambiguate_same_body_at_distinct_cast_boundaries(t
     graph.outputs = outputs
 
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path, force_loop_targets=True)
+    write_trace_inventory(graph, path, force_loop_targets=True, ctx=_TARGET_CTX)
     names = [record.name for record in load_golden_records(load_golden_file(path))]
     assert len(names) == len(set(names))
 
@@ -355,7 +373,7 @@ def test_exact_loop_targets_disambiguate_same_body_at_distinct_cast_boundaries(t
 def test_combined_trace_inventory_deduplicates_identical_loop_targets(tmp_path) -> None:
     graph = trace_inline_code("torch.relu(torch.randn(8))")["graph"]
     path = tmp_path / "combined.yaml"
-    result = write_trace_inventories({"pre1": graph, "pre8": graph.copy()}, path, model="org/model@revision")
+    result = write_trace_inventories({"pre1": graph, "pre8": graph.copy()}, path, model="org/model@revision", ctx=_TARGET_CTX)
     document = load_golden_file(path)
     records = load_golden_records(document)
 
@@ -373,7 +391,7 @@ def test_trace_yaml_uses_compact_graph_rows_but_block_candidate_rows(tmp_path) -
     graph.inputs, graph.outputs = ["x0", "x1"], ["linear"]
 
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path)
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     text = path.read_text()
 
     assert "inputs: [x0, x1]" in text
@@ -385,6 +403,6 @@ def test_trace_yaml_uses_compact_graph_rows_but_block_candidate_rows(tmp_path) -
 def test_trace_refuses_to_replace_existing_yaml(tmp_path) -> None:
     graph = trace_inline_code("torch.relu(torch.randn(8))")["graph"]
     path = tmp_path / "working.yaml"
-    write_trace_inventory(graph, path)
+    write_trace_inventory(graph, path, ctx=_TARGET_CTX)
     with pytest.raises(FileExistsError, match="refusing to replace"):
-        write_trace_inventory(graph, path)
+        write_trace_inventory(graph, path, ctx=_TARGET_CTX)


### PR DESCRIPTION
## The suite passes or fails by which runner it draws

`tests/compiler/cli/test_trace.py` writes its inventories through `Context.probe()`, which stamps
the **live device's** card into the file. Reading a record back reconstructs that card from the
`emmy.gpu` registry, and #552 made an unregistered card a hard error rather than a fallback —
correctly, since falling back would featurize one card's records as another's.

The `test` job runs on runner group `ubuntu-runners`, which is mixed:

| runner | `gpu.live_name()` | result |
| --- | --- | --- |
| `ubuntu-latest-m-*` (CPU) | `None` | nothing stamped, tests pass |
| `berserk-gpu-1` (**GTX 1080 Ti**, not in `KNOWN_GPUS`) | the card | 2 tests fail |

```
ValueError: unknown GPU 'NVIDIA GeForce GTX 1080 Ti' — no entry in the emmy.gpu registry,
so its device-physical features cannot be reconstructed.
```

via `record.shape_key` → `structural_features` → `_derive_structural_features` →
`Context.from_target`. It surfaced on #569, which happened to draw the GPU box; the same tests
passed on #570 ten minutes earlier on a CPU runner. 13 of the 14 inventory call sites in this file
carry the dependency — only the two that touch `shape_key` / `structural_features` trip on it.

## Fix

These are unit tests about fusion, loop-target selection, and shape keys; none is about the host's
silicon. Pin a target context at every inventory call site, the way `test_golden_file_replay`
already does.

Two follow-ons:

- With the live device no longer stamped, one test's `set(document) - {"gpu_name"}` escape hatch is
  dead — the document is deterministic now, so it asserts the exact key set.
- Stamping was only ever covered by accident, on GPU runners. One test now covers it deterministically
  by naming a registered card instead of whatever is plugged in.

## Verification

Simulated the runner by patching `gpu.live_name` to return the 1080 Ti:

| tree | result |
| --- | --- |
| unmodified `origin/main` | **fails exactly the two tests CI failed** |
| this branch | 22 passed |

Also under the same simulation: `tests/compiler/cli` 196 passed / 40 skipped, and a wider sweep
(`compiler/{cli,pipeline,loader,backend}`, `benchmark`, `commands`) 752 passed / 89 skipped — no
other latent live-GPU dependency in what runs locally. `ruff check` + `ruff format --check` clean.

Not addressed here: whether `berserk-gpu-1` belongs in the `ubuntu-runners` pool, and whether the
1080 Ti should be in `KNOWN_GPUS` at all — it is sm_61, which emmy does not target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)