### PR TITLE
Restore the fit byte-identity and freeze test files deleted in #551

### DIFF
--- a/tests/compiler/pipeline/search/data/test_freeze.py
+++ b/tests/compiler/pipeline/search/data/test_freeze.py
@@ -1,0 +1,339 @@
+"""The measurement freeze (v3) — the leaf sanity filter, freeze-twice
+determinism over the per-GPU YAML directory, load-time feature re-derivation, the
+loader's hard-error contract, and the DB/freeze interchange seam (``load_node_rows``).
+
+The freeze is Phase 3 of the offline-prior rework: a fit must be a pure function of
+(repo, pinned data), so one command snapshots the live node DB into a digest-pinned
+directory of golden-spelled per-GPU YAML files. These tests never touch a GPU — the
+plausibility physics itself is not covered here; the specs here are
+small fp32 matmuls so the loader's snippet re-trace stays cheap (and lru-cached)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+import yaml
+
+from emmy.compiler.pipeline.search.data import Dataset
+from emmy.compiler.pipeline.search.data.freeze import (
+    FREEZE_KIND,
+    FREEZE_VER,
+    MANIFEST_NAME,
+    freeze_reason,
+    load_freeze,
+    load_node_rows,
+    write_freeze,
+)
+from emmy.compiler.pipeline.search.data.shape import ShapeKey
+from emmy.compiler.pipeline.search.db import SearchDB
+from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
+from tests.compiler.pipeline.search.helpers import GPU_5090 as _GPU
+from tests.compiler.pipeline.search.helpers import impossible_staged_feats
+from tests.compiler.pipeline.search.helpers import node_row as _row
+
+_GPU2 = "NVIDIA GeForce RTX 4090"
+
+# Small declarative identities — the loader re-traces each DISTINCT shape once (cached).
+_SPEC_A = {"kernel": "matmul", "M": 64, "N": 64, "K": 64, "dtype": "fp32", "trans_b": False, "dynamic": False}
+_SPEC_B = {"kernel": "matmul", "M": 64, "N": 64, "K": 128, "dtype": "fp32", "trans_b": False, "dynamic": False}
+
+
+def _feats(*, opt: float = 3.0, cc: float = 120.0, **knobs) -> dict:
+    """Write-time features consistent with ``_SPEC_A``-sized shapes: the regime stamps the
+    freeze needs (``H_cc`` / ``H_opt``), plausible extents, and the tunable knobs that
+    must survive the round trip verbatim."""
+    return {
+        "H_cc": cc,
+        "H_opt": opt,
+        "S_ext_free_prod": 4096.0,
+        "S_ext_free_max": 64.0,
+        "S_ext_reduce_max": 64.0,
+        "S_ext_n_free_axis": 2.0,
+        "S_ext_n_reduce_axis": 1.0,
+        "S_loop_depth": 3.0,
+        "S_dtype_f32": 3.0,
+        "TILE": "f2x2",
+        "WORK": "t16x16",
+        **knobs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# freeze_reason — the sanity filter
+# ---------------------------------------------------------------------------
+
+
+def test_reason_keeps_ordinary_leaf() -> None:
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats())) is None
+
+
+def test_reason_keeps_bench_fail_leaf_as_negative() -> None:
+    # A fail's value_us is the watchdog sentinel — absurd as a latency, but the row is
+    # a durable "doesn't build/launch here" negative and must freeze.
+    assert freeze_reason(_row("k", value_us=9.17, features=_feats(), status="bench_fail")) is None
+
+
+def test_reason_drops_rows_without_regime_stamps() -> None:
+    feats = {k: v for k, v in _feats().items() if k != "H_cc"}
+    assert "missing H_" in freeze_reason(_row("k", value_us=500.0, features=feats))
+
+
+def test_reason_drops_non_leaves() -> None:
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), is_leaf=False)) is not None
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), is_leaf=None)) is not None
+
+
+def test_reason_drops_stale_feat_ver() -> None:
+    stale = FEATURIZER_VERSION - 1
+    assert freeze_reason(_row("k", value_us=500.0, features=_feats(), feat_ver=stale)) is not None
+    # ... including fail rows: a negative spelled in a retired vocabulary is unreadable too.
+    assert freeze_reason(_row("k", value_us=9.17, features=_feats(), status="bench_fail", feat_ver=stale)) is not None
+
+
+def test_reason_drops_implausible_value() -> None:
+    # The shared f16 mlp_down extents at 9.17 µs imply ~6500 TFLOP/s.
+    from tests.compiler.pipeline.search.helpers import F16_MATMUL_FEATS
+
+    feats = {"H_cc": 120.0, "H_opt": 3.0, **F16_MATMUL_FEATS}
+    assert "implausible value" in freeze_reason(_row("k", value_us=9.17, features=feats))
+
+
+def test_reason_drops_impossible_kernel() -> None:
+    # The square.512 residue: over-cap cp.async slab -> legal-looking latency, invalid kernel.
+    feats = {"H_cc": 120.0, "H_opt": 3.0, **impossible_staged_feats()}
+    assert "impossible kernel" in freeze_reason(_row("k", value_us=2.02, features=feats))
+
+
+# ---------------------------------------------------------------------------
+# write_freeze / load_freeze round trip
+# ---------------------------------------------------------------------------
+
+
+def _seed_db(path, rows) -> None:
+    db = SearchDB(path)
+    db.record_nodes(rows)
+    db.close()
+
+
+_SEED = [
+    # _SPEC_A's -O3/-O1 twins on the 5090 — same declarative op, two lanes.
+    _row("leaf-a3", value_us=500.0, op_sig="mm1", features=_feats(), run_id="run-a"),
+    _row("leaf-a1", value_us=900.0, op_sig="mm1", features=_feats(opt=1.0), run_id="run-a"),
+    _row("leaf-b", value_us=480.0, op_sig="mm2", gpu=_GPU2, features=_feats(cc=89.0), run_id="run-b"),
+    _row("leaf-fail", value_us=60000.0, op_sig="mm2", features=_feats(), status="bench_fail", run_id="run-a"),
+    _row("branch", value_us=480.0, op_sig="mm1", features=_feats(), is_leaf=False),
+    _row("leaf-stale", value_us=500.0, op_sig="mm1", features=_feats(), feat_ver=FEATURIZER_VERSION - 1),
+    _row("leaf-legacy", value_us=500.0, op_sig="mm1", features=_feats()),  # no identity — never freezes
+]
+_N_KEPT = 5
+
+
+def test_write_freeze_round_trip(tmp_path) -> None:
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    out = tmp_path / "freeze"
+    manifest = write_freeze(db_path, out, note="unit-test policy")
+
+    assert manifest["kind"] == FREEZE_KIND
+    assert manifest["freeze_ver"] == FREEZE_VER
+    assert manifest["feat_ver"] == manifest["knob_ver"] == manifest["encoding_ver"] == FEATURIZER_VERSION
+    assert manifest["counts"] == {"rows": _N_KEPT, "ok": 4, "bench_fail": 1, "per_gpu": {_GPU2: 1, _GPU: 4}}
+    assert manifest["run_ids"] == ["run", "run-a", "run-b"]
+    assert manifest["policy_note"] == "unit-test policy"
+    assert manifest["source_db"] == str(db_path.resolve())
+    # One YAML per (gpu, cap); device context is derived while measured structural features persist.
+    assert set(manifest["files"]) == {"nvidia_geforce_rtx_5090_sm120.yaml", "nvidia_geforce_rtx_4090_sm89.yaml"}
+    doc = yaml.safe_load((out / "nvidia_geforce_rtx_5090_sm120.yaml").read_text())
+    assert doc["gpu_name"] == _GPU and doc["compute_cap"] == [12, 0]
+    assert all(set(c) & {"H_cc", "H_opt"} == set() for c in doc["configs"])
+    assert all(not any(k.startswith(("S_", "H_")) for k in c["knobs"]) for c in doc["configs"])
+    assert all(c["structural_features"] for c in doc["configs"])
+
+    loaded_manifest, rows = load_freeze(out)
+    assert loaded_manifest == manifest
+    assert len(rows) == _N_KEPT
+    by_run_value = {(r.run_id, r.value_us): r for r in rows}
+    a3 = by_run_value[("run-a", 500.0)]
+    a1 = by_run_value[("run-a", 900.0)]
+    fail = by_run_value[("run-a", 60000.0)]
+    assert a3.status == "ok" and a3.measured_at == "2026-07-09T00:00:00+00:00"
+    assert fail.status == "bench_fail"
+    # Features are RE-DERIVED: card-faithful H_* (H_cc from the file cap), the opt lane
+    # from the row's own field, full traced S_* keying to the spec, tunables verbatim.
+    assert a3.features["H_cc"] == 120.0 and a3.features["H_opt"] == 3.0
+    assert a1.features["H_opt"] == 1.0
+    assert a3.features["TILE"] == "f2x2"
+    assert ShapeKey.from_s_features(a3.features).joins(ShapeKey.from_matmul(_SPEC_A["M"], _SPEC_A["N"], _SPEC_A["K"], _SPEC_A["dtype"]))
+    assert a3.feat_ver == FEATURIZER_VERSION
+    # Treeless contract + stored DB identity: -O1/-O3 twins share one op_sig.
+    assert all(r.parent_key is None and r.depth == 0 and r.visits == 0 and r.is_leaf is True for r in rows)
+    assert a3.op_sig == a1.op_sig == "mm1"
+    assert a3.op_sig != fail.op_sig and a3.node_key != a1.node_key
+    # The Dataset seams read freeze rows unchanged. ``from_node_rows`` has one caller today;
+    # ``fold_node_rows`` has none yet and is the grouping the measured-metric work builds on.
+    assert len(Dataset.from_node_rows(rows)) == _N_KEPT
+    assert {g: len(rs) for g, rs in Dataset.fold_node_rows(rows, by="gpu").items()} == {_GPU: 4, _GPU2: 1}
+    assert {sig: len(rs) for sig, rs in Dataset.fold_node_rows(rows, by="op").items()} == {a3.op_sig: 3, fail.op_sig: 2}
+
+
+def test_freeze_twice_same_digest(tmp_path) -> None:
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    m1 = write_freeze(db_path, tmp_path / "f1")
+    m2 = write_freeze(db_path, tmp_path / "f2")
+    assert m1["sha256"] == m2["sha256"]
+    assert m1["files"] == m2["files"]
+    for name in m1["files"]:
+        assert (tmp_path / "f1" / name).read_bytes() == (tmp_path / "f2" / name).read_bytes()
+
+
+def test_freeze_digest_insertion_order_independent(tmp_path) -> None:
+    _seed_db(tmp_path / "fwd.db", _SEED)
+    _seed_db(tmp_path / "rev.db", list(reversed(_SEED)))
+    m_fwd = write_freeze(tmp_path / "fwd.db", tmp_path / "fwd")
+    m_rev = write_freeze(tmp_path / "rev.db", tmp_path / "rev")
+    assert m_fwd["sha256"] == m_rev["sha256"]
+
+
+def test_refreezing_a_freeze_is_stable(tmp_path) -> None:
+    # write_freeze reads through load_node_rows, so a freeze re-freezes: the loaded rows
+    # carry the stored structural measurements, and the digests must not drift.
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    m1 = write_freeze(db_path, tmp_path / "f1")
+    m2 = write_freeze(tmp_path / "f1", tmp_path / "f2")
+    assert m1["sha256"] == m2["sha256"]
+
+
+# ---------------------------------------------------------------------------
+# the loader's hard-error contract
+# ---------------------------------------------------------------------------
+
+
+def _frozen(tmp_path):
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    out = tmp_path / "freeze"
+    write_freeze(db_path, out)
+    return out
+
+
+def test_load_freeze_digest_mismatch_hard_error(tmp_path) -> None:
+    out = _frozen(tmp_path)
+    f = out / "nvidia_geforce_rtx_4090_sm89.yaml"
+    f.write_text(f.read_text().replace("value_us: 480.0", "value_us: 4.0"))
+    with pytest.raises(RuntimeError, match="corrupt"):
+        load_freeze(out)
+
+
+def test_load_freeze_missing_listed_file_hard_error(tmp_path) -> None:
+    out = _frozen(tmp_path)
+    (out / "nvidia_geforce_rtx_4090_sm89.yaml").unlink()
+    with pytest.raises(RuntimeError, match="missing"):
+        load_freeze(out)
+
+
+def test_load_freeze_ver_mismatch_hard_error(tmp_path) -> None:
+    out = _frozen(tmp_path)
+    manifest = json.loads((out / MANIFEST_NAME).read_text())
+    manifest["freeze_ver"] = FREEZE_VER + 1
+    (out / MANIFEST_NAME).write_text(json.dumps(manifest))
+    with pytest.raises(RuntimeError, match="freeze_ver"):
+        load_freeze(out)
+
+
+def test_load_freeze_foreign_dir_hard_error(tmp_path) -> None:
+    plain = tmp_path / "not-a-freeze"
+    plain.mkdir()
+    with pytest.raises(RuntimeError, match="not a measurement freeze"):
+        load_freeze(plain)
+
+
+def test_load_freeze_malformed_structural_features_hard_error(tmp_path) -> None:
+    out = _frozen(tmp_path)
+    name = "nvidia_geforce_rtx_5090_sm120.yaml"
+    doc = yaml.safe_load((out / name).read_text())
+    for c in doc["configs"]:
+        c["structural_features"] = "not-a-mapping"
+    (out / name).write_text(yaml.safe_dump(doc, sort_keys=True, width=120))
+    manifest = json.loads((out / MANIFEST_NAME).read_text())
+    # Keep the digest honest so schema validation (not integrity) is what trips.
+    from emmy.compiler.pipeline.search.data.freeze import _row_line
+
+    digest = hashlib.sha256()
+    for c in doc["configs"]:
+        digest.update(_row_line(c))
+    manifest["files"][name]["sha256"] = digest.hexdigest()
+    (out / MANIFEST_NAME).write_text(json.dumps(manifest))
+    with pytest.raises(RuntimeError, match="lacks op_sig/structural_features"):
+        load_freeze(out)
+
+
+def test_write_freeze_nothing_survives_hard_error(tmp_path) -> None:
+    # A store with no leaves has no measurement rows to freeze.
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, [_row("branch", value_us=500.0, features=_feats(), is_leaf=False)])
+    with pytest.raises(RuntimeError, match="no freezable leaf rows"):
+        write_freeze(db_path, tmp_path / "freeze")
+
+
+def test_write_freeze_refuses_to_replace_non_freeze_dir(tmp_path) -> None:
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    target = tmp_path / "precious"
+    target.mkdir()
+    (target / "notes.txt").write_text("do not delete\n")
+    with pytest.raises(RuntimeError, match="refusing to replace"):
+        write_freeze(db_path, target)
+    assert (target / "notes.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# load_node_rows — the DB/freeze interchange seam
+# ---------------------------------------------------------------------------
+
+
+def test_load_node_rows_zero_byte_file_is_empty_db(tmp_path) -> None:
+    # sqlite creates the DB file empty before the first write (an aborted tune), and a
+    # 0-byte file IS a valid empty sqlite DB — it must yield no rows, not a freeze error.
+    empty = tmp_path / "autotune.db"
+    empty.touch()
+    assert load_node_rows(empty) == []
+
+
+def test_load_node_rows_refuses_v1_jsonl_freeze(tmp_path) -> None:
+    v1 = tmp_path / "freeze.jsonl"
+    header = {"kind": FREEZE_KIND, "freeze_ver": 1, "sha256": "deadbeef"}
+    v1.write_text(json.dumps(header) + "\n" + '{"node_key": "k"}\n')
+    with pytest.raises(RuntimeError, match="superseded"):
+        load_node_rows(v1)
+
+
+def test_open_readonly_rejects_v1_freeze_with_pointer(tmp_path) -> None:
+    # A v1-style JSON file handed to a perf-table consumer (eval variants/knobs/failures
+    # --db) must fail at open with a named reason, not a bare sqlite DatabaseError.
+    v1 = tmp_path / "freeze.jsonl"
+    v1.write_text(json.dumps({"kind": FREEZE_KIND, "freeze_ver": 1}) + "\n")
+    with pytest.raises(RuntimeError, match="nodes-dataset"):
+        SearchDB.open_readonly(v1)
+    garbage = tmp_path / "notes.txt"
+    garbage.write_text("hello\n")
+    with pytest.raises(RuntimeError, match="not a sqlite database"):
+        SearchDB.open_readonly(garbage)
+
+
+def test_load_node_rows_sniffs_db_and_freeze_dir(tmp_path) -> None:
+    db_path = tmp_path / "autotune.db"
+    _seed_db(db_path, _SEED)
+    out = tmp_path / "freeze"
+    write_freeze(db_path, out)
+    from_db = load_node_rows(db_path)
+    from_freeze = load_node_rows(out)
+    assert len(from_db) == len(_SEED)  # raw iter_nodes view — everything
+    assert len(from_freeze) == _N_KEPT
+    garbage = tmp_path / "notes.txt"
+    garbage.write_text("hello\n")
+    with pytest.raises(RuntimeError, match="neither a sqlite node DB nor"):
+        load_node_rows(garbage)

--- a/tests/compiler/pipeline/search/helpers.py
+++ b/tests/compiler/pipeline/search/helpers.py
@@ -1,0 +1,65 @@
+"""Shared node-row builders for the search-package tests.
+
+The dicts here are PHYSICS-CALIBRATED against the node-store plausibility gate, which
+``test_freeze.py``'s filter composes: a row is kept or dropped by the same predicates the
+gate applies, so these spellings must track the featurizer vocabulary and the GPU registry
+or the freeze suite silently stops exercising the real filter.
+"""
+
+from __future__ import annotations
+
+from emmy.compiler.pipeline.search.db import NodeRow
+
+GPU_5090 = "NVIDIA GeForce RTX 5090"  # registry records fp32/fp16 peaks -> the plausibility gate is active
+
+# The poisoned class's shape: symbolic-M mlp_down (free excludes the symbolic axis,
+# benched at the dynamic hint), fp16 operands. 2*4096*14336*512 FLOPs. The stamps
+# certify every loop multiplies the iteration space (depth 3 = 1 free + 1 reduce +
+# 1 symbolic — the dynM matmul spelling), which is what licenses the free x red work
+# formula: 9.17 us implies ~6500 TFLOP/s (implausible) while 500 us is honest.
+F16_MATMUL_FEATS = {
+    "S_ext_free_prod": 4096.0,
+    "S_ext_reduce_max": 14336.0,
+    "S_ext_n_free_axis": 1.0,
+    "S_ext_n_reduce_axis": 1.0,
+    "S_loop_depth": 3.0,
+    "S_ext_n_symbolic_axis": 1.0,
+    "S_dtype_f16": 2.0,
+    "TILE@a2": "mma_m16n8k16_f16/f2x8/k8",
+    "WORK": "w1x8",
+    "REDUCE@a2": "g2k",
+}
+
+
+def impossible_staged_feats() -> dict:
+    """The square.512.dynM residue: a cp.async-staged warp tile whose slab (139 KB for
+    w1x8/f2x8/k8) exceeds the ~99 KB dynamic-smem cap could never launch — but the
+    combine-only ~2 µs it left behind implies a LEGAL 133 TFLOP/s on that small shape,
+    so only the kernel-validity check catches it. The same config unstaged is real."""
+    return {
+        **{k: v for k, v in F16_MATMUL_FEATS.items() if not k.startswith(("S_ext_free", "S_ext_reduce"))},
+        "S_ext_free_prod": 512.0,
+        "S_ext_reduce_max": 512.0,
+        "STAGE@a2": "d1/smem-async",
+    }
+
+
+def node_row(key: str, *, value_us: float, features: dict | None = None, gpu: str = GPU_5090, **over) -> NodeRow:
+    """A leaf ``NodeRow`` on a registry-known card, ``**over`` overriding any field."""
+    kw = dict(
+        node_key=key,
+        parent_key=None,
+        context_key="ctx",
+        op_sig="op",
+        features=dict(F16_MATMUL_FEATS if features is None else features),
+        value_us=value_us,
+        depth=5,
+        gpu=gpu,
+        visits=1,
+        is_leaf=True,
+        status="ok",
+        run_id="run",
+        measured_at="2026-07-09T00:00:00+00:00",
+    )
+    kw.update(over)
+    return NodeRow(**kw)

--- a/tests/compiler/pipeline/search/prior/test_fit_cv.py
+++ b/tests/compiler/pipeline/search/prior/test_fit_cv.py
@@ -91,8 +91,8 @@ def test_dual_rank_tie_plateau():
 
 def test_best_rank_collapses_to_the_single_golden_functions_at_one_positive():
     """THE compatibility guard. A pool with one positive must score exactly what it scored before the field
-    became a set — otherwise every fitted artifact moves, which is what the byte-identity tests in
-    ``test_prior_fit`` fail on. Checked at every index, so the tie conventions are covered on both sides of a
+    became a set — otherwise every fitted artifact moves, and nothing in the suite compares a fit against the
+    previous release's numbers. Checked at every index, so the tie conventions are covered on both sides of a
     plateau, not just at the winner."""
     scores = np.array([5.0, 3.0, 5.0, 5.0, 7.0])
     for i in range(len(scores)):

--- a/tests/compiler/pipeline/search/prior/test_prior_fit.py
+++ b/tests/compiler/pipeline/search/prior/test_prior_fit.py
@@ -1,0 +1,314 @@
+"""The extracted OfflinePrior fit core (``search/prior/fit``) — the two preservation
+guarantees the extraction from the original fit script must keep:
+
+1. The fit is a pure, deterministic function of (cases, seed): the same inputs
+   produce a byte-identical weights artifact, so a refit is reproducible and an
+   A/B between two fits measures the fit inputs, never run-to-run noise.
+2. The fit-time rank evaluation and the deployed :class:`OfflinePrior` scoring
+   order candidates identically for the shipped incumbent weights — including the
+   atomic-free interaction, which both sides now read through one shared definition.
+   That is the invariant that makes fit-time golden ranks transfer to ``eval offline``
+   and greedy-deploy ranks.
+"""
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
+from emmy.compiler.pipeline.search.prior.fit import (
+    DEFAULT_L2,
+    Group,
+    LinearFit,
+    LinearTrainer,
+    feature_matrix,
+    fit_weights,
+    gate_columns,
+    mean_log_rank,
+    rank_of_golden,
+    raw_weights,
+)
+from emmy.compiler.pipeline.search.prior.linear_model import GATE_DEFAULTS, LinearModel, gate_values
+from emmy.compiler.pipeline.search.prior.offline import _DEFAULT_FILE, OfflinePrior
+
+# Seed for the fitted scalar params — the interaction OFF at the shipped threshold, the state a
+# fresh fit starts from.
+SEED_PARAMS = np.array([0.0, 4.0])
+
+# The two features the OfflinePrior reads through the atomic-free interaction rather than as plain
+# linear terms — kept out of the synthetic rows below so that comparison isolates the linear part.
+_INTERACTION_FEATURES = {"D_finalize_kernel", "D_splitk"}
+
+
+def _synthetic_cases(n_cases=6, n_rows=40, n_feats=8, seed=1234):
+    """A small fixed case set in the fitter's input shape (:class:`Group`), with sparse
+    rows so the absent-feature = 0.0 path (the matrix packing's zero columns) is live."""
+    rng = np.random.default_rng(seed)
+    names = [f"D_f{i}" for i in range(n_feats)]
+    cases = []
+    for c in range(n_cases):
+        feats = []
+        for _ in range(n_rows):
+            row = {n: float(rng.integers(-4, 5)) for n in names}
+            feats.append({k: v for k, v in row.items() if rng.random() > 0.25})
+        tier = ["thread", "warp", "reduce", "dyn"][c % 4]
+        # The dynamic cases carry the routing stamp on every row, as the golden case builder writes
+        # it; ``Group.from_dicts`` lifts it into ``Group.dynamic`` and out of the fitted matrix.
+        if tier == "dyn":
+            feats = [{**f, "S_ext_n_symbolic_axis": 1.0} for f in feats]
+        cases.append(Group.from_dicts(f"x/case{c}", f"case{c}", tier, "x", f"shape{c}", int(rng.integers(0, n_rows)), feats))
+    return cases, names
+
+
+# The incumbent a synthetic fit chains from: no weights to warm-start (the fits below set
+# ``warm_start=False`` anyway), the interaction seeded OFF at the shipped threshold, and the shipped
+# exp scale — which the trainer carries into the fitted model rather than fitting.
+SEED_MODEL = LinearModel(
+    weights={}, weights_dynamic=None, scale=0.1, atomic_free_weight=float(SEED_PARAMS[0]), atomic_free_split_threshold=float(SEED_PARAMS[1])
+)
+
+
+def _trainer(names, samples=200, **kwargs):
+    return LinearTrainer(feature_names=tuple(names), init=SEED_MODEL, samples=samples, random_state=0, warm_start=False, **kwargs)
+
+
+def _run_fit(samples=200):
+    """One trainer invocation on the fixed synthetic case set, as artifact JSON bytes."""
+    cases, names = _synthetic_cases()
+    fit = _trainer(names, samples).fit(cases)
+    provenance = {"fitted": "2026-01-01", "script": "test", "args": {"samples": samples, "seed": 0}}
+    return json.dumps(fit.model.to_artifact(provenance=provenance), indent=2)
+
+
+# --- determinism / byte-identity ---------------------------------------------------
+
+
+def test_fit_twice_is_byte_identical():
+    a, b = _run_fit(), _run_fit()
+    assert a == b
+    art = json.loads(a)
+    assert art["weights"] and art["weights_dynamic"]  # a real fit, not an empty pass-through
+
+
+def test_one_trainer_instance_refits_identically():
+    """``fit`` is pure: the same trainer instance fitted twice returns equal models, and fitting
+    does not mutate the trainer. That is what lets ONE instance serve every cross-validation fold
+    with no copying — the property an sklearn-style ``clone`` would otherwise have to provide."""
+    cases, names = _synthetic_cases()
+    trainer = _trainer(names, samples=20)
+    first, second = trainer.fit(cases), trainer.fit(cases)
+    assert first.model == second.model
+    assert first.static_ranks == second.static_ranks
+    assert trainer == _trainer(names, samples=20)
+    # A fit with no dynamic groups leaves that weight set unfitted rather than substituting one,
+    # and says so in the provenance line the artifact records.
+    static_only = trainer.fit([c for c in cases if not c.dynamic])
+    assert static_only.model.weights_dynamic is None and static_only.dyn_ranks is None
+    assert "no dynamic cases" in static_only.notes and "dynamic top1" in first.notes
+
+
+def test_fitting_one_slice_does_not_perturb_the_next():
+    """Fold independence. ``run_axis`` used to hand each fold a fresh ``default_rng(seed)``; that
+    guarantee now lives inside ``fit``, which builds its own RNG from ``random_state``. So fitting
+    slice A and then slice B must give B exactly what fitting B alone gives — otherwise a fold's
+    result would depend on how many folds ran before it, and adding one golden family would silently
+    move every later fold's numbers."""
+    cases, names = _synthetic_cases()
+    trainer = _trainer(names, samples=20)
+    a, b = cases[:4], cases[2:]
+    trainer.fit(a)
+    after_a = trainer.fit(b)
+    assert after_a.model == trainer.fit(b).model  # same trainer, no carried RNG state
+    assert after_a.model == _trainer(names, samples=20).fit(b).model  # and none carried on the object either
+
+
+def test_built_artifact_loads_through_offline_prior(tmp_path, monkeypatch):
+    """The assembled artifact is loadable by the deployed prior's strict loader
+    (current feat_ver, complete params) — a fit output is never a dead file."""
+    path = tmp_path / "fitted.json"
+    path.write_text(_run_fit(samples=20))
+    monkeypatch.setenv("EMMY_OFFLINE_FILE", str(path))
+    p = OfflinePrior()
+    assert p.mean_score_features({}) == 1.0  # neutral with no opinion, per the Prior contract
+    assert json.loads(path.read_text())["feat_ver"] == FEATURIZER_VERSION
+
+
+# --- incumbent rank agreement: fit-time eval vs deployed scoring -------------------
+
+
+@pytest.mark.parametrize("dynamic", [False, True], ids=["static", "dynamic"])
+def test_incumbent_weights_rank_identically_through_fit_eval_and_prior(dynamic):
+    """Score synthetic rows with the SHIPPED incumbent weights two ways — the fit
+    module's linear matrix scoring (descending) and ``OfflinePrior``'s latency proxy
+    (ascending) — and require identical ranks, ties included. The proxy is a monotone
+    squash of the same linear quality, so any divergence is a real drift between the
+    fitter's objective and what actually deploys."""
+    art = json.loads(_DEFAULT_FILE.read_text())
+    w_set = art["weights_dynamic"] if dynamic else art["weights"]
+    names = sorted(k for k in w_set if k not in _INTERACTION_FEATURES)
+    w_vec = np.array([w_set[n] for n in names])
+
+    rng = np.random.default_rng(7)
+    rows, qualities = [], []
+    while len(rows) < 60:
+        row = {n: float(rng.integers(-2, 3)) for n in names if rng.random() > 0.3}
+        q = sum(w_set[k] * v for k, v in row.items())
+        # Keep qualities pairwise-distinct: a float-roundoff "tie" between the two
+        # summation orders would flip the tie-pessimistic rank for reasons that have
+        # nothing to do with the invariant under test.
+        if all(abs(q - other) > 1e-6 for other in qualities):
+            rows.append(row)
+            qualities.append(q)
+
+    prior = OfflinePrior()
+    linear_scores = feature_matrix(rows, names) @ w_vec
+    stamp = {"S_ext_n_symbolic_axis": 1.0} if dynamic else {}
+    proxies = np.array([prior.mean_score_features({**row, **stamp}) for row in rows])
+
+    for i in range(len(rows)):
+        assert rank_of_golden(linear_scores, i) == rank_of_golden(-proxies, i)
+
+
+@pytest.mark.parametrize("dynamic", [False, True])
+def test_dict_and_matrix_paths_score_identically(dynamic):
+    """One definition, two access shapes. :meth:`LinearModel.quality` scores a live candidate from a
+    feature dict; the fitter scores a packed pool as a matrix. They must agree row for row, including
+    the atomic-free interaction on both sides of its split threshold (scored with the interaction ON,
+    since the shipped weight is 0.0 and a zero term would make the comparison vacuous).
+
+    This also pins the routing agreement, which is the part that CAN break: the dict path reads the
+    symbolic-axis stamp off the row it is scoring, the matrix path reads ``Group.dynamic`` off the
+    pool. Same rows, so they must land on the same weight set."""
+    art = json.loads(_DEFAULT_FILE.read_text())
+    params = {"atomic_free_weight": 5.0, "atomic_free_split_threshold": 4.0}
+    # ONE model object behind both paths — the prior scores dicts through it, the fit scores matrices.
+    model = LinearModel(weights=art["weights"], weights_dynamic=art["weights_dynamic"], scale=0.1, **params)
+    prior, fit = OfflinePrior(model=model), LinearFit(model, [], [])
+
+    rng = np.random.default_rng(11)
+    names = sorted(set(art["weights"]) | _INTERACTION_FEATURES)
+    stamp = {"S_ext_n_symbolic_axis": 1.0} if dynamic else {}
+    rows = [
+        {
+            **{n: float(rng.integers(-2, 3)) for n in names if rng.random() > 0.3},
+            "D_finalize_kernel": float(rng.integers(0, 2)),
+            "D_splitk": float(rng.choice([1, 2, 4, 8])),  # straddles the threshold in both directions
+            **stamp,
+        }
+        for _ in range(60)
+    ]
+    group = Group.from_dicts("x/case", "case", "dyn" if dynamic else "warp", "x", "case", 0, rows)
+    assert group.dynamic is dynamic  # routed by the rows' stamp, not the tier label
+    fitted = fit.score_rows(group)
+    deployed = np.array([prior.quality(row) for row in rows])
+    assert np.allclose(fitted, deployed)
+
+
+def test_model_artifact_round_trips():
+    """``LinearModel`` → artifact → ``LinearModel`` is exact, so the file a fit ships and the model
+    that produced it rank identically. The params block keeps its full key set (order is free — the
+    writer preserves insertion order, so only the shape matters here)."""
+    art = json.loads(_DEFAULT_FILE.read_text())
+    model = LinearModel.from_artifact(art)
+    assert LinearModel.from_artifact(model.to_artifact(provenance={})) == model
+    assert model.to_artifact(provenance={})["params"] == art["params"]
+
+
+def test_gate_values_and_gate_columns_agree_including_the_defaults():
+    """The interaction's two inputs are read one way for a dict and another for a matrix, and both
+    must yield the same numbers — including for a featurization that omits them, where the defaults
+    are the whole answer. Both now read :data:`GATE_DEFAULTS`, so this pins that they stay in step,
+    and that its ORDER is the order ``atomic_free_term`` takes its positional arguments in."""
+    assert tuple(GATE_DEFAULTS) == ("D_finalize_kernel", "D_splitk")  # finalize first, as the term reads them
+
+    present = {"D_finalize_kernel": 1.0, "D_splitk": 8.0}
+    absent: dict[str, float] = {"D_other": 3.0}
+    for feats in (present, absent):
+        # Like for like: a pool's column list IS its rows' feature names, which is what makes "the
+        # name is missing" and "the key is missing" the same condition on the two sides.
+        names = sorted(feats)
+        cols = gate_columns(feature_matrix([feats], names), names)
+        assert [float(c[0]) for c in cols] == list(gate_values(feats))
+    assert gate_values(absent) == tuple(GATE_DEFAULTS.values())  # nothing stamped → the declared defaults
+
+
+def test_gate_columns_survive_the_in_place_z_scoring():
+    """The interaction's inputs stay in RAW units through the fit's standardization. ``fit_weights``
+    z-scores its pools IN PLACE (the memory fix that keeps an 18 GB corpus fittable), so the columns
+    must be copied out beforehand: a view would be standardized underneath the comparison, and a split
+    COUNT centred near zero never clears its threshold, silently switching the whole term off."""
+    names = ["D_finalize_kernel", "D_splitk", "D_other"]
+    mat = np.array([[1.0, 8.0, 5.0], [0.0, 2.0, 7.0], [1.0, 4.0, 9.0]])
+    fin, spl = gate_columns(mat, names)
+    mat -= mat.mean(0)
+    mat /= mat.std(0)  # exactly what fit_weights does to its pools afterwards
+    assert list(fin) == [1.0, 0.0, 1.0]
+    assert list(spl) == [8.0, 2.0, 4.0]
+
+
+# --- raw-space L2 regularization ---------------------------------------------------
+
+
+def _cases_with_flat_feature():
+    """The synthetic set plus one constant feature: its z-scored column is all zeros, so
+    the rank objective is COMPLETELY flat in its weight — the identifiability failure
+    behind the D_pow2_threads 686 incident, in miniature."""
+    cases, names = _synthetic_cases()
+    flat_cases = [
+        replace(g, feat_names=(*g.feat_names, "D_flat"), feats=np.hstack([g.feats, np.full((len(g.feats), 1), 3.0)])) for g in cases
+    ]
+    return flat_cases, [*names, "D_flat"]
+
+
+def test_l2_heals_poisoned_seed_on_rank_flat_feature():
+    """A poisoned incumbent weight on a rank-flat feature survives an unregularized
+    descent-from-seed refit untouched (the objective gives it no gradient); with the
+    L2 penalty in the loss the descent walks the flat direction down to ~zero without
+    giving up rank quality: at the default strength no rank-worsening step is ever
+    accepted (the penalty quantum is orders below the rank quantum), so refitting from
+    a converged incumbent can only hold or improve the data term."""
+    cases, names = _cases_with_flat_feature()
+    ones = np.ones(len(names))
+
+    # Converge unregularized from zero, then poison the flat feature — the shipped-686
+    # shape: an incumbent that is a data-term optimum plus an unidentified magnitude.
+    base_w, _, base_ranks, _, base_sd = fit_weights(
+        cases, names, ones, seed_w=np.zeros(len(names)), seed_params=SEED_PARAMS, rng=np.random.default_rng(0), samples=0, l2=0.0
+    )
+    poisoned = base_w / base_sd  # the incumbent's raw weights
+    poisoned[names.index("D_flat")] = 5.0
+
+    healed = {}
+    for l2 in (0.0, DEFAULT_L2):
+        w, _, ranks, _, sd = fit_weights(
+            cases, names, ones, seed_w=poisoned, seed_params=SEED_PARAMS, rng=np.random.default_rng(0), samples=0, l2=l2
+        )
+        healed[l2] = (raw_weights(names, w, sd), ranks)
+    assert abs(healed[0.0][0]["D_flat"] - 5.0) < 1e-9  # unregularized: the poison survives
+    assert abs(healed[DEFAULT_L2][0].get("D_flat", 0.0)) < 0.5  # regularized: walked to ~zero
+    assert mean_log_rank(healed[DEFAULT_L2][1]) <= mean_log_rank(base_ranks) + 1e-9  # rank quality held or improved
+
+
+def test_l2_default_is_rank_neutral_on_random_restart():
+    """At the declared default strength the penalty is a tie-breaker: any genuine rank
+    improvement dwarfs it, so regularizing cannot cost fit quality. Asserted on the
+    objective, not on rank-by-rank equality — walking a rank-flat direction toward zero is
+    exactly what the penalty is for, and a step that is neutral in rank but better in
+    magnitude legitimately sends the descent down a different (here, marginally better) path."""
+    cases, names = _synthetic_cases()
+    ranks = {}
+    for l2 in (0.0, DEFAULT_L2):
+        _, _, r, _, _ = fit_weights(
+            cases,
+            names,
+            np.ones(len(names)),
+            seed_w=np.zeros(len(names)),
+            seed_params=SEED_PARAMS,
+            rng=np.random.default_rng(0),
+            samples=200,
+            l2=l2,
+        )
+        ranks[l2] = r
+    assert mean_log_rank(ranks[DEFAULT_L2]) <= mean_log_rank(ranks[0.0]) + 1e-9


### PR DESCRIPTION
## What this is

#551 ("Pipeline strategies") removed **26 test files / 6602 lines** from the search package while the code they cover stayed live — its test suite went from 7400 lines to 1901. This restores **two** of them, chosen because they guard properties the upcoming offline-prior work depends on. Both pass unmodified at HEAD.

The other 24 are deliberately out of scope here.

## Why these two, specifically

Each was checked against a regression the upcoming work could plausibly introduce. In both cases the rest of the suite is blind to it:

| probe | caught by | rest of suite |
| --- | --- | --- |
| 5% divergence injected into `LinearModel.quality_rows`, i.e. the dict and matrix scoring paths disagreeing | `test_dict_and_matrix_paths_score_identically` | 83 tests across `test_fit_cv`, `test_catboost_model`, `test_eval` — all pass |
| `load_freeze` stops overriding `H_opt` with the row's stored value | `test_write_freeze_round_trip`, `test_refreezing_a_freeze_is_stable` | 111 tests — all pass |

- **`prior/test_prior_fit.py`** (13 tests) — the linear fit is a pure function of `(groups, hyperparameters)`, one trainer instance serves every CV fold without copying, and the fitter's objective and the deployed `OfflinePrior` order candidates identically.
- **`data/test_freeze.py`** (22 tests) — the measurement freeze round-trips, digests are insertion-order independent, re-freezing is stable, and every loader hard-error path (digest mismatch, missing file, version mismatch, foreign directory) is exercised. The freeze loader had **no** coverage at all.

## The two supporting files

- **`helpers.py`** — `tests/ARCHITECTURE.md` names it by path as the home for search-only node builders, and **that reference is currently dangling on main**. `test_freeze` uses all four of its public names. Its docstring now names only its real consumer, since `test_node_gate.py` is not restored here.
- **`data/__init__.py`** — required. Without it, pytest's prepend import mode imports the module as top-level `test_freeze` and its `from tests.compiler.…` import fails.

## Corrections made while restoring

- `test_fit_cv.py`'s one-positive guard claimed a moved artifact is "what the byte-identity tests in `test_prior_fit` fail on". **It is not** — those compare two fits of the *same* code, so they pin determinism, not value. Verified by hand: making `Group.from_dicts` keep the routing column leaves all 13 passing. Reworded to what is true — nothing in the suite compares a fit against the previous release's numbers.
- Dropped two `monkeypatch.delenv("EMMY_OFFLINE_FILE")` calls that the autouse `_isolate_offline_file` fixture has done suite-wide since #355, plus the now-unused parameters.
- Fixed `test_freeze`'s docstring pointer to `test_node_gate.py`, deleted in #551 and not restored.

## Not restored

`test_anchor_walk_treats_freeze_rows_as_treeless` — it reached into `diagnostics._anchor_walk`, a private symbol of the `prior/` subpackage, from a test module in `data/`, and its treeless property is already asserted in the round-trip test.

## Known, left alone

`tests/durations.json` still has 62 stale entries across 17 files from the #551 deletion; this restore makes 12 of them live again. Regenerating wholesale would re-time the whole suite for a two-file change, so it is left as pre-existing.

## Verification

`make test` — 3008 passed, 578 skipped, 1 xfailed. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXPHwChs61iSChSCddZJoG