### PR TITLE
Pack the routing column so the tree can read it

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -428,8 +428,9 @@ What a newcomer needs to know about the fit:
   the prior object). A weight key that is no longer used, inside an artifact of the current version, is
   simply ignored. `EMMY_OFFLINE_FILE` (or `emmy eval … --offline-file`) swaps in a candidate fit for an A/B.
 - A separate `weights_dynamic` set ranks kernels whose tiles are masked because an axis is symbolic; it is selected on
-  the stamped `S_ext_n_symbolic_axis`. That stamp **routes and never carries a weight**, and the fit holds it out of
-  the feature matrix structurally rather than by feature view. The reason is identifiability: the stamp is constant
+  the stamped `S_ext_n_symbolic_axis`. That stamp **routes and never carries a weight**: the dataset packs it like
+  any other column, and the linear fit narrows it out of its own descent coordinates (`descent_cols`) while a tree
+  splits on it to price both regimes in one model. The reason is identifiability: the stamp is constant
   across a candidate pool, so a linear term on it shifts every candidate equally and cancels out of the within-pool
   ranking. The rank objective cannot see such a term at all, which makes whatever value a descent lands on there
   noise rather than a fitted quantity.

--- a/emmy/compiler/pipeline/search/prior/catboost_model.py
+++ b/emmy/compiler/pipeline/search/prior/catboost_model.py
@@ -7,9 +7,9 @@ everything the linear model needed *because* it is additive:
 
 - **No weight sets.** A linear model prices a symbolic-axis (masked-tile) kernel with a second weight vector
   because it cannot form a product; a tree splits on ``S_ext_n_symbolic_axis`` and prices both regimes inside one
-  model. The routing feature is therefore an ordinary COLUMN here (:data:`~.linear_model.ROUTING_FEATURES` is held
-  out of :class:`~.fit.group.Group`'s matrix, so the trainer re-adds it from ``Group.dynamic``), and a live
-  candidate already carries it in its own featurization.
+  model. The routing feature is therefore an ordinary COLUMN here — :class:`~.fit.group.Group` packs it like any
+  other and the trainer reads it straight from the matrix, matching the live candidate, which already carries it
+  in its own featurization.
 - **No fitted scalar interaction.** The atomic-free split-K gate is a hand-built term in the linear model because
   the deployed quality cannot express it as a weight. A tree forms ``D_finalize_kernel × D_splitk`` from the two
   columns, so nothing here corresponds to it.

--- a/emmy/compiler/pipeline/search/prior/fit/catboost.py
+++ b/emmy/compiler/pipeline/search/prior/fit/catboost.py
@@ -29,10 +29,9 @@ A further round instead mines **hard negatives** — the rows the current model 
 implemented and reachable (``--rounds 2``) but OFF by default, because the one measurement of it says it hurts;
 :data:`DEFAULT_ROUNDS` carries the numbers and the likely reason.
 
-The routing feature (``S_ext_n_symbolic_axis``) is an ordinary column here, re-added from ``Group.dynamic``,
-which :meth:`~.group.Group.from_dicts` holds out of the matrix so it can never become a linear descent
-coordinate. For a tree it is simply a feature to split on — one model prices both regimes, where the linear model
-needs a second weight set.
+The routing feature (``S_ext_n_symbolic_axis``) is an ordinary packed column here, read like any other.
+For a tree it is simply a feature to split on — one model prices both regimes, where the linear model needs a
+second weight set and therefore narrows the column out (:func:`~..linear_model.descent_cols`).
 """
 
 from __future__ import annotations
@@ -46,7 +45,6 @@ import numpy as np
 from emmy.compiler.pipeline.search.prior.catboost_model import ABSENT, DEFAULT_SCALE, CatBoostModel, new_ranker
 from emmy.compiler.pipeline.search.prior.fit.group import Group
 from emmy.compiler.pipeline.search.prior.fit.rank import best_rank, topk_table
-from emmy.compiler.pipeline.search.prior.linear_model import ROUTING_FEATURES
 
 logger = logging.getLogger(__name__)
 
@@ -92,12 +90,6 @@ class CatBoostTrainer:
     random_state: int = 0
     scale: float = DEFAULT_SCALE
 
-    @property
-    def cols(self) -> tuple[str, ...]:
-        """The model's column order: the feature view plus the routing stamp the dataset holds out of its
-        matrix. Spelled once, so the training matrix and the deployed model's ``cols`` cannot disagree."""
-        return (*self.feature_names, *ROUTING_FEATURES)
-
     def fit(self, groups: list[Group]) -> CatBoostFit:
         """Fit over ``groups``, mining hard negatives across :attr:`rounds`.
 
@@ -106,7 +98,7 @@ class CatBoostTrainer:
         rounds they have survived, and the point of mining is to shift the distribution, not to accumulate
         emphasis on the first draw."""
         rng = np.random.default_rng(self.random_state)
-        cols = list(self.cols)
+        cols = list(self.feature_names)
         pools = [g.matrix(cols, fill=ABSENT) for g in groups]
         # Sampled negative indices per pool, grown each round. The pinned rows are added at assembly time, so
         # one can never be sampled in as a negative — against itself or against a verified sibling.
@@ -186,7 +178,7 @@ class CatBoostTrainer:
             nan_mode="Min",  # absent (NaN) features get their own split-off bucket — see catboost_model
         )
         booster.fit(Pool(np.concatenate(x), np.concatenate(y), group_id=np.concatenate(gid)))
-        return CatBoostModel(booster=booster, cols=self.cols, scale=self.scale)
+        return CatBoostModel(booster=booster, cols=self.feature_names, scale=self.scale)
 
 
 @dataclass(frozen=True)

--- a/emmy/compiler/pipeline/search/prior/fit/group.py
+++ b/emmy/compiler/pipeline/search/prior/fit/group.py
@@ -42,8 +42,8 @@ from emmy.compiler.pipeline.search.prior.linear_model import ROUTING_FEATURES, L
 # (32 for the f32-accumulate atom, 16 for the f16-accumulate one). The ``S_*`` / ``H_*`` shape/regime features
 # are constant within a shape, so they drop out of a within-shape ranking — a weight on one is invisible to the
 # rank objective (it shifts every candidate in the pool by the same amount) and therefore unidentifiable. The
-# routing stamp is the same kind of quantity, which is why it is held out of the matrix entirely rather than
-# merely excluded from a view: see :data:`~..linear_model.ROUTING_FEATURES`.
+# routing stamp is the same kind of quantity, which is why the LINEAR model narrows it out of its own
+# coordinates (:func:`~..linear_model.descent_cols`) while the matrix still carries it for a tree to split on.
 #
 # ``MMA_acc_bits`` is load-bearing: the f16-accumulate fork is spelled in the TILE codec's atom token, so a row
 # taking it is identical under every ``D_*`` feature to its f32-accumulate sibling. While the view dropped it,
@@ -110,8 +110,8 @@ TREE_FEATURES = (
 # Both exclusions are expressiveness-neutral by construction — the model can express exactly the same
 # ranking functions with these 53 coordinates as with all 72 — so this buys a smaller, faster,
 # better-identified fit, not a different model. (Naming no ``S_ext_*`` stamp costs the view nothing on the
-# weight-set choice either: the routing stamp never reaches the matrix in the first place, and ``Group.dynamic``
-# carries the answer.)
+# weight-set choice either: :attr:`Group.dynamic` carries the answer, and the linear fit narrows the stamp
+# out of its coordinates regardless of the view.)
 #
 # ``D_stage_prefetch`` is the one feature here that is a step rather than a measurement — see its
 # definition in ``search/features.py`` for why the linear model cannot form it from ``D_stage_depth``.
@@ -148,10 +148,12 @@ def feature_view(spec: str):
     model ignores it.
 
     :data:`~..linear_model.ROUTING_FEATURES` are kept by EVERY view, named or not, and cannot be excluded.
-    They select a weight set rather than contribute a term, and :meth:`Group.from_dicts` lifts them out of
-    the matrix afterwards, so keeping them costs a view nothing. A view that could drop them would instead
-    route every pool to the static weight set and report a fit with zero dynamic cases — silently, since
-    nothing downstream can tell an unfittable dynamic set from a genuinely static dataset."""
+    They select a weight set rather than contribute a term, and the packed column is what a tree splits the
+    two regimes on, so keeping them costs a view nothing. A view that could drop them would instead route
+    every pool to the static weight set and report a fit with zero dynamic cases — silently, since nothing
+    downstream can tell an unfittable dynamic set from a genuinely static dataset. What keeps the stamp out
+    of a LINEAR descent is the model class narrowing its own coordinates
+    (:func:`~..linear_model.descent_cols`), not the dataset withholding the column."""
     pats = [p.strip() for p in spec.split(",") if p.strip()]
     keep = _matcher([p for p in pats if not p.startswith("-")])
     drop = _matcher([p[1:] for p in pats if p.startswith("-")])
@@ -209,7 +211,8 @@ class Group:
         total: int | None = None,
     ) -> Group:
         """Pack per-row feature dicts into the matrix representation: ``feat_names`` is the sorted
-        union of the pool's keys, the matrix a column per name (absent key = 0.0). Callers
+        union of the pool's keys, the matrix a column per name (absent key = ``NaN``, the more
+        informative of the two fills — see :meth:`matrix`). Callers
         drop the dicts after this — the matrix is the stored representation.
 
         ``pinned`` is the pool's positive row index, or several of them; either spelling normalizes to a sorted
@@ -218,9 +221,10 @@ class Group:
         to "nothing was sampled" - see :attr:`total`.
 
         The routing features (:data:`~..linear_model.ROUTING_FEATURES`) are read off the pool into
-        :attr:`dynamic` and then LEFT OUT of ``feat_names``, so a weight-set selector can never
-        become a descent coordinate. Reading row 0 is exact: the stamp comes from the shape, which
-        every candidate in a pool shares.
+        :attr:`dynamic` AND packed like every other column: a tree splits the two regimes on it, and the
+        linear model narrows it out of its own coordinates (:func:`~..linear_model.descent_cols`). Packing
+        every column is what keeps one model class from deciding for the other. Reading row 0 is exact: the
+        stamp comes from the shape, which every candidate in a pool shares.
 
         The stamp must agree with ``tier``, and disagreeing is a hard error. The two reach here by
         different routes — the stamp through the featurizer, the tier from the source record's own
@@ -234,7 +238,7 @@ class Group:
                 f"the source record's flag and its featurized rows disagree about the weight set"
             )
         rows = (pinned,) if isinstance(pinned, int) else pinned
-        names = tuple(sorted({k for f in feats for k in f} - set(ROUTING_FEATURES)))
+        names = tuple(sorted({k for f in feats for k in f}))
         positives = tuple(sorted({int(i) for i in rows}))
         matrix = feature_matrix(feats, list(names), fill=np.nan)
         return cls(key, name, tier, gpu, shape, dynamic, positives, names, matrix, len(feats) if total is None else total)

--- a/emmy/compiler/pipeline/search/prior/fit/linear.py
+++ b/emmy/compiler/pipeline/search/prior/fit/linear.py
@@ -38,6 +38,7 @@ from emmy.compiler.pipeline.search.prior.linear_model import (
     FITTED_PARAMS,
     GATE_DEFAULTS,
     LinearModel,
+    descent_cols,
     gate_columns,
     quality_columns,
 )
@@ -249,7 +250,7 @@ class LinearTrainer:
 
         The static group list must be non-empty — the dynamic stage seeds from it. Callers guard
         that; this does not."""
-        names = list(self.feature_names)
+        names = list(descent_cols(self.feature_names))
         static_groups = [g for g in groups if not g.dynamic]
         dyn_groups = [g for g in groups if g.dynamic]
         rng = np.random.default_rng(self.random_state)

--- a/emmy/compiler/pipeline/search/prior/linear_model.py
+++ b/emmy/compiler/pipeline/search/prior/linear_model.py
@@ -34,9 +34,23 @@ import numpy as np
 from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
 
 # Features that SELECT a weight set rather than contribute a term. Owned here because routing is the model's
-# business; ``fit/group.py`` imports this to hold the columns out of the fitted matrix entirely, so a routing
-# feature cannot become a descent coordinate by accident.
+# business: :func:`descent_cols` keeps them out of the linear descent, and no other model class is bound by that.
 ROUTING_FEATURES = ("S_ext_n_symbolic_axis",)
+
+
+def descent_cols(names) -> tuple[str, ...]:
+    """``names`` minus the routing stamps — the coordinates a linear descent may walk (why: the module
+    docstring's identifiability argument).
+
+    The narrowing lives with the model class, not with the dataset: the dataset packs every column it is
+    given, and a tree splits on this one. A dataset that withheld it to protect THIS model class would be
+    deciding for both — and did, leaving the tree a column of NaN.
+
+    Filtering preserves relative order, so ``descent_cols(sorted(union | routing))`` is
+    ``sorted(union - routing)`` exactly, which is why packing the column left every fitted artifact
+    byte-identical."""
+    return tuple(n for n in names if n not in ROUTING_FEATURES)
+
 
 # The scalar params the FIT searches, in descent-coordinate order — the atomic-free interaction, the one term
 # the deployed quality cannot express as a linear weight. ``fit/linear.py`` walks exactly these coordinates.
@@ -129,6 +143,25 @@ class LinearModel:
     # alongside the weights. A constant the fit cannot see is a constant the fit optimizes around.
     atomic_free_weight: float
     atomic_free_split_threshold: float
+
+    def __post_init__(self) -> None:
+        """A routing feature may never carry a fitted weight.
+
+        Withholding the column from the matrix used to make this structural. It is a convention now that
+        every column is packed and each model class narrows for itself (:func:`descent_cols`), so it gains
+        a guard at construction — the one place a hand-edited artifact is also caught.
+
+        Worth being precise about the harm, since the module docstring above says such a term "cancels
+        exactly": within one candidate pool it does, and it cancels out of the greedy argmin, out of
+        ``normalize_policy`` and out of ``TiltBlend`` for the same reason. The exception is
+        ``policy/greedy._resolved_price``, which SUMS per-kernel scores to compare whole kernel sets — a
+        routing weight there scales every symbolic-axis kernel's price and biases the fusion comparison."""
+        for name, w_set in (("weights", self.weights), ("weights_dynamic", self.weights_dynamic)):
+            if bad := set(w_set or {}) & set(ROUTING_FEATURES):
+                raise ValueError(
+                    f"{name} carries a fitted weight for routing feature(s) {sorted(bad)} — a routing stamp is "
+                    f"constant within a candidate pool, so it selects a weight set and never contributes a term"
+                )
 
     # --- the shared model surface (Prior's own names) ---------------------------------------------------
 

--- a/tests/compiler/pipeline/search/prior/test_catboost_model.py
+++ b/tests/compiler/pipeline/search/prior/test_catboost_model.py
@@ -30,7 +30,7 @@ def _groups(n_pools: int = 8, n_rows: int = 30, dynamic: bool = False) -> list[G
     """Pools whose golden is the row maximizing ``D_a`` — a signal any working ranker recovers, and one
     that is invisible to ``D_b`` (pure noise), so a fitted model must have learned the right column."""
     rng = np.random.default_rng(0)
-    stamp = {"S_ext_n_symbolic_axis": 1.0} if dynamic else {}
+    stamp = {"S_ext_n_symbolic_axis": 1.0 if dynamic else 0.0}
     out = []
     for gi in range(n_pools):
         rows = [{"D_a": float(i), "D_b": float(rng.integers(0, 5)), **stamp} for i in range(n_rows)]
@@ -38,8 +38,8 @@ def _groups(n_pools: int = 8, n_rows: int = 30, dynamic: bool = False) -> list[G
     return out
 
 
-def _fit(groups=None, **kw) -> CatBoostModel:
-    trainer = CatBoostTrainer(feature_names=FEATURES, iterations=40, negatives=12, **kw)
+def _fit(groups=None, *, feature_names=FEATURES, **kw) -> CatBoostModel:
+    trainer = CatBoostTrainer(feature_names=feature_names, iterations=40, negatives=12, **kw)
     return trainer.fit(groups if groups is not None else _groups()).model
 
 
@@ -54,11 +54,50 @@ def test_fit_recovers_the_planted_signal():
     assert "not byte-reproducible" in fit.notes
 
 
+def test_the_tree_prices_the_two_regimes_from_the_routing_column():
+    """The capability the packed column restores. Static and dynamic pools here rank OPPOSITELY on ``D_a``,
+    which one model can only fit by splitting on the regime. While the column arrived all-NaN every row sat
+    in one bucket, the split was unavailable, and the fit had to compromise across the two regimes.
+
+    Guards the fix at the level it operates: not the column's name, its contents."""
+    rng = np.random.default_rng(0)
+
+    def pools(dynamic, offset):
+        out = []
+        for gi in range(8):
+            rows = [
+                {"D_a": float(i), "D_b": float(rng.integers(0, 5)), "S_ext_n_symbolic_axis": 1.0 if dynamic else 0.0} for i in range(30)
+            ]
+            pinned = 0 if dynamic else 29  # dynamic pools want the LOW D_a row, static the high one
+            out.append(
+                Group.from_dicts(
+                    f"gpuA/p{gi + offset}", f"p{gi + offset}", "dyn" if dynamic else "warp", "gpuA", f"shape{gi + offset}", pinned, rows
+                )
+            )
+        return out
+
+    groups = pools(False, 0) + pools(True, 8)
+    fit = CatBoostTrainer(feature_names=(*FEATURES, "S_ext_n_symbolic_axis"), iterations=60, negatives=12).fit(groups)
+    assert fit.ranks == [0] * 16
+    importance = dict(zip(fit.model.cols, fit.model.booster.get_feature_importance(type="PredictionValuesChange"), strict=True))
+    assert importance["S_ext_n_symbolic_axis"] > 0.0
+
+
 def test_routing_stamp_is_an_ordinary_column():
-    """The tree prices both regimes in ONE model: the stamp the dataset holds out of its matrix comes back
-    as a plain column, so there is no second weight set and no unfittable-dynamic-set fold to exclude."""
-    model = _fit(_groups() + _groups(dynamic=True))
-    assert model.cols == (*FEATURES, "S_ext_n_symbolic_axis")
+    """The tree prices both regimes in ONE model: the routing stamp is a plain packed column it reads like
+    any other, so there is no second weight set and no unfittable-dynamic-set fold to exclude.
+
+    The load-bearing assertion is that the column arrives with the STAMP in it. It used to arrive all-NaN:
+    the dataset withheld the name, the trainer appended it to ``cols`` anyway, and ``Group.matrix`` filled
+    a column it could not find with ``ABSENT``. Every training row landed in one bucket while every live
+    candidate carried a real 0.0/1.0 — a train/serve skew that ``cols`` alone could never reveal."""
+    routing = ("S_ext_n_symbolic_axis",)
+    groups = _groups() + _groups(dynamic=True)
+    model = _fit(groups, feature_names=(*FEATURES, *routing))
+    assert model.cols == (*FEATURES, *routing)
+    static, dynamic = groups[0], groups[-1]
+    assert (dynamic.matrix(list(routing), fill=ABSENT) == 1.0).all()
+    assert (static.matrix(list(routing), fill=ABSENT) == 0.0).all()
 
 
 def test_trainer_declares_no_fittability_constraint():
@@ -124,10 +163,10 @@ def test_fit_treats_every_pin_as_a_positive():
     fit = CatBoostTrainer(feature_names=FEATURES, iterations=40, negatives=8).fit(groups)
     assert fit.rows == 6 * (8 + 2)
     assert set(np.argsort(-fit.score_rows(groups[0]), kind="stable")[:2].tolist()) == {18, 19}
-    # Both pins land on one leaf, so they TIE — and the fit objective counts a tie against the golden, which
-    # is why two verified rows at the top score rank 1 rather than 0. Nothing to fix: deploy takes the
-    # earlier-emitted one, and it is verified too.
-    assert fit.ranks == [1] * 6
+    # Was [1] * 6 while the trainer appended a routing name the matrix could not fill: the resulting
+    # all-NaN column collapsed rows 18 and 19 onto one leaf, so the two pins tied and a tie counts against
+    # the golden. Without that junk column the tree separates them and each golden ranks first.
+    assert fit.ranks == [0] * 6
 
 
 # --- the model surface -------------------------------------------------------------

--- a/tests/compiler/pipeline/search/prior/test_fit_cv.py
+++ b/tests/compiler/pipeline/search/prior/test_fit_cv.py
@@ -31,7 +31,7 @@ from emmy.compiler.pipeline.search.prior.fit import (
 )
 from emmy.compiler.pipeline.search.prior.fit import cv as fit_cv
 from emmy.compiler.pipeline.search.prior.fit.run import run_fit
-from emmy.compiler.pipeline.search.prior.linear_model import LinearModel
+from emmy.compiler.pipeline.search.prior.linear_model import LinearModel, descent_cols
 
 # --- feature view ------------------------------------------------------------------
 
@@ -255,15 +255,16 @@ def test_builder_folds_away_a_golden_recorded_twice_at_one_config(monkeypatch):
 
 
 def _case(name, tier, gpu, pinned=1, n_rows=6, key=None, shape=None):
-    """A tiny case whose rows carry a monotone D_a so a samples=0 descent has signal. A ``dyn``
-    case carries the routing stamp on every row, exactly as the golden case builder writes it —
-    that stamp, not the tier label, is what puts the group on the dynamic weight set.
+    """A tiny case whose rows carry a monotone D_a so a samples=0 descent has signal. EVERY case
+    carries the routing stamp on every row, as the featurizer writes it (``passes/identity._extents``
+    emits the key unconditionally, 0.0 when no axis is symbolic) — that stamp's VALUE, not the tier
+    label, is what puts the group on the dynamic weight set.
 
     ``pinned`` is the pool's positive row, or several of them (a pool the builder matched more than
     one golden into). ``shape`` is the fold group; it defaults to the name with any ``.dynM`` suffix
     stripped, which mirrors what the builder does for real: a dynamic golden enumerates its static
     twin's pool, so the twins share a group."""
-    stamp = {"S_ext_n_symbolic_axis": 1.0} if tier == "dyn" else {}
+    stamp = {"S_ext_n_symbolic_axis": 1.0 if tier == "dyn" else 0.0}
     feats = [{"D_a": float(i), "D_b": float((i * 7) % 3), **stamp} for i in range(n_rows)]
     shape = shape or name.removesuffix(".dynM")
     return Group.from_dicts(key or f"{gpu}/{name}", name, tier, gpu, shape, pinned, feats)
@@ -286,17 +287,23 @@ def _cases():
 
 
 def test_routing_stamp_selects_the_weight_set_and_never_becomes_a_coordinate():
-    """``S_ext_n_symbolic_axis`` picks the weight set and is then held OUT of the fitted matrix.
+    """``S_ext_n_symbolic_axis`` picks the weight set, is PACKED like any other column, and is narrowed
+    out by the linear model class rather than by the dataset.
 
-    Holding it out is structural, not a feature-view choice: the stamp is constant across a pool, so
-    a weight on it shifts every candidate equally and cancels out of the within-shape ranking. The
-    rank objective cannot see it, which makes any value a descent lands on there noise — so it must
-    not be reachable as a coordinate at all."""
+    A weight on it would be noise — the stamp is constant across a pool, so a term on it shifts every
+    candidate equally and cancels out of the within-shape ranking, leaving its value to the regularizer.
+    That is a fact about additive models, though, not about the data: a tree splits on the regime
+    happily. So the dataset packs the column and :func:`descent_cols` withholds it from the descent,
+    which is what keeps the two model classes from constraining each other."""
     static, dyn = _case("m.512", "warp", "gpuA"), _case("m.512.dynM", "dyn", "gpuA")
     assert (static.dynamic, dyn.dynamic) == (False, True)
+    # Packed, and carrying the real stamp — not a name the matrix cannot fill. A NaN column here rather
+    # than 1.0 is the train/serve skew this replaced: live candidates always carry the value.
+    assert "S_ext_n_symbolic_axis" in dyn.feat_names
+    assert (dyn.matrix(["S_ext_n_symbolic_axis"], fill=np.nan) == 1.0).all()
     for case in (static, dyn):
-        assert "S_ext_n_symbolic_axis" not in case.feat_names
         assert case.feats.shape[1] == len(case.feat_names)
+        assert "S_ext_n_symbolic_axis" not in descent_cols(case.feat_names)
     # The tier decides nothing, but it still has to AGREE: it and the stamp are the same fact arriving
     # by two routes, so a disagreement means one of them is wrong and the pool would otherwise train
     # under the wrong weight set with nothing reporting it.
@@ -304,6 +311,18 @@ def test_routing_stamp_selects_the_weight_set_and_never_becomes_a_coordinate():
         Group.from_dicts("gpuA/x", "x", "warp", "gpuA", "x", 0, [{"D_a": 1.0, "S_ext_n_symbolic_axis": 1.0}])
     with pytest.raises(ValueError, match="disagree about the weight set"):
         Group.from_dicts("gpuA/x", "x", "dyn", "gpuA", "x", 0, [{"D_a": 1.0}])
+
+
+def test_a_routing_feature_may_never_carry_a_fitted_weight():
+    """The guard that replaced the structural one. While the dataset withheld the routing column, no descent
+    could reach it; now that every column is packed, the rule is enforced where a violation would do harm —
+    a routing weight in a shipped artifact becomes an additive term on every live candidate. Checking at
+    construction catches every route in, a hand-edited artifact included."""
+    for field in ("weights", "weights_dynamic"):
+        sets = {"weights": {"D_a": 1.0}, "weights_dynamic": {"D_a": 1.0}}
+        sets[field] = {**sets[field], "S_ext_n_symbolic_axis": 0.5}
+        with pytest.raises(ValueError, match="never contributes a term"):
+            LinearModel(scale=0.1, atomic_free_weight=0.0, atomic_free_split_threshold=4.0, **sets)
 
 
 def test_matrix_fill_declares_the_absent_semantics():

--- a/tests/compiler/pipeline/search/prior/test_prior_fit.py
+++ b/tests/compiler/pipeline/search/prior/test_prior_fit.py
@@ -44,7 +44,7 @@ _INTERACTION_FEATURES = {"D_finalize_kernel", "D_splitk"}
 
 def _synthetic_cases(n_cases=6, n_rows=40, n_feats=8, seed=1234):
     """A small fixed case set in the fitter's input shape (:class:`Group`), with sparse
-    rows so the absent-feature = 0.0 path (the matrix packing's zero columns) is live."""
+    rows so the absent-feature path (the matrix packing's fill columns) is live."""
     rng = np.random.default_rng(seed)
     names = [f"D_f{i}" for i in range(n_feats)]
     cases = []
@@ -54,12 +54,14 @@ def _synthetic_cases(n_cases=6, n_rows=40, n_feats=8, seed=1234):
             row = {n: float(rng.integers(-4, 5)) for n in names}
             feats.append({k: v for k, v in row.items() if rng.random() > 0.25})
         tier = ["thread", "warp", "reduce", "dyn"][c % 4]
-        # The dynamic cases carry the routing stamp on every row, as the golden case builder writes
-        # it; ``Group.from_dicts`` lifts it into ``Group.dynamic`` and out of the fitted matrix.
-        if tier == "dyn":
-            feats = [{**f, "S_ext_n_symbolic_axis": 1.0} for f in feats]
+        # EVERY pool carries the routing stamp, as the featurizer writes it (``passes/identity._extents``
+        # emits the key unconditionally, 0.0 when no axis is symbolic) — a static pool stamps 0.0, it does
+        # not omit the key. ``Group`` packs it like any other column and the linear trainer narrows it out.
+        feats = [{**f, "S_ext_n_symbolic_axis": 1.0 if tier == "dyn" else 0.0} for f in feats]
         cases.append(Group.from_dicts(f"x/case{c}", f"case{c}", tier, "x", f"shape{c}", int(rng.integers(0, n_rows)), feats))
-    return cases, names
+    # The feature list the trainer is given is the union of the PACKED columns, exactly as
+    # ``commands/fit.py`` builds it — so it includes the routing stamp, and the fit has to narrow it out.
+    return cases, sorted({n for c in cases for n in c.feat_names})
 
 
 # The incumbent a synthetic fit chains from: no weights to warm-start (the fits below set
@@ -90,6 +92,10 @@ def test_fit_twice_is_byte_identical():
     assert a == b
     art = json.loads(a)
     assert art["weights"] and art["weights_dynamic"]  # a real fit, not an empty pass-through
+    # The trainer was handed the routing stamp among its feature names (the union of packed columns) and
+    # must not have fitted a weight for it: constant within a pool, so any value there is noise, and it
+    # would become an additive term on every symbolic-axis kernel in the cross-kernel price sum.
+    assert not {n for n in (*art["weights"], *art["weights_dynamic"]) if n.startswith("S_ext")}
 
 
 def test_one_trainer_instance_refits_identically():


### PR DESCRIPTION
## The bug

`Group.from_dicts` stripped `ROUTING_FEATURES` (`S_ext_n_symbolic_axis`) from `feat_names`, to stop the linear descent gaining a pool-constant coordinate. `CatBoostTrainer.cols` then appended that name back, believing — as three docstrings said — that the value came *"re-added from `Group.dynamic`"*.

It did not. `Group.dynamic` is a bool field, not a column, so `Group.matrix(cols, fill=ABSENT)` found no such column and filled it with `NaN` for **every training row of every pool**. Live candidates carry a real value, so the tree trained on a bucket it never sees at serve time — and could not price the static/dynamic regimes at all.

Reproduced directly:

```
feat_names        : ('D_a',)
trainer cols      : ('D_a', 'S_ext_n_symbolic_axis')
routing column    : [nan nan nan nan]     <- the bug
stamp in the rows : [1.0, 1.0, 1.0, 1.0]
```

`test_routing_stamp_is_an_ordinary_column` passed throughout — it asserted `model.cols`, i.e. the column's *name*, never its contents.

## What it cost

Measured on pools where the static and dynamic halves rank oppositely on `D_a` — something one model can only fit by splitting on the regime:

| | routing feature importance | mean golden rank | goldens ranked first |
| --- | --- | --- | --- |
| before | **0.00%** | 0.375 | 10 of 16 |
| after | **17.71%** | 0.0 | 16 of 16 |

A real capability loss, not a cosmetic layering issue.

## The fix

Stop having the dataset decide for both model classes. Every column is packed; each model class narrows to what it reads.

- `descent_cols(names)` lands in `linear_model.py` beside `ROUTING_FEATURES`, whose comment already claimed routing as the model's business.
- `CatBoostTrainer` reads `feature_names` directly. Its `cols` property became an identity function, so it is **deleted** rather than kept for a docstring to live in — the fix removes a special case instead of adding one.

## Linear is byte-identical, verified not assumed

Fitting the same synthetic cases against an `origin/main` worktree and against this branch: the packed feature list grows **8 names → 9**, and the artifact is **byte-identical**, with no routing key in either weight set. That holds because filtering preserves relative order, so `descent_cols(sorted(union | routing))` is exactly `sorted(union - routing)`.

## The guard that replaces the structural one

Withholding the column made a routing weight structurally unreachable. That is a convention now, so `LinearModel.__post_init__` rejects a routing key carrying a fitted weight.

The docstring is precise about *why*, because the module also says such a term "cancels exactly" — and within a pool it does, as it does out of the greedy argmin, `normalize_policy` and `TiltBlend`. It does **not** cancel in `policy/greedy._resolved_price`, which sums per-kernel scores to compare whole kernel sets, so a routing weight there would scale every symbolic-axis kernel's price and bias the fusion comparison.

## A fixture bug found while fixing this one

The test fixtures stamped the routing key only on dynamic pools. But `passes/identity._extents` emits it **unconditionally** — `0.0` when no axis is symbolic, pinned by `test_structural_features.py:129`. Asserting `NaN` for the static half would have *moved* the train/serve skew to the static side rather than removing it. Fixtures now stamp `0.0`/`1.0` as production does.

## Tests that would catch this regression

The re-pointed tests fail on the old behaviour and pass on the new — verified by restoring the strip and re-running:

- `test_the_tree_prices_the_two_regimes_from_the_routing_column` (new) — pins the capability, not the column name.
- `test_routing_stamp_is_an_ordinary_column` — now asserts the column's **contents** (`0.0` static / `1.0` dynamic).
- `test_fit_twice_is_byte_identical` — now hands the trainer the union of packed columns, as `commands/fit.py` does, so byte-identity runs with the stamp present and asserts no routing weight comes back out.

`test_fit_treats_every_pin_as_a_positive` moved `[1] * 6` → `[0] * 6`: the all-NaN column collapsed rows 18/19 onto one leaf so the pins tied, and a tie counts against the golden. Ranks improving, not regressing.

## Docs

`emmy/compiler/pipeline/ARCHITECTURE.md` stated the deleted behaviour ("the fit holds it out of the feature matrix structurally rather than by feature view") and is corrected, along with every stale docstring in `group.py`, `fit/catboost.py`, `catboost_model.py` and `linear_model.py`.

## Verification

`make test` — 3010 passed, 578 skipped, 1 xfailed. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXPHwChs61iSChSCddZJoG