### PR TITLE
Clarify tile operand bindings and elide empty projections

### DIFF
--- a/emmy/compiler/ir/ARCHITECTURE.md
+++ b/emmy/compiler/ir/ARCHITECTURE.md
@@ -607,9 +607,10 @@ downstream in `lowering/kernel` against the op tree + schedule. The older tile-l
 **The structural dump** (`tile/_dump.pretty` / `TileOp.pretty_body`, what `emmy compile --ir tile` and the `EMMY_DUMP_DIR`
 `.txt` artifacts print) renders the STORED tree as a tree, never a lowered nest — the dump is where a reader meets the
 term directly, so it has to show what the term IS. Each node prints its kind and stored params as labelled branches
-(`operands` first, then `init` / `lift` / `combine`, with the bilinear reading labelling its edges `operand[a]` /
-`operand[b<i>]` — the same `a` / `b` tokens the path codec spells, so a dump line matches a `PLACE@a` key by eye),
-and every operand edge is recursed into and tagged with its inhabitant — `‹computed›`
+(`operands` first, then `init` / `lift` / `combine`). Every edge uses its bound lift parameter or parameters as its
+label (`operand[p]:` or `operand[p, q]:`), making the positional substitution explicit even though the bilinear view
+prints A before B while its stored operand order is `(b₀, a, b₁…)`, and every operand edge is recursed into and tagged
+with its inhabitant — `‹computed›`
 for an inline node subtree, `‹materialized›` for a leaf gmem `Load`. **A λ-valued field labels its own branch with its
 signature and nests its body two under it** — `lift:` / `combine:` / `fn:` all read the same way, so a binder is always
 adjacent to what it binds; none of them ride the node header, where on a big fold the signature sat a screenful above

--- a/emmy/compiler/ir/tile/ARCHITECTURE.md
+++ b/emmy/compiler/ir/tile/ARCHITECTURE.md
@@ -76,7 +76,10 @@ positionally per scope with the cross-scope aliasing pattern kept). Consumed by 
 
 ## An operand edge has two inhabitants
 
-MATERIALIZED (a gmem `Load`) or COMPUTED (the node itself, stored INLINE; the cone built by `ops.make_cone`).
+MATERIALIZED (a gmem `Load`) or COMPUTED (the node itself, stored INLINE; the cone built by `ops.make_cone`). The
+structural dump puts each bound result directly in the edge label (`operand[result]:`) before the load or subtree; a
+product-valued edge lists every bound result. This keeps the lift's positional substitutions visible when a derived
+reading presents the edges in role order instead of stored operand order.
 
 **Edge iff closed** holds BY CONSTRUCTION — operands bind positionally, so a subtree that reads a name from its
 enclosing body cannot be one. The closure SCAN survives only as the validation reading, living with its one consumer
@@ -136,8 +139,9 @@ Every schedule slice lives in **`TileOp.schedule`**, a dict keyed by the tree-pa
 ONE walker plus one resolver, short-path-canonical: bare for the primary node, axis-suffixed where a kernel holds
 several sites of one family. Read
 and written through `ops.Sched`, which is also the one home of the `(m, n)` binding rule (`Sched.placed` /
-`Sched.tile_of`). The path codec spells `map` / `fold` / `a` / `b` segments off the derived readings — `PLACE@a`'s
-golden rows depend on it. A sliced axis's window is the one `Axis.window`.
+`Sched.tile_of`). The path codec spells `map` / `fold` / `a` / `b` segments off the derived readings. A computed-A
+cone accepts the explicit `PLACE@a` spelling; when it is the root contraction's shallowest seam, short-path
+canonicalization spells it as bare `PLACE`. A sliced axis's window is the one `Axis.window`.
 
 Since step 7 the wire forms are SITE-LOCAL: the worker inventory is spelled once in `WORK`
 (`w<M>x<N>[+p<np>]` / `t<N>[x<M>]`, the producer band riding `+p`), and `TILE` / `REDUCE` values shed their worker

--- a/emmy/compiler/ir/tile/_dump.py
+++ b/emmy/compiler/ir/tile/_dump.py
@@ -6,7 +6,7 @@ reads made ``ops`` half presentation."""
 
 from __future__ import annotations
 
-from emmy.compiler.ir.pure.fold import Fold
+from emmy.compiler.ir.pure.fold import Fold, _operand_result_names
 from emmy.compiler.ir.stmt import Body, Load
 from emmy.compiler.ir.stmt.base import Stmt, pretty_body
 from emmy.compiler.ir.tile.ops import axis_names, sched_of
@@ -35,11 +35,11 @@ def unplaced_slices(tile) -> list[tuple[str, object]]:
 # --------------------------------------------------------------------------- #
 # The structural dump — the STORED term as a tree, and NOTHING derived.
 #
-# The tile term is a tree of three node kinds over operand EDGES, and every fact a pass
+# The tile term is a tree of one node kind over operand EDGES, and every fact a pass
 # dispatches on is a stored param on a node (this module's whole premise). The dump renders
 # exactly that: each node's own header, its stored params as labelled branches, and each operand
-# edge recursed into — so an inline COMPUTED edge is visibly a subtree and a MATERIALIZED one
-# visibly a leaf ``Load``.
+# edge's positional lambda binding before recursing into it — so an inline COMPUTED edge is
+# visibly a subtree and a MATERIALIZED one visibly a leaf ``Load``.
 #
 # It renders NO derived material. The structure is already complete in the stored tree — the
 # operand edges and their nesting — and a derived evaluation (the per-cell step, the synthesized
@@ -153,30 +153,37 @@ def _subtree(node, ctx: _Ctx):
     return lambda cont: _branch(_items(node, ctx), cont)
 
 
-def _edge(label: str, edge, ctx: _Ctx) -> tuple[str, object]:
-    """One operand edge as a tree item — a ``Load`` is a leaf spelled inline, a computed edge
-    recurses into the node stored on it."""
+def _edge(edge, ctx: _Ctx, result: str | None = None) -> tuple[str, object]:
+    """One operand edge and the lift params it binds — a ``Load`` is a leaf spelled inline, a
+    computed edge recurses into the node stored on it. The binding is explicit because the
+    bilinear view prints edges in A/B role order, which can differ from the lift's positional
+    parameter order."""
+    names = _operand_result_names(edge)
+    head = f"operand[{', '.join(names)}]" + (f" -> {result}" if result is not None else "")
     if isinstance(edge, Load):
-        return f"{label}: {edge.pretty()[0].strip()}   ‹materialized›", lambda cont: []
-    return f"{label}: {_head(edge, ctx)}   ‹computed›", _subtree(edge, ctx)
+        load = edge.pretty()[0].strip().removeprefix(f"{edge.name} = ")
+        return f"{head}: {load}   ‹materialized›", lambda cont: []
+    return f"{head}: {_head(edge, ctx)}   ‹computed›", _subtree(edge, ctx)
 
 
 def _items(node, ctx: _Ctx) -> list[tuple[str, object]]:
-    """A node's STORED children, each a labelled branch. Nothing derived: the step, the
-    synthesized nodes inside it and the lowered nest are all consequences of these params."""
+    """A node's STORED children, each a labelled branch with operand bindings explicit. Nothing
+    derived: the step, the synthesized nodes inside it and the lowered nest are all consequences
+    of these params."""
     items: list[tuple[str, object]] = []
     if not isinstance(node, Fold):
         return items
     con = node._contraction
     if con is not None:
-        # The bilinear reading labels its edges ``a`` / ``b`` — the same labels the path codec
-        # spells, so a reader can match a dump line to a ``PLACE@a`` key by eye.
+        # The bilinear reading presents A before its B channels even though its stored operand
+        # order is ``(b₀, a, b₁…)``. Each edge's bracket names the positional lift param, so
+        # the presentation order cannot be mistaken for the binding order.
         a, chans = con
-        items.append(_edge("operand[a]", a, ctx))
+        items.append(_edge(a, ctx))
         one = len(chans) == 1
-        items += [_edge("operand[b]" if one else f"operand[b{i}] -> {ch.acc}", ch.b, ctx) for i, ch in enumerate(chans)]
+        items += [_edge(ch.b, ctx, None if one else ch.acc) for ch in chans]
     else:
-        items += [_edge(f"operand[{i}]", e, ctx) for i, e in enumerate(node.operands)]
+        items += [_edge(e, ctx) for e in node.operands]
     if node.axis is not None:
         init = ", ".join(x if isinstance(x, str) else format(x, "g") for x in node.init)
         items.append((f"init: ({init})", lambda cont: []))
@@ -199,11 +206,11 @@ def _branch(items: list[tuple[str, object]], cont: str) -> list[str]:
 
 def pretty(op, indent: str = "", *, tile=None) -> list[str]:
     """Structurally pretty-print a kernel op (for dumps) as the STORED tree and nothing else —
-    each node's kind and params, its operand edges recursed into. No derived material: the
-    per-cell step, the nodes synthesized inside it and the lowered nest all follow from these
-    params (``--ir loop`` is where a body lives). Pass ``tile`` — the owning ``TileOp`` — to
-    annotate each node with the schedule slices keyed against it. A bare stmt falls back to its
-    own pretty."""
+    each node's kind and params, and which lift param each recursed operand edge binds. No derived
+    material: the per-cell step, the nodes synthesized inside it and the lowered nest all follow
+    from these params (``--ir loop`` is where a body lives). Pass ``tile`` — the owning
+    ``TileOp`` — to annotate each node with the schedule slices keyed against it. A bare stmt
+    falls back to its own pretty."""
     ctx = _Ctx(tile, root=op)
     if isinstance(op, Fold):
         return [f"{indent}{_head(op, ctx)}", *_branch(_items(op, ctx), indent)]

--- a/emmy/compiler/pipeline/passes/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/passes/ARCHITECTURE.md
@@ -678,8 +678,9 @@ rides the engine's splice event, which every fragment goes through. (The histori
 `loop/stamp` and `lowering/tile` plus a recognize-time deferral guarding their ordering — is gone with it.)
 
 **Placement (phase 4).** `PLACE@<child-path> = cut | fuse` is the per-seam edge property on the recognized
-tree — a `PLACE` site is every NON-ROOT node (the child names its parent↔child seam; the cone edge spells `PLACE@a`
-through the view-role label), spelled/resolved by the same tree-path codec as the schedule families. Resolution is
+tree — a `PLACE` site is every NON-ROOT node (the child names its parent↔child seam; a cone edge accepts the
+`PLACE@a` view-role spelling and canonicalizes to bare `PLACE` when it is the root contraction's shallowest seam),
+spelled/resolved by the same tree-path codec as the schedule families. Resolution is
 decided BEFORE any schedule fork exists (`010_recognize` consults `route_cut` right after the lift / prologue
 bind) and it is RECURSIVE. An authoritative `PLACE` pin decides outright; UNPINNED, placement is an enumerated
 STRUCTURAL fork — the fused form beside one cut fragment per legal seam, so tune discovers cuts and a compile

--- a/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
+++ b/emmy/compiler/pipeline/passes/lowering/tile/_classify.py
@@ -287,9 +287,11 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     one :class:`Channel` per ⊗-fold, the column axis joining the grid.
 
     Returns the same ``(Fold, column Axis, stores)`` the old recognize-time binder returned — or
-    ``None`` (not this shape). A VIEW, not a rewrite: ``classify`` stores the canonical projection
-    tree; this derivation runs on demand at the schedule (``_views``) and the golden decode,
-    because which of the two readings a fork row realizes is a decision about the SCHEDULE.
+    ``None`` (not this shape). The returned contraction keeps a wrapping projection only when its
+    body has real work; an empty identity projection carries no information. A VIEW, not a rewrite:
+    ``classify`` stores the canonical projection tree; this derivation runs on demand at the
+    schedule (``_views``) and the golden decode, because which of the two readings a fork row
+    realizes is a decision about the SCHEDULE.
 
     The statistic's OWN composed score binds too (the old ``bound_producer``): a single fold edge
     on the statistic re-binds through :func:`bind_bilinear` — tried against each free axis as the
@@ -408,7 +410,9 @@ def fused_view(tile) -> tuple[Fold, object, tuple] | None:
     )
     from emmy.compiler.ir.tile.ir import Store  # noqa: PLC0415
 
-    return Fold.projection(body=Body((*prefix, *tail)), operands=(con,)), n_ax, tuple(Store(write=w) for w in writes)
+    projection = Body((*prefix, *tail))
+    root = Fold.projection(body=projection, operands=(con,)) if projection else con
+    return root, n_ax, tuple(Store(write=w) for w in writes)
 
 
 def _cone_value_key(name: str, defs: dict) -> tuple:

--- a/tests/compiler/ir/tile/test_operand_edges.py
+++ b/tests/compiler/ir/tile/test_operand_edges.py
@@ -100,14 +100,13 @@ def test_external_reads_cover_every_channel() -> None:
 
 
 def test_pretty_prints_the_channels_once() -> None:
-    """One shared A edge, one branch per channel — the dump names the ``a`` / ``b`` edge labels the
-    path codec spells, so a ``PLACE@a`` key can be matched to a dump line by eye."""
+    """One shared A edge, one branch per channel, each labelled by the lift param it binds."""
     from emmy.compiler.ir.tile._dump import pretty
 
     text = "\n".join(pretty(_product()))
-    assert text.count("operand[a]:") == 1  # the SHARED A edge — printed once, not once per channel
+    assert text.count("operand[xhat]:") == 1  # the SHARED A edge — printed once, not once per channel
     assert text.count("xhat = multiply") == 1  # and its cone body with it
-    assert "operand[b0] -> acc_g" in text and "operand[b1] -> acc_u" in text
+    assert "operand[acc_g_b] -> acc_g" in text and "operand[acc_u_b] -> acc_u" in text
 
 
 # --- closure: the predicate a placement cut asks ------------------------------------------------- #

--- a/tests/compiler/ir/tile/test_structural_dump.py
+++ b/tests/compiler/ir/tile/test_structural_dump.py
@@ -9,11 +9,11 @@ evaluation (the per-cell step, the nodes synthesized inside it, the lowered nest
 of the stored params and is never printed: showing it beside storage is the inversion the layer
 exists to prevent, and it was the bulk of the output.
 
-These pin: (a) every stored param of each node kind reaches the dump; (b) edges nest, are labelled
-by inhabitant, and appear exactly once; (c) nothing derived appears — including the one slice whose
-site is synthesized, which lands in the schedule region rather than reconstructing its node;
-(d) schedule slices annotate a node only when the owning ``TileOp`` supplies them — never from the
-term; (e) a λ that is not closed says what it captures.
+These pin: (a) every stored param of each node kind reaches the dump; (b) edges say which lambda
+params they bind, nest, are labelled by inhabitant, and appear exactly once; (c) nothing derived
+appears — including the one slice whose site is synthesized, which lands in the schedule region
+rather than reconstructing its node; (d) schedule slices annotate a node only when the owning
+``TileOp`` supplies them — never from the term; (e) a λ that is not closed says what it captures.
 """
 
 from __future__ import annotations
@@ -85,10 +85,12 @@ def test_fold_dump_shows_every_stored_param() -> None:
 def test_contraction_dump_shows_the_k_axis_and_every_channel() -> None:
     text = "\n".join(pretty(_product()))
     assert "Fold[k in 0..256] contraction" in text
-    assert "├─ operand[a]: a_e = load x[m, k]" in text
+    assert "├─ operand[a_e]: load x[m, k]" in text
     # Sharing is arity: one ``a``, one branch per channel, each naming its own accumulator.
-    assert "├─ operand[b0] -> acc_g: acc_g_b = load Wg[k, n]" in text
-    assert "├─ operand[b1] -> acc_u: acc_u_b = load Wu[k, n]" in text
+    assert "├─ operand[acc_g_b] -> acc_g: load Wg[k, n]" in text
+    assert "├─ operand[acc_u_b] -> acc_u: load Wu[k, n]" in text
+    # The binding labels connect role-ordered edges above to their actual positional lift params.
+    assert "lift: λ(k, acc_g_b, a_e, acc_u_b) -> (acc_g__v, acc_u__v)" in text
 
 
 def test_map_dump_shows_the_binder_and_its_sources() -> None:
@@ -98,9 +100,18 @@ def test_map_dump_shows_the_binder_and_its_sources() -> None:
     m = Fold.projection(operands=(_stat_fold(),), body=Body((Assign(name="o", op="rsqrt", args=("acc0",)),)))
     text = "\n".join(pretty(m))
     assert text.splitlines()[0] == "Fold  free"
-    assert "├─ operand[0]: Fold[k in 0..512] planar" in text
+    assert "├─ operand[acc0]: Fold[k in 0..512] planar" in text
     assert "└─ lift: λ(acc0) -> (o)" in text
     assert "     o = rsqrt(acc0)" in text  # the body, indented two under the signature
+
+
+def test_a_product_edge_shows_every_lambda_param_it_binds() -> None:
+    """One operand edge can supply several result components, so the dump names every scalar
+    substituted for that edge instead of leaving the positional binding implicit."""
+    node = Fold.projection(operands=(_product(),), body=Body((Assign(name="o", op="add", args=("acc_g", "acc_u")),)))
+    text = "\n".join(pretty(node))
+    assert "operand[acc_g, acc_u]: Fold[k in 0..256] contraction" in text
+    assert "lift: λ(acc_g, acc_u) -> (o)" in text
 
 
 def test_the_fn_branch_survives_an_empty_body() -> None:
@@ -121,7 +132,7 @@ def test_a_computed_edge_nests_as_a_subtree_a_materialized_one_is_a_leaf() -> No
     """The two inhabitants of an operand edge, told apart in the dump: the cone recurses into its
     own node, the gmem loads do not."""
     lines = pretty(_product(a=_cone()))
-    (a_line,) = [ln for ln in lines if "operand[a]:" in ln]
+    (a_line,) = [ln for ln in lines if "operand[xhat]:" in ln]
     assert "‹computed›" in a_line and "Fold  free" in a_line
     assert any("‹materialized›" in ln and "load Wg" in ln for ln in lines)
     # The cone's own body is reached BELOW the a edge — the subtree is really rendered.
@@ -172,7 +183,7 @@ def test_an_edge_is_rendered_once_not_once_per_derived_position() -> None:
     assert any(s is fold.operands[0] for s in fold.step_stmts())  # the premise: one object, two positions
     text = "\n".join(pretty(fold))
     assert text.count("Fold[kslice in 0..128] contraction") == 1
-    assert text.count("operand[a]: a_e = load x[m, kslice]") == 1
+    assert text.count("operand[a_e]: load x[m, kslice]") == 1
 
 
 def test_a_slice_keyed_against_derived_material_prints_in_the_schedule_region() -> None:

--- a/tests/compiler/passes/test_online_softmax_channels.py
+++ b/tests/compiler/passes/test_online_softmax_channels.py
@@ -219,7 +219,7 @@ def test_twisted_statistic_binds_the_sweep_as_one_contraction() -> None:
     bound = fused_view(tile)
     assert bound is not None, "the sweep must bind as a computed-A contraction over the twisted statistic"
     node, n_axis, _stores = bound
-    con = node.operands[0]
+    con = node
     assert is_contraction(con) and con.axis.extent == Dim(128), "one contraction over the whole reduce axis"
     assert n_axis.extent == Dim(32), "the output column axis joins the grid"
     assert con.a.operands[0].operands == (stat,), "the A cone's source is the pair, its K seam the node boundary"
@@ -247,7 +247,7 @@ def test_twisted_statistic_survives_the_loop_dialect_round_trip() -> None:
     relifted = recognized_tile(LoopOp(body=Body.coerce(stmts)))
     again = fused_view(relifted)
     assert again is not None, "the round trip must not cost the region its computed-A binding"
-    assert is_contraction(again[0].operands[0]), "and it must come back as the SAME one contraction"
+    assert is_contraction(again[0]), "and it must come back as the SAME bare contraction"
 
 
 # --------------------------------------------------------------------------------------------

--- a/tests/compiler/passes/test_placement_routing.py
+++ b/tests/compiler/passes/test_placement_routing.py
@@ -122,13 +122,12 @@ def test_place_sites_are_the_non_root_nodes() -> None:
     all_sites = sites(c_map)
     seams = family_sites("PLACE", all_sites)
     assert seams and all(s.depth > 1 for s in seams)
-    # The cone edge spells through the view-role label — the plan's worked spelling.
-    cone = c_map.operands[0].a  # noqa: F841 — the a edge carries its role label on the stored node
-    labels = {spell(c_map, "PLACE", s.node, all_sites=all_sites) for s in seams}
-    assert "PLACE@a" in labels
-    assert resolve(c_map, "PLACE@a", all_sites=all_sites).node is next(
-        s.node for s in seams if spell(c_map, "PLACE", s.node, all_sites=all_sites) == "PLACE@a"
-    )
+    # With the empty projection elided, the A cone is the root contraction's shallowest seam, so
+    # the shortest canonical spelling is bare. The explicit view-role spelling remains accepted for
+    # scoped pins and recorded evidence.
+    cone = c_map.a
+    assert spell(c_map, "PLACE", cone, all_sites=all_sites) == "PLACE"
+    assert resolve(c_map, "PLACE@a", all_sites=all_sites).node is cone
 
 
 # --- the realizer: pin-driven cuts, fuse-default, recursion ---------------------------------------

--- a/tests/compiler/passes/test_recognize_boundary_rules.py
+++ b/tests/compiler/passes/test_recognize_boundary_rules.py
@@ -345,8 +345,9 @@ def test_norm_linear_cone_is_an_inline_node_tree():
 
     _, tile = _resolve(_norm_linear_graph(), pick=_is_warp_row)
     # The single-channel form's projection was ONLY the root ``Write`` — moved to ``TileOp.stores``
-    # (1q), so the row stores the BARE product fold (the ``Map`` wrapper dropped with its last stmt).
-    fold = tile.op.operands[0] if (isinstance(tile.op, Fold) and tile.op.axis is None) else tile.op
+    # (1q), so the row stores the BARE product fold (the ``Map`` wrapper drops with its last stmt).
+    fold = tile.op
+    assert fold.role is AxisRole.CONTRACTION, "an empty identity projection must not wrap the product fold"
     assert len(tile.stores) == 1 and tile.stores[0].write.output == "y"
     c = fold
     assert not isinstance(c.a, Load)


### PR DESCRIPTION
## Summary

- label structural-dump operand edges with the lambda values they bind, including multi-result edges
- elide empty identity projections from fused computed-A contractions while retaining wrappers with real epilogues
- keep explicit `PLACE@a` pins resolvable and document the new bare canonical spelling for the shallowest A seam

## Testing

- `venv/bin/ruff check`
- `venv/bin/ruff format --check`
- `venv/bin/pytest -q -p no:randomly tests/compiler/` (1888 passed, 502 skipped, 1 xfailed)