### PR TITLE
Let each model class own how it projects a candidate pool

### DIFF
--- a/emmy/compiler/pipeline/ARCHITECTURE.md
+++ b/emmy/compiler/pipeline/ARCHITECTURE.md
@@ -467,7 +467,7 @@ The names below recur throughout this document; together they are the whole publ
 
 | Member | Caller | What it is |
 |--------|--------|------------|
-| `score(knobs)` | MCTS selection (PUCT) only | Predicted latency, used to steer exploration. On the composite prior this is the one call that blends the two halves (see the calibration-gate section below). |
+| `policy(knobs_list)` | MCTS selection (PUCT) only | How much the model prefers each sibling in ONE fork's set, normalized within it. The one call that may combine the two halves (see the calibration-gate section below). |
 | `mean_score` / `mean_scores` | deploy + eval ranking | The model's latency prediction for one row / for a batch of candidates. `FallbackPrior` routes these to the online half when it is `trustworthy`, else to the offline half — no blending. |
 | `evidence_pick(rows)` | deploy tier 2 | The pick made from measured reservoir rows (defined below). Returns `(index, measured_µs)` or `None`. Consulted whatever the calibration verdict says, because measured evidence needs no trusted model: a quarantined model — or a checkpoint whose reservoir has rows but no fitted model yet — still supplies this tier. |
 | `pick(rows)` | deploy + eval | `evidence_pick` first; when no candidate has evidence, the `mean_scores` argmin with the canonical tie-break. Returns `(index, µs)` — a measured µs when evidence decided, a predicted one otherwise. This covers tiers 2 and 4 only: `greedy_decide` puts the verified tier above it and the DB tier between the two, so the `Prior` never owns the whole hierarchy. |
@@ -477,7 +477,7 @@ The names below recur throughout this document; together they are the whole publ
 
 ### The deploy evidence hierarchy
 
-`TuningSearch` (`tune`) ranks the PUCT frontier with the prior's `score`. `greedy_decide` (`compile` / `run`, via
+`TuningSearch` (`tune`) ranks the PUCT frontier with the prior's `policy`. `greedy_decide` (`compile` / `run`, via
 `Run.resolve`) never explores: at each fork it picks once, working down the list below from the top. **This list is
 the authoritative order** — the summaries elsewhere in this file defer to it.
 

--- a/emmy/compiler/pipeline/search/prior/catboost_model.py
+++ b/emmy/compiler/pipeline/search/prior/catboost_model.py
@@ -2,7 +2,8 @@
 second model class :class:`~emmy.compiler.pipeline.search.prior.offline.OfflinePrior` can rank with.
 
 Same contract as the linear model and the same two access shapes over one arithmetic: a feature-dict path (how a
-live candidate is scored) and a packed-matrix path (what ``emmy fit`` trains and evaluates on). What differs is
+live candidate is scored) and a packed-matrix path (what ``emmy fit`` trains and evaluates on, entered for a
+whole candidate pool through :meth:`CatBoostModel.score_rows`). What differs is
 everything the linear model needed *because* it is additive:
 
 - **No weight sets.** A linear model prices a symbolic-axis (masked-tile) kernel with a second weight vector
@@ -36,11 +37,16 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION
+
+if TYPE_CHECKING:
+    # Annotation only: importing ``search.data`` for real would pull it (and, through ``freeze.py``, yaml and
+    # subprocess) onto the deploy path, which loads none of it today.
+    from emmy.compiler.pipeline.search.data.group import Group
 
 # The artifact's ``params`` block for this model class, in written order — the twin of the linear model's
 # ``PARAM_ORDER``. ``offline._load_artifact`` demands exactly the keys the writer emits, so a new scalar param is
@@ -158,6 +164,15 @@ class CatBoostModel:
     def matrix(self, feats_list: list[dict]) -> np.ndarray:
         """Feature dicts packed into this model's own column order, absent key = :data:`ABSENT`."""
         return np.array([[f.get(c, ABSENT) for c in self.cols] for f in feats_list], dtype=float)
+
+    def score_rows(self, group: Group) -> np.ndarray:
+        """:meth:`quality_rows` over a whole packed pool — the pool-shaped entry point :class:`~..linear_model.LinearModel`
+        also answers, and the ONE place the tree's column choice is made: :attr:`cols` in its own order,
+        absent filling to :data:`ABSENT`, which is what the booster was trained against.
+
+        Never ``None``: one model prices both regimes, so the linear model's "this fold fit no dynamic
+        weight set" case cannot arise here."""
+        return self.quality_rows(group.matrix(list(self.cols), fill=ABSENT))
 
     def quality_rows(self, mat: np.ndarray) -> np.ndarray:
         """Per-row ranking quality (higher = predicted faster) over a matrix already in :attr:`cols` order — the

--- a/emmy/compiler/pipeline/search/prior/fit/catboost.py
+++ b/emmy/compiler/pipeline/search/prior/fit/catboost.py
@@ -229,9 +229,10 @@ class CatBoostFit:
     rows: int
 
     def score_rows(self, group: Group) -> np.ndarray:
-        """The group's per-row quality (higher = predicted faster) over its FULL pool, scored exactly as the
-        shipped prior ranks. Training sampled negatives; the metric never does."""
-        return self.model.quality_rows(group.matrix(list(self.model.cols), fill=ABSENT))
+        """The trainer protocol's scoring entry point, answered by the fitted model itself — the column
+        choice is the model's, not a copy of it kept here. Over the group's FULL pool: training sampled
+        negatives, the metric never does."""
+        return self.model.score_rows(group)
 
     @property
     def notes(self) -> str:

--- a/emmy/compiler/pipeline/search/prior/fit/linear.py
+++ b/emmy/compiler/pipeline/search/prior/fit/linear.py
@@ -37,7 +37,6 @@ from emmy.compiler.pipeline.search.data.group import Group
 from emmy.compiler.pipeline.search.prior.fit.rank import best_rank, topk_table
 from emmy.compiler.pipeline.search.prior.linear_model import (
     FITTED_PARAMS,
-    GATE_DEFAULTS,
     LinearModel,
     descent_cols,
     gate_columns,
@@ -307,16 +306,10 @@ class LinearFit:
     dyn_ranks: list[int] | None
 
     def score_rows(self, group: Group) -> np.ndarray | None:
-        """The group's per-row quality (higher = predicted faster), scored exactly as the shipped
-        prior ranks. ``None`` when the group needs the dynamic set and this fit has none."""
-        if group.dynamic and self.model.weights_dynamic is None:
-            return None
-        # The gate columns must be present whether or not the weight dict names them (a pruned
-        # zero weight drops the key), so score over the union. The weight set itself comes from
-        # the model, which is where the static-vs-dynamic choice is made — this must not become a
-        # second copy of that routing.
-        names = sorted(set(self.model.weight_set(group.dynamic)) | set(GATE_DEFAULTS))
-        return self.model.quality_rows(group.matrix(names), names, dynamic=group.dynamic)
+        """The trainer protocol's scoring entry point (:func:`~.cv.case_ranks` calls it), answered by the
+        fitted model itself — the column choice and the weight-set routing are the model's, not a copy of
+        them kept here."""
+        return self.model.score_rows(group)
 
     @property
     def notes(self) -> str:

--- a/emmy/compiler/pipeline/search/prior/linear_model.py
+++ b/emmy/compiler/pipeline/search/prior/linear_model.py
@@ -5,10 +5,13 @@ Two access shapes over one arithmetic: :meth:`LinearModel.quality` takes a featu
 scores a live candidate) and :meth:`LinearModel.quality_rows` takes a packed pool matrix (what ``emmy fit``
 descends on — one fp16 golden enumerates ~78k rows, so the per-dict path is not an option there). Before this
 module the two were separate transcriptions of the same formula kept in step by a parity test; drift between them
-would mean the fitter optimizing something other than what deploys.
+would mean the fitter optimizing something other than what deploys. :meth:`LinearModel.score_rows` is the front
+door onto the matrix shape rather than a third shape: it takes a whole candidate pool and decides, once and here,
+which columns this model class wants out of it.
 
 The public scoring methods borrow ``Prior``'s own featurized surface — ``mean_score_features``,
-``mean_scores_features`` and ``explain_features``. That is deliberate: ``FallbackPrior`` and the attribution
+``mean_scores_features`` and ``explain_features`` (``quality`` / ``quality_rows`` / ``score_rows`` are this
+module's own vocabulary, not ``Prior``'s). That is deliberate: ``FallbackPrior`` and the attribution
 diagnostics already compose priors on exactly those, so a holder can delegate to any model through them without a
 second vocabulary. :mod:`.catboost_model` is the other model class answering the same surface.
 :meth:`~LinearModel.quality` / :meth:`~LinearModel.quality_rows` are linear-only — the pre-transform ranking
@@ -30,10 +33,16 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from emmy.compiler.pipeline.search.features import FEATURIZER_VERSION, ROUTING_FEATURES, is_dynamic_row
+
+if TYPE_CHECKING:
+    # Annotation only: importing ``search.data`` for real would pull it (and, through ``freeze.py``, yaml and
+    # subprocess) onto the deploy path, which loads none of it today.
+    from emmy.compiler.pipeline.search.data.group import Group
 
 
 def descent_cols(names) -> tuple[str, ...]:
@@ -223,6 +232,26 @@ class LinearModel:
         return quality_columns(
             mat, vec, gate_columns(mat, names), weight=self.atomic_free_weight, threshold=self.atomic_free_split_threshold
         )
+
+    def score_rows(self, group: Group) -> np.ndarray | None:
+        """:meth:`quality_rows` over a whole packed pool — the pool-shaped entry point, and the ONE place the
+        linear model's column choice is made. :class:`~..catboost_model.CatBoostModel` answers the same
+        shape, which is what lets the trainer and the fold harness hand either model class a group and rank it
+        without knowing which one they hold.
+
+        Two things a caller must not re-derive, which is why they live here rather than at each call site.
+        The COLUMNS are the weight set's names UNION :data:`GATE_DEFAULTS`: the interaction's two inputs have
+        to be present whether or not the weight dict names them, since a pruned zero weight drops the key.
+        The WEIGHT SET comes from :meth:`weight_set`, so the static-vs-dynamic choice is made once, here,
+        and a second copy of that routing cannot drift from it.
+
+        ``None`` when the group needs the dynamic set and this model has none — the unfittable
+        cross-validation fold. Asking :meth:`weight_set` instead would raise, and a fold harness wants an
+        answer it can skip on, not an exception."""
+        if group.dynamic and self.weights_dynamic is None:
+            return None
+        names = sorted(set(self.weight_set(group.dynamic)) | set(GATE_DEFAULTS))
+        return self.quality_rows(group.matrix(names), names, dynamic=group.dynamic)
 
     def weight_set(self, dynamic: bool) -> dict[str, float]:
         """The weight dict a row of this kind scores under — the ONE place the two sets are chosen between.

--- a/tests/compiler/pipeline/search/prior/test_catboost_model.py
+++ b/tests/compiler/pipeline/search/prior/test_catboost_model.py
@@ -115,6 +115,24 @@ def test_score_rows_covers_the_full_pool_not_the_sample():
     assert fit.score_rows(groups[0]).shape == (30,)
 
 
+def test_score_rows_projects_onto_the_models_own_columns():
+    """A pool need not carry the columns the model was trained on, nor in its order — projecting it is the
+    MODEL's job now, and every other pool in this file stamps every column, so nothing else reaches this.
+
+    Column ORDER is the catchable half, and this pins it: the same pool read in the wrong order scores
+    differently. The FILL is deliberately not asserted through a score — CatBoost's ``nan_mode="Min"`` puts
+    NaN on the same side of every split as the training minimum, and ``0.0`` IS that minimum here, so a
+    mis-filled column would score identically. That is why the fill is pinned where it is decided
+    (:func:`test_absent_features_are_nan_not_zero`) rather than by its effect."""
+    model = _fit()  # trained on ("D_a", "D_b")
+    group = Group.from_dicts("gpuA/p", "p", "warp", "gpuA", "s", 0, [{"D_a": float(i)} for i in range(6)])
+    assert group.feat_names == ("D_a",)  # the pool is missing a column the model wants
+
+    scores = model.score_rows(group)
+    assert np.array_equal(scores, model.quality_rows(group.matrix(list(model.cols), fill=ABSENT)))
+    assert not np.array_equal(replace(model, cols=("D_b", "D_a")).score_rows(group), scores)
+
+
 def test_hard_negative_mining_grows_the_training_set():
     """Round 0 draws negatives uniformly; each further round adds the rows the current model ranks near the
     golden. More rounds therefore train on strictly more rows — the mechanism, not merely the flag."""

--- a/tests/compiler/pipeline/search/prior/test_prior_fit.py
+++ b/tests/compiler/pipeline/search/prior/test_prior_fit.py
@@ -211,6 +211,34 @@ def test_dict_and_matrix_paths_score_identically(dynamic):
     assert np.allclose(fitted, deployed)
 
 
+def test_an_unfittable_dynamic_fold_scores_as_none_rather_than_raising():
+    """A model fit with no symbolic-axis cases has no dynamic weight set, and a dynamic pool handed to it
+    is unanswerable rather than wrong. ``None`` is the word for that, and it must survive the forward from
+    the fit to the model — :func:`~.cv.case_ranks` skips such a group, where a raised exception would abort
+    the whole cross-validation run and a zero vector would silently rank the pool by emission order.
+
+    Untested before this: ``weight_set`` RAISES on a missing dynamic set, so the guard that turns that into
+    a ``None`` is the only thing standing between an unfittable fold and a crashed run.
+
+    Static pools still score normally on the same model: it is the missing WEIGHT SET that is the limit,
+    not the model."""
+    static_only = LinearModel(
+        weights={"D_threads": 1.0},
+        weights_dynamic=None,
+        scale=0.1,
+        atomic_free_weight=0.0,
+        atomic_free_split_threshold=4.0,
+    )
+    rows = [{"D_threads": float(i), "S_ext_n_symbolic_axis": 1.0} for i in range(5)]
+    dyn = Group.from_dicts("x/d", "d", "dyn", "x", "d", 0, rows)
+    static = Group.from_dicts("x/s", "s", "warp", "x", "s", 0, [{"D_threads": float(i)} for i in range(5)])
+
+    assert dyn.dynamic and not static.dynamic
+    for caller in (static_only, LinearFit(static_only, [], [])):  # the model, and the fit that forwards to it
+        assert caller.score_rows(dyn) is None
+        assert caller.score_rows(static) is not None
+
+
 def test_model_artifact_round_trips():
     """``LinearModel`` → artifact → ``LinearModel`` is exact, so the file a fit ships and the model
     that produced it rank identically. The params block keeps its full key set (order is free — the


### PR DESCRIPTION
## Why

`LinearFit.score_rows` rebuilt `LinearModel`'s own column contract from the outside — the weight set UNION
`GATE_DEFAULTS`, plus the static-vs-dynamic routing and the guard for a fold that fit no dynamic set.
`CatBoostFit.score_rows` did the same for the tree's `cols` and its `NaN` fill. Both are facts about a model,
reconstructed by its holder — and the two model classes do not even agree on a `quality_rows` signature
(`LinearModel.quality_rows(mat, names, *, dynamic)` vs `CatBoostModel.quality_rows(mat)`), so that difference
leaked into every caller.

Step 4 of the evaluation-metrics rework, and the later steps need one pool-shaped entry point that does not care
which model class it is holding.

## What

- **`score_rows(group)` on `LinearModel` and `CatBoostModel`.** Each decides its own columns and its own
  absent-feature fill. The two `Fit` classes become one-line forwards; the trainer protocol `cv.case_ranks`
  speaks is unchanged.
- `fit/linear.py` drops its `GATE_DEFAULTS` import — it only ever had it to re-derive the model's contract.
- Annotations import `Group` under `TYPE_CHECKING`: a real import would pull `search/data`, and through
  `freeze.py` yaml and subprocess, onto the deploy path, which loads none of it today (checked with
  `sys.modules` before/after importing `prior.offline`).

## Scope note

The plan for this step also put `score_rows` on `Prior` / `OfflinePrior` / `OnlinePrior` / `FallbackPrior`. I
built that and then removed it, for two reasons found in review:

- **`OnlinePrior.score_rows` would have been wrong for every `Group` the repo builds.** `OnlinePrior._cols` is
  the reservoir's full `knob_features` vocabulary; a `Group` is filtered through `feature_view`, and every view —
  `DEFAULT_FEATURES`, `TREE_FEATURES`, `MATMUL_FEATURES` — drops all 20 `S_*`/`H_*` columns, which is precisely
  what `online.py` says the model exists to read. Measured on a real golden: 65 featurized keys, 20 structural,
  0 of them surviving any view. The pool would have arrived as `NaN` in every structural column and scored as a
  near-constant vector — plausible numbers rather than an error.
- **The `Prior` half had no caller.** Whether an online score over a pool is even meaningful depends on that pool
  carrying the model's vocabulary, and that is a judgement the report should make when it exists — not one to
  pre-answer here.

## Tests

Two, both for behaviour nothing reached before:

- A pool whose columns are not the model's is now projected by the model, so the tree gets one pinning that it
  uses its OWN column order. The fill is deliberately *not* asserted through a score: CatBoost's
  `nan_mode="Min"` puts `NaN` on the same side of every split as the training minimum, and `0.0` is that minimum
  here, so a mis-filled column scores identically — which is why the fill stays pinned where it is decided.
- A model with no dynamic weight set answers `None` for a symbolic-axis pool rather than raising. `weight_set`
  raises, so that guard is the only thing between an unfittable fold and an aborted cross-validation run.

## Also

The `Prior` API table claims to list the whole public API and documented `score(knobs)`. `def score` exists
nowhere under `search/`; `base.py` records it as retired and MCTS calls `policy` (`policy/mcts.py:424`).

## Verification

- `make test`: 3013 passed, 578 skipped, 1 xfailed. `make lint` clean.
- No behaviour change: the same synthetic corpus refits byte-identically against the pre-Step-3 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXPHwChs61iSChSCddZJoG