### PR TITLE
Rebench and retune DeepSeek V4 Flash 0731 on 16x V100 at the current revision

### DIFF
--- a/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/RESULTS.md
+++ b/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/RESULTS.md
@@ -5,93 +5,82 @@ platform section below describes the archive named in it and nothing else.
 
 ## NVIDIA Tesla V100 SXM3 32GB × 16 — `results_v100x16.tar.gz`
 
-**Question.** Does the maintained TP8×PP2 recipe still deploy, serve, and perform on a 16× V100 SXM3 host, and how
-stable is the result across repeats?
+**Question.** Does the maintained TP8×PP2 recipe still deploy, serve, and perform on 16× V100 SXM3, and how stable is
+the result across repeats?
 
 **Protocol.** `emmy bench experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3` against a pre-allocated 16× V100 SXM3
 host over SSH. One matrix row (`v100x16`). Four client repeats, each preceded by 8 warm-up requests; each repeat sends
 8 unique 1,024-token prompts at concurrency 8 and requests 64 output tokens with greedy decoding (`temperature: 0.0`,
 `seed: 731`) and `ignore_eos`, so every request produces exactly 64 tokens. Repeat 1 primes the prompt set after
-deployment; repeats 2–4 are the steady-state result. Spread is the population standard deviation across those three
-repeats.
+deployment; repeats 2–4 are the steady-state result. Spread is the population standard deviation across those three.
 
-**Run.** Timestamp `2026-08-19T19:14:45Z`, run ID `20260819T191445Z`, repository revision `12bb850e` (clean tree),
+**Run.** Timestamp `2026-08-21T02:57:30Z`, run ID `20260821T025730Z`, repository revision `fd7b09041` (clean tree),
 row `v100x16` / `661253606d45`, status `succeeded`. Archive members:
 
 ```
-2026-08-19_19-14-45/benchmark.log
-2026-08-19_19-14-45/benchmark_v100_x_16.log
-2026-08-19_19-14-45/v100x16_661253606d45.benchmark.log
-2026-08-19_19-14-45/v100x16_661253606d45.experiment.yaml
-2026-08-19_19-14-45/v100x16_661253606d45.server.log
+2026-08-21_02-57-30/benchmark.log
+2026-08-21_02-57-30/benchmark_v100_x_16.log
+2026-08-21_02-57-30/v100x16_661253606d45.benchmark.log
+2026-08-21_02-57-30/v100x16_661253606d45.experiment.yaml
+2026-08-21_02-57-30/v100x16_661253606d45.server.log
 ```
 
 **Machine and software.** Ubuntu 24.04.1, kernel 6.8.0-124-generic, 2× Intel Xeon Platinum 8168 (80 logical CPUs),
-1.44 TB RAM, 16× Tesla V100-SXM3-32GB behind 12 NVSwitches, driver 580.159.03, CUDA 13.0. Engine image
-`cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608`
-(`sha256:276240257b224097876b5b6db8f0d32484dff6a6f168d6b03d6df188e5c65bc1`), vLLM
-`1.2.3.dev87+gd76126608.d20260810`. Model revision `7872f01b1d1fe23eabc4c98b48bffcef5a386062`, FP16 weights with
-`deepseek_v4_fp8` quantization and an FP8 KV cache, TP8 × PP2, context 1,048,576, `gpu_memory_utilization` 0.90.
+1,338 GB RAM, 16× Tesla V100-SXM3-32GB behind 12 NVSwitches, driver 580.159.03. Engine image
+`cloudriftai/1cat-vllm-deepseek-v4-flash-0731:1.2.3-d76126608`, vLLM `v1.2.3.dev87+gd76126608`. Model revision
+`7872f01b1d1fe23eabc4c98b48bffcef5a386062`, FP16 weights with `deepseek_v4_fp8` quantization and an FP8 KV cache,
+TP8 × PP2, context 1,048,576, `gpu_memory_utilization` 0.90.
 
 **Result.** The row succeeded. All 32 requests across the four repeats completed; 0 failed.
 
 | Repeat | Duration (s) | req/s | Output tok/s | Total tok/s | Mean TTFT (ms) | Mean TPOT (ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1 (priming) | 23.72 | 0.34 | 21.59 | 367.00 | 8,266.85 | 243.89 |
-| 2 | 16.59 | 0.48 | 30.86 | 524.56 | 3,876.69 | 201.79 |
-| 3 | 16.47 | 0.49 | 31.09 | 528.57 | 3,821.34 | 200.67 |
-| 4 | 16.52 | 0.48 | 30.99 | 526.78 | 3,817.99 | 201.62 |
+| 1 (priming) | 23.86 | 0.34 | 21.46 | 364.83 | 8,326.03 | 245.23 |
+| 2 | 16.67 | 0.48 | 30.72 | 522.23 | 3,322.63 | 210.94 |
+| 3 | 16.52 | 0.48 | 31.00 | 526.98 | 3,242.14 | 210.25 |
+| 4 | 16.70 | 0.48 | 30.66 | 521.30 | 3,830.34 | 204.17 |
 
 Steady state over repeats 2–4 (24 requests, 0 failures):
 
 | Metric | Mean ± population SD |
 | --- | ---: |
-| Benchmark duration | 16.5267 ± 0.0492 s |
-| Request throughput | 0.4833 ± 0.0047 req/s |
-| Output token throughput | 30.9800 ± 0.0942 tok/s |
-| Total token throughput | 526.6367 ± 1.6402 tok/s |
-| Mean TTFT | 3,838.6733 ± 26.9166 ms |
-| Mean TPOT / ITL | 201.3600 ± 0.4928 ms |
+| Benchmark duration | 16.6300 ± 0.0787 s |
+| Request throughput | 0.4800 ± 0.0000 req/s |
+| Output token throughput | 30.7933 ± 0.1482 tok/s |
+| Total token throughput | 523.5033 ± 2.4875 tok/s |
+| Mean TTFT | 3,465.04 ± 260.39 ms |
+| Mean TPOT / ITL | 208.4533 ± 3.0418 ms |
 
-**Repeat variation.** Repeats 2–4 are very tight: duration varies by 0.3%, output throughput by 0.3%, and mean TPOT by
-0.2%. The priming repeat is a clear outlier (44% longer, TTFT 2.2× the steady mean) and is excluded, which the protocol
-anticipates.
+**Repeat variation.** Throughput is tight across repeats 2–4 (duration 0.5%, output throughput 0.5%). TTFT is not:
+the three steady repeats span 3,242–3,830 ms, a 17% spread, against 27 ms of spread in the 2026-08-19 run. The
+priming repeat is a clear outlier and is excluded, which the protocol anticipates.
 
-**Deployment timing.** `remote_provision` 7.04 s, `image_pull` 2.36 s and `model_download` 3.41 s (both cached from an
-earlier deployment on this host), `weights_load` 24.32 s, `cuda_graph_capture` 7.00 s, `engine_warmup` 22.52 s,
-`startup` 92.09 s, `model_load_and_warmup` 145.92 s, `smoke_test` 4.10 s, `benchmark` 242.21 s, `total` 405.04 s.
+**Deployment timing.** `remote_provision` 6.95 s, `image_pull` 2.44 s and `model_download` 3.68 s (both cached on this
+host), `weights_load` 27.00 s, `cuda_graph_capture` 6.00 s, `engine_warmup` 23.73 s, `startup` 89.14 s,
+`model_load_and_warmup` 145.87 s, `smoke_test` 4.29 s, `benchmark` 241.09 s, `total` 404.32 s.
 
-**Comparison with the 2026-08-11 qualification.** That run measured the same recipe and workload on a *different* 16×
-V100 SXM3 host running driver 580.173.02. This is a directional comparison across two machines, not a controlled A/B:
-only one variable was intended to change (the host), but driver version changed with it.
+**Comparison with the 2026-08-19 run.** Same host, same recipe, same image; the repository revision moved from
+`12bb850e` to `fd7b09041` (16 merged pull requests, including a recognition rebuild and two compiler-cache changes).
 
-| Metric | 2026-08-11 | 2026-08-19 | Change |
+| Metric | 2026-08-19 (`12bb850e`) | 2026-08-21 (`fd7b09041`) | Change |
 | --- | ---: | ---: | ---: |
-| Benchmark duration | 14.9793 s | 16.5267 s | +10.3% |
-| Request throughput | 0.5341 req/s | 0.4833 req/s | −9.5% |
-| Output token throughput | 34.1830 tok/s | 30.9800 tok/s | −9.4% |
-| Total token throughput | 581.1111 tok/s | 526.6367 tok/s | −9.4% |
-| Mean TTFT | 2,580.88 ms | 3,838.67 ms | +48.7% |
-| Mean TPOT / ITL | 195.949 ms | 201.360 ms | +2.8% |
+| Output token throughput | 30.9800 ± 0.0942 tok/s | 30.7933 ± 0.1482 tok/s | −0.6% |
+| Total token throughput | 526.6367 ± 1.6402 tok/s | 523.5033 ± 2.4875 tok/s | −0.6% |
+| Mean TTFT | 3,838.67 ± 26.92 ms | 3,465.04 ± 260.39 ms | −9.7% |
+| Mean TPOT / ITL | 201.360 ± 0.493 ms | 208.453 ± 3.042 ms | +3.5% |
 
-The gap is concentrated in prefill: decode cost (TPOT) is within 2.8%, while TTFT is roughly half again as large. Both
-runs are internally stable, so the difference is a property of the two machines rather than measurement noise. The
-harness does not isolate host from driver, so this experiment cannot attribute the prefill difference to either one.
+Throughput is unchanged within noise. TTFT improved by about 10% but its spread grew tenfold, so the two runs' TTFT
+distributions overlap and the shift is not established by this evidence. The engine image is byte-identical between
+the runs, so nothing in the serving stack changed; these are host-level run-to-run differences.
 
-**Zero-JIT claim.** The recipe describes this configuration as having a zero-JIT request cache. That does not hold on
-this deployment: the server log records eight distinct Triton kernels JIT-compiling during inference —
-`_build_c128a_topk_metadata_kernel`, `_build_prefill_chunk_metadata_kernel`, `_combine_topk_swa_indices_kernel`,
-`_compute_prefill_metadata_kernel`, `_dequantize_and_gather_k_kernel`, `_sm70_qnorm_rope_kernel`,
-`_sm70_sparse_gathered_kernel`, and `quantize_and_insert_k_kernel`. All of them compile once,
-during the first repeat's warm-up phase, and none recurs; they inflate the priming repeat and leave repeats 2–4
-unaffected.
+**Zero-JIT claim.** Unchanged from the previous run: eight distinct Triton kernels still JIT-compile once during the
+first repeat's warm-up and none recurs, so they cost the priming repeat only.
 
-**Conclusion.** The maintained recipe deploys and serves correctly on 16× V100 SXM3 with zero failed requests and
-highly reproducible steady-state throughput. Short-context performance on this host is about 9% below the 2026-08-11
-measurement, with the shortfall almost entirely in prefill latency.
+**Context.** The engine again allocated KV capacity for 4,244,903 tokens on PP0 and 4,281,497 on PP1.
 
-**Limitations.** One workload shape only (1,024 in / 64 out, concurrency 8) on one matrix row — it justifies the
-recommended configuration but says nothing about long-context or high-concurrency behaviour. `emmy bench` deployed a
-fresh server for this run, so the numbers are cold-cache-then-warmed, not steady-state under sustained production load.
-The cross-run comparison above changes two variables at once. No Emmy lane exists for this model, so there is no
-compiler-vs-stock comparison to report.
+**Conclusion.** The maintained recipe deploys and serves correctly on 16× V100 SXM3 at the current repository
+revision, with zero failed requests and steady-state throughput indistinguishable from the previous run.
+
+**Limitations.** One workload shape (1,024 in / 64 out, concurrency 8) on one matrix row. `emmy bench` deploys a fresh
+server, so the numbers are cold-cache-then-warmed rather than sustained production load. The TTFT comparison above is
+directional only. No Emmy lane exists for this model, so there is no compiler-versus-stock comparison.

--- a/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/results_v100x16.tar.gz
+++ b/experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3/results_v100x16.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9102d5d7674da9356333f0a8fa9a7630b2566b2142a3b4a14ffa14f2e1a64b7e
-size 18750
+oid sha256:82e66a51bc349d0b410a51411260cde0ae87607ca2222d3e5351c05dbeeb7d8f
+size 18935

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -55,6 +55,49 @@ two distributions overlap and neither shift is established here. The engine imag
 The recipe's zero-JIT intent is still not fully met: eight Triton kernels JIT-compile once during the first repeat's
 warm-up and none recurs, so they cost the priming repeat only.
 
+## These numbers are vLLM without Emmy kernels
+
+Every serving number in this report was produced by vLLM alone, with no Emmy kernels in the process. The deployed
+container runs 1Cat/vLLM; the recipe sets no `EMMY_*` variable, passes no Emmy plugin, and the archived server log for
+the reported run contains no mention of Emmy at all. The `VLLM_SM70_*` variables it does set are the 1Cat fork's own
+Volta features — flash attention, and the turbomind FP8 / MXFP4 quantized paths — not Emmy code. So the baseline a
+reader usually wants, "vLLM without Emmy", is exactly what the throughput, TTFT and TPOT figures above already measure.
+
+What does not exist for this model is the other arm: vLLM **with** Emmy kernels. Emmy's serving A/B is
+`emmy serve <model> --bench` against `emmy serve <model> --bench --stock`, and neither side of it can run here, for two
+independent reasons.
+
+**The Emmy side has no executable serving path for this architecture.** `emmy/serving/twins.py` routes DeepSeek V4 away
+from the serving twins to a config-only provider, because "its HCA/CSA compressors and hyper-connection residual
+streams do not fit the classic external-attention seam"; `emmy/serving/ARCHITECTURE.md` adds that they "cannot be
+represented by the classic `(q, k, v)` serving seam, so claiming split twins would omit deployed operations", and that
+executable split capture rejects DeepSeek's shared-`kv_proj` layout. That provider exists for the in-model golden
+audit, not for serving. Consistent with that, `docker/vllm-emmy-serve/models/` holds serving configs only for
+`gemma-4-12b`, and no `cloudriftai/vllm-emmy-deepseek-v4-flash-0731` image exists. This is the same Emmy-eligibility
+gate recorded at the top of this report.
+
+**The stock side has no Volta kernels.** Measured on the target host with `vllm/vllm-openai@sha256:03768d94…`, the
+exact stock image the sibling `DeepSeek-V4-Flash` recipe pins for this checkpoint on H200 (vLLM
+`0.22.1rc1.dev332+g2c9c07c85`, torch `2.11.0+cu130`):
+
+| Check | Result |
+| --- | --- |
+| `torch.cuda.get_device_capability(0)` | `(7, 0)` — Tesla V100-SXM3-32GB |
+| `torch.cuda.get_arch_list()` | `sm_75, sm_80, sm_86, sm_90, sm_100, sm_120` — **no `sm_70`** |
+| A plain 256×256 fp16 matmul | `CUDA error: no kernel image is available for execution on the device` |
+
+PyTorch warns the device is unsupported before any vLLM code runs, and a single matmul fails, so the engine never
+reaches model loading. That is an architecture gap rather than anything specific to DeepSeek V4, and it is why every
+V100 recipe in this repository pins a 1Cat SM70 build instead of a stock image. `emmy serve` invokes `vllm serve` from
+the Python environment (`vllm` is the optional `serving` extra), so its stock lane would hit exactly this wall; the
+SM70 build that does run Volta is delivered as a container, not a wheel.
+
+**What the numbers therefore are.** A pure vLLM result on the only engine build that runs this checkpoint on Volta,
+measured against itself across repository revisions. They are not a speedup over anything: there is no Emmy-accelerated
+arm to beat, and no stock arm that survives the architecture gap. The `emmy bench` reproduction accordingly has no
+second engine lane to filter to. The compiler work recorded below is kernel-level evidence (the golden) and is
+independent of serving eligibility.
+
 ## Context and accuracy
 
 The engine allocated KV capacity for 4,244,903 tokens on PP0 and 4,281,497 tokens on PP1, reporting 4.05×/4.08×

--- a/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
+++ b/recipes/DeepSeek-V4-Flash-0731/RESULTS.md
@@ -1,8 +1,9 @@
 # DeepSeek V4 Flash 0731 on 16× V100 SXM3 32 GB
 
-Status: serving-qualified with the 1Cat/vLLM engine pinned by the recipe. Verification refresh of 2026-08-19 on a
-second 16× V100 SXM3 host. Emmy serving remains ineligible: the DeepSeek V4 compressor and hyper-connection path has
-no executable external-attention serving ABI, so `EMMY_FAST_MATH` is not set and there is no Emmy comparison lane.
+Status: serving-qualified with the 1Cat/vLLM engine pinned by the recipe. Reverified 2026-08-21 on 16× V100 SXM3 at
+repository revision `fd7b09041`. Emmy serving remains ineligible: the DeepSeek V4 compressor and hyper-connection
+path has no executable external-attention serving ABI, so `EMMY_FAST_MATH` is not set and there is no Emmy
+comparison lane.
 
 ## Qualified deployment
 
@@ -32,7 +33,7 @@ ensure `nvidia-fabricmanager` matching the driver is running first.
 
 ## Best recipe performance
 
-Measured 2026-08-19 with the pinned 1,048,576-context recipe at repository revision `12bb850e`. Four client repeats;
+Measured 2026-08-21 with the pinned 1,048,576-context recipe at repository revision `fd7b09041`. Four client repeats;
 the first primes the prompt set after deployment and is excluded. Each repeat used eight unique 1,024-token prompts at
 concurrency 8 and requested 64 output tokens with greedy decoding and ignored EOS. All 24 reported requests completed
 with exact token counts. Spread is the population standard deviation across the three steady repeats.
@@ -40,22 +41,19 @@ with exact token counts. Spread is the population standard deviation across the 
 | Metric | Three-repeat mean ± standard deviation |
 | --- | ---: |
 | Successful / failed requests | 24 / 0 |
-| Benchmark duration | 16.5267 ± 0.0492 s |
-| Request throughput | 0.4833 ± 0.0047 requests/s |
-| Output throughput | 30.9800 ± 0.0942 tokens/s |
-| Total token throughput | 526.6367 ± 1.6402 tokens/s |
-| Mean TTFT | 3,838.67 ± 26.92 ms |
-| Mean TPOT / ITL | 201.360 ± 0.493 ms |
+| Benchmark duration | 16.6300 ± 0.0787 s |
+| Request throughput | 0.4800 ± 0.0000 requests/s |
+| Output throughput | 30.7933 ± 0.1482 tokens/s |
+| Total token throughput | 523.5033 ± 2.4875 tokens/s |
+| Mean TTFT | 3,465.04 ± 260.39 ms |
+| Mean TPOT / ITL | 208.453 ± 3.042 ms |
 
-This is about 9% below the 2026-08-11 qualification on the previous 16× V100 host (driver 580.173.02), which measured
-34.1830 ± 0.2886 output tokens/s. Decode cost is nearly unchanged (TPOT 201.36 ms vs 195.949 ms, +2.8%); essentially
-all of the gap is prefill (TTFT 3,838.67 ms vs 2,580.88 ms, +48.7%). Both runs are internally stable, so this is a
-machine-level difference rather than noise; the two runs differ in both host and driver version, and this evidence
-cannot separate them.
+Throughput is unchanged from the 2026-08-19 measurement (30.9800 ± 0.0942 tokens/s) across 16 merged pull requests.
+TTFT reads about 10% lower and TPOT about 3% higher, but the steady TTFT spread grew from 27 ms to 260 ms, so those
+two distributions overlap and neither shift is established here. The engine image is byte-identical between the runs.
 
-The recipe's zero-JIT intent is not fully met. Eight Triton kernels JIT-compile once during the first repeat's
-warm-up — including the prefill-metadata and SM70 quantized-attention paths — and none recurs, so they cost the
-priming repeat only. The per-kernel list is in the experiment report.
+The recipe's zero-JIT intent is still not fully met: eight Triton kernels JIT-compile once during the first repeat's
+warm-up and none recurs, so they cost the priming repeat only.
 
 ## Context and accuracy
 
@@ -116,7 +114,7 @@ therefore ran against the committed inventory rather than a freshly re-derived o
 | --- | --- | --- |
 | Repository-level validation | committed file | passes |
 | Strict decode of every realization | committed file | 279 / 279 |
-| Reconstruct and lower every target | Tesla V100-SXM3-32GB (sm_70) | 279 / 279, exit 0, 3 min 54 s |
+| Reconstruct and lower every target | Tesla V100-SXM3-32GB (sm_70) | 279 / 279, exit 0, 3 min 16 s |
 
 ### `REDUCE=g2a`: a validator false negative, now fixed and re-measured
 
@@ -151,38 +149,54 @@ Each row keeps its `g2a` knobs — the configuration is real and ties with greed
 runs on each side. Across the file, realizations materially slower than greedy fall from 41 to 11, and the remaining
 eleven are sub-microsecond pointwise kernels.
 
-### Tuning: equal-budget hybrid versus MCTS-only
+### Tuning: equal-budget hybrid versus MCTS-only (2026-08-21, whole model)
 
-Scope: the 9 `g2a` realizations. The other 270 are at or above greedy and carry no headroom, and a full 279-target arm
-measured out at roughly ten hours per arm. This is a scoped kernel result, not a whole-model performance claim.
+The previous round had to scope its A/B to nine targets because `emmy tune` re-validated and rewrote the whole
+document on every incremental persist. With that fixed upstream, both arms now sweep the **entire 279-target
+inventory** at roughly 15 measured rows per minute against about 3.4 before — 1 h 18 m per arm instead of an
+estimated ten hours.
 
-Both arms started from the same inventory-only base (no knobs, timings, or ranking), an empty tune DB and online prior,
-separate empty cubin caches, `--max-candidates 8`, `--patience 4`, `--seed 731`, 9 GPUs, same compiler revision, MCTS
-arm first. The hybrid arm added 4 knob proposals per target, each reserving a candidate slot before MCTS. MCTS
-completed 9/9 targets with 145 benches; hybrid 9/9 with 171. On the O1 ranking lane MCTS produced the better candidate
-on 6 targets, hybrid on 1, with 2 ties.
+Both arms started from the same inventory-only base (no knobs, timings, or ranking), an empty tune DB and online
+prior, separate empty cubin caches, `--max-candidates 8`, `--patience 4`, `--seed 731`, all 16 GPUs, same compiler
+revision, MCTS arm first. The hybrid arm added 18 knob proposals across 8 realizations, each reserving a candidate
+slot before MCTS. The arms came out closely matched, which is what makes the comparison fair:
 
-The O1 ranking lane misranks this model badly, so every conclusion below is from repeated deployable O3 measurement:
+| Arm | Wall clock | Benches | Measured rows | ok / bench_fail | Prior calibration |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| MCTS-only | 1:17:57 | 9,156 | 3,312 | 2,279 / 1,033 | +0.96 |
+| Hybrid | 1:18:56 | 9,200 | 3,343 | 2,296 / 1,047 | +0.93 |
 
-| Target | Candidate | O3 run 1 | O3 run 2 |
-| --- | --- | ---: | ---: |
-| `model-seam.k_linear_db1eb0` | greedy (isolated) | 2,854.9 µs | 2,855.9 µs |
-| | MCTS winner `TILE=f2x8, WORK=t64x8` | 2,804.7 µs | 2,510.8 µs |
-| | **hybrid proposal `REDUCE=coop, WORK=t128`** | **1,014.8 µs** | **902.1 µs** |
-| `layer0.i003.k_linear_reduce_f6a146` | greedy (isolated) | 910.3 µs | 910.3 µs |
-| | MCTS winner `TILE=f1x2, WORK=t32x8` | 2,526.2 µs | 2,520.1 µs |
-| | hybrid `REDUCE=coop, TILE=f2x2, WORK=t16x8` | 2,367.5 µs | 2,487.3 µs |
-| `layer3.i064.k_linear_reduce_f6a146` | greedy (isolated) | 912.4 µs | 909.3 µs |
-| | MCTS winner `TILE=f1x2, WORK=t32x8` | 2,401.3 µs | 2,522.1 µs |
+**Outcome: no winner, and nothing promoted.** Across 279 targets the O1 ranking lane put hybrid ahead on 44, MCTS
+ahead on 44, and tied the remaining 169. The golden is unchanged by this round.
 
-The hybrid proposal wins decisively on the one target with real headroom — 2.8–3.2× faster than greedy and about
-2.5× faster than the MCTS-only winner — and it is exactly the hypothesis the `g2a` evidence suggested: drop `g2a`
-and use the cooperative reduce with a thread work inventory. It is promoted into the golden with its two O3
-measurements.
+That result is less interesting than why. After the previous round resolved the `g2a` cluster, this golden loses
+19.2 ms to greedy in total, and **19.2 ms of it sits in one realization** — `model-seam.k_linear_d74dc7` at 0.876×
+(154.2 ms against greedy's 135.0 ms). Every other slower-than-greedy row is under 3 µs. It is also the last
+`model-seam` row still on the Volta MMA warp tile, while its winning siblings all use a cooperative reduce over a
+thread work inventory — the same swap that won 2.82× on `k_linear_db1eb0` last round. So the hybrid arm proposed
+exactly that.
 
-The eight `k_linear_reduce_f6a146` realizations keep their `g2a` knobs. No searched or proposed candidate beat
-greedy there, and once the validator fix let the incumbent bench, `g2a` measured as a tie with greedy on all
-eight — so the recorded configuration stands and only its stale measurements needed refreshing.
+**Every candidate for that target was killed by a watchdog rather than measured.** In the tune lane the proposals hit
+the 2.0 s GPU-time budget; only the alternative MMA work shape survived, at 176.2 ms, worse than the incumbent. The
+O3 verification lane cannot settle it either: there the *greedy baseline itself* exceeds the 100 s wall budget and is
+SIGKILL'd, so the run produces no comparable output at all. This kernel is simply too large for the budgets the
+benchmark harness applies, and its 19.2 ms of headroom is currently unreachable by tuning — not refuted, unmeasurable.
+
+**Bench failures.** About 31% of rows in each arm failed to bench, near-identically in both, so they do not bias the
+comparison:
+
+| Class | MCTS | Hybrid |
+| --- | ---: | ---: |
+| nvcc compile failed | 451 | 462 |
+| bench worker exceeded the 16 s wall budget | 434 | 460 |
+| benchmark run exceeded the 2.0 s GPU-time budget | 137 | 129 |
+| hung kernel | 7 | 3 |
+
+Every one of the nvcc failures is the same defect: generated CUDA for a `k_div_*` kernel emits `float v0 = in0 + in2;`
+where `in0` was never declared, and nvcc rejects it (2,173 occurrences in the hybrid log, one kernel family, no other
+compiler message). It reaches only searched variants — the golden's own recorded configurations compile and replay
+cleanly — so it costs search coverage rather than deployed correctness. Knob values do not separate failing from
+passing rows and all 462 failing rows are distinct ops, so the trigger is structural to that kernel family.
 
 ### Reproducing the compiler work
 


### PR DESCRIPTION
Re-benches serving and re-tunes the compiler inventory for `deepseek-ai/DeepSeek-V4-Flash-0731` on the same 16× V100 SXM3 host, at repository revision `fd7b09041` — i.e. with #558, #567, #569 and #570 all in place. Artifacts only; no code changes, and **the golden is unchanged**.

## Serving: unchanged across 16 merged PRs

24/24 steady requests, 0 failures.

| Metric | 2026-08-19 (`12bb850e`) | 2026-08-21 (`fd7b09041`) |
| --- | ---: | ---: |
| Output throughput | 30.9800 ± 0.0942 tok/s | 30.7933 ± 0.1482 tok/s |
| Total throughput | 526.6367 ± 1.6402 tok/s | 523.5033 ± 2.4875 tok/s |
| Mean TTFT | 3,838.67 ± 26.92 ms | 3,465.04 ± 260.39 ms |
| Mean TPOT / ITL | 201.360 ± 0.493 ms | 208.453 ± 3.042 ms |

Throughput is flat. TTFT reads ~10% lower and TPOT ~3% higher, but the steady TTFT spread grew from 27 ms to 260 ms, so those distributions overlap and neither shift is claimed. The engine image is byte-identical between the runs, so nothing in the serving stack changed. The golden replays 279/279 on sm_70, exit 0, in 3 min 16 s (was 3 min 54 s).

## These serving numbers are vLLM without Emmy kernels

Worth stating plainly, because it is the first thing a reader asks: **the throughput, TTFT and TPOT figures above are already the "vLLM without Emmy" baseline.** Nothing Emmy runs in the served process — the container is 1Cat/vLLM, the recipe sets no `EMMY_*` variable and passes no Emmy plugin, and the archived server log for the reported run contains no mention of Emmy at all. The `VLLM_SM70_*` variables it does set are the 1Cat fork's own Volta features (flash attention, turbomind FP8/MXFP4), not Emmy code.

What is missing is the *other* arm — vLLM **with** Emmy kernels. Emmy's serving A/B is `emmy serve --bench` against `emmy serve --bench --stock`, and neither side of it can run for this model here:

**The Emmy side has no executable serving path for this architecture.** `emmy/serving/twins.py` routes DeepSeek V4 away from the serving twins to a config-only provider, because "its HCA/CSA compressors and hyper-connection residual streams do not fit the classic external-attention seam"; `emmy/serving/ARCHITECTURE.md` adds that they "cannot be represented by the classic `(q, k, v)` serving seam, so claiming split twins would omit deployed operations", and that executable split capture rejects DeepSeek's shared-`kv_proj` layout. That provider backs the in-model golden audit, not serving. Consistent with it, `docker/vllm-emmy-serve/models/` holds serving configs only for `gemma-4-12b`, and no `cloudriftai/vllm-emmy-deepseek-v4-flash-0731` image exists — the same Emmy-eligibility gate already recorded at the top of the report.

**The stock side has no Volta kernels**, so it cannot provide a second lane either. Measured on the target host with `vllm/vllm-openai@sha256:03768d94…`, the exact stock image the sibling `DeepSeek-V4-Flash` recipe pins for this checkpoint on H200 (vLLM `0.22.1rc1.dev332+g2c9c07c85`, torch `2.11.0+cu130`):

| Check | Result |
| --- | --- |
| `torch.cuda.get_device_capability(0)` | `(7, 0)` — Tesla V100-SXM3-32GB |
| `torch.cuda.get_arch_list()` | `sm_75, sm_80, sm_86, sm_90, sm_100, sm_120` — **no `sm_70`** |
| A plain 256×256 fp16 matmul | `CUDA error: no kernel image is available for execution on the device` |

PyTorch warns the device is unsupported before any vLLM code runs, so the engine never reaches model loading. `emmy serve` invokes `vllm serve` from the Python environment (`vllm` is the optional `serving` extra), so its stock lane hits exactly this wall; the SM70 build that does run Volta ships as a container, not a wheel. It is also why every V100 recipe in this repository pins a 1Cat SM70 image.

**So:** a pure vLLM result on the only engine build that runs this checkpoint on Volta, measured against itself across revisions. Not a speedup over anything — there is no Emmy-accelerated arm to beat and no stock arm that survives the architecture gap. The compiler work below is kernel-level evidence (the golden) and is independent of serving eligibility.

## Tuning: the first whole-model A/B

#569 is what made this possible. Removing the per-target document rewrite took a full 279-target arm from an estimated ten hours to **1 h 18 m** (~15 measured rows/min against ~3.4), so both arms swept the entire inventory at matched budget instead of the nine targets the previous round could afford.

| Arm | Wall clock | Benches | Rows | ok / bench_fail | Prior calibration |
| --- | ---: | ---: | ---: | ---: | ---: |
| MCTS-only | 1:17:57 | 9,156 | 3,312 | 2,279 / 1,033 | +0.96 |
| Hybrid | 1:18:56 | 9,200 | 3,343 | 2,296 / 1,047 | +0.93 |

Identical starting state (inventory-only base, empty DB and online prior, separate empty cubin caches, `--max-candidates 8 --patience 4 --seed 731`, 16 GPUs, MCTS arm first). The hybrid arm added 18 proposals across 8 realizations.

**Outcome: 44 hybrid, 44 MCTS, 169 ties on the O1 lane. Nothing promoted; the golden is untouched.**

## Why nothing moved — the headroom is unmeasurable, not absent

After the previous round resolved the `g2a` cluster, this golden loses 19.2 ms to greedy in total and **19.2 ms of it sits in a single realization**: `model-seam.k_linear_d74dc7` at 0.876× (154.2 ms against greedy's 135.0 ms). Every other slower-than-greedy row is under 3 µs.

It is also the last `model-seam` row still on the Volta MMA warp tile, while its winning siblings all use a cooperative reduce over a thread work inventory — the swap that won 2.82× on `k_linear_db1eb0` last round. The hybrid arm proposed exactly that.

Every candidate for that target was **killed by a watchdog rather than measured**:

- tune lane — the 2.0 s GPU-time budget; only the alternative MMA work shape survived, at 176.2 ms, worse than the incumbent;
- O3 verification lane — the *greedy baseline itself* exceeds the 100 s wall budget and is SIGKILL'd, so the run yields no comparable output at all.

So the largest remaining win in this golden cannot currently be evaluated on this hardware. Not refuted — unmeasurable.

## A codegen defect worth a follow-up

About 31% of rows in each arm failed to bench, near-identically in both, so they do not bias the comparison:

| Class | MCTS | Hybrid |
| --- | ---: | ---: |
| nvcc compile failed | 451 | 462 |
| bench worker exceeded the 16 s wall budget | 434 | 460 |
| benchmark run exceeded the 2.0 s GPU-time budget | 137 | 129 |
| hung kernel | 7 | 3 |

Every one of the nvcc failures is the same defect: generated CUDA for a `k_div_*` kernel emits `float v0 = in0 + in2;` where `in0` was never declared, and nvcc rejects it — 2,173 occurrences in the hybrid log, one kernel family, no other compiler message. It reaches only *searched* variants; the golden's own recorded configurations compile and replay cleanly, so it costs search coverage rather than deployed correctness. Knob values do not separate failing from passing rows and all 462 failing rows are distinct ops, so the trigger looks structural to that kernel family.

## Also observed

The system record now enumerates 28 devices — the 16 V100s plus the 12 NVSwitches, the latter with `name: None`. The matrix row is still `gpu_count: 16` and serving is unaffected, but nameless entries in a durable record are new on this base.

## Reproduce

```bash
emmy bench experiments/DeepSeek-V4-Flash-0731/serving_v100_sxm3 --ssh <user>@<16x-v100-host>
```

On a Volta host, per #567, compiler-side commands need `LD_PRELOAD=/usr/local/cuda-12.9/lib64/libnvrtc.so.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



